### PR TITLE
perf(desktop): widen / remove short polling intervals

### DIFF
--- a/src/components/desktop/ApprovalBanner.tsx
+++ b/src/components/desktop/ApprovalBanner.tsx
@@ -219,13 +219,13 @@ export function ApprovalBanner() {
       const data = (await res.json()) as { approvals?: ApprovalRecord[] };
       setApprovals(data.approvals ?? []);
     } catch {
-      // silent — poll ticks again in 3s
+      // silent — poll ticks again on next interval
     }
   }, []);
 
   useEffect(() => {
     void load();
-    const id = setInterval(load, 3000);
+    const id = setInterval(load, 5000);
     return () => clearInterval(id);
   }, [load]);
 

--- a/src/components/desktop/LiveOutput.tsx
+++ b/src/components/desktop/LiveOutput.tsx
@@ -658,7 +658,7 @@ export function LiveOutput({
       debounceTimer = setTimeout(() => { void fetchDiffs(); }, 150);
     };
     fetchNowRef.current();
-    pollRef.current = setInterval(() => { void fetchDiffs(); }, reviewWsConnected ? 15_000 : 4_000);
+    pollRef.current = setInterval(() => { void fetchDiffs(); }, reviewWsConnected ? 15_000 : 8_000);
     return () => {
       if (pollRef.current) clearInterval(pollRef.current);
       if (debounceTimer) clearTimeout(debounceTimer);

--- a/src/components/desktop/O8InboxPane.tsx
+++ b/src/components/desktop/O8InboxPane.tsx
@@ -68,7 +68,7 @@ export function O8InboxPane() {
     refresh();
     const handleEvent = () => refresh();
     window.addEventListener(REFRESH_EVENT, handleEvent);
-    const interval = window.setInterval(refresh, 8000);
+    const interval = window.setInterval(refresh, 15000);
     return () => {
       window.removeEventListener(REFRESH_EVENT, handleEvent);
       window.clearInterval(interval);

--- a/src/components/desktop/agent-panel-chat/AgentPanelChat.tsx
+++ b/src/components/desktop/agent-panel-chat/AgentPanelChat.tsx
@@ -712,7 +712,7 @@ export function AgentPanelChat({
     const handler = () => { void fetchSessions(); };
     const wsEvents = ['o8:inbox', 'o8:agent-lifecycle'];
     for (const e of wsEvents) window.addEventListener(e, handler);
-    const fallbackId = setInterval(() => void fetchSessions(), wsConnected ? 120_000 : 8_000);
+    const fallbackId = setInterval(() => void fetchSessions(), wsConnected ? 120_000 : 15_000);
     return () => { clearInterval(fallbackId); for (const e of wsEvents) window.removeEventListener(e, handler); };
   }, [fetchSessions, wsConnected]);
 

--- a/src/components/desktop/repo-registry/useRepoCardModel.ts
+++ b/src/components/desktop/repo-registry/useRepoCardModel.ts
@@ -222,7 +222,7 @@ export function useRepoCardModel({
         .catch(() => {});
     }
     fetchLogs();
-    const id = setInterval(fetchLogs, 3000);
+    const id = setInterval(fetchLogs, 5000);
     return () => clearInterval(id);
   }, [devLogsOpen, devServerRunning, repo.localPath]);
 

--- a/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
+++ b/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
@@ -437,7 +437,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
       void poll();
       pollRef.current = window.setInterval(() => {
         void poll();
-      }, 1200);
+      }, 2000);
     }, 400);
   }, [clearPolling, transcriptUrl]);
 

--- a/src/components/desktop/thoughts/chat-panel/ComposerArea.tsx
+++ b/src/components/desktop/thoughts/chat-panel/ComposerArea.tsx
@@ -81,7 +81,7 @@ function ComposerStatusBar({
       setElapsed(anchor === null ? 0 : Date.now() - anchor);
     };
     const frame = window.requestAnimationFrame(tick);
-    const id = window.setInterval(tick, 500);
+    const id = window.setInterval(tick, 1000);
     return () => {
       window.cancelAnimationFrame(frame);
       window.clearInterval(id);

--- a/src/components/desktop/thoughts/mission-panel/PacketReviewPanel.tsx
+++ b/src/components/desktop/thoughts/mission-panel/PacketReviewPanel.tsx
@@ -12,7 +12,7 @@ interface PacketReviewPanelProps {
   onToggleShowAllFiles: () => void;
 }
 
-const APPROVAL_POLL_INTERVAL_MS = 3_000;
+const APPROVAL_POLL_INTERVAL_MS = 5_000;
 
 function isMergeApproval(approval: ApprovalRecord) {
   return approval.continuation?.kind === 'lane' && approval.continuation.verb === 'merge';


### PR DESCRIPTION
## Summary

Surgical perf-only sweep — widened short polling intervals across the desktop UI to reduce render churn and main-thread pressure on the prod app. No visual changes; no WS server changes.

## Intervals widened

| File | Before | After | Justification |
|---|---|---|---|
| `src/components/desktop/ApprovalBanner.tsx:228` | 3000ms | 5000ms | Always-mounted chrome banner under TitleBar. Approvals are urgent but no WS push channel exists, so it stays poll-only. 5s matches the existing `ApprovalQueuePanel` `POLL_INTERVAL` constant — keeps the cadence consistent and halves the request rate when the queue is empty (the banner has a zero-footprint render in that state). |
| `src/components/desktop/thoughts/ThoughtsChatPanel.tsx:438` | 1200ms | 2000ms | Transcript poll fired while waiting for a reply. The WS bridge already pushes deltas via `o8:realtime` — this loop is the redundant safety-net. 2s is the floor per the audit rules and the `idlePollsRef >= 4` self-stop logic still triggers in 8s of quiet (was 4.8s) — well under any user-perceptible delay. |
| `src/components/desktop/repo-registry/useRepoCardModel.ts:225` | 3000ms | 5000ms | Dev server log polling. Gated behind `devLogsOpen && devServerRunning` (only fires when the user has expanded the logs panel for a running server). 5s still feels live for tail-style logs and cuts the request rate by 40%. |
| `src/components/desktop/thoughts/mission-panel/PacketReviewPanel.tsx:15` | 3000ms (`APPROVAL_POLL_INTERVAL_MS`) | 5000ms | Merge-gate approval poll, only mounted when a packet card is expanded with an active approval query. 5s aligns with the rest of the approval cadence. |
| `src/components/desktop/thoughts/chat-panel/ComposerArea.tsx:84` | 500ms | 1000ms | Pure display tick for the elapsed-time counter (`formatElapsed` floors to seconds anyway, so 500ms was redundant — every other tick was a no-op render). 1s matches `OrchestratorHeader` and `ReloadBanner` and eliminates ~30 unnecessary `setElapsed` calls per minute while a turn is running. |
| `src/components/desktop/LiveOutput.tsx:661` | 4000ms (when WS down) | 8000ms (when WS down) | Diff-stats fallback poll. WS path is unchanged at 15s. The 4s value only fires when `reviewWsConnected === false`, but during reconnect storms it can stack with other fallbacks. 8s is still well inside the duration of any review session. |
| `src/components/desktop/agent-panel-chat/AgentPanelChat.tsx:715` | 8000ms (when WS down) | 15000ms (when WS down) | Sessions list fallback poll. WS path is 120s. Aligned with the sibling `fetchTranscript` fallback (also 15s) so the two loops fire at the same cadence rather than racing. |
| `src/components/desktop/O8InboxPane.tsx:71` | 8000ms | 15000ms | Supervisor inbox poll. The pane already has a `o8:inbox-refresh` event listener for explicit invalidations, and the WS bridge dispatches `o8:inbox` events on the inbox channel. 15s is a safety net rather than the primary refresh path. |

## Intentionally left alone

- `src/components/desktop/repo-registry/shared.tsx:558` (80ms) — Braille spinner animation, not polling.
- `src/components/desktop/workspace-terminal/OrchestratorHeader.tsx:170` (1000ms) — Visible elapsed counter, only mounted while busy.
- `src/components/desktop/thoughts/chat-panel/ReloadBanner.tsx:32` (1000ms) — Visible elapsed counter on the MCP-reload banner, auto-dismisses in 6s.
- `src/components/desktop/ConnectionBanner.tsx:62` (1000ms) — Disconnect counter, only renders while WS is down.
- `src/components/desktop/thoughts/useOrchestratorStream.ts:746` (200ms) — Bounded WS-reconnect retry loop with `setTimeout(..., 5000)` upper bound; not a continuous poll.
- All `src/lib/**` server-side timers (10s+ intervals) — not on the UI thread.

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Manually verify in prod build: approval banner still updates within ~5s of a new approval landing
- [ ] Manually verify the Composer elapsed counter still ticks every second visually
- [ ] Manually verify dev server log panel still feels live when polling