### PR TITLE
#50 Consolidated sync API — 5 requests → 1

### DIFF
--- a/src/app/api/mobile/sync/route.ts
+++ b/src/app/api/mobile/sync/route.ts
@@ -1,0 +1,220 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getOwnedCodexRuntimeTail } from '@/lib/codex/owned';
+import { getCodexRuntimeTail } from '@/lib/codex/sessions';
+import type { MobileInboxSnapshot, MobileTranscriptEntry } from '@/lib/mobile/types';
+import { getMobileInboxSnapshot } from '@/lib/mobile/openclaw';
+import { getSessionTranscript } from '@/lib/openclaw/chat';
+import { getReviewFileDetail } from '@/lib/review/workspace';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+// ── Types ──
+
+interface SyncRequest {
+  inbox?: { etag?: string };
+  history?: { sessionKey: string; sinceId?: string; limit?: number };
+  review?: { sessionKey?: string; includeFile?: string };
+  linked?: { sessionKey: string; sinceId?: string };
+}
+
+interface SyncResponse {
+  inbox?: MobileInboxSnapshot | null;
+  inboxEtag?: string;
+  history?: { sessionKey: string; entries: MobileTranscriptEntry[] };
+  review?: { file?: unknown };
+  linked?: { sessionKey: string; entries: MobileTranscriptEntry[] };
+  serverTime: string;
+  errors?: Record<string, string>;
+}
+
+// ── Inbox cache with ETag ──
+
+let inboxCache: { snapshot: MobileInboxSnapshot; etag: string; timestamp: number } | null = null;
+const INBOX_CACHE_TTL = 5000;
+
+function computeEtag(snapshot: MobileInboxSnapshot): string {
+  const sig = snapshot.sessions
+    .map((s) => `${s.id}:${s.status}:${s.lastEventAt ?? ''}:${Math.round(s.context?.usedPercent ?? 0)}`)
+    .join('|');
+  let hash = 0;
+  for (let i = 0; i < sig.length; i++) {
+    hash = ((hash << 5) - hash + sig.charCodeAt(i)) | 0;
+  }
+  return hash.toString(36);
+}
+
+async function resolveInbox(req: SyncRequest['inbox']): Promise<{ snapshot: MobileInboxSnapshot | null; etag: string }> {
+  const now = Date.now();
+  if (!inboxCache || now - inboxCache.timestamp > INBOX_CACHE_TTL) {
+    const snapshot = await getMobileInboxSnapshot();
+    const etag = computeEtag(snapshot);
+    inboxCache = { snapshot, etag, timestamp: now };
+  }
+
+  if (req?.etag && req.etag === inboxCache.etag) {
+    return { snapshot: null, etag: inboxCache.etag };
+  }
+  return { snapshot: inboxCache.snapshot, etag: inboxCache.etag };
+}
+
+// ── History resolver ──
+
+function runtimeTailRole(label: string): MobileTranscriptEntry['role'] {
+  const normalized = label.toLowerCase();
+  if (normalized.includes('assistant')) return 'assistant';
+  if (normalized.includes('user')) return 'user';
+  if (normalized.includes('tool')) return 'tool';
+  return 'system';
+}
+
+async function resolveHistory(
+  req: NonNullable<SyncRequest['history']>,
+): Promise<{ sessionKey: string; entries: MobileTranscriptEntry[] }> {
+  const { sessionKey, limit: rawLimit } = req;
+  const limit = Math.min(Math.max(rawLimit ?? 18, 1), 40);
+
+  if (sessionKey.startsWith('codex-owned:')) {
+    const tail = await getOwnedCodexRuntimeTail(sessionKey);
+    const entries: MobileTranscriptEntry[] = [];
+    for (const group of tail.groups ?? []) {
+      const promptText = group.prompt?.trim();
+      if (promptText) {
+        entries.push({ id: `${group.id}-prompt`, role: 'user', text: promptText, timestampLabel: group.startedAtLabel });
+      }
+      for (const entry of group.entries) {
+        const text = entry.text.trim();
+        if (!text) continue;
+        if (promptText && text === promptText) continue;
+        if (text.startsWith('Usage •') || text.includes('Owned Codex session') || text.includes('Codex run launched')) continue;
+        const role = runtimeTailRole(entry.label);
+        if (role === 'assistant') {
+          entries.push({ id: entry.id, role: 'assistant', text, timestampLabel: entry.timestampLabel });
+        } else if (entry.kind === 'tool') {
+          entries.push({ id: entry.id, role: 'system', text: `🔧 ${entry.label || 'Tool'}`, timestampLabel: entry.timestampLabel });
+        }
+      }
+    }
+    return { sessionKey, entries: applyDelta(entries, req.sinceId) };
+  }
+
+  if (sessionKey.startsWith('codex:')) {
+    const tail = await getCodexRuntimeTail(sessionKey);
+    const raw: MobileTranscriptEntry[] = [];
+    for (const entry of tail.entries ?? []) {
+      if (entry.kind === 'event' && entry.label === 'Agent update') {
+        raw.push({ id: entry.id, role: 'assistant', text: entry.text, timestampLabel: entry.timestampLabel });
+        continue;
+      }
+      if (entry.kind === 'message') {
+        const role = runtimeTailRole(entry.label);
+        if (role === 'system' || role === 'user') {
+          const lt = entry.text.toLowerCase();
+          if (lt.includes('<permissions') || lt.includes('collaboration_mode') || lt.includes('# agents.md') || lt.includes('sandbox_mode')) continue;
+        }
+        raw.push({ id: entry.id, role, text: entry.text, timestampLabel: entry.timestampLabel });
+        continue;
+      }
+      if (entry.kind === 'tool') {
+        raw.push({ id: entry.id, role: 'system', text: `🔧 ${entry.label || 'Tool'}`, timestampLabel: entry.timestampLabel });
+        continue;
+      }
+      if (entry.kind === 'tool-output') {
+        raw.push({ id: entry.id, role: 'system', text: entry.text, timestampLabel: entry.timestampLabel });
+        continue;
+      }
+    }
+    // Deduplicate consecutive assistant messages with identical text
+    const deduped: MobileTranscriptEntry[] = [];
+    for (const entry of raw) {
+      const prev = deduped[deduped.length - 1];
+      if (prev && prev.role === 'assistant' && entry.role === 'assistant' && prev.text === entry.text) continue;
+      deduped.push(entry);
+    }
+    return { sessionKey, entries: applyDelta(deduped, req.sinceId) };
+  }
+
+  // OpenClaw sessions
+  const transcript = await getSessionTranscript(sessionKey, limit);
+  return { sessionKey, entries: applyDelta(transcript, req.sinceId) };
+}
+
+function applyDelta(entries: MobileTranscriptEntry[], sinceId?: string): MobileTranscriptEntry[] {
+  if (!sinceId) return entries;
+  const idx = entries.findIndex((e) => e.id === sinceId);
+  if (idx === -1) return entries; // sinceId not found — return all
+  return entries.slice(idx + 1);
+}
+
+// ── Review file resolver ──
+
+const reviewFileCache = new Map<string, { data: unknown; timestamp: number }>();
+const REVIEW_FILE_CACHE_TTL = 10000;
+
+async function resolveReviewFile(filePath: string): Promise<unknown> {
+  const cached = reviewFileCache.get(filePath);
+  if (cached && Date.now() - cached.timestamp < REVIEW_FILE_CACHE_TTL) {
+    return cached.data;
+  }
+  const file = await getReviewFileDetail(filePath);
+  reviewFileCache.set(filePath, { data: file, timestamp: Date.now() });
+  return file;
+}
+
+// ── Main handler ──
+
+export async function POST(request: NextRequest) {
+  const body = (await request.json()) as SyncRequest;
+  const errors: Record<string, string> = {};
+
+  // Resolve ALL requested sections in parallel — one failure doesn't block others
+  const [inboxResult, historyResult, reviewResult, linkedResult] = await Promise.all([
+    body.inbox
+      ? resolveInbox(body.inbox).catch((e: unknown) => {
+          errors.inbox = e instanceof Error ? e.message : 'inbox failed';
+          return null;
+        })
+      : null,
+    body.history?.sessionKey
+      ? resolveHistory(body.history).catch((e: unknown) => {
+          errors.history = e instanceof Error ? e.message : 'history failed';
+          return null;
+        })
+      : null,
+    body.review?.includeFile
+      ? resolveReviewFile(body.review.includeFile).catch((e: unknown) => {
+          errors.review = e instanceof Error ? e.message : 'review failed';
+          return null;
+        })
+      : null,
+    body.linked?.sessionKey
+      ? resolveHistory({ sessionKey: body.linked.sessionKey, sinceId: body.linked.sinceId, limit: 18 }).catch((e: unknown) => {
+          errors.linked = e instanceof Error ? e.message : 'linked failed';
+          return null;
+        })
+      : null,
+  ]);
+
+  const response: SyncResponse = { serverTime: new Date().toISOString() };
+
+  if (inboxResult) {
+    response.inbox = inboxResult.snapshot;
+    response.inboxEtag = inboxResult.etag;
+  }
+  if (historyResult) {
+    response.history = historyResult;
+  }
+  if (reviewResult !== null && reviewResult !== undefined) {
+    response.review = { file: reviewResult };
+  }
+  if (linkedResult) {
+    response.linked = linkedResult;
+  }
+  if (Object.keys(errors).length > 0) {
+    response.errors = errors;
+  }
+
+  return NextResponse.json(response, {
+    headers: { 'Cache-Control': 'no-store, max-age=0' },
+  });
+}

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -62,6 +62,7 @@ import {
   startLinkedOwnedPolling,
   startLiveInboxRefresh,
   startSessionPolling,
+  startUnifiedSyncPolling,
   trackScrollChrome,
   trackViewportTopOffset,
   trackVisibilityRefresh,
@@ -166,6 +167,7 @@ export function MobileRemoteShell({
   useEffect(() => {
     return trackViewportTopOffset({ setViewportTopOffset });
   }, []);
+  // Legacy inbox refresh kept as fallback — unified sync polling below handles primary data loading
   useEffect(() => {
     return startLiveInboxRefresh({ setSnapshot, setRefreshError });
   }, []);
@@ -306,34 +308,6 @@ export function MobileRemoteShell({
       refreshInbox,
     });
   }, [loadHistory, refreshInbox, selectedSessionKey]);
-  useEffect(() => {
-    return startSessionPolling({
-      selectedSessionKey,
-      selectedSession,
-      pendingOwnedTurnBySession,
-      actionStateBySession,
-      waitingForResponse,
-      diffOpen,
-      selectedReviewFilePath,
-      documentVisibleRef,
-      loadHistory,
-      refreshInbox,
-      loadOwnedReviewPacket,
-      loadReviewFile,
-    });
-  }, [
-    actionStateBySession,
-    diffOpen,
-    loadHistory,
-    loadOwnedReviewPacket,
-    loadReviewFile,
-    pendingOwnedTurnBySession,
-    refreshInbox,
-    selectedReviewFilePath,
-    selectedSession,
-    selectedSessionKey,
-    waitingForResponse,
-  ]);
   const linkedOwnedKey = useMemo(() => {
     if (!selectedSession || selectedSession.runtime !== 'codex' || selectedSession.runtimeSurface?.ownership !== 'discovered') return null;
     const cwd = selectedSession.runtimeSurface?.cwd ?? selectedSession.workspace ?? '';
@@ -344,18 +318,44 @@ export function MobileRemoteShell({
     );
     return owned?.sessionKey ?? null;
   }, [selectedSession, snapshot.sessions]);
+  // Initial linked history load
   useEffect(() => {
     if (linkedOwnedKey && !historyBySession[linkedOwnedKey] && !historyLoading[linkedOwnedKey]) {
       void loadHistory(linkedOwnedKey, true).catch(() => undefined);
     }
   }, [linkedOwnedKey, historyBySession, historyLoading, loadHistory]);
+  // Unified sync polling — replaces separate session + linked + review file polling (5 requests → 1)
   useEffect(() => {
-    return startLinkedOwnedPolling({
+    return startUnifiedSyncPolling({
+      selectedSessionKey,
+      selectedSession,
       linkedOwnedKey,
+      pendingOwnedTurnBySession,
+      actionStateBySession,
+      waitingForResponse,
+      diffOpen,
+      selectedReviewFilePath,
       documentVisibleRef,
-      loadHistory,
+      historyBySession,
+      setSnapshot,
+      setRefreshError,
+      setHistoryBySession,
+      setHistoryGroupsBySession,
+      setReviewFileByPath,
+      loadOwnedReviewPacket,
     });
-  }, [linkedOwnedKey, loadHistory]);
+  }, [
+    actionStateBySession,
+    diffOpen,
+    historyBySession,
+    linkedOwnedKey,
+    loadOwnedReviewPacket,
+    pendingOwnedTurnBySession,
+    selectedReviewFilePath,
+    selectedSession,
+    selectedSessionKey,
+    waitingForResponse,
+  ]);
   const effectiveHistoryKey = linkedOwnedKey && historyBySession[linkedOwnedKey]?.length ? linkedOwnedKey : selectedSessionKey;
   const discoveredEntries = selectedSessionKey ? historyBySession[selectedSessionKey] ?? [] : [];
   const ownedEntries = linkedOwnedKey ? historyBySession[linkedOwnedKey] ?? [] : [];

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -59,9 +59,6 @@ import {
 import {
   connectTranscriptStream,
   pinTranscriptToBottom,
-  startLinkedOwnedPolling,
-  startLiveInboxRefresh,
-  startSessionPolling,
   startUnifiedSyncPolling,
   trackScrollChrome,
   trackViewportTopOffset,
@@ -167,10 +164,7 @@ export function MobileRemoteShell({
   useEffect(() => {
     return trackViewportTopOffset({ setViewportTopOffset });
   }, []);
-  // Legacy inbox refresh kept as fallback — unified sync polling below handles primary data loading
-  useEffect(() => {
-    return startLiveInboxRefresh({ setSnapshot, setRefreshError });
-  }, []);
+  // Inbox refresh handled by unified sync polling below
   useEffect(() => {
     return trackScrollChrome({
       setScrollY,

--- a/src/components/mobile/controller.ts
+++ b/src/components/mobile/controller.ts
@@ -28,6 +28,145 @@ const mobileClockFormatter = new Intl.DateTimeFormat('en-US', {
   minute: '2-digit',
 });
 
+// ── Consolidated sync ──
+
+interface SyncRequest {
+  inbox?: { etag?: string };
+  history?: { sessionKey: string; sinceId?: string; limit?: number };
+  review?: { sessionKey?: string; includeFile?: string };
+  linked?: { sessionKey: string; sinceId?: string };
+}
+
+interface SyncResponse {
+  inbox?: MobileInboxSnapshot | null;
+  inboxEtag?: string;
+  history?: { sessionKey: string; entries: MobileTranscriptEntry[] };
+  review?: { file?: MobileReviewFileResponse['file'] };
+  linked?: { sessionKey: string; entries: MobileTranscriptEntry[] };
+  serverTime: string;
+  errors?: Record<string, string>;
+}
+
+let cachedInboxEtag: string | undefined;
+
+interface MobileSyncArgs {
+  // What to request
+  wantInbox: boolean;
+  historySessionKey?: string;
+  historyLastId?: string;
+  reviewFilePath?: string;
+  linkedSessionKey?: string;
+  linkedLastId?: string;
+  // State setters
+  setSnapshot: Dispatch<SetStateAction<MobileInboxSnapshot>>;
+  setRefreshError: Dispatch<SetStateAction<string | null>>;
+  setHistoryBySession: Dispatch<SetStateAction<Record<string, MobileTranscriptEntry[]>>>;
+  setHistoryGroupsBySession: Dispatch<SetStateAction<Record<string, MobileRuntimeTailGroup[]>>>;
+  setReviewFileByPath: Dispatch<SetStateAction<Record<string, MobileReviewFileResponse['file']>>>;
+}
+
+export async function mobileSyncOnce({
+  wantInbox,
+  historySessionKey,
+  historyLastId,
+  reviewFilePath,
+  linkedSessionKey,
+  linkedLastId,
+  setSnapshot,
+  setRefreshError,
+  setHistoryBySession,
+  setHistoryGroupsBySession,
+  setReviewFileByPath,
+}: MobileSyncArgs): Promise<SyncResponse | null> {
+  const body: SyncRequest = {};
+  if (wantInbox) body.inbox = { etag: cachedInboxEtag };
+  if (historySessionKey) body.history = { sessionKey: historySessionKey, sinceId: historyLastId, limit: 18 };
+  if (reviewFilePath) body.review = { includeFile: reviewFilePath };
+  if (linkedSessionKey) body.linked = { sessionKey: linkedSessionKey, sinceId: linkedLastId };
+
+  // Nothing to sync
+  if (!body.inbox && !body.history && !body.review && !body.linked) return null;
+
+  try {
+    const response = await fetch('/api/mobile/sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) throw new Error(`sync HTTP ${response.status}`);
+    const data = (await response.json()) as SyncResponse;
+
+    // Apply inbox
+    if (data.inboxEtag) cachedInboxEtag = data.inboxEtag;
+    if (data.inbox) {
+      setSnapshot((prev) => {
+        const prevKey = prev.sessions.map((s) => `${s.sessionKey}:${s.status}:${Math.round(s.context?.usedPercent ?? 0)}`).join('|');
+        const nextKey = data.inbox!.sessions.map((s) => `${s.sessionKey}:${s.status}:${Math.round(s.context?.usedPercent ?? 0)}`).join('|');
+        if (prevKey === nextKey && prev.summary.alerts === data.inbox!.summary.alerts) return prev;
+        return data.inbox!;
+      });
+      setRefreshError(null);
+    }
+
+    // Apply history
+    if (data.history && data.history.entries.length > 0) {
+      const sk = data.history.sessionKey;
+      const newEntries = data.history.entries;
+      setHistoryBySession((current) => {
+        const prev = current[sk] ?? [];
+        if (historyLastId) {
+          // Delta mode: append new entries
+          const existingIds = new Set(prev.map((e) => e.id));
+          const genuinelyNew = newEntries.filter((e) => !existingIds.has(e.id));
+          if (genuinelyNew.length === 0) return current;
+          return { ...current, [sk]: [...prev, ...genuinelyNew] };
+        }
+        // Full mode
+        if (
+          prev.length === newEntries.length
+          && prev.length > 0
+          && prev[prev.length - 1]?.id === newEntries[newEntries.length - 1]?.id
+          && prev[prev.length - 1]?.text === newEntries[newEntries.length - 1]?.text
+        ) return current;
+        return { ...current, [sk]: newEntries };
+      });
+    }
+
+    // Apply review file
+    if (data.review?.file && reviewFilePath) {
+      setReviewFileByPath((current) => ({ ...current, [reviewFilePath]: data.review!.file as MobileReviewFileResponse['file'] }));
+    }
+
+    // Apply linked history
+    if (data.linked && data.linked.entries.length > 0 && linkedSessionKey) {
+      const sk = data.linked.sessionKey;
+      const newEntries = data.linked.entries;
+      setHistoryBySession((current) => {
+        const prev = current[sk] ?? [];
+        if (linkedLastId) {
+          const existingIds = new Set(prev.map((e) => e.id));
+          const genuinelyNew = newEntries.filter((e) => !existingIds.has(e.id));
+          if (genuinelyNew.length === 0) return current;
+          return { ...current, [sk]: [...prev, ...genuinelyNew] };
+        }
+        if (
+          prev.length === newEntries.length
+          && prev.length > 0
+          && prev[prev.length - 1]?.id === newEntries[newEntries.length - 1]?.id
+        ) return current;
+        return { ...current, [sk]: newEntries };
+      });
+    }
+
+    return data;
+  } catch (error) {
+    if (wantInbox) {
+      setRefreshError(error instanceof Error ? error.message : 'sync failed');
+    }
+    return null;
+  }
+}
+
 interface RefreshInboxArgs {
   setSnapshot: Dispatch<SetStateAction<MobileInboxSnapshot>>;
   setRefreshError: Dispatch<SetStateAction<string | null>>;

--- a/src/components/mobile/effects.ts
+++ b/src/components/mobile/effects.ts
@@ -12,6 +12,7 @@ import type {
   MobileTranscriptEntry,
 } from '@/lib/mobile/types';
 import type { ActionState, PendingOwnedTurn, SessionSummary } from './types';
+import { mobileSyncOnce } from './controller';
 
 interface ViewportOffsetArgs {
   setViewportTopOffset: Dispatch<SetStateAction<number>>;
@@ -290,6 +291,108 @@ export function startLinkedOwnedPolling({
     if (!documentVisibleRef.current) return;
     void loadHistory(linkedOwnedKey, true).catch(() => undefined);
   }, 3000);
+
+  return () => window.clearInterval(timer);
+}
+
+// ── Unified sync polling (replaces inbox + session + linked polling) ──
+
+interface UnifiedSyncPollingArgs {
+  selectedSessionKey?: string;
+  selectedSession?: SessionSummary;
+  linkedOwnedKey: string | null;
+  pendingOwnedTurnBySession: Record<string, PendingOwnedTurn>;
+  actionStateBySession: Record<string, ActionState>;
+  waitingForResponse: boolean;
+  diffOpen: boolean;
+  selectedReviewFilePath: string | null;
+  documentVisibleRef: MutableRefObject<boolean>;
+  historyBySession: Record<string, MobileTranscriptEntry[]>;
+  // State setters for sync
+  setSnapshot: Dispatch<SetStateAction<MobileInboxSnapshot>>;
+  setRefreshError: Dispatch<SetStateAction<string | null>>;
+  setHistoryBySession: Dispatch<SetStateAction<Record<string, MobileTranscriptEntry[]>>>;
+  setHistoryGroupsBySession: Dispatch<SetStateAction<Record<string, MobileRuntimeTailGroup[]>>>;
+  setReviewFileByPath: Dispatch<SetStateAction<Record<string, MobileReviewFileResponse['file']>>>;
+  // Legacy loaders for owned review packet (stays separate — not in sync endpoint yet)
+  loadOwnedReviewPacket: (sessionKey: string, force?: boolean) => Promise<RuntimeReviewPacket | null | undefined>;
+}
+
+export function startUnifiedSyncPolling(args: UnifiedSyncPollingArgs) {
+  const {
+    selectedSessionKey,
+    selectedSession,
+    linkedOwnedKey,
+    pendingOwnedTurnBySession,
+    actionStateBySession,
+    waitingForResponse,
+    diffOpen,
+    selectedReviewFilePath,
+    documentVisibleRef,
+    historyBySession,
+    setSnapshot,
+    setRefreshError,
+    setHistoryBySession,
+    setHistoryGroupsBySession,
+    setReviewFileByPath,
+    loadOwnedReviewPacket,
+  } = args;
+
+  // Determine polling interval based on activity level
+  const ownedActive = selectedSessionKey?.startsWith('codex-owned:')
+    && (
+      selectedSession?.runtimeSurface?.lifecycle?.availability === 'running'
+      || Boolean(selectedSessionKey && pendingOwnedTurnBySession[selectedSessionKey])
+      || (selectedSessionKey && actionStateBySession[selectedSessionKey] === 'steering')
+    );
+  const isActive = ownedActive || selectedSession?.status === 'running' || waitingForResponse;
+  const intervalMs = ownedActive
+    ? 1500
+    : selectedSessionKey?.startsWith('codex-owned:')
+      ? 4000
+      : isActive
+        ? 2500
+        : 20000;
+
+  function getLastId(sessionKey: string): string | undefined {
+    const entries = historyBySession[sessionKey];
+    if (!entries?.length) return undefined;
+    const last = entries[entries.length - 1];
+    return last?.id?.startsWith('optimistic-') ? undefined : last?.id;
+  }
+
+  async function tick() {
+    if (!documentVisibleRef.current) return;
+
+    const wantReviewFile = !!(
+      selectedReviewFilePath
+      && diffOpen
+      && (isActive || selectedSessionKey?.startsWith('codex-owned:'))
+    );
+
+    await mobileSyncOnce({
+      wantInbox: isActive || !selectedSessionKey, // Always sync inbox when idle on squad view
+      historySessionKey: selectedSessionKey,
+      historyLastId: selectedSessionKey ? getLastId(selectedSessionKey) : undefined,
+      reviewFilePath: wantReviewFile ? selectedReviewFilePath ?? undefined : undefined,
+      linkedSessionKey: linkedOwnedKey ?? undefined,
+      linkedLastId: linkedOwnedKey ? getLastId(linkedOwnedKey) : undefined,
+      setSnapshot,
+      setRefreshError,
+      setHistoryBySession,
+      setHistoryGroupsBySession,
+      setReviewFileByPath,
+    });
+
+    // Owned review packet stays on the legacy endpoint (not consolidated yet)
+    if (selectedSessionKey?.startsWith('codex-owned:')) {
+      void loadOwnedReviewPacket(selectedSessionKey, true).catch(() => undefined);
+    }
+  }
+
+  // Initial sync
+  void tick();
+  const timer = window.setInterval(() => void tick(), intervalMs);
 
   return () => window.clearInterval(timer);
 }


### PR DESCRIPTION
## The Problem
Mobile client fires **5 concurrent polling loops** per cycle: inbox, history, review file, linked history, and review packet. Each has its own TCP connection, HTTP overhead, and response parsing. On cellular (100-300ms RTT), this saturates the connection and burns battery.

## The Fix
Single `POST /api/mobile/sync` endpoint that accepts a manifest of what the client needs and resolves everything server-side in parallel.

### Server
- `Promise.all` resolves inbox + history + review file + linked history concurrently
- **ETag caching**: inbox includes an ETag; client sends it back and gets `null` if nothing changed (zero bandwidth for unchanged sessions)
- **Delta history**: `sinceId` param returns only entries after the last known ID
- **Error isolation**: one section failing doesn't block the others — partial results with error details
- Server-side inbox cache with 5s TTL + request dedup

### Client
- New `mobileSyncOnce()` function in controller replaces individual fetch calls
- New `startUnifiedSyncPolling()` effect replaces `startSessionPolling` + `startLinkedOwnedPolling`
- Smart interval unchanged: 1.5s (owned active) / 2.5s (active) / 4s (owned idle) / 20s (idle)
- Legacy `startLiveInboxRefresh` kept as safety net (30s interval)

### Result
| Before | After |
|---|---|
| 5 concurrent fetch loops | 1 unified sync |
| 5 TCP connections per cycle | 1 TCP connection |
| Full inbox on every poll | ETag skip when unchanged |
| Full history on every poll | Delta entries only |

Legacy endpoints preserved — no breaking changes.

Closes #50