### PR TITLE
#47 Virtual scrolling — O(n) DOM nodes → O(15)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@json-render/core": "^0.14.0",
         "@json-render/react": "^0.14.0",
         "@json-render/shadcn": "^0.14.0",
+        "@tanstack/react-virtual": "^3.13.22",
         "lucide-react": "^0.577.0",
         "next": "^16.1.6",
         "react": "^19.2.4",
@@ -2991,6 +2992,33 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.22",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.22.tgz",
+      "integrity": "sha512-EaOrBBJLi3M0bTMQRjGkxLXRw7Gizwntoy5E2Q2UnSbML7Mo2a1P/Hfkw5tw9FLzK62bj34Jl6VNbQfRV6eJcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.22",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.22.tgz",
+      "integrity": "sha512-isuUGKsc5TAPDoHSbWTbl1SCil54zOS2MiWz/9GCWHPUQOvNTQx8qJEWC7UWR0lShhbK0Lmkcf0SZYxvch7G3g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@json-render/core": "^0.14.0",
     "@json-render/react": "^0.14.0",
     "@json-render/shadcn": "^0.14.0",
+    "@tanstack/react-virtual": "^3.13.22",
     "lucide-react": "^0.577.0",
     "next": "^16.1.6",
     "react": "^19.2.4",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2477,8 +2477,12 @@ button.workflow-file-item.workflow-file-item-active {
 }
 
 .remodex-message-stack {
-  display: grid;
-  gap: 1rem;
+  display: block;
+  flex: 1;
+  min-height: 0;
+}
+.remodex-message-stack > [data-index] {
+  padding-bottom: 1rem;
 }
 
 .remodex-scroll-anchor {

--- a/src/components/mobile/ChatView.tsx
+++ b/src/components/mobile/ChatView.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { memo, useCallback, useEffect, useRef } from 'react';
+import { useWindowVirtualizer } from '@tanstack/react-virtual';
 import Image from 'next/image';
 import { ChevronRight, FileDiff, FileText, Image as ImageIcon } from 'lucide-react';
 import type { MobileTranscriptMedia } from '@/lib/mobile/types';
@@ -9,6 +13,158 @@ import {
   mediaHref,
   roleLabel,
 } from './utils';
+
+// ── Memoized message bubble — only re-renders when its own data changes ──
+
+interface MessageBubbleProps {
+  entry: ChatViewProps['transcriptEntries'][number];
+  index: number;
+  previousEntry: ChatViewProps['transcriptEntries'][number] | null;
+  isLatest: boolean;
+  isNewMessage: boolean;
+  isOwnedCodexSession: boolean;
+  selectedSession: ChatViewProps['selectedSession'];
+  selectedReviewFile: ChatViewProps['selectedReviewFile'];
+  renderMessageBody: ChatViewProps['renderMessageBody'];
+  setExpandedMedia: ChatViewProps['setExpandedMedia'];
+  onOpenDiff: ChatViewProps['onOpenDiff'];
+  onScrollToLatestMessage: ChatViewProps['onScrollToLatestMessage'];
+}
+
+const MessageBubble = memo(function MessageBubble({
+  entry,
+  index,
+  previousEntry,
+  isLatest,
+  isNewMessage,
+  isOwnedCodexSession,
+  selectedSession,
+  selectedReviewFile,
+  renderMessageBody,
+  setExpandedMedia,
+  onOpenDiff,
+  onScrollToLatestMessage,
+}: MessageBubbleProps) {
+  const isUser = entry.role === 'user';
+  const hasText = Boolean(entry.text.trim());
+  const hasMedia = Boolean(entry.media?.length);
+  const fadeClass = isNewMessage ? ' remodex-turn-new' : '';
+  const speakerChanged = !previousEntry || previousEntry.role !== entry.role;
+  const showTimestamp = (() => {
+    if (!previousEntry?.timestampLabel || !entry.timestampLabel) return speakerChanged;
+    const previous = new Date(`1970-01-01 ${previousEntry.timestampLabel}`).getTime();
+    const current = new Date(`1970-01-01 ${entry.timestampLabel}`).getTime();
+    if (Number.isNaN(previous) || Number.isNaN(current)) return speakerChanged;
+    return Math.abs(current - previous) >= 15 * 60 * 1000;
+  })();
+
+  if (isUser) {
+    return (
+      <div className={`remodex-user-turn-wrap${fadeClass}`}>
+        {hasText ? <div className="remodex-user-bubble">{renderMessageBody(entry.text, `${entry.id}-user`)}</div> : null}
+        {hasMedia ? <MediaGrid media={entry.media ?? []} align="right" setExpandedMedia={setExpandedMedia} onScrollToLatestMessage={onScrollToLatestMessage} /> : null}
+        {showTimestamp ? <span className="remodex-turn-time">{entry.timestampLabel ?? 'now'}</span> : null}
+      </div>
+    );
+  }
+
+  const isCompaction = entry.role === 'system' && entry.text.toLowerCase().includes('compaction');
+  if (isCompaction) {
+    return (
+      <div className="remodex-compaction-card">
+        <span className="remodex-compaction-icon" aria-hidden="true">⟳</span>
+        <span className="remodex-compaction-label">Context compacted</span>
+        {showTimestamp ? <span className="remodex-compaction-time">{entry.timestampLabel ?? ''}</span> : null}
+      </div>
+    );
+  }
+
+  const agentName = isOwnedCodexSession ? 'Codex' : (selectedSession?.isCurrentSession ? 'Mister' : undefined);
+
+  return (
+    <article className={`remodex-message-card remodex-message-card-assistant${fadeClass}`}>
+      {speakerChanged ? (
+        <div className="remodex-message-head">
+          <span>{roleLabel(entry.role, agentName)}</span>
+        </div>
+      ) : null}
+      {hasText ? renderMessageBody(entry.text, `${entry.id}-assistant`) : null}
+      {hasMedia ? <MediaGrid media={entry.media ?? []} align="left" setExpandedMedia={setExpandedMedia} onScrollToLatestMessage={onScrollToLatestMessage} /> : null}
+      {isLatest && selectedReviewFile ? (
+        <button type="button" className="remodex-inline-diff-thumb" onClick={onOpenDiff}>
+          <div className="remodex-inline-diff-mini">
+            <FileDiff size={16} strokeWidth={1.8} />
+          </div>
+          <div className="remodex-inline-diff-copy">
+            <strong>{selectedReviewFile.path.split('/').pop() ?? selectedReviewFile.path}</strong>
+            <span>{`${selectedReviewFile.additions ?? 0} additions, ${selectedReviewFile.deletions ?? 0} removals`}</span>
+          </div>
+          <ChevronRight size={16} strokeWidth={1.6} className="remodex-inline-diff-chevron" />
+        </button>
+      ) : null}
+    </article>
+  );
+});
+
+// ── Media grid (extracted for memo boundary) ──
+
+function MediaGrid({
+  media,
+  align,
+  setExpandedMedia,
+  onScrollToLatestMessage,
+}: {
+  media: MobileTranscriptMedia[];
+  align: 'left' | 'right';
+  setExpandedMedia: (media: MobileTranscriptMedia | null) => void;
+  onScrollToLatestMessage: () => void;
+}) {
+  return (
+    <div className={`remodex-media-grid ${align === 'right' ? 'remodex-media-grid-right' : ''}`}>
+      {media.map((item) => {
+        if (isImageMedia(item)) {
+          return (
+            <button
+              key={item.path}
+              type="button"
+              className="remodex-media-card remodex-media-card-image"
+              onClick={() => setExpandedMedia(item)}
+            >
+              <Image
+                src={mediaHref(item.path)}
+                alt={item.name}
+                width={1200}
+                height={900}
+                unoptimized
+                loading="lazy"
+                onLoadingComplete={() => onScrollToLatestMessage()}
+              />
+              <span className="remodex-media-card-caption">Tap to expand</span>
+            </button>
+          );
+        }
+
+        return (
+          <div key={item.path} className="remodex-media-card remodex-media-card-file">
+            <div className="remodex-media-file-icon">
+              {item.kind === 'pdf' ? <FileText size={18} strokeWidth={2.1} /> : <ImageIcon size={18} strokeWidth={2.1} />}
+            </div>
+            <div className="remodex-media-file-copy">
+              <strong>{item.name}</strong>
+              <span>{item.kind === 'pdf' ? 'PDF artifact' : 'File artifact'}</span>
+            </div>
+            <div className="remodex-media-file-actions">
+              <a href={mediaHref(item.path)} target="_blank" rel="noreferrer">Open</a>
+              <a href={mediaHref(item.path, true)} download={item.name}>Save</a>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Virtualized chat view ──
 
 export function ChatView({
   transcriptEntries,
@@ -28,131 +184,102 @@ export function ChatView({
   onOpenDiff,
   onScrollToLatestMessage,
 }: ChatViewProps) {
-  function renderMediaGrid(media: MobileTranscriptMedia[], align: 'left' | 'right' = 'left') {
-    return (
-      <div className={`remodex-media-grid ${align === 'right' ? 'remodex-media-grid-right' : ''}`}>
-        {media.map((item) => {
-          if (isImageMedia(item)) {
-            return (
-              <button
-                key={item.path}
-                type="button"
-                className="remodex-media-card remodex-media-card-image"
-                onClick={() => setExpandedMedia(item)}
-              >
-                <Image
-                  src={mediaHref(item.path)}
-                  alt={item.name}
-                  width={1200}
-                  height={900}
-                  unoptimized
-                  loading="lazy"
-                  onLoadingComplete={() => {
-                    onScrollToLatestMessage();
-                  }}
-                />
-                <span className="remodex-media-card-caption">Tap to expand</span>
-              </button>
-            );
-          }
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const stickToBottomRef = useRef(true);
 
-          return (
-            <div key={item.path} className="remodex-media-card remodex-media-card-file">
-              <div className="remodex-media-file-icon">
-                {item.kind === 'pdf' ? <FileText size={18} strokeWidth={2.1} /> : <ImageIcon size={18} strokeWidth={2.1} />}
-              </div>
-              <div className="remodex-media-file-copy">
-                <strong>{item.name}</strong>
-                <span>{item.kind === 'pdf' ? 'PDF artifact' : 'File artifact'}</span>
-              </div>
-              <div className="remodex-media-file-actions">
-                <a href={mediaHref(item.path)} target="_blank" rel="noreferrer">Open</a>
-                <a href={mediaHref(item.path, true)} download={item.name}>Save</a>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    );
-  }
+  const getIsNew = useCallback((entryId: string) => {
+    return hydrated
+      && seenMessageIdsRef.current != null
+      && seenMessageIdsRef.current.size > 0
+      && !seenMessageIdsRef.current.has(entryId);
+  }, [hydrated, seenMessageIdsRef]);
+
+  const markSeen = useCallback((entryId: string) => {
+    seenMessageIdsRef.current?.add(entryId);
+  }, [seenMessageIdsRef]);
+
+  const estimateSize = useCallback((index: number) => {
+    const entry = transcriptEntries[index];
+    if (!entry) return 60;
+    const textLen = entry.text?.length ?? 0;
+    const hasMedia = Boolean(entry.media?.length);
+    if (entry.role === 'user') return Math.max(52, 52 + Math.ceil(textLen / 60) * 20 + (hasMedia ? 200 : 0));
+    if (entry.role === 'system' && entry.text.toLowerCase().includes('compaction')) return 44;
+    return Math.max(64, 64 + Math.ceil(textLen / 50) * 22 + (hasMedia ? 200 : 0));
+  }, [transcriptEntries]);
+
+  const virtualizer = useWindowVirtualizer({
+    count: transcriptEntries.length,
+    estimateSize,
+    overscan: 8,
+    scrollMargin: listRef.current?.offsetTop ?? 0,
+  });
+
+  // Stick-to-bottom: auto-scroll when new messages arrive
+  useEffect(() => {
+    if (!stickToBottomRef.current || transcriptEntries.length === 0) return;
+    requestAnimationFrame(() => {
+      window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' });
+    });
+  }, [transcriptEntries.length]);
+
+  // Track scroll position to determine stick-to-bottom
+  useEffect(() => {
+    const handleScroll = () => {
+      const distanceFromBottom = document.documentElement.scrollHeight - window.scrollY - window.innerHeight;
+      stickToBottomRef.current = distanceFromBottom < 120;
+    };
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const hasEntries = transcriptEntries.length > 0;
+  const virtualItems = virtualizer.getVirtualItems();
 
   return (
     <>
-      <div className="remodex-message-stack">
-        {transcriptEntries.length ? transcriptEntries.map((entry, index) => {
-          const isUser = entry.role === 'user';
-          const isLatest = !transcriptEntries.slice(index + 1).some((item) => item.role === 'assistant');
-          const hasText = Boolean(entry.text.trim());
-          const hasMedia = Boolean(entry.media?.length);
-          const isNewMessage = hydrated
-            && seenMessageIdsRef.current != null
-            && seenMessageIdsRef.current.size > 0
-            && !seenMessageIdsRef.current.has(entry.id);
-          if (isNewMessage) {
-            seenMessageIdsRef.current?.add(entry.id);
-          }
-          const fadeClass = isNewMessage ? ' remodex-turn-new' : '';
-          const previousEntry = index > 0 ? transcriptEntries[index - 1] : null;
-          const speakerChanged = !previousEntry || previousEntry.role !== entry.role;
-          const showTimestamp = (() => {
-            if (!previousEntry?.timestampLabel || !entry.timestampLabel) {
-              return speakerChanged;
-            }
-            const previous = new Date(`1970-01-01 ${previousEntry.timestampLabel}`).getTime();
-            const current = new Date(`1970-01-01 ${entry.timestampLabel}`).getTime();
-            if (Number.isNaN(previous) || Number.isNaN(current)) {
-              return speakerChanged;
-            }
-            return Math.abs(current - previous) >= 15 * 60 * 1000;
-          })();
+      <div ref={listRef} className="remodex-message-stack">
+        {hasEntries ? (
+          <div style={{ height: virtualizer.getTotalSize(), width: '100%', position: 'relative' }}>
+            {virtualItems.map((virtualRow) => {
+              const entry = transcriptEntries[virtualRow.index];
+              const previousEntry = virtualRow.index > 0 ? transcriptEntries[virtualRow.index - 1] : null;
+              const isLatest = !transcriptEntries.slice(virtualRow.index + 1).some((item) => item.role === 'assistant');
+              const isNew = getIsNew(entry.id);
+              if (isNew) markSeen(entry.id);
 
-          if (isUser) {
-            return (
-              <div key={entry.id} className={`remodex-user-turn-wrap${fadeClass}`}>
-                {hasText ? <div className="remodex-user-bubble">{renderMessageBody(entry.text, `${entry.id}-user`)}</div> : null}
-                {hasMedia ? renderMediaGrid(entry.media ?? [], 'right') : null}
-                {showTimestamp ? <span className="remodex-turn-time">{entry.timestampLabel ?? 'now'}</span> : null}
-              </div>
-            );
-          }
-
-          const isCompaction = entry.role === 'system' && entry.text.toLowerCase().includes('compaction');
-          if (isCompaction) {
-            return (
-              <div key={entry.id} className="remodex-compaction-card">
-                <span className="remodex-compaction-icon" aria-hidden="true">⟳</span>
-                <span className="remodex-compaction-label">Context compacted</span>
-                {showTimestamp ? <span className="remodex-compaction-time">{entry.timestampLabel ?? ''}</span> : null}
-              </div>
-            );
-          }
-
-          const agentName = isOwnedCodexSession ? 'Codex' : (selectedSession?.isCurrentSession ? 'Mister' : undefined);
-
-          return (
-            <article key={entry.id} className={`remodex-message-card remodex-message-card-assistant${fadeClass}`}>
-              {speakerChanged ? (
-                <div className="remodex-message-head">
-                  <span>{roleLabel(entry.role, agentName)}</span>
+              return (
+                <div
+                  key={entry.id}
+                  data-index={virtualRow.index}
+                  ref={virtualizer.measureElement}
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    transform: `translateY(${virtualRow.start - (virtualizer.options.scrollMargin ?? 0)}px)`,
+                  }}
+                >
+                  <MessageBubble
+                    entry={entry}
+                    index={virtualRow.index}
+                    previousEntry={previousEntry}
+                    isLatest={isLatest}
+                    isNewMessage={isNew}
+                    isOwnedCodexSession={isOwnedCodexSession}
+                    selectedSession={selectedSession}
+                    selectedReviewFile={selectedReviewFile}
+                    renderMessageBody={renderMessageBody}
+                    setExpandedMedia={setExpandedMedia}
+                    onOpenDiff={onOpenDiff}
+                    onScrollToLatestMessage={onScrollToLatestMessage}
+                  />
                 </div>
-              ) : null}
-              {hasText ? renderMessageBody(entry.text, `${entry.id}-assistant`) : null}
-              {hasMedia ? renderMediaGrid(entry.media ?? []) : null}
-              {isLatest && selectedReviewFile ? (
-                <button type="button" className="remodex-inline-diff-thumb" onClick={onOpenDiff}>
-                  <div className="remodex-inline-diff-mini">
-                    <FileDiff size={16} strokeWidth={1.8} />
-                  </div>
-                  <div className="remodex-inline-diff-copy">
-                    <strong>{selectedReviewFile.path.split('/').pop() ?? selectedReviewFile.path}</strong>
-                    <span>{`${selectedReviewFile.additions ?? 0} additions, ${selectedReviewFile.deletions ?? 0} removals`}</span>
-                  </div>
-                  <ChevronRight size={16} strokeWidth={1.6} className="remodex-inline-diff-chevron" />
-                </button>
-              ) : null}
-            </article>
-          );
-        }) : transcriptLoading ? (
+              );
+            })}
+          </div>
+        ) : transcriptLoading ? (
           <div className="remodex-skeleton-stack">
             <div className="remodex-skeleton-bubble remodex-skeleton-assistant" />
             <div className="remodex-skeleton-bubble remodex-skeleton-user" />


### PR DESCRIPTION
## The Problem
All transcript entries render as real DOM nodes. 50+ message session = 50+ `<article>` elements, each with inline markdown parsing. New message → ALL existing messages re-render.

## The Fix
`@tanstack/react-virtual` with `useWindowVirtualizer`:
- Only ~15 DOM nodes rendered at any time (visible + 8 overscan)
- `React.memo` on `MessageBubble` — individual messages skip re-render unless their data changes
- Dynamic height estimation + `measureElement` callback for pixel-accurate heights after first paint
- Stick-to-bottom behavior preserved via scroll distance tracking

### Performance Impact
| Metric | Before | After |
|---|---|---|
| DOM nodes (50-msg session) | 50+ articles | ~15 articles |
| New message render | Re-renders ALL messages | Renders 1 new + reflows ~2 |
| Scroll performance | DOM bloat → jank | Constant ~15 nodes |
| Memory | All messages in DOM | Only visible in DOM |

Closes #47