### PR TITLE
feat: Worktree Isolation Phase 1 — WorktreeManager, Launch Integration, UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ build/
 coverage/
 *.log
 *.tsbuildinfo
+
+# Worktree isolation
+.cortex-worktrees/

--- a/src/app/api/worktrees/merge/route.ts
+++ b/src/app/api/worktrees/merge/route.ts
@@ -1,0 +1,221 @@
+/**
+ * Worktree Merge API
+ *
+ * POST /api/worktrees/merge — Create PR, merge to main, or discard a worktree
+ *
+ * @see https://github.com/hurttlocker/cortex-ide/issues/70
+ */
+
+export const dynamic = 'force-dynamic';
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { NextResponse, type NextRequest } from 'next/server';
+import { getWorktreeManager } from '@/lib/worktree/launch';
+import type { MergeResult } from '@/lib/worktree/types';
+
+const execFileAsync = promisify(execFile);
+
+interface MergeBody {
+  repo: string;
+  worktreeId: string;
+  action: 'pr' | 'merge' | 'discard';
+  /** Target branch for merge (default: main) */
+  targetBranch?: string;
+  /** PR title override */
+  prTitle?: string;
+  /** PR body override */
+  prBody?: string;
+}
+
+export async function POST(req: NextRequest) {
+  let body: MergeBody;
+  try {
+    body = (await req.json()) as MergeBody;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (!body.repo || !body.worktreeId || !body.action) {
+    return NextResponse.json(
+      { error: 'repo, worktreeId, and action are required' },
+      { status: 400 },
+    );
+  }
+
+  const mgr = getWorktreeManager(body.repo);
+  const worktree = await mgr.get(body.worktreeId);
+
+  if (!worktree) {
+    return NextResponse.json({ error: 'Worktree not found' }, { status: 404 });
+  }
+
+  try {
+    let result: MergeResult;
+
+    switch (body.action) {
+      case 'pr':
+        result = await createPR(worktree.path, worktree.branch, worktree.dirtyFiles, {
+          title: body.prTitle,
+          body: body.prBody,
+          targetBranch: body.targetBranch ?? 'main',
+          agentType: worktree.agentType,
+        });
+        // Cleanup worktree but keep branch (PR needs it)
+        if (result.ok) {
+          await mgr.cleanup(body.worktreeId, { force: true, deleteBranch: false });
+        }
+        break;
+
+      case 'merge':
+        result = await mergeToTarget(body.repo, worktree.path, worktree.branch, body.targetBranch ?? 'main');
+        if (result.ok) {
+          await mgr.cleanup(body.worktreeId, { force: true, deleteBranch: true });
+        }
+        break;
+
+      case 'discard':
+        await mgr.cleanup(body.worktreeId, { force: true, deleteBranch: true });
+        result = { action: 'discard', ok: true, note: `Discarded worktree ${body.worktreeId}` };
+        break;
+
+      default:
+        return NextResponse.json({ error: 'Unknown action' }, { status: 400 });
+    }
+
+    return NextResponse.json(result);
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Unknown error' },
+      { status: 500 },
+    );
+  }
+}
+
+// ── PR Creation ──
+
+async function createPR(
+  worktreePath: string,
+  branch: string,
+  dirtyFiles: string[],
+  opts: { title?: string; body?: string; targetBranch: string; agentType: string },
+): Promise<MergeResult> {
+  // Commit any uncommitted changes
+  try {
+    await execFileAsync('git', ['add', '-A'], { cwd: worktreePath, timeout: 10_000 });
+    await execFileAsync('git', ['commit', '-m', `chore: worktree changes from ${opts.agentType}`], {
+      cwd: worktreePath,
+      timeout: 10_000,
+    });
+  } catch {
+    // May already be committed — that's fine
+  }
+
+  // Push branch
+  try {
+    await execFileAsync('git', ['push', '-u', 'origin', branch], {
+      cwd: worktreePath,
+      timeout: 30_000,
+    });
+  } catch (err) {
+    return {
+      action: 'pr',
+      ok: false,
+      note: `Failed to push branch: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  // Create PR via gh CLI
+  const title = opts.title ?? `Agent work: ${branch.split('/').pop()}`;
+  const fileList = dirtyFiles.map((f) => `- \`${f}\``).join('\n');
+  const prBody = opts.body ?? `## Changes\nAgent: ${opts.agentType}\n\n### Files Modified (${dirtyFiles.length})\n${fileList}\n\n---\n*Created by Cortex IDE WorktreeManager*`;
+
+  try {
+    const { stdout } = await execFileAsync('gh', [
+      'pr', 'create',
+      '--title', title,
+      '--body', prBody,
+      '--base', opts.targetBranch,
+      '--head', branch,
+    ], { cwd: worktreePath, timeout: 30_000 });
+
+    const prUrl = stdout.trim();
+    return {
+      action: 'pr',
+      ok: true,
+      note: `PR created: ${prUrl}`,
+      prUrl,
+    };
+  } catch (err) {
+    return {
+      action: 'pr',
+      ok: false,
+      note: `Failed to create PR: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+// ── Direct Merge ──
+
+async function mergeToTarget(
+  repoRoot: string,
+  worktreePath: string,
+  branch: string,
+  targetBranch: string,
+): Promise<MergeResult> {
+  // Commit any uncommitted changes first
+  try {
+    await execFileAsync('git', ['add', '-A'], { cwd: worktreePath, timeout: 10_000 });
+    await execFileAsync('git', ['commit', '-m', `chore: worktree changes`], {
+      cwd: worktreePath,
+      timeout: 10_000,
+    });
+  } catch {
+    // Already committed
+  }
+
+  // Check for conflicts before merging
+  try {
+    // Dry run: attempt merge in the repo root
+    const { stdout: mergeCheck } = await execFileAsync('git', [
+      'merge-tree', '--write-tree', targetBranch, branch,
+    ], { cwd: repoRoot, timeout: 10_000 });
+
+    if (mergeCheck.includes('CONFLICT')) {
+      return {
+        action: 'merge',
+        ok: false,
+        note: 'Merge conflicts detected. Use "Create PR" instead for manual resolution.',
+      };
+    }
+  } catch {
+    // merge-tree may not be available; fall through to try merge
+  }
+
+  // Perform the actual merge from the repo root
+  try {
+    await execFileAsync('git', ['checkout', targetBranch], {
+      cwd: repoRoot,
+      timeout: 10_000,
+    });
+
+    await execFileAsync('git', ['merge', '--no-ff', branch, '-m', `Merge worktree: ${branch}`], {
+      cwd: repoRoot,
+      timeout: 15_000,
+    });
+
+    return {
+      action: 'merge',
+      ok: true,
+      note: `Merged ${branch} into ${targetBranch}`,
+    };
+  } catch (err) {
+    // Abort any partial merge
+    await execFileAsync('git', ['merge', '--abort'], { cwd: repoRoot, timeout: 5000 }).catch(() => {});
+    return {
+      action: 'merge',
+      ok: false,
+      note: `Merge failed: ${err instanceof Error ? err.message : String(err)}. Use "Create PR" instead.`,
+    };
+  }
+}

--- a/src/app/api/worktrees/route.ts
+++ b/src/app/api/worktrees/route.ts
@@ -1,0 +1,132 @@
+/**
+ * Worktree API Routes
+ *
+ * GET  /api/worktrees?repo=<path>    — List all worktrees + conflict status
+ * POST /api/worktrees                — Create a new worktree
+ * DELETE /api/worktrees              — Cleanup/prune worktrees
+ *
+ * @see https://github.com/hurttlocker/cortex-ide/issues/67
+ */
+
+export const dynamic = 'force-dynamic';
+
+import { NextResponse, type NextRequest } from 'next/server';
+import { getWorktreeManager, getActiveWorktreeSummary } from '@/lib/worktree/launch';
+
+// ── GET: List worktrees + conflicts ──
+
+export async function GET(req: NextRequest) {
+  const repo = req.nextUrl.searchParams.get('repo');
+  if (!repo) {
+    return NextResponse.json({ error: 'repo parameter required' }, { status: 400 });
+  }
+
+  try {
+    const summary = await getActiveWorktreeSummary(repo);
+    return NextResponse.json(summary);
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Unknown error' },
+      { status: 500 },
+    );
+  }
+}
+
+// ── POST: Create worktree ──
+
+interface CreateBody {
+  repo: string;
+  agentType: string;
+  taskName: string;
+  baseBranch?: string;
+  skipSetup?: boolean;
+}
+
+export async function POST(req: NextRequest) {
+  let body: CreateBody;
+  try {
+    body = (await req.json()) as CreateBody;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (!body.repo || !body.agentType || !body.taskName) {
+    return NextResponse.json(
+      { error: 'repo, agentType, and taskName are required' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const mgr = getWorktreeManager(body.repo);
+    const worktree = await mgr.create({
+      agentType: body.agentType,
+      taskName: body.taskName,
+      baseBranch: body.baseBranch,
+      skipSetup: body.skipSetup,
+    });
+
+    return NextResponse.json({ worktree }, { status: 201 });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Unknown error' },
+      { status: 500 },
+    );
+  }
+}
+
+// ── DELETE: Cleanup or prune ──
+
+interface DeleteBody {
+  repo: string;
+  worktreeId?: string;
+  action: 'cleanup' | 'prune';
+  force?: boolean;
+  deleteBranch?: boolean;
+  maxAgeMs?: number;
+}
+
+export async function DELETE(req: NextRequest) {
+  let body: DeleteBody;
+  try {
+    body = (await req.json()) as DeleteBody;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (!body.repo || !body.action) {
+    return NextResponse.json(
+      { error: 'repo and action are required' },
+      { status: 400 },
+    );
+  }
+
+  const mgr = getWorktreeManager(body.repo);
+
+  try {
+    if (body.action === 'prune') {
+      const pruned = await mgr.prune(body.maxAgeMs);
+      return NextResponse.json({ pruned, count: pruned.length });
+    }
+
+    if (body.action === 'cleanup') {
+      if (!body.worktreeId) {
+        return NextResponse.json({ error: 'worktreeId required for cleanup' }, { status: 400 });
+      }
+
+      await mgr.cleanup(body.worktreeId, {
+        force: body.force,
+        deleteBranch: body.deleteBranch,
+      });
+
+      return NextResponse.json({ ok: true, cleaned: body.worktreeId });
+    }
+
+    return NextResponse.json({ error: 'Unknown action' }, { status: 400 });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Unknown error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/mobile/WorktreeActions.tsx
+++ b/src/components/mobile/WorktreeActions.tsx
@@ -1,0 +1,157 @@
+/**
+ * WorktreeActions — Merge/PR/Discard actions for completed worktree sessions.
+ *
+ * Appears in the agent pill when an agent session completes with dirty files.
+ * Three actions: Create PR, Merge to main, Discard.
+ *
+ * @see https://github.com/hurttlocker/cortex-ide/issues/67
+ * @see https://github.com/hurttlocker/cortex-ide/issues/70
+ */
+
+import { memo, useCallback, useState } from 'react';
+import type { WorktreeInfo, MergeResult } from '@/lib/worktree/types';
+
+interface WorktreeActionsProps {
+  worktree: WorktreeInfo;
+  repoRoot: string;
+  onResult: (result: MergeResult) => void;
+}
+
+type ActionType = 'pr' | 'merge' | 'discard';
+
+export const WorktreeActions = memo(function WorktreeActions({
+  worktree,
+  repoRoot,
+  onResult,
+}: WorktreeActionsProps) {
+  const [loading, setLoading] = useState<ActionType | null>(null);
+  const [confirmed, setConfirmed] = useState<ActionType | null>(null);
+
+  const handleAction = useCallback(async (action: ActionType) => {
+    // Discard requires confirmation
+    if (action === 'discard' && confirmed !== 'discard') {
+      setConfirmed('discard');
+      return;
+    }
+
+    setLoading(action);
+    setConfirmed(null);
+
+    try {
+      const res = await fetch('/api/worktrees/merge', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          repo: repoRoot,
+          worktreeId: worktree.id,
+          action,
+        }),
+      });
+
+      const result = (await res.json()) as MergeResult;
+      onResult(result);
+    } catch (err) {
+      onResult({
+        action,
+        ok: false,
+        note: err instanceof Error ? err.message : 'Unknown error',
+      });
+    } finally {
+      setLoading(null);
+    }
+  }, [worktree.id, repoRoot, onResult, confirmed]);
+
+  const fileCount = worktree.dirtyFiles.length;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '6px',
+        marginTop: '6px',
+        padding: '8px',
+        borderRadius: '10px',
+        backgroundColor: 'rgba(255,255,255,0.04)',
+      }}
+    >
+      {/* Status line */}
+      <div
+        style={{
+          fontSize: '11px',
+          color: '#34c759',
+          fontWeight: 600,
+          display: 'flex',
+          alignItems: 'center',
+          gap: '4px',
+        }}
+      >
+        <span>✓</span>
+        <span>Done — {fileCount} file{fileCount !== 1 ? 's' : ''} changed</span>
+      </div>
+
+      {/* Action buttons */}
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '6px' }}>
+        <button
+          type="button"
+          onClick={() => handleAction('pr')}
+          disabled={loading !== null}
+          style={{
+            padding: '6px 0',
+            borderRadius: '8px',
+            backgroundColor: '#007aff',
+            border: 'none',
+            color: '#fff',
+            fontSize: '11px',
+            fontWeight: 600,
+            cursor: 'pointer',
+            opacity: loading === 'pr' ? 0.6 : loading ? 0.4 : 1,
+            WebkitTapHighlightColor: 'transparent',
+          }}
+        >
+          {loading === 'pr' ? '…' : 'Create PR'}
+        </button>
+
+        <button
+          type="button"
+          onClick={() => handleAction('merge')}
+          disabled={loading !== null}
+          style={{
+            padding: '6px 0',
+            borderRadius: '8px',
+            backgroundColor: '#34c759',
+            border: 'none',
+            color: '#fff',
+            fontSize: '11px',
+            fontWeight: 600,
+            cursor: 'pointer',
+            opacity: loading === 'merge' ? 0.6 : loading ? 0.4 : 1,
+            WebkitTapHighlightColor: 'transparent',
+          }}
+        >
+          {loading === 'merge' ? '…' : 'Merge'}
+        </button>
+
+        <button
+          type="button"
+          onClick={() => handleAction('discard')}
+          disabled={loading !== null}
+          style={{
+            padding: '6px 0',
+            borderRadius: '8px',
+            backgroundColor: confirmed === 'discard' ? '#ff3b30' : 'rgba(255,59,48,0.15)',
+            border: 'none',
+            color: confirmed === 'discard' ? '#fff' : '#ff3b30',
+            fontSize: '11px',
+            fontWeight: 600,
+            cursor: 'pointer',
+            opacity: loading === 'discard' ? 0.6 : loading ? 0.4 : 1,
+            WebkitTapHighlightColor: 'transparent',
+          }}
+        >
+          {loading === 'discard' ? '…' : confirmed === 'discard' ? 'Confirm' : 'Discard'}
+        </button>
+      </div>
+    </div>
+  );
+});

--- a/src/components/mobile/WorktreeBadge.tsx
+++ b/src/components/mobile/WorktreeBadge.tsx
@@ -1,0 +1,94 @@
+/**
+ * WorktreeBadge — Inline worktree indicator for agent pills in squad panel.
+ *
+ * Shows: branch name, dirty file count, conflict warning.
+ * Designed to be compact — fits inside the existing agent pill layout.
+ *
+ * @see https://github.com/hurttlocker/cortex-ide/issues/67
+ */
+
+import { memo } from 'react';
+import type { WorktreeInfo } from '@/lib/worktree/types';
+
+interface WorktreeBadgeProps {
+  worktree: WorktreeInfo;
+  hasConflict?: boolean;
+}
+
+export const WorktreeBadge = memo(function WorktreeBadge({ worktree, hasConflict }: WorktreeBadgeProps) {
+  const branchShort = worktree.branch
+    .replace(/^worktree\/[^/]+\//, '')
+    .slice(0, 24);
+
+  const fileCount = worktree.dirtyFiles.length;
+  const statusColor = worktree.status === 'active'
+    ? '#34c759'
+    : worktree.status === 'stale'
+      ? '#8e8e93'
+      : '#007aff';
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '4px',
+        marginTop: '2px',
+        fontSize: '10px',
+        letterSpacing: '-0.01em',
+        lineHeight: 1,
+        color: '#8e8e93',
+      }}
+    >
+      {/* Git branch icon (inline SVG for zero deps) */}
+      <svg width="10" height="10" viewBox="0 0 16 16" fill="none" style={{ flexShrink: 0 }}>
+        <circle cx="5" cy="4" r="1.5" stroke="#8e8e93" strokeWidth="1.5" fill="none" />
+        <circle cx="5" cy="12" r="1.5" stroke="#8e8e93" strokeWidth="1.5" fill="none" />
+        <circle cx="11" cy="6" r="1.5" stroke={statusColor} strokeWidth="1.5" fill="none" />
+        <line x1="5" y1="5.5" x2="5" y2="10.5" stroke="#8e8e93" strokeWidth="1.5" />
+        <path d="M5 7.5 C5 7.5 7 6 11 6" stroke="#8e8e93" strokeWidth="1.5" fill="none" />
+      </svg>
+
+      <span style={{ color: '#b0b0b0', maxWidth: '100px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {branchShort}
+      </span>
+
+      {fileCount > 0 ? (
+        <span
+          style={{
+            color: statusColor,
+            fontWeight: 600,
+            fontSize: '9px',
+          }}
+        >
+          {fileCount} {fileCount === 1 ? 'file' : 'files'}
+        </span>
+      ) : null}
+
+      {hasConflict ? (
+        <span
+          title="Conflicts with another agent's worktree"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '2px',
+            color: '#ff9f0a',
+            fontWeight: 600,
+            fontSize: '9px',
+          }}
+        >
+          <span
+            style={{
+              width: '5px',
+              height: '5px',
+              borderRadius: '50%',
+              backgroundColor: '#ff9f0a',
+              flexShrink: 0,
+            }}
+          />
+          conflict
+        </span>
+      ) : null}
+    </div>
+  );
+});

--- a/src/components/mobile/WorktreeSummary.tsx
+++ b/src/components/mobile/WorktreeSummary.tsx
@@ -1,0 +1,200 @@
+/**
+ * WorktreeSummary — Summary card for all active worktrees in a repo.
+ *
+ * Shows: active count, total disk, conflict status, prune button.
+ * Lives above the squad grid when worktrees are active.
+ *
+ * @see https://github.com/hurttlocker/cortex-ide/issues/67
+ */
+
+import { memo, useCallback, useState } from 'react';
+import type { WorktreeInfo, ConflictReport } from '@/lib/worktree/types';
+
+interface WorktreeSummaryProps {
+  worktrees: WorktreeInfo[];
+  conflicts: { safe: boolean; count: number };
+  onPrune: () => void | Promise<void>;
+  onWorktreeSelect?: (worktreeId: string) => void;
+}
+
+const AGENT_COLORS: Record<string, string> = {
+  'claude-code': '#cc785c',  // Claude warm orange
+  'codex': '#10a37f',        // Codex green
+  'openclaw': '#ff3b30',     // OpenClaw red
+};
+
+export const WorktreeSummary = memo(function WorktreeSummary({
+  worktrees,
+  conflicts,
+  onPrune,
+  onWorktreeSelect,
+}: WorktreeSummaryProps) {
+  const [pruning, setPruning] = useState(false);
+
+  const active = worktrees.filter((wt) =>
+    wt.status === 'active' || wt.status === 'ready' || wt.status === 'setup',
+  );
+
+  if (active.length === 0) return null;
+
+  const handlePrune = useCallback(async () => {
+    setPruning(true);
+    try {
+      await onPrune();
+    } finally {
+      setPruning(false);
+    }
+  }, [onPrune]);
+
+  const totalFiles = active.reduce((sum, wt) => sum + wt.dirtyFiles.length, 0);
+
+  return (
+    <div
+      style={{
+        margin: '0 12px 8px',
+        padding: '10px 14px',
+        borderRadius: '14px',
+        backgroundColor: '#1c1c1e',
+        border: '1px solid rgba(255,255,255,0.06)',
+      }}
+    >
+      {/* Header row */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: '8px',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+            <circle cx="5" cy="4" r="1.5" stroke="#8e8e93" strokeWidth="1.5" fill="none" />
+            <circle cx="5" cy="12" r="1.5" stroke="#8e8e93" strokeWidth="1.5" fill="none" />
+            <circle cx="11" cy="6" r="1.5" stroke="#34c759" strokeWidth="1.5" fill="none" />
+            <line x1="5" y1="5.5" x2="5" y2="10.5" stroke="#8e8e93" strokeWidth="1.5" />
+            <path d="M5 7.5 C5 7.5 7 6 11 6" stroke="#8e8e93" strokeWidth="1.5" fill="none" />
+          </svg>
+          <span
+            style={{
+              fontSize: '12px',
+              fontWeight: 600,
+              color: '#e5e5ea',
+              letterSpacing: '-0.02em',
+            }}
+          >
+            Worktrees
+          </span>
+          <span
+            style={{
+              fontSize: '11px',
+              color: '#8e8e93',
+              fontWeight: 500,
+            }}
+          >
+            {active.length} active · {totalFiles} files
+          </span>
+        </div>
+
+        {!conflicts.safe ? (
+          <span
+            style={{
+              fontSize: '10px',
+              fontWeight: 600,
+              color: '#ff9f0a',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '3px',
+            }}
+          >
+            <span
+              style={{
+                width: '5px',
+                height: '5px',
+                borderRadius: '50%',
+                backgroundColor: '#ff9f0a',
+              }}
+            />
+            {conflicts.count} conflict{conflicts.count !== 1 ? 's' : ''}
+          </span>
+        ) : null}
+      </div>
+
+      {/* Worktree mini-pills */}
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '6px',
+          marginBottom: '8px',
+        }}
+      >
+        {active.map((wt) => {
+          const color = AGENT_COLORS[wt.agentType] ?? '#8e8e93';
+          const label = wt.id.slice(0, 16);
+
+          return (
+            <button
+              key={wt.id}
+              type="button"
+              onClick={() => onWorktreeSelect?.(wt.id)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '4px',
+                padding: '3px 8px',
+                borderRadius: '8px',
+                backgroundColor: 'rgba(255,255,255,0.06)',
+                border: 'none',
+                cursor: 'pointer',
+                fontSize: '10px',
+                color: '#e5e5ea',
+                letterSpacing: '-0.01em',
+                WebkitTapHighlightColor: 'transparent',
+              }}
+            >
+              <span
+                style={{
+                  width: '6px',
+                  height: '6px',
+                  borderRadius: '50%',
+                  backgroundColor: color,
+                  flexShrink: 0,
+                }}
+              />
+              {label}
+              {wt.dirtyFiles.length > 0 ? (
+                <span style={{ color: '#8e8e93' }}>
+                  {wt.dirtyFiles.length}f
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Actions row */}
+      <div style={{ display: 'flex', gap: '8px' }}>
+        <button
+          type="button"
+          onClick={handlePrune}
+          disabled={pruning}
+          style={{
+            padding: '4px 10px',
+            borderRadius: '8px',
+            backgroundColor: 'rgba(255,255,255,0.08)',
+            border: 'none',
+            color: '#8e8e93',
+            fontSize: '11px',
+            fontWeight: 500,
+            cursor: 'pointer',
+            opacity: pruning ? 0.5 : 1,
+            WebkitTapHighlightColor: 'transparent',
+          }}
+        >
+          {pruning ? 'Pruning…' : 'Prune stale'}
+        </button>
+      </div>
+    </div>
+  );
+});

--- a/src/lib/worktree/index.ts
+++ b/src/lib/worktree/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Worktree Isolation — Barrel Export
+ *
+ * @see https://github.com/hurttlocker/cortex-ide/issues/65
+ */
+
+export { WorktreeManager } from './manager';
+
+export {
+  prepareLaunchWorktree,
+  shouldIsolate,
+  linkSessionToWorktree,
+  getWorktreeManager,
+  getActiveWorktreeSummary,
+} from './launch';
+
+export type {
+  WorktreeInfo,
+  WorktreeStatus,
+  AgentType,
+  ConflictReport,
+  ConflictEntry,
+  CreateWorktreeOptions,
+  CleanupOptions,
+  MergeResult,
+  WorktreeMetaStore,
+  WorktreeMetaEntry,
+} from './types';
+
+export type {
+  WorktreeLaunchResult,
+  WorktreeLaunchOptions,
+} from './launch';

--- a/src/lib/worktree/launch.ts
+++ b/src/lib/worktree/launch.ts
@@ -1,0 +1,161 @@
+/**
+ * Worktree Launch Integration
+ *
+ * Wires WorktreeManager into the agent launch flow.
+ * - Claude Code: appends --worktree flag (Claude creates + manages worktree natively)
+ * - Codex / others: creates managed worktree, sets cwd for agent launch
+ *
+ * Auto-toggle: worktree isolation defaults ON when repo has active agents,
+ * OFF when it's the first/only agent.
+ *
+ * @see https://github.com/hurttlocker/cortex-ide/issues/68
+ */
+
+import { WorktreeManager } from './manager';
+import type { AgentType, WorktreeInfo } from './types';
+
+// Cache managers per repo to avoid re-instantiating
+const managers = new Map<string, WorktreeManager>();
+
+function getManager(repoRoot: string): WorktreeManager {
+  let mgr = managers.get(repoRoot);
+  if (!mgr) {
+    mgr = new WorktreeManager(repoRoot);
+    managers.set(repoRoot, mgr);
+  }
+  return mgr;
+}
+
+/**
+ * Resolve launch options for an agent, potentially creating a worktree.
+ *
+ * Returns:
+ * - { worktree, cwd, claudeWorktreeFlag } if isolation was applied
+ * - null if no isolation needed (first agent, or user opted out)
+ */
+export interface WorktreeLaunchResult {
+  /** The worktree metadata */
+  worktree: WorktreeInfo;
+  /** CWD to launch the agent in (worktree path for managed, repo root for Claude) */
+  cwd: string;
+  /** For Claude Code: the --worktree flag value to pass */
+  claudeWorktreeFlag?: string;
+}
+
+export interface WorktreeLaunchOptions {
+  /** Repository root path */
+  repoRoot: string;
+  /** Agent type being launched */
+  agentType: AgentType;
+  /** Human-readable task name */
+  taskName: string;
+  /** Base branch (default: current HEAD) */
+  baseBranch?: string;
+  /** Force isolation on/off. If undefined, auto-decides based on active agents. */
+  isolate?: boolean;
+  /** Skip project setup (npm install, etc.) */
+  skipSetup?: boolean;
+}
+
+/**
+ * Should this launch get worktree isolation?
+ *
+ * Auto-logic:
+ * - If isolate is explicitly set, respect it
+ * - If there are already active worktrees for this repo, isolate
+ * - If this is the first/only agent, don't isolate (no conflict risk)
+ */
+export async function shouldIsolate(opts: WorktreeLaunchOptions): Promise<boolean> {
+  if (opts.isolate !== undefined) return opts.isolate;
+
+  const mgr = getManager(opts.repoRoot);
+  const existing = await mgr.list();
+  const active = existing.filter(
+    (wt) => wt.status === 'active' || wt.status === 'ready' || wt.status === 'setup',
+  );
+
+  // If there's already at least one active worktree, this new agent needs isolation
+  return active.length > 0;
+}
+
+/**
+ * Prepare a worktree for an agent launch.
+ *
+ * For Claude Code: creates metadata entry, returns flag to pass to CLI.
+ * For Codex / others: creates real worktree, runs setup, returns cwd.
+ *
+ * Returns null if isolation is not needed.
+ */
+export async function prepareLaunchWorktree(
+  opts: WorktreeLaunchOptions,
+): Promise<WorktreeLaunchResult | null> {
+  const isolate = await shouldIsolate(opts);
+  if (!isolate) return null;
+
+  const mgr = getManager(opts.repoRoot);
+
+  const worktree = await mgr.create({
+    agentType: opts.agentType,
+    taskName: opts.taskName,
+    baseBranch: opts.baseBranch,
+    skipSetup: opts.skipSetup,
+  });
+
+  if (opts.agentType === 'claude-code') {
+    return {
+      worktree,
+      cwd: opts.repoRoot, // Claude runs from repo root, creates worktree itself
+      claudeWorktreeFlag: worktree.id, // Pass as: claude --worktree ${flag}
+    };
+  }
+
+  return {
+    worktree,
+    cwd: worktree.path, // Codex and others run inside the worktree directory
+  };
+}
+
+/**
+ * Link a launched agent session to its worktree.
+ * Called after successful agent launch to associate the session key.
+ */
+export async function linkSessionToWorktree(
+  repoRoot: string,
+  worktreeId: string,
+  sessionKey: string,
+): Promise<void> {
+  const mgr = getManager(repoRoot);
+  await mgr.linkSession(worktreeId, sessionKey);
+}
+
+/**
+ * Get the WorktreeManager for a repo (for direct use in API routes).
+ */
+export function getWorktreeManager(repoRoot: string): WorktreeManager {
+  return getManager(repoRoot);
+}
+
+/**
+ * Get worktree info for all repos that have active worktrees.
+ * Used by the squad panel to show worktree indicators.
+ */
+export async function getActiveWorktreeSummary(repoRoot: string): Promise<{
+  worktrees: WorktreeInfo[];
+  conflicts: { safe: boolean; count: number };
+  totalDiskUsage: number;
+}> {
+  const mgr = getManager(repoRoot);
+  const [worktrees, conflicts] = await Promise.all([
+    mgr.list(),
+    mgr.detectConflicts(),
+  ]);
+
+  return {
+    worktrees,
+    conflicts: {
+      safe: conflicts.safe,
+      count: conflicts.overlapping.length,
+    },
+    totalDiskUsage: 0, // Lazy — computed on demand, not at list time
+  };
+}

--- a/src/lib/worktree/manager.ts
+++ b/src/lib/worktree/manager.ts
@@ -1,0 +1,519 @@
+/**
+ * WorktreeManager — Orchestration Layer for Git Worktree Isolation
+ *
+ * Manages worktree lifecycle for ALL agent types:
+ * - Claude Code: passes through --worktree flag (Claude handles creation natively)
+ * - Codex / others: creates and manages worktrees via git commands
+ *
+ * ~300 lines. Not a git reimplementation — thin orchestration on top of
+ * git worktree + agent-specific behavior.
+ *
+ * Designed to generalize to IsolationProvider (containers, VMs) in 2028.
+ *
+ * @see https://github.com/hurttlocker/cortex-ide/issues/65
+ * @see https://github.com/hurttlocker/cortex-ide/issues/66
+ */
+
+import { execFile } from 'node:child_process';
+import { access, mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import type {
+  AgentType,
+  CleanupOptions,
+  ConflictReport,
+  CreateWorktreeOptions,
+  WorktreeInfo,
+  WorktreeMetaEntry,
+  WorktreeMetaStore,
+  WorktreeStatus,
+} from './types';
+
+const execFileAsync = promisify(execFile);
+const WORKTREE_DIR_NAME = '.cortex-worktrees';
+const META_FILENAME = '.meta.json';
+const CLAUDE_WORKTREE_DIR = '.claude/worktrees';
+const STALE_THRESHOLD_MS = 24 * 60 * 60_000; // 24 hours
+
+/**
+ * Sanitize a task name into a safe directory/branch name.
+ * Replaces spaces with dashes, strips special chars, lowercases.
+ */
+function sanitizeTaskName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9-_]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 60);
+}
+
+export class WorktreeManager {
+  private repoRoot: string;
+  private worktreeBase: string;
+  private metaPath: string;
+
+  constructor(repoRoot: string) {
+    this.repoRoot = repoRoot;
+    this.worktreeBase = path.join(repoRoot, WORKTREE_DIR_NAME);
+    this.metaPath = path.join(this.worktreeBase, META_FILENAME);
+  }
+
+  // ── Create ──
+
+  /**
+   * Create a new isolated worktree for an agent.
+   * Claude Code: records metadata only (Claude creates worktree via --worktree flag)
+   * Codex/others: git worktree add + optional setup
+   */
+  async create(opts: CreateWorktreeOptions): Promise<WorktreeInfo> {
+    const taskId = sanitizeTaskName(opts.taskName);
+    const baseBranch = opts.baseBranch ?? await this.getCurrentBranch();
+    const branchName = `worktree/${opts.agentType}/${taskId}`;
+    const now = Date.now();
+
+    if (opts.agentType === 'claude-code') {
+      // Claude manages its own worktree — we just track it
+      const claudeWorktreePath = path.join(this.repoRoot, CLAUDE_WORKTREE_DIR, taskId);
+
+      const info: WorktreeInfo = {
+        id: taskId,
+        path: claudeWorktreePath,
+        branch: branchName,
+        baseBranch,
+        agentType: 'claude-code',
+        status: 'creating',
+        createdAt: now,
+        lastActivityAt: now,
+        dirtyFiles: [],
+        claudeManaged: true,
+      };
+
+      await this.saveMeta(taskId, {
+        id: taskId,
+        agentType: 'claude-code',
+        baseBranch,
+        createdAt: now,
+        claudeManaged: true,
+        taskName: opts.taskName,
+      });
+
+      return info;
+    }
+
+    // For Codex and all other agents: we manage the full worktree lifecycle
+    const worktreePath = path.join(this.worktreeBase, taskId);
+
+    // Ensure worktree base directory exists
+    await mkdir(this.worktreeBase, { recursive: true });
+
+    // Create the worktree + branch
+    await execFileAsync('git', [
+      'worktree', 'add',
+      worktreePath,
+      '-b', branchName,
+      baseBranch,
+    ], { cwd: this.repoRoot, timeout: 30_000 });
+
+    const info: WorktreeInfo = {
+      id: taskId,
+      path: worktreePath,
+      branch: branchName,
+      baseBranch,
+      agentType: opts.agentType,
+      status: 'setup',
+      createdAt: now,
+      lastActivityAt: now,
+      dirtyFiles: [],
+      claudeManaged: false,
+    };
+
+    // Save metadata
+    await this.saveMeta(taskId, {
+      id: taskId,
+      agentType: opts.agentType,
+      baseBranch,
+      createdAt: now,
+      claudeManaged: false,
+      taskName: opts.taskName,
+    });
+
+    // Run project setup unless skipped
+    if (!opts.skipSetup) {
+      info.status = 'setup';
+      await this.runSetup(worktreePath);
+    }
+
+    info.status = 'ready';
+    return info;
+  }
+
+  // ── List ──
+
+  /**
+   * List all worktrees (both managed and Claude-native).
+   * Combines git worktree list with our metadata.
+   */
+  async list(): Promise<WorktreeInfo[]> {
+    const [gitWorktrees, meta] = await Promise.all([
+      this.gitWorktreeList(),
+      this.loadAllMeta(),
+    ]);
+
+    const results: WorktreeInfo[] = [];
+
+    for (const [id, entry] of Object.entries(meta)) {
+      const gitWt = gitWorktrees.find((g) => g.path === entry.id || g.branch?.includes(id));
+      const worktreePath = entry.claudeManaged
+        ? path.join(this.repoRoot, CLAUDE_WORKTREE_DIR, id)
+        : path.join(this.worktreeBase, id);
+
+      // Check if directory actually exists
+      const exists = await this.pathExists(worktreePath);
+      if (!exists && !entry.claudeManaged) continue; // Cleaned up externally
+
+      const dirtyFiles = exists ? await this.getDirtyFiles(worktreePath, entry.baseBranch) : [];
+      const lastActivity = exists ? await this.getLastModified(worktreePath) : entry.createdAt;
+      const status = this.inferStatus(lastActivity, dirtyFiles, entry);
+
+      results.push({
+        id,
+        path: worktreePath,
+        branch: gitWt?.branch ?? `worktree/${entry.agentType}/${id}`,
+        baseBranch: entry.baseBranch,
+        agentType: entry.agentType,
+        sessionKey: entry.sessionKey,
+        status,
+        createdAt: entry.createdAt,
+        lastActivityAt: lastActivity,
+        dirtyFiles,
+        claudeManaged: entry.claudeManaged,
+      });
+    }
+
+    // Sort by most recent activity
+    results.sort((a, b) => b.lastActivityAt - a.lastActivityAt);
+    return results;
+  }
+
+  /**
+   * Get a single worktree by ID.
+   */
+  async get(worktreeId: string): Promise<WorktreeInfo | null> {
+    const all = await this.list();
+    return all.find((wt) => wt.id === worktreeId) ?? null;
+  }
+
+  // ── Setup ──
+
+  /**
+   * Auto-detect project type and run appropriate install command.
+   * Skips install if lock file matches the main repo (deps unchanged).
+   */
+  async runSetup(worktreePath: string): Promise<void> {
+    // Node.js — check if deps changed before installing
+    const hasPackageLock = await this.pathExists(path.join(worktreePath, 'package-lock.json'));
+    const hasPackageJson = await this.pathExists(path.join(worktreePath, 'package.json'));
+
+    if (hasPackageLock) {
+      // Check if lock file is identical to main repo (skip install)
+      const mainLock = await this.safeReadFile(path.join(this.repoRoot, 'package-lock.json'));
+      const wtLock = await this.safeReadFile(path.join(worktreePath, 'package-lock.json'));
+
+      if (mainLock && wtLock && mainLock === wtLock) {
+        // Same deps — symlink node_modules from main repo
+        try {
+          const mainNodeModules = path.join(this.repoRoot, 'node_modules');
+          const wtNodeModules = path.join(worktreePath, 'node_modules');
+          if (await this.pathExists(mainNodeModules)) {
+            await execFileAsync('ln', ['-s', mainNodeModules, wtNodeModules], { timeout: 5000 });
+            return;
+          }
+        } catch { /* fall through to npm ci */ }
+      }
+
+      await execFileAsync('npm', ['ci', '--prefer-offline'], {
+        cwd: worktreePath,
+        timeout: 120_000,
+        env: { ...process.env, NODE_ENV: 'development' },
+      });
+    } else if (hasPackageJson) {
+      await execFileAsync('npm', ['install'], {
+        cwd: worktreePath,
+        timeout: 120_000,
+        env: { ...process.env, NODE_ENV: 'development' },
+      });
+    }
+
+    // Python
+    if (await this.pathExists(path.join(worktreePath, 'requirements.txt'))) {
+      await execFileAsync('pip', ['install', '-r', 'requirements.txt'], {
+        cwd: worktreePath,
+        timeout: 120_000,
+      }).catch(() => { /* pip may not be available */ });
+    }
+
+    // Go
+    if (await this.pathExists(path.join(worktreePath, 'go.mod'))) {
+      await execFileAsync('go', ['mod', 'download'], {
+        cwd: worktreePath,
+        timeout: 60_000,
+      }).catch(() => { /* go may not be available */ });
+    }
+
+    // Rust
+    if (await this.pathExists(path.join(worktreePath, 'Cargo.toml'))) {
+      await execFileAsync('cargo', ['fetch'], {
+        cwd: worktreePath,
+        timeout: 120_000,
+      }).catch(() => { /* cargo may not be available */ });
+    }
+  }
+
+  // ── Conflict Detection ──
+
+  /**
+   * Detect file overlaps across all active worktrees.
+   * Returns a ConflictReport with overlapping files and severity.
+   */
+  async detectConflicts(): Promise<ConflictReport> {
+    const worktrees = await this.list();
+    const active = worktrees.filter((wt) =>
+      wt.status === 'active' || wt.status === 'ready' || wt.dirtyFiles.length > 0,
+    );
+
+    const overlapping: ConflictReport['overlapping'] = [];
+
+    for (let i = 0; i < active.length; i++) {
+      const filesA = new Set(active[i]!.dirtyFiles);
+      for (let j = i + 1; j < active.length; j++) {
+        for (const file of active[j]!.dirtyFiles) {
+          if (filesA.has(file)) {
+            overlapping.push({
+              file,
+              worktreeIds: [active[i]!.id, active[j]!.id],
+              severity: 'conflict', // File-level is always conflict; line-level analysis is Phase 2 (#69)
+            });
+          }
+        }
+      }
+    }
+
+    return { overlapping, safe: overlapping.length === 0 };
+  }
+
+  // ── Cleanup ──
+
+  /**
+   * Remove a worktree and optionally its branch.
+   */
+  async cleanup(worktreeId: string, opts?: CleanupOptions): Promise<void> {
+    const meta = await this.loadAllMeta();
+    const entry = meta[worktreeId];
+
+    if (entry?.claudeManaged) {
+      // Claude-managed: just remove our metadata; Claude handles its own cleanup
+      await this.removeMeta(worktreeId);
+      return;
+    }
+
+    const worktreePath = path.join(this.worktreeBase, worktreeId);
+
+    // Remove the git worktree
+    const args = ['worktree', 'remove', worktreePath];
+    if (opts?.force) args.push('--force');
+
+    try {
+      await execFileAsync('git', args, { cwd: this.repoRoot, timeout: 15_000 });
+    } catch (err) {
+      // If directory already gone, that's fine
+      const msg = err instanceof Error ? err.message : '';
+      if (!msg.includes('is not a working tree')) throw err;
+    }
+
+    // Optionally delete the branch
+    if (opts?.deleteBranch && entry) {
+      const branchName = `worktree/${entry.agentType}/${worktreeId}`;
+      await execFileAsync('git', ['branch', '-D', branchName], {
+        cwd: this.repoRoot,
+        timeout: 5000,
+      }).catch(() => { /* branch may not exist */ });
+    }
+
+    // Remove our metadata
+    await this.removeMeta(worktreeId);
+  }
+
+  /**
+   * Prune all stale worktrees (no activity for maxAgeMs).
+   */
+  async prune(maxAgeMs = STALE_THRESHOLD_MS): Promise<string[]> {
+    const worktrees = await this.list();
+    const now = Date.now();
+    const pruned: string[] = [];
+
+    for (const wt of worktrees) {
+      if (now - wt.lastActivityAt > maxAgeMs && wt.status !== 'active') {
+        await this.cleanup(wt.id, { force: true, deleteBranch: true });
+        pruned.push(wt.id);
+      }
+    }
+
+    // Also run git's built-in prune for any orphaned worktrees
+    await execFileAsync('git', ['worktree', 'prune'], {
+      cwd: this.repoRoot,
+      timeout: 10_000,
+    }).catch(() => {});
+
+    return pruned;
+  }
+
+  // ── Link to Agent Session ──
+
+  /**
+   * Associate a worktree with an agent session key.
+   */
+  async linkSession(worktreeId: string, sessionKey: string): Promise<void> {
+    const meta = await this.loadAllMeta();
+    const entry = meta[worktreeId];
+    if (entry) {
+      entry.sessionKey = sessionKey;
+      await this.writeMetaStore({ version: 1, worktrees: meta });
+    }
+  }
+
+  // ── Private Helpers ──
+
+  private async getCurrentBranch(): Promise<string> {
+    const { stdout } = await execFileAsync('git', ['branch', '--show-current'], {
+      cwd: this.repoRoot,
+      timeout: 5000,
+    });
+    return stdout.trim() || 'main';
+  }
+
+  private async gitWorktreeList(): Promise<Array<{ path: string; branch?: string }>> {
+    try {
+      const { stdout } = await execFileAsync('git', ['worktree', 'list', '--porcelain'], {
+        cwd: this.repoRoot,
+        timeout: 5000,
+      });
+
+      const entries: Array<{ path: string; branch?: string }> = [];
+      let current: { path: string; branch?: string } | null = null;
+
+      for (const line of stdout.split('\n')) {
+        if (line.startsWith('worktree ')) {
+          if (current) entries.push(current);
+          current = { path: line.slice('worktree '.length) };
+        } else if (line.startsWith('branch ') && current) {
+          current.branch = line.slice('branch refs/heads/'.length);
+        }
+      }
+      if (current) entries.push(current);
+
+      return entries;
+    } catch {
+      return [];
+    }
+  }
+
+  async getDirtyFiles(worktreePath: string, baseBranch?: string): Promise<string[]> {
+    try {
+      // Uncommitted changes
+      const { stdout: uncommitted } = await execFileAsync('git', ['diff', '--name-only'], {
+        cwd: worktreePath,
+        timeout: 5000,
+      });
+
+      // Staged changes
+      const { stdout: staged } = await execFileAsync('git', ['diff', '--name-only', '--cached'], {
+        cwd: worktreePath,
+        timeout: 5000,
+      });
+
+      // Committed changes since base (if base provided)
+      let committed = '';
+      if (baseBranch) {
+        try {
+          const { stdout } = await execFileAsync('git', ['diff', '--name-only', `${baseBranch}...HEAD`], {
+            cwd: worktreePath,
+            timeout: 5000,
+          });
+          committed = stdout;
+        } catch { /* base branch may not be reachable */ }
+      }
+
+      const allFiles = [...uncommitted.split('\n'), ...staged.split('\n'), ...committed.split('\n')]
+        .map((f) => f.trim())
+        .filter(Boolean);
+
+      return [...new Set(allFiles)];
+    } catch {
+      return [];
+    }
+  }
+
+  private async getLastModified(dirPath: string): Promise<number> {
+    try {
+      const s = await stat(dirPath);
+      return s.mtimeMs;
+    } catch {
+      return Date.now();
+    }
+  }
+
+  private inferStatus(lastActivity: number, dirtyFiles: string[], _entry: WorktreeMetaEntry): WorktreeStatus {
+    const ageMs = Date.now() - lastActivity;
+    if (ageMs > STALE_THRESHOLD_MS) return 'stale';
+    if (dirtyFiles.length > 0 && ageMs < 5 * 60_000) return 'active';
+    if (dirtyFiles.length > 0) return 'ready';
+    return 'ready';
+  }
+
+  private async pathExists(p: string): Promise<boolean> {
+    try {
+      await access(p);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async safeReadFile(p: string): Promise<string | null> {
+    try {
+      return await readFile(p, 'utf-8');
+    } catch {
+      return null;
+    }
+  }
+
+  // ── Metadata Persistence ──
+
+  private async loadAllMeta(): Promise<Record<string, WorktreeMetaEntry>> {
+    try {
+      const raw = await readFile(this.metaPath, 'utf-8');
+      const store = JSON.parse(raw) as WorktreeMetaStore;
+      return store.worktrees;
+    } catch {
+      return {};
+    }
+  }
+
+  private async writeMetaStore(store: WorktreeMetaStore): Promise<void> {
+    await mkdir(path.dirname(this.metaPath), { recursive: true });
+    await writeFile(this.metaPath, JSON.stringify(store, null, 2), 'utf-8');
+  }
+
+  private async saveMeta(id: string, entry: WorktreeMetaEntry): Promise<void> {
+    const existing = await this.loadAllMeta();
+    existing[id] = entry;
+    await this.writeMetaStore({ version: 1, worktrees: existing });
+  }
+
+  private async removeMeta(id: string): Promise<void> {
+    const existing = await this.loadAllMeta();
+    delete existing[id];
+    await this.writeMetaStore({ version: 1, worktrees: existing });
+  }
+}

--- a/src/lib/worktree/types.ts
+++ b/src/lib/worktree/types.ts
@@ -1,0 +1,114 @@
+/**
+ * Worktree Isolation Types
+ *
+ * Shared types for the WorktreeManager service.
+ * Designed to generalize to IsolationProvider (containers, VMs) in 2028.
+ */
+
+export type WorktreeStatus = 'creating' | 'setup' | 'ready' | 'active' | 'stale' | 'merging' | 'cleaning';
+
+export type AgentType = 'claude-code' | 'codex' | (string & {});
+
+/**
+ * Metadata for a single worktree.
+ */
+export interface WorktreeInfo {
+  /** Unique worktree identifier (derived from taskName) */
+  id: string;
+  /** Absolute filesystem path to worktree directory */
+  path: string;
+  /** Git branch name */
+  branch: string;
+  /** Branch this was created from */
+  baseBranch: string;
+  /** Which agent type is using this worktree */
+  agentType: AgentType;
+  /** Linked agent session key (if running) */
+  sessionKey?: string;
+  /** Current lifecycle status */
+  status: WorktreeStatus;
+  /** When the worktree was created */
+  createdAt: number;
+  /** Last file modification timestamp */
+  lastActivityAt: number;
+  /** Disk usage in bytes (lazy, computed on demand) */
+  diskUsageBytes?: number;
+  /** Files modified since worktree creation */
+  dirtyFiles: string[];
+  /** Whether Claude manages this worktree natively (--worktree flag) */
+  claudeManaged: boolean;
+}
+
+/**
+ * Report of file overlaps across active worktrees.
+ */
+export interface ConflictReport {
+  overlapping: ConflictEntry[];
+  /** True if no overlapping files exist */
+  safe: boolean;
+}
+
+export interface ConflictEntry {
+  /** File path relative to repo root */
+  file: string;
+  /** Which worktrees have modified this file */
+  worktreeIds: [string, string];
+  /** warning = same file different sections, conflict = overlapping lines */
+  severity: 'warning' | 'conflict';
+}
+
+/**
+ * Options for creating a worktree.
+ */
+export interface CreateWorktreeOptions {
+  /** Agent type (determines creation strategy) */
+  agentType: AgentType;
+  /** Human-readable task name (used for branch + dir naming) */
+  taskName: string;
+  /** Base branch to create from (default: HEAD) */
+  baseBranch?: string;
+  /** Skip auto-setup (npm install, etc.) */
+  skipSetup?: boolean;
+}
+
+/**
+ * Options for cleaning up a worktree.
+ */
+export interface CleanupOptions {
+  /** Force removal even with uncommitted changes */
+  force?: boolean;
+  /** Also delete the branch */
+  deleteBranch?: boolean;
+}
+
+/**
+ * Result of a merge/PR action.
+ */
+export interface MergeResult {
+  /** Action that was taken */
+  action: 'pr' | 'merge' | 'discard';
+  /** Whether the action succeeded */
+  ok: boolean;
+  /** Human-readable description */
+  note: string;
+  /** PR URL if action was 'pr' */
+  prUrl?: string;
+}
+
+/**
+ * Metadata stored in .cortex-worktrees/.meta.json
+ */
+export interface WorktreeMetaStore {
+  version: 1;
+  worktrees: Record<string, WorktreeMetaEntry>;
+}
+
+export interface WorktreeMetaEntry {
+  id: string;
+  agentType: AgentType;
+  sessionKey?: string;
+  baseBranch: string;
+  createdAt: number;
+  claudeManaged: boolean;
+  taskName: string;
+}


### PR DESCRIPTION
## Epic #65 — Git Worktree Isolation: Phase 1 (Core)

Implements all three Phase 1 issues in a single commit (1,634 lines, zero new dependencies).

### #66 WorktreeManager Service (`src/lib/worktree/manager.ts`, 519 lines)
The core orchestration layer. Manages worktree lifecycle for ALL agent types:

- **Create**: Claude Code → records metadata only (Claude handles via `--worktree` flag). Codex/others → `git worktree add` + auto-setup.
- **Track**: Metadata stored in `.cortex-worktrees/.meta.json`. Combines git porcelain output with our metadata.
- **Setup**: Auto-detects project type (package-lock.json, requirements.txt, go.mod, Cargo.toml). Symlinks node_modules when deps match main repo (skip 200MB re-install).
- **Conflict Detection**: Scans dirty files across all active worktrees, reports overlapping files.
- **Cleanup**: `git worktree remove` + optional branch delete. Claude-managed worktrees: metadata cleanup only.
- **Prune**: Removes stale worktrees (>24h no activity) + runs `git worktree prune` for orphans.

### #67 Worktree UI (`src/components/mobile/Worktree*.tsx`, 451 lines)
Three React components for the squad panel:

- **WorktreeBadge**: Inline indicator showing branch name, dirty file count, conflict warning. Designed for agent pill layout.
- **WorktreeSummary**: Summary card above squad grid — active count, total files, mini-pills per worktree, prune button.
- **WorktreeActions**: Merge/PR/Discard action buttons for completed sessions. Discard requires tap-to-confirm.

API endpoints:
- `GET /api/worktrees?repo=<path>` — List all worktrees + conflict status
- `POST /api/worktrees` — Create a new worktree
- `DELETE /api/worktrees` — Cleanup or prune worktrees
- `POST /api/worktrees/merge` — Create PR, merge to main, or discard

### #68 Launch Integration (`src/lib/worktree/launch.ts`, 161 lines)
Wires WorktreeManager into the agent launch flow:

- **Auto-toggle**: Isolation defaults ON when repo already has active agents, OFF for first/only agent.
- **Claude Code**: Returns `--worktree` flag for native isolation passthrough.
- **Codex/others**: Creates managed worktree, runs project setup, returns cwd for agent launch.
- **Session linking**: `linkSessionToWorktree()` associates agent session with worktree metadata.
- **Per-repo caching**: Single WorktreeManager instance per repo root.

### Architecture Notes
- Designed for `IsolationProvider` generalization (containers, VMs) in 2028 — see #71, #72
- All inline styles (iOS Safari pattern consistent with existing codebase)
- `.cortex-worktrees/` added to `.gitignore`
- Clean TypeScript compilation, zero new dependencies
- Total: 1,634 lines across 10 files