### PR TITLE
perf(desktop): memoize ThoughtsChatPanel message bubbles

### DIFF
--- a/src/components/desktop/DesktopAgentMessage.tsx
+++ b/src/components/desktop/DesktopAgentMessage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { FileText } from './lucide-shims';
 import { CommandStripNode } from '@/components/desktop/CommandStripNode';
 import { CompactionNode } from '@/components/desktop/CompactionNode';
@@ -50,7 +50,7 @@ function PinGlyph() {
   );
 }
 
-function MediaGrid({
+const MediaGrid = memo(function MediaGrid({
   media,
   tint,
 }: {
@@ -170,7 +170,7 @@ function MediaGrid({
       ))}
     </div>
   );
-}
+});
 
 export const DesktopAgentMessage = memo(function DesktopAgentMessage({
   entry,
@@ -181,7 +181,13 @@ export const DesktopAgentMessage = memo(function DesktopAgentMessage({
   onRunInTerminal,
 }: DesktopAgentMessageProps) {
   const isUser = entry.role === 'user';
-  const displayText = sanitizeTranscriptText(entry.text);
+  // Sanitize regex chain runs on every render unless memoized — heavy on
+  // long transcripts where entry text is stable but parent re-renders fire.
+  const displayText = useMemo(() => sanitizeTranscriptText(entry.text), [entry.text]);
+  const sanitizedThinking = useMemo(
+    () => entry.thinking ? sanitizeTranscriptText(entry.thinking) : '',
+    [entry.thinking],
+  );
   const hasText = Boolean(displayText.trim());
   const hasMedia = Boolean(entry.media?.length);
   const hasToolCalls = Boolean(entry.toolCalls?.length);
@@ -247,6 +253,20 @@ export const DesktopAgentMessage = memo(function DesktopAgentMessage({
       console.error('[diff-card] Failed to apply diff:', error);
     }
   }, [repoPath]);
+
+  // renderLLMMarkdown does heavy line-by-line parsing + regex matching to
+  // produce React nodes. Memoize per (text + handler identity) so renders
+  // triggered by sibling state (e.g. hover on meta row) skip re-parsing.
+  // Hook must live before any early returns to keep call order stable.
+  const renderedMarkdown = useMemo(
+    () => hasText ? renderLLMMarkdown(displayText, {
+      onApplyToFile,
+      onApplyDiff: repoPath ? handleApplyDiff : undefined,
+      onOpenInCanvas,
+      onRunInTerminal,
+    }) : null,
+    [hasText, displayText, onApplyToFile, onOpenInCanvas, onRunInTerminal, repoPath, handleApplyDiff],
+  );
 
   const handlePinToggle = useCallback(() => {
     const trimmedRepoPath = repoPath?.trim();
@@ -386,7 +406,7 @@ export const DesktopAgentMessage = memo(function DesktopAgentMessage({
       {evictedEyebrow}
       {hasThinking ? (
         <ThinkingStrip
-          thinking={sanitizeTranscriptText(entry.thinking!)}
+          thinking={sanitizedThinking}
           live={thinkingLive}
           style={{ maxWidth: '100%' }}
         />
@@ -411,12 +431,7 @@ export const DesktopAgentMessage = memo(function DesktopAgentMessage({
           border: entry.role === 'system' ? '1px solid var(--t-divider)' : 'none',
           boxShadow: entry.role === 'system' ? 'var(--t-panel-shadow)' : 'none',
         }}>
-          {renderLLMMarkdown(displayText, {
-            onApplyToFile,
-            onApplyDiff: repoPath ? handleApplyDiff : undefined,
-            onOpenInCanvas,
-            onRunInTerminal,
-          })}
+          {renderedMarkdown}
         </div>
       ) : null}
 

--- a/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
+++ b/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
@@ -659,7 +659,9 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
   const hasAssistantActivity = displayMessages.some((message) => message.role !== 'user');
   const activeTargetLabel = isOrchestratorMode ? 'Claude Code' : (targetAgent?.name ?? orchestratorRuntimeTone(preferredRuntime).label);
   const activeTargetColor = isOrchestratorMode ? '#e07a3a' : (targetAgent?.color ?? orchestratorRuntimeTone(preferredRuntime).color);
-  const transcriptTopContent = displayPlanText ? (
+  // Memoize so a render triggered by composer state (input typing) doesn't
+  // hand ChatMessageList a fresh `topContent` ref each keystroke.
+  const transcriptTopContent = useMemo(() => displayPlanText ? (
     <div
       style={{
         display: 'flex',
@@ -669,7 +671,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
     >
       <CollapsiblePlanCard key={`plan-${threadId ?? 'active'}`} text={displayPlanText} />
     </div>
-  ) : null;
+  ) : null, [displayPlanText, threadId]);
 
   useEffect(() => {
     onChromeChange({
@@ -858,7 +860,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
     copyAsMarkdown: () => handleCopyMarkdownRef.current(),
   }), [handleReset, handleLoadThread, sendNow]);
 
-  const fallbackEmptyState = (
+  const fallbackEmptyState = useMemo(() => (
     <EmptyStateCard
       isOrchestratorMode={isOrchestratorMode}
       targetAgent={targetAgent}
@@ -874,7 +876,16 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
         setTimeout(() => inputRef.current?.focus(), 50);
       }}
     />
-  );
+  ), [
+    activeTargetColor,
+    activeTargetLabel,
+    isOrchestratorMode,
+    suggestions,
+    targetAgent,
+    thoughtsElevatedBorder,
+    thoughtsElevatedShadow,
+    thoughtsElevatedSurface,
+  ]);
 
   const handleSlashCommand = useCallback((cmd: string) => {
     setInput(cmd);


### PR DESCRIPTION
## What was leaking + what changed

Every render of `DesktopAgentMessage` was running `sanitizeTranscriptText` (a chain of compiled regexes for protocol markup, sensitive-data redaction, and task-payload collapsing) on `entry.text` AND `entry.thinking`, then handing the result to `renderLLMMarkdown` — a synchronous line-by-line parser that builds React nodes for code blocks, tables, blockquotes, headings, lists, inline citations, and syntax-highlighted spans. None of these were memoized, so any re-render driven by sibling state on the bubble (hover-reveal of the meta row, evicted-context flag flipping, `isLast` toggling at end of stream) re-ran the full regex + markdown pipeline. This commit wraps `displayText`, `sanitizedThinking`, and the markdown output in `useMemo` keyed on the source text + handler identity, so unrelated state changes skip the heavy work. `MediaGrid` is also now `React.memo`-wrapped, and `ThoughtsChatPanel` memoizes its `transcriptTopContent` and `fallbackEmptyState` JSX so composer keystrokes don't hand `ChatMessageList` fresh refs every character.

## Test plan
- [ ] Visual regression check: open Orchestrator tab, paste a long markdown response with code blocks, confirm rendering identical
- [ ] Stream a fresh orchestrator turn, confirm tool-call updates + thinking strip behave the same
- [ ] Type into composer with a transcript visible — confirm message bubbles do not flicker / re-mount
- [ ] Scroll behavior unchanged