### PR TITLE
feat(desktop): one-click rerun-with-feedback on rejected reviews (#662)

### DIFF
--- a/src/app/api/orchestrator/rerun-with-feedback/route.ts
+++ b/src/app/api/orchestrator/rerun-with-feedback/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest } from 'next/server';
+import { requirePanelAuth } from '@/lib/panel/auth';
+import { rerunWithFeedback } from '@/lib/orchestrator/operator-mission-service';
+import { asRecord, operatorError, operatorSuccess, parseJsonBody } from '../_utils';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const MAX_FEEDBACK_LENGTH = 4000;
+
+export async function POST(request: NextRequest) {
+  const denied = requirePanelAuth(request);
+  if (denied) return denied;
+
+  const body = await parseJsonBody(request);
+  const record = asRecord(body);
+  if (!record) {
+    return operatorError('invalid_request', 'Invalid JSON body.', 400);
+  }
+
+  const packetId = typeof record.packetId === 'string' ? record.packetId.trim() : '';
+  if (!packetId) {
+    return operatorError('invalid_request', 'packetId is required.', 400);
+  }
+
+  const feedbackRaw = typeof record.feedback === 'string' ? record.feedback : '';
+  const feedback = feedbackRaw.trim();
+  if (!feedback) {
+    return operatorError('invalid_request', 'feedback is required.', 400);
+  }
+  if (feedback.length > MAX_FEEDBACK_LENGTH) {
+    return operatorError(
+      'invalid_request',
+      `feedback exceeds maximum length of ${MAX_FEEDBACK_LENGTH} characters.`,
+      400,
+    );
+  }
+
+  try {
+    const result = await rerunWithFeedback({ packetId, feedback });
+    return operatorSuccess(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to rerun packet with feedback.';
+    return operatorError('rerun_failed', message, 500, error);
+  }
+}

--- a/src/components/desktop/thoughts/mission-panel/PacketCard.tsx
+++ b/src/components/desktop/thoughts/mission-panel/PacketCard.tsx
@@ -11,6 +11,7 @@ import { PacketDetailsPopover } from '@/components/desktop/thoughts/PacketDetail
 import type { EditingField, ReviewPanelState } from './types';
 import { PacketMetaRows } from './PacketMetaRows';
 import { PacketReviewPanel } from './PacketReviewPanel';
+import { RejectedFeedbackPanel } from './RejectedFeedbackPanel';
 
 interface PacketCardProps {
   packet: OrchestratorPacket;
@@ -69,6 +70,10 @@ export function PacketCard({
     packet.status === 'awaiting_review'
     || (packet.status === 'blocked' && packet.blockedReason === 'Awaiting operator input')
   );
+  // #662 — Rejected packets get a one-click rerun-with-feedback panel.
+  // Detect via packet.review?.approved === false rather than packet.status,
+  // since submitPacketReview leaves status untouched.
+  const isRejected = packet.review?.approved === false;
 
   const packetPrompt = [packet.title, packet.summary].map((part) => part.trim()).filter(Boolean).join('\n\n') || null;
 
@@ -515,6 +520,22 @@ export function PacketCard({
               onReviewAction={onReviewAction}
               onToggleShowAllFiles={onToggleShowAllFiles}
             />
+          ) : null}
+
+          {isRejected ? (
+            <div
+              style={{
+                paddingTop: 8,
+                paddingRight: 10,
+                paddingBottom: 10,
+                paddingLeft: 10,
+                borderTopWidth: showReviewSection ? 0 : 1,
+                borderTopStyle: 'solid',
+                borderTopColor: 'var(--t-divider-subtle)',
+              }}
+            >
+              <RejectedFeedbackPanel packet={packet} />
+            </div>
           ) : null}
         </div>
       ) : (

--- a/src/components/desktop/thoughts/mission-panel/RejectedFeedbackPanel.tsx
+++ b/src/components/desktop/thoughts/mission-panel/RejectedFeedbackPanel.tsx
@@ -1,0 +1,285 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+
+interface RejectedFeedbackPanelProps {
+  packet: OrchestratorPacket;
+}
+
+const MAX_FEEDBACK_LENGTH = 4000;
+
+/**
+ * #662 — One-click rerun-with-feedback.
+ *
+ * Surfaces on a rejected packet card body. Operator types feedback, hits the
+ * button, the API resets+redispatches with the feedback prepended to the
+ * original prompt. The rejected lane is archived (not deleted) so the diff
+ * stays in lane history.
+ */
+export function RejectedFeedbackPanel({ packet }: RejectedFeedbackPanelProps) {
+  const [feedback, setFeedback] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+
+  const trimmed = feedback.trim();
+  const canSubmit = trimmed.length > 0 && trimmed.length <= MAX_FEEDBACK_LENGTH && !submitting;
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    setNote(null);
+    try {
+      const response = await fetch('/api/orchestrator/rerun-with-feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ packetId: packet.id, feedback: trimmed }),
+      });
+      const payload = await response.json().catch(() => null) as {
+        ok?: boolean;
+        result?: { note?: string };
+        error?: { message?: string };
+      } | null;
+      if (!response.ok || !payload?.ok) {
+        throw new Error(payload?.error?.message ?? 'Unable to rerun this packet.');
+      }
+      setNote(payload.result?.note ?? `Packet ${packet.referenceLabel} relaunched with feedback.`);
+      setFeedback('');
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Unable to rerun this packet.');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [canSubmit, packet.id, packet.referenceLabel, trimmed]);
+
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+      event.preventDefault();
+      void handleSubmit();
+    }
+  }, [handleSubmit]);
+
+  const charCount = feedback.length;
+  const overLimit = charCount > MAX_FEEDBACK_LENGTH;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        paddingTop: 10,
+        paddingRight: 11,
+        paddingBottom: 10,
+        paddingLeft: 11,
+        borderRadius: 14,
+        background: 'var(--t-panel)',
+        borderWidth: 1,
+        borderStyle: 'solid',
+        borderColor: 'rgba(239, 68, 68, 0.24)',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <svg
+          width={14}
+          height={14}
+          viewBox="0 0 256 256"
+          fill="#b91c1c"
+          aria-hidden="true"
+          style={{ flexShrink: 0 }}
+        >
+          {/* Phosphor: arrow-counter-clockwise */}
+          <path d="M224,128a96,96,0,1,1-21.95-61.09,8,8,0,1,1-12.33,10.18A80,80,0,1,0,207.6,136H176a8,8,0,0,1,0-16h40a8,8,0,0,1,8,8Z" />
+        </svg>
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 800,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            color: '#b91c1c',
+          }}
+        >
+          Rejected
+        </span>
+        <span
+          style={{
+            fontSize: 11,
+            color: 'var(--t-text-secondary)',
+            fontWeight: 600,
+            letterSpacing: '-0.005em',
+          }}
+        >
+          Try again with feedback
+        </span>
+      </div>
+
+      <textarea
+        value={feedback}
+        onChange={(event) => setFeedback(event.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={`Tell ${packet.referenceLabel} what to fix. The original prompt is preserved; this gets appended.`}
+        rows={3}
+        disabled={submitting}
+        style={{
+          width: '100%',
+          resize: 'vertical',
+          minHeight: 64,
+          maxHeight: 220,
+          paddingTop: 8,
+          paddingRight: 10,
+          paddingBottom: 8,
+          paddingLeft: 10,
+          borderRadius: 12,
+          borderWidth: 1,
+          borderStyle: 'solid',
+          borderColor: overLimit ? 'rgba(239, 68, 68, 0.4)' : 'var(--t-panel-border)',
+          background: 'var(--t-input-bg)',
+          color: 'var(--t-text)',
+          fontSize: 12,
+          lineHeight: 1.5,
+          fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+          letterSpacing: '-0.005em',
+          outline: 'none',
+          opacity: submitting ? 0.6 : 1,
+          transition: 'border-color 200ms cubic-bezier(0.4, 1.4, 0.6, 1)',
+        }}
+        aria-label="Operator feedback for rerun"
+      />
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <button
+          type="button"
+          onClick={() => { void handleSubmit(); }}
+          disabled={!canSubmit}
+          title="Reset this packet's worktree and redispatch with feedback (Cmd+Enter)"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 6,
+            minWidth: 44,
+            height: 44,
+            paddingLeft: 14,
+            paddingRight: 14,
+            borderRadius: 14,
+            borderWidth: 0,
+            background: canSubmit ? '#2563eb' : 'var(--t-divider)',
+            color: canSubmit ? '#fff' : 'var(--t-text-faint)',
+            fontSize: 12,
+            fontWeight: 700,
+            letterSpacing: '-0.01em',
+            cursor: canSubmit ? 'pointer' : 'not-allowed',
+            opacity: submitting ? 0.7 : 1,
+            transition: 'background 200ms cubic-bezier(0.4, 1.4, 0.6, 1), transform 150ms cubic-bezier(0.4, 1.4, 0.6, 1)',
+            fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+          }}
+          onMouseDown={(event) => {
+            if (canSubmit) event.currentTarget.style.transform = 'scale(0.97)';
+          }}
+          onMouseUp={(event) => {
+            event.currentTarget.style.transform = 'scale(1)';
+          }}
+          onMouseLeave={(event) => {
+            event.currentTarget.style.transform = 'scale(1)';
+          }}
+        >
+          {submitting ? (
+            <>
+              <svg
+                width={14}
+                height={14}
+                viewBox="0 0 256 256"
+                fill="currentColor"
+                aria-hidden="true"
+                style={{ animation: 'spin 0.9s linear infinite' }}
+              >
+                {/* Phosphor: circle-notch */}
+                <path d="M232,128a104,104,0,0,1-208,0c0-41,23.81-78.36,60.66-95.27a8,8,0,0,1,6.68,14.54C60.15,61.59,40,93.27,40,128a88,88,0,0,0,176,0c0-34.73-20.15-66.41-51.34-80.73a8,8,0,0,1,6.68-14.54C208.19,49.64,232,87,232,128Z" />
+              </svg>
+              Relaunching…
+            </>
+          ) : (
+            <>
+              <svg
+                width={14}
+                height={14}
+                viewBox="0 0 256 256"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                {/* Phosphor: arrow-clockwise */}
+                <path d="M232,56v48a8,8,0,0,1-8,8H176a8,8,0,0,1,0-16h28.4L182.13,77.66a87.9,87.9,0,1,0,1.21,123.86,8,8,0,1,1,11.59,11A104,104,0,1,1,193,66.69L216,89.43V56a8,8,0,0,1,16,0Z" />
+              </svg>
+              Try again with feedback
+            </>
+          )}
+        </button>
+        <span
+          style={{
+            fontSize: 10,
+            color: overLimit ? '#b91c1c' : 'var(--t-text-faint)',
+            fontWeight: 600,
+            fontFamily: 'var(--font-mono, "SF Mono", Menlo, monospace)',
+          }}
+        >
+          {charCount}/{MAX_FEEDBACK_LENGTH}
+        </span>
+        {!submitting && !error && trimmed.length === 0 ? (
+          <span style={{ fontSize: 10.5, color: 'var(--t-text-faint)' }}>
+            Cmd+Enter to submit
+          </span>
+        ) : null}
+      </div>
+
+      {error ? (
+        <div
+          role="alert"
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            color: '#b91c1c',
+            paddingTop: 6,
+            paddingRight: 9,
+            paddingBottom: 6,
+            paddingLeft: 9,
+            borderRadius: 8,
+            background: 'rgba(239, 68, 68, 0.06)',
+            borderWidth: 1,
+            borderStyle: 'solid',
+            borderColor: 'rgba(239, 68, 68, 0.16)',
+          }}
+        >
+          {error}
+        </div>
+      ) : null}
+
+      {!error && note ? (
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            color: '#15803d',
+            paddingTop: 6,
+            paddingRight: 9,
+            paddingBottom: 6,
+            paddingLeft: 9,
+            borderRadius: 8,
+            background: 'rgba(34, 197, 94, 0.08)',
+            borderWidth: 1,
+            borderStyle: 'solid',
+            borderColor: 'rgba(34, 197, 94, 0.18)',
+          }}
+        >
+          {note}
+        </div>
+      ) : null}
+
+      <style>
+        {`@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }`}
+      </style>
+    </div>
+  );
+}

--- a/src/lib/orchestrator/operator-mission-service.ts
+++ b/src/lib/orchestrator/operator-mission-service.ts
@@ -24,3 +24,6 @@ export {
 } from './operator-mission-service/merge';
 
 export { resetPacket } from './operator-mission-service/reset';
+
+export { rerunWithFeedback } from './operator-mission-service/rerun-with-feedback';
+export type { RerunWithFeedbackInput } from './operator-mission-service/rerun-with-feedback';

--- a/src/lib/orchestrator/operator-mission-service/rerun-with-feedback.ts
+++ b/src/lib/orchestrator/operator-mission-service/rerun-with-feedback.ts
@@ -1,0 +1,170 @@
+import { withLockedState, writeOrchestratorControlPlaneState } from '@/lib/orchestrator/control-plane';
+import { runDispatchTick } from '@/lib/orchestrator/dispatch';
+import { archiveLane, listLanes, updateLane } from '@/lib/lane/registry';
+import { getWorktreeManager } from '@/lib/worktree/launch';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import { log } from './shared';
+
+/**
+ * #662 — One-click rerun-with-feedback.
+ *
+ * Used after the operator rejects a diff. Within a single locked write:
+ *   1. Archives the rejected lane (preserves its diff in lane history),
+ *      prunes the worktree.
+ *   2. Resets the packet to dispatchable state.
+ *   3. Appends the operator's feedback to the packet summary (which is what
+ *      `buildPacketPrompt` actually feeds the agent) and the prompt
+ *      (surfaced in the details popover).
+ *   4. Runs a dispatch tick so the packet relaunches in a fresh worktree.
+ *
+ * Doing the reset + dispatch inside one `withLockedState` block keeps
+ * the operation atomic — no headless-tick can race in between and read
+ * a partially-mutated mission.
+ */
+export interface RerunWithFeedbackInput {
+  packetId: string;
+  feedback: string;
+}
+
+const FEEDBACK_HEADING = '## Operator feedback';
+// Match an existing feedback section (preceded by 1+ blank lines) and
+// everything after it, so repeat reruns replace the prior feedback rather
+// than stacking.
+const FEEDBACK_SECTION_RX = new RegExp(`\\n+${FEEDBACK_HEADING}[\\s\\S]*$`);
+
+function appendFeedback(base: string, feedback: string) {
+  const trimmed = base.trim();
+  const stripped = trimmed.replace(FEEDBACK_SECTION_RX, '').trim();
+  const trimmedFeedback = feedback.trim();
+  if (!stripped) return `${FEEDBACK_HEADING}\n${trimmedFeedback}`;
+  return `${stripped}\n\n${FEEDBACK_HEADING}\n${trimmedFeedback}`;
+}
+
+/**
+ * Mirrors the resetPacket lane-archival path. Returns the first worktree
+ * path encountered so the caller can prune it.
+ */
+function archiveLanesForPacket(packetId: string, referenceLabel: string): string | null {
+  let worktreePath: string | null = null;
+  try {
+    const bound = listLanes().filter(
+      (lane) => lane.packetId === packetId
+        && lane.status !== 'archived'
+        && lane.status !== 'completed',
+    );
+    for (const lane of bound) {
+      if (!worktreePath && lane.worktreePath) {
+        worktreePath = lane.worktreePath;
+      }
+      try {
+        // Clear packetId first so reconciler can't re-bind this lane.
+        updateLane(lane.id, { packetId: '' });
+        archiveLane(lane.id, 'user');
+        console.log(`[rerun-with-feedback] Archived stale lane ${lane.id} for packet ${referenceLabel}`);
+      } catch (error) {
+        console.warn(
+          `[rerun-with-feedback] Could not archive lane ${lane.id}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  } catch (error) {
+    console.warn(
+      `[rerun-with-feedback] Lane registry lookup failed for packet ${referenceLabel}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  return worktreePath;
+}
+
+async function pruneWorktree(repoPath: string | null | undefined, worktreePath: string): Promise<boolean> {
+  if (!repoPath) return false;
+  try {
+    const manager = await getWorktreeManager(repoPath);
+    const worktrees = await manager.list();
+    const match = worktrees.find((wt) => worktreePath.includes(wt.id));
+    if (!match) return false;
+    await manager.cleanup(match.id, { force: true, deleteBranch: true });
+    log(`[rerun-with-feedback] Pruned worktree ${match.id}`);
+    return true;
+  } catch {
+    log(`[rerun-with-feedback] Could not prune worktree at ${worktreePath} — may already be gone`);
+    return false;
+  }
+}
+
+function resetPacketFields(packet: OrchestratorPacket) {
+  // Mirrors resetPacket's mission-state mutations. Intentional duplication
+  // so the reset is part of our locked write rather than a non-atomic
+  // in-memory broadcast.
+  packet.status = 'draft';
+  packet.queueState = 'queued';
+  packet.releaseState = 'pending';
+  packet.blockedReason = null;
+  packet.lane = null;
+  packet.review = null;
+  packet.lastEventAt = null;
+  packet.lastEventLabel = null;
+  packet.recoveryCount = 0;
+  packet.lastRecoveryAt = null;
+}
+
+export async function rerunWithFeedback(input: RerunWithFeedbackInput) {
+  const packetId = input.packetId.trim();
+  if (!packetId) {
+    throw new Error('packetId is required.');
+  }
+  const feedback = input.feedback.trim();
+  if (!feedback) {
+    throw new Error('feedback is required.');
+  }
+
+  let worktreePruned = false;
+  let referenceLabel = packetId;
+
+  const { state: finalState } = await withLockedState(async (current) => {
+    const packet = current.packets.find((candidate) => candidate.id === packetId);
+    if (!packet) {
+      throw new Error(`Packet ${packetId} not found.`);
+    }
+    referenceLabel = packet.referenceLabel;
+
+    // Snapshot originals BEFORE reset clears them.
+    const originalSummary = packet.summary;
+    const originalPrompt = packet.prompt?.trim()
+      || [packet.title, originalSummary].map((part) => part.trim()).filter(Boolean).join('\n\n');
+
+    // Step 1 — archive the rejected lane (preserves its diff in lane
+    // history) and prune the worktree so the redispatch starts clean.
+    const worktreePath = archiveLanesForPacket(packetId, packet.referenceLabel);
+    if (worktreePath) {
+      worktreePruned = await pruneWorktree(current.repoPath, worktreePath);
+    }
+
+    // Step 2 — reset packet fields so the dispatch tick treats it as queued.
+    resetPacketFields(packet);
+
+    // Step 3 — apply feedback to summary (consumed by buildPacketPrompt)
+    // and prompt (surfaced in the details popover).
+    packet.summary = appendFeedback(originalSummary, feedback);
+    packet.prompt = appendFeedback(originalPrompt, feedback);
+
+    // Step 4 — run a dispatch tick so the packet relaunches with the
+    // updated prompt.
+    const afterDispatch = await runDispatchTick(current);
+    writeOrchestratorControlPlaneState(afterDispatch);
+  });
+
+  const dispatchedPacket = finalState.packets.find((candidate) => candidate.id === packetId) ?? null;
+  const dispatched = Boolean(dispatchedPacket?.lane?.laneId || dispatchedPacket?.lane?.sessionKey);
+
+  log(`Rerun-with-feedback for packet ${referenceLabel} (${packetId}). dispatched=${dispatched}`);
+
+  return {
+    packetId,
+    referenceLabel,
+    dispatched,
+    worktreePruned,
+    note: dispatched
+      ? `Packet ${referenceLabel} relaunched with operator feedback.`
+      : `Packet ${referenceLabel} reset and queued. Awaiting next dispatch tick.`,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a textarea + "Try again with feedback" button to packet cards with a rejected review (`packet.review.approved === false`).
- Single click reset+redispatch with operator feedback prepended to the dispatched prompt — closes the manual "compose follow-up packet" loop.
- Rejected lane stays archived (not deleted) so its diff is preserved in lane history.

## What it does

When the operator hits **Try again with feedback** on a rejected packet card, one atomic `withLockedState` block:

1. Archives the rejected lane (preserves diff in lane history) and prunes the worktree so the rerun starts clean.
2. Resets the packet to dispatchable state (status=draft, queueState=queued, lane/review nulled).
3. Appends `## Operator feedback\n<feedback>` to the packet `summary` (consumed by `buildPacketPrompt`) and `prompt` (surfaced in the details popover). Repeat reruns replace the prior feedback section rather than stacking.
4. Runs a dispatch tick so the packet relaunches in a fresh worktree with the augmented prompt.

## Files

- `src/components/desktop/thoughts/mission-panel/RejectedFeedbackPanel.tsx` — new UI surface. Textarea + primary 44px button (Cmd+Enter to submit), 4000-char cap, optimistic note + error states. Inline styles only, palette tokens, raw Phosphor SVG icons, spring transitions.
- `src/components/desktop/thoughts/mission-panel/PacketCard.tsx` — wires the panel in via an `isRejected = packet.review?.approved === false` derivation.
- `src/lib/orchestrator/operator-mission-service/rerun-with-feedback.ts` — new service. Inlines the lane-archival / worktree-prune / packet-reset logic from `resetPacket` so the entire reset+dispatch runs inside one locked write (no headless-tick race).
- `src/lib/orchestrator/operator-mission-service.ts` — exports `rerunWithFeedback` + its input type.
- `src/app/api/orchestrator/rerun-with-feedback/route.ts` — new POST route. Auto-gated by the existing `/api/orchestrator/` prefix in `src/middleware.ts`. Validates `packetId` + `feedback` (non-empty, ≤ 4000 chars).

## Test plan

- [ ] Reject a packet via the existing review flow. Card body shows the new "Rejected" panel with textarea + button.
- [ ] Submit empty feedback → button disabled.
- [ ] Submit feedback > 4000 chars → button disabled, char counter turns red.
- [ ] Cmd+Enter inside the textarea submits.
- [ ] On submit: packet flips back to queued/launching, fresh worktree appears (old worktree gone), new lane row in SQLite (old one archived not deleted), dispatched prompt includes `## Operator feedback\n<feedback>` after the original packet body.
- [ ] Hit reject again on the second run → submit new feedback → confirm the prior feedback section is replaced (not stacked) in the dispatched prompt.

Closes #662.