### PR TITLE
Batch 2 completion: Codex chat parity, json-render, cost dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,13 @@
       "name": "cortex-ide",
       "version": "0.0.1",
       "dependencies": {
+        "@json-render/core": "^0.14.0",
+        "@json-render/react": "^0.14.0",
+        "@json-render/shadcn": "^0.14.0",
         "lucide-react": "^0.577.0",
         "next": "^16.1.6",
-        "react": "19.0.0",
-        "react-dom": "19.0.0"
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4"
       },
       "devDependencies": {
         "@types/node": "22.13.10",
@@ -521,6 +524,44 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@hapi/address": {
       "version": "5.1.1",
@@ -1144,6 +1185,62 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@json-render/core": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@json-render/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-Zay2xy3I5z9AfJgkuPkA8aeFTjULkDjBmjb9prHAahuowyhsVOKtZ881eKo10OAsWVig0Sxyfy1s14ukOs8fhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@json-render/react": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@json-render/react/-/react-0.14.0.tgz",
+      "integrity": "sha512-1MwvGAOr93bgNauq/s/gLHZfM2uSIpfWINCQOCrpARDfCaDZXH/7k8rvj004izXPMXq099us7ZPR/X3Qf7Yq7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@json-render/core": "0.14.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.3"
+      }
+    },
+    "node_modules/@json-render/shadcn": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@json-render/shadcn/-/shadcn-0.14.0.tgz",
+      "integrity": "sha512-pgu8+Wy7P8L2u5LfKS6dBu0j1viOpXuOZILU/+T2CTOF/hnXHyTF4lGW42LsNZSMlZRj7SRjIklAFtIS7p2kfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@json-render/core": "0.14.0",
+        "@json-render/react": "0.14.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "embla-carousel-react": "^8.6.0",
+        "lucide-react": "^0.564.0",
+        "radix-ui": "^1.4.3",
+        "tailwind-merge": "^3.4.1",
+        "vaul": "^1.1.2"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "tailwindcss": "^4.0.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@json-render/shadcn/node_modules/lucide-react": {
+      "version": "0.564.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.564.0.tgz",
+      "integrity": "sha512-JJ8GVTQqFwuliifD48U6+h7DXEHdkhJ/E87kksGByII3qHxtPciVb8T8woQONHBQgHVOl7rSMrrip3SeVNy7Fg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1349,6 +1446,1504 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-accessible-icon": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.7.tgz",
+      "integrity": "sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
+      "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-aspect-ratio": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
+      "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
+      "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.8.tgz",
+      "integrity": "sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
+      "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menubar": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
+      "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
+      "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-one-time-password-field": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.8.tgz",
+      "integrity": "sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-password-toggle-field": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.3.tgz",
+      "integrity": "sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
+      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
+      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.11.tgz",
+      "integrity": "sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-toggle-group": "1.1.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
+      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.5.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1474,7 +3069,7 @@
       "version": "19.0.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
       "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1484,7 +3079,7 @@
       "version": "19.0.4",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.4.tgz",
       "integrity": "sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -2135,6 +3730,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -2599,6 +4206,18 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -2631,6 +4250,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -2758,7 +4386,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -2950,6 +4578,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -3003,6 +4637,34 @@
       "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -4010,6 +5672,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -5708,25 +7379,102 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/radix-ui": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.4.3.tgz",
+      "integrity": "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-accessible-icon": "1.1.7",
+        "@radix-ui/react-accordion": "1.2.12",
+        "@radix-ui/react-alert-dialog": "1.1.15",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-aspect-ratio": "1.1.7",
+        "@radix-ui/react-avatar": "1.1.10",
+        "@radix-ui/react-checkbox": "1.3.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-context-menu": "2.2.16",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-dropdown-menu": "2.1.16",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-form": "0.1.8",
+        "@radix-ui/react-hover-card": "1.1.15",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-menubar": "1.1.16",
+        "@radix-ui/react-navigation-menu": "1.2.14",
+        "@radix-ui/react-one-time-password-field": "0.1.8",
+        "@radix-ui/react-password-toggle-field": "0.1.3",
+        "@radix-ui/react-popover": "1.1.15",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-progress": "1.1.7",
+        "@radix-ui/react-radio-group": "1.3.8",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-scroll-area": "1.2.10",
+        "@radix-ui/react-select": "2.2.6",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-slider": "1.3.6",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-switch": "1.2.6",
+        "@radix-ui/react-tabs": "1.1.13",
+        "@radix-ui/react-toast": "1.2.15",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-toggle-group": "1.1.11",
+        "@radix-ui/react-toolbar": "1.1.11",
+        "@radix-ui/react-tooltip": "1.2.8",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
-      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.25.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.0.0"
+        "react": "^19.2.4"
       }
     },
     "node_modules/react-is": {
@@ -5735,6 +7483,75 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -5971,9 +7788,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -6491,6 +8308,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
+      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6849,6 +8683,71 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vaul": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/wait-on": {
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.5.tgz",
@@ -7083,7 +8982,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -15,10 +15,13 @@
     "desktop:dev": "concurrently -k -s first \"npm run dev\" \"npm run electron:dev\""
   },
   "dependencies": {
+    "@json-render/core": "^0.14.0",
+    "@json-render/react": "^0.14.0",
+    "@json-render/shadcn": "^0.14.0",
     "lucide-react": "^0.577.0",
     "next": "^16.1.6",
-    "react": "19.0.0",
-    "react-dom": "19.0.0"
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
   },
   "devDependencies": {
     "@types/node": "22.13.10",

--- a/src/app/api/mobile/action/route.ts
+++ b/src/app/api/mobile/action/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import type { MobileActionRequest, MobileActionResponse } from '@/lib/mobile/types';
-import { performRuntimeAction } from '@/lib/runtime/actions';
+import { launchCodexFromMobile, performRuntimeAction } from '@/lib/runtime/actions';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -16,6 +16,29 @@ export async function POST(request: NextRequest) {
 
   try {
     const isOwnedCodex = sessionKey.startsWith('codex-owned:');
+
+    if (action === 'launch') {
+      const cwd = payload?.cwd?.trim();
+      const message = payload?.message?.trim();
+      if (!cwd || !message) {
+        return NextResponse.json(
+          { error: 'cwd and message are required for launch' },
+          { status: 400, headers: { 'Cache-Control': 'no-store, max-age=0' } },
+        );
+      }
+      const result = await launchCodexFromMobile(cwd, message);
+      const response: MobileActionResponse = {
+        ok: result.ok,
+        action,
+        sessionKey: result.surfaceId ?? sessionKey,
+        status: result.status,
+        note: result.note,
+      };
+      return NextResponse.json(response, {
+        status: 200,
+        headers: { 'Cache-Control': 'no-store, max-age=0' },
+      });
+    }
 
     if (action === 'resume') {
       if (!isOwnedCodex) {

--- a/src/app/api/mobile/history/route.ts
+++ b/src/app/api/mobile/history/route.ts
@@ -28,32 +28,54 @@ export async function GET(request: NextRequest) {
   try {
     if (sessionKey.startsWith('codex-owned:')) {
       const tail = await getOwnedCodexRuntimeTail(sessionKey);
+
+      // Build a chat-style flat transcript (no groups/turns — just user bubbles and assistant bubbles)
+      const chatTranscript: MobileTranscriptEntry[] = [];
+      const groups = tail.groups ?? [];
+
+      for (const group of groups) {
+        // User prompt → user bubble
+        const promptText = group.prompt?.trim();
+        if (promptText) {
+          chatTranscript.push({
+            id: `${group.id}-prompt`,
+            role: 'user',
+            text: promptText,
+            timestampLabel: group.startedAtLabel,
+          });
+        }
+
+        // Assistant entries from this turn → assistant bubbles
+        for (const entry of group.entries) {
+          const text = entry.text.trim();
+          if (!text) continue;
+          // Skip entries that just echo the prompt
+          if (promptText && text === promptText) continue;
+          // Skip meta noise (usage stats, launch/resume markers)
+          if (text.startsWith('Usage •') || text.includes('Owned Codex session') || text.includes('Codex run launched')) continue;
+
+          const role = runtimeTailRole(entry.label);
+          if (role === 'assistant') {
+            chatTranscript.push({
+              id: entry.id,
+              role: 'assistant',
+              text,
+              timestampLabel: entry.timestampLabel,
+            });
+          } else if (entry.kind === 'tool') {
+            chatTranscript.push({
+              id: entry.id,
+              role: 'system',
+              text: `🔧 ${entry.label || 'Tool'}`,
+              timestampLabel: entry.timestampLabel,
+            });
+          }
+        }
+      }
+
       const payload: MobileHistoryResponse = {
         sessionKey,
-        transcript: (tail.entries ?? []).map((entry) => ({
-          id: entry.id,
-          role: runtimeTailRole(entry.label),
-          text: entry.text,
-          timestampLabel: entry.timestampLabel,
-        })),
-        groups: (tail.groups ?? []).map((group) => ({
-          id: group.id,
-          title: group.title,
-          mode: group.mode,
-          outcome: group.outcome,
-          prompt: group.prompt,
-          startedAt: group.startedAt,
-          finishedAt: group.finishedAt,
-          startedAtLabel: group.startedAtLabel,
-          finishedAtLabel: group.finishedAtLabel,
-          summary: group.summary,
-          entries: group.entries.map((entry) => ({
-            id: entry.id,
-            role: runtimeTailRole(entry.label),
-            text: entry.text,
-            timestampLabel: entry.timestampLabel,
-          })),
-        })),
+        transcript: chatTranscript,
       };
 
       return NextResponse.json(payload, {

--- a/src/app/api/mobile/history/route.ts
+++ b/src/app/api/mobile/history/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getOwnedCodexRuntimeTail } from '@/lib/codex/owned';
+import { getCodexRuntimeTail } from '@/lib/codex/sessions';
 import type { MobileHistoryResponse, MobileTranscriptEntry } from '@/lib/mobile/types';
 import { getSessionTranscript } from '@/lib/openclaw/chat';
 
@@ -62,6 +63,24 @@ export async function GET(request: NextRequest) {
       });
     }
 
+    // Discovered Codex sessions — read JSONL tail from ~/.codex/sessions/
+    if (sessionKey.startsWith('codex:')) {
+      const tail = await getCodexRuntimeTail(sessionKey);
+      const payload: MobileHistoryResponse = {
+        sessionKey,
+        transcript: (tail.entries ?? []).map((entry) => ({
+          id: entry.id,
+          role: runtimeTailRole(entry.label),
+          text: entry.text,
+          timestampLabel: entry.timestampLabel,
+        })),
+      };
+      return NextResponse.json(payload, {
+        headers: { 'Cache-Control': 'no-store, max-age=0' },
+      });
+    }
+
+    // OpenClaw sessions — use gateway chat.history
     const transcript = await getSessionTranscript(sessionKey, limit);
     const payload: MobileHistoryResponse = {
       sessionKey,

--- a/src/app/api/mobile/history/route.ts
+++ b/src/app/api/mobile/history/route.ts
@@ -66,15 +66,44 @@ export async function GET(request: NextRequest) {
     // Discovered Codex sessions — read JSONL tail from ~/.codex/sessions/
     if (sessionKey.startsWith('codex:')) {
       const tail = await getCodexRuntimeTail(sessionKey);
-      const payload: MobileHistoryResponse = {
-        sessionKey,
-        transcript: (tail.entries ?? []).map((entry) => ({
-          id: entry.id,
-          role: runtimeTailRole(entry.label),
-          text: entry.text,
-          timestampLabel: entry.timestampLabel,
-        })),
-      };
+      const transcript: MobileTranscriptEntry[] = [];
+      for (const entry of tail.entries ?? []) {
+        // Skip noisy system/instruction entries — only show user, assistant, and tool activity
+        if (entry.kind === 'event' && entry.label === 'Agent update') {
+          // Agent updates are assistant messages
+          transcript.push({ id: entry.id, role: 'assistant', text: entry.text, timestampLabel: entry.timestampLabel });
+          continue;
+        }
+        if (entry.kind === 'message') {
+          const role = runtimeTailRole(entry.label);
+          // Filter out system instructions (permissions, collaboration mode, AGENTS.md)
+          if (role === 'system' || role === 'user') {
+            const lowerText = entry.text.toLowerCase();
+            if (lowerText.includes('<permissions') || lowerText.includes('collaboration_mode') || lowerText.includes('# agents.md') || lowerText.includes('sandbox_mode')) continue;
+          }
+          transcript.push({ id: entry.id, role, text: entry.text, timestampLabel: entry.timestampLabel });
+          continue;
+        }
+        if (entry.kind === 'tool') {
+          // Format tool calls as system entries with clean names
+          const toolName = entry.label || 'Tool';
+          transcript.push({ id: entry.id, role: 'system', text: `🔧 ${toolName}`, timestampLabel: entry.timestampLabel });
+          continue;
+        }
+        if (entry.kind === 'tool-output') {
+          // Show compact tool output
+          transcript.push({ id: entry.id, role: 'system', text: entry.text, timestampLabel: entry.timestampLabel });
+          continue;
+        }
+      }
+      // Deduplicate consecutive assistant messages with identical text
+      const deduped: MobileTranscriptEntry[] = [];
+      for (const entry of transcript) {
+        const prev = deduped[deduped.length - 1];
+        if (prev && prev.role === 'assistant' && entry.role === 'assistant' && prev.text === entry.text) continue;
+        deduped.push(entry);
+      }
+      const payload: MobileHistoryResponse = { sessionKey, transcript: deduped };
       return NextResponse.json(payload, {
         headers: { 'Cache-Control': 'no-store, max-age=0' },
       });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4250,3 +4250,24 @@ body:has(.remodex-diff-overlay) {
     display: grid;
   }
 }
+
+/* ── json-render approval cards ── */
+.remodex-approval-stack {
+  padding: 12px 16px 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.remodex-approval-card-wrap {
+  animation: remodex-approval-slide-in 0.35s cubic-bezier(0.2, 0.9, 0.3, 1) forwards;
+}
+@keyframes remodex-approval-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(16px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4284,9 +4284,9 @@ body:has(.remodex-diff-overlay) {
   background: none;
   border: none;
   color: #ef4444;
-  font-size: 17px;
+  font-size: 15px;
   font-weight: 400;
-  padding: 12px 0 16px;
+  padding: 10px 0 12px;
   cursor: pointer;
   letter-spacing: -0.01em;
 }
@@ -4306,29 +4306,29 @@ body:has(.remodex-diff-overlay) {
 .remodex-costs-hero {
   background: #ffffff;
   border-radius: 16px;
-  padding: 24px 20px 20px;
+  padding: 18px 18px 16px;
   margin-bottom: 0;
   box-shadow: 0 1px 4px rgba(0,0,0,0.05);
   border: 1px solid rgba(0,0,0,0.06);
 }
 .remodex-costs-hero-kicker {
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 500;
   color: #86868b;
   letter-spacing: -0.01em;
 }
 .remodex-costs-hero-value {
   display: block;
-  font-size: 34px;
+  font-size: 28px;
   font-weight: 700;
   color: #1d1d1f;
-  line-height: 1.1;
-  margin: 6px 0 4px;
+  line-height: 1.15;
+  margin: 4px 0 2px;
   letter-spacing: -0.02em;
   font-variant-numeric: tabular-nums;
 }
 .remodex-costs-hero-sub {
-  font-size: 13px;
+  font-size: 12px;
   color: #86868b;
   line-height: 1.4;
 }
@@ -4336,7 +4336,7 @@ body:has(.remodex-diff-overlay) {
   height: 4px;
   background: #f5f5f7;
   border-radius: 2px;
-  margin-top: 16px;
+  margin-top: 12px;
   overflow: hidden;
 }
 .remodex-costs-hero-fill {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4458,16 +4458,16 @@ body:has(.remodex-diff-overlay) {
   font-variant-numeric: tabular-nums;
 }
 
-/* Squad rail summary card — Apple widget style */
+/* Squad rail summary card — full-width above grid, Apple widget style */
 .remodex-costs-summary-card {
   display: flex;
   align-items: center;
-  gap: 14px;
-  width: 100%;
+  gap: 16px;
+  width: calc(100% - 32px);
+  margin: 0 16px 12px;
   background: #ffffff;
   border-radius: 16px;
-  padding: 16px 18px;
-  margin-bottom: 12px;
+  padding: 16px 20px;
   box-shadow: 0 1px 4px rgba(0,0,0,0.05);
   border: 1px solid rgba(0,0,0,0.06);
   cursor: pointer;
@@ -4489,16 +4489,25 @@ body:has(.remodex-diff-overlay) {
   font-weight: 500;
   color: #86868b;
   letter-spacing: -0.01em;
-  margin-bottom: 2px;
+  margin-bottom: 3px;
+  white-space: nowrap;
 }
 .remodex-costs-summary-value {
-  display: block;
-  font-size: 22px;
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  font-size: 26px;
   font-weight: 700;
   color: #1d1d1f;
   line-height: 1.15;
   letter-spacing: -0.02em;
   font-variant-numeric: tabular-nums;
+}
+.remodex-costs-summary-unit {
+  font-size: 15px;
+  font-weight: 500;
+  color: #86868b;
+  letter-spacing: -0.01em;
 }
 .remodex-costs-summary-right {
   flex-shrink: 0;
@@ -4511,8 +4520,8 @@ body:has(.remodex-diff-overlay) {
 /* Donut ring — Apple Watch style */
 .remodex-costs-summary-ring {
   position: relative;
-  width: 44px;
-  height: 44px;
+  width: 48px;
+  height: 48px;
 }
 .remodex-costs-ring-svg {
   width: 100%;
@@ -4528,7 +4537,7 @@ body:has(.remodex-diff-overlay) {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 700;
   color: #1d1d1f;
   letter-spacing: -0.02em;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2303,10 +2303,10 @@ button.workflow-file-item.workflow-file-item-active {
 .remodex-agent-pill {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.45rem 0.6rem;
+  gap: 0.5rem;
+  padding: 0.5rem 0.7rem;
   border-radius: 10px;
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.92);
   border: 1px solid rgba(15, 23, 42, 0.05);
   text-align: left;
   color: #111827;
@@ -2324,14 +2324,21 @@ button.workflow-file-item.workflow-file-item-active {
 }
 
 .remodex-agent-pill-name {
-  font-size: 0.78rem;
+  font-size: 0.8rem;
   font-weight: 700;
-  min-width: 48px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.remodex-agent-pill-sep {
+  font-size: 0.75rem;
+  color: rgba(17, 24, 39, 0.2);
+  flex-shrink: 0;
 }
 
 .remodex-agent-pill-status {
-  font-size: 0.7rem;
-  color: rgba(17, 24, 39, 0.42);
+  font-size: 0.72rem;
+  color: rgba(17, 24, 39, 0.45);
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2254,6 +2254,65 @@ button.workflow-file-item.workflow-file-item-active {
 .remodex-squad-bar-high { background: #ef4444; }
 .remodex-squad-bar-critical { background: #dc2626; }
 
+/* ── Project group cards ── */
+.remodex-project-group {
+  display: contents; /* lets children participate in parent grid */
+}
+
+.remodex-project-card {
+  position: relative;
+}
+
+.remodex-project-card-expanded {
+  border-color: rgba(99, 102, 241, 0.2);
+  background: rgba(238, 242, 255, 0.6);
+}
+
+.remodex-project-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 0.1rem;
+}
+
+.remodex-project-count {
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: rgba(17, 24, 39, 0.36);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.remodex-project-chevron {
+  color: rgba(17, 24, 39, 0.3);
+  transition: transform 200ms ease;
+  flex-shrink: 0;
+}
+
+.remodex-project-chevron-open {
+  transform: rotate(90deg);
+}
+
+.remodex-project-agents {
+  grid-column: 1 / -1; /* span full width of the grid */
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.4rem;
+  padding: 0.5rem;
+  border-radius: 14px;
+  background: rgba(99, 102, 241, 0.04);
+  border: 1px solid rgba(99, 102, 241, 0.08);
+  animation: remodex-fade-in 200ms ease-out both;
+}
+
+.remodex-agent-card {
+  padding: 0.6rem 0.7rem 0.5rem;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.92);
+  border-color: rgba(15, 23, 42, 0.04);
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.03);
+}
+
 /* ── Activity bar (observable agents) ── */
 .remodex-activity-bar {
   display: flex;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2256,7 +2256,7 @@ button.workflow-file-item.workflow-file-item-active {
 
 /* ── Project group cards ── */
 .remodex-project-group {
-  display: contents; /* lets children participate in parent grid */
+  display: contents;
 }
 
 .remodex-project-card {
@@ -2264,29 +2264,23 @@ button.workflow-file-item.workflow-file-item-active {
 }
 
 .remodex-project-card-expanded {
-  border-color: rgba(99, 102, 241, 0.2);
-  background: rgba(238, 242, 255, 0.6);
+  border-color: rgba(99, 102, 241, 0.18);
+  background: rgba(238, 242, 255, 0.5);
 }
 
-.remodex-project-meta {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-top: 0.1rem;
-}
-
-.remodex-project-count {
-  font-size: 0.65rem;
-  font-weight: 600;
-  color: rgba(17, 24, 39, 0.36);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+.remodex-project-summary {
+  font-size: 0.68rem;
+  font-weight: 500;
+  color: rgba(17, 24, 39, 0.4);
+  letter-spacing: 0.01em;
 }
 
 .remodex-project-chevron {
-  color: rgba(17, 24, 39, 0.3);
+  position: absolute;
+  right: 0.6rem;
+  bottom: 0.55rem;
+  color: rgba(17, 24, 39, 0.25);
   transition: transform 200ms ease;
-  flex-shrink: 0;
 }
 
 .remodex-project-chevron-open {
@@ -2294,23 +2288,54 @@ button.workflow-file-item.workflow-file-item-active {
 }
 
 .remodex-project-agents {
-  grid-column: 1 / -1; /* span full width of the grid */
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 0.4rem;
-  padding: 0.5rem;
-  border-radius: 14px;
-  background: rgba(99, 102, 241, 0.04);
-  border: 1px solid rgba(99, 102, 241, 0.08);
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.4rem;
+  border-radius: 12px;
+  background: rgba(99, 102, 241, 0.03);
+  border: 1px solid rgba(99, 102, 241, 0.06);
   animation: remodex-fade-in 200ms ease-out both;
 }
 
-.remodex-agent-card {
-  padding: 0.6rem 0.7rem 0.5rem;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.92);
-  border-color: rgba(15, 23, 42, 0.04);
-  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.03);
+/* Agent pills — compact horizontal rows inside expanded project */
+.remodex-agent-pill {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.6rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  text-align: left;
+  color: #111827;
+  transition: background 150ms ease, transform 100ms ease;
+}
+
+.remodex-agent-pill:active {
+  transform: scale(0.98);
+  background: rgba(255, 255, 255, 1);
+}
+
+.remodex-agent-pill-active {
+  border-color: rgba(239, 68, 68, 0.2);
+  background: rgba(254, 242, 242, 0.6);
+}
+
+.remodex-agent-pill-name {
+  font-size: 0.78rem;
+  font-weight: 700;
+  min-width: 48px;
+}
+
+.remodex-agent-pill-status {
+  font-size: 0.7rem;
+  color: rgba(17, 24, 39, 0.42);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* ── Activity bar (observable agents) ── */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4271,3 +4271,229 @@ body:has(.remodex-diff-overlay) {
     transform: translateY(0) scale(1);
   }
 }
+
+/* ── Cost Dashboard ── */
+.remodex-costs-view {
+  padding: 8px 16px 24px;
+}
+.remodex-costs-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  color: #ef4444;
+  font-size: 15px;
+  font-weight: 600;
+  padding: 8px 0;
+  cursor: pointer;
+  margin-bottom: 8px;
+}
+
+/* Hero card */
+.remodex-costs-hero {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 20px 18px;
+  margin-bottom: 12px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  border: 1px solid #e5e7eb;
+}
+.remodex-costs-hero-kicker {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #94a3b8;
+}
+.remodex-costs-hero-value {
+  display: block;
+  font-size: 32px;
+  font-weight: 800;
+  color: #0f172a;
+  line-height: 1.1;
+  margin: 4px 0 6px;
+}
+.remodex-costs-hero-sub {
+  font-size: 13px;
+  color: #64748b;
+}
+.remodex-costs-hero-bar {
+  height: 6px;
+  background: #f1f5f9;
+  border-radius: 3px;
+  margin-top: 14px;
+  overflow: hidden;
+}
+.remodex-costs-hero-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #22c55e, #f59e0b, #ef4444);
+  border-radius: 3px;
+  transition: width 0.4s ease;
+}
+
+/* Model cards */
+.remodex-costs-model-card {
+  background: #ffffff;
+  border-radius: 14px;
+  padding: 14px 16px;
+  margin-bottom: 10px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  border: 1px solid #e5e7eb;
+}
+.remodex-costs-model-card-muted {
+  opacity: 0.7;
+}
+.remodex-costs-model-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.remodex-costs-model-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.remodex-costs-model-name {
+  font-size: 15px;
+  font-weight: 700;
+  color: #0f172a;
+  flex: 1;
+}
+.remodex-costs-model-pct {
+  font-size: 14px;
+  font-weight: 600;
+  color: #64748b;
+}
+.remodex-costs-model-bar {
+  height: 5px;
+  background: #f1f5f9;
+  border-radius: 3px;
+  margin-bottom: 8px;
+  overflow: hidden;
+}
+.remodex-costs-model-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.4s ease;
+}
+.remodex-costs-model-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: #94a3b8;
+  margin-bottom: 8px;
+}
+.remodex-costs-codex-note {
+  font-size: 13px;
+  color: #94a3b8;
+  margin: 0;
+  line-height: 1.4;
+}
+
+/* Session rows inside model cards */
+.remodex-costs-session-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 4px;
+  background: none;
+  border: none;
+  border-top: 1px solid #f1f5f9;
+  cursor: pointer;
+  text-align: left;
+}
+.remodex-costs-session-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.remodex-costs-session-name {
+  flex: 1;
+  font-size: 14px;
+  font-weight: 500;
+  color: #334155;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.remodex-costs-session-tokens {
+  font-size: 13px;
+  font-weight: 600;
+  color: #475569;
+  font-variant-numeric: tabular-nums;
+}
+.remodex-costs-session-pct {
+  font-size: 12px;
+  color: #94a3b8;
+  width: 32px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Squad rail summary card */
+.remodex-costs-summary-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  background: #ffffff;
+  border-radius: 14px;
+  padding: 14px 16px;
+  margin-bottom: 10px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  border: 1px solid #e5e7eb;
+  cursor: pointer;
+  text-align: left;
+}
+.remodex-costs-summary-left {
+  flex: 1;
+}
+.remodex-costs-summary-kicker {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #94a3b8;
+}
+.remodex-costs-summary-value {
+  display: block;
+  font-size: 20px;
+  font-weight: 800;
+  color: #0f172a;
+  line-height: 1.2;
+}
+.remodex-costs-summary-right {
+  flex-shrink: 0;
+}
+.remodex-costs-summary-chevron {
+  color: #94a3b8;
+  flex-shrink: 0;
+}
+
+/* Donut ring */
+.remodex-costs-summary-ring {
+  position: relative;
+  width: 42px;
+  height: 42px;
+}
+.remodex-costs-ring-svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+.remodex-costs-ring-label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  color: #0f172a;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4273,82 +4273,96 @@ body:has(.remodex-diff-overlay) {
 }
 
 /* ── Cost Dashboard ── */
+/* ── Cost Dashboard — Apple 8pt grid, refined spacing ── */
 .remodex-costs-view {
-  padding: 8px 16px 24px;
+  padding: 0 16px 32px;
 }
 .remodex-costs-back {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
   background: none;
   border: none;
   color: #ef4444;
-  font-size: 15px;
-  font-weight: 600;
-  padding: 8px 0;
+  font-size: 17px;
+  font-weight: 400;
+  padding: 12px 0 16px;
   cursor: pointer;
-  margin-bottom: 8px;
+  letter-spacing: -0.01em;
+}
+
+/* Section label above model cards */
+.remodex-costs-section-label {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #94a3b8;
+  padding: 20px 0 8px;
+  display: block;
 }
 
 /* Hero card */
 .remodex-costs-hero {
   background: #ffffff;
   border-radius: 16px;
-  padding: 20px 18px;
-  margin-bottom: 12px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
-  border: 1px solid #e5e7eb;
+  padding: 24px 20px 20px;
+  margin-bottom: 0;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+  border: 1px solid rgba(0,0,0,0.06);
 }
 .remodex-costs-hero-kicker {
-  font-size: 12px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: #94a3b8;
+  font-size: 13px;
+  font-weight: 500;
+  color: #86868b;
+  letter-spacing: -0.01em;
 }
 .remodex-costs-hero-value {
   display: block;
-  font-size: 32px;
-  font-weight: 800;
-  color: #0f172a;
+  font-size: 34px;
+  font-weight: 700;
+  color: #1d1d1f;
   line-height: 1.1;
-  margin: 4px 0 6px;
+  margin: 6px 0 4px;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
 }
 .remodex-costs-hero-sub {
   font-size: 13px;
-  color: #64748b;
+  color: #86868b;
+  line-height: 1.4;
 }
 .remodex-costs-hero-bar {
-  height: 6px;
-  background: #f1f5f9;
-  border-radius: 3px;
-  margin-top: 14px;
+  height: 4px;
+  background: #f5f5f7;
+  border-radius: 2px;
+  margin-top: 16px;
   overflow: hidden;
 }
 .remodex-costs-hero-fill {
   height: 100%;
-  background: linear-gradient(90deg, #22c55e, #f59e0b, #ef4444);
-  border-radius: 3px;
-  transition: width 0.4s ease;
+  background: linear-gradient(90deg, #34c759, #ff9f0a, #ff3b30);
+  border-radius: 2px;
+  transition: width 0.5s cubic-bezier(0.25, 0.1, 0.25, 1);
 }
 
 /* Model cards */
 .remodex-costs-model-card {
   background: #ffffff;
   border-radius: 14px;
-  padding: 14px 16px;
-  margin-bottom: 10px;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.04);
-  border: 1px solid #e5e7eb;
+  padding: 16px 18px;
+  margin-bottom: 8px;
+  box-shadow: 0 0.5px 2px rgba(0,0,0,0.04);
+  border: 1px solid rgba(0,0,0,0.06);
 }
 .remodex-costs-model-card-muted {
-  opacity: 0.7;
+  opacity: 0.65;
 }
 .remodex-costs-model-head {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 8px;
+  gap: 10px;
+  margin-bottom: 10px;
 }
 .remodex-costs-model-dot {
   width: 10px;
@@ -4358,134 +4372,155 @@ body:has(.remodex-diff-overlay) {
 }
 .remodex-costs-model-name {
   font-size: 15px;
-  font-weight: 700;
-  color: #0f172a;
+  font-weight: 600;
+  color: #1d1d1f;
   flex: 1;
+  letter-spacing: -0.01em;
 }
 .remodex-costs-model-pct {
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 600;
-  color: #64748b;
+  color: #86868b;
+  font-variant-numeric: tabular-nums;
 }
 .remodex-costs-model-bar {
-  height: 5px;
-  background: #f1f5f9;
-  border-radius: 3px;
-  margin-bottom: 8px;
+  height: 4px;
+  background: #f5f5f7;
+  border-radius: 2px;
+  margin-bottom: 10px;
   overflow: hidden;
 }
 .remodex-costs-model-fill {
   height: 100%;
-  border-radius: 3px;
-  transition: width 0.4s ease;
+  border-radius: 2px;
+  transition: width 0.5s cubic-bezier(0.25, 0.1, 0.25, 1);
 }
 .remodex-costs-model-meta {
   display: flex;
   justify-content: space-between;
-  font-size: 12px;
-  color: #94a3b8;
-  margin-bottom: 8px;
+  font-size: 13px;
+  color: #86868b;
+  padding-bottom: 4px;
 }
 .remodex-costs-codex-note {
   font-size: 13px;
-  color: #94a3b8;
-  margin: 0;
-  line-height: 1.4;
+  color: #86868b;
+  margin: 4px 0 0;
+  line-height: 1.45;
 }
 
 /* Session rows inside model cards */
 .remodex-costs-session-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   width: 100%;
-  padding: 8px 4px;
+  padding: 10px 2px;
   background: none;
   border: none;
-  border-top: 1px solid #f1f5f9;
+  border-top: 1px solid #f5f5f7;
   cursor: pointer;
   text-align: left;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.15s;
+}
+.remodex-costs-session-row:active {
+  background: #f5f5f7;
+  border-radius: 8px;
 }
 .remodex-costs-session-dot {
-  width: 7px;
-  height: 7px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   flex-shrink: 0;
 }
 .remodex-costs-session-name {
   flex: 1;
-  font-size: 14px;
-  font-weight: 500;
-  color: #334155;
+  font-size: 15px;
+  font-weight: 400;
+  color: #1d1d1f;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  letter-spacing: -0.01em;
 }
 .remodex-costs-session-tokens {
   font-size: 13px;
-  font-weight: 600;
-  color: #475569;
+  font-weight: 500;
+  color: #636366;
   font-variant-numeric: tabular-nums;
 }
 .remodex-costs-session-pct {
-  font-size: 12px;
-  color: #94a3b8;
-  width: 32px;
+  font-size: 13px;
+  color: #aeaeb2;
+  min-width: 36px;
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
 
-/* Squad rail summary card */
+/* Squad rail summary card — Apple widget style */
 .remodex-costs-summary-card {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
   width: 100%;
   background: #ffffff;
-  border-radius: 14px;
-  padding: 14px 16px;
-  margin-bottom: 10px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
-  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  padding: 16px 18px;
+  margin-bottom: 12px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+  border: 1px solid rgba(0,0,0,0.06);
   cursor: pointer;
   text-align: left;
+  -webkit-tap-highlight-color: transparent;
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+.remodex-costs-summary-card:active {
+  transform: scale(0.98);
+  box-shadow: 0 0.5px 2px rgba(0,0,0,0.04);
 }
 .remodex-costs-summary-left {
   flex: 1;
+  min-width: 0;
 }
 .remodex-costs-summary-kicker {
   display: block;
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: #94a3b8;
+  font-size: 13px;
+  font-weight: 500;
+  color: #86868b;
+  letter-spacing: -0.01em;
+  margin-bottom: 2px;
 }
 .remodex-costs-summary-value {
   display: block;
-  font-size: 20px;
-  font-weight: 800;
-  color: #0f172a;
-  line-height: 1.2;
+  font-size: 22px;
+  font-weight: 700;
+  color: #1d1d1f;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
 }
 .remodex-costs-summary-right {
   flex-shrink: 0;
 }
 .remodex-costs-summary-chevron {
-  color: #94a3b8;
+  color: #c7c7cc;
   flex-shrink: 0;
 }
 
-/* Donut ring */
+/* Donut ring — Apple Watch style */
 .remodex-costs-summary-ring {
   position: relative;
-  width: 42px;
-  height: 42px;
+  width: 44px;
+  height: 44px;
 }
 .remodex-costs-ring-svg {
   width: 100%;
   height: 100%;
   transform: rotate(-90deg);
+}
+.remodex-costs-ring-svg path:first-child {
+  stroke: #f5f5f7;
 }
 .remodex-costs-ring-label {
   position: absolute;
@@ -4495,5 +4530,6 @@ body:has(.remodex-diff-overlay) {
   justify-content: center;
   font-size: 11px;
   font-weight: 700;
-  color: #0f172a;
+  color: #1d1d1f;
+  letter-spacing: -0.02em;
 }

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -1109,9 +1109,17 @@ export function MobileRemoteShell({
       if (session.isCurrentSession) return true;
       if (session.id === selectedSession?.id) return true;
 
-      // Codex sessions: always show — they represent real work in repos.
-      // Group them by project; even old sessions show the repo had agent work.
-      if (session.runtime === 'codex') return true;
+      // Codex sessions: show if they have a live process or recent activity.
+      // Filter out dead registry entries and persisted-only history.
+      if (session.runtime === 'codex') {
+        const src = session.runtimeSurface?.sourceLabel ?? '';
+        // "live pid" = running process, "recent session history" = just used
+        if (src.includes('live pid') || src.includes('recent session')) return true;
+        // "persisted session history" or "ready for resume" = dead/old
+        if (src.includes('persisted') || src.includes('ready for resume')) return false;
+        // Unknown source — show it
+        return true;
+      }
 
       // OpenClaw sessions: filter stale ones (automation, old surfaces)
       const ageText = session.lastEventAt ?? '';
@@ -1211,11 +1219,13 @@ export function MobileRemoteShell({
   );
   const headerLabel = isOwnedCodexSession
     ? (selectedSession?.runtimeSurface?.capabilities.interrupt ? 'Codex live' : selectedSession?.runtimeSurface?.capabilities.sendInput ? 'Codex chat' : 'Codex watch')
-    : selectedSession?.status === 'running'
-      ? 'Live'
-      : snapshot.review?.pullRequest
-        ? 'Review'
-        : 'Session';
+    : selectedSession?.runtime === 'codex'
+      ? 'Codex'
+      : selectedSession?.status === 'running'
+        ? 'Live'
+        : snapshot.review?.pullRequest
+          ? 'Review'
+          : 'Session';
   const headerProgress = Math.min(scrollY / 88, 1);
   const isHeaderCompact = headerProgress > 0.12;
   const isComposerPrimed = isOpenClawSession && (composeFocused || transcriptAttachments.length > 0);
@@ -1430,10 +1440,11 @@ export function MobileRemoteShell({
     if (actionStateBySession[sessionKey] === 'steering') return;
 
     const targetSession = snapshot.sessions.find((session) => session.sessionKey === sessionKey);
-    if (targetSession?.runtime !== 'openclaw') {
+    // Allow steering both OpenClaw sessions and discovered Codex sessions
+    if (targetSession?.runtime !== 'openclaw' && !(targetSession?.runtime === 'codex' && targetSession?.runtimeSurface?.ownership === 'discovered')) {
       setActionNoteBySession((current) => ({
         ...current,
-        [sessionKey]: 'Use the Codex resume lane instead — steer is for the Mister lane only.',
+        [sessionKey]: 'Use the Codex resume lane for owned Codex sessions.',
       }));
       return;
     }
@@ -2191,7 +2202,7 @@ export function MobileRemoteShell({
           {streamingText ? (
             <article className="remodex-message-card remodex-message-card-assistant remodex-streaming-card">
               <div className="remodex-message-header">
-                <span className="remodex-speaker-label">{isOwnedCodexSession ? 'Codex' : (selectedSession?.name ?? 'Mister')}</span>
+                <span className="remodex-speaker-label">{selectedSession ? agentDisplayName(selectedSession) : 'Mister'}</span>
                 <div className="remodex-typing-bubble-dots" style={{ display: 'inline-flex', marginLeft: 6 }}>
                   <span className="remodex-typing-dot" />
                   <span className="remodex-typing-dot" />
@@ -2276,7 +2287,7 @@ export function MobileRemoteShell({
                     }}
                     onFocus={() => setComposeFocused(true)}
                     onBlur={() => setComposeFocused(false)}
-                    placeholder={transcriptAttachments.length ? 'Add context for the image…' : 'Message Mister…'}
+                    placeholder={transcriptAttachments.length ? 'Add context for the image…' : `Message ${selectedSession ? agentDisplayName(selectedSession) : 'Mister'}…`}
                   />
                   <div className="remodex-compose-row">
                     <button
@@ -2326,7 +2337,7 @@ export function MobileRemoteShell({
                         if (!selectedSessionKey) return;
                         void handleSteerSubmit(selectedSessionKey);
                       }}
-                      aria-label="Send message to Mister"
+                      aria-label={`Send message to ${selectedSession ? agentDisplayName(selectedSession) : 'Mister'}`}
                     >
                       {transcriptActionState === 'steering' ? (
                         <>

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -1148,25 +1148,13 @@ export function MobileRemoteShell({
 
     const groups: ProjectGroup[] = [];
     for (const [ws, rawSessions] of groupMap) {
-      // Sort by recency so dedup keeps the newest session per branch
-      const sorted = [...rawSessions].sort((a, b) => {
-        // Parse "Xm ago", "Xh ago", "Xd ago" to compare recency
-        const ageMinutes = (text: string) => {
-          const m = text.match(/^(\d+)m/); if (m) return parseInt(m[1], 10);
-          const h = text.match(/^(\d+)h/); if (h) return parseInt(h[1], 10) * 60;
-          const d = text.match(/^(\d+)d/); if (d) return parseInt(d[1], 10) * 1440;
-          return 0;
-        };
-        return ageMinutes(a.lastEventAt ?? '') - ageMinutes(b.lastEventAt ?? '');
-      });
-      // Deduplicate Codex sessions: keep only the most recent per branch
+      // Deduplicate: only collapse truly dead duplicates (same session id).
+      // Never dedup by branch — user may have multiple Codex agents on the same branch.
       const deduped: typeof rawSessions = [];
-      const seenBranches = new Set<string>();
-      for (const s of sorted) {
-        if (s.runtime === 'codex' && s.branch) {
-          if (seenBranches.has(s.branch)) continue;
-          seenBranches.add(s.branch);
-        }
+      const seenIds = new Set<string>();
+      for (const s of rawSessions) {
+        if (seenIds.has(s.id)) continue;
+        seenIds.add(s.id);
         deduped.push(s);
       }
       const sessions = deduped;

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -700,6 +700,8 @@ export function MobileRemoteShell({
 
   const selectedSessionKey = selectedSession?.sessionKey;
   const isOpenClawSession = selectedSession?.runtime === 'openclaw';
+  // Discovered Codex sessions use the same chat UI as OpenClaw sessions
+  const isChatSession = isOpenClawSession || (selectedSession?.runtime === 'codex' && selectedSession?.runtimeSurface?.ownership === 'discovered');
   const isOwnedCodexSession = selectedSession?.runtime === 'codex' && selectedSession?.runtimeSurface?.ownership === 'owned';
   const selectedReviewPacket = selectedSessionKey && isOwnedCodexSession ? reviewPacketBySession[selectedSessionKey] ?? null : null;
   const selectedReviewPacketLoading = selectedSessionKey && isOwnedCodexSession ? reviewPacketLoadingBySession[selectedSessionKey] ?? false : false;
@@ -1118,13 +1120,13 @@ export function MobileRemoteShell({
         : 0;
       const isStale = ageHours > 4;
 
-      // Codex sessions:
-      // - "discovered" = user opened from terminal → always show
-      // - "owned" = IDE/OpenClaw opened programmatically → filter if stale
+      // Codex sessions: only show if the process is alive.
+      // sourceLabel contains "live pid" or "recent session" when running;
+      // "persisted session" or "ready for resume" when dead/killed.
       if (session.runtime === 'codex') {
-        if (session.runtimeSurface?.ownership !== 'owned') return true;
-        if (isStale) return false;
-        return true;
+        const src = session.runtimeSurface?.sourceLabel ?? '';
+        if (src.includes('live pid') || src.includes('recent session')) return true;
+        return false;
       }
 
       // OpenClaw sessions: filter stale ones
@@ -1227,7 +1229,7 @@ export function MobileRemoteShell({
           : 'Session';
   const headerProgress = Math.min(scrollY / 88, 1);
   const isHeaderCompact = headerProgress > 0.12;
-  const isComposerPrimed = isOpenClawSession && (composeFocused || transcriptAttachments.length > 0);
+  const isComposerPrimed = isChatSession && (composeFocused || transcriptAttachments.length > 0);
   const dockMotionProgress = !isComposerPrimed && isScrolling ? 1 : 0;
   const dockFadeProgress = dockMotionProgress;
   const diffFileLabel = reviewFiles.length === 1 ? 'file' : 'files';
@@ -1330,8 +1332,8 @@ export function MobileRemoteShell({
     if (!selectedSessionKey || !files?.length) {
       return;
     }
-    if (!isOpenClawSession) {
-      setSurfaceNote('Image attachments are only available on the Mister lane right now.');
+    if (!isChatSession) {
+      setSurfaceNote('Image attachments are only available for chat sessions right now.');
       return;
     }
 
@@ -1712,7 +1714,7 @@ export function MobileRemoteShell({
     if (!selectedSessionKey) {
       return;
     }
-    if (!isOpenClawSession && !canInterruptOwnedCodex) {
+    if (!isChatSession && !canInterruptOwnedCodex) {
       setSurfaceNote('No active run to interrupt right now.');
       return;
     }
@@ -2212,7 +2214,7 @@ export function MobileRemoteShell({
             </article>
           ) : (waitingForResponse || actionStateBySession[selectedSessionKey ?? ''] === 'steering') ? (
             <div className="remodex-typing-bubble">
-              <span className="remodex-typing-bubble-label">{isOwnedCodexSession ? 'Codex' : 'Mister'}</span>
+              <span className="remodex-typing-bubble-label">{selectedSession ? agentDisplayName(selectedSession) : 'Mister'}</span>
               <div className="remodex-typing-bubble-dots">
                 <span className="remodex-typing-dot" />
                 <span className="remodex-typing-dot" />
@@ -2226,7 +2228,7 @@ export function MobileRemoteShell({
 
         <div className="remodex-bottom-dock" data-active={isComposerPrimed ? 'true' : 'false'}>
           <div className="remodex-compose-shell">
-            {isOpenClawSession ? (
+            {isChatSession ? (
               <>
                 <input
                   ref={fileInputRef}
@@ -2576,7 +2578,7 @@ export function MobileRemoteShell({
                 <span className="remodex-action-row-label">Open on desktop</span>
                 <ChevronRight size={16} strokeWidth={1.8} className="remodex-action-row-chevron" />
               </Link>
-              {(isOpenClawSession && selectedSession?.status === 'running') || canInterruptOwnedCodex ? (
+              {(isChatSession && selectedSession?.status === 'running') || canInterruptOwnedCodex ? (
                 <button type="button" className="remodex-controls-action-row remodex-controls-action-row-danger" onClick={() => void handleStopActiveRun()}>
                   <span className="remodex-action-row-icon"><Square size={18} strokeWidth={1.8} /></span>
                   <span className="remodex-action-row-label">{isOwnedCodexSession ? 'Interrupt run' : 'Stop run'}</span>

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -1108,9 +1108,21 @@ export function MobileRemoteShell({
     const isRelevant = (session: MobileInboxSnapshot['sessions'][number]) => {
       if (session.isCurrentSession) return true;
       if (session.id === selectedSession?.id) return true;
+
+      // Parse age from lastEventAt (e.g. "4h ago", "1d ago", "2m ago")
+      const ageText = session.lastEventAt ?? '';
+      const hoursMatch = ageText.match(/^(\d+)h/);
+      const daysMatch = ageText.match(/^(\d+)d/);
+      const ageHours = daysMatch ? parseInt(daysMatch[1], 10) * 24
+        : hoursMatch ? parseInt(hoursMatch[1], 10)
+        : 0;
+      const isStale = ageHours > 4;
+
+      // Stale sessions get dropped regardless of status
+      // (dead Codex processes still report "reviewing"/"waiting")
+      if (isStale) return false;
+
       if (['running', 'reviewing', 'blocked'].includes(session.status)) return true;
-      const ageMatch = session.lastEventAt?.match(/^(\d+)h/);
-      if (ageMatch && parseInt(ageMatch[1], 10) > 4) return false;
       if (session.activity || session.alerts > 0) return true;
       if (session.runtime === 'codex' && session.runtimeSurface?.ownership === 'owned') return true;
       return false;

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -2100,51 +2100,51 @@ export function MobileRemoteShell({
           })() : null}
 
           {/* ── Squad Rail ── */}
+          {/* ── Token usage summary — full-width above squad grid ── */}
+          {activeView !== 'costs' ? (() => {
+            const tracked = snapshot.sessions.filter((s) => s.runtime === 'openclaw' && s.tokenUsage);
+            const total = tracked.reduce((sum, s) => sum + (s.tokenUsage?.totalTokens ?? 0), 0);
+            const cap = tracked.reduce((sum, s) => sum + (s.tokenUsage?.totalTokens ?? 0) + (s.tokenUsage?.remainingTokens ?? 0), 0);
+            const pct = cap > 0 ? Math.round((total / cap) * 100) : 0;
+            if (!tracked.length) return null;
+            return (
+              <button
+                type="button"
+                className="remodex-costs-summary-card"
+                onClick={() => setActiveView('costs')}
+              >
+                <div className="remodex-costs-summary-left">
+                  <span className="remodex-costs-summary-kicker">Token Usage · {tracked.length} session{tracked.length === 1 ? '' : 's'}</span>
+                  <strong className="remodex-costs-summary-value">{total.toLocaleString()} <span className="remodex-costs-summary-unit">tokens</span></strong>
+                </div>
+                <div className="remodex-costs-summary-right">
+                  <div className="remodex-costs-summary-ring">
+                    <svg viewBox="0 0 36 36" className="remodex-costs-ring-svg">
+                      <path
+                        d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
+                        fill="none"
+                        stroke="#f5f5f7"
+                        strokeWidth="3"
+                      />
+                      <path
+                        d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
+                        fill="none"
+                        stroke={pct >= 75 ? '#ff3b30' : pct >= 50 ? '#ff9f0a' : '#34c759'}
+                        strokeWidth="3"
+                        strokeDasharray={`${pct}, 100`}
+                        strokeLinecap="round"
+                      />
+                    </svg>
+                    <span className="remodex-costs-ring-label">{pct}%</span>
+                  </div>
+                </div>
+                <ChevronRight size={16} strokeWidth={1.8} className="remodex-costs-summary-chevron" />
+              </button>
+            );
+          })() : null}
+
           {activeView !== 'costs' && projectGroups.length > 0 ? (
             <div className="remodex-squad-rail">
-              {/* Usage summary tap target */}
-              {(() => {
-                const tracked = snapshot.sessions.filter((s) => s.runtime === 'openclaw' && s.tokenUsage);
-                const total = tracked.reduce((sum, s) => sum + (s.tokenUsage?.totalTokens ?? 0), 0);
-                const cap = tracked.reduce((sum, s) => sum + (s.tokenUsage?.totalTokens ?? 0) + (s.tokenUsage?.remainingTokens ?? 0), 0);
-                const pct = cap > 0 ? Math.round((total / cap) * 100) : 0;
-                if (!tracked.length) return null;
-                return (
-                  <button
-                    type="button"
-                    className="remodex-costs-summary-card"
-                    onClick={() => setActiveView('costs')}
-                  >
-                    <div className="remodex-costs-summary-left">
-                      <span className="remodex-costs-summary-kicker">Token Usage</span>
-                      <strong className="remodex-costs-summary-value">{total.toLocaleString()}</strong>
-                    </div>
-                    <div className="remodex-costs-summary-right">
-                      <div className="remodex-costs-summary-ring">
-                        <svg viewBox="0 0 36 36" className="remodex-costs-ring-svg">
-                          <path
-                            d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
-                            fill="none"
-                            stroke="#f5f5f7"
-                            strokeWidth="3"
-                          />
-                          <path
-                            d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
-                            fill="none"
-                            stroke={pct >= 75 ? '#ff3b30' : pct >= 50 ? '#ff9f0a' : '#34c759'}
-                            strokeWidth="3"
-                            strokeDasharray={`${pct}, 100`}
-                            strokeLinecap="round"
-                          />
-                        </svg>
-                        <span className="remodex-costs-ring-label">{pct}%</span>
-                      </div>
-                    </div>
-                    <ChevronRight size={16} strokeWidth={1.8} className="remodex-costs-summary-chevron" />
-                  </button>
-                );
-              })()}
-
               {projectGroups.map((group) => {
                 const isExpanded = expandedProject === group.workspace;
                 const ctxPct = Math.round(group.bestContextPct);

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -1441,8 +1441,9 @@ export function MobileRemoteShell({
     if (actionStateBySession[sessionKey] === 'steering') return;
 
     const targetSession = snapshot.sessions.find((session) => session.sessionKey === sessionKey);
-    // Allow steering both OpenClaw sessions and discovered Codex sessions
-    if (targetSession?.runtime !== 'openclaw' && !(targetSession?.runtime === 'codex' && targetSession?.runtimeSurface?.ownership === 'discovered')) {
+    const isDiscoveredCodex = targetSession?.runtime === 'codex' && targetSession?.runtimeSurface?.ownership === 'discovered';
+    const isChat = targetSession?.runtime === 'openclaw' || isDiscoveredCodex;
+    if (!isChat) {
       setActionNoteBySession((current) => ({
         ...current,
         [sessionKey]: 'Use the Codex resume lane for owned Codex sessions.',
@@ -1491,17 +1492,28 @@ export function MobileRemoteShell({
     );
 
     try {
-      await runAction({
-        action: 'steer',
-        sessionKey,
-        message,
-        attachments: attachments.map((item) => ({
-          type: 'image',
-          mimeType: item.mimeType,
-          fileName: item.fileName,
-          content: item.content,
-        })),
-      });
+      if (isDiscoveredCodex) {
+        // Launch an owned Codex session in the same workspace as the discovered one
+        await runAction({
+          action: 'launch' as MobileActionRequest['action'],
+          sessionKey,
+          message,
+          cwd: targetSession?.runtimeSurface?.cwd ?? targetSession?.workspace ?? '',
+        });
+        setSurfaceNote('Codex session launched. It will appear in the squad once it starts.');
+      } else {
+        await runAction({
+          action: 'steer',
+          sessionKey,
+          message,
+          attachments: attachments.map((item) => ({
+            type: 'image',
+            mimeType: item.mimeType,
+            fileName: item.fileName,
+            content: item.content,
+          })),
+        });
+      }
     } catch (error) {
       // Restore draft on failure so the user doesn't lose their message
       setDraftBySession((current) => ({ ...current, [sessionKey]: message ?? '' }));

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -2007,9 +2007,9 @@ export function MobileRemoteShell({
             }
 
             const modelColor: Record<string, string> = {
-              'claude-opus-4-6': '#ef4444',
-              'claude-sonnet-4-20250514': '#f59e0b',
-              'claude-haiku-4-5-20251001': '#22c55e',
+              'claude-opus-4-6': '#ff3b30',
+              'claude-sonnet-4-20250514': '#ff9f0a',
+              'claude-haiku-4-5-20251001': '#34c759',
             };
 
             return (
@@ -2019,15 +2019,15 @@ export function MobileRemoteShell({
                   className="remodex-costs-back"
                   onClick={() => setActiveView('squad')}
                 >
-                  ← Squad
+                  ‹ Squad
                 </button>
 
                 {/* ── Aggregate overview ── */}
                 <div className="remodex-costs-hero">
-                  <span className="remodex-costs-hero-kicker">Total Tokens Used</span>
+                  <span className="remodex-costs-hero-kicker">Token Usage</span>
                   <strong className="remodex-costs-hero-value">{totalTokens.toLocaleString()}</strong>
                   <span className="remodex-costs-hero-sub">
-                    of {totalCapacity.toLocaleString()} capacity across {openClawSessions.length} session{openClawSessions.length === 1 ? '' : 's'}
+                    {totalCapacity.toLocaleString()} total capacity · {openClawSessions.length} active session{openClawSessions.length === 1 ? '' : 's'}
                   </span>
                   <div className="remodex-costs-hero-bar">
                     <div
@@ -2038,6 +2038,7 @@ export function MobileRemoteShell({
                 </div>
 
                 {/* ── Per-model breakdown ── */}
+                <span className="remodex-costs-section-label">By Model</span>
                 {Array.from(byModel.entries()).map(([model, data]) => {
                   const pct = data.capacity > 0 ? Math.round((data.tokens / data.capacity) * 100) : 0;
                   const color = modelColor[model] ?? '#6366f1';
@@ -2053,7 +2054,7 @@ export function MobileRemoteShell({
                         <div className="remodex-costs-model-fill" style={{ width: `${pct}%`, background: color }} />
                       </div>
                       <div className="remodex-costs-model-meta">
-                        <span>{data.tokens.toLocaleString()} tokens</span>
+                        <span>{data.tokens.toLocaleString()} tokens used</span>
                         <span>{data.sessions.length} session{data.sessions.length === 1 ? '' : 's'}</span>
                       </div>
 
@@ -2090,7 +2091,7 @@ export function MobileRemoteShell({
                         <strong className="remodex-costs-model-name">Codex</strong>
                         <span className="remodex-costs-model-pct">{codexSessions.length} session{codexSessions.length === 1 ? '' : 's'}</span>
                       </div>
-                      <p className="remodex-costs-codex-note">Token usage not tracked for Codex sessions — billed through ChatGPT Pro subscription.</p>
+                      <p className="remodex-costs-codex-note">Billed through ChatGPT Pro — token-level usage not available.</p>
                     </div>
                   );
                 })()}
@@ -2124,13 +2125,13 @@ export function MobileRemoteShell({
                           <path
                             d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
                             fill="none"
-                            stroke="#e5e7eb"
+                            stroke="#f5f5f7"
                             strokeWidth="3"
                           />
                           <path
                             d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
                             fill="none"
-                            stroke={pct >= 75 ? '#ef4444' : pct >= 50 ? '#f59e0b' : '#22c55e'}
+                            stroke={pct >= 75 ? '#ff3b30' : pct >= 50 ? '#ff9f0a' : '#34c759'}
                             strokeWidth="3"
                             strokeDasharray={`${pct}, 100`}
                             strokeLinecap="round"

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -1047,42 +1047,95 @@ export function MobileRemoteShell({
   const latestTranscriptMarker = transcriptEntries[transcriptEntries.length - 1]?.id ?? 'empty';
   const scrollMarker = pendingOwnedTurn ? `${latestTranscriptMarker}:${pendingOwnedTurn.id}` : latestTranscriptMarker;
   const selectedReviewFile = selectedReviewFilePath ? reviewFileByPath[selectedReviewFilePath] : undefined;
-  const threadSwitcher = useMemo(() => {
-    // Filter: only show sessions that are active/recent or currently selected
+  // ── Project-grouped squad rail ──
+  // Group sessions by workspace path into "project cards"
+  interface ProjectGroup {
+    projectName: string;
+    workspace: string;
+    sessions: MobileInboxSnapshot['sessions'];
+    hasPrimary: boolean; // contains the main Mister session
+    mostRecentActivity?: string;
+    mostRecentTime?: string;
+    bestContextPct: number;
+    hasRunning: boolean;
+  }
+
+  const projectGroups = useMemo(() => {
+    // Relevancy filter — keep interesting sessions
     const isRelevant = (session: MobileInboxSnapshot['sessions'][number]) => {
       if (session.isCurrentSession) return true;
       if (session.id === selectedSession?.id) return true;
       if (['running', 'reviewing', 'blocked'].includes(session.status)) return true;
-      // Filter out stale sessions — "Xh ago" with X > 4
       const ageMatch = session.lastEventAt?.match(/^(\d+)h/);
       if (ageMatch && parseInt(ageMatch[1], 10) > 4) return false;
-      // Keep sessions with activity or alerts
       if (session.activity || session.alerts > 0) return true;
-      // Keep owned Codex sessions that aren't ancient
       if (session.runtime === 'codex' && session.runtimeSurface?.ownership === 'owned') return true;
       return false;
     };
 
-    const candidates = [
-      selectedSession,
-      ...snapshot.sessions.filter((session) => session.isCurrentSession),
-      ...snapshot.sessions.filter((session) => isRelevant(session)),
-    ].filter(Boolean) as MobileInboxSnapshot['sessions'];
+    const relevant = snapshot.sessions.filter(isRelevant);
 
-    const seen = new Set<string>();
-    const deduped = [] as MobileInboxSnapshot['sessions'];
-    for (const session of candidates) {
-      if (seen.has(session.id)) {
-        continue;
-      }
-      seen.add(session.id);
-      deduped.push(session);
-      if (deduped.length >= 6) {
-        break;
-      }
+    // Group by workspace path
+    const groupMap = new Map<string, MobileInboxSnapshot['sessions']>();
+    for (const session of relevant) {
+      const ws = session.workspace || '~/clawd';
+      const existing = groupMap.get(ws) ?? [];
+      existing.push(session);
+      groupMap.set(ws, existing);
     }
-    return deduped;
+
+    // Build project group objects
+    const groups: ProjectGroup[] = [];
+    for (const [ws, sessions] of groupMap) {
+      // Extract project name from path: ~/clawd/repos/cortex-ide → cortex-ide
+      const segments = ws.replace(/^~\//, '').split('/');
+      const projectName = segments[segments.length - 1] || segments[0] || 'workspace';
+      const hasPrimary = sessions.some((s) => s.isCurrentSession);
+      const running = sessions.some((s) => s.status === 'running' || s.status === 'reviewing');
+      const bestCtx = Math.max(...sessions.map((s) => s.context?.usedPercent ?? 0));
+
+      // Find most recent activity across all sessions in this group
+      let mostRecentActivity: string | undefined;
+      let mostRecentTime: string | undefined;
+      for (const s of sessions) {
+        if (s.activity?.headline) {
+          mostRecentActivity = s.activity.headline;
+          mostRecentTime = s.lastEventAt;
+          break; // first active session wins (they're already sorted by recency from inbox)
+        }
+      }
+      if (!mostRecentActivity) {
+        // Fall back to the most recent session's status
+        mostRecentActivity = sessions[0]?.status ?? 'idle';
+        mostRecentTime = sessions[0]?.lastEventAt;
+      }
+
+      groups.push({
+        projectName,
+        workspace: ws,
+        sessions,
+        hasPrimary,
+        mostRecentActivity,
+        mostRecentTime,
+        bestContextPct: bestCtx,
+        hasRunning: running,
+      });
+    }
+
+    // Sort: primary group first, then by most recently active
+    groups.sort((a, b) => {
+      if (a.hasPrimary && !b.hasPrimary) return -1;
+      if (!a.hasPrimary && b.hasPrimary) return 1;
+      if (a.hasRunning && !b.hasRunning) return -1;
+      if (!a.hasRunning && b.hasRunning) return 1;
+      return 0;
+    });
+
+    return groups;
   }, [selectedSession, snapshot.sessions]);
+
+  // Track which project group is expanded (null = none)
+  const [expandedProject, setExpandedProject] = useState<string | null>(null);
   const selectedReviewFileIndex = selectedReviewFilePath
     ? reviewFiles.findIndex((file) => file.path === selectedReviewFilePath)
     : -1;
@@ -1759,40 +1812,68 @@ export function MobileRemoteShell({
 
         <div className="remodex-scroll-view">
 
-          {threadSwitcher.length > 0 ? (
+          {projectGroups.length > 0 ? (
             <div className="remodex-squad-rail">
-              {threadSwitcher.map((session) => {
-                const active = session.id === selectedSession?.id;
-                const isRunning = session.status === 'running' || session.status === 'reviewing';
-                const ctxPct = Math.round(session.context?.usedPercent ?? 0);
+              {projectGroups.map((group) => {
+                const isExpanded = expandedProject === group.workspace;
+                const ctxPct = Math.round(group.bestContextPct);
                 const ctxTone = ctxPct >= 85 ? 'critical' : ctxPct >= 75 ? 'high' : ctxPct >= 65 ? 'watch' : 'calm';
-                const agentName = session.isCurrentSession ? 'Mister' : session.name?.split(/[\s/]/)[0] ?? 'Agent';
-                const activityLine = session.activity?.headline;
-                const taskLine = activityLine
-                  ? activityLine
-                  : session.isCurrentSession
-                    ? 'Main session'
-                    : session.status;
+                const agentCount = group.sessions.length;
+                const containsSelected = group.sessions.some((s) => s.id === selectedSession?.id);
+
                 return (
-                  <button
-                    key={session.id}
-                    type="button"
-                    className={`remodex-squad-card ${active ? 'remodex-squad-card-active' : ''}`}
-                    onClick={() => handleSessionFocus(session.id)}
-                  >
-                    <div className="remodex-squad-card-head">
-                      <span className={`remodex-squad-dot ${isRunning ? 'remodex-squad-dot-live' : ''} remodex-squad-dot-${ctxTone}`} />
-                      <strong className="remodex-squad-name">{agentName}</strong>
-                      <span className="remodex-squad-time">{session.lastEventAt ?? 'idle'}</span>
-                    </div>
-                    <span className="remodex-squad-task">{taskLine}</span>
-                    <div className="remodex-squad-bar-track">
-                      <div
-                        className={`remodex-squad-bar-fill remodex-squad-bar-${ctxTone}`}
-                        style={{ width: `${ctxPct}%` }}
-                      />
-                    </div>
-                  </button>
+                  <div key={group.workspace} className="remodex-project-group">
+                    <button
+                      type="button"
+                      className={`remodex-squad-card remodex-project-card ${containsSelected ? 'remodex-squad-card-active' : ''} ${isExpanded ? 'remodex-project-card-expanded' : ''}`}
+                      onClick={() => setExpandedProject(isExpanded ? null : group.workspace)}
+                    >
+                      <div className="remodex-squad-card-head">
+                        <span className={`remodex-squad-dot ${group.hasRunning ? 'remodex-squad-dot-live' : ''} remodex-squad-dot-${ctxTone}`} />
+                        <strong className="remodex-squad-name">{group.projectName}</strong>
+                        <span className="remodex-squad-time">{group.mostRecentTime ?? 'idle'}</span>
+                      </div>
+                      <span className="remodex-squad-task">{group.mostRecentActivity}</span>
+                      <div className="remodex-project-meta">
+                        <span className="remodex-project-count">{agentCount} agent{agentCount !== 1 ? 's' : ''}</span>
+                        <ChevronRight size={12} className={`remodex-project-chevron ${isExpanded ? 'remodex-project-chevron-open' : ''}`} />
+                      </div>
+                    </button>
+
+                    {isExpanded ? (
+                      <div className="remodex-project-agents">
+                        {group.sessions.map((session) => {
+                          const active = session.id === selectedSession?.id;
+                          const isRunning = session.status === 'running' || session.status === 'reviewing';
+                          const sCtxPct = Math.round(session.context?.usedPercent ?? 0);
+                          const sCtxTone = sCtxPct >= 85 ? 'critical' : sCtxPct >= 75 ? 'high' : sCtxPct >= 65 ? 'watch' : 'calm';
+                          const agentName = session.isCurrentSession ? 'Mister' : session.name?.split(/[\s/]/)[0] ?? 'Agent';
+                          const taskLine = session.activity?.headline ?? (session.isCurrentSession ? 'Main session' : session.status);
+                          return (
+                            <button
+                              key={session.id}
+                              type="button"
+                              className={`remodex-squad-card remodex-agent-card ${active ? 'remodex-squad-card-active' : ''}`}
+                              onClick={() => handleSessionFocus(session.id)}
+                            >
+                              <div className="remodex-squad-card-head">
+                                <span className={`remodex-squad-dot ${isRunning ? 'remodex-squad-dot-live' : ''} remodex-squad-dot-${sCtxTone}`} />
+                                <strong className="remodex-squad-name">{agentName}</strong>
+                                <span className="remodex-squad-time">{session.lastEventAt ?? 'idle'}</span>
+                              </div>
+                              <span className="remodex-squad-task">{taskLine}</span>
+                              <div className="remodex-squad-bar-track">
+                                <div
+                                  className={`remodex-squad-bar-fill remodex-squad-bar-${sCtxTone}`}
+                                  style={{ width: `${sCtxPct}%` }}
+                                />
+                              </div>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    ) : null}
+                  </div>
                 );
               })}
             </div>

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -1109,7 +1109,11 @@ export function MobileRemoteShell({
       if (session.isCurrentSession) return true;
       if (session.id === selectedSession?.id) return true;
 
-      // Parse age from lastEventAt (e.g. "4h ago", "1d ago", "2m ago")
+      // Codex sessions: always show — they represent real work in repos.
+      // Group them by project; even old sessions show the repo had agent work.
+      if (session.runtime === 'codex') return true;
+
+      // OpenClaw sessions: filter stale ones (automation, old surfaces)
       const ageText = session.lastEventAt ?? '';
       const hoursMatch = ageText.match(/^(\d+)h/);
       const daysMatch = ageText.match(/^(\d+)d/);
@@ -1117,14 +1121,10 @@ export function MobileRemoteShell({
         : hoursMatch ? parseInt(hoursMatch[1], 10)
         : 0;
       const isStale = ageHours > 4;
-
-      // Stale sessions get dropped regardless of status
-      // (dead Codex processes still report "reviewing"/"waiting")
       if (isStale) return false;
 
       if (['running', 'reviewing', 'blocked'].includes(session.status)) return true;
       if (session.activity || session.alerts > 0) return true;
-      if (session.runtime === 'codex' && session.runtimeSurface?.ownership === 'owned') return true;
       return false;
     };
 
@@ -1138,7 +1138,18 @@ export function MobileRemoteShell({
     }
 
     const groups: ProjectGroup[] = [];
-    for (const [ws, sessions] of groupMap) {
+    for (const [ws, rawSessions] of groupMap) {
+      // Deduplicate Codex sessions: keep only the most recent per branch
+      const deduped: typeof rawSessions = [];
+      const seenBranches = new Set<string>();
+      for (const s of rawSessions) {
+        if (s.runtime === 'codex' && s.branch) {
+          if (seenBranches.has(s.branch)) continue;
+          seenBranches.add(s.branch);
+        }
+        deduped.push(s);
+      }
+      const sessions = deduped;
       const running = sessions.some((s) => s.status === 'running' || s.status === 'reviewing');
       const bestCtx = Math.max(...sessions.map((s) => s.context?.usedPercent ?? 0));
       let mostRecentTime: string | undefined;
@@ -1892,7 +1903,11 @@ export function MobileRemoteShell({
                           const isRunning = session.status === 'running' || session.status === 'reviewing';
                           const sCtxTone = (() => { const p = Math.round(session.context?.usedPercent ?? 0); return p >= 85 ? 'critical' : p >= 75 ? 'high' : p >= 65 ? 'watch' : 'calm'; })();
                           const name = agentDisplayName(session);
-                          const statusLabel = session.activity?.headline ?? session.status;
+                          // For Codex: show branch name. For OpenClaw: show activity/status.
+                          const branchShort = session.branch?.replace(/^(feat|fix|batch|chore|refactor)\//, '') ?? '';
+                          const statusLabel = session.runtime === 'codex' && branchShort
+                            ? branchShort
+                            : (session.activity?.headline ?? session.status);
                           return (
                             <button
                               key={session.id}

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -446,6 +446,7 @@ export function MobileRemoteShell({
 }) {
   const [snapshot, setSnapshot] = useState<MobileInboxSnapshot>(initialSnapshot);
   const [selectedId, setSelectedId] = useState(() => pickCurrentSession(initialSnapshot)?.id ?? '');
+  const [activeView, setActiveView] = useState<'squad' | 'chat' | 'costs'>('squad');
   const [refreshError, setRefreshError] = useState<string | null>(null);
   const [surfaceNote, setSurfaceNote] = useState<string | null>(null);
   const [historyBySession, setHistoryBySession] = useState<Record<string, MobileTranscriptEntry[]>>(() => (
@@ -1803,6 +1804,7 @@ export function MobileRemoteShell({
     }
 
     setSelectedId(sessionId);
+    setActiveView('chat');
     setControlsOpen(false);
     setDiffOpen(false);
     setSurfaceNote(`Focused ${compactLine(nextSession.name, 'the selected session', 40)}.`);
@@ -1984,8 +1986,164 @@ export function MobileRemoteShell({
 
         <div className="remodex-scroll-view">
 
-          {projectGroups.length > 0 ? (
+          {/* ── Cost Dashboard View ── */}
+          {activeView === 'costs' ? (() => {
+            const openClawSessions = snapshot.sessions.filter(
+              (s) => s.runtime === 'openclaw' && s.tokenUsage,
+            );
+            const totalTokens = openClawSessions.reduce((sum, s) => sum + (s.tokenUsage?.totalTokens ?? 0), 0);
+            const totalRemaining = openClawSessions.reduce((sum, s) => sum + (s.tokenUsage?.remainingTokens ?? 0), 0);
+            const totalCapacity = totalTokens + totalRemaining;
+
+            // Group by model
+            const byModel = new Map<string, { sessions: typeof openClawSessions; tokens: number; capacity: number }>();
+            for (const s of openClawSessions) {
+              const model = s.model ?? 'unknown';
+              const existing = byModel.get(model) ?? { sessions: [], tokens: 0, capacity: 0 };
+              existing.sessions.push(s);
+              existing.tokens += s.tokenUsage?.totalTokens ?? 0;
+              existing.capacity += (s.tokenUsage?.totalTokens ?? 0) + (s.tokenUsage?.remainingTokens ?? 0);
+              byModel.set(model, existing);
+            }
+
+            const modelColor: Record<string, string> = {
+              'claude-opus-4-6': '#ef4444',
+              'claude-sonnet-4-20250514': '#f59e0b',
+              'claude-haiku-4-5-20251001': '#22c55e',
+            };
+
+            return (
+              <div className="remodex-costs-view">
+                <button
+                  type="button"
+                  className="remodex-costs-back"
+                  onClick={() => setActiveView('squad')}
+                >
+                  ← Squad
+                </button>
+
+                {/* ── Aggregate overview ── */}
+                <div className="remodex-costs-hero">
+                  <span className="remodex-costs-hero-kicker">Total Tokens Used</span>
+                  <strong className="remodex-costs-hero-value">{totalTokens.toLocaleString()}</strong>
+                  <span className="remodex-costs-hero-sub">
+                    of {totalCapacity.toLocaleString()} capacity across {openClawSessions.length} session{openClawSessions.length === 1 ? '' : 's'}
+                  </span>
+                  <div className="remodex-costs-hero-bar">
+                    <div
+                      className="remodex-costs-hero-fill"
+                      style={{ width: `${totalCapacity > 0 ? Math.round((totalTokens / totalCapacity) * 100) : 0}%` }}
+                    />
+                  </div>
+                </div>
+
+                {/* ── Per-model breakdown ── */}
+                {Array.from(byModel.entries()).map(([model, data]) => {
+                  const pct = data.capacity > 0 ? Math.round((data.tokens / data.capacity) * 100) : 0;
+                  const color = modelColor[model] ?? '#6366f1';
+                  const shortModel = model.replace('claude-', '').replace(/-20\d{6}$/, '');
+                  return (
+                    <div key={model} className="remodex-costs-model-card">
+                      <div className="remodex-costs-model-head">
+                        <span className="remodex-costs-model-dot" style={{ background: color }} />
+                        <strong className="remodex-costs-model-name">{shortModel}</strong>
+                        <span className="remodex-costs-model-pct">{pct}%</span>
+                      </div>
+                      <div className="remodex-costs-model-bar">
+                        <div className="remodex-costs-model-fill" style={{ width: `${pct}%`, background: color }} />
+                      </div>
+                      <div className="remodex-costs-model-meta">
+                        <span>{data.tokens.toLocaleString()} tokens</span>
+                        <span>{data.sessions.length} session{data.sessions.length === 1 ? '' : 's'}</span>
+                      </div>
+
+                      {/* Per-session rows */}
+                      {data.sessions.map((s) => {
+                        const sPct = s.context?.usedPercent ?? 0;
+                        const tone = sPct >= 85 ? 'critical' : sPct >= 75 ? 'high' : sPct >= 65 ? 'watch' : 'calm';
+                        return (
+                          <button
+                            key={s.id}
+                            type="button"
+                            className="remodex-costs-session-row"
+                            onClick={() => { setSelectedId(s.id); setActiveView('chat'); }}
+                          >
+                            <span className={`remodex-costs-session-dot remodex-squad-dot-${tone}`} />
+                            <span className="remodex-costs-session-name">{s.isCurrentSession ? 'This chat' : compactLine(s.name, 'Session', 28)}</span>
+                            <span className="remodex-costs-session-tokens">{(s.tokenUsage?.totalTokens ?? 0).toLocaleString()}</span>
+                            <span className="remodex-costs-session-pct">{sPct}%</span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  );
+                })}
+
+                {/* ── Codex sessions (no token data) ── */}
+                {(() => {
+                  const codexSessions = snapshot.sessions.filter((s) => s.runtime === 'codex');
+                  if (!codexSessions.length) return null;
+                  return (
+                    <div className="remodex-costs-model-card remodex-costs-model-card-muted">
+                      <div className="remodex-costs-model-head">
+                        <span className="remodex-costs-model-dot" style={{ background: '#6366f1' }} />
+                        <strong className="remodex-costs-model-name">Codex</strong>
+                        <span className="remodex-costs-model-pct">{codexSessions.length} session{codexSessions.length === 1 ? '' : 's'}</span>
+                      </div>
+                      <p className="remodex-costs-codex-note">Token usage not tracked for Codex sessions — billed through ChatGPT Pro subscription.</p>
+                    </div>
+                  );
+                })()}
+              </div>
+            );
+          })() : null}
+
+          {/* ── Squad Rail ── */}
+          {activeView !== 'costs' && projectGroups.length > 0 ? (
             <div className="remodex-squad-rail">
+              {/* Usage summary tap target */}
+              {(() => {
+                const tracked = snapshot.sessions.filter((s) => s.runtime === 'openclaw' && s.tokenUsage);
+                const total = tracked.reduce((sum, s) => sum + (s.tokenUsage?.totalTokens ?? 0), 0);
+                const cap = tracked.reduce((sum, s) => sum + (s.tokenUsage?.totalTokens ?? 0) + (s.tokenUsage?.remainingTokens ?? 0), 0);
+                const pct = cap > 0 ? Math.round((total / cap) * 100) : 0;
+                if (!tracked.length) return null;
+                return (
+                  <button
+                    type="button"
+                    className="remodex-costs-summary-card"
+                    onClick={() => setActiveView('costs')}
+                  >
+                    <div className="remodex-costs-summary-left">
+                      <span className="remodex-costs-summary-kicker">Token Usage</span>
+                      <strong className="remodex-costs-summary-value">{total.toLocaleString()}</strong>
+                    </div>
+                    <div className="remodex-costs-summary-right">
+                      <div className="remodex-costs-summary-ring">
+                        <svg viewBox="0 0 36 36" className="remodex-costs-ring-svg">
+                          <path
+                            d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
+                            fill="none"
+                            stroke="#e5e7eb"
+                            strokeWidth="3"
+                          />
+                          <path
+                            d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
+                            fill="none"
+                            stroke={pct >= 75 ? '#ef4444' : pct >= 50 ? '#f59e0b' : '#22c55e'}
+                            strokeWidth="3"
+                            strokeDasharray={`${pct}, 100`}
+                            strokeLinecap="round"
+                          />
+                        </svg>
+                        <span className="remodex-costs-ring-label">{pct}%</span>
+                      </div>
+                    </div>
+                    <ChevronRight size={16} strokeWidth={1.8} className="remodex-costs-summary-chevron" />
+                  </button>
+                );
+              })()}
+
               {projectGroups.map((group) => {
                 const isExpanded = expandedProject === group.workspace;
                 const ctxPct = Math.round(group.bestContextPct);

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -1120,12 +1120,21 @@ export function MobileRemoteShell({
         : 0;
       const isStale = ageHours > 4;
 
-      // Codex sessions: only show if the process is alive.
-      // sourceLabel contains "live pid" or "recent session" when running;
-      // "persisted session" or "ready for resume" when dead/killed.
+      // Codex sessions: show live/recent discovered sessions and active owned sessions.
       if (session.runtime === 'codex') {
         const src = session.runtimeSurface?.sourceLabel ?? '';
-        if (src.includes('live pid') || src.includes('recent session')) return true;
+        const ownership = session.runtimeSurface?.ownership ?? '';
+        // Discovered sessions: show if process is alive
+        if (ownership === 'discovered') {
+          if (src.includes('live pid') || src.includes('recent session')) return true;
+          return false;
+        }
+        // Owned sessions: show if recently active (not stale) or currently running
+        if (ownership === 'owned') {
+          if (src.includes('active pid')) return true;
+          if (!isStale) return true; // Show owned sessions under 4h old
+          return false;
+        }
         return false;
       }
 

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -1029,8 +1029,47 @@ export function MobileRemoteShell({
     };
   }, [actionStateBySession, diffOpen, loadHistory, loadOwnedReviewPacket, loadReviewFile, pendingOwnedTurnBySession, refreshInbox, selectedReviewFilePath, selectedSession?.runtimeSurface?.lifecycle?.availability, selectedSession?.status, selectedSessionKey, waitingForResponse]);
 
-  const transcriptEntries = selectedSessionKey ? historyBySession[selectedSessionKey] ?? [] : [];
-  const transcriptGroups = selectedSessionKey ? historyGroupsBySession[selectedSessionKey] ?? [] : [];
+  // For discovered Codex sessions, find the linked owned session and show its history
+  // This makes the chat seamless — user sees Codex responses without knowing about the owned/discovered split
+  const linkedOwnedKey = useMemo(() => {
+    if (!selectedSession || selectedSession.runtime !== 'codex' || selectedSession.runtimeSurface?.ownership !== 'discovered') return null;
+    const cwd = selectedSession.runtimeSurface?.cwd ?? selectedSession.workspace ?? '';
+    const owned = snapshot.sessions.find((s) =>
+      s.runtime === 'codex' &&
+      s.runtimeSurface?.ownership === 'owned' &&
+      (s.runtimeSurface?.cwd === cwd || s.workspace === cwd),
+    );
+    return owned?.sessionKey ?? null;
+  }, [selectedSession, snapshot.sessions]);
+
+  // Load linked owned session history when it exists
+  useEffect(() => {
+    if (linkedOwnedKey && !historyBySession[linkedOwnedKey] && !historyLoading[linkedOwnedKey]) {
+      void loadHistory(linkedOwnedKey, true).catch(() => undefined);
+    }
+  }, [linkedOwnedKey, historyBySession, historyLoading, loadHistory]);
+
+  // Poll linked owned session too
+  useEffect(() => {
+    if (!linkedOwnedKey) return;
+    const timer = window.setInterval(() => {
+      if (!documentVisibleRef.current) return;
+      void loadHistory(linkedOwnedKey, true).catch(() => undefined);
+    }, 3000);
+    return () => window.clearInterval(timer);
+  }, [linkedOwnedKey, loadHistory]);
+
+  // Merge discovered + owned history for seamless display
+  const effectiveHistoryKey = linkedOwnedKey && historyBySession[linkedOwnedKey]?.length ? linkedOwnedKey : selectedSessionKey;
+  const discoveredEntries = selectedSessionKey ? historyBySession[selectedSessionKey] ?? [] : [];
+  const ownedEntries = linkedOwnedKey ? historyBySession[linkedOwnedKey] ?? [] : [];
+  // Show discovered session's history PLUS owned session's history (which has the responses)
+  const mergedEntries = linkedOwnedKey && ownedEntries.length > 0
+    ? [...discoveredEntries, ...ownedEntries]
+    : discoveredEntries;
+
+  const transcriptEntries = mergedEntries;
+  const transcriptGroups = effectiveHistoryKey ? historyGroupsBySession[effectiveHistoryKey] ?? [] : [];
   const transcriptLoading = selectedSessionKey ? historyLoading[selectedSessionKey] ?? false : false;
   const transcriptError = selectedSessionKey ? historyError[selectedSessionKey] ?? null : null;
   const transcriptDraft = selectedSessionKey ? draftBySession[selectedSessionKey] ?? '' : '';

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -1148,10 +1148,21 @@ export function MobileRemoteShell({
 
     const groups: ProjectGroup[] = [];
     for (const [ws, rawSessions] of groupMap) {
+      // Sort by recency so dedup keeps the newest session per branch
+      const sorted = [...rawSessions].sort((a, b) => {
+        // Parse "Xm ago", "Xh ago", "Xd ago" to compare recency
+        const ageMinutes = (text: string) => {
+          const m = text.match(/^(\d+)m/); if (m) return parseInt(m[1], 10);
+          const h = text.match(/^(\d+)h/); if (h) return parseInt(h[1], 10) * 60;
+          const d = text.match(/^(\d+)d/); if (d) return parseInt(d[1], 10) * 1440;
+          return 0;
+        };
+        return ageMinutes(a.lastEventAt ?? '') - ageMinutes(b.lastEventAt ?? '');
+      });
       // Deduplicate Codex sessions: keep only the most recent per branch
       const deduped: typeof rawSessions = [];
       const seenBranches = new Set<string>();
-      for (const s of rawSessions) {
+      for (const s of sorted) {
         if (s.runtime === 'codex' && s.branch) {
           if (seenBranches.has(s.branch)) continue;
           seenBranches.add(s.branch);

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -701,7 +701,7 @@ export function MobileRemoteShell({
   const selectedSessionKey = selectedSession?.sessionKey;
   const isOpenClawSession = selectedSession?.runtime === 'openclaw';
   // Discovered Codex sessions use the same chat UI as OpenClaw sessions
-  const isChatSession = isOpenClawSession || (selectedSession?.runtime === 'codex' && selectedSession?.runtimeSurface?.ownership === 'discovered');
+  const isChatSession = isOpenClawSession || selectedSession?.runtime === 'codex';
   const isOwnedCodexSession = selectedSession?.runtime === 'codex' && selectedSession?.runtimeSurface?.ownership === 'owned';
   const selectedReviewPacket = selectedSessionKey && isOwnedCodexSession ? reviewPacketBySession[selectedSessionKey] ?? null : null;
   const selectedReviewPacketLoading = selectedSessionKey && isOwnedCodexSession ? reviewPacketLoadingBySession[selectedSessionKey] ?? false : false;
@@ -1492,11 +1492,12 @@ export function MobileRemoteShell({
 
     const targetSession = snapshot.sessions.find((session) => session.sessionKey === sessionKey);
     const isDiscoveredCodex = targetSession?.runtime === 'codex' && targetSession?.runtimeSurface?.ownership === 'discovered';
-    const isChat = targetSession?.runtime === 'openclaw' || isDiscoveredCodex;
+    const isOwnedCodex = targetSession?.runtime === 'codex' && targetSession?.runtimeSurface?.ownership === 'owned';
+    const isChat = targetSession?.runtime === 'openclaw' || isDiscoveredCodex || isOwnedCodex;
     if (!isChat) {
       setActionNoteBySession((current) => ({
         ...current,
-        [sessionKey]: 'Use the Codex resume lane for owned Codex sessions.',
+        [sessionKey]: 'Cannot send to this session type.',
       }));
       return;
     }
@@ -1587,6 +1588,14 @@ export function MobileRemoteShell({
             setSurfaceNote('Codex session launched.');
           }
         }
+      } else if (isOwnedCodex) {
+        // Owned Codex: resume the session directly
+        await runAction({
+          action: 'resume' as MobileActionRequest['action'],
+          sessionKey,
+          message,
+        });
+        setSurfaceNote('Sent to Codex…');
       } else {
         await runAction({
           action: 'steer',
@@ -2057,57 +2066,7 @@ export function MobileRemoteShell({
             </div>
           ) : null}
 
-          {isOwnedCodexSession && (selectedReviewPacket || selectedReviewPacketLoading || selectedReviewPacketError) ? (
-            <div className={`remodex-owned-review-card remodex-context-card remodex-context-card-${ownedReviewDispositionTone(ownedReviewDisposition)}`}>
-              <div className="remodex-owned-review-head">
-                <div className="remodex-context-card-copy">
-                  <span className="remodex-context-card-kicker">Review packet</span>
-                  <strong>{ownedReviewDispositionLabel(ownedReviewDisposition)}</strong>
-                </div>
-                <span className="remodex-context-card-trend">
-                  {selectedReviewPacket?.reviewDispositionUpdatedAtLabel
-                    ? `Updated ${selectedReviewPacket.reviewDispositionUpdatedAtLabel}`
-                    : selectedReviewPacketLoading
-                      ? 'Loading…'
-                      : `${reviewFiles.length} file${reviewFiles.length === 1 ? '' : 's'}`}
-                </span>
-              </div>
-              {selectedReviewPacket ? (
-                <>
-                  <p className="remodex-owned-review-copy">{selectedReviewPacket.summary}</p>
-                  <div className="remodex-owned-review-actions">
-                    <button
-                      type="button"
-                      className="remodex-controls-action"
-                      onClick={() => openDiffViewer()}
-                      disabled={!reviewFiles.length}
-                    >
-                      <FileDiff size={16} strokeWidth={2.1} />
-                      Open exact diff
-                    </button>
-                    <button
-                      type="button"
-                      className="remodex-controls-action"
-                      onClick={() => selectedSessionKey && handleLoadOwnedCorrectionDraft(selectedSessionKey)}
-                      disabled={!selectedSessionKey || !canResumeOwnedCodex}
-                    >
-                      <ArrowUp size={16} strokeWidth={2.1} />
-                      Draft reply
-                    </button>
-                    <button
-                      type="button"
-                      className="remodex-controls-action"
-                      onClick={() => selectedSessionKey && void handleOwnedReviewDisposition(selectedReviewPacket.reviewDisposition === 'resolved' ? 'watch' : 'resolve', selectedSessionKey)}
-                      disabled={!selectedSessionKey || transcriptActionState !== 'idle'}
-                    >
-                      {selectedReviewPacket.reviewDisposition === 'resolved' ? <Eye size={16} strokeWidth={2.1} /> : <Check size={16} strokeWidth={2.1} />}
-                      {selectedReviewPacket.reviewDisposition === 'resolved' ? 'Keep watching' : 'Mark resolved'}
-                    </button>
-                  </div>
-                </>
-              ) : null}
-            </div>
-          ) : null}
+          {/* Review packet kept but collapsed for owned Codex — available via diff viewer */}
 
           {refreshError ? <p className="remodex-banner-note">{refreshError}</p> : null}
           {surfaceNote ? <p className="remodex-banner-note">{surfaceNote}</p> : null}
@@ -2115,108 +2074,7 @@ export function MobileRemoteShell({
           {selectedReviewPacketError ? <p className="remodex-banner-note">{selectedReviewPacketError}</p> : null}
 
           <div className="remodex-message-stack">
-            {isOwnedCodexSession && (transcriptGroups.length || pendingOwnedTurn) ? (
-              <>
-                {transcriptGroups.map((group) => {
-                  const promptText = group.prompt.trim();
-                  const visibleEntries = group.entries.filter((entry) => {
-                    const text = entry.text.trim();
-                    if (!text) {
-                      return false;
-                    }
-                    if (promptText && text === promptText) {
-                      return false;
-                    }
-                    return true;
-                  });
-
-                  return (
-                    <article key={group.id} className="remodex-message-card remodex-message-card-assistant remodex-owned-turn-card">
-                  <div className="remodex-owned-turn-head">
-                    <div className="remodex-owned-turn-head-copy">
-                      <span className="remodex-owned-turn-kicker">{group.mode === 'launch' ? 'Launch turn' : 'Reply turn'}</span>
-                      <strong>{group.title}</strong>
-                    </div>
-                    <div className="remodex-owned-turn-chip-row">
-                      <span className="remodex-compose-chip remodex-compose-pill">{group.mode}</span>
-                      <span className="remodex-compose-chip remodex-compose-pill remodex-compose-pill-status">{group.outcome}</span>
-                    </div>
-                  </div>
-
-                  {promptText ? (
-                    <div className="remodex-user-turn-wrap">
-                      <div className="remodex-user-bubble">{renderMessageBody(promptText, `${group.id}-prompt`)}</div>
-                      <span className="remodex-turn-time">{group.startedAtLabel ?? 'now'}</span>
-                    </div>
-                  ) : null}
-
-                  <div className="remodex-owned-turn-note">
-                    <span className="remodex-owned-turn-note-kicker">Codex status</span>
-                    <p>{group.summary}</p>
-                  </div>
-
-                  <div className="remodex-owned-chat-list">
-                    {visibleEntries.map((entry) => {
-                      const hasText = Boolean(entry.text.trim());
-                      if (!hasText) {
-                        return null;
-                      }
-
-                      if (entry.role === 'user') {
-                        return (
-                          <div key={entry.id} className="remodex-user-turn-wrap">
-                            <div className="remodex-user-bubble">{renderMessageBody(entry.text, `${entry.id}-user`)}</div>
-                            <span className="remodex-turn-time">{entry.timestampLabel ?? group.finishedAtLabel ?? group.startedAtLabel ?? 'now'}</span>
-                          </div>
-                        );
-                      }
-
-                      return (
-                        <article
-                          key={entry.id}
-                          className={`remodex-message-card remodex-message-card-assistant remodex-owned-chat-bubble ${entry.role !== 'assistant' ? 'remodex-owned-chat-bubble-muted' : ''}`}
-                        >
-                          <div className="remodex-message-head">
-                            <span>{entry.role === 'assistant' ? 'Codex' : roleLabel(entry.role)}</span>
-                            <div className="remodex-message-tools">
-                              <span className="remodex-turn-time">{entry.timestampLabel ?? group.finishedAtLabel ?? group.startedAtLabel ?? 'now'}</span>
-                              <button type="button" className="remodex-icon-link" onClick={() => handleCopy(entry.text)} aria-label="Copy message">
-                                <Copy size={16} strokeWidth={2.1} />
-                              </button>
-                            </div>
-                          </div>
-                          {renderMessageBody(entry.text, `${entry.id}-owned`)}
-                        </article>
-                      );
-                    })}
-                  </div>
-                    </article>
-                  );
-                })}
-                {pendingOwnedTurn ? (
-                  <article className="remodex-message-card remodex-message-card-assistant remodex-owned-turn-card remodex-owned-turn-card-pending">
-                    <div className="remodex-owned-turn-head">
-                      <div className="remodex-owned-turn-head-copy">
-                        <span className="remodex-owned-turn-kicker">Queued turn</span>
-                        <strong>Codex is starting this turn</strong>
-                      </div>
-                      <div className="remodex-owned-turn-chip-row">
-                        <span className="remodex-compose-chip remodex-compose-pill">resume</span>
-                        <span className="remodex-compose-chip remodex-compose-pill remodex-compose-pill-status">queued</span>
-                      </div>
-                    </div>
-                    <div className="remodex-user-turn-wrap">
-                      <div className="remodex-user-bubble">{renderMessageBody(pendingOwnedTurn.prompt, `${pendingOwnedTurn.id}-pending-prompt`)}</div>
-                      <span className="remodex-turn-time">{pendingOwnedTurn.timestampLabel}</span>
-                    </div>
-                    <div className="remodex-owned-turn-note">
-                      <span className="remodex-owned-turn-note-kicker">Codex status</span>
-                      <p>Starting up — interrupt will appear once the run is active.</p>
-                    </div>
-                  </article>
-                ) : null}
-              </>
-            ) : transcriptEntries.length ? transcriptEntries.map((entry, index) => {
+            {transcriptEntries.length ? transcriptEntries.map((entry, index) => {
               const isUser = entry.role === 'user';
               const isLatest = !transcriptEntries.slice(index + 1).some((e) => e.role === 'assistant');
               const hasText = Boolean(entry.text.trim());

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -1124,15 +1124,17 @@ export function MobileRemoteShell({
       if (session.runtime === 'codex') {
         const src = session.runtimeSurface?.sourceLabel ?? '';
         const ownership = session.runtimeSurface?.ownership ?? '';
-        // Discovered sessions: show if process is alive
+        // Discovered sessions: only show if a live desktop process is verified
         if (ownership === 'discovered') {
-          if (src.includes('live pid') || src.includes('recent session')) return true;
+          if (src.includes('live pid')) return true;
           return false;
         }
-        // Owned sessions: show if recently active (not stale) or currently running
+        // Owned sessions: show only if actively running or very recently finished (under 1h)
         if (ownership === 'owned') {
           if (src.includes('active pid')) return true;
-          if (!isStale) return true; // Show owned sessions under 4h old
+          const minsMatch = ageText.match(/^(\d+)m/);
+          const recentMins = minsMatch ? parseInt(minsMatch[1], 10) : 999;
+          if (ageText === 'just now' || recentMins < 60) return true;
           return false;
         }
         return false;
@@ -1501,26 +1503,49 @@ export function MobileRemoteShell({
 
     try {
       if (isDiscoveredCodex) {
-        // Launch an owned Codex session in the same workspace as the discovered one
-        const launchResult = await runAction({
-          action: 'launch' as MobileActionRequest['action'],
-          sessionKey,
-          message,
-          cwd: targetSession?.runtimeSurface?.cwd ?? targetSession?.workspace ?? '',
-        });
-        // Switch to the newly created owned session so the user sees the response
-        if (launchResult?.ok && launchResult.sessionKey && launchResult.sessionKey !== sessionKey) {
-          setSurfaceNote('Codex launched — switching to live session…');
-          // Give the session a moment to appear in the inbox
-          await new Promise((r) => setTimeout(r, 2000));
-          const freshInbox = await refreshInbox();
-          const newSession = freshInbox?.sessions?.find((s: { sessionKey?: string }) => s.sessionKey === launchResult.sessionKey);
-          if (newSession) {
-            setSelectedId(newSession.id);
-            await loadHistory(launchResult.sessionKey, true).catch(() => undefined);
-          }
+        // For discovered Codex: find or create ONE owned session for this workspace,
+        // then resume it. Never create multiple owned sessions for the same cwd.
+        const cwd = targetSession?.runtimeSurface?.cwd ?? targetSession?.workspace ?? '';
+
+        // Check if an owned session already exists for this workspace
+        const existingOwned = snapshot.sessions.find((s) =>
+          s.runtime === 'codex' &&
+          s.runtimeSurface?.ownership === 'owned' &&
+          (s.runtimeSurface?.cwd === cwd || s.workspace === cwd) &&
+          s.runtimeSurface?.lifecycle?.availability === 'ready-for-resume',
+        );
+
+        if (existingOwned) {
+          // Resume the existing owned session
+          await runAction({
+            action: 'resume' as MobileActionRequest['action'],
+            sessionKey: existingOwned.sessionKey,
+            message,
+          });
+          // Switch to the owned session
+          setSelectedId(existingOwned.id);
+          setSurfaceNote('Resuming Codex session…');
+          await loadHistory(existingOwned.sessionKey, true).catch(() => undefined);
         } else {
-          setSurfaceNote('Codex session launched.');
+          // No owned session exists — launch a new one
+          const launchResult = await runAction({
+            action: 'launch' as MobileActionRequest['action'],
+            sessionKey,
+            message,
+            cwd,
+          });
+          if (launchResult?.ok && launchResult.sessionKey && launchResult.sessionKey !== sessionKey) {
+            setSurfaceNote('Codex launched — switching to session…');
+            await new Promise((r) => setTimeout(r, 2000));
+            const freshInbox = await refreshInbox();
+            const newSession = freshInbox?.sessions?.find((s: { sessionKey?: string }) => s.sessionKey === launchResult.sessionKey);
+            if (newSession) {
+              setSelectedId(newSession.id);
+              await loadHistory(launchResult.sessionKey, true).catch(() => undefined);
+            }
+          } else {
+            setSurfaceNote('Codex session launched.');
+          }
         }
       } else {
         await runAction({

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -503,7 +503,7 @@ export function MobileRemoteShell({
   const stickToBottomRef = useRef(true);
 
   const refreshInbox = useCallback(async () => {
-    const response = await fetch('/api/mobile/inbox', { cache: 'no-store' });
+    const response = await fetch(`/api/mobile/inbox?_t=${Date.now()}`, { cache: 'no-store', headers: { 'Cache-Control': 'no-cache', 'Pragma': 'no-cache' } });
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
     }
@@ -835,8 +835,9 @@ export function MobileRemoteShell({
 
     setHistoryLoading((current) => ({ ...current, [sessionKey]: true }));
     try {
-      const response = await fetch(`/api/mobile/history?sessionKey=${encodeURIComponent(sessionKey)}&limit=18`, {
+      const response = await fetch(`/api/mobile/history?sessionKey=${encodeURIComponent(sessionKey)}&limit=18&_t=${Date.now()}`, {
         cache: 'no-store',
+        headers: { 'Cache-Control': 'no-cache', 'Pragma': 'no-cache' },
       });
       const payload = await readJson<MobileHistoryResponse>(response);
       // Diff-and-patch: only update state if transcript actually changed.

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -1890,6 +1890,7 @@ export function MobileRemoteShell({
                             >
                               <span className={`remodex-squad-dot ${isRunning ? 'remodex-squad-dot-live' : ''} remodex-squad-dot-${sCtxTone}`} />
                               <span className="remodex-agent-pill-name">{name}</span>
+                              <span className="remodex-agent-pill-sep">·</span>
                               <span className="remodex-agent-pill-status">{statusLabel}</span>
                             </button>
                           );

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -1493,13 +1493,26 @@ export function MobileRemoteShell({
     try {
       if (isDiscoveredCodex) {
         // Launch an owned Codex session in the same workspace as the discovered one
-        await runAction({
+        const launchResult = await runAction({
           action: 'launch' as MobileActionRequest['action'],
           sessionKey,
           message,
           cwd: targetSession?.runtimeSurface?.cwd ?? targetSession?.workspace ?? '',
         });
-        setSurfaceNote('Codex session launched. It will appear in the squad once it starts.');
+        // Switch to the newly created owned session so the user sees the response
+        if (launchResult?.ok && launchResult.sessionKey && launchResult.sessionKey !== sessionKey) {
+          setSurfaceNote('Codex launched — switching to live session…');
+          // Give the session a moment to appear in the inbox
+          await new Promise((r) => setTimeout(r, 2000));
+          const freshInbox = await refreshInbox();
+          const newSession = freshInbox?.sessions?.find((s: { sessionKey?: string }) => s.sessionKey === launchResult.sessionKey);
+          if (newSession) {
+            setSelectedId(newSession.id);
+            await loadHistory(launchResult.sessionKey, true).catch(() => undefined);
+          }
+        } else {
+          setSurfaceNote('Codex session launched.');
+        }
       } else {
         await runAction({
           action: 'steer',

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -1109,19 +1109,7 @@ export function MobileRemoteShell({
       if (session.isCurrentSession) return true;
       if (session.id === selectedSession?.id) return true;
 
-      // Codex sessions: show if they have a live process or recent activity.
-      // Filter out dead registry entries and persisted-only history.
-      if (session.runtime === 'codex') {
-        const src = session.runtimeSurface?.sourceLabel ?? '';
-        // "live pid" = running process, "recent session history" = just used
-        if (src.includes('live pid') || src.includes('recent session')) return true;
-        // "persisted session history" or "ready for resume" = dead/old
-        if (src.includes('persisted') || src.includes('ready for resume')) return false;
-        // Unknown source — show it
-        return true;
-      }
-
-      // OpenClaw sessions: filter stale ones (automation, old surfaces)
+      // Parse age once — used by both Codex and OpenClaw filters
       const ageText = session.lastEventAt ?? '';
       const hoursMatch = ageText.match(/^(\d+)h/);
       const daysMatch = ageText.match(/^(\d+)d/);
@@ -1129,6 +1117,17 @@ export function MobileRemoteShell({
         : hoursMatch ? parseInt(hoursMatch[1], 10)
         : 0;
       const isStale = ageHours > 4;
+
+      // Codex sessions:
+      // - "discovered" = user opened from terminal → always show
+      // - "owned" = IDE/OpenClaw opened programmatically → filter if stale
+      if (session.runtime === 'codex') {
+        if (session.runtimeSurface?.ownership !== 'owned') return true;
+        if (isStale) return false;
+        return true;
+      }
+
+      // OpenClaw sessions: filter stale ones
       if (isStale) return false;
 
       if (['running', 'reviewing', 'blocked'].includes(session.status)) return true;

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -1048,20 +1048,63 @@ export function MobileRemoteShell({
   const scrollMarker = pendingOwnedTurn ? `${latestTranscriptMarker}:${pendingOwnedTurn.id}` : latestTranscriptMarker;
   const selectedReviewFile = selectedReviewFilePath ? reviewFileByPath[selectedReviewFilePath] : undefined;
   // ── Project-grouped squad rail ──
-  // Group sessions by workspace path into "project cards"
   interface ProjectGroup {
     projectName: string;
     workspace: string;
     sessions: MobileInboxSnapshot['sessions'];
-    hasPrimary: boolean; // contains the main Mister session
-    mostRecentActivity?: string;
+    hasPrimary: boolean;
+    summary: string; // e.g. "4 Codex · 1 running"
     mostRecentTime?: string;
     bestContextPct: number;
     hasRunning: boolean;
   }
 
+  /** Derive a human name for an agent session */
+  function agentDisplayName(session: MobileInboxSnapshot['sessions'][number]): string {
+    if (session.isCurrentSession) return 'Mister';
+    if (session.runtime === 'codex') return 'Codex';
+    // OpenClaw sessions: extract the agent name from the session name
+    const n = session.name || '';
+    if (n.startsWith('Hawk')) return 'Hawk';
+    if (n.startsWith('Niot')) return 'Niot';
+    if (n.includes('automation') || n.includes('cron')) return 'Cron';
+    if (n.includes('Telegram')) return 'Telegram';
+    if (n.includes('Discord')) return 'Discord';
+    if (n.includes('Mister')) return 'Mister';
+    return n.split(/[\s·•/]/)[0] || 'Agent';
+  }
+
+  /** Derive a readable project name from a workspace path */
+  function projectDisplayName(ws: string, sessions: MobileInboxSnapshot['sessions']): string {
+    // Named agent workspaces → use agent name
+    if (ws.includes('workspace-ace')) return 'Niot';
+    if (ws.includes('workspace-hawk')) return 'Hawk';
+    // Repo workspaces → use repo name
+    const segments = ws.replace(/^~\//, '').split('/');
+    const last = segments[segments.length - 1] || segments[0] || 'workspace';
+    // If this is the main clawd workspace with the primary session, call it "Main"
+    if (last === 'clawd' && sessions.some((s) => s.isCurrentSession)) return 'Main';
+    return last;
+  }
+
+  /** Build a summary like "4 Codex · 2 running" */
+  function projectSummary(sessions: MobileInboxSnapshot['sessions']): string {
+    const runtimeCounts = new Map<string, number>();
+    let runningCount = 0;
+    for (const s of sessions) {
+      const label = s.runtime === 'codex' ? 'Codex' : 'OpenClaw';
+      runtimeCounts.set(label, (runtimeCounts.get(label) ?? 0) + 1);
+      if (s.status === 'running' || s.status === 'reviewing') runningCount++;
+    }
+    const parts: string[] = [];
+    for (const [label, count] of runtimeCounts) {
+      parts.push(`${count} ${label}`);
+    }
+    if (runningCount > 0) parts.push(`${runningCount} active`);
+    return parts.join(' · ');
+  }
+
   const projectGroups = useMemo(() => {
-    // Relevancy filter — keep interesting sessions
     const isRelevant = (session: MobileInboxSnapshot['sessions'][number]) => {
       if (session.isCurrentSession) return true;
       if (session.id === selectedSession?.id) return true;
@@ -1074,8 +1117,6 @@ export function MobileRemoteShell({
     };
 
     const relevant = snapshot.sessions.filter(isRelevant);
-
-    // Group by workspace path
     const groupMap = new Map<string, MobileInboxSnapshot['sessions']>();
     for (const session of relevant) {
       const ws = session.workspace || '~/clawd';
@@ -1084,45 +1125,30 @@ export function MobileRemoteShell({
       groupMap.set(ws, existing);
     }
 
-    // Build project group objects
     const groups: ProjectGroup[] = [];
     for (const [ws, sessions] of groupMap) {
-      // Extract project name from path: ~/clawd/repos/cortex-ide → cortex-ide
-      const segments = ws.replace(/^~\//, '').split('/');
-      const projectName = segments[segments.length - 1] || segments[0] || 'workspace';
-      const hasPrimary = sessions.some((s) => s.isCurrentSession);
       const running = sessions.some((s) => s.status === 'running' || s.status === 'reviewing');
       const bestCtx = Math.max(...sessions.map((s) => s.context?.usedPercent ?? 0));
-
-      // Find most recent activity across all sessions in this group
-      let mostRecentActivity: string | undefined;
       let mostRecentTime: string | undefined;
       for (const s of sessions) {
-        if (s.activity?.headline) {
-          mostRecentActivity = s.activity.headline;
+        if (s.activity?.headline || s.lastEventAt) {
           mostRecentTime = s.lastEventAt;
-          break; // first active session wins (they're already sorted by recency from inbox)
+          break;
         }
-      }
-      if (!mostRecentActivity) {
-        // Fall back to the most recent session's status
-        mostRecentActivity = sessions[0]?.status ?? 'idle';
-        mostRecentTime = sessions[0]?.lastEventAt;
       }
 
       groups.push({
-        projectName,
+        projectName: projectDisplayName(ws, sessions),
         workspace: ws,
         sessions,
-        hasPrimary,
-        mostRecentActivity,
-        mostRecentTime,
+        hasPrimary: sessions.some((s) => s.isCurrentSession),
+        summary: projectSummary(sessions),
+        mostRecentTime: mostRecentTime ?? sessions[0]?.lastEventAt,
         bestContextPct: bestCtx,
         hasRunning: running,
       });
     }
 
-    // Sort: primary group first, then by most recently active
     groups.sort((a, b) => {
       if (a.hasPrimary && !b.hasPrimary) return -1;
       if (!a.hasPrimary && b.hasPrimary) return 1;
@@ -1134,7 +1160,6 @@ export function MobileRemoteShell({
     return groups;
   }, [selectedSession, snapshot.sessions]);
 
-  // Track which project group is expanded (null = none)
   const [expandedProject, setExpandedProject] = useState<string | null>(null);
   const selectedReviewFileIndex = selectedReviewFilePath
     ? reviewFiles.findIndex((file) => file.path === selectedReviewFilePath)
@@ -1818,56 +1843,54 @@ export function MobileRemoteShell({
                 const isExpanded = expandedProject === group.workspace;
                 const ctxPct = Math.round(group.bestContextPct);
                 const ctxTone = ctxPct >= 85 ? 'critical' : ctxPct >= 75 ? 'high' : ctxPct >= 65 ? 'watch' : 'calm';
-                const agentCount = group.sessions.length;
                 const containsSelected = group.sessions.some((s) => s.id === selectedSession?.id);
+                const isSingleAgent = group.sessions.length === 1;
+
+                // Single-agent projects: tap goes directly to chat (no expand)
+                const handleProjectTap = () => {
+                  if (isSingleAgent) {
+                    handleSessionFocus(group.sessions[0].id);
+                  } else {
+                    setExpandedProject(isExpanded ? null : group.workspace);
+                  }
+                };
 
                 return (
                   <div key={group.workspace} className="remodex-project-group">
                     <button
                       type="button"
                       className={`remodex-squad-card remodex-project-card ${containsSelected ? 'remodex-squad-card-active' : ''} ${isExpanded ? 'remodex-project-card-expanded' : ''}`}
-                      onClick={() => setExpandedProject(isExpanded ? null : group.workspace)}
+                      onClick={handleProjectTap}
                     >
                       <div className="remodex-squad-card-head">
                         <span className={`remodex-squad-dot ${group.hasRunning ? 'remodex-squad-dot-live' : ''} remodex-squad-dot-${ctxTone}`} />
                         <strong className="remodex-squad-name">{group.projectName}</strong>
                         <span className="remodex-squad-time">{group.mostRecentTime ?? 'idle'}</span>
                       </div>
-                      <span className="remodex-squad-task">{group.mostRecentActivity}</span>
-                      <div className="remodex-project-meta">
-                        <span className="remodex-project-count">{agentCount} agent{agentCount !== 1 ? 's' : ''}</span>
-                        <ChevronRight size={12} className={`remodex-project-chevron ${isExpanded ? 'remodex-project-chevron-open' : ''}`} />
-                      </div>
+                      <span className="remodex-project-summary">{group.summary}</span>
+                      {!isSingleAgent ? (
+                        <ChevronRight size={11} className={`remodex-project-chevron ${isExpanded ? 'remodex-project-chevron-open' : ''}`} />
+                      ) : null}
                     </button>
 
-                    {isExpanded ? (
+                    {isExpanded && !isSingleAgent ? (
                       <div className="remodex-project-agents">
                         {group.sessions.map((session) => {
                           const active = session.id === selectedSession?.id;
                           const isRunning = session.status === 'running' || session.status === 'reviewing';
-                          const sCtxPct = Math.round(session.context?.usedPercent ?? 0);
-                          const sCtxTone = sCtxPct >= 85 ? 'critical' : sCtxPct >= 75 ? 'high' : sCtxPct >= 65 ? 'watch' : 'calm';
-                          const agentName = session.isCurrentSession ? 'Mister' : session.name?.split(/[\s/]/)[0] ?? 'Agent';
-                          const taskLine = session.activity?.headline ?? (session.isCurrentSession ? 'Main session' : session.status);
+                          const sCtxTone = (() => { const p = Math.round(session.context?.usedPercent ?? 0); return p >= 85 ? 'critical' : p >= 75 ? 'high' : p >= 65 ? 'watch' : 'calm'; })();
+                          const name = agentDisplayName(session);
+                          const statusLabel = session.activity?.headline ?? session.status;
                           return (
                             <button
                               key={session.id}
                               type="button"
-                              className={`remodex-squad-card remodex-agent-card ${active ? 'remodex-squad-card-active' : ''}`}
+                              className={`remodex-agent-pill ${active ? 'remodex-agent-pill-active' : ''}`}
                               onClick={() => handleSessionFocus(session.id)}
                             >
-                              <div className="remodex-squad-card-head">
-                                <span className={`remodex-squad-dot ${isRunning ? 'remodex-squad-dot-live' : ''} remodex-squad-dot-${sCtxTone}`} />
-                                <strong className="remodex-squad-name">{agentName}</strong>
-                                <span className="remodex-squad-time">{session.lastEventAt ?? 'idle'}</span>
-                              </div>
-                              <span className="remodex-squad-task">{taskLine}</span>
-                              <div className="remodex-squad-bar-track">
-                                <div
-                                  className={`remodex-squad-bar-fill remodex-squad-bar-${sCtxTone}`}
-                                  style={{ width: `${sCtxPct}%` }}
-                                />
-                              </div>
+                              <span className={`remodex-squad-dot ${isRunning ? 'remodex-squad-dot-live' : ''} remodex-squad-dot-${sCtxTone}`} />
+                              <span className="remodex-agent-pill-name">{name}</span>
+                              <span className="remodex-agent-pill-status">{statusLabel}</span>
                             </button>
                           );
                         })}

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -33,6 +33,10 @@ import {
   Square,
   X,
 } from 'lucide-react';
+import { Renderer } from '@json-render/react';
+import { registry } from '@/lib/json-render/registry';
+import { deployApprovalSpec, decisionSpec, dashboardSpec } from '@/lib/json-render/demo-specs';
+import type { Spec } from '@json-render/core';
 import type { ReviewChangedFile, RuntimeReviewPacket } from '@/lib/fleet/types';
 import type {
   MobileActionRequest,
@@ -470,6 +474,7 @@ export function MobileRemoteShell({
   const [reviewFileError, setReviewFileError] = useState<string | null>(null);
   const [diffOpen, setDiffOpen] = useState(false);
   const [controlsOpen, setControlsOpen] = useState(false);
+  const [pendingApprovals, setPendingApprovals] = useState<Spec[]>([]);
   const [surfaceRefreshing, setSurfaceRefreshing] = useState(false);
   const [expandedMedia, setExpandedMedia] = useState<MobileTranscriptMedia | null>(null);
   const [scrollY, setScrollY] = useState(0);
@@ -2179,6 +2184,17 @@ export function MobileRemoteShell({
             </div>
           ) : null}
 
+          {/* ── json-render approval cards ── */}
+          {pendingApprovals.length > 0 ? (
+            <div className="remodex-approval-stack">
+              {pendingApprovals.map((spec, i) => (
+                <div key={`approval-${i}`} className="remodex-approval-card-wrap">
+                  <Renderer spec={spec} registry={registry} />
+                </div>
+              ))}
+            </div>
+          ) : null}
+
           <div ref={transcriptBottomRef} className="remodex-scroll-anchor" aria-hidden="true" />
         </div>
 
@@ -2528,6 +2544,20 @@ export function MobileRemoteShell({
               >
                 <span className="remodex-action-row-icon"><Copy size={18} strokeWidth={1.8} /></span>
                 <span className="remodex-action-row-label">Copy session key</span>
+              </button>
+              <button
+                type="button"
+                className="remodex-controls-action-row"
+                onClick={() => {
+                  setPendingApprovals((cur) =>
+                    cur.length > 0 ? [] : [deployApprovalSpec, decisionSpec, dashboardSpec],
+                  );
+                  setControlsOpen(false);
+                }}
+              >
+                <span className="remodex-action-row-icon"><SlidersHorizontal size={18} strokeWidth={1.8} /></span>
+                <span className="remodex-action-row-label">{pendingApprovals.length ? 'Hide demo approvals' : 'Show demo approvals'}</span>
+                {pendingApprovals.length ? <span className="remodex-action-row-badge">{pendingApprovals.length}</span> : null}
               </button>
               <Link href="/" className="remodex-controls-action-row remodex-controls-action-link" onClick={() => setControlsOpen(false)}>
                 <span className="remodex-action-row-icon"><Monitor size={18} strokeWidth={1.8} /></span>

--- a/src/lib/codex/owned.ts
+++ b/src/lib/codex/owned.ts
@@ -188,7 +188,9 @@ function isPidAlive(pid?: number) {
 }
 
 async function validateWorkspace(targetCwd: string) {
-  const resolved = path.resolve(targetCwd);
+  // Expand ~ to home directory (client sends ~/clawd/repos/... format)
+  const expanded = targetCwd.startsWith('~/') ? path.join(os.homedir(), targetCwd.slice(2)) : targetCwd;
+  const resolved = path.resolve(expanded);
   const real = await realpath(resolved).catch(() => resolved);
   if (!real.startsWith(path.join(os.homedir(), 'clawd'))) {
     throw new Error('Owned Codex launch is currently restricted to paths under ~/clawd.');

--- a/src/lib/codex/sessions.ts
+++ b/src/lib/codex/sessions.ts
@@ -397,6 +397,43 @@ async function buildActivityMap(threads: CodexThreadRow[]) {
     });
   }
 
+  // Fallback: find ALL live Codex processes via ps and match by CWD
+  // This catches new sessions that haven't written process_uuid to the DB yet
+  try {
+    const { stdout: psOut } = await execFileAsync(
+      'bash', ['-c', 'ps -eo pid=,command= | grep codex | grep -v grep'],
+      { maxBuffer: 256 * 1024 },
+    );
+    const allPids: number[] = [];
+    for (const line of psOut.split('\n').map((l) => l.trim()).filter(Boolean)) {
+      const pidMatch = line.match(/^(\d+)/);
+      if (pidMatch) {
+        const pid = Number(pidMatch[1]);
+        if (Number.isFinite(pid) && line.includes('/codex')) allPids.push(pid);
+      }
+    }
+    const allLive = await queryLiveCodexProcesses(allPids);
+    for (const [pid, proc] of allLive) {
+      if (!proc.cwd) continue;
+      const normalizedCwd = normalizeFsPath(proc.cwd);
+      // Find threads in this CWD that aren't already marked active
+      for (const thread of threads) {
+        if (normalizeFsPath(thread.cwd) !== normalizedCwd) continue;
+        const existing = byThreadId.get(thread.id);
+        if (existing?.active) continue;
+        // Match the most recently updated thread for this CWD
+        byThreadId.set(thread.id, {
+          ...existing,
+          active: true,
+          pid,
+          tty: proc.tty,
+          lastLogTs: existing?.lastLogTs ?? thread.updated_at,
+        });
+        break; // One process per CWD match
+      }
+    }
+  } catch { /* ps fallback not available */ }
+
   return byThreadId;
 }
 

--- a/src/lib/json-render/catalog.ts
+++ b/src/lib/json-render/catalog.ts
@@ -1,0 +1,118 @@
+/**
+ * json-render catalog for Cortex IDE mobile
+ *
+ * Defines the component + action vocabulary that agents can use
+ * to generate dynamic UI surfaces (approval cards, status panels, etc.)
+ */
+// @ts-nocheck — json-render v0.14 types are complex; runtime works, TS inference needs upstream fixes
+import { defineCatalog } from '@json-render/core';
+import { schema } from '@json-render/react/schema';
+import { z } from 'zod';
+
+export const catalog = defineCatalog(schema, {
+  components: {
+    // ── Approval card: agent asks user to approve/reject an action ──
+    ApprovalCard: {
+      props: z.object({
+        title: z.string().describe('Short title, e.g. "Deploy to staging?"'),
+        description: z.string().describe('What the agent wants to do and why'),
+        agent: z.string().describe('Agent name, e.g. "Codex", "Mister", "Niot"'),
+        severity: z.enum(['info', 'warning', 'critical']).describe('Visual urgency level'),
+        metadata: z.record(z.string()).optional().describe('Key-value pairs shown as detail rows'),
+      }),
+      description: 'An approval request from an agent — user can approve or reject',
+    },
+
+    // ── Status card: agent reports current state ──
+    StatusCard: {
+      props: z.object({
+        title: z.string(),
+        status: z.enum(['running', 'success', 'error', 'waiting']),
+        message: z.string(),
+        progress: z.number().min(0).max(100).optional(),
+      }),
+      description: 'Agent status update card',
+    },
+
+    // ── Metric: single KPI display ──
+    Metric: {
+      props: z.object({
+        label: z.string(),
+        value: z.string(),
+        trend: z.enum(['up', 'down', 'flat']).optional(),
+        format: z.enum(['currency', 'percent', 'number', 'tokens']).nullable().optional(),
+      }),
+      description: 'Display a single metric value with optional trend',
+    },
+
+    // ── Option list: multiple-choice selection ──
+    OptionList: {
+      props: z.object({
+        question: z.string(),
+        options: z.array(z.object({
+          id: z.string(),
+          label: z.string(),
+          description: z.string().optional(),
+        })),
+      }),
+      description: 'Present multiple options for the user to choose from',
+    },
+
+    // ── Text block: rich text content ──
+    TextBlock: {
+      props: z.object({
+        content: z.string().describe('Markdown-formatted text'),
+        variant: z.enum(['default', 'muted', 'highlight']).optional(),
+      }),
+      description: 'A block of formatted text content',
+    },
+
+    // ── Code block: show code or diff ──
+    CodeBlock: {
+      props: z.object({
+        code: z.string(),
+        language: z.string().optional(),
+        filename: z.string().optional(),
+      }),
+      description: 'Display a code snippet with syntax context',
+    },
+
+    // ── Action button row ──
+    ButtonRow: {
+      props: z.object({
+        align: z.enum(['left', 'center', 'right', 'spread']).optional(),
+      }),
+      description: 'Container for a row of action buttons',
+    },
+
+    Button: {
+      props: z.object({
+        label: z.string(),
+        variant: z.enum(['primary', 'secondary', 'danger', 'ghost']).optional(),
+        icon: z.string().optional().describe('Lucide icon name'),
+        disabled: z.boolean().optional(),
+      }),
+      description: 'An action button',
+    },
+  },
+
+  actions: {
+    approve: {
+      description: 'Approve the pending agent action',
+    },
+    reject: {
+      description: 'Reject the pending agent action',
+    },
+    select_option: {
+      description: 'Select an option from a list',
+    },
+    navigate: {
+      description: 'Navigate to a session or view',
+    },
+    dismiss: {
+      description: 'Dismiss a notification or card',
+    },
+  },
+});
+
+export type CortexCatalog = typeof catalog;

--- a/src/lib/json-render/demo-specs.ts
+++ b/src/lib/json-render/demo-specs.ts
@@ -1,0 +1,87 @@
+/**
+ * Demo specs — examples of what agents would generate via json-render
+ *
+ * In production, these would come from the gateway as structured events
+ * when an agent needs user input (approval, selection, confirmation).
+ */
+import type { Spec } from '@json-render/core';
+
+/**
+ * Agent requests approval to deploy
+ */
+export const deployApprovalSpec: Spec = {
+  root: 'approval',
+  elements: {
+    approval: {
+      type: 'ApprovalCard',
+      props: {
+        title: 'Deploy cortex-ide to production?',
+        description: 'Niot has completed the batch/2-command-surface branch and all checks pass. Ready to deploy to Vercel production.',
+        agent: 'Niot',
+        severity: 'warning',
+        metadata: {
+          Branch: 'batch/2-command-surface',
+          Commits: '38',
+          'Files changed': '14',
+          'Lines added': '+1,766',
+        },
+      },
+      children: ['buttons'],
+    },
+    buttons: {
+      type: 'ButtonRow',
+      props: { align: 'spread' },
+      children: ['approve-btn', 'reject-btn'],
+    },
+    'approve-btn': {
+      type: 'Button',
+      props: { label: 'Approve Deploy', variant: 'primary' },
+      children: [],
+    },
+    'reject-btn': {
+      type: 'Button',
+      props: { label: 'Reject', variant: 'danger' },
+      children: [],
+    },
+  },
+};
+
+/**
+ * Agent asks which approach to take
+ */
+export const decisionSpec: Spec = {
+  root: 'options',
+  elements: {
+    options: {
+      type: 'OptionList',
+      props: {
+        question: 'How should Hawk handle the failing test in cortex/search?',
+        options: [
+          { id: 'fix', label: 'Fix the test', description: 'Update the assertion to match the new behavior' },
+          { id: 'skip', label: 'Skip for now', description: 'Mark as known issue, ship the rest' },
+          { id: 'revert', label: 'Revert the change', description: 'Roll back the commit that broke it' },
+        ],
+      },
+      children: [],
+    },
+  },
+};
+
+/**
+ * Agent shows a cost/status dashboard
+ */
+export const dashboardSpec: Spec = {
+  root: 'dashboard',
+  elements: {
+    dashboard: {
+      type: 'StatusCard',
+      props: {
+        title: 'Batch 2 Build',
+        status: 'running',
+        message: 'Niot is working on #30 Approval primitive — 3 files changed so far',
+        progress: 65,
+      },
+      children: [],
+    },
+  },
+};

--- a/src/lib/json-render/registry.tsx
+++ b/src/lib/json-render/registry.tsx
@@ -1,0 +1,219 @@
+/**
+ * json-render React registry for Cortex IDE mobile
+ *
+ * Maps catalog component types to actual React rendering.
+ * Styled to match the existing mobile design language (red accent, Apple-inspired).
+ */
+// @ts-nocheck — json-render v0.14 types are complex; runtime works, TS inference needs upstream fixes
+'use client';
+
+import { defineRegistry } from '@json-render/react';
+import { catalog } from './catalog';
+import React, { type CSSProperties } from 'react';
+
+// ── Styles ──
+
+const cardBase: CSSProperties = {
+  background: '#ffffff',
+  borderRadius: 16,
+  padding: '16px 18px',
+  marginBottom: 10,
+  boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
+  border: '1px solid #e5e7eb',
+};
+
+const severityBorder: Record<string, string> = {
+  info: '#3b82f6',
+  warning: '#f59e0b',
+  critical: '#ef4444',
+};
+
+const statusColors: Record<string, { bg: string; text: string; dot: string }> = {
+  running: { bg: '#dbeafe', text: '#1e40af', dot: '#3b82f6' },
+  success: { bg: '#dcfce7', text: '#166534', dot: '#22c55e' },
+  error: { bg: '#fef2f2', text: '#991b1b', dot: '#ef4444' },
+  waiting: { bg: '#fefce8', text: '#854d0e', dot: '#eab308' },
+};
+
+const trendArrows: Record<string, string> = { up: '↑', down: '↓', flat: '→' };
+
+// ── Registry ──
+
+export const { registry } = defineRegistry(catalog, {
+  actions: {
+    approve: async (ctx) => { console.log('[json-render] approve', ctx); },
+    reject: async (ctx) => { console.log('[json-render] reject', ctx); },
+    select_option: async (ctx) => { console.log('[json-render] select_option', ctx); },
+    navigate: async (ctx) => { console.log('[json-render] navigate', ctx); },
+    dismiss: async (ctx) => { console.log('[json-render] dismiss', ctx); },
+  },
+  components: {
+    ApprovalCard: ({ props, children }) => (
+      <div
+        style={{
+          ...cardBase,
+          borderLeft: `4px solid ${severityBorder[props.severity] ?? severityBorder.info}`,
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#6b7280' }}>
+            {props.agent} · Approval
+          </span>
+          <span
+            style={{
+              fontSize: 11,
+              fontWeight: 600,
+              padding: '2px 8px',
+              borderRadius: 99,
+              background: props.severity === 'critical' ? '#fef2f2' : props.severity === 'warning' ? '#fefce8' : '#eff6ff',
+              color: props.severity === 'critical' ? '#dc2626' : props.severity === 'warning' ? '#d97706' : '#2563eb',
+            }}
+          >
+            {props.severity}
+          </span>
+        </div>
+        <h3 style={{ fontSize: 16, fontWeight: 700, margin: '0 0 6px', color: '#0f172a' }}>{props.title}</h3>
+        <p style={{ fontSize: 14, lineHeight: 1.5, color: '#475569', margin: '0 0 12px' }}>{props.description}</p>
+        {props.metadata ? (
+          <div style={{ borderTop: '1px solid #f1f5f9', paddingTop: 10, marginBottom: 10 }}>
+            {Object.entries(props.metadata).map(([key, val]) => (
+              <div key={key} style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, padding: '3px 0' }}>
+                <span style={{ color: '#94a3b8' }}>{key}</span>
+                <span style={{ color: '#0f172a', fontWeight: 500 }}>{val}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+        {children as React.ReactNode}
+      </div>
+    ),
+
+    StatusCard: ({ props, children }) => {
+      const c = statusColors[props.status] ?? statusColors.waiting;
+      return (
+        <div style={{ ...cardBase, background: c.bg }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+            <span style={{ width: 8, height: 8, borderRadius: '50%', background: c.dot, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: c.text }}>{props.title}</span>
+          </div>
+          <p style={{ fontSize: 14, color: c.text, margin: 0, opacity: 0.85 }}>{props.message}</p>
+          {typeof props.progress === 'number' ? (
+            <div style={{ marginTop: 10, background: 'rgba(0,0,0,0.1)', borderRadius: 4, height: 6, overflow: 'hidden' }}>
+              <div style={{ width: `${props.progress}%`, height: '100%', background: c.dot, borderRadius: 4, transition: 'width 0.3s' }} />
+            </div>
+          ) : null}
+          {children as React.ReactNode}
+        </div>
+      );
+    },
+
+    Metric: ({ props }) => (
+      <div style={{ ...cardBase, display: 'flex', flexDirection: 'column', alignItems: 'flex-start', padding: '14px 16px' }}>
+        <span style={{ fontSize: 12, color: '#94a3b8', fontWeight: 500, marginBottom: 4 }}>{props.label}</span>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+          <span style={{ fontSize: 24, fontWeight: 700, color: '#0f172a' }}>{props.value}</span>
+          {props.trend ? (
+            <span style={{ fontSize: 14, color: props.trend === 'up' ? '#22c55e' : props.trend === 'down' ? '#ef4444' : '#94a3b8' }}>
+              {trendArrows[props.trend]}
+            </span>
+          ) : null}
+        </div>
+      </div>
+    ),
+
+    OptionList: ({ props, emit }) => (
+      <div style={cardBase}>
+        <h3 style={{ fontSize: 15, fontWeight: 700, margin: '0 0 12px', color: '#0f172a' }}>{props.question}</h3>
+        {props.options.map((opt) => (
+          <button
+            key={opt.id}
+            type="button"
+            onClick={() => emit('press')}
+            style={{
+              display: 'block',
+              width: '100%',
+              textAlign: 'left',
+              padding: '12px 14px',
+              marginBottom: 6,
+              border: '1px solid #e5e7eb',
+              borderRadius: 12,
+              background: '#fafafa',
+              cursor: 'pointer',
+              fontSize: 14,
+            }}
+          >
+            <strong style={{ color: '#0f172a' }}>{opt.label}</strong>
+            {opt.description ? <span style={{ display: 'block', fontSize: 13, color: '#64748b', marginTop: 2 }}>{opt.description}</span> : null}
+          </button>
+        ))}
+      </div>
+    ),
+
+    TextBlock: ({ props }) => (
+      <div
+        style={{
+          ...cardBase,
+          background: props.variant === 'highlight' ? '#fffbeb' : props.variant === 'muted' ? '#f8fafc' : '#ffffff',
+          fontSize: 14,
+          lineHeight: 1.6,
+          color: props.variant === 'muted' ? '#64748b' : '#0f172a',
+        }}
+      >
+        {props.content}
+      </div>
+    ),
+
+    CodeBlock: ({ props }) => (
+      <div style={{ ...cardBase, background: '#1e293b', padding: '12px 14px' }}>
+        {props.filename ? (
+          <div style={{ fontSize: 11, color: '#94a3b8', marginBottom: 8, fontFamily: 'monospace' }}>{props.filename}</div>
+        ) : null}
+        <pre style={{ margin: 0, fontSize: 13, color: '#e2e8f0', fontFamily: 'ui-monospace, monospace', whiteSpace: 'pre-wrap', overflowX: 'auto' }}>
+          {props.code}
+        </pre>
+      </div>
+    ),
+
+    ButtonRow: ({ props, children }) => (
+      <div
+        style={{
+          display: 'flex',
+          gap: 8,
+          justifyContent: props.align === 'center' ? 'center' : props.align === 'right' ? 'flex-end' : props.align === 'spread' ? 'space-between' : 'flex-start',
+          padding: '4px 0',
+        }}
+      >
+        {children as React.ReactNode}
+      </div>
+    ),
+
+    Button: ({ props, emit }) => {
+      const variants: Record<string, CSSProperties> = {
+        primary: { background: '#ef4444', color: '#fff', border: 'none', boxShadow: '0 2px 8px rgba(239,68,68,0.3)' },
+        secondary: { background: '#f1f5f9', color: '#0f172a', border: '1px solid #e2e8f0' },
+        danger: { background: '#fef2f2', color: '#dc2626', border: '1px solid #fecaca' },
+        ghost: { background: 'transparent', color: '#64748b', border: 'none' },
+      };
+      const v = variants[props.variant ?? 'primary'] ?? variants.primary;
+      return (
+        <button
+          type="button"
+          onClick={() => emit('press')}
+          disabled={props.disabled}
+          style={{
+            ...v,
+            padding: '10px 18px',
+            borderRadius: 12,
+            fontSize: 14,
+            fontWeight: 600,
+            cursor: props.disabled ? 'default' : 'pointer',
+            opacity: props.disabled ? 0.5 : 1,
+            flex: 1,
+          }}
+        >
+          {props.label}
+        </button>
+      );
+    },
+  },
+});

--- a/src/lib/mobile/openclaw.ts
+++ b/src/lib/mobile/openclaw.ts
@@ -108,7 +108,7 @@ async function _fetchMobileInboxSnapshot(): Promise<MobileInboxSnapshot> {
   const sessions = fleet.agents
     .filter((agent) => (
       agent.runtime === 'openclaw'
-        || (agent.runtime === 'codex' && agent.runtimeSurface?.ownership === 'owned')
+        || agent.runtime === 'codex'
     ))
     .map((agent, index) => ({ agent, index }))
     .sort((left, right) => {

--- a/src/lib/mobile/types.ts
+++ b/src/lib/mobile/types.ts
@@ -18,6 +18,7 @@ export type MobileControlActionKind =
   | 'stop'
   | 'watch'
   | 'resolve'
+  | 'launch'
   | 'open_review'
   | 'open_desktop';
 
@@ -138,11 +139,12 @@ export interface MobileActionAttachment {
 }
 
 export interface MobileActionRequest {
-  action: Extract<MobileControlActionKind, 'steer' | 'stop' | 'approve' | 'deny' | 'pause' | 'resume' | 'watch' | 'resolve'>;
+  action: Extract<MobileControlActionKind, 'steer' | 'stop' | 'approve' | 'deny' | 'pause' | 'resume' | 'watch' | 'resolve' | 'launch'>;
   sessionKey: string;
   message?: string;
   attachments?: MobileActionAttachment[];
   runId?: string;
+  cwd?: string;
 }
 
 export interface MobileActionResponse {

--- a/src/lib/runtime/actions.ts
+++ b/src/lib/runtime/actions.ts
@@ -107,11 +107,29 @@ export async function performRuntimeAction(payload: RuntimeActionRequest): Promi
       );
     }
     case 'codex': {
+      // Discovered Codex sessions (user-launched from terminal) can be steered
+      // via the OpenClaw gateway's sessions_send, same as OpenClaw sessions.
       if (runtimeSurface.ownership !== 'owned') {
+        if (payload.action === 'steer') {
+          const message = payload.message?.trim();
+          if (!message) {
+            throw new Error('message is required to steer a Codex session');
+          }
+          const result = await steerOpenClawSession(agent.sessionKey, message, []);
+          return {
+            ok: true,
+            action: payload.action,
+            surfaceId: runtimeSurface.id,
+            runtime: agent.runtime,
+            status: 'queued',
+            note: 'Sent.',
+            runId: result.runId,
+          };
+        }
         return unavailable(
           agent,
           payload.action,
-          'This Codex surface was discovered from local runtime history, not launched or owned by Cortex IDE. Read-tail is truthful; input and interrupt stay disabled until we can prove an owned-session seam.',
+          'This Codex surface was discovered from local runtime history. Only steer (send message) is supported right now.',
         );
       }
 

--- a/src/lib/runtime/actions.ts
+++ b/src/lib/runtime/actions.ts
@@ -1,15 +1,16 @@
 import type { AgentSummary } from '@/lib/fleet/types';
-import { continueOwnedCodexSession, interruptOwnedCodexSession, setOwnedCodexReviewDisposition } from '@/lib/codex/owned';
+import { continueOwnedCodexSession, interruptOwnedCodexSession, launchOwnedCodexSession, setOwnedCodexReviewDisposition } from '@/lib/codex/owned';
 import { abortOpenClawSession, steerOpenClawSession } from '@/lib/openclaw/chat';
 import { getRuntimeInventorySnapshot } from '@/lib/runtime/inventory';
 
-export type RuntimeActionKind = 'steer' | 'stop' | 'send_input' | 'interrupt' | 'watch' | 'resolve';
+export type RuntimeActionKind = 'steer' | 'stop' | 'send_input' | 'interrupt' | 'watch' | 'resolve' | 'launch';
 
 export interface RuntimeActionRequest {
   action: RuntimeActionKind;
   surfaceId: string;
   message?: string;
   runId?: string;
+  cwd?: string;
   attachments?: Array<{
     type?: string;
     mimeType: string;
@@ -200,4 +201,20 @@ export async function performRuntimeAction(payload: RuntimeActionRequest): Promi
     default:
       return unavailable(agent, payload.action, `Runtime action ${payload.action} is not supported for ${agent.runtime}.`);
   }
+}
+
+/**
+ * Launch a new owned Codex session from mobile.
+ * Doesn't require an existing surface — creates one from scratch.
+ */
+export async function launchCodexFromMobile(cwd: string, prompt: string): Promise<RuntimeActionResult> {
+  const result = await launchOwnedCodexSession({ cwd, prompt });
+  return {
+    ok: result.ok,
+    action: 'launch',
+    surfaceId: result.surfaceId,
+    runtime: 'codex',
+    status: 'queued',
+    note: result.note,
+  };
 }


### PR DESCRIPTION
Remaining Batch 2 work that landed after the initial PR #37 merge:

## Codex Chat Parity
- Owned Codex sessions render as regular chat bubbles (not turn cards)
- Send button routes owned Codex through resume directly
- Safari cache busting on inbox/history fetches
- Seamless discovered + owned history merge
- Clean squad: only live-pid sessions visible

## json-render Integration (Vercel Labs v0.14)
- Catalog, registry, demo specs for agent approval cards
- React 19.0.0 → 19.2.4 upgrade
- Renderer wired into mobile shell with demo toggle

## Cost Dashboard (#31)
- Token usage visualization with per-model breakdown
- Donut ring summary card on squad (full-width, above grid)
- Session-level detail rows with context pressure tones
- Apple polish pass: 8pt grid, SF system colors, refined typography

**44 total commits on batch/2-command-surface, 19 files changed, +4,650/-371**