### PR TITLE
feat(desktop): hit-zone audit — Approval surfaces (44pt minimum)

### DIFF
--- a/src/components/desktop/ApprovalBanner.tsx
+++ b/src/components/desktop/ApprovalBanner.tsx
@@ -79,7 +79,10 @@ const summaryLead: CSSProperties = {
   textOverflow: 'ellipsis',
 };
 
+// Visual chip stays 24px tall; an invisible 44×44pt overlay child extends the
+// click region (Apple HIG minimum). Buttons are `position: relative` hosts.
 const expandButton: CSSProperties = {
+  position: 'relative',
   height: 24,
   paddingTop: 0,
   paddingBottom: 0,
@@ -106,6 +109,7 @@ const expandButton: CSSProperties = {
 };
 
 const compactReject: CSSProperties = {
+  position: 'relative',
   height: 24,
   paddingTop: 0,
   paddingBottom: 0,
@@ -130,6 +134,19 @@ const compactReject: CSSProperties = {
   boxSizing: 'border-box',
 };
 
+// Invisible overlay child that expands a button's click region to >=44×44pt
+// without changing the visual chip. Clicks land on the parent <button> via
+// DOM bubbling. Spans must NOT have pointer-events: none.
+const hitZoneOverlay: CSSProperties = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  width: '100%',
+  minWidth: 44,
+  height: 44,
+  transform: 'translate(-50%, -50%)',
+};
+
 const compactApprove: CSSProperties = {
   ...compactReject,
   borderColor: ACCENT_ORANGE,
@@ -152,7 +169,9 @@ const listRow: CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   gap: 10,
-  height: 32,
+  // Row grows to 44pt so adjacent button hit zones don't overlap across rows.
+  // The button chips stay visually compact via their own height: 24.
+  minHeight: 44,
   paddingLeft: 14,
   paddingRight: 10,
   borderBottomWidth: 1,
@@ -252,6 +271,7 @@ export function ApprovalBanner() {
               style={expandButton}
               title={expanded ? 'Collapse queue' : 'Show remaining approvals'}
             >
+              <span aria-hidden="true" style={hitZoneOverlay} />
               {expanded ? `Hide ${extraCount}` : `Show ${extraCount} more`}
               <span aria-hidden="true" style={{ fontSize: 8, opacity: 0.7 }}>{expanded ? '▴' : '▾'}</span>
             </button>
@@ -262,6 +282,7 @@ export function ApprovalBanner() {
             onClick={() => resolve(leading.id, 'reject')}
             style={{ ...compactReject, opacity: leadingBusy ? 0.55 : 1, cursor: leadingBusy ? 'wait' : 'pointer' }}
           >
+            <span aria-hidden="true" style={hitZoneOverlay} />
             Reject
           </button>
           <button
@@ -270,6 +291,7 @@ export function ApprovalBanner() {
             onClick={() => resolve(leading.id, 'approve')}
             style={{ ...compactApprove, opacity: leadingBusy ? 0.7 : 1, cursor: leadingBusy ? 'wait' : 'pointer' }}
           >
+            <span aria-hidden="true" style={hitZoneOverlay} />
             {leadingBusy ? '…' : 'Approve'}
           </button>
         </div>
@@ -290,6 +312,7 @@ export function ApprovalBanner() {
                     onClick={() => resolve(approval.id, 'reject')}
                     style={{ ...compactReject, opacity: isBusy ? 0.55 : 1, cursor: isBusy ? 'wait' : 'pointer' }}
                   >
+                    <span aria-hidden="true" style={hitZoneOverlay} />
                     Reject
                   </button>
                   <button
@@ -298,6 +321,7 @@ export function ApprovalBanner() {
                     onClick={() => resolve(approval.id, 'approve')}
                     style={{ ...compactApprove, opacity: isBusy ? 0.7 : 1, cursor: isBusy ? 'wait' : 'pointer' }}
                   >
+                    <span aria-hidden="true" style={hitZoneOverlay} />
                     {isBusy ? '…' : 'Approve'}
                   </button>
                 </div>

--- a/src/components/desktop/ApprovalReviewScreenshot.tsx
+++ b/src/components/desktop/ApprovalReviewScreenshot.tsx
@@ -250,7 +250,8 @@ export function ApprovalReviewScreenshot({ approval }: { approval: ApprovalRecor
                 onClick={() => setExpanded(false)}
                 style={{
                   minWidth: 86,
-                  height: 38,
+                  minHeight: 44,
+                  height: 44,
                   paddingTop: 0,
                   paddingBottom: 0,
                   paddingLeft: 14,

--- a/src/components/desktop/AuditLogPanel.tsx
+++ b/src/components/desktop/AuditLogPanel.tsx
@@ -295,7 +295,8 @@ function PillSelect({
       value={value}
       onChange={(event) => onChange(event.target.value)}
       style={{
-        minHeight: 32,
+        minHeight: 44,
+        minWidth: 44,
         borderRadius: 10,
         borderWidth: 1,
         borderStyle: 'solid',
@@ -498,18 +499,20 @@ export function AuditLogPanel() {
               onClick={() => { void loadApprovals(true); }}
               disabled={refreshing}
               style={{
-                minHeight: 32,
+                minHeight: 44,
+                minWidth: 44,
                 borderRadius: 10,
                 borderWidth: 0,
                 borderStyle: 'none',
                 backgroundColor: 'transparent',
                 color: refreshing ? '#8b95a3' : '#6b7280',
                 paddingTop: 4,
-                paddingRight: 0,
+                paddingRight: 8,
                 paddingBottom: 4,
-                paddingLeft: 0,
+                paddingLeft: 8,
                 display: 'inline-flex',
                 alignItems: 'center',
+                justifyContent: 'center',
                 gap: 5,
                 fontSize: 12,
                 fontWeight: 500,
@@ -673,16 +676,17 @@ export function AuditLogPanel() {
                 setSelectedRange('all');
               }}
               style={{
-                minHeight: 32,
+                minHeight: 44,
+                minWidth: 44,
                 borderRadius: 10,
                 borderWidth: 0,
                 borderStyle: 'none',
                 backgroundColor: 'transparent',
                 color: '#2563eb',
                 paddingTop: 4,
-                paddingRight: 8,
+                paddingRight: 10,
                 paddingBottom: 4,
-                paddingLeft: 8,
+                paddingLeft: 10,
                 fontSize: 12,
                 fontWeight: 500,
                 letterSpacing: '-0.01em',

--- a/src/components/desktop/agent-panel-chat/ApprovalCards.tsx
+++ b/src/components/desktop/agent-panel-chat/ApprovalCards.tsx
@@ -28,11 +28,16 @@ function GateReportSection({ approval }: { approval: SidebarApproval }) {
         type="button"
         onClick={() => setExpanded((prev) => !prev)}
         style={{
+          position: 'relative',
+          minHeight: 44,
           display: 'flex',
           alignItems: 'center',
           gap: 6,
           width: '100%',
-          padding: '6px 8px',
+          paddingTop: 6,
+          paddingRight: 8,
+          paddingBottom: 6,
+          paddingLeft: 8,
           borderRadius: 8,
           border: '1px solid rgba(239, 68, 68, 0.12)',
           background: 'rgba(239, 68, 68, 0.04)',
@@ -156,7 +161,11 @@ function ConflictSection({
             onClick={() => setSelectedStrategy(opt.value)}
             style={{
               flex: 1,
-              padding: '6px 4px',
+              minHeight: 44,
+              paddingTop: 6,
+              paddingRight: 4,
+              paddingBottom: 6,
+              paddingLeft: 4,
               borderRadius: 8,
               border: selectedStrategy === opt.value
                 ? '1px solid rgba(37, 99, 235, 0.3)'
@@ -192,7 +201,11 @@ function ConflictSection({
           disabled={resolvingId === approval.id}
           style={{
             flex: 1,
-            padding: '7px 0',
+            minHeight: 44,
+            paddingTop: 7,
+            paddingRight: 0,
+            paddingBottom: 7,
+            paddingLeft: 0,
             borderRadius: 8,
             border: 'none',
             background: '#16a34a',
@@ -210,7 +223,12 @@ function ConflictSection({
           onClick={() => onResolve(approval.id, 'reject')}
           disabled={resolvingId === approval.id}
           style={{
-            padding: '7px 12px',
+            minHeight: 44,
+            minWidth: 44,
+            paddingTop: 7,
+            paddingRight: 12,
+            paddingBottom: 7,
+            paddingLeft: 12,
             borderRadius: 8,
             border: '1px solid rgba(239, 68, 68, 0.18)',
             background: 'rgba(239, 68, 68, 0.06)',
@@ -415,7 +433,11 @@ export const SidebarApprovalCard = memo(function SidebarApprovalCard({
                       disabled={resolvingId === approval.id}
                       style={{
                         flex: 1,
-                        padding: '8px 0',
+                        minHeight: 44,
+                        paddingTop: 8,
+                        paddingRight: 0,
+                        paddingBottom: 8,
+                        paddingLeft: 0,
                         borderRadius: 10,
                         border: 'none',
                         background: '#16a34a',
@@ -445,7 +467,11 @@ export const SidebarApprovalCard = memo(function SidebarApprovalCard({
                       disabled={resolvingId === approval.id}
                       style={{
                         flex: 1,
-                        padding: '8px 0',
+                        minHeight: 44,
+                        paddingTop: 8,
+                        paddingRight: 0,
+                        paddingBottom: 8,
+                        paddingLeft: 0,
                         borderRadius: 10,
                         border: '1px solid rgba(239, 68, 68, 0.18)',
                         background: 'rgba(239, 68, 68, 0.06)',

--- a/src/components/desktop/thoughts/mission-panel/PacketReviewPanel.tsx
+++ b/src/components/desktop/thoughts/mission-panel/PacketReviewPanel.tsx
@@ -223,10 +223,15 @@ export function PacketReviewPanel({
                 onClick={() => { void resolveMergeApproval('approve'); }}
                 disabled={approvalBusyAction !== null}
                 style={{
+                  minHeight: 44,
+                  minWidth: 44,
                   border: '1px solid rgba(34, 197, 94, 0.28)',
                   background: 'rgba(34, 197, 94, 0.1)',
                   color: '#15803d',
-                  padding: '6px 10px',
+                  paddingTop: 6,
+                  paddingRight: 10,
+                  paddingBottom: 6,
+                  paddingLeft: 10,
                   borderRadius: 8,
                   fontSize: 11,
                   fontWeight: 700,
@@ -241,10 +246,15 @@ export function PacketReviewPanel({
                 onClick={() => { void resolveMergeApproval('reject'); }}
                 disabled={approvalBusyAction !== null}
                 style={{
+                  minHeight: 44,
+                  minWidth: 44,
                   border: '1px solid rgba(239, 68, 68, 0.24)',
                   background: 'rgba(239, 68, 68, 0.08)',
                   color: '#b91c1c',
-                  padding: '6px 10px',
+                  paddingTop: 6,
+                  paddingRight: 10,
+                  paddingBottom: 6,
+                  paddingLeft: 10,
                   borderRadius: 8,
                   fontSize: 11,
                   fontWeight: 700,
@@ -374,14 +384,20 @@ export function PacketReviewPanel({
               type="button"
               onClick={onToggleShowAllFiles}
               style={{
+                minHeight: 44,
+                minWidth: 44,
                 border: 'none',
                 background: 'transparent',
                 color: '#2563eb',
                 fontSize: 11,
                 fontWeight: 700,
                 cursor: 'pointer',
-                padding: 0,
+                paddingTop: 0,
+                paddingRight: 8,
+                paddingBottom: 0,
+                paddingLeft: 0,
                 alignSelf: 'flex-start',
+                textAlign: 'left',
               }}
             >
               {reviewState?.showAllFiles ? 'Show less' : `Show all ${reviewFiles.length} files`}
@@ -402,10 +418,15 @@ export function PacketReviewPanel({
           onClick={() => onReviewAction('create_pr')}
           disabled={reviewState?.action === 'create_pr' || reviewState?.loading}
           style={{
+            minHeight: 44,
+            minWidth: 44,
             border: '1px solid rgba(34, 197, 94, 0.25)',
             background: 'rgba(34, 197, 94, 0.08)',
             color: '#16a34a',
-            padding: '6px 10px',
+            paddingTop: 6,
+            paddingRight: 10,
+            paddingBottom: 6,
+            paddingLeft: 10,
             borderRadius: 8,
             fontSize: 11,
             fontWeight: 700,
@@ -420,10 +441,15 @@ export function PacketReviewPanel({
           onClick={() => onReviewAction('merge')}
           disabled={reviewState?.action === 'merge' || reviewState?.loading}
           style={{
+            minHeight: 44,
+            minWidth: 44,
             border: '1px solid rgba(37, 99, 235, 0.2)',
             background: 'rgba(37, 99, 235, 0.06)',
             color: '#2563eb',
-            padding: '6px 10px',
+            paddingTop: 6,
+            paddingRight: 10,
+            paddingBottom: 6,
+            paddingLeft: 10,
             borderRadius: 8,
             fontSize: 11,
             fontWeight: 700,
@@ -438,7 +464,21 @@ export function PacketReviewPanel({
             href={reviewState.prUrl}
             target="_blank"
             rel="noreferrer"
-            style={{ fontSize: 11, fontWeight: 700, color: '#2563eb', textDecoration: 'none' }}
+            style={{
+              minHeight: 44,
+              minWidth: 44,
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              paddingTop: 0,
+              paddingRight: 8,
+              paddingBottom: 0,
+              paddingLeft: 8,
+              fontSize: 11,
+              fontWeight: 700,
+              color: '#2563eb',
+              textDecoration: 'none',
+            }}
           >
             Open PR
           </a>


### PR DESCRIPTION
## Summary
Apple HIG hit-zone sweep across the five Approval-related desktop surfaces. Visible chip sizes preserved; click regions grown to >=44x44pt either by bumping the button's own min dimensions or wrapping the visual chip with an invisible aria-hidden overlay child that extends the click region.

## Files touched
- `src/components/desktop/ApprovalBanner.tsx` — compact 24px chips (Reject / Approve / Show more) gain a 44pt overlay child; expanded list rows raised to `minHeight: 44` so adjacent hit zones don't collide.
- `src/components/desktop/agent-panel-chat/ApprovalCards.tsx` — gate-report toggle, conflict strategy tiles, conflict Merge/Reject, and main Approve/Reject all hit `minHeight: 44`.
- `src/components/desktop/AuditLogPanel.tsx` — PillSelect, Refresh, and Clear Filters buttons raised to `minHeight: 44`.
- `src/components/desktop/ApprovalReviewScreenshot.tsx` — modal Close grew from 38px to 44px.
- `src/components/desktop/thoughts/mission-panel/PacketReviewPanel.tsx` — merge-gate Approve/Reject, Create PR / Merge, Open PR link, and "Show all files" button raised to `minHeight: 44`.

## Test plan
- [x] `npx tsc --noEmit` returns 0 errors
- [ ] Visual smoke on the installed o8.app: ApprovalBanner chips still render at 24px tall, but tap area extends across the bar
- [ ] AuditLogPanel filter pills still read as compact (visual unchanged, only hit zone grew via padding/min dims)
- [ ] PacketReviewPanel buttons still feel like inline pills, not chunky bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)