### PR TITLE
#30 Approval primitive — agent approval cards with demo flow

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4354,12 +4354,12 @@ body:has(.remodex-diff-overlay) {
 
 /* Action buttons */
 .remodex-approval-actions {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 10px;
 }
 .remodex-approval-btn {
-  flex: 1;
-  padding: 12px 0;
+  padding: 13px 0;
   border-radius: 12px;
   font-size: 15px;
   font-weight: 600;
@@ -4367,14 +4367,15 @@ body:has(.remodex-diff-overlay) {
   border: none;
   transition: transform 0.1s, opacity 0.1s;
   -webkit-tap-highlight-color: transparent;
+  text-align: center;
 }
 .remodex-approval-btn:active {
-  transform: scale(0.97);
+  transform: scale(0.96);
 }
 .remodex-approval-btn-approve {
-  background: #34c759;
+  background: #ef4444;
   color: #ffffff;
-  box-shadow: 0 2px 8px rgba(52,199,89,0.3);
+  box-shadow: 0 2px 10px rgba(239,68,68,0.3);
 }
 .remodex-approval-btn-reject {
   background: #f5f5f7;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4251,25 +4251,177 @@ body:has(.remodex-diff-overlay) {
   }
 }
 
-/* ── json-render approval cards ── */
+/* ── Approval cards ── */
 .remodex-approval-stack {
-  padding: 12px 16px 4px;
+  padding: 8px 16px 4px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 .remodex-approval-card-wrap {
-  animation: remodex-approval-slide-in 0.35s cubic-bezier(0.2, 0.9, 0.3, 1) forwards;
+  animation: remodex-approval-slide-in 0.4s cubic-bezier(0.2, 0.9, 0.3, 1) forwards;
+}
+.remodex-approval-resolved {
+  animation: remodex-approval-fade-out 1.2s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  animation-delay: 0.3s;
 }
 @keyframes remodex-approval-slide-in {
-  from {
-    opacity: 0;
-    transform: translateY(16px) scale(0.97);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
+  from { opacity: 0; transform: translateY(20px) scale(0.96); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+@keyframes remodex-approval-fade-out {
+  from { opacity: 1; transform: scale(1); max-height: 400px; margin-bottom: 10px; }
+  to { opacity: 0; transform: scale(0.95); max-height: 0; margin-bottom: 0; overflow: hidden; }
+}
+
+.remodex-approval-card {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 16px 18px;
+  border: 1px solid rgba(0,0,0,0.06);
+  border-left: 4px solid #007aff;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+}
+
+/* Header */
+.remodex-approval-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+.remodex-approval-agent {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.remodex-approval-agent-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.remodex-approval-agent-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: #86868b;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.remodex-approval-time {
+  font-size: 12px;
+  color: #aeaeb2;
+}
+
+/* Content */
+.remodex-approval-title {
+  font-size: 17px;
+  font-weight: 700;
+  color: #1d1d1f;
+  margin: 0 0 6px;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+}
+.remodex-approval-desc {
+  font-size: 14px;
+  color: #636366;
+  margin: 0 0 12px;
+  line-height: 1.45;
+}
+
+/* Metadata */
+.remodex-approval-meta {
+  border-top: 1px solid #f5f5f7;
+  padding-top: 10px;
+  margin-bottom: 14px;
+}
+.remodex-approval-meta-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 4px 0;
+}
+.remodex-approval-meta-key {
+  font-size: 13px;
+  color: #aeaeb2;
+}
+.remodex-approval-meta-val {
+  font-size: 13px;
+  font-weight: 500;
+  color: #1d1d1f;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Action buttons */
+.remodex-approval-actions {
+  display: flex;
+  gap: 10px;
+}
+.remodex-approval-btn {
+  flex: 1;
+  padding: 12px 0;
+  border-radius: 12px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.1s, opacity 0.1s;
+  -webkit-tap-highlight-color: transparent;
+}
+.remodex-approval-btn:active {
+  transform: scale(0.97);
+}
+.remodex-approval-btn-approve {
+  background: #34c759;
+  color: #ffffff;
+  box-shadow: 0 2px 8px rgba(52,199,89,0.3);
+}
+.remodex-approval-btn-reject {
+  background: #f5f5f7;
+  color: #636366;
+}
+.remodex-approval-btn-reject:active {
+  background: #e8e8ed;
+}
+
+/* Resolved state */
+.remodex-approval-resolved-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 12px 0;
+  border-radius: 12px;
+  font-size: 15px;
+  font-weight: 600;
+}
+.remodex-approval-resolved-approved {
+  background: rgba(52,199,89,0.12);
+  color: #34c759;
+}
+.remodex-approval-resolved-rejected {
+  background: rgba(255,59,48,0.08);
+  color: #ff3b30;
+}
+
+/* Notification badge on hamburger */
+.remodex-approval-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  background: #ff9f0a;
+  color: #ffffff;
+  font-size: 11px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+  pointer-events: none;
 }
 
 /* ── Cost Dashboard ── */

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -2356,35 +2356,98 @@ export function MobileRemoteShell({
                 const elapsed = Math.round((Date.now() - approval.createdAt) / 60_000);
                 const timeLabel = elapsed < 1 ? 'just now' : `${elapsed}m ago`;
 
+                const cardStyle: CSSProperties = {
+                  background: '#ffffff',
+                  borderRadius: 16,
+                  padding: '16px 18px',
+                  border: '1px solid rgba(0,0,0,0.06)',
+                  borderLeft: `4px solid ${severityColor}`,
+                  boxShadow: '0 2px 8px rgba(0,0,0,0.06)',
+                };
+                const headerStyle: CSSProperties = {
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  marginBottom: 10,
+                };
+                const agentDotStyle: CSSProperties = {
+                  width: 8, height: 8, borderRadius: '50%',
+                  background: severityColor, display: 'inline-block', marginRight: 8,
+                };
+                const agentNameStyle: CSSProperties = {
+                  fontSize: 13, fontWeight: 600, color: '#86868b',
+                  textTransform: 'uppercase', letterSpacing: '0.03em',
+                };
+                const timeStyle: CSSProperties = {
+                  fontSize: 12, color: '#aeaeb2',
+                };
+                const titleStyle: CSSProperties = {
+                  fontSize: 17, fontWeight: 700, color: '#1d1d1f',
+                  margin: '0 0 6px', letterSpacing: '-0.02em', lineHeight: 1.25,
+                };
+                const descStyle: CSSProperties = {
+                  fontSize: 14, color: '#636366', margin: '0 0 12px', lineHeight: 1.45,
+                };
+                const metaWrapStyle: CSSProperties = {
+                  borderTop: '1px solid #f5f5f7', paddingTop: 10, marginBottom: 14,
+                };
+                const metaRowStyle: CSSProperties = {
+                  display: 'flex', justifyContent: 'space-between',
+                  alignItems: 'baseline', padding: '4px 0',
+                };
+                const metaKeyStyle: CSSProperties = { fontSize: 13, color: '#aeaeb2' };
+                const metaValStyle: CSSProperties = {
+                  fontSize: 13, fontWeight: 500, color: '#1d1d1f',
+                  fontVariantNumeric: 'tabular-nums',
+                };
+                const actionsStyle: CSSProperties = {
+                  display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10,
+                };
+                const btnBase: CSSProperties = {
+                  padding: '13px 0', borderRadius: 12, fontSize: 15,
+                  fontWeight: 600, border: 'none', textAlign: 'center',
+                  WebkitTapHighlightColor: 'transparent', cursor: 'pointer',
+                };
+                const rejectBtnStyle: CSSProperties = {
+                  ...btnBase, background: '#f5f5f7', color: '#636366',
+                };
+                const approveBtnStyle: CSSProperties = {
+                  ...btnBase, background: '#ef4444', color: '#ffffff',
+                  boxShadow: '0 2px 10px rgba(239,68,68,0.3)',
+                };
+                const resolvedBarStyle: CSSProperties = {
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  gap: 6, padding: '12px 0', borderRadius: 12, fontSize: 15, fontWeight: 600,
+                  background: resolved === 'approved' ? 'rgba(52,199,89,0.12)' : 'rgba(255,59,48,0.08)',
+                  color: resolved === 'approved' ? '#34c759' : '#ff3b30',
+                };
+
                 return (
                   <div
                     key={approval.id}
                     className={`remodex-approval-card-wrap ${resolved ? 'remodex-approval-resolved' : ''}`}
                   >
-                    <div
-                      className="remodex-approval-card"
-                      style={{ borderLeftColor: severityColor }}
-                    >
-                      {/* Header */}
-                      <div className="remodex-approval-header">
-                        <div className="remodex-approval-agent">
-                          <span className="remodex-approval-agent-dot" style={{ background: severityColor }} />
-                          <span className="remodex-approval-agent-name">{approval.agent}</span>
+                    <div style={cardStyle}>
+                      {/* Header — agent + time inline */}
+                      <div style={headerStyle}>
+                        <div style={{ display: 'flex', alignItems: 'center' }}>
+                          <span style={agentDotStyle} />
+                          <span style={agentNameStyle}>{approval.agent}</span>
                         </div>
-                        <span className="remodex-approval-time">{timeLabel}</span>
+                        <span style={timeStyle}>{timeLabel}</span>
                       </div>
 
                       {/* Title + description */}
-                      <h3 className="remodex-approval-title">{approval.title}</h3>
-                      <p className="remodex-approval-desc">{approval.description}</p>
+                      <h3 style={titleStyle}>{approval.title}</h3>
+                      <p style={descStyle}>{approval.description}</p>
 
                       {/* Metadata rows */}
                       {approval.metadata ? (
-                        <div className="remodex-approval-meta">
+                        <div style={metaWrapStyle}>
                           {Object.entries(approval.metadata).map(([key, val]) => (
-                            <div key={key} className="remodex-approval-meta-row">
-                              <span className="remodex-approval-meta-key">{key}</span>
-                              <span className="remodex-approval-meta-val">{val}</span>
+                            <div key={key} style={metaRowStyle}>
+                              <span style={metaKeyStyle}>{key}</span>
+                              <span style={metaValStyle}>{val}</span>
                             </div>
                           ))}
                         </div>
@@ -2392,15 +2455,15 @@ export function MobileRemoteShell({
 
                       {/* Action buttons or resolved state */}
                       {resolved ? (
-                        <div className={`remodex-approval-resolved-bar remodex-approval-resolved-${resolved}`}>
+                        <div style={resolvedBarStyle}>
                           <span>{resolved === 'approved' ? '✓' : '✕'}</span>
                           <span>{resolved === 'approved' ? 'Approved' : 'Rejected'}</span>
                         </div>
                       ) : (
-                        <div className="remodex-approval-actions">
+                        <div style={actionsStyle}>
                           <button
                             type="button"
-                            className="remodex-approval-btn remodex-approval-btn-reject"
+                            style={rejectBtnStyle}
                             onClick={() => {
                               setResolvedApprovals((cur) => ({ ...cur, [approval.id]: 'rejected' }));
                               setSurfaceNote(`❌ Rejected: ${approval.title}`);
@@ -2413,7 +2476,7 @@ export function MobileRemoteShell({
                           </button>
                           <button
                             type="button"
-                            className="remodex-approval-btn remodex-approval-btn-approve"
+                            style={approveBtnStyle}
                             onClick={() => {
                               setResolvedApprovals((cur) => ({ ...cur, [approval.id]: 'approved' }));
                               setSurfaceNote(`✅ Approved: ${approval.title}`);

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -33,10 +33,8 @@ import {
   Square,
   X,
 } from 'lucide-react';
-import { Renderer } from '@json-render/react';
-import { registry } from '@/lib/json-render/registry';
-import { deployApprovalSpec, decisionSpec, dashboardSpec } from '@/lib/json-render/demo-specs';
-import type { Spec } from '@json-render/core';
+import { demoApprovals } from '@/lib/json-render/demo-specs';
+import type { ApprovalRequest } from '@/lib/json-render/demo-specs';
 import type { ReviewChangedFile, RuntimeReviewPacket } from '@/lib/fleet/types';
 import type {
   MobileActionRequest,
@@ -475,7 +473,8 @@ export function MobileRemoteShell({
   const [reviewFileError, setReviewFileError] = useState<string | null>(null);
   const [diffOpen, setDiffOpen] = useState(false);
   const [controlsOpen, setControlsOpen] = useState(false);
-  const [pendingApprovals, setPendingApprovals] = useState<Spec[]>([]);
+  const [pendingApprovals, setPendingApprovals] = useState<ApprovalRequest[]>([]);
+  const [resolvedApprovals, setResolvedApprovals] = useState<Record<string, 'approved' | 'rejected'>>({});
   const [surfaceRefreshing, setSurfaceRefreshing] = useState(false);
   const [expandedMedia, setExpandedMedia] = useState<MobileTranscriptMedia | null>(null);
   const [scrollY, setScrollY] = useState(0);
@@ -1948,15 +1947,20 @@ export function MobileRemoteShell({
           data-context-visible="false"
           data-visible={headerVisible ? 'true' : 'false'}
         >
-          <button
-            type="button"
-            className="remodex-circle-button"
-            aria-label="Conversation controls"
-            onClick={() => setControlsOpen(true)}
-            style={{ background: '#ef4444', color: '#ffffff', border: 'none', boxShadow: '0 4px 12px rgba(239,68,68,0.25)' }}
-          >
-            <Menu size={18} strokeWidth={2.1} />
-          </button>
+          <div style={{ position: 'relative' }}>
+            <button
+              type="button"
+              className="remodex-circle-button"
+              aria-label="Conversation controls"
+              onClick={() => setControlsOpen(true)}
+              style={{ background: '#ef4444', color: '#ffffff', border: 'none', boxShadow: '0 4px 12px rgba(239,68,68,0.25)' }}
+            >
+              <Menu size={18} strokeWidth={2.1} />
+            </button>
+            {pendingApprovals.length > 0 ? (
+              <span className="remodex-approval-badge">{pendingApprovals.length}</span>
+            ) : null}
+          </div>
           <div className="remodex-title-shell">
             <div className="remodex-title-stack">
               <span className="remodex-title-kicker">{headerLabel}</span>
@@ -2343,14 +2347,89 @@ export function MobileRemoteShell({
             </div>
           ) : null}
 
-          {/* ── json-render approval cards ── */}
+          {/* ── Approval cards ── */}
           {pendingApprovals.length > 0 ? (
             <div className="remodex-approval-stack">
-              {pendingApprovals.map((spec, i) => (
-                <div key={`approval-${i}`} className="remodex-approval-card-wrap">
-                  <Renderer spec={spec} registry={registry} />
-                </div>
-              ))}
+              {pendingApprovals.map((approval) => {
+                const resolved = resolvedApprovals[approval.id];
+                const severityColor = approval.severity === 'critical' ? '#ff3b30' : approval.severity === 'warning' ? '#ff9f0a' : '#007aff';
+                const elapsed = Math.round((Date.now() - approval.createdAt) / 60_000);
+                const timeLabel = elapsed < 1 ? 'just now' : `${elapsed}m ago`;
+
+                return (
+                  <div
+                    key={approval.id}
+                    className={`remodex-approval-card-wrap ${resolved ? 'remodex-approval-resolved' : ''}`}
+                  >
+                    <div
+                      className="remodex-approval-card"
+                      style={{ borderLeftColor: severityColor }}
+                    >
+                      {/* Header */}
+                      <div className="remodex-approval-header">
+                        <div className="remodex-approval-agent">
+                          <span className="remodex-approval-agent-dot" style={{ background: severityColor }} />
+                          <span className="remodex-approval-agent-name">{approval.agent}</span>
+                        </div>
+                        <span className="remodex-approval-time">{timeLabel}</span>
+                      </div>
+
+                      {/* Title + description */}
+                      <h3 className="remodex-approval-title">{approval.title}</h3>
+                      <p className="remodex-approval-desc">{approval.description}</p>
+
+                      {/* Metadata rows */}
+                      {approval.metadata ? (
+                        <div className="remodex-approval-meta">
+                          {Object.entries(approval.metadata).map(([key, val]) => (
+                            <div key={key} className="remodex-approval-meta-row">
+                              <span className="remodex-approval-meta-key">{key}</span>
+                              <span className="remodex-approval-meta-val">{val}</span>
+                            </div>
+                          ))}
+                        </div>
+                      ) : null}
+
+                      {/* Action buttons or resolved state */}
+                      {resolved ? (
+                        <div className={`remodex-approval-resolved-bar remodex-approval-resolved-${resolved}`}>
+                          <span>{resolved === 'approved' ? '✓' : '✕'}</span>
+                          <span>{resolved === 'approved' ? 'Approved' : 'Rejected'}</span>
+                        </div>
+                      ) : (
+                        <div className="remodex-approval-actions">
+                          <button
+                            type="button"
+                            className="remodex-approval-btn remodex-approval-btn-reject"
+                            onClick={() => {
+                              setResolvedApprovals((cur) => ({ ...cur, [approval.id]: 'rejected' }));
+                              setSurfaceNote(`❌ Rejected: ${approval.title}`);
+                              setTimeout(() => {
+                                setPendingApprovals((cur) => cur.filter((a) => a.id !== approval.id));
+                              }, 1500);
+                            }}
+                          >
+                            {approval.actions.reject.label}
+                          </button>
+                          <button
+                            type="button"
+                            className="remodex-approval-btn remodex-approval-btn-approve"
+                            onClick={() => {
+                              setResolvedApprovals((cur) => ({ ...cur, [approval.id]: 'approved' }));
+                              setSurfaceNote(`✅ Approved: ${approval.title}`);
+                              setTimeout(() => {
+                                setPendingApprovals((cur) => cur.filter((a) => a.id !== approval.id));
+                              }, 1500);
+                            }}
+                          >
+                            {approval.actions.approve.label}
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           ) : null}
 
@@ -2709,8 +2788,9 @@ export function MobileRemoteShell({
                 className="remodex-controls-action-row"
                 onClick={() => {
                   setPendingApprovals((cur) =>
-                    cur.length > 0 ? [] : [deployApprovalSpec, decisionSpec, dashboardSpec],
+                    cur.length > 0 ? [] : [...demoApprovals],
                   );
+                  setResolvedApprovals({});
                   setControlsOpen(false);
                 }}
               >

--- a/src/lib/json-render/demo-specs.ts
+++ b/src/lib/json-render/demo-specs.ts
@@ -1,87 +1,77 @@
 /**
- * Demo specs — examples of what agents would generate via json-render
+ * Demo approval requests — structured data that the mobile shell renders
+ * as native approval cards.
  *
- * In production, these would come from the gateway as structured events
- * when an agent needs user input (approval, selection, confirmation).
+ * In production, these would arrive from the gateway when an agent hits
+ * a checkpoint requiring human confirmation (deploy, destructive action,
+ * spend threshold, permission escalation).
  */
-import type { Spec } from '@json-render/core';
 
-/**
- * Agent requests approval to deploy
- */
-export const deployApprovalSpec: Spec = {
-  root: 'approval',
-  elements: {
-    approval: {
-      type: 'ApprovalCard',
-      props: {
-        title: 'Deploy cortex-ide to production?',
-        description: 'Niot has completed the batch/2-command-surface branch and all checks pass. Ready to deploy to Vercel production.',
-        agent: 'Niot',
-        severity: 'warning',
-        metadata: {
-          Branch: 'batch/2-command-surface',
-          Commits: '38',
-          'Files changed': '14',
-          'Lines added': '+1,766',
-        },
-      },
-      children: ['buttons'],
-    },
-    buttons: {
-      type: 'ButtonRow',
-      props: { align: 'spread' },
-      children: ['approve-btn', 'reject-btn'],
-    },
-    'approve-btn': {
-      type: 'Button',
-      props: { label: 'Approve Deploy', variant: 'primary' },
-      children: [],
-    },
-    'reject-btn': {
-      type: 'Button',
-      props: { label: 'Reject', variant: 'danger' },
-      children: [],
-    },
-  },
-};
+export interface ApprovalRequest {
+  id: string;
+  agent: string;
+  severity: 'info' | 'warning' | 'critical';
+  title: string;
+  description: string;
+  metadata?: Record<string, string>;
+  actions: {
+    approve: { label: string };
+    reject: { label: string };
+  };
+  createdAt: number;
+}
 
-/**
- * Agent asks which approach to take
- */
-export const decisionSpec: Spec = {
-  root: 'options',
-  elements: {
-    options: {
-      type: 'OptionList',
-      props: {
-        question: 'How should Hawk handle the failing test in cortex/search?',
-        options: [
-          { id: 'fix', label: 'Fix the test', description: 'Update the assertion to match the new behavior' },
-          { id: 'skip', label: 'Skip for now', description: 'Mark as known issue, ship the rest' },
-          { id: 'revert', label: 'Revert the change', description: 'Roll back the commit that broke it' },
-        ],
-      },
-      children: [],
+export const demoApprovals: ApprovalRequest[] = [
+  {
+    id: 'demo-deploy-001',
+    agent: 'Niot',
+    severity: 'warning',
+    title: 'Deploy cortex-ide to production?',
+    description: 'Branch batch/2-command-surface has 44 commits and all checks pass. Ready to deploy to Vercel production.',
+    metadata: {
+      Branch: 'batch/2-command-surface',
+      Commits: '44',
+      'Files changed': '19',
+      'Lines added': '+4,650',
     },
-  },
-};
-
-/**
- * Agent shows a cost/status dashboard
- */
-export const dashboardSpec: Spec = {
-  root: 'dashboard',
-  elements: {
-    dashboard: {
-      type: 'StatusCard',
-      props: {
-        title: 'Batch 2 Build',
-        status: 'running',
-        message: 'Niot is working on #30 Approval primitive — 3 files changed so far',
-        progress: 65,
-      },
-      children: [],
+    actions: {
+      approve: { label: 'Approve' },
+      reject: { label: 'Reject' },
     },
+    createdAt: Date.now() - 120_000,
   },
-};
+  {
+    id: 'demo-permission-002',
+    agent: 'Codex',
+    severity: 'critical',
+    title: 'Delete 23 stale branches?',
+    description: 'Codex wants to run git branch cleanup on cortex-ide. This will permanently delete 23 remote branches older than 30 days.',
+    metadata: {
+      Repository: 'hurttlocker/cortex-ide',
+      Branches: '23',
+      Action: 'git push origin --delete',
+    },
+    actions: {
+      approve: { label: 'Allow' },
+      reject: { label: 'Deny' },
+    },
+    createdAt: Date.now() - 45_000,
+  },
+  {
+    id: 'demo-decision-003',
+    agent: 'Hawk',
+    severity: 'info',
+    title: 'Skip failing test in cortex/search?',
+    description: 'The BM25 relevance test is flaky after the index migration. Hawk recommends marking it as known and shipping the rest of the PR.',
+    metadata: {
+      Test: 'search.bm25.relevance',
+      'Failure rate': '2 of 10 runs',
+      PR: '#42',
+    },
+    actions: {
+      approve: { label: 'Skip & Ship' },
+      reject: { label: 'Fix First' },
+    },
+    createdAt: Date.now() - 10_000,
+  },
+];


### PR DESCRIPTION
Native approval card surface for agent checkpoint requests.

## What it does
- **Approval cards** render inline in the chat view when an agent needs human confirmation
- Three severity levels: info (blue), warning (amber), critical (red) — each with colored left border and dot
- **Metadata rows** show structured context (branch, commits, files, etc.)
- **Approve/Reject buttons** with distinct styles (green approve, gray reject)
- **Resolved state** — card shows ✓ Approved or ✕ Rejected, then fades out with animation
- **Notification badge** on hamburger menu (amber dot with count) when approvals are pending
- **Demo toggle** in controls sheet shows 3 mock scenarios:
  - Niot: deploy to production (warning)
  - Codex: delete 23 branches (critical)
  - Hawk: skip failing test (info)

## Design
Apple-native styling: SF system colors, 16px radius cards, 12px rounded buttons, tap feedback, slide-in/fade-out animations.

In production, approval requests will come from the gateway when agents hit checkpoints. The card data structure is already defined as `ApprovalRequest` interface.