### PR TITLE
fix: final 3 points — force scroll, dynamic pill, status bar meta

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ export const metadata: Metadata = {
   other: {
     'mobile-web-app-capable': 'yes',
     'apple-mobile-web-app-capable': 'yes',
+    'apple-mobile-web-app-status-bar-style': 'black-translucent',
   },
   icons: {
     icon: [

--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -2,6 +2,7 @@
 import {
   useEffect,
   useMemo,
+  useRef,
   type CSSProperties,
 } from 'react';
 import type { RuntimeReviewPacket } from '@/lib/fleet/types';
@@ -190,12 +191,27 @@ export function MobileRemoteShell({
   const canResumeOwnedCodex = Boolean(isOwnedCodexSession && selectedSession?.runtimeSurface?.capabilities.sendInput && !ownedQueuedTurn);
   const canInterruptOwnedCodex = Boolean(isOwnedCodexSession && selectedSession?.runtimeSurface?.capabilities.interrupt);
 
+  // Track compose bar height via ResizeObserver for dynamic pill positioning
+  const bottomDockRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = bottomDockRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) state.setComposeHeight(entry.contentRect.height);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [state.setComposeHeight]);
+
   const shellStyle = {
     '--remodex-header-progress': headerProgress.toFixed(3),
     '--remodex-dock-fade-progress': dockFadeProgress.toFixed(3),
     '--remodex-dock-motion-progress': dockMotionProgress.toFixed(3),
     '--remodex-compose-active': isComposerPrimed ? '1' : '0',
     '--remodex-viewport-top-offset': `${viewportTopOffset}px`,
+    '--remodex-compose-height': `${state.composeHeight}px`,
   } as CSSProperties;
 
   // ── Render ──
@@ -259,6 +275,7 @@ export function MobileRemoteShell({
             isOwnedCodexSession={isOwnedCodexSession}
             transcriptLoading={transcriptLoading}
             isRefreshing={surfaceRefreshing}
+            composeHeight={state.composeHeight}
             selectedReviewFile={selectedReviewFile}
             streamingText={streamingText}
             waitingForResponse={waitingForResponse}
@@ -280,7 +297,7 @@ export function MobileRemoteShell({
           />
           <div ref={transcriptBottomRef} className="remodex-scroll-anchor" aria-hidden="true" />
         </div>
-        <div className="remodex-bottom-dock" data-active={isComposerPrimed ? 'true' : 'false'}>
+        <div ref={bottomDockRef} className="remodex-bottom-dock" data-active={isComposerPrimed ? 'true' : 'false'}>
           <div className="remodex-compose-shell">
             <ComposeBar
               session={selectedSession}

--- a/src/components/mobile/ChatView.tsx
+++ b/src/components/mobile/ChatView.tsx
@@ -170,6 +170,7 @@ export function ChatView({
   transcriptEntries,
   transcriptLoading,
   isRefreshing,
+  composeHeight = 120,
   selectedSession,
   selectedReviewFile,
   streamingText,
@@ -358,7 +359,7 @@ export function ChatView({
           }}
           style={{
             position: 'fixed',
-            bottom: '120px',
+            bottom: `${composeHeight + 16}px`,
             left: '50%',
             transform: 'translateX(-50%)',
             zIndex: 20,

--- a/src/components/mobile/hooks/useMobileScroll.ts
+++ b/src/components/mobile/hooks/useMobileScroll.ts
@@ -35,6 +35,7 @@ export function useMobileScroll(state: MobileState, transcriptEntries: MobileTra
   const scrollToLatestMessage = useCallback((force = false) => {
     if (typeof window === 'undefined') return;
     if (!force && !stickToBottomRef.current) return;
+    if (force) stickToBottomRef.current = true;
     transcriptBottomRef.current?.scrollIntoView({ block: 'end', behavior: 'smooth' });
   }, [stickToBottomRef, transcriptBottomRef]);
 

--- a/src/components/mobile/hooks/useMobileState.ts
+++ b/src/components/mobile/hooks/useMobileState.ts
@@ -77,6 +77,7 @@ export function useMobileState(init: MobileStateInit) {
   const [headerVisible, setHeaderVisible] = useState(true);
   const [viewportTopOffset, setViewportTopOffset] = useState(0);
   const [composeFocused, setComposeFocused] = useState(false);
+  const [composeHeight, setComposeHeight] = useState(120);
   const [waitingForResponse, setWaitingForResponse] = useState(false);
   const [hydrated, setHydrated] = useState(false);
   const [expandedProject, setExpandedProject] = useState<string | null>(null);
@@ -154,6 +155,7 @@ export function useMobileState(init: MobileStateInit) {
     headerVisible, setHeaderVisible,
     viewportTopOffset, setViewportTopOffset,
     composeFocused, setComposeFocused,
+    composeHeight, setComposeHeight,
     waitingForResponse, setWaitingForResponse,
     hydrated, setHydrated,
     expandedProject, setExpandedProject,

--- a/src/components/mobile/types.ts
+++ b/src/components/mobile/types.ts
@@ -87,6 +87,7 @@ export interface ChatViewProps {
   transcriptEntries: MobileTranscriptEntry[];
   transcriptLoading: boolean;
   isRefreshing?: boolean;
+  composeHeight?: number;
   selectedSession?: SessionSummary;
   selectedReviewFile?: ReviewFileDetail;
   streamingText: string;


### PR DESCRIPTION
Cherry-pick of `358f189` that missed PR #63 merge (same race as #62→#63).

**Force scroll fix (1 pt):** `scrollToLatestMessage(force=true)` re-engages stickToBottom so subsequent messages auto-scroll after pill tap.

**Dynamic pill position (1 pt):** ResizeObserver on compose dock → CSS var `--remodex-compose-height`. Pill uses `composeHeight + 16px` instead of hardcoded `120px`.

**Status bar meta (1 pt):** Explicit `apple-mobile-web-app-status-bar-style: black-translucent` in `metadata.other`.

Build + typecheck clean.