### PR TITLE
fix(orchestrator): dedupe streaming + completion response (no double-text)

### DIFF
--- a/src/lib/lane/orchestrator-stream-events.ts
+++ b/src/lib/lane/orchestrator-stream-events.ts
@@ -21,11 +21,21 @@ type ContentBlock = {
 interface ToolCallTracker {
   recordToolUse: (tool: { id?: string | null; name: string; input: unknown }) => void;
   resolveToolResult: (toolUseId?: string | null) => { id?: string | null; name: string; input: unknown } | null;
+  /**
+   * Mark a content block index as having streamed text via a `content_block_delta`
+   * event. Used to dedupe the trailing `assistant` summary event, which re-emits
+   * the full assembled text for every block — without this guard, every
+   * delta-streamed turn would render the response twice in the chat bubble.
+   */
+  recordTextDelta: (index: number) => void;
+  /** True if `recordTextDelta` was called for this content block index this turn. */
+  hasStreamedText: (index: number) => boolean;
 }
 
 export function createToolCallTracker(): ToolCallTracker {
   const pendingById = new Map<string, { id?: string | null; name: string; input: unknown }>();
   const pendingQueue: Array<{ id?: string | null; name: string; input: unknown }> = [];
+  const streamedTextIndices = new Set<number>();
 
   return {
     recordToolUse(tool) {
@@ -51,6 +61,12 @@ export function createToolCallTracker(): ToolCallTracker {
       if (!matched) return null;
       if (matched.id) pendingById.delete(matched.id);
       return matched;
+    },
+    recordTextDelta(index) {
+      streamedTextIndices.add(index);
+    },
+    hasStreamedText(index) {
+      return streamedTextIndices.has(index);
     },
   };
 }
@@ -93,7 +109,9 @@ export function processStreamEvent(
     case 'content_block_delta': {
       const delta = event.delta as Record<string, unknown> | undefined;
       if (!delta) break;
+      const blockIndex = typeof event.index === 'number' ? event.index : -1;
       if (delta.type === 'text_delta' && typeof delta.text === 'string') {
+        if (blockIndex >= 0) tracker.recordTextDelta(blockIndex);
         onEvent({ type: 'text', text: delta.text });
       } else if (delta.type === 'thinking_delta' && typeof delta.thinking === 'string') {
         onEvent({ type: 'thinking', text: delta.thinking });
@@ -127,11 +145,22 @@ export function processStreamEvent(
     }
 
     case 'assistant': {
+      // Claude Code's stream-json mode emits `content_block_delta` events for
+      // text as it streams, AND a final `assistant` event containing the full
+      // assembled message. Re-emitting text from the assistant event after
+      // deltas already flowed produces "OK, still here.OK, still here." in
+      // the chat bubble. We dedupe per-block-index: if any text_delta already
+      // emitted for this content block, skip the assistant copy.
       const message = event.message as Record<string, unknown> | undefined;
       const content = message?.content;
       if (!Array.isArray(content)) break;
-      for (const block of content as ContentBlock[]) {
+      content.forEach((rawBlock, index) => {
+        const block = rawBlock as ContentBlock;
         if (block.type === 'text' && typeof block.text === 'string') {
+          if (tracker.hasStreamedText(index)) {
+            console.log(`[stream-dedupe] skipping assistant text block ${index} (already streamed via deltas, ${block.text.length} chars)`);
+            return;
+          }
           onEvent({ type: 'text', text: block.text });
         } else if (block.type === 'thinking' && typeof block.thinking === 'string') {
           onEvent({ type: 'thinking', text: block.thinking });
@@ -144,7 +173,7 @@ export function processStreamEvent(
           tracker.recordToolUse(nextTool);
           onEvent({ type: 'tool_use', ...nextTool });
         }
-      }
+      });
       break;
     }
 


### PR DESCRIPTION
## Bug

User dogfooded the prod app and saw the orchestrator's reply rendered twice in one bubble: `"OK, still here.OK, still here."` (same text emitted twice back-to-back inside a single message).

## Where the bug lived

`src/lib/lane/orchestrator-stream-events.ts` — the `processStreamEvent` function (specifically the interaction between the `content_block_delta` case at line 93 and the `assistant` case at line 129 of the pre-fix file).

Claude Code is invoked with `--output-format stream-json --verbose` (see `src/lib/lane/orchestrator-session.ts:569,573`). In that mode Claude Code emits **both**:

1. Incremental `content_block_delta` events (with `delta.type === 'text_delta'`) as the model streams
2. A final `assistant` event whose `message.content` is the FULL assembled message including all text blocks

The handler treated both as new text and called `onEvent({ type: 'text', ... })` twice — once during streaming (chunks fill in real time) and again at completion (the assistant summary re-pushed the full response). The downstream `socket.ts → flushCurrentAssistant` joins all chunks for the bubble, so the final string is `streamed_text + assistant_text` where the two are identical.

Pre-fix, `assistant` case did:

```ts
for (const block of content as ContentBlock[]) {
  if (block.type === 'text' && typeof block.text === 'string') {
    onEvent({ type: 'text', text: block.text });   // <-- always re-emits, even if delta already streamed
  }
  ...
}
```

This repo already had the same fix elsewhere — `src/app/api/claude-code/send/route.ts:116` guards with `if (mergedText && !fullResponse)`. The orchestrator path missed it.

## Fix

Extend `createToolCallTracker()` (used per-turn by `sendToOrchestrator`) with two helpers:

- `recordTextDelta(index)` — called from the `content_block_delta` text_delta path, marks that index as having already streamed.
- `hasStreamedText(index)` — called from the `assistant` path; if true for that block index, skip the text block.

The dedupe is per `content_block_index` (Anthropic stream events include a top-level `index` field on `content_block_delta`, paired with the array order of `assistant.message.content`). Per-block is more defensive than a single boolean — handles a hypothetical mixed turn where some blocks streamed and some didn't.

A `[stream-dedupe]` log fires every time we drop an assistant text block, so future dogfood can confirm.

## Why this fixes it

- Streaming case (the user's bug): deltas fire → `recordTextDelta(0)` → assistant event arrives → `hasStreamedText(0)` is true → skip text block 0 → bubble shows the streamed response exactly once.
- Non-streaming case (no deltas, only assistant — happens when Claude Code collapses tiny turns): `recordTextDelta` never called → `hasStreamedText(0)` is false → assistant text block emitted normally. Existing behavior preserved.
- Tool blocks in the assistant event remain deduped via the existing `recordToolUse` ID check — unchanged.

## Test plan

- [ ] Open Orchestrator tab, send a quick message, verify reply appears once.
- [ ] Send a longer message that streams clearly, watch the bubble — should still render once at full length.
- [ ] Send a message where the model uses tools, then summarizes — text should not duplicate.
- [ ] Tail server logs and look for `[stream-dedupe] skipping assistant text block` — confirms the dedupe path is firing.
- [ ] `npx tsc --noEmit` passes (verified locally).