### PR TITLE
fix: Worktree Audit — 7 safety + polish fixes

### DIFF
--- a/src/app/api/worktrees/merge/route.ts
+++ b/src/app/api/worktrees/merge/route.ts
@@ -16,6 +16,17 @@ import type { MergeResult } from '@/lib/worktree/types';
 
 const execFileAsync = promisify(execFile);
 
+const API_TOKEN = process.env.WS_TOKEN ?? 'cortex-ide';
+
+function checkAuth(req: NextRequest): NextResponse | null {
+  const auth = req.headers.get('authorization');
+  const token = auth?.startsWith('Bearer ') ? auth.slice(7) : req.nextUrl.searchParams.get('token');
+  if (token !== API_TOKEN) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return null;
+}
+
 interface MergeBody {
   repo: string;
   worktreeId: string;
@@ -29,6 +40,9 @@ interface MergeBody {
 }
 
 export async function POST(req: NextRequest) {
+  const denied = checkAuth(req);
+  if (denied) return denied;
+
   let body: MergeBody;
   try {
     body = (await req.json()) as MergeBody;
@@ -174,9 +188,29 @@ async function mergeToTarget(
     // Already committed
   }
 
-  // Check for conflicts before merging
+  // Safety: refuse to merge if repo root has uncommitted changes
   try {
-    // Dry run: attempt merge in the repo root
+    const { stdout: dirtyCheck } = await execFileAsync('git', ['status', '--porcelain'], {
+      cwd: repoRoot,
+      timeout: 5000,
+    });
+    if (dirtyCheck.trim().length > 0) {
+      return {
+        action: 'merge',
+        ok: false,
+        note: 'Repo root has uncommitted changes. Commit or stash first, or use "Create PR" instead.',
+      };
+    }
+  } catch {
+    return {
+      action: 'merge',
+      ok: false,
+      note: 'Could not verify repo root is clean. Use "Create PR" instead.',
+    };
+  }
+
+  // Check for conflicts before merging using merge-tree (no working tree mutation)
+  try {
     const { stdout: mergeCheck } = await execFileAsync('git', [
       'merge-tree', '--write-tree', targetBranch, branch,
     ], { cwd: repoRoot, timeout: 10_000 });
@@ -192,7 +226,17 @@ async function mergeToTarget(
     // merge-tree may not be available; fall through to try merge
   }
 
-  // Perform the actual merge from the repo root
+  // Save current branch to restore after merge
+  let originalBranch: string | null = null;
+  try {
+    const { stdout } = await execFileAsync('git', ['branch', '--show-current'], {
+      cwd: repoRoot,
+      timeout: 5000,
+    });
+    originalBranch = stdout.trim() || null;
+  } catch { /* best effort */ }
+
+  // Perform the merge
   try {
     await execFileAsync('git', ['checkout', targetBranch], {
       cwd: repoRoot,
@@ -204,6 +248,14 @@ async function mergeToTarget(
       timeout: 15_000,
     });
 
+    // Restore original branch if it was different from target
+    if (originalBranch && originalBranch !== targetBranch) {
+      await execFileAsync('git', ['checkout', originalBranch], {
+        cwd: repoRoot,
+        timeout: 10_000,
+      }).catch(() => { /* best effort restore */ });
+    }
+
     return {
       action: 'merge',
       ok: true,
@@ -212,6 +264,13 @@ async function mergeToTarget(
   } catch (err) {
     // Abort any partial merge
     await execFileAsync('git', ['merge', '--abort'], { cwd: repoRoot, timeout: 5000 }).catch(() => {});
+    // Restore original branch
+    if (originalBranch) {
+      await execFileAsync('git', ['checkout', originalBranch], {
+        cwd: repoRoot,
+        timeout: 10_000,
+      }).catch(() => {});
+    }
     return {
       action: 'merge',
       ok: false,

--- a/src/app/api/worktrees/route.ts
+++ b/src/app/api/worktrees/route.ts
@@ -13,9 +13,23 @@ export const dynamic = 'force-dynamic';
 import { NextResponse, type NextRequest } from 'next/server';
 import { getWorktreeManager, getActiveWorktreeSummary } from '@/lib/worktree/launch';
 
+const API_TOKEN = process.env.WS_TOKEN ?? 'cortex-ide';
+
+function checkAuth(req: NextRequest): NextResponse | null {
+  const auth = req.headers.get('authorization');
+  const token = auth?.startsWith('Bearer ') ? auth.slice(7) : req.nextUrl.searchParams.get('token');
+  if (token !== API_TOKEN) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return null;
+}
+
 // ── GET: List worktrees + conflicts ──
 
 export async function GET(req: NextRequest) {
+  const denied = checkAuth(req);
+  if (denied) return denied;
+
   const repo = req.nextUrl.searchParams.get('repo');
   if (!repo) {
     return NextResponse.json({ error: 'repo parameter required' }, { status: 400 });
@@ -43,6 +57,9 @@ interface CreateBody {
 }
 
 export async function POST(req: NextRequest) {
+  const denied = checkAuth(req);
+  if (denied) return denied;
+
   let body: CreateBody;
   try {
     body = (await req.json()) as CreateBody;
@@ -87,6 +104,9 @@ interface DeleteBody {
 }
 
 export async function DELETE(req: NextRequest) {
+  const denied = checkAuth(req);
+  if (denied) return denied;
+
   let body: DeleteBody;
   try {
     body = (await req.json()) as DeleteBody;

--- a/src/components/mobile/WorktreeSummary.tsx
+++ b/src/components/mobile/WorktreeSummary.tsx
@@ -30,6 +30,7 @@ export const WorktreeSummary = memo(function WorktreeSummary({
   onWorktreeSelect,
 }: WorktreeSummaryProps) {
   const [pruning, setPruning] = useState(false);
+  const [pruneConfirm, setPruneConfirm] = useState(false);
 
   const active = worktrees.filter((wt) =>
     wt.status === 'active' || wt.status === 'ready' || wt.status === 'setup',
@@ -38,13 +39,19 @@ export const WorktreeSummary = memo(function WorktreeSummary({
   if (active.length === 0) return null;
 
   const handlePrune = useCallback(async () => {
+    if (!pruneConfirm) {
+      setPruneConfirm(true);
+      setTimeout(() => setPruneConfirm(false), 3000);
+      return;
+    }
     setPruning(true);
+    setPruneConfirm(false);
     try {
       await onPrune();
     } finally {
       setPruning(false);
     }
-  }, [onPrune]);
+  }, [onPrune, pruneConfirm]);
 
   const totalFiles = active.reduce((sum, wt) => sum + wt.dirtyFiles.length, 0);
 
@@ -182,17 +189,18 @@ export const WorktreeSummary = memo(function WorktreeSummary({
           style={{
             padding: '4px 10px',
             borderRadius: '8px',
-            backgroundColor: 'rgba(255,255,255,0.08)',
+            backgroundColor: pruneConfirm ? '#ff3b30' : 'rgba(255,255,255,0.08)',
             border: 'none',
-            color: '#8e8e93',
+            color: pruneConfirm ? '#fff' : '#8e8e93',
             fontSize: '11px',
-            fontWeight: 500,
+            fontWeight: pruneConfirm ? 600 : 500,
             cursor: 'pointer',
             opacity: pruning ? 0.5 : 1,
+            transition: 'background-color 0.15s, color 0.15s',
             WebkitTapHighlightColor: 'transparent',
           }}
         >
-          {pruning ? 'Pruning…' : 'Prune stale'}
+          {pruning ? 'Pruning…' : pruneConfirm ? 'Confirm prune' : 'Prune stale'}
         </button>
       </div>
     </div>

--- a/src/lib/worktree/launch.ts
+++ b/src/lib/worktree/launch.ts
@@ -150,12 +150,14 @@ export async function getActiveWorktreeSummary(repoRoot: string): Promise<{
     mgr.detectConflicts(),
   ]);
 
+  const totalDiskUsage = worktrees.reduce((sum, wt) => sum + (wt.diskUsageBytes ?? 0), 0);
+
   return {
     worktrees,
     conflicts: {
       safe: conflicts.safe,
       count: conflicts.overlapping.length,
     },
-    totalDiskUsage: 0, // Lazy — computed on demand, not at list time
+    totalDiskUsage,
   };
 }

--- a/src/lib/worktree/manager.ts
+++ b/src/lib/worktree/manager.ts
@@ -5,8 +5,7 @@
  * - Claude Code: passes through --worktree flag (Claude handles creation natively)
  * - Codex / others: creates and manages worktrees via git commands
  *
- * ~300 lines. Not a git reimplementation — thin orchestration on top of
- * git worktree + agent-specific behavior.
+ * Thin orchestration on top of git worktree + agent-specific behavior.
  *
  * Designed to generalize to IsolationProvider (containers, VMs) in 2028.
  *
@@ -19,7 +18,6 @@ import { access, mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promi
 import path from 'node:path';
 import { promisify } from 'node:util';
 import type {
-  AgentType,
   CleanupOptions,
   ConflictReport,
   CreateWorktreeOptions,
@@ -67,10 +65,18 @@ export class WorktreeManager {
    * Codex/others: git worktree add + optional setup
    */
   async create(opts: CreateWorktreeOptions): Promise<WorktreeInfo> {
-    const taskId = sanitizeTaskName(opts.taskName);
+    let taskId = sanitizeTaskName(opts.taskName);
     const baseBranch = opts.baseBranch ?? await this.getCurrentBranch();
-    const branchName = `worktree/${opts.agentType}/${taskId}`;
     const now = Date.now();
+
+    // Avoid ID collisions (e.g. "fix auth" and "fix-auth" both sanitize to "fix-auth")
+    const existingMeta = await this.loadAllMeta();
+    if (existingMeta[taskId]) {
+      const suffix = Math.random().toString(36).slice(2, 6);
+      taskId = `${taskId}-${suffix}`;
+    }
+
+    const branchName = `worktree/${opts.agentType}/${taskId}`;
 
     if (opts.agentType === 'claude-code') {
       // Claude manages its own worktree — we just track it
@@ -96,6 +102,7 @@ export class WorktreeManager {
         createdAt: now,
         claudeManaged: true,
         taskName: opts.taskName,
+        status: 'creating',
       });
 
       return info;
@@ -128,7 +135,7 @@ export class WorktreeManager {
       claudeManaged: false,
     };
 
-    // Save metadata
+    // Save metadata with 'creating' status before setup
     await this.saveMeta(taskId, {
       id: taskId,
       agentType: opts.agentType,
@@ -136,15 +143,18 @@ export class WorktreeManager {
       createdAt: now,
       claudeManaged: false,
       taskName: opts.taskName,
+      status: 'creating',
     });
 
     // Run project setup unless skipped
     if (!opts.skipSetup) {
       info.status = 'setup';
+      await this.updateMetaStatus(taskId, 'setup');
       await this.runSetup(worktreePath);
     }
 
     info.status = 'ready';
+    await this.updateMetaStatus(taskId, 'ready');
     return info;
   }
 
@@ -175,6 +185,7 @@ export class WorktreeManager {
       const dirtyFiles = exists ? await this.getDirtyFiles(worktreePath, entry.baseBranch) : [];
       const lastActivity = exists ? await this.getLastModified(worktreePath) : entry.createdAt;
       const status = this.inferStatus(lastActivity, dirtyFiles, entry);
+      const diskUsageBytes = exists ? await this.getDiskUsage(worktreePath) : 0;
 
       results.push({
         id,
@@ -186,6 +197,7 @@ export class WorktreeManager {
         status,
         createdAt: entry.createdAt,
         lastActivityAt: lastActivity,
+        diskUsageBytes,
         dirtyFiles,
         claudeManaged: entry.claudeManaged,
       });
@@ -454,6 +466,16 @@ export class WorktreeManager {
     }
   }
 
+  private async getDiskUsage(dirPath: string): Promise<number> {
+    try {
+      const { stdout } = await execFileAsync('du', ['-sk', dirPath], { timeout: 5000 });
+      const kb = parseInt(stdout.split('\t')[0] ?? '0', 10);
+      return kb * 1024;
+    } catch {
+      return 0;
+    }
+  }
+
   private async getLastModified(dirPath: string): Promise<number> {
     try {
       const s = await stat(dirPath);
@@ -463,7 +485,10 @@ export class WorktreeManager {
     }
   }
 
-  private inferStatus(lastActivity: number, dirtyFiles: string[], _entry: WorktreeMetaEntry): WorktreeStatus {
+  private inferStatus(lastActivity: number, dirtyFiles: string[], entry: WorktreeMetaEntry): WorktreeStatus {
+    // Preserve explicit lifecycle states tracked in metadata
+    if (entry.status === 'creating' || entry.status === 'setup') return entry.status;
+
     const ageMs = Date.now() - lastActivity;
     if (ageMs > STALE_THRESHOLD_MS) return 'stale';
     if (dirtyFiles.length > 0 && ageMs < 5 * 60_000) return 'active';
@@ -515,5 +540,14 @@ export class WorktreeManager {
     const existing = await this.loadAllMeta();
     delete existing[id];
     await this.writeMetaStore({ version: 1, worktrees: existing });
+  }
+
+  private async updateMetaStatus(id: string, status: WorktreeStatus): Promise<void> {
+    const existing = await this.loadAllMeta();
+    const entry = existing[id];
+    if (entry) {
+      entry.status = status;
+      await this.writeMetaStore({ version: 1, worktrees: existing });
+    }
   }
 }

--- a/src/lib/worktree/types.ts
+++ b/src/lib/worktree/types.ts
@@ -111,4 +111,6 @@ export interface WorktreeMetaEntry {
   createdAt: number;
   claudeManaged: boolean;
   taskName: string;
+  /** Explicit lifecycle status — preserved through inferStatus */
+  status?: WorktreeStatus;
 }


### PR DESCRIPTION
## Audit Fixes for PR #74 (Worktree Isolation Phase 1)

### High
1. **Safe merge** — mergeToTarget() now checks for dirty repo root before git checkout, and restores the original branch after merge. Refuses to merge if uncommitted changes exist.

### Medium
2. **API auth** — All worktree routes require Bearer token or ?token= query param, matching WS server auth pattern.
3. **Status tracking** — inferStatus() preserves creating/setup lifecycle states from metadata instead of overriding with timestamp inference.

### Low
4. **Collision guard** — Duplicate worktree IDs get random 4-char suffix.
5. **Prune confirmation** — Tap-to-confirm (3s auto-dismiss) matching discard pattern.
6. **Disk usage** — Computed via du -sk instead of hardcoded 0.
7. **Stale comment** — Removed "~300 lines" doc comment.

6 files changed, +141 / -16. Clean typecheck.
