### PR TITLE
chore: remove stale runtimes + fix canvas picker dark mode

### DIFF
--- a/docs/anthropic-harness-ban-impact.md
+++ b/docs/anthropic-harness-ban-impact.md
@@ -1,0 +1,69 @@
+# Anthropic Third-Party Harness Ban: Impact on o8
+
+**Date:** 2026-04-05
+**Status:** No impact on o8 production
+
+## What happened
+
+On April 4, 2026, Anthropic severed third-party tool access to Claude subscription tokens. OAuth tokens from Pro/Max subscriptions no longer function outside Anthropic's own interfaces (Claude Code, Claude.ai, Claude Desktop). Third-party harnesses like OpenClaw must now use pay-as-you-go API billing. Source: [ccleaks.com/news/anthropic-kills-third-party-harnesses](https://ccleaks.com/news/anthropic-kills-third-party-harnesses)
+
+## Why o8 is unaffected
+
+### o8 is a control plane, not a harness
+
+A harness intercepts or reroutes Claude subscription tokens through a non-Anthropic OAuth flow. o8 does neither. It is a governance layer that sits above runtimes — it doesn't replace them.
+
+### Claude Code adapter calls the CLI directly
+
+The Claude Code runtime adapter (`src/lib/runtimes/claude-code.ts`) shells out to the `claude` binary at `~/.local/bin/claude`. This is identical to a user typing `claude` in their terminal. The adapter:
+
+- Discovers sessions from `~/.claude/projects/`
+- Reads JSONL transcript files from disk
+- Launches/resumes/interrupts via `claude` CLI flags (`-c`, `-n`, `-w`)
+
+No subscription tokens are proxied, intercepted, or rerouted. o8 talks to Claude Code the same way any terminal does.
+
+### Codex adapter is OpenAI
+
+The second runtime adapter (`src/lib/runtimes/codex.ts`) uses the Codex CLI, which is an OpenAI product. Entirely outside Anthropic's scope.
+
+### OpenClaw was already removed
+
+OpenClaw — the third-party harness most directly targeted by this ban — was removed from o8's runtime code prior to this announcement. The only remnants were:
+
+- One stale marketing string in the onboarding carousel (removed in #494)
+- Two legacy shell scripts in `scripts/` (dead code, not called by the app)
+- ~30 references in `docs/` and agent configs (historical documentation)
+
+No production code path depended on OpenClaw.
+
+### AI Router delegates to Gemini and Codex
+
+The AI Router MCP (`~/.claude/mcp-servers/ai-router/`) delegates research tasks to Gemini CLI (Google, $20 subscription) with Codex (OpenAI) as fallback. No Anthropic subscription tokens are involved in delegation.
+
+## What would affect us
+
+If Anthropic were to restrict programmatic invocation of the `claude` CLI — i.e., making it so only interactive terminal sessions work — that would break o8's Claude Code adapter. This seems unlikely since:
+
+1. Claude Code is designed for automation (it accepts `--json`, `--print`, piped input)
+2. Anthropic actively promotes Claude Code in CI/CD and scripting contexts
+3. The Claude Code SDK exists specifically for programmatic use
+
+If this ever changed, o8's adapter interface (`AgentRuntime` in `src/lib/runtimes/types.ts`) abstracts the runtime layer. Switching to a different Claude integration (API direct, SDK, etc.) would be a single adapter swap, not an architectural change.
+
+## The ban actually strengthens o8's position
+
+Anthropic locking down how Claude can be used makes governance layers more valuable:
+
+- **Users need sanctioned interfaces.** o8 works within them (Claude Code CLI), not around them.
+- **Cost visibility matters more.** With harnesses gone, users on API billing need usage tracking and approval controls — exactly what o8 provides.
+- **The "bring your own runtime" model wins.** o8 doesn't depend on any single provider's auth model. It governs whatever runtimes the user has installed.
+
+## Residual cleanup
+
+| Item | Status | PR |
+|------|--------|----|
+| OpenCode + Aider removed from CLI agent lists | Done | #494 |
+| OpenClaw removed from onboarding copy | Done | #494 |
+| Legacy `scripts/rest-api-patch.sh` and `rest-api-watchdog.sh` | Dead code, can delete when convenient | — |
+| OpenClaw references in `docs/` | Historical context, no action needed | — |

--- a/src/components/desktop/ContextualPanel.tsx
+++ b/src/components/desktop/ContextualPanel.tsx
@@ -22,8 +22,6 @@ const CLI_AGENTS = [
   { id: 'claude', label: 'Claude Code', color: '#e07a3a', command: 'claude' },
   { id: 'codex', label: 'Codex', color: '#6b7280', command: 'codex' },
   { id: 'gemini', label: 'Gemini CLI', color: '#4285f4', command: 'gemini' },
-  { id: 'opencode', label: 'OpenCode', color: '#f97316', command: 'opencode' },
-  { id: 'aider', label: 'Aider', color: '#eab308', command: 'aider' },
 ] as const;
 
 type CliAgent = (typeof CLI_AGENTS)[number];

--- a/src/components/desktop/Onboarding.tsx
+++ b/src/components/desktop/Onboarding.tsx
@@ -121,7 +121,7 @@ const FEATURES = [
   { title: 'Command your AI agents', subtitle: 'Dispatch tasks to Claude, Codex, or any runtime. Watch them work in real-time.', previewLabel: 'Agent dashboard with live sessions' },
   { title: 'Approve from anywhere', subtitle: 'Review code, approve merges, and steer agents from your phone.', previewLabel: 'Mobile approval surface' },
   { title: 'Organizational memory', subtitle: 'Your codebase context persists across sessions. Agents never start from zero.', previewLabel: 'Cortex memory graph' },
-  { title: 'Every runtime, one dashboard', subtitle: 'Claude Code, Codex, Gemini, OpenClaw — unified under one governance layer.', previewLabel: 'Multi-runtime workspace' },
+  { title: 'Every runtime, one dashboard', subtitle: 'Claude Code, Codex, Gemini — unified under one governance layer.', previewLabel: 'Multi-runtime workspace' },
 ];
 
 const SLIDE_MS = 5000;

--- a/src/components/desktop/WorkspaceTerminal.tsx
+++ b/src/components/desktop/WorkspaceTerminal.tsx
@@ -211,8 +211,6 @@ const CLI_AGENTS = [
   { id: 'claude', label: 'Claude Code', color: '#e07a3a', command: 'claude' },
   { id: 'codex', label: 'Codex', color: '#6b7280', command: 'codex' },
   { id: 'gemini', label: 'Gemini CLI', color: '#4285f4', command: 'gemini' },
-  { id: 'opencode', label: 'OpenCode', color: '#f97316', command: 'opencode' },
-  { id: 'aider', label: 'Aider', color: '#eab308', command: 'aider' },
 ];
 
 interface RegisteredRepo {
@@ -3136,6 +3134,8 @@ const TabBar = memo(function TabBar({
             marginTop: 4,
             minWidth: 220,
             background: THEME_PANEL_GLASS,
+            backdropFilter: 'blur(24px) saturate(1.6)',
+            WebkitBackdropFilter: 'blur(24px) saturate(1.6)',
             border: '1px solid var(--t-panel-border)',
             borderRadius: 10,
             overflow: 'hidden',
@@ -3269,9 +3269,9 @@ const TabBar = memo(function TabBar({
                   paddingBottom: 6,
                   paddingLeft: 10,
                   border: 'none',
-                  borderBottom: '1px solid #f1f5f9',
+                  borderBottom: '1px solid var(--t-divider)',
                   background: 'transparent',
-                  color: '#94a3b8',
+                  color: 'var(--t-text-muted)',
                   fontSize: 11,
                   cursor: 'pointer',
                   fontFamily: '-apple-system, system-ui, sans-serif',
@@ -3310,19 +3310,19 @@ const TabBar = memo(function TabBar({
                     paddingLeft: 12,
                     border: 'none',
                     background: 'transparent',
-                    color: '#1e293b',
+                    color: 'var(--t-text)',
                     fontSize: 13,
                     fontFamily: '-apple-system, system-ui, sans-serif',
                     cursor: 'pointer',
                     textAlign: 'left',
                     transition: 'background 100ms',
                   }}
-                  onMouseEnter={(e) => { (e.currentTarget).style.background = '#f1f5f9'; }}
+                  onMouseEnter={(e) => { (e.currentTarget).style.background = 'var(--t-hover)'; }}
                   onMouseLeave={(e) => { (e.currentTarget).style.background = 'transparent'; }}
                 >
                   <span style={{ width: 20, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                     {agent.id === 'shell' ? (
-                      <TerminalIcon size={14} style={{ color: '#94a3b8' }} />
+                      <TerminalIcon size={14} style={{ color: 'var(--t-text-muted)' }} />
                     ) : (
                       <AgentDot color={agent.color} size={10} />
                     )}
@@ -3330,7 +3330,7 @@ const TabBar = memo(function TabBar({
                   <div>
                     <div style={{ fontWeight: 500 }}>{agent.label}</div>
                     {agent.command && (
-                      <div style={{ fontSize: 11, color: '#94a3b8', fontFamily: 'ui-monospace, monospace' }}>
+                      <div style={{ fontSize: 11, color: 'var(--t-text-faint)', fontFamily: 'ui-monospace, monospace' }}>
                         $ {agent.command}
                       </div>
                     )}
@@ -3354,9 +3354,9 @@ const TabBar = memo(function TabBar({
                   paddingBottom: 6,
                   paddingLeft: 10,
                   border: 'none',
-                  borderBottom: '1px solid #f1f5f9',
+                  borderBottom: '1px solid var(--t-divider)',
                   background: 'transparent',
-                  color: '#94a3b8',
+                  color: 'var(--t-text-muted)',
                   fontSize: 11,
                   cursor: 'pointer',
                   fontFamily: '-apple-system, system-ui, sans-serif',
@@ -3387,14 +3387,14 @@ const TabBar = memo(function TabBar({
                     paddingLeft: 12,
                     border: 'none',
                     background: 'transparent',
-                    color: '#1e293b',
+                    color: 'var(--t-text)',
                     fontSize: 13,
                     fontFamily: '-apple-system, system-ui, sans-serif',
                     cursor: 'pointer',
                     textAlign: 'left',
                     transition: 'background 100ms',
                   }}
-                  onMouseEnter={(e) => { (e.currentTarget).style.background = '#f1f5f9'; }}
+                  onMouseEnter={(e) => { (e.currentTarget).style.background = 'var(--t-hover)'; }}
                   onMouseLeave={(e) => { (e.currentTarget).style.background = 'transparent'; }}
                 >
                   <span style={{ width: 20, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -3402,7 +3402,7 @@ const TabBar = memo(function TabBar({
                   </span>
                   <div>
                     <div style={{ fontWeight: 500 }}>{rt.label}</div>
-                    <div style={{ fontSize: 11, color: '#94a3b8' }}>Agent conversation</div>
+                    <div style={{ fontSize: 11, color: 'var(--t-text-faint)' }}>Agent conversation</div>
                   </div>
                 </button>
               ))}
@@ -3423,9 +3423,9 @@ const TabBar = memo(function TabBar({
                   paddingBottom: 6,
                   paddingLeft: 10,
                   border: 'none',
-                  borderBottom: '1px solid #f1f5f9',
+                  borderBottom: '1px solid var(--t-divider)',
                   background: 'transparent',
-                  color: '#94a3b8',
+                  color: 'var(--t-text-muted)',
                   fontSize: 11,
                   cursor: 'pointer',
                   fontFamily: '-apple-system, system-ui, sans-serif',
@@ -3440,7 +3440,7 @@ const TabBar = memo(function TabBar({
                 paddingLeft: 10,
                 fontSize: 10,
                 fontWeight: 600,
-                color: '#94a3b8',
+                color: 'var(--t-text-faint)',
                 letterSpacing: '0.05em',
                 textTransform: 'uppercase',
               }}>
@@ -3467,20 +3467,20 @@ const TabBar = memo(function TabBar({
                   paddingLeft: 12,
                   border: 'none',
                   background: 'transparent',
-                  color: '#64748b',
+                  color: 'var(--t-text-secondary)',
                   fontSize: 13,
                   cursor: 'pointer',
                   textAlign: 'left',
                   fontFamily: '-apple-system, system-ui, sans-serif',
                   transition: 'background 100ms',
                 }}
-                onMouseEnter={(e) => { (e.currentTarget).style.background = '#f1f5f9'; }}
+                onMouseEnter={(e) => { (e.currentTarget).style.background = 'var(--t-hover)'; }}
                 onMouseLeave={(e) => { (e.currentTarget).style.background = 'transparent'; }}
               >
-                <TerminalIcon size={14} style={{ color: '#94a3b8' }} />
+                <TerminalIcon size={14} style={{ color: 'var(--t-text-muted)' }} />
                 <div>
                   <div style={{ fontWeight: 500 }}>No repo (home dir)</div>
-                  <div style={{ fontSize: 11, color: '#94a3b8' }}>~/</div>
+                  <div style={{ fontSize: 11, color: 'var(--t-text-faint)' }}>~/</div>
                 </div>
               </button>
 
@@ -3493,7 +3493,7 @@ const TabBar = memo(function TabBar({
                   paddingLeft: 10,
                   fontSize: 10,
                   fontWeight: 600,
-                  color: '#94a3b8',
+                  color: 'var(--t-text-faint)',
                   letterSpacing: '0.05em',
                   textTransform: 'uppercase',
                 }}>
@@ -3521,20 +3521,20 @@ const TabBar = memo(function TabBar({
                     paddingLeft: 12,
                     border: 'none',
                     background: 'transparent',
-                    color: '#1e293b',
+                    color: 'var(--t-text)',
                     fontSize: 13,
                     cursor: 'pointer',
                     textAlign: 'left',
                     fontFamily: '-apple-system, system-ui, sans-serif',
                     transition: 'background 100ms',
                   }}
-                  onMouseEnter={(e) => { (e.currentTarget).style.background = '#f1f5f9'; }}
+                  onMouseEnter={(e) => { (e.currentTarget).style.background = 'var(--t-hover)'; }}
                   onMouseLeave={(e) => { (e.currentTarget).style.background = 'transparent'; }}
                 >
                   <AgentDot color={selectedAgent.color} size={8} />
                   <div>
                     <div style={{ fontWeight: 500 }}>{repo.name}</div>
-                    <div style={{ fontSize: 11, color: '#94a3b8', fontFamily: 'ui-monospace, monospace' }}>
+                    <div style={{ fontSize: 11, color: 'var(--t-text-faint)', fontFamily: 'ui-monospace, monospace' }}>
                       {repo.localPath.replace(/^\/Users\/[^/]+\//, '~/')}
                     </div>
                   </div>
@@ -3542,7 +3542,7 @@ const TabBar = memo(function TabBar({
               ))}
 
               {/* Divider */}
-              <div style={{ height: 1, background: '#f1f5f9', marginTop: 4, marginBottom: 4 }} />
+              <div style={{ height: 1, background: 'var(--t-divider)', marginTop: 4, marginBottom: 4 }} />
 
               {/* Open folder — native dialog */}
               <button
@@ -3588,17 +3588,17 @@ const TabBar = memo(function TabBar({
                   paddingLeft: 12,
                   border: 'none',
                   background: 'transparent',
-                  color: '#1e293b',
+                  color: 'var(--t-text)',
                   fontSize: 13,
                   cursor: 'pointer',
                   textAlign: 'left',
                   fontFamily: '-apple-system, system-ui, sans-serif',
                   transition: 'background 100ms',
                 }}
-                onMouseEnter={(e) => { (e.currentTarget).style.background = '#f1f5f9'; }}
+                onMouseEnter={(e) => { (e.currentTarget).style.background = 'var(--t-hover)'; }}
                 onMouseLeave={(e) => { (e.currentTarget).style.background = 'transparent'; }}
               >
-                <span style={{ fontSize: 14, color: '#94a3b8', width: 20, textAlign: 'center' }}>📂</span>
+                <span style={{ fontSize: 14, color: 'var(--t-text-muted)', width: 20, textAlign: 'center' }}>📂</span>
                 <div style={{ fontWeight: 500 }}>Open folder...</div>
               </button>
             </>)}


### PR DESCRIPTION
## Summary
- Remove OpenCode and Aider from CLI agent selector lists (both WorkspaceTerminal and ContextualPanel) — not shipped runtimes
- Remove OpenClaw from onboarding feature carousel copy
- Fix canvas terminal picker dropdown to use theme CSS variables (`var(--t-*)`) instead of hardcoded light-mode hex colors — dropdown now renders with proper glass background, text contrast, and hover states in dark mode
- Add `backdropFilter` to picker dropdown container for glass effect

## Test plan
- [ ] Open canvas, click the "+" picker — verify only Terminal, Claude Code, Codex, Gemini CLI appear
- [ ] Switch to dark mode — verify the dropdown has grey glass background (not white)
- [ ] Verify text and hover states are readable in both light and dark themes
- [ ] Open global terminal panel (bottom), verify same agent list cleanup
- [ ] Check onboarding carousel no longer mentions OpenClaw

🤖 Generated with [Claude Code](https://claude.com/claude-code)