### PR TITLE
feat(desktop): hit-zone audit — WorkspaceTerminal headers (44pt minimum)

### DIFF
--- a/src/components/desktop/workspace-terminal/AgentTileLayout.tsx
+++ b/src/components/desktop/workspace-terminal/AgentTileLayout.tsx
@@ -162,6 +162,9 @@ export function AgentTileLayout({
             />
           </div>
           {index < sessions.length - 1 ? (
+            // Apple HIG drag handle: visible bar stays at 4px to keep panes
+            // tight, but the draggable region is widened via transparent
+            // padding so the cursor zone meets the 44pt minimum.
             <div
               role="separator"
               aria-orientation="vertical"
@@ -170,16 +173,47 @@ export function AgentTileLayout({
               onMouseEnter={() => setHoveredDivider(index)}
               onMouseLeave={() => setHoveredDivider((current) => current === index ? null : current)}
               style={{
+                position: 'relative',
                 width: DIVIDER_WIDTH,
                 minWidth: DIVIDER_WIDTH,
                 cursor: 'col-resize',
-                borderRadius: 999,
-                background: hoveredDivider === index || draggingDivider === index
-                  ? 'var(--t-border-hover, var(--t-accent-border))'
-                  : 'var(--t-border)',
+                background: 'transparent',
                 flexShrink: 0,
               }}
-            />
+            >
+              <span
+                aria-hidden="true"
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  bottom: 0,
+                  left: '50%',
+                  width: DIVIDER_WIDTH,
+                  transform: 'translateX(-50%)',
+                  borderRadius: 999,
+                  background: hoveredDivider === index || draggingDivider === index
+                    ? 'var(--t-border-hover, var(--t-accent-border))'
+                    : 'var(--t-border)',
+                  pointerEvents: 'none',
+                }}
+              />
+              <span
+                aria-hidden="true"
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  bottom: 0,
+                  left: '50%',
+                  // Hit zone widened to 12px per side (24px total) — full HIG
+                  // 44 would overhang the panes and steal pane-internal clicks.
+                  // The handle is full-height vertically so the long-axis
+                  // dimension already exceeds 44pt for any pane > 44 tall.
+                  width: 24,
+                  transform: 'translateX(-50%)',
+                  background: 'transparent',
+                }}
+              />
+            </div>
           ) : null}
         </Fragment>
       ))}

--- a/src/components/desktop/workspace-terminal/PreviewPane.tsx
+++ b/src/components/desktop/workspace-terminal/PreviewPane.tsx
@@ -31,11 +31,16 @@ function PreviewToolbar({
       style={{
         display: 'flex',
         alignItems: 'center',
-        height: 32,
+        // Apple HIG 44pt hit-zone — toolbar holds three interactive controls
+        // (Select / Refresh / Close), each needs a 44x44 region.
+        height: 44,
+        minHeight: 44,
         paddingLeft: 12,
         paddingRight: 8,
         background: 'var(--t-bg-subtle)',
-        borderBottom: '1px solid var(--t-divider)',
+        borderBottomWidth: 1,
+        borderBottomStyle: 'solid',
+        borderBottomColor: 'var(--t-divider)',
         gap: 8,
         flexShrink: 0,
       }}
@@ -59,6 +64,7 @@ function PreviewToolbar({
         onClick={onToggleSelection}
         title={selectionEnabled ? 'Element selection is active' : 'Select an element in the preview'}
         style={{
+          position: 'relative',
           display: 'inline-flex',
           alignItems: 'center',
           gap: 6,
@@ -68,8 +74,10 @@ function PreviewToolbar({
           paddingLeft: 9,
           paddingRight: 9,
           borderRadius: 999,
-          border: selectionEnabled ? '1px solid rgba(37,99,235,0.28)' : '1px solid rgba(148,163,184,0.18)',
-          background: selectionEnabled ? 'rgba(37,99,235,0.08)' : 'rgba(255,255,255,0.82)',
+          borderWidth: 1,
+          borderStyle: 'solid',
+          borderColor: selectionEnabled ? 'rgba(37,99,235,0.28)' : 'rgba(148,163,184,0.18)',
+          background: selectionEnabled ? 'rgba(37,99,235,0.08)' : 'var(--t-bg-card)',
           color: selectionEnabled ? '#1d4ed8' : '#475569',
           cursor: 'pointer',
           fontSize: 11,
@@ -77,6 +85,7 @@ function PreviewToolbar({
           flexShrink: 0,
         }}
       >
+        <span aria-hidden="true" style={previewHitZoneStyle} />
         <Crosshair size={12} />
         Select
       </button>
@@ -84,43 +93,50 @@ function PreviewToolbar({
         type="button"
         onClick={onRefresh}
         title="Refresh"
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: 24,
-          height: 24,
-          border: 'none',
-          background: 'transparent',
-          color: '#64748b',
-          cursor: 'pointer',
-          borderRadius: 4,
-        }}
+        style={previewIconButtonStyle}
       >
+        <span aria-hidden="true" style={previewHitZoneStyle} />
         <RefreshCw size={14} />
       </button>
       <button
         type="button"
         onClick={onClose}
         title="Close preview"
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: 24,
-          height: 24,
-          border: 'none',
-          background: 'transparent',
-          color: '#64748b',
-          cursor: 'pointer',
-          borderRadius: 4,
-        }}
+        style={previewIconButtonStyle}
       >
+        <span aria-hidden="true" style={previewHitZoneStyle} />
         <X size={14} />
       </button>
     </div>
   );
 }
+
+// Visible toolbar buttons stay at 24x24 to fit the 32px preview strip; the
+// transparent overlay below expands the click region to 44x44 for HIG.
+const previewIconButtonStyle = {
+  position: 'relative',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 24,
+  height: 24,
+  borderWidth: 0,
+  borderStyle: 'none',
+  background: 'transparent',
+  color: '#64748b',
+  cursor: 'pointer',
+  borderRadius: 4,
+} as const;
+
+const previewHitZoneStyle = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  width: 44,
+  height: 44,
+  transform: 'translate(-50%, -50%)',
+  background: 'transparent',
+} as const;
 
 interface PreviewPaneProps {
   previews: LocalhostPreview[];

--- a/src/components/desktop/workspace-terminal/TabBar.tsx
+++ b/src/components/desktop/workspace-terminal/TabBar.tsx
@@ -112,7 +112,12 @@ export const TabBar = memo(function TabBar({
       style={{
         display: 'flex',
         alignItems: 'stretch',
-        height: 36,
+        // Apple HIG 44px hit-zone minimum for tabs + scroll affordances + chrome
+        // buttons living inside this strip. Visible tab pills stay compact via
+        // their own padding; the bar height ensures every interactive child has
+        // room to grow to 44.
+        height: 44,
+        minHeight: 44,
         // Match the chat-surface bg so the TabBar blends with the workspace
         // content below instead of reading as a separate gray strip.
         background: 'var(--t-chat-surface-bg, #ffffff)',
@@ -128,13 +133,18 @@ export const TabBar = memo(function TabBar({
       <div style={{ position: 'relative', display: 'flex', flex: 1, overflow: 'hidden' }}>
         {canScrollLeft ? (
           <div
+            role="button"
+            tabIndex={0}
+            aria-label="Scroll tabs left"
             onClick={() => scrollTabs('left')}
+            onKeyDown={(event) => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); scrollTabs('left'); } }}
             style={{
               position: 'absolute',
               left: 0,
               top: 0,
               bottom: 0,
-              width: 28,
+              width: 44,
+              minWidth: 44,
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
@@ -149,13 +159,18 @@ export const TabBar = memo(function TabBar({
         ) : null}
         {canScrollRight ? (
           <div
+            role="button"
+            tabIndex={0}
+            aria-label="Scroll tabs right"
             onClick={() => scrollTabs('right')}
+            onKeyDown={(event) => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); scrollTabs('right'); } }}
             style={{
               position: 'absolute',
               right: 0,
               top: 0,
               bottom: 0,
-              width: 28,
+              width: 44,
+              minWidth: 44,
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
@@ -258,12 +273,16 @@ export const TabBar = memo(function TabBar({
                   display: 'flex',
                   alignItems: 'center',
                   gap: 6,
-                  paddingTop: 4,
-                  paddingBottom: 4,
+                  // Tab button fills the full 44px tab-bar height to satisfy
+                  // Apple HIG. The visible pill background sits inside via the
+                  // internal padding so the label still reads compact.
+                  minHeight: 44,
+                  paddingTop: 10,
+                  paddingBottom: 10,
                   paddingLeft: 10,
                   paddingRight: 8,
-                  marginTop: 4,
-                  marginBottom: 4,
+                  marginTop: 0,
+                  marginBottom: 0,
                   marginLeft: 2,
                   marginRight: 2,
                   borderWidth: 0,
@@ -322,6 +341,7 @@ export const TabBar = memo(function TabBar({
                   <span
                     role="button"
                     tabIndex={0}
+                    aria-label={`Close ${primaryLabel} tab`}
                     onClick={(event) => {
                       event.stopPropagation();
                       onCloseTab(tab.id);
@@ -333,6 +353,11 @@ export const TabBar = memo(function TabBar({
                       }
                     }}
                     style={{
+                      // Apple HIG hit-zone: visible glyph stays small (14x14) but
+                      // the click region expands to 44x44 via the transparent
+                      // overlay child below. Position relative so the absolute
+                      // overlay anchors to this element.
+                      position: 'relative',
                       display: 'inline-flex',
                       alignItems: 'center',
                       justifyContent: 'center',
@@ -346,14 +371,26 @@ export const TabBar = memo(function TabBar({
                       transition: 'background 100ms, color 100ms',
                     }}
                     onMouseEnter={(event) => {
-                      (event.target as HTMLElement).style.background = 'rgba(239, 68, 68, 0.15)';
-                      (event.target as HTMLElement).style.color = '#ef4444';
+                      event.currentTarget.style.background = 'rgba(239, 68, 68, 0.15)';
+                      event.currentTarget.style.color = '#ef4444';
                     }}
                     onMouseLeave={(event) => {
-                      (event.target as HTMLElement).style.background = 'transparent';
-                      (event.target as HTMLElement).style.color = '#475569';
+                      event.currentTarget.style.background = 'transparent';
+                      event.currentTarget.style.color = '#475569';
                     }}
                   >
+                    <span
+                      aria-hidden="true"
+                      style={{
+                        position: 'absolute',
+                        top: '50%',
+                        left: '50%',
+                        width: 44,
+                        height: 44,
+                        transform: 'translate(-50%, -50%)',
+                        background: 'transparent',
+                      }}
+                    />
                     <PhosphorXBold size={9} />
                   </span>
                 ) : null}
@@ -392,6 +429,7 @@ export const TabBar = memo(function TabBar({
               onMouseEnter={hoverChromeOn}
               onMouseLeave={hoverChromeOff}
             >
+              <span aria-hidden="true" style={chromeButtonHitZoneStyle} />
               <PhosphorSplitVertical size={14} />
             </button>
           ) : null}
@@ -404,6 +442,7 @@ export const TabBar = memo(function TabBar({
               onMouseEnter={closeHoverOn}
               onMouseLeave={closeHoverOff}
             >
+              <span aria-hidden="true" style={chromeButtonHitZoneStyle} />
               <PhosphorXCircle size={14} />
             </button>
           ) : null}
@@ -413,7 +452,11 @@ export const TabBar = memo(function TabBar({
   );
 });
 
+// Visible chrome button stays at 24x24 so the split/close glyphs read as
+// compact chrome rather than primary actions; the transparent overlay below
+// expands the click region to the HIG 44x44 minimum.
 const chromeButtonStyle = {
+  position: 'relative',
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -426,7 +469,17 @@ const chromeButtonStyle = {
   color: 'var(--t-text-muted)',
   cursor: 'pointer',
   transition: 'background 100ms, color 100ms',
-};
+} as const;
+
+const chromeButtonHitZoneStyle = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  width: 44,
+  height: 44,
+  transform: 'translate(-50%, -50%)',
+  background: 'transparent',
+} as const;
 
 function hoverChromeOn(event: MouseEvent<HTMLButtonElement>) {
   event.currentTarget.style.background = 'var(--t-hover)';


### PR DESCRIPTION
## Summary

Apple HIG sweep across the WorkspaceTerminal chrome so every interactive element has a 44x44pt click region. Visible glyphs stay compact via transparent hit-zone overlays where the visual size is design-load-bearing.

## Files touched

- `src/components/desktop/workspace-terminal/TabBar.tsx`
  - Bar height 36 -> 44 (every interactive child now has room to grow to 44).
  - Tab pill stretches to full bar height (`minHeight: 44`, vertical padding rebalanced; visible label still reads compact).
  - Tab close glyph keeps 14x14 visual but gains a 44x44 transparent overlay child for the click region; tightened the hover handlers to use `currentTarget` so the overlay child doesn't steal hover state.
  - Scroll affordances (left/right caret) widened 28 -> 44, gained `role="button"`, `tabIndex`, `aria-label`, and Enter/Space keyboard handlers.
  - Split-pane / close-tile chrome buttons keep 24x24 visual with a 44x44 transparent overlay hit zone (extracted `chromeButtonHitZoneStyle`).
- `src/components/desktop/workspace-terminal/AgentTileLayout.tsx`
  - Vertical resize handle: visible bar still 4px (rendered via an inner pointer-events-none span so the visual bar tracks hovered/dragging state); drag region widened to 24px total via a transparent overlay. Full HIG 44 would overhang the panes and steal pane-internal clicks; the long axis is full-height which already exceeds 44 for any non-trivial pane.
- `src/components/desktop/workspace-terminal/PreviewPane.tsx`
  - Toolbar height 32 -> 44.
  - Select / Refresh / Close buttons keep their compact glyphs with 44x44 transparent overlays (extracted `previewIconButtonStyle` and `previewHitZoneStyle`).
  - Replaced hardcoded `rgba(255,255,255,0.82)` with `var(--t-bg-card)` and dropped `border` / `borderBottom` shorthand for longhand (CLAUDE.md compliance).

## Already compliant (no change)

- `src/components/desktop/workspace-terminal/OrchestratorHeader.tsx` — every toggle button + the New conversation button is already `height: 44`.
- `src/components/desktop/workspace-terminal/AgentTilePane.tsx` — close button is already 44x44 and the steer composer's submit button is 44x44.

## Test plan

- [ ] Tabs are visibly slightly taller; clicks anywhere in the bar land on the right tab.
- [ ] Closing a non-orchestrator tab works whether the click lands precisely on the X glyph or in the surrounding 44x44 zone.
- [ ] Tab scroll arrows show up when many tabs are open and accept Enter/Space focus.
- [ ] Split/close chrome buttons in a tiled workspace still feel compact but are easier to hit.
- [ ] Drag the resize divider in a multi-agent split — handle stays slim but the cursor zone is forgiving.
- [ ] Localhost preview toolbar feels comfortable; Select/Refresh/Close still readable, no overlap with iframe content.
- [ ] `npx tsc --noEmit` clean (verified locally, exit 0).