### PR TITLE
feat(desktop): multi-window / split-pane orchestrator transcripts (#663)

### DIFF
--- a/src/components/desktop/SessionPillContextMenu.tsx
+++ b/src/components/desktop/SessionPillContextMenu.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+/**
+ * SessionPillContextMenu — right-click menu for session pills (issue #663).
+ *
+ * Floating menu portal-rendered at the cursor coordinate. Backdrop click,
+ * escape, and any selection close it. Apple HIG: 44px touch targets,
+ * spring-curve open animation, palette tokens only.
+ */
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
+import { createPortal } from 'react-dom';
+
+export type SessionPillSplitDirection = 'horizontal' | 'vertical';
+
+export interface SessionPillContextMenuItem {
+  id: string;
+  label: string;
+  description?: string;
+  iconDirection: SessionPillSplitDirection;
+  disabled?: boolean;
+  onSelect: () => void;
+}
+
+interface SessionPillContextMenuProps {
+  open: boolean;
+  x: number;
+  y: number;
+  items: SessionPillContextMenuItem[];
+  onClose: () => void;
+}
+
+const MENU_WIDTH = 248;
+const ESTIMATED_ROW_HEIGHT = 56;
+
+export function SessionPillContextMenu({
+  open,
+  x,
+  y,
+  items,
+  onClose,
+}: SessionPillContextMenuProps) {
+  const [mounted, setMounted] = useState(false);
+  const [entered, setEntered] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      // Schedule the reset on the next frame so we don't synchronously call
+      // setState during render in the parent's reconciliation pass.
+      const raf = requestAnimationFrame(() => setEntered(false));
+      return () => cancelAnimationFrame(raf);
+    }
+    const mountRaf = requestAnimationFrame(() => {
+      setMounted(true);
+      // Two RAFs so the spring kick-in doesn't get squashed by the same paint.
+      const enterRaf = requestAnimationFrame(() => setEntered(true));
+      return () => cancelAnimationFrame(enterRaf);
+    });
+    return () => cancelAnimationFrame(mountRaf);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onClose, open]);
+
+  if (!open || !mounted) return null;
+  if (typeof document === 'undefined') return null;
+
+  // Keep the menu inside the viewport.
+  const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1200;
+  const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : 800;
+  const menuHeight = items.length * ESTIMATED_ROW_HEIGHT + 12;
+  const left = Math.max(8, Math.min(x, viewportWidth - MENU_WIDTH - 8));
+  const top = Math.max(8, Math.min(y, viewportHeight - menuHeight - 8));
+
+  const containerStyle: CSSProperties = {
+    position: 'fixed',
+    left,
+    top,
+    width: MENU_WIDTH,
+    background: 'var(--t-bg-card)',
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: 'var(--t-border)',
+    borderRadius: 14,
+    boxShadow: 'var(--t-glass-shadow, 0 18px 38px rgba(15, 23, 42, 0.18))',
+    paddingTop: 6,
+    paddingRight: 6,
+    paddingBottom: 6,
+    paddingLeft: 6,
+    zIndex: 240,
+    transformOrigin: 'top left',
+    transform: entered ? 'scale(1) translateY(0)' : 'scale(0.96) translateY(-4px)',
+    opacity: entered ? 1 : 0,
+    // Apple HIG-ish spring curve for the pop-in.
+    transition: 'transform 220ms cubic-bezier(0.34, 1.36, 0.64, 1), opacity 160ms ease',
+    fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+  };
+
+  const backdrop = (
+    <div
+      onClick={onClose}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'transparent',
+        zIndex: 239,
+      }}
+    />
+  );
+
+  return createPortal(
+    <>
+      {backdrop}
+      <div
+        ref={menuRef}
+        role="menu"
+        aria-orientation="vertical"
+        style={containerStyle}
+      >
+        {items.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            disabled={item.disabled}
+            onClick={() => {
+              if (item.disabled) return;
+              item.onSelect();
+              onClose();
+            }}
+            style={{
+              width: '100%',
+              minHeight: 44,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              paddingTop: 8,
+              paddingRight: 12,
+              paddingBottom: 8,
+              paddingLeft: 12,
+              borderRadius: 10,
+              borderWidth: 0,
+              background: 'transparent',
+              color: item.disabled ? 'var(--t-text-faint)' : 'var(--t-text)',
+              cursor: item.disabled ? 'not-allowed' : 'pointer',
+              textAlign: 'left',
+              fontFamily: 'inherit',
+            }}
+            onMouseEnter={(event) => {
+              if (item.disabled) return;
+              event.currentTarget.style.background = 'var(--t-panel)';
+            }}
+            onMouseLeave={(event) => {
+              event.currentTarget.style.background = 'transparent';
+            }}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: 8,
+                borderWidth: 1,
+                borderStyle: 'solid',
+                borderColor: 'var(--t-border)',
+                background: 'var(--t-panel)',
+                color: 'var(--t-text-secondary)',
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+              }}
+            >
+              <SplitDirectionIcon direction={item.iconDirection} />
+            </span>
+            <span
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 2,
+                minWidth: 0,
+                flex: 1,
+              }}
+            >
+              <span
+                style={{
+                  fontSize: 12.5,
+                  fontWeight: 600,
+                  color: 'inherit',
+                  letterSpacing: '-0.01em',
+                }}
+              >
+                {item.label}
+              </span>
+              {item.description ? (
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: 'var(--t-text-secondary)',
+                    fontWeight: 500,
+                  }}
+                >
+                  {item.description}
+                </span>
+              ) : null}
+            </span>
+          </button>
+        ))}
+      </div>
+    </>,
+    document.body,
+  );
+}
+
+function SplitDirectionIcon({ direction }: { direction: SessionPillSplitDirection }) {
+  if (direction === 'vertical') {
+    return (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <rect x="3.5" y="5" width="7.5" height="14" rx="2" />
+        <rect x="13" y="5" width="7.5" height="14" rx="2" />
+      </svg>
+    );
+  }
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="3.5" y="3.5" width="17" height="7.5" rx="2" />
+      <rect x="3.5" y="13" width="17" height="7.5" rx="2" />
+    </svg>
+  );
+}

--- a/src/components/desktop/SessionTranscriptPane.tsx
+++ b/src/components/desktop/SessionTranscriptPane.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+/**
+ * SessionTranscriptPane — sessionKey-only transcript surface.
+ *
+ * Thin adapter over AgentTilePane that resolves the agent record from the
+ * orchestrator data context, so the pane can mount in any tile (split-pane
+ * orchestrator transcripts, future side-by-side comparison views, etc.)
+ * without callers having to thread agent metadata through.
+ *
+ * Issue #663: extract per-session transcript view as
+ * <SessionTranscriptPane sessionKey={key} /> so it can mount in any tile.
+ */
+import { useCallback, useMemo } from 'react';
+import { useOrchestratorData } from './orchestrator-data-context';
+import { AgentTilePane } from './workspace-terminal/AgentTilePane';
+
+interface SessionTranscriptPaneProps {
+  sessionKey: string;
+  focused?: boolean;
+  onFocus?: (sessionKey: string) => void;
+  onClose?: (sessionKey: string) => void;
+}
+
+export function SessionTranscriptPane({
+  sessionKey,
+  focused = false,
+  onFocus,
+  onClose,
+}: SessionTranscriptPaneProps) {
+  const data = useOrchestratorData();
+  const agent = useMemo(
+    () => (data?.agents ?? []).find((entry) => entry.sessionKey === sessionKey) ?? null,
+    [data?.agents, sessionKey],
+  );
+
+  const handleFocus = useCallback((key: string) => {
+    onFocus?.(key);
+  }, [onFocus]);
+
+  const handleClose = useCallback((key: string) => {
+    onClose?.(key);
+  }, [onClose]);
+
+  return (
+    <AgentTilePane
+      sessionKey={sessionKey}
+      agent={agent}
+      focused={focused}
+      onClose={handleClose}
+      onFocus={handleFocus}
+    />
+  );
+}

--- a/src/components/desktop/SessionVisualizer.tsx
+++ b/src/components/desktop/SessionVisualizer.tsx
@@ -4,12 +4,23 @@ import { memo, useMemo } from 'react';
 import type { FleetAgent } from './thoughts/types';
 import { ORCHESTRATOR_RUNTIMES } from '@/lib/orchestrator/runtime-capabilities';
 
+export interface SessionPillContextMenuRequest {
+  sessionKey: string;
+  sessionName: string;
+  isTiled: boolean;
+  clientX: number;
+  clientY: number;
+}
+
 interface SessionVisualizerProps {
   agents: FleetAgent[];
   tiledSessions?: string[];
   onSelectSession?: (sessionKey: string) => void;
   onToggleTileSession?: (sessionKey: string) => void;
   onClearTiles?: () => void;
+  /** Right-click on a session pill (issue #663). Receives cursor coordinates
+   * so the consumer can render a context menu portal. */
+  onRequestContextMenu?: (request: SessionPillContextMenuRequest) => void;
 }
 
 export type VisualStatus = 'running' | 'waiting' | 'idle' | 'error';
@@ -110,6 +121,7 @@ function SessionVisualizerBase({
   onSelectSession,
   onToggleTileSession,
   onClearTiles,
+  onRequestContextMenu,
 }: SessionVisualizerProps) {
   const sessions = useMemo(() => agents.map(toVisualSession), [agents]);
   const tiledSet = useMemo(() => new Set(tiledSessions), [tiledSessions]);
@@ -284,6 +296,16 @@ function SessionVisualizerBase({
               <div
                 key={session.key}
                 title={`${session.name} — ${session.headline}`}
+                onContextMenu={onRequestContextMenu ? (event) => {
+                  event.preventDefault();
+                  onRequestContextMenu({
+                    sessionKey: session.key,
+                    sessionName: session.name,
+                    isTiled: tiled,
+                    clientX: event.clientX,
+                    clientY: event.clientY,
+                  });
+                } : undefined}
                 style={{
                   position: 'relative',
                   minWidth: 148,
@@ -460,3 +482,8 @@ function SessionVisualizerBase({
 }
 
 export const SessionVisualizer = memo(SessionVisualizerBase);
+
+// Re-export the per-session transcript surface so consumers can mount it in
+// any tile (issue #663). Implementation lives next to it for cohesion; this
+// file is the discoverable home.
+export { SessionTranscriptPane } from './SessionTranscriptPane';

--- a/src/components/desktop/workspace-terminal/OrchestratorTab.tsx
+++ b/src/components/desktop/workspace-terminal/OrchestratorTab.tsx
@@ -54,7 +54,12 @@ import {
 import { ORCHESTRATOR_TOKEN_EVENT, type OrchestratorTokenUsageDetail } from '@/components/desktop/thoughts/useOrchestratorStream';
 import { ThoughtsMissionPanel } from '@/components/desktop/thoughts/ThoughtsMissionPanel';
 import { buildAgentTargets } from '@/components/desktop/thoughts/utils';
-import { AgentTileLayout } from './AgentTileLayout';
+import { SessionPillContextMenu } from '@/components/desktop/SessionPillContextMenu';
+import { SessionVisualizer } from '@/components/desktop/SessionVisualizer';
+import { SessionTileSurface } from './SessionTileSurface';
+import { useSessionTiles, buildPillContextMenuItems } from './use-session-tiles';
+// Issue #663: SessionTileSurface replaces the legacy flat AgentTileLayout
+// row. The old layout component is no longer imported here.
 
 interface OrchestratorTabProps {
   tabId: string;
@@ -245,8 +250,6 @@ function OrchestratorTabInner({ tabId, active, repoPath, repoLabel }: Orchestrat
   const [historyOpen, setHistoryOpen] = useState(() => readBooleanPref(HISTORY_OPEN_KEY));
   const [agentsOpen, setAgentsOpen] = useState(() => readBooleanPref(AGENTS_OPEN_KEY));
   const [missionOpen, setMissionOpen] = useState(() => readBooleanPref(MISSION_OPEN_KEY));
-  const [tiledSessions, setTiledSessions] = useState<string[]>([]);
-  const [tileDockExpanded, setTileDockExpanded] = useState(true);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [paletteDraft, setPaletteDraft] = useState<{ id: string; text: string } | null>(null);
   const chatPanelRef = useRef<ThoughtsChatPanelHandle>(null);
@@ -293,22 +296,11 @@ function OrchestratorTabInner({ tabId, active, repoPath, repoLabel }: Orchestrat
     () => buildAgentTargets(agents, preferredRuntime),
     [agents, preferredRuntime],
   );
-  const isTiled = tiledSessions.length > 1;
-
-  useEffect(() => {
-    const activeSessions = new Set(
-      agents.map((agent) => agent.sessionKey).filter((sessionKey): sessionKey is string => Boolean(sessionKey)),
-    );
-    setTiledSessions((current) => {
-      const next = current.filter((sessionKey) => activeSessions.has(sessionKey));
-      return next.length === current.length ? current : next;
-    });
-  }, [agents]);
-
-  useEffect(() => {
-    if (!isTiled) return;
-    setTileDockExpanded(true);
-  }, [isTiled]);
+  const liveSessionKeys = useMemo(
+    () => agents.map((agent) => agent.sessionKey).filter((key): key is string => Boolean(key)),
+    [agents],
+  );
+  const sessionTiles = useSessionTiles({ tabId, liveSessionKeys });
 
   useEffect(() => {
     const activeGroupIds = comparisonGroups.map((group) => group.groupId);
@@ -336,9 +328,9 @@ function OrchestratorTabInner({ tabId, active, repoPath, repoLabel }: Orchestrat
     }
 
     autoTiledComparisonGroupIdRef.current = nextAutoTileGroup.groupId;
-    setTiledSessions(sessionKeys);
+    sessionTiles.autoTileSessions(sessionKeys);
     console.log(`[best-of-n] Auto-tiled comparison group ${nextAutoTileGroup.groupId}`);
-  }, [comparisonGroups]);
+  }, [comparisonGroups, sessionTiles]);
 
   const handleTogglePermission = useCallback(() => {
     setPermissionMode((current) => {
@@ -389,13 +381,6 @@ function OrchestratorTabInner({ tabId, active, repoPath, repoLabel }: Orchestrat
     }
   }, [missionOpen, residency]);
 
-  const handleCloseTileSession = useCallback((sessionKey: string) => {
-    setTiledSessions((current) => current.filter((key) => key !== sessionKey));
-  }, []);
-
-  const handleToggleTileDock = useCallback(() => {
-    setTileDockExpanded((current) => !current);
-  }, []);
 
   const handleSelectThread = useCallback((threadTabId: string) => {
     chatPanelRef.current?.loadThread(threadTabId);
@@ -690,8 +675,18 @@ function OrchestratorTabInner({ tabId, active, repoPath, repoLabel }: Orchestrat
         </div>
       </div>
 
-      {/* SESSIONS strip retired — the workspace tab strip above already
-          represents active agents. See issue #604. */}
+      {/* Sessions strip — pills for active agents. Right-click to split a
+          transcript into a tile beside the chat (issue #663). */}
+      {agents.length > 0 ? (
+        <SessionVisualizer
+          agents={agents}
+          tiledSessions={sessionTiles.tiledSessions}
+          onSelectSession={data.onSelectSession}
+          onToggleTileSession={sessionTiles.toggleTileSession}
+          onClearTiles={sessionTiles.clearAllTiles}
+          onRequestContextMenu={sessionTiles.requestPillContextMenu}
+        />
+      ) : null}
 
       {readyComparisonGroups.length > 0 ? (
         <div
@@ -758,124 +753,15 @@ function OrchestratorTabInner({ tabId, active, repoPath, repoLabel }: Orchestrat
             position: 'relative',
           }}
         >
-          {isTiled ? (
-            <div
-              style={{
-                flex: 1,
-                minHeight: 0,
-                display: 'flex',
-                flexDirection: 'column',
-              }}
-            >
-              <AgentTileLayout
-                sessions={tiledSessions}
-                agents={agents}
-                onCloseSession={handleCloseTileSession}
-              />
-              <div
-                style={{
-                  height: tileDockExpanded ? 232 : 160,
-                  minHeight: tileDockExpanded ? 232 : 160,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  borderTopWidth: 1,
-                  borderTopStyle: 'solid',
-                  borderTopColor: 'var(--t-divider-subtle)',
-                  background: 'var(--t-bg-card)',
-                  flexShrink: 0,
-                }}
-              >
-                <div
-                  style={{
-                    height: 44,
-                    minHeight: 44,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    gap: 12,
-                    paddingTop: 0,
-                    paddingRight: 12,
-                    paddingBottom: 0,
-                    paddingLeft: 16,
-                    borderBottomWidth: 1,
-                    borderBottomStyle: 'solid',
-                    borderBottomColor: 'var(--t-border)',
-                    background: 'var(--t-panel)',
-                  }}
-                >
-                  <div
-                    style={{
-                      minWidth: 0,
-                      display: 'flex',
-                      flexDirection: 'column',
-                      gap: 2,
-                    }}
-                  >
-                    <div
-                      style={{
-                        fontSize: 12,
-                        fontWeight: 700,
-                        color: 'var(--t-text)',
-                        letterSpacing: '-0.01em',
-                      }}
-                    >
-                      Orchestrator chat
-                    </div>
-                    <div
-                      style={{
-                        fontSize: 10.5,
-                        fontWeight: 500,
-                        color: 'var(--t-text-secondary)',
-                      }}
-                    >
-                      Send follow-ups here while monitoring live agent panes.
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    aria-label={tileDockExpanded ? 'Collapse orchestrator chat dock' : 'Expand orchestrator chat dock'}
-                    title={tileDockExpanded ? 'Collapse chat dock' : 'Expand chat dock'}
-                    onClick={handleToggleTileDock}
-                    style={{
-                      width: 44,
-                      height: 44,
-                      borderRadius: 12,
-                      borderWidth: 0,
-                      background: 'transparent',
-                      color: 'var(--t-text-secondary)',
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      cursor: 'pointer',
-                      flexShrink: 0,
-                    }}
-                    onMouseEnter={(event) => {
-                      event.currentTarget.style.background = 'var(--t-bg-card)';
-                      event.currentTarget.style.color = 'var(--t-text)';
-                    }}
-                    onMouseLeave={(event) => {
-                      event.currentTarget.style.background = 'transparent';
-                      event.currentTarget.style.color = 'var(--t-text-secondary)';
-                    }}
-                  >
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.1" strokeLinecap="round" strokeLinejoin="round">
-                      {tileDockExpanded ? <path d="M18 14l-6-6-6 6" /> : <path d="M6 10l6 6 6-6" />}
-                    </svg>
-                  </button>
-                </div>
-                <div
-                  style={{
-                    flex: 1,
-                    minHeight: 0,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    overflow: 'hidden',
-                  }}
-                >
-                  {thoughtsChatPanel}
-                </div>
-              </div>
-            </div>
+          {sessionTiles.isTiled ? (
+            <SessionTileSurface
+              layout={sessionTiles.layout}
+              focusedSessionKey={sessionTiles.focusedSessionKey}
+              chatSlot={thoughtsChatPanel}
+              onResizeSplit={sessionTiles.resizeSplit}
+              onCloseLeaf={sessionTiles.closeSessionLeafById}
+              onFocusSession={sessionTiles.setFocusedSessionKey}
+            />
           ) : thoughtsChatPanel}
         </div>
 
@@ -928,6 +814,20 @@ function OrchestratorTabInner({ tabId, active, repoPath, repoLabel }: Orchestrat
         onClose={() => setPaletteOpen(false)}
         onPick={handlePalettePick}
       />
+      {sessionTiles.pillContextMenu ? (
+        <SessionPillContextMenu
+          open
+          x={sessionTiles.pillContextMenu.request.clientX}
+          y={sessionTiles.pillContextMenu.request.clientY}
+          items={buildPillContextMenuItems(
+            sessionTiles.pillContextMenu.request,
+            sessionTiles.sessionLeaves,
+            sessionTiles.splitSessionFromMenu,
+            sessionTiles.closeSessionLeafById,
+          )}
+          onClose={sessionTiles.closePillContextMenu}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/desktop/workspace-terminal/SessionTileSurface.tsx
+++ b/src/components/desktop/workspace-terminal/SessionTileSurface.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+/**
+ * SessionTileSurface — recursive renderer for the orchestrator session tile
+ * tree (issue #663). Each leaf hosts either the orchestrator chat (rendered
+ * via the `chatSlot` prop) or a SessionTranscriptPane.
+ *
+ * Mirrors TileContainer's flat-render strategy: walks the tree once per
+ * layout change, computes a leaf rect map, then renders every leaf as an
+ * absolutely-positioned sibling of the container so React preserves
+ * component state across split/resize/close changes.
+ */
+import { useCallback, useMemo, useRef, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
+import { SessionTranscriptPane } from '@/components/desktop/SessionTranscriptPane';
+import {
+  collectAllLeaves,
+  computeSessionTileLayout,
+  type SessionTileLayout,
+  type SessionTileRect,
+  type SessionTileSplitDirection,
+  type SessionTileSplitFrame,
+} from '@/lib/orchestrator/session-tiles';
+
+interface SessionTileSurfaceProps {
+  layout: SessionTileLayout;
+  focusedSessionKey: string | null;
+  chatSlot: ReactNode;
+  onResizeSplit: (splitId: string, ratio: number) => void;
+  onCloseLeaf: (leafId: string) => void;
+  onFocusSession: (sessionKey: string) => void;
+}
+
+const HANDLE_SIZE = 8;
+
+export function SessionTileSurface({
+  layout,
+  focusedSessionKey,
+  chatSlot,
+  onResizeSplit,
+  onCloseLeaf,
+  onFocusSession,
+}: SessionTileSurfaceProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const { leaves, leafRects, splitFrames } = useMemo(() => {
+    const { leafRects, splitFrames } = computeSessionTileLayout(layout.root);
+    const leaves = collectAllLeaves(layout.root);
+    return { leaves, leafRects, splitFrames };
+  }, [layout.root]);
+
+  const makeResizeStart = useCallback(
+    (splitId: string, direction: SessionTileSplitDirection, container: SessionTileRect) =>
+      (event: ReactMouseEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        const surface = containerRef.current;
+        if (!surface) return;
+        const rect = surface.getBoundingClientRect();
+        const splitPx = {
+          left: rect.left + rect.width * container.left,
+          top: rect.top + rect.height * container.top,
+          width: rect.width * container.width,
+          height: rect.height * container.height,
+        };
+        const handleMove = (moveEvent: MouseEvent) => {
+          const ratio = direction === 'vertical'
+            ? (moveEvent.clientX - splitPx.left) / splitPx.width
+            : (moveEvent.clientY - splitPx.top) / splitPx.height;
+          onResizeSplit(splitId, ratio);
+        };
+        const handleUp = () => {
+          document.removeEventListener('mousemove', handleMove);
+          document.removeEventListener('mouseup', handleUp);
+          document.body.style.cursor = '';
+          document.body.style.userSelect = '';
+        };
+        document.body.style.cursor = direction === 'vertical' ? 'col-resize' : 'row-resize';
+        document.body.style.userSelect = 'none';
+        document.addEventListener('mousemove', handleMove);
+        document.addEventListener('mouseup', handleUp);
+      },
+    [onResizeSplit],
+  );
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        position: 'relative',
+        flex: 1,
+        minHeight: 0,
+        minWidth: 0,
+        background: 'var(--t-chat-surface-bg, #ffffff)',
+      }}
+    >
+      {leaves.map((leaf) => {
+        const rect = leafRects.get(leaf.id);
+        if (!rect) return null;
+        return (
+          <div
+            key={leaf.id}
+            style={{
+              position: 'absolute',
+              left: `${rect.left * 100}%`,
+              top: `${rect.top * 100}%`,
+              width: `${rect.width * 100}%`,
+              height: `${rect.height * 100}%`,
+              display: 'flex',
+              flexDirection: 'column',
+              minWidth: 0,
+              minHeight: 0,
+              overflow: 'hidden',
+              transition: 'left 220ms cubic-bezier(0.22, 1, 0.36, 1), top 220ms cubic-bezier(0.22, 1, 0.36, 1), width 220ms cubic-bezier(0.22, 1, 0.36, 1), height 220ms cubic-bezier(0.22, 1, 0.36, 1)',
+            }}
+          >
+            {leaf.kind === 'chat' ? (
+              <div
+                style={{
+                  flex: 1,
+                  minHeight: 0,
+                  minWidth: 0,
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
+              >
+                {chatSlot}
+              </div>
+            ) : leaf.sessionKey ? (
+              <div
+                style={{
+                  flex: 1,
+                  minHeight: 0,
+                  minWidth: 0,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  paddingTop: 8,
+                  paddingRight: 8,
+                  paddingBottom: 8,
+                  paddingLeft: 8,
+                }}
+              >
+                <SessionTranscriptPane
+                  sessionKey={leaf.sessionKey}
+                  focused={focusedSessionKey === leaf.sessionKey}
+                  onFocus={onFocusSession}
+                  onClose={() => onCloseLeaf(leaf.id)}
+                />
+              </div>
+            ) : null}
+          </div>
+        );
+      })}
+      {splitFrames.map((frame) => (
+        <SessionResizeHandle
+          key={frame.id}
+          frame={frame}
+          onMouseDown={makeResizeStart(frame.id, frame.direction, frame.container)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function SessionResizeHandle({
+  frame,
+  onMouseDown,
+}: {
+  frame: SessionTileSplitFrame;
+  onMouseDown: (event: ReactMouseEvent<HTMLDivElement>) => void;
+}) {
+  const isVertical = frame.direction === 'vertical';
+  const style: CSSProperties = isVertical
+    ? {
+        position: 'absolute',
+        left: `calc(${frame.boundary.left * 100}% - ${HANDLE_SIZE / 2}px)`,
+        top: `${frame.boundary.top * 100}%`,
+        width: HANDLE_SIZE,
+        height: `${frame.boundary.height * 100}%`,
+        cursor: 'col-resize',
+      }
+    : {
+        position: 'absolute',
+        left: `${frame.boundary.left * 100}%`,
+        top: `calc(${frame.boundary.top * 100}% - ${HANDLE_SIZE / 2}px)`,
+        width: `${frame.boundary.width * 100}%`,
+        height: HANDLE_SIZE,
+        cursor: 'row-resize',
+      };
+  return (
+    <div
+      onMouseDown={onMouseDown}
+      onMouseEnter={(event) => {
+        const bar = event.currentTarget.firstElementChild as HTMLElement | null;
+        if (bar) bar.style.opacity = '1';
+      }}
+      onMouseLeave={(event) => {
+        const bar = event.currentTarget.firstElementChild as HTMLElement | null;
+        if (bar) bar.style.opacity = '0';
+      }}
+      style={{
+        ...style,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'transparent',
+        zIndex: 10,
+      }}
+    >
+      <div
+        style={{
+          width: isVertical ? 3 : 42,
+          height: isVertical ? 42 : 3,
+          borderRadius: 999,
+          backgroundColor: 'var(--t-drag-handle, var(--t-border))',
+          opacity: 0,
+          transition: 'opacity 150ms ease',
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/desktop/workspace-terminal/use-session-tiles.ts
+++ b/src/components/desktop/workspace-terminal/use-session-tiles.ts
@@ -1,0 +1,247 @@
+'use client';
+
+/**
+ * useSessionTiles — orchestrator session tile state + handlers (issue #663).
+ *
+ * Encapsulates the SessionTileLayout state, persistence, focus pointer,
+ * pill context menu state, and the split/close/resize/clear callbacks so
+ * OrchestratorTab.tsx stays under the 800-line ceiling.
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type {
+  SessionPillContextMenuItem,
+} from '@/components/desktop/SessionPillContextMenu';
+import type {
+  SessionPillContextMenuRequest,
+} from '@/components/desktop/SessionVisualizer';
+import {
+  clearSessionTiles,
+  closeSessionLeaf,
+  collectSessionKeys,
+  collectSessionLeaves,
+  createDefaultSessionTileLayout,
+  deserializeSessionTileLayout,
+  pruneStaleSessions,
+  resizeSessionSplit,
+  serializeSessionTileLayout,
+  splitChatWithSession,
+  splitSessionWithSession,
+  type SessionTileLayout,
+} from '@/lib/orchestrator/session-tiles';
+
+function sessionTileStorageKey(tabId: string): string {
+  return `o8:orchestrator:session-tiles:tab:${tabId}`;
+}
+
+function readStoredSessionTileLayout(tabId: string): SessionTileLayout {
+  if (typeof window === 'undefined') return createDefaultSessionTileLayout();
+  try {
+    const raw = window.localStorage.getItem(sessionTileStorageKey(tabId));
+    return deserializeSessionTileLayout(raw) ?? createDefaultSessionTileLayout();
+  } catch {
+    return createDefaultSessionTileLayout();
+  }
+}
+
+function persistSessionTileLayout(tabId: string, layout: SessionTileLayout): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(sessionTileStorageKey(tabId), serializeSessionTileLayout(layout));
+  } catch {
+    // ignore
+  }
+}
+
+interface UseSessionTilesArgs {
+  tabId: string;
+  /** sessionKeys of every active fleet agent — used to prune stale leaves. */
+  liveSessionKeys: string[];
+}
+
+export interface UseSessionTilesReturn {
+  layout: SessionTileLayout;
+  setLayout: React.Dispatch<React.SetStateAction<SessionTileLayout>>;
+  tiledSessions: string[];
+  isTiled: boolean;
+  sessionLeaves: ReturnType<typeof collectSessionLeaves>;
+  focusedSessionKey: string | null;
+  setFocusedSessionKey: React.Dispatch<React.SetStateAction<string | null>>;
+  pillContextMenu: { request: SessionPillContextMenuRequest } | null;
+  closeSessionLeafById: (leafId: string) => void;
+  toggleTileSession: (sessionKey: string) => void;
+  clearAllTiles: () => void;
+  resizeSplit: (splitId: string, ratio: number) => void;
+  requestPillContextMenu: (request: SessionPillContextMenuRequest) => void;
+  closePillContextMenu: () => void;
+  splitSessionFromMenu: (sessionKey: string, direction: 'horizontal' | 'vertical') => void;
+  /** Auto-tile N sessions side-by-side (Best-of-N comparison group). */
+  autoTileSessions: (sessionKeys: string[]) => void;
+}
+
+export function useSessionTiles({ tabId, liveSessionKeys }: UseSessionTilesArgs): UseSessionTilesReturn {
+  const [layout, setLayout] = useState<SessionTileLayout>(
+    () => readStoredSessionTileLayout(tabId),
+  );
+  const [focusedSessionKey, setFocusedSessionKey] = useState<string | null>(null);
+  const [pillContextMenu, setPillContextMenu] = useState<{
+    request: SessionPillContextMenuRequest;
+  } | null>(null);
+
+  const tiledSessions = useMemo(() => collectSessionKeys(layout.root), [layout.root]);
+  const sessionLeaves = useMemo(() => collectSessionLeaves(layout.root), [layout.root]);
+  const isTiled = tiledSessions.length > 0;
+
+  // Persist whenever the layout changes.
+  useEffect(() => {
+    persistSessionTileLayout(tabId, layout);
+  }, [tabId, layout]);
+
+  // Drop session leaves whose underlying agent has gone away. Defer to a
+  // microtask so the prune doesn't trip the synchronous-setState lint rule
+  // and so React batches it with any other commit-time updates.
+  useEffect(() => {
+    const liveSet = new Set(liveSessionKeys);
+    const handle = window.setTimeout(() => {
+      setLayout((current) => {
+        const next = pruneStaleSessions(current, liveSet);
+        return next === current ? current : next;
+      });
+    }, 0);
+    return () => window.clearTimeout(handle);
+  }, [liveSessionKeys]);
+
+  // Keep focused-session pointer valid as the tree changes.
+  useEffect(() => {
+    if (!focusedSessionKey) return;
+    if (tiledSessions.includes(focusedSessionKey)) return;
+    const handle = window.setTimeout(() => {
+      setFocusedSessionKey(tiledSessions[0] ?? null);
+    }, 0);
+    return () => window.clearTimeout(handle);
+  }, [focusedSessionKey, tiledSessions]);
+
+  const closeSessionLeafById = useCallback((leafId: string) => {
+    setLayout((current) => closeSessionLeaf(current, leafId));
+  }, []);
+
+  const toggleTileSession = useCallback((sessionKey: string) => {
+    setLayout((current) => {
+      const existing = collectSessionLeaves(current.root)
+        .find((leaf) => leaf.sessionKey === sessionKey);
+      if (existing) {
+        return closeSessionLeaf(current, existing.id);
+      }
+      return splitChatWithSession(current, sessionKey, 'vertical');
+    });
+  }, []);
+
+  const clearAllTiles = useCallback(() => {
+    setLayout((current) => clearSessionTiles(current));
+  }, []);
+
+  const resizeSplit = useCallback((splitId: string, ratio: number) => {
+    setLayout((current) => resizeSessionSplit(current, splitId, ratio));
+  }, []);
+
+  const requestPillContextMenu = useCallback((request: SessionPillContextMenuRequest) => {
+    setPillContextMenu({ request });
+  }, []);
+
+  const closePillContextMenu = useCallback(() => {
+    setPillContextMenu(null);
+  }, []);
+
+  const splitSessionFromMenu = useCallback((
+    sessionKey: string,
+    direction: 'horizontal' | 'vertical',
+  ) => {
+    setLayout((current) => {
+      // No duplicate tiles — abort if the session is already in the tree.
+      if (collectSessionLeaves(current.root).some((leaf) => leaf.sessionKey === sessionKey)) {
+        return current;
+      }
+      const existingLeaves = collectSessionLeaves(current.root);
+      if (existingLeaves.length === 0) {
+        return splitChatWithSession(current, sessionKey, direction);
+      }
+      const lastLeaf = existingLeaves[existingLeaves.length - 1]!;
+      return splitSessionWithSession(current, lastLeaf.id, sessionKey, direction);
+    });
+    setFocusedSessionKey(sessionKey);
+  }, []);
+
+  const autoTileSessions = useCallback((sessionKeys: string[]) => {
+    if (sessionKeys.length === 0) return;
+    setLayout((current) => {
+      let next = current;
+      for (let index = 0; index < sessionKeys.length; index += 1) {
+        const key = sessionKeys[index]!;
+        if (index === 0) {
+          next = splitChatWithSession(next, key, 'vertical');
+        } else {
+          const previousLeaf = collectSessionLeaves(next.root)
+            .find((leaf) => leaf.sessionKey === sessionKeys[index - 1]);
+          if (previousLeaf) {
+            next = splitSessionWithSession(next, previousLeaf.id, key, 'vertical');
+          }
+        }
+      }
+      return next;
+    });
+  }, []);
+
+  return {
+    layout,
+    setLayout,
+    tiledSessions,
+    isTiled,
+    sessionLeaves,
+    focusedSessionKey,
+    setFocusedSessionKey,
+    pillContextMenu,
+    closeSessionLeafById,
+    toggleTileSession,
+    clearAllTiles,
+    resizeSplit,
+    requestPillContextMenu,
+    closePillContextMenu,
+    splitSessionFromMenu,
+    autoTileSessions,
+  };
+}
+
+export function buildPillContextMenuItems(
+  request: SessionPillContextMenuRequest,
+  sessionLeaves: ReturnType<typeof collectSessionLeaves>,
+  onSplitSession: (sessionKey: string, direction: 'horizontal' | 'vertical') => void,
+  onCloseLeaf: (leafId: string) => void,
+): SessionPillContextMenuItem[] {
+  const existingLeaf = sessionLeaves.find((leaf) => leaf.sessionKey === request.sessionKey) ?? null;
+  if (existingLeaf) {
+    return [
+      {
+        id: 'close-tile',
+        label: 'Close split',
+        description: `Hide ${request.sessionName} from the workspace`,
+        iconDirection: 'vertical',
+        onSelect: () => onCloseLeaf(existingLeaf.id),
+      },
+    ];
+  }
+  return [
+    {
+      id: 'split-right',
+      label: 'Open in split right',
+      description: 'Place transcript beside the chat',
+      iconDirection: 'vertical',
+      onSelect: () => onSplitSession(request.sessionKey, 'vertical'),
+    },
+    {
+      id: 'split-below',
+      label: 'Open in split below',
+      description: 'Stack transcript under the chat',
+      iconDirection: 'horizontal',
+      onSelect: () => onSplitSession(request.sessionKey, 'horizontal'),
+    },
+  ];
+}

--- a/src/lib/orchestrator/session-tiles.ts
+++ b/src/lib/orchestrator/session-tiles.ts
@@ -1,0 +1,409 @@
+/**
+ * Session tile tree — recursive split layout for orchestrator transcripts.
+ *
+ * This is a self-contained mini-system that mirrors the dashboard tile
+ * primitives in `lib/tiles/operations.ts` but stays separate so we don't
+ * pollute `TileContent` with orchestrator-only kinds. The dashboard tile
+ * layout (TILE_LAYOUT_VERSION 4) is untouched by this module.
+ *
+ * Each leaf carries either the orchestrator chat or a session transcript.
+ * Splits are 'vertical' (children side-by-side, "open in split right") or
+ * 'horizontal' (stacked, "open in split below").
+ *
+ * Persisted per OrchestratorTab id under `o8:orchestrator:session-tiles:tab:<id>`.
+ */
+export type SessionTileSplitDirection = 'horizontal' | 'vertical';
+
+export type SessionTileLeafKind = 'chat' | 'session';
+
+export interface SessionTileLeaf {
+  type: 'leaf';
+  id: string;
+  kind: SessionTileLeafKind;
+  /** Required when kind === 'session'. Identifies the agent transcript. */
+  sessionKey?: string;
+}
+
+export interface SessionTileSplit {
+  type: 'split';
+  id: string;
+  direction: SessionTileSplitDirection;
+  ratio: number;
+  children: [SessionTileNode, SessionTileNode];
+}
+
+export type SessionTileNode = SessionTileLeaf | SessionTileSplit;
+
+export interface SessionTileLayout {
+  version: number;
+  root: SessionTileNode;
+}
+
+export const SESSION_TILE_LAYOUT_VERSION = 1;
+const MIN_RATIO = 0.2;
+const MAX_RATIO = 0.8;
+
+function makeId(prefix: 'leaf' | 'split'): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function clampRatio(value: number): number {
+  if (!Number.isFinite(value)) return 0.5;
+  return Math.min(MAX_RATIO, Math.max(MIN_RATIO, value));
+}
+
+export function isSessionTileLeaf(node: SessionTileNode): node is SessionTileLeaf {
+  return node.type === 'leaf';
+}
+
+export function isSessionTileSplit(node: SessionTileNode): node is SessionTileSplit {
+  return node.type === 'split';
+}
+
+export function createDefaultSessionTileLayout(): SessionTileLayout {
+  return {
+    version: SESSION_TILE_LAYOUT_VERSION,
+    root: { type: 'leaf', id: 'chat-root', kind: 'chat' },
+  };
+}
+
+export function findSessionLeafByKey(
+  node: SessionTileNode,
+  sessionKey: string,
+): SessionTileLeaf | null {
+  if (isSessionTileLeaf(node)) {
+    return node.kind === 'session' && node.sessionKey === sessionKey ? node : null;
+  }
+  return findSessionLeafByKey(node.children[0], sessionKey)
+    ?? findSessionLeafByKey(node.children[1], sessionKey);
+}
+
+export function collectSessionLeaves(node: SessionTileNode): SessionTileLeaf[] {
+  if (isSessionTileLeaf(node)) {
+    return node.kind === 'session' ? [node] : [];
+  }
+  return [
+    ...collectSessionLeaves(node.children[0]),
+    ...collectSessionLeaves(node.children[1]),
+  ];
+}
+
+export function collectSessionKeys(node: SessionTileNode): string[] {
+  return collectSessionLeaves(node)
+    .map((leaf) => leaf.sessionKey)
+    .filter((key): key is string => Boolean(key));
+}
+
+export function findChatLeaf(node: SessionTileNode): SessionTileLeaf | null {
+  if (isSessionTileLeaf(node)) {
+    return node.kind === 'chat' ? node : null;
+  }
+  return findChatLeaf(node.children[0]) ?? findChatLeaf(node.children[1]);
+}
+
+/**
+ * Add a session pane by splitting the chat leaf. If the chat is already
+ * split or the session is already in the tree, no-op.
+ */
+export function splitChatWithSession(
+  layout: SessionTileLayout,
+  sessionKey: string,
+  direction: SessionTileSplitDirection,
+  ratio = 0.5,
+): SessionTileLayout {
+  if (findSessionLeafByKey(layout.root, sessionKey)) {
+    return layout;
+  }
+  const chatLeaf = findChatLeaf(layout.root);
+  if (!chatLeaf) {
+    // Shouldn't happen — chat is always present — but guard anyway.
+    return layout;
+  }
+
+  function walk(node: SessionTileNode): SessionTileNode {
+    if (isSessionTileLeaf(node)) {
+      if (node.id !== chatLeaf!.id) return node;
+      const sessionLeaf: SessionTileLeaf = {
+        type: 'leaf',
+        id: makeId('leaf'),
+        kind: 'session',
+        sessionKey,
+      };
+      return {
+        type: 'split',
+        id: makeId('split'),
+        direction,
+        ratio: clampRatio(ratio),
+        // For "split right" (vertical) and "split below" (horizontal) the
+        // chat stays in the first slot (left/top), session goes second.
+        children: [node, sessionLeaf],
+      };
+    }
+    const next0 = walk(node.children[0]);
+    const next1 = walk(node.children[1]);
+    if (next0 === node.children[0] && next1 === node.children[1]) return node;
+    return { ...node, children: [next0, next1] };
+  }
+
+  return { ...layout, root: walk(layout.root) };
+}
+
+/**
+ * Add a second session pane by splitting an existing session leaf — used
+ * when the user right-clicks a pill while the chat is already split out.
+ */
+export function splitSessionWithSession(
+  layout: SessionTileLayout,
+  targetLeafId: string,
+  newSessionKey: string,
+  direction: SessionTileSplitDirection,
+  ratio = 0.5,
+): SessionTileLayout {
+  if (findSessionLeafByKey(layout.root, newSessionKey)) {
+    return layout;
+  }
+
+  function walk(node: SessionTileNode): SessionTileNode {
+    if (isSessionTileLeaf(node)) {
+      if (node.id !== targetLeafId) return node;
+      const newLeaf: SessionTileLeaf = {
+        type: 'leaf',
+        id: makeId('leaf'),
+        kind: 'session',
+        sessionKey: newSessionKey,
+      };
+      return {
+        type: 'split',
+        id: makeId('split'),
+        direction,
+        ratio: clampRatio(ratio),
+        children: [node, newLeaf],
+      };
+    }
+    const next0 = walk(node.children[0]);
+    const next1 = walk(node.children[1]);
+    if (next0 === node.children[0] && next1 === node.children[1]) return node;
+    return { ...node, children: [next0, next1] };
+  }
+
+  return { ...layout, root: walk(layout.root) };
+}
+
+/** Remove the leaf identified by leafId. Closing the chat leaf is a no-op. */
+export function closeSessionLeaf(
+  layout: SessionTileLayout,
+  leafId: string,
+): SessionTileLayout {
+  function walk(node: SessionTileNode): { next: SessionTileNode; closed: boolean } {
+    if (isSessionTileLeaf(node)) {
+      return { next: node, closed: false };
+    }
+    const [first, second] = node.children;
+    if (isSessionTileLeaf(first) && first.id === leafId && first.kind !== 'chat') {
+      return { next: second, closed: true };
+    }
+    if (isSessionTileLeaf(second) && second.id === leafId && second.kind !== 'chat') {
+      return { next: first, closed: true };
+    }
+    const left = walk(first);
+    if (left.closed) {
+      return {
+        next: { ...node, children: [left.next, second] },
+        closed: true,
+      };
+    }
+    const right = walk(second);
+    if (right.closed) {
+      return {
+        next: { ...node, children: [first, right.next] },
+        closed: true,
+      };
+    }
+    return { next: node, closed: false };
+  }
+
+  const result = walk(layout.root);
+  return result.closed ? { ...layout, root: result.next } : layout;
+}
+
+/**
+ * Drop every session leaf whose sessionKey is no longer in the active
+ * agents set. The chat leaf is preserved. If the tree collapses to a
+ * single chat leaf, returns the default layout.
+ */
+export function pruneStaleSessions(
+  layout: SessionTileLayout,
+  liveSessionKeys: Set<string>,
+): SessionTileLayout {
+  const stale = collectSessionLeaves(layout.root)
+    .filter((leaf) => !leaf.sessionKey || !liveSessionKeys.has(leaf.sessionKey));
+  if (stale.length === 0) return layout;
+
+  let next = layout;
+  for (const leaf of stale) {
+    next = closeSessionLeaf(next, leaf.id);
+  }
+  return next;
+}
+
+export function resizeSessionSplit(
+  layout: SessionTileLayout,
+  splitId: string,
+  ratio: number,
+): SessionTileLayout {
+  function walk(node: SessionTileNode): SessionTileNode {
+    if (isSessionTileLeaf(node)) return node;
+    if (node.id === splitId) {
+      return { ...node, ratio: clampRatio(ratio) };
+    }
+    const next0 = walk(node.children[0]);
+    const next1 = walk(node.children[1]);
+    if (next0 === node.children[0] && next1 === node.children[1]) return node;
+    return { ...node, children: [next0, next1] };
+  }
+  return { ...layout, root: walk(layout.root) };
+}
+
+export function clearSessionTiles(layout: SessionTileLayout): SessionTileLayout {
+  if (isSessionTileLeaf(layout.root) && layout.root.kind === 'chat') {
+    return layout;
+  }
+  return createDefaultSessionTileLayout();
+}
+
+export function hasAnySessionLeaf(layout: SessionTileLayout): boolean {
+  return collectSessionLeaves(layout.root).length > 0;
+}
+
+// --- Persistence ---
+
+function isPlainSessionLeaf(value: unknown): value is SessionTileLeaf {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as { type?: unknown; id?: unknown; kind?: unknown; sessionKey?: unknown };
+  if (v.type !== 'leaf' || typeof v.id !== 'string') return false;
+  if (v.kind !== 'chat' && v.kind !== 'session') return false;
+  if (v.kind === 'session' && typeof v.sessionKey !== 'string') return false;
+  return true;
+}
+
+function isPlainSessionNode(value: unknown): value is SessionTileNode {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as {
+    type?: unknown;
+    id?: unknown;
+    direction?: unknown;
+    ratio?: unknown;
+    children?: unknown;
+  };
+  if (v.type === 'leaf') return isPlainSessionLeaf(value);
+  if (v.type !== 'split') return false;
+  return typeof v.id === 'string'
+    && (v.direction === 'horizontal' || v.direction === 'vertical')
+    && typeof v.ratio === 'number'
+    && Array.isArray(v.children)
+    && v.children.length === 2
+    && isPlainSessionNode(v.children[0])
+    && isPlainSessionNode(v.children[1]);
+}
+
+export function serializeSessionTileLayout(layout: SessionTileLayout): string {
+  return JSON.stringify({
+    version: SESSION_TILE_LAYOUT_VERSION,
+    root: layout.root,
+  });
+}
+
+export function deserializeSessionTileLayout(
+  raw: string | null | undefined,
+): SessionTileLayout | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as { version?: unknown; root?: unknown };
+    if (parsed.version !== SESSION_TILE_LAYOUT_VERSION) return null;
+    if (!isPlainSessionNode(parsed.root)) return null;
+    return { version: SESSION_TILE_LAYOUT_VERSION, root: parsed.root };
+  } catch {
+    return null;
+  }
+}
+
+// --- Layout computation (mirrors lib/tiles/operations.ts) ---
+
+export interface SessionTileRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface SessionTileSplitFrame {
+  id: string;
+  direction: SessionTileSplitDirection;
+  container: SessionTileRect;
+  boundary: SessionTileRect;
+}
+
+export function computeSessionTileLayout(
+  root: SessionTileNode,
+  viewport: SessionTileRect = { left: 0, top: 0, width: 1, height: 1 },
+): {
+  leafRects: Map<string, SessionTileRect>;
+  splitFrames: SessionTileSplitFrame[];
+} {
+  const leafRects = new Map<string, SessionTileRect>();
+  const splitFrames: SessionTileSplitFrame[] = [];
+
+  function walk(node: SessionTileNode, rect: SessionTileRect): void {
+    if (isSessionTileLeaf(node)) {
+      leafRects.set(node.id, rect);
+      return;
+    }
+    if (node.direction === 'vertical') {
+      const leftWidth = rect.width * node.ratio;
+      const first: SessionTileRect = { ...rect, width: leftWidth };
+      const second: SessionTileRect = {
+        ...rect,
+        left: rect.left + leftWidth,
+        width: rect.width - leftWidth,
+      };
+      splitFrames.push({
+        id: node.id,
+        direction: node.direction,
+        container: rect,
+        boundary: { left: rect.left + leftWidth, top: rect.top, width: 0, height: rect.height },
+      });
+      walk(node.children[0], first);
+      walk(node.children[1], second);
+      return;
+    }
+    const topHeight = rect.height * node.ratio;
+    const first: SessionTileRect = { ...rect, height: topHeight };
+    const second: SessionTileRect = {
+      ...rect,
+      top: rect.top + topHeight,
+      height: rect.height - topHeight,
+    };
+    splitFrames.push({
+      id: node.id,
+      direction: node.direction,
+      container: rect,
+      boundary: { left: rect.left, top: rect.top + topHeight, width: rect.width, height: 0 },
+    });
+    walk(node.children[0], first);
+    walk(node.children[1], second);
+  }
+
+  walk(root, viewport);
+  return { leafRects, splitFrames };
+}
+
+export function collectAllLeaves(node: SessionTileNode): SessionTileLeaf[] {
+  if (isSessionTileLeaf(node)) return [node];
+  return [
+    ...collectAllLeaves(node.children[0]),
+    ...collectAllLeaves(node.children[1]),
+  ];
+}

--- a/src/lib/tiles/operations.ts
+++ b/src/lib/tiles/operations.ts
@@ -9,7 +9,11 @@ import type {
 } from '@/lib/tiles/types';
 import { isTileLeafNode, isTileSplitNode } from '@/lib/tiles/types';
 
-const TILE_LAYOUT_VERSION = 4; // v4: thoughts/mission/history tile kinds retired; Orchestrator lives as a tab now
+// v4: thoughts/mission/history tile kinds retired; Orchestrator lives as a tab now.
+// Issue #663 added split-pane orchestrator transcripts but uses a separate
+// SessionTileLayout tree (lib/orchestrator/session-tiles.ts) so this version
+// stays at 4 — no new kinds added here.
+const TILE_LAYOUT_VERSION = 4;
 const MIN_SPLIT_RATIO = 0.2;
 const MAX_SPLIT_RATIO = 0.8;
 


### PR DESCRIPTION
Closes #663.

## Summary
- Right-click on a session pill in the orchestrator's pill strip to open the transcript in a split right (vertical) or split below (horizontal) tile beside the chat.
- Splits stack: right-click another pill while one is already split out and it lands beside the most recent session pane. Closing a pane returns to single-pane.
- Layout persists per-tab to `o8:orchestrator:session-tiles:tab:<tabId>` and auto-prunes when the underlying agent disappears.
- Best-of-N comparison auto-tiling now lays the comparison panes out beside the chat instead of replacing it.

## What landed
- `src/components/desktop/SessionTranscriptPane.tsx` — sessionKey-only adapter over `AgentTilePane` so the transcript can mount in any tile.
- `src/components/desktop/workspace-terminal/SessionTileSurface.tsx` — recursive split-pane renderer with spring-curve drag handles, mirrors `TileContainer`.
- `src/components/desktop/SessionPillContextMenu.tsx` — portal-rendered context menu, 44px touch targets, palette tokens, escape + backdrop close.
- `src/lib/orchestrator/session-tiles.ts` — tree primitives parallel to the dashboard tile system, separate `SESSION_TILE_LAYOUT_VERSION = 1`.
- `src/components/desktop/workspace-terminal/use-session-tiles.ts` — hook that owns session tile state, persistence, and split/close/resize handlers.
- `SessionVisualizer` pill strip is back inside `OrchestratorTab` with `onRequestContextMenu`.
- Legacy flat `AgentTileLayout` row + chat-dock is retired (not imported anymore; file remains for reference).

## Constraints respected
- Inline styles only, palette tokens (`var(--t-*)`) throughout.
- `TILE_LAYOUT_VERSION` stays at 4 — no new tile kinds added to the dashboard system. Issue #663 uses a separate `SessionTileLayout` tree.
- `OrchestratorTab.tsx` shrunk from 933 → 833 lines via the `use-session-tiles` extraction.
- Phosphor raw SVG only, no emoji.
- Apple HIG spring curve on context-menu pop and split-pane transitions.

## Test plan
- [ ] Open the Orchestrator tab with at least 2 active agents.
- [ ] Right-click a session pill, confirm "Open in split right" / "Open in split below" appear.
- [ ] Pick "split right" and confirm the transcript opens beside the chat with a draggable boundary.
- [ ] Right-click a different pill, confirm it appends to the existing layout.
- [ ] Close one pane via the X — workspace returns to the previous (or single) layout.
- [ ] Reload the app and confirm the layout is restored from localStorage.
- [ ] Trigger a Best-of-N comparison — verify auto-tile lays the panes out next to the chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)