### PR TITLE
feat: universal runtime adapter contract + Claude Code integration

### DIFF
--- a/docs/runtime-adapter-v2.md
+++ b/docs/runtime-adapter-v2.md
@@ -1,0 +1,295 @@
+# Runtime Adapter v2 — Universal Agent Runtime Contract
+
+## Problem
+
+Cortex IDE currently has 1,788 lines of Codex-specific code (`sessions.ts` + `owned.ts`) and 257 lines of OpenClaw-specific code (`openclaw.ts`), plus a `switch (agent.runtime)` dispatch in `actions.ts`. Adding Claude Code means either:
+
+- **Duplicate** another ~1,500 lines (unsustainable)
+- **Abstract** the common shape into a contract (one file per runtime)
+
+## Design Principles
+
+1. **Adding a new agent runtime = one file.** Implement the interface, register it, done.
+2. **The UI never knows what runtime it's talking to.** Squad view, chat, diff, compose — all work through the contract.
+3. **Capabilities are declared, not assumed.** Each runtime says what it can do. UI adapts.
+4. **Discovery is local-first.** Runtimes find sessions on disk, not via cloud APIs.
+5. **Progressive disclosure.** Simple runtimes can implement 3 methods. Complex ones implement 12.
+
+## The Contract
+
+```typescript
+// src/lib/runtimes/types.ts
+
+export type RuntimeId = 'openclaw' | 'codex' | 'claude-code' | string;
+
+/**
+ * What a runtime can do. UI uses this to show/hide controls.
+ * All default to false — a runtime opts IN to capabilities.
+ */
+export interface RuntimeCapabilities {
+  /** Can discover existing sessions on disk/network */
+  discover: boolean;
+  /** Can read session transcript/history */
+  readTranscript: boolean;
+  /** Can launch a new session with a prompt */
+  launch: boolean;
+  /** Can send follow-up messages to an existing session */
+  resume: boolean;
+  /** Can interrupt/stop a running session */
+  interrupt: boolean;
+  /** Can provide changed files / diff context */
+  reviewDiffs: boolean;
+  /** Can provide cost/token telemetry */
+  costTelemetry: boolean;
+  /** Supports real-time streaming of output */
+  streaming: boolean;
+}
+
+/**
+ * Normalized session shape. Every runtime maps its internal format to this.
+ */
+export interface RuntimeSession {
+  /** Unique key for this session across all runtimes */
+  sessionKey: string;
+  /** Runtime that owns this session */
+  runtimeId: RuntimeId;
+  /** Human-readable name (e.g., "cortex-ide • main") */
+  displayName: string;
+  /** Working directory */
+  cwd: string;
+  /** Git branch if known */
+  branch?: string;
+  /** Repository slug if known (e.g., "hurttlocker/cortex-ide") */
+  repoSlug?: string;
+  /** Current status */
+  status: 'running' | 'idle' | 'waiting' | 'reviewing' | 'failed';
+  /** Ownership model */
+  ownership: 'discovered' | 'owned' | 'provider';
+  /** What can be done with this session right now */
+  capabilities: {
+    canSendInput: boolean;
+    canInterrupt: boolean;
+    canReviewDiffs: boolean;
+  };
+  /** When this session was last active */
+  lastActivityAt: Date;
+  /** The initial task/prompt */
+  initialTask?: string;
+  /** Model being used */
+  model?: string;
+  /** Lifecycle state for owned sessions */
+  lifecycle?: {
+    availability: 'awaiting-thread' | 'running' | 'ready-for-resume';
+    lastOutcome?: 'finished' | 'interrupted' | 'failed';
+    summary?: string;
+  };
+}
+
+/**
+ * Normalized transcript entry. Every runtime maps its log format to this.
+ */
+export interface RuntimeTranscriptEntry {
+  id: string;
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  text: string;
+  timestamp: Date;
+  /** Tool name if role=tool */
+  toolName?: string;
+  /** File path if the entry involves a file */
+  filePath?: string;
+}
+
+/**
+ * Changed file from a session's work.
+ */
+export interface RuntimeChangedFile {
+  path: string;
+  status: 'added' | 'modified' | 'deleted' | 'renamed';
+  additions: number;
+  deletions: number;
+}
+
+/**
+ * Result of a launch/resume/interrupt action.
+ */
+export interface RuntimeActionResult {
+  ok: boolean;
+  note: string;
+  sessionKey?: string;
+}
+
+/**
+ * THE CONTRACT. Every agent runtime implements this.
+ *
+ * Simple runtimes can throw "not supported" for optional methods.
+ * The `capabilities` property tells the UI what's available.
+ */
+export interface AgentRuntime {
+  /** Unique runtime identifier */
+  readonly id: RuntimeId;
+  /** Display name for UI */
+  readonly displayName: string;
+  /** What this runtime supports */
+  readonly capabilities: RuntimeCapabilities;
+
+  // ── Discovery ──
+
+  /**
+   * Find all sessions this runtime knows about.
+   * Called on initial load and periodic refresh.
+   */
+  discoverSessions(): Promise<RuntimeSession[]>;
+
+  // ── Transcript ──
+
+  /**
+   * Read transcript entries for a session.
+   * @param sessionKey - The session to read
+   * @param sinceId - Only return entries after this ID (for incremental fetch)
+   * @param limit - Max entries to return
+   */
+  readTranscript(
+    sessionKey: string,
+    sinceId?: string,
+    limit?: number,
+  ): Promise<RuntimeTranscriptEntry[]>;
+
+  // ── Lifecycle ──
+
+  /**
+   * Launch a new session with a prompt.
+   * Returns the created session info.
+   */
+  launch(opts: {
+    cwd: string;
+    prompt: string;
+    model?: string;
+  }): Promise<RuntimeActionResult>;
+
+  /**
+   * Send a follow-up message to an existing session.
+   */
+  resume(sessionKey: string, message: string): Promise<RuntimeActionResult>;
+
+  /**
+   * Interrupt/stop a running session.
+   */
+  interrupt(sessionKey: string): Promise<RuntimeActionResult>;
+
+  // ── Review ──
+
+  /**
+   * Get changed files from a session's work.
+   */
+  getChangedFiles(sessionKey: string): Promise<RuntimeChangedFile[]>;
+
+  // ── Telemetry (optional) ──
+
+  /**
+   * Get cost/usage data for a session.
+   */
+  getTelemetry?(sessionKey: string): Promise<{
+    totalTokens?: number;
+    remainingTokens?: number;
+    estimatedCostUsd?: number;
+  }>;
+}
+```
+
+## Registry
+
+```typescript
+// src/lib/runtimes/registry.ts
+
+const runtimes = new Map<RuntimeId, AgentRuntime>();
+
+export function registerRuntime(runtime: AgentRuntime): void {
+  runtimes.set(runtime.id, runtime);
+}
+
+export function getRuntime(id: RuntimeId): AgentRuntime | undefined {
+  return runtimes.get(id);
+}
+
+export function getAllRuntimes(): AgentRuntime[] {
+  return [...runtimes.values()];
+}
+
+/**
+ * Discover sessions across ALL registered runtimes.
+ * This replaces the current Codex-specific + OpenClaw-specific discovery.
+ */
+export async function discoverAllSessions(): Promise<RuntimeSession[]> {
+  const results = await Promise.allSettled(
+    getAllRuntimes()
+      .filter((r) => r.capabilities.discover)
+      .map((r) => r.discoverSessions()),
+  );
+  return results
+    .filter((r): r is PromiseFulfilledResult<RuntimeSession[]> => r.status === 'fulfilled')
+    .flatMap((r) => r.value);
+}
+```
+
+## Implementation Plan
+
+### Phase 1: Contract + Registry (this PR)
+- `src/lib/runtimes/types.ts` — The contract (above)
+- `src/lib/runtimes/registry.ts` — Registration + unified discovery
+- `src/lib/runtimes/openclaw.ts` — Wrap existing OpenClaw code
+- `src/lib/runtimes/codex.ts` — Wrap existing Codex code
+- `src/lib/runtimes/index.ts` — Barrel export + auto-registration
+
+**No UI changes. No behavior changes.** Just introduce the abstraction and verify it produces the same fleet snapshot.
+
+### Phase 2: Claude Code runtime
+- `src/lib/runtimes/claude-code.ts` — Implement the contract for Claude Code
+- Discovery: Read `~/.claude/projects/*/` JSONL files
+- Transcript: Parse Claude Code's message format
+- Launch: `claude -p --print --permission-mode bypassPermissions`
+- Resume: `claude --resume <sessionId>`
+- Review: Git diff from session's CWD
+
+### Phase 3: Wire UI through contract
+- Replace `switch (agent.runtime)` in `actions.ts` with `getRuntime(agent.runtime).resume()`
+- Replace direct Codex/OpenClaw imports in inventory with `discoverAllSessions()`
+- Fleet snapshot builder uses registry instead of hardcoded discovery
+
+### Phase 4: Future runtimes (zero-effort adds)
+- Aider: `src/lib/runtimes/aider.ts`
+- Cursor Agent: `src/lib/runtimes/cursor.ts`
+- OpenCode: `src/lib/runtimes/opencode.ts`
+- Any MCP-based agent: `src/lib/runtimes/mcp.ts`
+
+## File Layout
+
+```
+src/lib/runtimes/
+├── types.ts          # Contract interfaces
+├── registry.ts       # Runtime registration + unified discovery
+├── index.ts          # Barrel + auto-registration
+├── openclaw.ts       # OpenClaw adapter (wraps existing code)
+├── codex.ts          # Codex adapter (wraps existing code)
+└── claude-code.ts    # Claude Code adapter (new)
+```
+
+## Migration Strategy
+
+Phase 1 wraps, doesn't rewrite. The existing `codex/sessions.ts` and `codex/owned.ts` stay untouched. `runtimes/codex.ts` calls into them and maps to the contract types. Same for OpenClaw.
+
+This means zero risk of breaking existing functionality while the abstraction proves itself.
+
+Once the abstraction is validated, Phase 3 can progressively remove the direct imports.
+
+## Capability Matrix
+
+| Capability | OpenClaw | Codex | Claude Code | Aider (future) |
+|---|---|---|---|---|
+| discover | ✅ (gateway) | ✅ (sqlite + fs) | ✅ (fs) | ✅ (fs) |
+| readTranscript | ✅ (chat.history) | ✅ (JSONL) | ✅ (JSONL) | ✅ (log files) |
+| launch | ❌ (mirror only) | ✅ (codex exec) | ✅ (claude -p) | ✅ (aider --message) |
+| resume | ✅ (chat.send) | ✅ (codex exec resume) | ✅ (claude --resume) | ❌ |
+| interrupt | ✅ (abort) | ✅ (SIGINT) | ✅ (SIGINT) | ✅ (SIGINT) |
+| reviewDiffs | ✅ (gateway) | ✅ (git diff) | ✅ (git diff) | ✅ (git diff) |
+| costTelemetry | ✅ (gateway) | ❌ | ❌ | ❌ |
+| streaming | ✅ (WS) | ✅ (stdout) | ✅ (stream-json) | ❌ |

--- a/src/lib/openclaw/fleet.ts
+++ b/src/lib/openclaw/fleet.ts
@@ -3,6 +3,7 @@ import { promisify } from 'node:util';
 import { demoFleet } from '@/lib/demo/fleet';
 import { getOwnedCodexFleetAdditions } from '@/lib/codex/owned';
 import { getCodexDiscoveredFleetAdditions } from '@/lib/codex/sessions';
+import { claudeCodeRuntime } from '@/lib/runtimes/claude-code';
 import type {
   AgentStatus,
   AgentSummary,
@@ -11,6 +12,7 @@ import type {
   SquadStatus,
   SquadSummary,
 } from '@/lib/fleet/types';
+import type { RuntimeSession } from '@/lib/runtimes/types';
 
 const execFileAsync = promisify(execFile);
 const WORKSPACE_ROOT = process.env.CORTEX_IDE_WORKSPACE_ROOT || '/Users/marquisehurtt/clawd';
@@ -194,6 +196,117 @@ function buildDemoFallback(reason: string): FleetSnapshot {
   };
 }
 
+function shortenHomePath(filePath: string): string {
+  const home = process.env.HOME ?? '/Users/unknown';
+  return filePath.startsWith(home) ? `~${filePath.slice(home.length)}` : filePath;
+}
+
+function mapClaudeCodeSessionToAgent(session: RuntimeSession): AgentSummary {
+  const ageMs = Date.now() - session.lastActivityAt.getTime();
+  return {
+    id: session.sessionKey,
+    name: session.displayName,
+    squadId: 'squad-claude-code',
+    runtime: 'claude-code',
+    model: session.model ?? 'claude',
+    status: session.status === 'running' ? 'running'
+      : session.status === 'reviewing' ? 'reviewing'
+      : 'idle',
+    currentTask: session.initialTask ?? 'Claude Code session',
+    workspace: shortenHomePath(session.cwd),
+    branch: session.branch ?? 'unknown',
+    sessionKey: session.sessionKey,
+    approvalStatus: 'none',
+    lastEventAt: relativeAge(ageMs),
+    context: { usedPercent: 0, trend: 'stable' },
+    alerts: 0,
+    sessionId: session.sessionKey.replace('claude-code:', ''),
+    sessionKind: 'terminal',
+    surfaceLabel: 'Claude Code terminal',
+    runtimeSurface: {
+      id: session.sessionKey,
+      runtime: 'claude-code',
+      kind: 'terminal-session',
+      ownership: session.ownership,
+      title: session.displayName,
+      cwd: shortenHomePath(session.cwd),
+      branch: session.branch,
+      sourceLabel: 'Local Claude Code discovery • ~/.claude/projects/',
+      tailSourceLabel: '~/.claude/projects/*.jsonl',
+      capabilities: {
+        attach: true,
+        readTail: true,
+        sendInput: session.sessionCapabilities.canSendInput,
+        interrupt: session.sessionCapabilities.canInterrupt,
+        resize: false,
+        diffContext: session.sessionCapabilities.canReviewDiffs,
+        reviewContext: true,
+      },
+      lifecycle: session.lifecycle ? {
+        availability: session.lifecycle.availability,
+        lastOutcome: session.lifecycle.lastOutcome,
+        lastRunMode: session.lifecycle.lastRunMode,
+        lastRunStartedAt: session.lifecycle.lastRunStartedAt,
+        lastRunFinishedAt: session.lifecycle.lastRunFinishedAt,
+        summary: session.lifecycle.summary,
+      } : undefined,
+      reviewContext: {
+        repoSlug: session.repoSlug,
+        branch: session.branch,
+        head: session.headSha,
+      },
+    },
+  };
+}
+
+async function discoverClaudeCodeSessions(): Promise<{
+  agents: AgentSummary[];
+  squads: SquadSummary[];
+  events: Array<{ id: string; agentId: string; squadId: string; severity: EventSeverity; title: string; detail: string; timestamp: string }>;
+  sourceLabel: string;
+  note: string;
+}> {
+  try {
+    const sessions = await claudeCodeRuntime.discoverSessions();
+    if (sessions.length === 0) {
+      return { agents: [], squads: [], events: [], sourceLabel: '', note: '' };
+    }
+
+    const agents = sessions.map(mapClaudeCodeSessionToAgent);
+    const squads: SquadSummary[] = [{
+      id: 'squad-claude-code',
+      name: 'Claude Code',
+      status: agents.some((a) => a.status === 'running') ? 'healthy' : 'watching',
+      throughputLabel: `${agents.length} local session${agents.length === 1 ? '' : 's'}`,
+      blockers: 0,
+      alerts: 0,
+      liveSessions: agents.length,
+      members: agents.map((a) => a.id),
+    }];
+
+    const events = agents.slice(0, 3).map((agent) => ({
+      id: `evt-cc-${agent.id}`,
+      agentId: agent.id,
+      squadId: agent.squadId,
+      severity: 'info' as EventSeverity,
+      title: `${agent.name} • Claude Code`,
+      detail: `${agent.currentTask?.slice(0, 120) ?? ''} • ${agent.lastEventAt}`,
+      timestamp: agent.lastEventAt,
+    }));
+
+    return {
+      agents,
+      squads,
+      events,
+      sourceLabel: `Claude Code discovery (${agents.length} session${agents.length === 1 ? '' : 's'})`,
+      note: `${agents.length} Claude Code session${agents.length === 1 ? '' : 's'} discovered from ~/.claude/projects/`,
+    };
+  } catch (err) {
+    console.error('[fleet] Claude Code discovery failed:', err);
+    return { agents: [], squads: [], events: [], sourceLabel: '', note: '' };
+  }
+}
+
 export async function getOpenClawFleetSnapshot(): Promise<FleetSnapshot> {
   try {
     const { stdout } = await execFileAsync('openclaw', ['status', '--json'], {
@@ -292,9 +405,10 @@ export async function getOpenClawFleetSnapshot(): Promise<FleetSnapshot> {
       timestamp: agent.lastEventAt,
     }));
 
-    const [ownedCodex, codexDiscovery] = await Promise.all([
+    const [ownedCodex, codexDiscovery, claudeCodeSessions] = await Promise.all([
       getOwnedCodexFleetAdditions(),
       getCodexDiscoveredFleetAdditions(),
+      discoverClaudeCodeSessions(),
     ]);
 
     const ownedThreadIds = new Set(ownedCodex.ownedThreadIds);
@@ -317,9 +431,9 @@ export async function getOpenClawFleetSnapshot(): Promise<FleetSnapshot> {
         } satisfies SquadSummary]
       : [];
 
-    const allAgents = [...agents, ...ownedCodex.agents, ...filteredDiscoveredAgents];
-    const allSquads = [...openClawSquads, ...ownedCodex.squads, ...filteredDiscoveredSquads];
-    const allEvents = [...openClawEvents, ...ownedCodex.events, ...filteredDiscoveredEvents];
+    const allAgents = [...agents, ...ownedCodex.agents, ...filteredDiscoveredAgents, ...claudeCodeSessions.agents];
+    const allSquads = [...openClawSquads, ...ownedCodex.squads, ...filteredDiscoveredSquads, ...claudeCodeSessions.squads];
+    const allEvents = [...openClawEvents, ...ownedCodex.events, ...filteredDiscoveredEvents, ...claudeCodeSessions.events];
 
     return {
       generatedAt: new Date().toISOString(),
@@ -329,6 +443,7 @@ export async function getOpenClawFleetSnapshot(): Promise<FleetSnapshot> {
           'runtime inventory • openclaw status --json',
           ownedCodex.sourceLabel,
           codexDiscovery.sourceLabel,
+          claudeCodeSessions.sourceLabel,
         ].filter(Boolean).join(' + '),
         gatewayLabel: parsed.gateway?.reachable
           ? `OpenClaw ${parsed.gateway?.self?.version ?? 'unknown'} • ${parsed.gateway?.mode ?? 'local'} gateway`
@@ -341,6 +456,7 @@ export async function getOpenClawFleetSnapshot(): Promise<FleetSnapshot> {
             : 'Mirroring existing OpenClaw sessions first. New sessions should only appear when you explicitly spawn them.',
           ownedCodex.note,
           codexDiscovery.note,
+          claudeCodeSessions.note,
         ].filter(Boolean).join(' '),
       },
       squads: allSquads,

--- a/src/lib/runtime/actions.ts
+++ b/src/lib/runtime/actions.ts
@@ -2,6 +2,7 @@ import type { AgentSummary } from '@/lib/fleet/types';
 import { continueOwnedCodexSession, interruptOwnedCodexSession, launchOwnedCodexSession, setOwnedCodexReviewDisposition } from '@/lib/codex/owned';
 import { abortOpenClawSession, steerOpenClawSession } from '@/lib/openclaw/chat';
 import { getRuntimeInventorySnapshot } from '@/lib/runtime/inventory';
+import { getRuntime } from '@/lib/runtimes/registry';
 
 export type RuntimeActionKind = 'steer' | 'stop' | 'send_input' | 'interrupt' | 'watch' | 'resolve' | 'launch';
 
@@ -198,8 +199,48 @@ export async function performRuntimeAction(payload: RuntimeActionRequest): Promi
         'This IDE-owned Codex surface supports launch/resume/interrupt and review-state disposition changes only in the bounded owned-session lane for now.',
       );
     }
-    default:
-      return unavailable(agent, payload.action, `Runtime action ${payload.action} is not supported for ${agent.runtime}.`);
+    default: {
+      // Registry-based dispatch for all other runtimes (claude-code, aider, etc.)
+      const runtime = getRuntime(agent.runtime);
+      if (!runtime) {
+        return unavailable(agent, payload.action, `Runtime action ${payload.action} is not supported for ${agent.runtime}.`);
+      }
+
+      if (payload.action === 'steer' || payload.action === 'send_input') {
+        const message = payload.message?.trim();
+        if (!message) throw new Error('message is required');
+        if (!runtime.capabilities.resume) {
+          return unavailable(agent, payload.action, `${agent.runtime} does not support resume/steer.`);
+        }
+        const result = await runtime.resume(agent.sessionKey, message);
+        return {
+          ok: result.ok,
+          action: payload.action,
+          surfaceId: runtimeSurface.id,
+          runtime: agent.runtime,
+          status: 'queued',
+          note: result.note,
+        };
+      }
+
+      if (payload.action === 'stop' || payload.action === 'interrupt') {
+        if (!runtime.capabilities.interrupt) {
+          return unavailable(agent, payload.action, `${agent.runtime} does not support interrupt.`);
+        }
+        const result = await runtime.interrupt(agent.sessionKey);
+        return {
+          ok: result.ok,
+          action: payload.action,
+          surfaceId: runtimeSurface.id,
+          runtime: agent.runtime,
+          status: 'completed',
+          note: result.note,
+          aborted: result.ok,
+        };
+      }
+
+      return unavailable(agent, payload.action, `Runtime action ${payload.action} is not wired for ${agent.runtime} yet.`);
+    }
   }
 }
 

--- a/src/lib/runtimes/claude-code.ts
+++ b/src/lib/runtimes/claude-code.ts
@@ -1,0 +1,477 @@
+/**
+ * Claude Code Runtime Adapter
+ *
+ * Discovers Claude Code sessions from ~/.claude/projects/,
+ * reads transcripts from JSONL files, and manages lifecycle
+ * via the `claude` CLI.
+ */
+
+import { execFile, spawn } from 'node:child_process';
+import { access, readdir, readFile, stat } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import type {
+  AgentRuntime,
+  RuntimeCapabilities,
+  RuntimeSession,
+  RuntimeTranscriptEntry,
+  RuntimeChangedFile,
+  RuntimeActionResult,
+  LaunchOptions,
+} from './types';
+
+const execFileAsync = promisify(execFile);
+
+const CLAUDE_HOME = process.env.CLAUDE_HOME || path.join(os.homedir(), '.claude');
+const CLAUDE_PROJECTS_DIR = path.join(CLAUDE_HOME, 'projects');
+const RECENT_WINDOW_MS = 6 * 60 * 60_000; // 6 hours
+
+const capabilities: RuntimeCapabilities = {
+  discover: true,
+  readTranscript: true,
+  launch: true,
+  resume: true,
+  interrupt: true,
+  reviewDiffs: true,
+  costTelemetry: false,
+  streaming: true,
+};
+
+// ── Path helpers ──
+
+/**
+ * Decode Claude Code's project directory name back to a filesystem path.
+ * e.g., "-Users-marquisehurtt-clawd" → "/Users/marquisehurtt/clawd"
+ */
+function decodeProjectPath(encodedName: string): string {
+  // Replace leading dash with /, then remaining dashes with /
+  // But we need to be careful: the encoding replaces / with -
+  return '/' + encodedName.slice(1).replace(/-/g, '/');
+}
+
+function shortenPath(filePath: string): string {
+  return filePath.replace(`${os.homedir()}/`, '~/');
+}
+
+/**
+ * Extract a human-readable project name from the path.
+ * e.g., "/Users/marquisehurtt/clawd/repos/cortex-ide" → "cortex-ide"
+ */
+function projectDisplayName(projectPath: string): string {
+  return path.basename(projectPath) || projectPath;
+}
+
+// ── Session JSONL parsing ──
+
+interface ClaudeCodeMessage {
+  type: 'user' | 'assistant' | 'system' | 'progress' | 'file-history-snapshot' | 'queue-operation';
+  uuid?: string;
+  timestamp?: string;
+  sessionId?: string;
+  cwd?: string;
+  gitBranch?: string;
+  message?: {
+    role: string;
+    content: MessageContent;
+  };
+}
+
+type ContentBlock = {
+  type: string;
+  text?: string;
+  name?: string;
+  input?: Record<string, unknown>;
+  tool_use_id?: string;
+  content?: string | Array<{ type: string; text?: string }>;
+};
+
+type MessageContent = string | ContentBlock[];
+
+function extractTextFromContent(content: MessageContent): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+
+  const parts: string[] = [];
+  for (const block of content) {
+    if (block.type === 'text' && block.text) {
+      parts.push(block.text);
+    } else if (block.type === 'tool_use' && block.name) {
+      const desc = block.input && typeof block.input === 'object'
+        ? (block.input as Record<string, unknown>).description ?? (block.input as Record<string, unknown>).command ?? ''
+        : '';
+      parts.push(`[Tool: ${block.name}${desc ? ` — ${String(desc).slice(0, 100)}` : ''}]`);
+    } else if (block.type === 'tool_result') {
+      const resultContent = block.content;
+      if (typeof resultContent === 'string') {
+        parts.push(resultContent.slice(0, 200));
+      } else if (Array.isArray(resultContent)) {
+        for (const sub of resultContent) {
+          if (sub.type === 'text' && sub.text) {
+            parts.push(sub.text.slice(0, 200));
+          }
+        }
+      }
+    }
+  }
+  return parts.join('\n');
+}
+
+function extractToolName(content: MessageContent): string | undefined {
+  if (!Array.isArray(content)) return undefined;
+  for (const block of content) {
+    if (block.type === 'tool_use' && block.name) return block.name;
+  }
+  return undefined;
+}
+
+function extractFilePath(content: MessageContent): string | undefined {
+  if (!Array.isArray(content)) return undefined;
+  for (const block of content) {
+    if (block.type === 'tool_use' && block.input && typeof block.input === 'object') {
+      const input = block.input as Record<string, unknown>;
+      if (typeof input.file_path === 'string') return input.file_path;
+      if (typeof input.path === 'string') return input.path;
+    }
+  }
+  return undefined;
+}
+
+// ── Session metadata ──
+
+interface SessionMeta {
+  sessionId: string;
+  projectDir: string;
+  projectPath: string;
+  jsonlPath: string;
+  lastModified: Date;
+  firstUserMessage?: string;
+  cwd?: string;
+  gitBranch?: string;
+}
+
+async function discoverProjectSessions(projectDirName: string): Promise<SessionMeta[]> {
+  const projectDir = path.join(CLAUDE_PROJECTS_DIR, projectDirName);
+  const projectPath = decodeProjectPath(projectDirName);
+
+  let entries: string[];
+  try {
+    entries = await readdir(projectDir);
+  } catch {
+    return [];
+  }
+
+  const sessions: SessionMeta[] = [];
+  const now = Date.now();
+
+  for (const entry of entries) {
+    if (!entry.endsWith('.jsonl')) continue;
+    const sessionId = entry.replace('.jsonl', '');
+    const jsonlPath = path.join(projectDir, entry);
+
+    try {
+      const fileStat = await stat(jsonlPath);
+      // Skip sessions older than the recent window
+      if (now - fileStat.mtimeMs > RECENT_WINDOW_MS) continue;
+
+      // Read first few lines to get metadata
+      const content = await readFile(jsonlPath, 'utf-8');
+      const lines = content.split('\n').filter(Boolean);
+
+      let firstUserMessage: string | undefined;
+      let cwd: string | undefined;
+      let gitBranch: string | undefined;
+
+      for (const line of lines.slice(0, 20)) {
+        try {
+          const parsed = JSON.parse(line) as ClaudeCodeMessage;
+          if (parsed.cwd && !cwd) cwd = parsed.cwd;
+          if (parsed.gitBranch && !gitBranch) gitBranch = parsed.gitBranch;
+          if (parsed.type === 'user' && parsed.message?.content && !firstUserMessage) {
+            const text = typeof parsed.message.content === 'string'
+              ? parsed.message.content
+              : extractTextFromContent(parsed.message.content);
+            firstUserMessage = text.slice(0, 200);
+          }
+          if (cwd && gitBranch && firstUserMessage) break;
+        } catch { /* skip malformed lines */ }
+      }
+
+      sessions.push({
+        sessionId,
+        projectDir,
+        projectPath,
+        jsonlPath,
+        lastModified: fileStat.mtime,
+        firstUserMessage,
+        cwd: cwd ?? projectPath,
+        gitBranch,
+      });
+    } catch { /* skip unreadable files */ }
+  }
+
+  return sessions;
+}
+
+// ── Live process detection ──
+
+interface LiveClaudeProcess {
+  pid: number;
+  cwd?: string;
+}
+
+async function findLiveClaudeProcesses(): Promise<LiveClaudeProcess[]> {
+  try {
+    const { stdout } = await execFileAsync('pgrep', ['-f', 'claude'], { timeout: 3000 });
+    const pids = stdout.trim().split('\n').filter(Boolean).map(Number).filter(Boolean);
+
+    const processes: LiveClaudeProcess[] = [];
+    for (const pid of pids) {
+      try {
+        const { stdout: cwdOut } = await execFileAsync('lsof', ['-p', String(pid), '-Fn'], { timeout: 2000 });
+        const cwdLine = cwdOut.split('\n').find((l) => l.startsWith('n') && l.includes('/'));
+        processes.push({ pid, cwd: cwdLine?.slice(1) });
+      } catch {
+        processes.push({ pid });
+      }
+    }
+    return processes;
+  } catch {
+    return [];
+  }
+}
+
+// ── Determine session status ──
+
+function inferSessionStatus(meta: SessionMeta, liveProcesses: LiveClaudeProcess[]): RuntimeSession['status'] {
+  // Check if a live claude process matches this session's CWD
+  const hasLiveProcess = liveProcesses.some((p) => p.cwd && meta.cwd && p.cwd.startsWith(meta.cwd));
+  if (hasLiveProcess) return 'running';
+
+  // Recent activity = reviewing, older = idle
+  const ageMs = Date.now() - meta.lastModified.getTime();
+  if (ageMs < 5 * 60_000) return 'reviewing'; // Active in last 5 min
+  return 'idle';
+}
+
+// ── The Runtime ──
+
+export const claudeCodeRuntime: AgentRuntime = {
+  id: 'claude-code',
+  displayName: 'Claude Code',
+  capabilities,
+
+  async discoverSessions(): Promise<RuntimeSession[]> {
+    let projectDirs: string[];
+    try {
+      projectDirs = await readdir(CLAUDE_PROJECTS_DIR);
+    } catch {
+      return [];
+    }
+
+    const [allSessions, liveProcesses] = await Promise.all([
+      Promise.all(projectDirs.map((dir) => discoverProjectSessions(dir))).then((r) => r.flat()),
+      findLiveClaudeProcesses(),
+    ]);
+
+    // Sort by most recent first
+    allSessions.sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime());
+
+    return allSessions.map((meta): RuntimeSession => {
+      const status = inferSessionStatus(meta, liveProcesses);
+      const name = `${projectDisplayName(meta.projectPath)}${meta.gitBranch ? ` • ${meta.gitBranch}` : ''}`;
+
+      return {
+        sessionKey: `claude-code:${meta.sessionId}`,
+        runtimeId: 'claude-code',
+        displayName: name,
+        cwd: meta.cwd ?? meta.projectPath,
+        branch: meta.gitBranch,
+        status,
+        ownership: 'discovered',
+        sessionCapabilities: {
+          canSendInput: status !== 'running', // Can resume if not actively running
+          canInterrupt: status === 'running',
+          canReviewDiffs: true,
+        },
+        lastActivityAt: meta.lastModified,
+        initialTask: meta.firstUserMessage,
+        model: 'claude',
+      };
+    });
+  },
+
+  async readTranscript(sessionKey: string, _sinceId?: string, limit = 50): Promise<RuntimeTranscriptEntry[]> {
+    const sessionId = sessionKey.replace('claude-code:', '');
+
+    // Find the JSONL file across all projects
+    let jsonlPath: string | null = null;
+    try {
+      const projectDirs = await readdir(CLAUDE_PROJECTS_DIR);
+      for (const dir of projectDirs) {
+        const candidate = path.join(CLAUDE_PROJECTS_DIR, dir, `${sessionId}.jsonl`);
+        try {
+          await access(candidate);
+          jsonlPath = candidate;
+          break;
+        } catch { /* not in this project */ }
+      }
+    } catch { /* projects dir missing */ }
+
+    if (!jsonlPath) return [];
+
+    const content = await readFile(jsonlPath, 'utf-8');
+    const lines = content.split('\n').filter(Boolean);
+
+    const entries: RuntimeTranscriptEntry[] = [];
+
+    for (const line of lines) {
+      try {
+        const parsed = JSON.parse(line) as ClaudeCodeMessage;
+        if (parsed.type !== 'user' && parsed.type !== 'assistant') continue;
+        if (!parsed.message?.content) continue;
+
+        const text = extractTextFromContent(parsed.message.content);
+        if (!text.trim()) continue;
+
+        entries.push({
+          id: parsed.uuid ?? `cc-${entries.length}`,
+          role: parsed.type === 'user' ? 'user' : 'assistant',
+          text,
+          timestamp: parsed.timestamp ? new Date(parsed.timestamp) : new Date(),
+          toolName: parsed.type === 'assistant' ? extractToolName(parsed.message.content) : undefined,
+          filePath: parsed.type === 'assistant' ? extractFilePath(parsed.message.content) : undefined,
+        });
+      } catch { /* skip malformed */ }
+    }
+
+    // Return last N entries
+    return entries.slice(-limit);
+  },
+
+  async launch(opts: LaunchOptions): Promise<RuntimeActionResult> {
+    try {
+      const child = spawn('claude', [
+        '-p', '--print',
+        '--permission-mode', 'bypassPermissions',
+        '--output-format', 'stream-json',
+        '--no-session-persistence',
+        opts.prompt,
+      ], {
+        cwd: opts.cwd,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        detached: true,
+        env: { ...process.env },
+      });
+
+      child.unref();
+
+      return {
+        ok: true,
+        note: `Claude Code session launched in ${shortenPath(opts.cwd)}`,
+        sessionKey: `claude-code:launched-${Date.now()}`,
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        note: `Failed to launch Claude Code: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  },
+
+  async resume(sessionKey: string, message: string): Promise<RuntimeActionResult> {
+    const sessionId = sessionKey.replace('claude-code:', '');
+
+    try {
+      const child = spawn('claude', [
+        '-p', '--print',
+        '--resume', sessionId,
+        '--permission-mode', 'bypassPermissions',
+        '--output-format', 'stream-json',
+        message,
+      ], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        detached: true,
+        env: { ...process.env },
+      });
+
+      child.unref();
+
+      return {
+        ok: true,
+        note: 'Message sent to Claude Code session.',
+        sessionKey,
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        note: `Failed to resume Claude Code session: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  },
+
+  async interrupt(sessionKey: string): Promise<RuntimeActionResult> {
+    // Find the process by matching the session
+    const liveProcesses = await findLiveClaudeProcesses();
+    if (liveProcesses.length === 0) {
+      return { ok: false, note: 'No live Claude Code process found to interrupt.' };
+    }
+
+    // Try SIGINT on all claude processes (they handle it gracefully)
+    let interrupted = false;
+    for (const proc of liveProcesses) {
+      try {
+        process.kill(proc.pid, 'SIGINT');
+        interrupted = true;
+      } catch { /* process may have exited */ }
+    }
+
+    return {
+      ok: interrupted,
+      note: interrupted
+        ? 'SIGINT sent to Claude Code process.'
+        : 'Could not interrupt Claude Code process.',
+      sessionKey,
+    };
+  },
+
+  async getChangedFiles(sessionKey: string): Promise<RuntimeChangedFile[]> {
+    const sessionId = sessionKey.replace('claude-code:', '');
+
+    // Find the session to get CWD
+    let cwd: string | null = null;
+    try {
+      const projectDirs = await readdir(CLAUDE_PROJECTS_DIR);
+      for (const dir of projectDirs) {
+        const jsonlPath = path.join(CLAUDE_PROJECTS_DIR, dir, `${sessionId}.jsonl`);
+        try {
+          await access(jsonlPath);
+          cwd = decodeProjectPath(dir);
+          break;
+        } catch { /* not in this project */ }
+      }
+    } catch { /* projects dir missing */ }
+
+    if (!cwd) return [];
+
+    // Use git diff to find changed files
+    try {
+      const { stdout } = await execFileAsync('git', ['diff', '--numstat', 'HEAD'], {
+        cwd,
+        timeout: 5000,
+      });
+
+      return stdout.trim().split('\n').filter(Boolean).map((line) => {
+        const [add, del, filePath] = line.split('\t');
+        return {
+          path: filePath ?? '',
+          status: 'modified' as const,
+          additions: parseInt(add ?? '0', 10) || 0,
+          deletions: parseInt(del ?? '0', 10) || 0,
+        };
+      });
+    } catch {
+      return [];
+    }
+  },
+};

--- a/src/lib/runtimes/codex.ts
+++ b/src/lib/runtimes/codex.ts
@@ -1,0 +1,167 @@
+/**
+ * Codex Runtime Adapter
+ *
+ * Wraps existing codex/sessions.ts and codex/owned.ts behind the
+ * universal AgentRuntime contract. No rewrite — delegates to existing code.
+ */
+
+import type {
+  AgentRuntime,
+  RuntimeCapabilities,
+  RuntimeSession,
+  RuntimeTranscriptEntry,
+  RuntimeChangedFile,
+  RuntimeActionResult,
+  LaunchOptions,
+} from './types';
+import { getCodexDiscoveredFleetAdditions, getCodexRuntimeTail } from '@/lib/codex/sessions';
+import {
+  launchOwnedCodexSession,
+  continueOwnedCodexSession,
+  interruptOwnedCodexSession,
+  getOwnedCodexFleetAdditions,
+  getOwnedCodexRuntimeTail,
+  getOwnedCodexReviewPacket,
+} from '@/lib/codex/owned';
+
+const capabilities: RuntimeCapabilities = {
+  discover: true,
+  readTranscript: true,
+  launch: true,
+  resume: true,
+  interrupt: true,
+  reviewDiffs: true,
+  costTelemetry: false,
+  streaming: true,
+};
+
+/**
+ * Map internal fleet AgentSummary to the universal RuntimeSession shape.
+ */
+function mapAgentToSession(
+  agent: { id: string; name: string; sessionKey: string; status: string; currentTask: string; workspace: string; branch: string; model: string; lastEventAt: string; runtimeSurface?: { ownership?: string; capabilities?: { sendInput?: boolean; interrupt?: boolean; diffContext?: boolean }; lifecycle?: { availability?: string; lastOutcome?: string; lastRunMode?: string; lastRunStartedAt?: string; lastRunFinishedAt?: string; summary?: string }; reviewContext?: { repoSlug?: string; branch?: string; head?: string }; cwd?: string } },
+): RuntimeSession {
+  const surface = agent.runtimeSurface;
+  const ownership = (surface?.ownership ?? 'discovered') as RuntimeSession['ownership'];
+  const status = (['running', 'idle', 'waiting', 'reviewing', 'failed'].includes(agent.status)
+    ? agent.status
+    : 'idle') as RuntimeSession['status'];
+
+  return {
+    sessionKey: agent.sessionKey,
+    runtimeId: 'codex',
+    displayName: agent.name,
+    cwd: surface?.cwd ?? agent.workspace,
+    branch: surface?.reviewContext?.branch ?? agent.branch,
+    headSha: surface?.reviewContext?.head,
+    repoSlug: surface?.reviewContext?.repoSlug,
+    status,
+    ownership,
+    sessionCapabilities: {
+      canSendInput: surface?.capabilities?.sendInput ?? false,
+      canInterrupt: surface?.capabilities?.interrupt ?? false,
+      canReviewDiffs: surface?.capabilities?.diffContext ?? false,
+    },
+    lastActivityAt: new Date(agent.lastEventAt),
+    initialTask: agent.currentTask,
+    model: agent.model,
+    lifecycle: surface?.lifecycle ? {
+      availability: (surface.lifecycle.availability ?? 'running') as 'awaiting-thread' | 'running' | 'ready-for-resume',
+      lastOutcome: surface.lifecycle.lastOutcome as 'finished' | 'interrupted' | 'failed' | undefined,
+      lastRunMode: surface.lifecycle.lastRunMode as 'launch' | 'resume' | undefined,
+      lastRunStartedAt: surface.lifecycle.lastRunStartedAt,
+      lastRunFinishedAt: surface.lifecycle.lastRunFinishedAt,
+      summary: surface.lifecycle.summary,
+    } : undefined,
+  };
+}
+
+export const codexRuntime: AgentRuntime = {
+  id: 'codex',
+  displayName: 'Codex',
+  capabilities,
+
+  async discoverSessions(): Promise<RuntimeSession[]> {
+    // Discover both user-launched (terminal) and IDE-owned sessions
+    const [discovered, owned] = await Promise.allSettled([
+      getCodexDiscoveredFleetAdditions(),
+      getOwnedCodexFleetAdditions(),
+    ]);
+
+    const sessions: RuntimeSession[] = [];
+
+    if (discovered.status === 'fulfilled') {
+      for (const agent of discovered.value.agents) {
+        sessions.push(mapAgentToSession(agent));
+      }
+    }
+
+    if (owned.status === 'fulfilled') {
+      for (const agent of owned.value.agents) {
+        sessions.push(mapAgentToSession(agent));
+      }
+    }
+
+    return sessions;
+  },
+
+  async readTranscript(sessionKey: string, _sinceId?: string, _limit?: number): Promise<RuntimeTranscriptEntry[]> {
+    // Route to the correct tail reader based on ownership
+    const isOwned = sessionKey.startsWith('codex-owned:');
+    const tail = isOwned
+      ? await getOwnedCodexRuntimeTail(sessionKey)
+      : await getCodexRuntimeTail(sessionKey);
+
+    return tail.entries.map((entry) => ({
+      id: entry.id,
+      role: entry.kind === 'message' ? 'assistant' as const
+        : entry.kind === 'tool' ? 'tool' as const
+        : entry.kind === 'tool-output' ? 'tool' as const
+        : 'system' as const,
+      text: entry.text,
+      timestamp: new Date(entry.timestampLabel ?? Date.now()),
+      toolName: entry.kind === 'tool' ? entry.label : undefined,
+    }));
+  },
+
+  async launch(opts: LaunchOptions): Promise<RuntimeActionResult> {
+    const result = await launchOwnedCodexSession({ cwd: opts.cwd, prompt: opts.prompt });
+    return {
+      ok: result.ok,
+      note: result.note,
+      sessionKey: result.surfaceId,
+    };
+  },
+
+  async resume(sessionKey: string, message: string): Promise<RuntimeActionResult> {
+    const result = await continueOwnedCodexSession(sessionKey, message);
+    return {
+      ok: true,
+      note: result.note,
+      sessionKey,
+    };
+  },
+
+  async interrupt(sessionKey: string): Promise<RuntimeActionResult> {
+    const result = await interruptOwnedCodexSession(sessionKey);
+    return {
+      ok: result.interrupted,
+      note: result.note,
+      sessionKey,
+    };
+  },
+
+  async getChangedFiles(sessionKey: string): Promise<RuntimeChangedFile[]> {
+    try {
+      const packet = await getOwnedCodexReviewPacket(sessionKey);
+      return (packet.changedFiles ?? []).map((f) => ({
+        path: f.path,
+        status: (f.status ?? 'modified') as RuntimeChangedFile['status'],
+        additions: f.additions ?? 0,
+        deletions: f.deletions ?? 0,
+      }));
+    } catch {
+      return [];
+    }
+  },
+};

--- a/src/lib/runtimes/index.ts
+++ b/src/lib/runtimes/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Runtime System — Barrel Export + Auto-Registration
+ *
+ * Import this module to register all known runtimes.
+ * New runtimes: add import + registerRuntime() call below.
+ */
+
+export type {
+  RuntimeId,
+  RuntimeCapabilities,
+  RuntimeSession,
+  RuntimeSessionStatus,
+  RuntimeSessionOwnership,
+  RuntimeTranscriptEntry,
+  TranscriptRole,
+  RuntimeChangedFile,
+  FileChangeStatus,
+  RuntimeActionResult,
+  LaunchOptions,
+  RuntimeTelemetry,
+  AgentRuntime,
+} from './types';
+
+export {
+  registerRuntime,
+  getRuntime,
+  getAllRuntimes,
+  getRegisteredRuntimeIds,
+  discoverAllSessions,
+  routeAction,
+} from './registry';
+
+// ── Auto-registration ──
+// Import and register all known runtimes.
+// To add a new runtime: import it and call registerRuntime().
+
+import { registerRuntime } from './registry';
+import { openclawRuntime } from './openclaw';
+import { codexRuntime } from './codex';
+import { claudeCodeRuntime } from './claude-code';
+
+registerRuntime(openclawRuntime);
+registerRuntime(codexRuntime);
+registerRuntime(claudeCodeRuntime);

--- a/src/lib/runtimes/openclaw.ts
+++ b/src/lib/runtimes/openclaw.ts
@@ -1,0 +1,120 @@
+/**
+ * OpenClaw Runtime Adapter
+ *
+ * Wraps existing OpenClaw gateway integration behind the universal
+ * AgentRuntime contract. Delegates to openclaw/chat.ts for actions.
+ */
+
+import type {
+  AgentRuntime,
+  RuntimeCapabilities,
+  RuntimeSession,
+  RuntimeTranscriptEntry,
+  RuntimeChangedFile,
+  RuntimeActionResult,
+  RuntimeTelemetry,
+  LaunchOptions,
+} from './types';
+import {
+  getSessionTranscript,
+  steerOpenClawSession,
+  abortOpenClawSession,
+} from '@/lib/openclaw/chat';
+import { getRuntimeInventorySnapshot } from '@/lib/runtime/inventory';
+
+const capabilities: RuntimeCapabilities = {
+  discover: true,
+  readTranscript: true,
+  launch: false, // Mirror-only — OpenClaw sessions are created externally
+  resume: true,
+  interrupt: true,
+  reviewDiffs: true,
+  costTelemetry: true,
+  streaming: true,
+};
+
+export const openclawRuntime: AgentRuntime = {
+  id: 'openclaw',
+  displayName: 'OpenClaw',
+  capabilities,
+
+  async discoverSessions(): Promise<RuntimeSession[]> {
+    const snapshot = await getRuntimeInventorySnapshot();
+    return snapshot.agents
+      .filter((agent) => agent.runtime === 'openclaw')
+      .map((agent) => ({
+        sessionKey: agent.sessionKey,
+        runtimeId: 'openclaw' as const,
+        displayName: agent.name,
+        cwd: agent.runtimeSurface?.cwd ?? agent.workspace,
+        branch: agent.runtimeSurface?.reviewContext?.branch ?? agent.branch,
+        headSha: agent.runtimeSurface?.reviewContext?.head,
+        repoSlug: agent.runtimeSurface?.reviewContext?.repoSlug,
+        status: (['running', 'idle', 'waiting', 'reviewing', 'failed'].includes(agent.status)
+          ? agent.status
+          : 'idle') as RuntimeSession['status'],
+        ownership: 'provider' as const,
+        sessionCapabilities: {
+          canSendInput: agent.runtimeSurface?.capabilities?.sendInput ?? true,
+          canInterrupt: agent.runtimeSurface?.capabilities?.interrupt ?? true,
+          canReviewDiffs: agent.runtimeSurface?.capabilities?.diffContext ?? true,
+        },
+        lastActivityAt: new Date(),
+        initialTask: agent.currentTask,
+        model: agent.model,
+      }));
+  },
+
+  async readTranscript(sessionKey: string, _sinceId?: string, limit = 12): Promise<RuntimeTranscriptEntry[]> {
+    const result = await getSessionTranscript(sessionKey, limit);
+    return result.map((entry) => ({
+      id: entry.id,
+      role: entry.role as RuntimeTranscriptEntry['role'],
+      text: entry.text,
+      timestamp: new Date(entry.timestamp ?? Date.now()),
+    }));
+  },
+
+  async launch(_opts: LaunchOptions): Promise<RuntimeActionResult> {
+    return {
+      ok: false,
+      note: 'OpenClaw sessions are created externally. Use the OpenClaw CLI or gateway to spawn new sessions.',
+    };
+  },
+
+  async resume(sessionKey: string, message: string): Promise<RuntimeActionResult> {
+    const result = await steerOpenClawSession(sessionKey, message, []);
+    return {
+      ok: true,
+      note: 'Sent.',
+      sessionKey,
+    };
+  },
+
+  async interrupt(sessionKey: string): Promise<RuntimeActionResult> {
+    const result = await abortOpenClawSession(sessionKey);
+    return {
+      ok: true,
+      note: result.aborted
+        ? 'Stop request sent to the active run.'
+        : 'No active run was in flight.',
+      sessionKey,
+    };
+  },
+
+  async getChangedFiles(_sessionKey: string): Promise<RuntimeChangedFile[]> {
+    // OpenClaw review context comes through the fleet snapshot, not per-session query
+    return [];
+  },
+
+  async getTelemetry(sessionKey: string): Promise<RuntimeTelemetry | undefined> {
+    const snapshot = await getRuntimeInventorySnapshot();
+    const agent = snapshot.agents.find((a) => a.sessionKey === sessionKey);
+    if (!agent?.tokenUsage) return undefined;
+    return {
+      totalTokens: agent.tokenUsage.totalTokens ?? undefined,
+      remainingTokens: agent.tokenUsage.remainingTokens ?? undefined,
+      estimatedCostUsd: agent.cost?.sessionUsd,
+    };
+  },
+};

--- a/src/lib/runtimes/registry.ts
+++ b/src/lib/runtimes/registry.ts
@@ -1,0 +1,98 @@
+/**
+ * Runtime Registry
+ *
+ * Central registration point for all agent runtimes.
+ * The UI and API layer talk to the registry, never to a specific runtime.
+ */
+
+import type { AgentRuntime, RuntimeId, RuntimeSession } from './types';
+
+const runtimes = new Map<RuntimeId, AgentRuntime>();
+
+/**
+ * Register an agent runtime. Called once at startup per runtime.
+ */
+export function registerRuntime(runtime: AgentRuntime): void {
+  if (runtimes.has(runtime.id)) {
+    console.warn(`[runtime-registry] Overwriting existing runtime: ${runtime.id}`);
+  }
+  runtimes.set(runtime.id, runtime);
+}
+
+/**
+ * Get a specific runtime by ID.
+ */
+export function getRuntime(id: RuntimeId): AgentRuntime | undefined {
+  return runtimes.get(id);
+}
+
+/**
+ * Get all registered runtimes.
+ */
+export function getAllRuntimes(): AgentRuntime[] {
+  return [...runtimes.values()];
+}
+
+/**
+ * Get all runtime IDs that are registered.
+ */
+export function getRegisteredRuntimeIds(): RuntimeId[] {
+  return [...runtimes.keys()];
+}
+
+/**
+ * Discover sessions across ALL registered runtimes in parallel.
+ * Failures in one runtime don't block others.
+ */
+export async function discoverAllSessions(): Promise<RuntimeSession[]> {
+  const discoverableRuntimes = getAllRuntimes().filter((r) => r.capabilities.discover);
+  if (discoverableRuntimes.length === 0) return [];
+
+  const results = await Promise.allSettled(
+    discoverableRuntimes.map(async (runtime) => {
+      try {
+        return await runtime.discoverSessions();
+      } catch (err) {
+        console.error(`[runtime-registry] Discovery failed for ${runtime.id}:`, err);
+        return [] as RuntimeSession[];
+      }
+    }),
+  );
+
+  return results
+    .filter((r): r is PromiseFulfilledResult<RuntimeSession[]> => r.status === 'fulfilled')
+    .flatMap((r) => r.value);
+}
+
+/**
+ * Perform an action on a session, routing to the correct runtime.
+ */
+export async function routeAction(
+  runtimeId: RuntimeId,
+  action: 'resume' | 'interrupt',
+  sessionKey: string,
+  message?: string,
+) {
+  const runtime = getRuntime(runtimeId);
+  if (!runtime) {
+    throw new Error(`Unknown runtime: ${runtimeId}`);
+  }
+
+  switch (action) {
+    case 'resume': {
+      if (!runtime.capabilities.resume) {
+        throw new Error(`Runtime ${runtimeId} does not support resume`);
+      }
+      if (!message) throw new Error('Message is required for resume');
+      return runtime.resume(sessionKey, message);
+    }
+    case 'interrupt': {
+      if (!runtime.capabilities.interrupt) {
+        throw new Error(`Runtime ${runtimeId} does not support interrupt`);
+      }
+      return runtime.interrupt(sessionKey);
+    }
+    default:
+      throw new Error(`Unknown action: ${action}`);
+  }
+}

--- a/src/lib/runtimes/types.ts
+++ b/src/lib/runtimes/types.ts
@@ -1,0 +1,219 @@
+/**
+ * Universal Agent Runtime Contract
+ *
+ * Every coding agent runtime (Codex, Claude Code, Aider, etc.) implements
+ * this interface. The UI talks to the registry, never to a specific runtime.
+ *
+ * Adding a new agent = one file implementing AgentRuntime.
+ */
+
+export type RuntimeId = 'openclaw' | 'codex' | 'claude-code' | (string & {});
+
+// ── Capabilities ──
+
+/**
+ * What a runtime can do. UI uses this to show/hide controls.
+ * All default to false — a runtime opts IN to capabilities.
+ */
+export interface RuntimeCapabilities {
+  /** Can discover existing sessions on disk/network */
+  discover: boolean;
+  /** Can read session transcript/history */
+  readTranscript: boolean;
+  /** Can launch a new session with a prompt */
+  launch: boolean;
+  /** Can send follow-up messages to an existing session */
+  resume: boolean;
+  /** Can interrupt/stop a running session */
+  interrupt: boolean;
+  /** Can provide changed files / diff context */
+  reviewDiffs: boolean;
+  /** Can provide cost/token telemetry */
+  costTelemetry: boolean;
+  /** Supports real-time streaming of output */
+  streaming: boolean;
+}
+
+// ── Session ──
+
+export type RuntimeSessionStatus = 'running' | 'idle' | 'waiting' | 'reviewing' | 'failed';
+export type RuntimeSessionOwnership = 'discovered' | 'owned' | 'provider';
+
+/**
+ * Normalized session shape. Every runtime maps its internal format to this.
+ */
+export interface RuntimeSession {
+  /** Unique key for this session across all runtimes */
+  sessionKey: string;
+  /** Runtime that owns this session */
+  runtimeId: RuntimeId;
+  /** Human-readable name (e.g., "cortex-ide • main") */
+  displayName: string;
+  /** Working directory */
+  cwd: string;
+  /** Git branch if known */
+  branch?: string;
+  /** Git commit SHA if known */
+  headSha?: string;
+  /** Repository slug if known (e.g., "hurttlocker/cortex-ide") */
+  repoSlug?: string;
+  /** Current status */
+  status: RuntimeSessionStatus;
+  /** Ownership model */
+  ownership: RuntimeSessionOwnership;
+  /** What can be done with this session right now */
+  sessionCapabilities: {
+    canSendInput: boolean;
+    canInterrupt: boolean;
+    canReviewDiffs: boolean;
+  };
+  /** When this session was last active */
+  lastActivityAt: Date;
+  /** The initial task/prompt */
+  initialTask?: string;
+  /** Model being used */
+  model?: string;
+  /** Lifecycle state for owned sessions */
+  lifecycle?: {
+    availability: 'awaiting-thread' | 'running' | 'ready-for-resume';
+    lastOutcome?: 'finished' | 'interrupted' | 'failed';
+    lastRunMode?: 'launch' | 'resume';
+    lastRunStartedAt?: string;
+    lastRunFinishedAt?: string;
+    summary?: string;
+  };
+  /** Process ID if running locally */
+  pid?: number;
+}
+
+// ── Transcript ──
+
+export type TranscriptRole = 'user' | 'assistant' | 'system' | 'tool';
+
+/**
+ * Normalized transcript entry. Every runtime maps its log format to this.
+ */
+export interface RuntimeTranscriptEntry {
+  id: string;
+  role: TranscriptRole;
+  text: string;
+  timestamp: Date;
+  /** Tool name if role=tool */
+  toolName?: string;
+  /** File path if the entry involves a file */
+  filePath?: string;
+}
+
+// ── Review ──
+
+export type FileChangeStatus = 'added' | 'modified' | 'deleted' | 'renamed';
+
+/**
+ * Changed file from a session's work.
+ */
+export interface RuntimeChangedFile {
+  path: string;
+  status: FileChangeStatus;
+  additions: number;
+  deletions: number;
+  originalPath?: string;
+}
+
+// ── Actions ──
+
+/**
+ * Result of a launch/resume/interrupt action.
+ */
+export interface RuntimeActionResult {
+  ok: boolean;
+  note: string;
+  sessionKey?: string;
+}
+
+/**
+ * Options for launching a new session.
+ */
+export interface LaunchOptions {
+  cwd: string;
+  prompt: string;
+  model?: string;
+}
+
+// ── Telemetry ──
+
+export interface RuntimeTelemetry {
+  totalTokens?: number;
+  remainingTokens?: number;
+  estimatedCostUsd?: number;
+}
+
+// ── THE CONTRACT ──
+
+/**
+ * Every agent runtime implements this interface.
+ *
+ * Simple runtimes can implement only discover + readTranscript.
+ * Complex ones implement all methods.
+ * The `capabilities` property tells the UI what's available.
+ */
+export interface AgentRuntime {
+  /** Unique runtime identifier */
+  readonly id: RuntimeId;
+  /** Display name for UI */
+  readonly displayName: string;
+  /** What this runtime supports */
+  readonly capabilities: RuntimeCapabilities;
+
+  // ── Discovery ──
+
+  /**
+   * Find all sessions this runtime knows about.
+   * Called on initial load and periodic refresh.
+   */
+  discoverSessions(): Promise<RuntimeSession[]>;
+
+  // ── Transcript ──
+
+  /**
+   * Read transcript entries for a session.
+   * @param sessionKey - The session to read
+   * @param sinceId - Only return entries after this ID (for incremental fetch)
+   * @param limit - Max entries to return
+   */
+  readTranscript(
+    sessionKey: string,
+    sinceId?: string,
+    limit?: number,
+  ): Promise<RuntimeTranscriptEntry[]>;
+
+  // ── Lifecycle ──
+
+  /**
+   * Launch a new session with a prompt.
+   */
+  launch(opts: LaunchOptions): Promise<RuntimeActionResult>;
+
+  /**
+   * Send a follow-up message to an existing session.
+   */
+  resume(sessionKey: string, message: string): Promise<RuntimeActionResult>;
+
+  /**
+   * Interrupt/stop a running session.
+   */
+  interrupt(sessionKey: string): Promise<RuntimeActionResult>;
+
+  // ── Review ──
+
+  /**
+   * Get changed files from a session's work.
+   */
+  getChangedFiles(sessionKey: string): Promise<RuntimeChangedFile[]>;
+
+  // ── Telemetry (optional) ──
+
+  /**
+   * Get cost/usage data for a session. Optional — return undefined if not supported.
+   */
+  getTelemetry?(sessionKey: string): Promise<RuntimeTelemetry | undefined>;
+}


### PR DESCRIPTION
## Runtime Adapter v2

**One file = one agent runtime.** This PR introduces the universal `AgentRuntime` contract and wires Claude Code as the first new runtime through it.

### What's in this PR

**The Contract** (`src/lib/runtimes/types.ts`):
- `AgentRuntime` interface: 7 methods (discover, readTranscript, launch, resume, interrupt, getChangedFiles, getTelemetry)
- `RuntimeCapabilities`: declared, not assumed — UI adapts to what each runtime supports
- `RuntimeSession`: normalized session shape across all runtimes

**The Registry** (`src/lib/runtimes/registry.ts`):
- `registerRuntime()` / `getRuntime()` / `getAllRuntimes()`
- `discoverAllSessions()`: queries all runtimes in parallel
- `routeAction()`: dispatch to the correct runtime

**Three Adapters:**
| Runtime | File | Lines | Discovery | Transcript | Launch | Resume | Interrupt | Review |
|---|---|---|---|---|---|---|---|---|
| OpenClaw | `openclaw.ts` | 120 | ✅ gateway | ✅ chat.history | ❌ mirror-only | ✅ chat.send | ✅ abort | ✅ |
| Codex | `codex.ts` | 167 | ✅ sqlite+fs | ✅ JSONL | ✅ codex exec | ✅ codex resume | ✅ SIGINT | ✅ git diff |
| Claude Code | `claude-code.ts` | 477 | ✅ ~/.claude/ | ✅ JSONL | ✅ claude -p | ✅ claude --resume | ✅ SIGINT | ✅ git diff |

**UI Wiring:**
- `actions.ts`: Registry-based fallback dispatch — any runtime not hardcoded routes through `getRuntime().resume()`
- `fleet.ts`: Claude Code sessions merged into fleet snapshot with squad, events, surfaces
- Claude Code sessions appear in Squad view as cards with status, branch, CWD

### Adding future runtimes

```typescript
// src/lib/runtimes/aider.ts — one file
export const aiderRuntime: AgentRuntime = {
  id: 'aider',
  displayName: 'Aider',
  capabilities: { discover: true, readTranscript: true, ... },
  async discoverSessions() { /* ... */ },
  async readTranscript() { /* ... */ },
  // ...
};
```

Then add one line to `index.ts`:
```typescript
registerRuntime(aiderRuntime);
```

No UI changes. No API changes. The entire IDE works.

### Closes
- #11 (Define runtime adapter contract)
- #17 (Generalize mobile bridge beyond Codex)

Build + typecheck clean. Claude Code transcript parsing verified against real `~/.claude/projects/` data.