### PR TITLE
fix: final 7 points — pre-fetch, new messages pill, event-driven push

### DIFF
--- a/src/components/mobile/ChatView.tsx
+++ b/src/components/mobile/ChatView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useWindowVirtualizer } from '@tanstack/react-virtual';
 import Image from 'next/image';
 import { ChevronRight, FileDiff, FileText, Image as ImageIcon } from 'lucide-react';
@@ -187,6 +187,8 @@ export function ChatView({
 }: ChatViewProps) {
   const listRef = useRef<HTMLDivElement | null>(null);
   const stickToBottomRef = useRef(true);
+  const [hasNewMessages, setHasNewMessages] = useState(false);
+  const prevEntryCountRef = useRef(transcriptEntries.length);
 
   const getIsNew = useCallback((entryId: string) => {
     return hydrated
@@ -224,15 +226,29 @@ export function ChatView({
     });
   }, [transcriptEntries.length]);
 
-  // Track scroll position to determine stick-to-bottom
+  // Track scroll position to determine stick-to-bottom + new message pill
   useEffect(() => {
     const handleScroll = () => {
       const distanceFromBottom = document.documentElement.scrollHeight - window.scrollY - window.innerHeight;
-      stickToBottomRef.current = distanceFromBottom < 120;
+      const atBottom = distanceFromBottom < 120;
+      stickToBottomRef.current = atBottom;
+      if (atBottom) setHasNewMessages(false);
     };
     window.addEventListener('scroll', handleScroll, { passive: true });
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
+
+  // Detect new assistant messages while scrolled up
+  useEffect(() => {
+    const prevCount = prevEntryCountRef.current;
+    prevEntryCountRef.current = transcriptEntries.length;
+    if (transcriptEntries.length > prevCount && !stickToBottomRef.current) {
+      const newEntries = transcriptEntries.slice(prevCount);
+      if (newEntries.some((e) => e.role === 'assistant')) {
+        setHasNewMessages(true);
+      }
+    }
+  }, [transcriptEntries]);
 
   const hasEntries = transcriptEntries.length > 0;
   const virtualItems = virtualizer.getVirtualItems();
@@ -331,6 +347,39 @@ export function ChatView({
             <span className="remodex-typing-dot" />
           </div>
         </div>
+      ) : null}
+
+      {hasNewMessages ? (
+        <button
+          type="button"
+          onClick={() => {
+            setHasNewMessages(false);
+            onScrollToLatestMessage(true);
+          }}
+          style={{
+            position: 'fixed',
+            bottom: '120px',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            zIndex: 20,
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+            padding: '8px 16px',
+            borderRadius: '20px',
+            backgroundColor: '#007aff',
+            color: '#ffffff',
+            fontSize: '13px',
+            fontWeight: 600,
+            border: 'none',
+            boxShadow: '0 4px 16px rgba(0,122,255,0.35)',
+            cursor: 'pointer',
+            animation: 'pill-bounce-in 0.3s ease-out',
+          }}
+        >
+          <span style={{ fontSize: '14px' }}>↓</span> New messages
+          <style>{`@keyframes pill-bounce-in { from { opacity: 0; transform: translateX(-50%) translateY(10px); } to { opacity: 1; transform: translateX(-50%) translateY(0); } }`}</style>
+        </button>
       ) : null}
 
       {isRefreshing && transcriptEntries.length > 0 ? (

--- a/src/components/mobile/hooks/useMobilePolling.ts
+++ b/src/components/mobile/hooks/useMobilePolling.ts
@@ -181,6 +181,41 @@ export function useMobilePolling(state: MobileState, wsConnected: boolean) {
     documentVisibleRef,
   ]);
 
+  // Pre-fetch adjacent session history during idle (#46 optimistic rendering)
+  useEffect(() => {
+    if (!selectedSessionKey || !snapshot.sessions.length) return;
+    const currentIndex = snapshot.sessions.findIndex((s) => s.sessionKey === selectedSessionKey);
+    if (currentIndex < 0) return;
+
+    // Gather up to 2 adjacent sessions that haven't been loaded yet
+    const adjacentKeys: string[] = [];
+    for (const offset of [1, -1]) {
+      const idx = currentIndex + offset;
+      if (idx >= 0 && idx < snapshot.sessions.length) {
+        const key = snapshot.sessions[idx].sessionKey;
+        if (key && !historyBySession[key]?.length && !historyLoading[key]) {
+          adjacentKeys.push(key);
+        }
+      }
+    }
+    if (adjacentKeys.length === 0) return;
+
+    // Use requestIdleCallback (or setTimeout fallback) to pre-fetch during idle
+    const idleCallback = typeof window.requestIdleCallback === 'function'
+      ? window.requestIdleCallback
+      : (cb: () => void) => window.setTimeout(cb, 2000);
+    const cancelIdle = typeof window.cancelIdleCallback === 'function'
+      ? window.cancelIdleCallback
+      : (id: number) => window.clearTimeout(id);
+
+    const id = idleCallback(() => {
+      for (const key of adjacentKeys) {
+        void loadHistory(key).catch(() => undefined);
+      }
+    });
+    return () => cancelIdle(id);
+  }, [selectedSessionKey, snapshot.sessions, historyBySession, historyLoading, loadHistory]);
+
   return {
     refreshInbox,
     loadHistory,

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -150,6 +150,17 @@ function connectGateway() {
         }
       }
     }
+
+    // Handle session events — push inbox on any session state change
+    if (parsed.type === 'event' && (
+      parsed.event === 'session.updated' ||
+      parsed.event === 'session.created' ||
+      parsed.event === 'session.deleted' ||
+      parsed.event === 'agent.status'
+    )) {
+      // Debounce: push inbox to all clients after a short delay
+      scheduleEventDrivenInboxPush();
+    }
   });
 
   ws.on('close', () => {
@@ -276,32 +287,59 @@ function onChatDelta(delta: ChatDelta) {
       send(client, { channel: 'chat', event: 'delta', data: { text, runId: delta.runId, seq: delta.seq } });
     } else if (delta.state === 'done') {
       send(client, { channel: 'chat', event: 'done', data: { text, runId: delta.runId, seq: delta.seq } });
+      // Event-driven push: immediately sync history + inbox on completion
+      setTimeout(() => pushHistoryForSession(delta.sessionKey), 500);
+      scheduleEventDrivenInboxPush();
     } else if (delta.state === 'error' || delta.state === 'aborted') {
       send(client, { channel: 'chat', event: 'error', data: { state: delta.state, error: delta.error, runId: delta.runId } });
+      scheduleEventDrivenInboxPush();
     }
   }
 }
 
 chatListeners.add(onChatDelta);
 
-// ── Polling loops (push changes to clients) ──
+// ── Event-driven push with safety-net polling ──
+
+let inboxPushTimer: ReturnType<typeof setTimeout> | null = null;
+const INBOX_PUSH_DEBOUNCE_MS = 300;
+const SAFETY_NET_INBOX_MS = 10_000; // 10s safety net (was 3s active poll)
+const SAFETY_NET_HISTORY_MS = 8_000; // 8s safety net (was 2s active poll)
+
+function scheduleEventDrivenInboxPush() {
+  if (inboxPushTimer) clearTimeout(inboxPushTimer);
+  inboxPushTimer = setTimeout(() => {
+    inboxPushTimer = null;
+    const activeClients = [...clients.values()].filter((c) => c.ws.readyState === WebSocket.OPEN);
+    if (activeClients.length === 0) return;
+    void Promise.allSettled(activeClients.map((c) => syncClientInbox(c)));
+  }, INBOX_PUSH_DEBOUNCE_MS);
+}
+
+function pushHistoryForSession(sessionKey: string) {
+  const matchingClients = [...clients.values()].filter(
+    (c) => c.ws.readyState === WebSocket.OPEN && c.sessionKey === sessionKey,
+  );
+  if (matchingClients.length === 0) return;
+  void Promise.allSettled(matchingClients.map((c) => syncClientHistory(c)));
+}
 
 function startPollingLoops() {
-  // Inbox poll — check for changes and push (parallel across clients)
+  // Safety-net inbox poll — reduced frequency since event-driven push handles most updates
   setInterval(() => {
     const activeClients = [...clients.values()].filter((c) => c.ws.readyState === WebSocket.OPEN);
     if (activeClients.length === 0) return;
     void Promise.allSettled(activeClients.map((c) => syncClientInbox(c)));
-  }, INBOX_POLL_MS);
+  }, SAFETY_NET_INBOX_MS);
 
-  // History poll — check for new entries and push (parallel across clients)
+  // Safety-net history poll — reduced frequency since chat.done triggers immediate push
   setInterval(() => {
     const activeClients = [...clients.values()].filter(
       (c) => c.ws.readyState === WebSocket.OPEN && c.sessionKey,
     );
     if (activeClients.length === 0) return;
     void Promise.allSettled(activeClients.map((c) => syncClientHistory(c)));
-  }, HISTORY_POLL_MS);
+  }, SAFETY_NET_HISTORY_MS);
 }
 
 // ── Server startup ──


### PR DESCRIPTION
## Missing commit from PR #62

The merge caught `cb8a222` but missed `8613e6c` which was pushed right before merge. This cherry-picks it cleanly.

### What's in this commit

**#46 Pre-fetching (3 pts):**
- Adjacent session history pre-fetched during idle via `requestIdleCallback`
- When viewing session A, loads ±1 sessions in background

**#47 New messages pill (2 pts):**
- Floating `↓ New messages` blue pill when scrolled up and new messages arrive
- Bounce-in animation, auto-dismiss on scroll to bottom

**#48 Server-side push (2 pts):**
- WS server subscribes to gateway events → immediate push instead of 3s polling
- Safety-net polling reduced from 3s/2s → 10s/8s (3-5x less traffic)

Build + typecheck clean.