### PR TITLE
feat(desktop): auto-hide merged + agent worktrees in Workspaces sidebar + hover-prune

### DIFF
--- a/src/app/api/panel/branches/route.ts
+++ b/src/app/api/panel/branches/route.ts
@@ -100,6 +100,32 @@ export async function GET(req: NextRequest) {
         continue;
       }
 
+      // `worktree-agent-*` is the Claude harness's internal worktree-branch
+      // naming convention for sub-agent runs. They are never user-facing
+      // workspaces — hide them unconditionally so the sidebar doesn't
+      // accumulate one row per completed sub-agent.
+      if (trimmedName.startsWith('worktree-agent-')) {
+        continue;
+      }
+
+      // Hide branches whose tip is already an ancestor of the default branch
+      // (i.e. fully merged into main). The current branch and any branch
+      // backing a live worktree are always preserved so the operator never
+      // loses their seat. `--is-ancestor` exits 0 for ancestor / 1 for not /
+      // 128 for missing ref, so only treat exitStatus 0 as "merged".
+      if (!isCurrent && !isWt && trimmedName !== defaultBranch) {
+        try {
+          execSync(
+            `git -C "${repoPath}" merge-base --is-ancestor "${trimmedName}" "${defaultBranch}"`,
+            { encoding: 'utf-8', timeout: 2000, stdio: 'pipe' },
+          );
+          // Exit code 0 → trimmedName is reachable from defaultBranch → merged.
+          continue;
+        } catch {
+          // Non-zero exit (or missing ref) → not merged. Keep the branch.
+        }
+      }
+
       // Get ahead/behind vs origin
       let ahead = 0, behind = 0;
       try {

--- a/src/components/desktop/repo-registry/RepoBranchRow.tsx
+++ b/src/components/desktop/repo-registry/RepoBranchRow.tsx
@@ -145,6 +145,15 @@ function RepoBranchRowBase({
   branchDeleteConfirm,
   setBranchDeleteConfirm,
 }: RepoBranchRowProps) {
+  // Per-row hover flag — gates the inline trash icon so it only appears on
+  // the entered row instead of every sibling. Local state is fine here; the
+  // hover doesn't need to coordinate across rows.
+  const [rowHovered, setRowHovered] = useState(false);
+  // Two-step delete confirm strip lives directly under the row. Soft-delete
+  // returns `canForce: true` when the branch isn't merged → reuses the
+  // existing `branchDeleteConfirm` flow. Pre-soft-delete confirm is local.
+  const [pendingDelete, setPendingDelete] = useState(false);
+
   // ── Agent hover state — opens the AgentStatusHover popover after a short
   // dwell so flicking past agent rows doesn't flash the card. The hover
   // only tracks the currently-entered row via `hoveredAgentKey`; the rect
@@ -305,10 +314,12 @@ function RepoBranchRowBase({
         onMouseEnter={(event) => {
           const target = event.currentTarget as HTMLDivElement;
           target.style.background = branchHoverBackground;
+          setRowHovered(true);
           scheduleBranchHover(branch.name, target, event.clientX, event.clientY);
         }}
         onMouseLeave={(event) => {
           (event.currentTarget as HTMLDivElement).style.background = branchBaseBackground;
+          setRowHovered(false);
           closeBranchHover();
         }}
         style={{
@@ -449,8 +460,118 @@ function RepoBranchRowBase({
             </span>
           );
         })()}
+
+        {/* Hover-revealed trash — manual prune for any branch the API kept
+            (e.g. unmerged branches still showing). Hidden on the current
+            branch + default branch (protected). 44pt minimum touch target
+            via the wrapper button; the icon itself is 12px to keep the row
+            compact. Click → pendingDelete strip; Confirm → handleDeleteBranch
+            (which itself escalates to force-delete via the existing
+            branchDeleteConfirm strip if the branch isn't merged). */}
+        {!branch.current && branch.name !== repo.defaultBranch ? (
+          <button
+            type="button"
+            aria-label={`Delete ${branch.name}`}
+            title={`Delete ${branch.name}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              setPendingDelete(true);
+            }}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 44,
+              height: 44,
+              marginTop: -14,
+              marginBottom: -14,
+              marginRight: -10,
+              flexShrink: 0,
+              border: 'none',
+              background: 'transparent',
+              color: 'var(--t-text-faint)',
+              cursor: 'pointer',
+              opacity: rowHovered ? 1 : 0,
+              transition: 'opacity 120ms ease, color 120ms ease',
+            }}
+            onMouseEnter={(event) => {
+              (event.currentTarget as HTMLButtonElement).style.color = '#c97070';
+            }}
+            onMouseLeave={(event) => {
+              (event.currentTarget as HTMLButtonElement).style.color = 'var(--t-text-faint)';
+            }}
+          >
+            <Trash2 size={12} strokeWidth={2} />
+          </button>
+        ) : null}
       </div>
       )}
+
+      {pendingDelete ? (
+        <div
+          style={{
+            marginLeft: 36,
+            marginTop: 4,
+            marginBottom: 4,
+            paddingTop: 6,
+            paddingBottom: 6,
+            paddingLeft: 8,
+            paddingRight: 8,
+            borderRadius: 8,
+            border: '1px solid rgba(239,68,68,0.15)',
+            background: 'rgba(254,242,242,0.9)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+        >
+          <AlertCircle size={11} strokeWidth={2} style={{ color: '#dc2626', flexShrink: 0 }} />
+          <span style={{ fontSize: 10, color: '#991b1b', flex: 1 }}>
+            Delete {branch.isWorktree ? 'worktree + branch' : 'branch'} {branch.name}?
+          </span>
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              setPendingDelete(false);
+            }}
+            style={{
+              fontSize: 10,
+              fontWeight: 500,
+              color: 'var(--t-text-muted)',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: '2px 6px',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              setPendingDelete(false);
+              if (worktree?.status === 'stale') {
+                void handleCleanupWorktree(worktree);
+                return;
+              }
+              void handleDeleteBranch(branch.name);
+            }}
+            style={{
+              fontSize: 10,
+              fontWeight: 700,
+              color: '#dc2626',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: '2px 6px',
+            }}
+          >
+            Delete
+          </button>
+        </div>
+      ) : null}
 
       {branchPackets.length > 0 || orderedBranchAgents.length > 0 ? (
         <div


### PR DESCRIPTION
## Summary

Repo cards in the left sidebar accumulated stale branch rows: branches merged into main, Claude harness `worktree-agent-*` worktrees, and discarded local-only branches. Operators had to mentally filter to find live workspaces.

This PR adds two complementary changes — an API-side filter that auto-hides the obviously stale rows, and a hover-revealed trash icon on each remaining row so operators can manually evict any straggler.

## Files modified

| File | What changed |
|---|---|
| `src/app/api/panel/branches/route.ts` | Added two filter rules (worktree-agent + merged-into-main) inside the existing `for-each-ref` enumeration loop. |
| `src/components/desktop/repo-registry/RepoBranchRow.tsx` | Added local `rowHovered` + `pendingDelete` state, a hover-only trash button on each branch row, and an inline confirm strip beneath the row that delegates to the existing `handleDeleteBranch` flow. |

## Filter logic added

In `GET /api/panel/branches`, after the existing `worktree/`-prefix skip:

1. **`worktree-agent-*`** — `if (trimmedName.startsWith('worktree-agent-')) continue;` — unconditional drop. These are the Claude harness's internal sub-agent worktrees and are never user-facing workspaces.
2. **Merged into default branch** — for any branch that is NOT current, NOT backing a live worktree, and NOT the default branch itself, run `git merge-base --is-ancestor <branch> <defaultBranch>`. Exit code 0 means the branch tip is reachable from main → drop. Non-zero (or missing ref) → keep.

The current branch and any branch with a live worktree are always preserved so the operator never loses their seat.

## Delete API used

The hover-trash flow reuses the existing endpoints — no new route added:

- `DELETE /api/panel/branches` (existing) — soft-deletes the branch, returns `{ canForce: true }` with HTTP 409 if not fully merged.
- `DELETE /api/worktrees` with `action: 'cleanup'` (existing) — used for worktrees in `stale` status.

The component flow: trash click → local `pendingDelete` confirm strip → confirm calls `handleDeleteBranch(branch.name)` from `useRepoCardModel` → if git refuses the soft delete, the existing `branchDeleteConfirm` "force delete" strip takes over.

## What changes visibly

**Before:** repo card expanded → branch list shows `perf/poll-cadence`, `perf/session-visualizer`, `perf/thoughts-chat`, `polish/hit-zone-settings`, `polish/dark-parity-canvas`, `worktree-agent-a2b1c0db`, `worktree-agent-a3a213e7`, etc. — many already merged or never user-facing.

**After:** the merged ones and every `worktree-agent-*` row are gone. Only branches with unmerged work, live worktrees, the current branch, or the default branch remain. Hover over any remaining row → small trash icon fades in on the right (44pt click region, 12px icon). Click it → red confirm strip drops down (`Delete branch X?  [Cancel] [Delete]`). Click Delete → the row disappears (or, for unmerged branches, escalates to the existing force-delete strip).

## Test plan

- [ ] Open a repo with merged feature branches in the sidebar; confirm they no longer render.
- [ ] Confirm any `worktree-agent-*` ref no longer renders.
- [ ] Confirm the current branch + default branch + branches with live worktrees still render.
- [ ] Hover a branch row → trash icon fades in; mouse out → fades out, no layout shift.
- [ ] Click trash → confirm strip appears; click Cancel → strip dismisses.
- [ ] Click trash → Delete on a merged branch → row vanishes.
- [ ] Click trash → Delete on an unmerged branch → existing "Not fully merged" force-delete strip appears.
- [ ] `npx tsc --noEmit` returns 0 (verified locally).