### PR TITLE
polish(desktop): normalize cubic-bezier transitions to canonical curves

### DIFF
--- a/src/components/desktop/AnalyticsPage.tsx
+++ b/src/components/desktop/AnalyticsPage.tsx
@@ -384,7 +384,7 @@ const BreakdownRows = memo(function BreakdownRows({
                 borderRadius: 1,
                 background: RAMS_ACCENT,
                 opacity: 0.7,
-                transition: 'width 300ms cubic-bezier(0.32, 0.72, 0, 1)',
+                transition: 'width 300ms cubic-bezier(0.22, 1, 0.36, 1)',
               }} />
             </div>
             <div style={{ display: 'flex', gap: 14 }}>

--- a/src/components/desktop/ApprovalQueuePanel.tsx
+++ b/src/components/desktop/ApprovalQueuePanel.tsx
@@ -663,7 +663,7 @@ export function ApprovalQueuePanel({ onClose, embedded }: { onClose?: () => void
               }}
             >
               <span style={{
-                transition: 'transform 150ms ease',
+                transition: 'transform 150ms cubic-bezier(0.22, 1, 0.36, 1)',
                 transform: showHistory ? 'rotate(90deg)' : 'rotate(0deg)',
                 display: 'inline-block',
               }}>

--- a/src/components/desktop/CodeBlock.tsx
+++ b/src/components/desktop/CodeBlock.tsx
@@ -250,7 +250,7 @@ function MermaidModal({ svgHtml, onClose }: { svgHtml: string; onClose: () => vo
             style={{
               transform: `translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
               transformOrigin: 'center center',
-              transition: dragging.current ? 'none' : 'transform 100ms ease',
+              transition: dragging.current ? 'none' : 'transform 100ms cubic-bezier(0.22, 1, 0.36, 1)',
             }}
           />
         </div>
@@ -591,7 +591,7 @@ export const CodeBlock = memo(function CodeBlock({ code, language, onOpenMermaid
           strokeWidth={2}
           style={{
             color: 'var(--t-text-muted)',
-            transition: 'transform 200ms ease',
+            transition: 'transform 200ms cubic-bezier(0.22, 1, 0.36, 1)',
             transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
           }}
         />

--- a/src/components/desktop/CollapsiblePlanCard.tsx
+++ b/src/components/desktop/CollapsiblePlanCard.tsx
@@ -23,7 +23,7 @@ function ChevronIcon({ open }: { open: boolean }) {
         display: 'block',
         flexShrink: 0,
         transform: open ? 'rotate(90deg)' : 'rotate(0deg)',
-        transition: 'transform 180ms ease',
+        transition: 'transform 180ms cubic-bezier(0.22, 1, 0.36, 1)',
       }}
       aria-hidden="true"
     >

--- a/src/components/desktop/CommandStripNode.tsx
+++ b/src/components/desktop/CommandStripNode.tsx
@@ -133,7 +133,7 @@ export function CommandStripNode({
             style={{
               flexShrink: 0,
               transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
-              transition: 'transform 180ms ease',
+              transition: 'transform 180ms cubic-bezier(0.22, 1, 0.36, 1)',
             }}
             aria-hidden="true"
           >

--- a/src/components/desktop/CompactionNode.tsx
+++ b/src/components/desktop/CompactionNode.tsx
@@ -128,7 +128,7 @@ export function CompactionNode({
               style={{
                 opacity: hasDetails ? 1 : 0.45,
                 transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
-                transition: 'transform 200ms ease',
+                transition: 'transform 200ms cubic-bezier(0.22, 1, 0.36, 1)',
               }}
             >
               <polyline points="6 9 12 15 18 9" />

--- a/src/components/desktop/DesktopToolCallStack.tsx
+++ b/src/components/desktop/DesktopToolCallStack.tsx
@@ -411,7 +411,7 @@ function FileMutationLine({ tool }: { tool: MobileTranscriptToolCall }) {
             style={{
               color: 'var(--t-text-faint)',
               transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
-              transition: 'transform 180ms ease',
+              transition: 'transform 180ms cubic-bezier(0.22, 1, 0.36, 1)',
               flexShrink: 0,
             }}
           />

--- a/src/components/desktop/LiveOutput.tsx
+++ b/src/components/desktop/LiveOutput.tsx
@@ -109,7 +109,7 @@ function DiffCard({ diff, isLatest }: { diff: DiffEntry; isLatest: boolean }) {
       background: isLatest
         ? 'rgba(147, 197, 253, 0.04)'
         : 'rgba(255, 255, 255, 0.015)',
-      animation: isLatest ? 'diffCardSlideIn 400ms cubic-bezier(0.32, 0.72, 0, 1)' : 'none',
+      animation: isLatest ? 'diffCardSlideIn 400ms cubic-bezier(0.22, 1, 0.36, 1)' : 'none',
       transition: 'border-color 200ms ease',
     }}>
       {/* File header */}
@@ -177,7 +177,7 @@ function DiffCard({ diff, isLatest }: { diff: DiffEntry; isLatest: boolean }) {
           size={12}
           color="rgba(148, 163, 184, 0.3)"
           style={{
-            transition: 'transform 200ms ease',
+            transition: 'transform 200ms cubic-bezier(0.22, 1, 0.36, 1)',
             transform: expanded ? 'rotate(0deg)' : 'rotate(-90deg)',
             flexShrink: 0,
           }}

--- a/src/components/desktop/O8ActivityPane.tsx
+++ b/src/components/desktop/O8ActivityPane.tsx
@@ -484,7 +484,7 @@ export const O8ActivityPane = memo(function O8ActivityPane({
                         width: 10, height: 20,
                         display: 'flex', alignItems: 'center', justifyContent: 'center',
                         flexShrink: 0, color: 'var(--t-text-faint)', fontSize: 10,
-                        transition: 'transform 150ms ease',
+                        transition: 'transform 150ms cubic-bezier(0.22, 1, 0.36, 1)',
                         transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)',
                       }}>
                         <svg width="7" height="7" viewBox="0 0 7 7" fill="currentColor"><path d="M1.5 0.5L5.5 3.5L1.5 6.5Z" /></svg>

--- a/src/components/desktop/O8ChangesPaneParts.tsx
+++ b/src/components/desktop/O8ChangesPaneParts.tsx
@@ -19,7 +19,7 @@ export function ChevronIcon({ open, size = 10, color = 'currentColor' }: { open:
         display: 'block',
         flexShrink: 0,
         transform: open ? 'rotate(90deg)' : 'rotate(0deg)',
-        transition: 'transform 140ms ease',
+        transition: 'transform 140ms cubic-bezier(0.22, 1, 0.36, 1)',
       }}
     >
       <polyline points="9 6 15 12 9 18" />

--- a/src/components/desktop/O8FilesPane.tsx
+++ b/src/components/desktop/O8FilesPane.tsx
@@ -28,7 +28,7 @@ interface O8FilesPaneProps {
 
 function ChevronIcon({ open, size = 12 }: { open: boolean; size?: number }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', transition: 'transform 120ms ease', transform: open ? 'rotate(90deg)' : 'rotate(0deg)' }}>
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', transition: 'transform 120ms cubic-bezier(0.22, 1, 0.36, 1)', transform: open ? 'rotate(90deg)' : 'rotate(0deg)' }}>
       <polyline points="9 18 15 12 9 6" />
     </svg>
   );

--- a/src/components/desktop/O8PRPane.tsx
+++ b/src/components/desktop/O8PRPane.tsx
@@ -76,7 +76,7 @@ function FileIcon({ size = 12 }: { size?: number }) {
 
 function ChevronIcon({ open, size = 10 }: { open: boolean; size?: number }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', transition: 'transform 120ms ease', transform: open ? 'rotate(90deg)' : 'rotate(0deg)' }}>
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', transition: 'transform 120ms cubic-bezier(0.22, 1, 0.36, 1)', transform: open ? 'rotate(90deg)' : 'rotate(0deg)' }}>
       <polyline points="9 18 15 12 9 6" />
     </svg>
   );

--- a/src/components/desktop/OrchestratorHistorySidebar.tsx
+++ b/src/components/desktop/OrchestratorHistorySidebar.tsx
@@ -394,7 +394,7 @@ function OrchestratorHistorySidebarBase({
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
-        transition: 'width 200ms ease, min-width 200ms ease',
+        transition: 'width 200ms cubic-bezier(0.22, 1, 0.36, 1), min-width 200ms cubic-bezier(0.22, 1, 0.36, 1)',
         background: 'var(--t-chat-surface-bg, #ffffff)',
         flexShrink: 0,
       }}

--- a/src/components/desktop/TitleBar.tsx
+++ b/src/components/desktop/TitleBar.tsx
@@ -367,7 +367,7 @@ export function TitleBar({
         <div style={{
           width: '100%',
           maxWidth: searchExpanded ? 640 : 320,
-          transition: 'max-width 250ms cubic-bezier(0.32, 0.72, 0, 1)',
+          transition: 'max-width 250ms cubic-bezier(0.22, 1, 0.36, 1)',
           position: 'relative',
         }}>
           {!searchExpanded ? (

--- a/src/components/desktop/WorkspacesPanel.tsx
+++ b/src/components/desktop/WorkspacesPanel.tsx
@@ -139,7 +139,7 @@ function CheckCircleIcon() {
 function ChevronIcon({ collapsed }: { collapsed: boolean }) {
   return (
     <svg width={12} height={12} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" style={{
-      display: 'block', flexShrink: 0, transition: 'transform 200ms cubic-bezier(0.32, 0.72, 0, 1)',
+      display: 'block', flexShrink: 0, transition: 'transform 200ms cubic-bezier(0.22, 1, 0.36, 1)',
       transform: collapsed ? 'rotate(-90deg)' : 'rotate(0deg)',
     }}>
       <polyline points="6 9 12 15 18 9"/>
@@ -159,7 +159,7 @@ function ProgressRing({ progress, size = 20 }: { progress: number; size?: number
       <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="var(--t-divider)" strokeWidth={2.5} />
       <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="#2563eb" strokeWidth={2.5}
         strokeDasharray={circumference} strokeDashoffset={offset} strokeLinecap="round"
-        style={{ transition: 'stroke-dashoffset 600ms cubic-bezier(0.32, 0.72, 0, 1)' }}
+        style={{ transition: 'stroke-dashoffset 600ms cubic-bezier(0.22, 1, 0.36, 1)' }}
       />
     </svg>
   );
@@ -407,7 +407,7 @@ export function WorkspacesPanel() {
       {!collapsed && (
         <div style={{
           padding: '0 12px 12px',
-          transition: 'max-height 250ms cubic-bezier(0.32, 0.72, 0, 1)',
+          transition: 'max-height 250ms cubic-bezier(0.22, 1, 0.36, 1)',
         }}>
           <StatusSection status="in_progress" cards={grouped.in_progress} />
           <StatusSection status="done" cards={grouped.done} />

--- a/src/components/desktop/agent-panel-chat/ApprovalCards.tsx
+++ b/src/components/desktop/agent-panel-chat/ApprovalCards.tsx
@@ -52,7 +52,7 @@ function GateReportSection({ approval }: { approval: SidebarApproval }) {
           display: 'inline-block',
           width: 12,
           textAlign: 'center',
-          transition: 'transform 150ms ease',
+          transition: 'transform 150ms cubic-bezier(0.22, 1, 0.36, 1)',
           transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
         }}>
           {'\u25B6'}

--- a/src/components/desktop/agent-panel-chat/Bubble.tsx
+++ b/src/components/desktop/agent-panel-chat/Bubble.tsx
@@ -635,7 +635,7 @@ function CollapsibleToolCalls({ toolCalls, marginTop }: { toolCalls: MobileTrans
           strokeWidth={2}
           style={{
             transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
-            transition: 'transform 150ms ease',
+            transition: 'transform 150ms cubic-bezier(0.22, 1, 0.36, 1)',
             flexShrink: 0,
           }}
         />

--- a/src/components/desktop/agent-panel-chat/ComposePane.tsx
+++ b/src/components/desktop/agent-panel-chat/ComposePane.tsx
@@ -99,7 +99,7 @@ const ThinkingXray = memo(function ThinkingXray({
           {(isThinking || isStreaming) && (
             <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor"
               strokeWidth="2.5" strokeLinecap="round" style={{
-                transition: 'transform 200ms ease',
+                transition: 'transform 200ms cubic-bezier(0.22, 1, 0.36, 1)',
                 transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
                 opacity: 0.5,
               }}>

--- a/src/components/desktop/agent-panel-chat/DesktopChatHeader.tsx
+++ b/src/components/desktop/agent-panel-chat/DesktopChatHeader.tsx
@@ -114,7 +114,7 @@ export const DesktopChatHeader = memo(function DesktopChatHeader({
               color="var(--t-text-faint)"
               style={{
                 flexShrink: 0,
-                transition: 'transform 200ms cubic-bezier(0.32, 0.72, 0, 1)',
+                transition: 'transform 200ms cubic-bezier(0.22, 1, 0.36, 1)',
                 transform: pickerOpen ? 'rotate(180deg)' : 'rotate(0deg)',
               }}
             />
@@ -258,7 +258,7 @@ export const DesktopChatHeader = memo(function DesktopChatHeader({
                       style={{
                         flexShrink: 0,
                         color: 'var(--t-text-muted)',
-                        transition: 'transform 220ms cubic-bezier(0.32, 0.72, 0, 1)',
+                        transition: 'transform 220ms cubic-bezier(0.22, 1, 0.36, 1)',
                         transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)',
                       }}
                     />

--- a/src/components/desktop/agent-panel/ActivityFeedControls.tsx
+++ b/src/components/desktop/agent-panel/ActivityFeedControls.tsx
@@ -108,7 +108,7 @@ function ActivityFeedControlsBase({
               style={{
                 color: 'var(--t-text-muted)',
                 transform: repoPickerOpen ? 'rotate(180deg)' : 'none',
-                transition: 'transform 200ms cubic-bezier(0.32, 0.72, 0, 1)',
+                transition: 'transform 200ms cubic-bezier(0.22, 1, 0.36, 1)',
               }}
             />
           </button>

--- a/src/components/desktop/agent-panel/shared.tsx
+++ b/src/components/desktop/agent-panel/shared.tsx
@@ -368,7 +368,7 @@ export function ActivityDock({
           style={{
             flexShrink: 0,
             transform: open ? 'rotate(0deg)' : 'rotate(-90deg)',
-            transition: 'transform 180ms cubic-bezier(0.32, 0.72, 0, 1)',
+            transition: 'transform 180ms cubic-bezier(0.22, 1, 0.36, 1)',
           }}
         />
         <span style={{ fontSize: 12, fontWeight: 600, letterSpacing: '-0.01em', color: 'var(--t-text-secondary)' }}>{title}</span>

--- a/src/components/desktop/canvas/CanvasDiffMermaidViewers.tsx
+++ b/src/components/desktop/canvas/CanvasDiffMermaidViewers.tsx
@@ -243,7 +243,7 @@ function MermaidViewerBase({ code }: { code: string }) {
             style={{
               transform: `translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
               transformOrigin: 'center center',
-              transition: dragging.current ? 'none' : 'transform 100ms ease',
+              transition: dragging.current ? 'none' : 'transform 100ms cubic-bezier(0.22, 1, 0.36, 1)',
             }}
           />
         ) : (

--- a/src/components/desktop/cortex-task-board/constants.ts
+++ b/src/components/desktop/cortex-task-board/constants.ts
@@ -3,7 +3,7 @@ import type { BoardColumnId } from '@/lib/board/types';
 import type { BoardComposerState } from './types';
 
 export const COLUMN_ORDER: BoardColumnId[] = ['backlog', 'in_progress', 'review', 'trash'];
-export const CARD_TRANSITION = 'all 180ms cubic-bezier(0.32, 0.72, 0, 1)';
+export const CARD_TRANSITION = 'all 180ms cubic-bezier(0.22, 1, 0.36, 1)';
 
 export const DEFAULT_COMPOSER_STATE: BoardComposerState = {
   title: '',

--- a/src/components/desktop/diff-utils.tsx
+++ b/src/components/desktop/diff-utils.tsx
@@ -83,7 +83,7 @@ function DiffHunk({ hunkHeader, lines, startIndex, defaultExpanded, containerWid
         <ChevronRight
           size={11}
           style={{
-            transition: 'transform 150ms ease',
+            transition: 'transform 150ms cubic-bezier(0.22, 1, 0.36, 1)',
             transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
             flexShrink: 0,
           }}

--- a/src/components/desktop/llm-chat/ChainOfThought.tsx
+++ b/src/components/desktop/llm-chat/ChainOfThought.tsx
@@ -65,7 +65,7 @@ function ChainOfThoughtBase({
             {isLive && activeStep ? activeStep.label : `Thought for ${durationSec ? `${durationSec}s` : `${completedCount} step${completedCount !== 1 ? 's' : ''}`}`}
           </div>
         </div>
-        <ChevronRight size={12} style={{ color: 'var(--t-text-muted)', transform: expanded ? 'rotate(90deg)' : 'rotate(0)', transition: 'transform 200ms ease', flexShrink: 0 }} />
+        <ChevronRight size={12} style={{ color: 'var(--t-text-muted)', transform: expanded ? 'rotate(90deg)' : 'rotate(0)', transition: 'transform 200ms cubic-bezier(0.22, 1, 0.36, 1)', flexShrink: 0 }} />
       </button>
       {expanded ? (
         <div style={{ marginTop: 4, marginLeft: 23, paddingLeft: 12, borderLeft: '2px solid var(--t-divider)', animation: 'llmFadeIn 200ms ease-out' }}>
@@ -121,7 +121,7 @@ function ThinkingText({ text }: { text: string }) {
         onClick={() => setShowRaw((value) => !value)}
         style={{ display: 'flex', alignItems: 'center', gap: 4, border: 'none', background: 'transparent', color: '#94a3b8', fontSize: 11, cursor: 'pointer', paddingTop: 4, paddingRight: 0, paddingBottom: 4, paddingLeft: 0 }}
       >
-        <ChevronRight size={10} style={{ transform: showRaw ? 'rotate(90deg)' : 'rotate(0)', transition: 'transform 200ms ease' }} />
+        <ChevronRight size={10} style={{ transform: showRaw ? 'rotate(90deg)' : 'rotate(0)', transition: 'transform 200ms cubic-bezier(0.22, 1, 0.36, 1)' }} />
         View raw thinking
       </button>
       {showRaw ? (

--- a/src/components/desktop/llm-chat/HistorySidebar.tsx
+++ b/src/components/desktop/llm-chat/HistorySidebar.tsx
@@ -31,7 +31,7 @@ function HistorySidebarBase({
   deleteHistory: (tabId: string) => void;
 }) {
   return (
-    <div style={{ width: historyOpen ? 260 : 0, minWidth: historyOpen ? 260 : 0, borderRight: historyOpen ? '1px solid var(--t-divider)' : 'none', display: 'flex', flexDirection: 'column', overflow: 'hidden', transition: 'width 200ms ease, min-width 200ms ease', background: 'var(--t-chat-surface-bg, #ffffff)' }}>
+    <div style={{ width: historyOpen ? 260 : 0, minWidth: historyOpen ? 260 : 0, borderRight: historyOpen ? '1px solid var(--t-divider)' : 'none', display: 'flex', flexDirection: 'column', overflow: 'hidden', transition: 'width 200ms cubic-bezier(0.22, 1, 0.36, 1), min-width 200ms cubic-bezier(0.22, 1, 0.36, 1)', background: 'var(--t-chat-surface-bg, #ffffff)' }}>
       {historyOpen ? (
         <>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', paddingTop: 12, paddingRight: 10, paddingBottom: 12, paddingLeft: 14, borderBottom: '1px solid var(--t-divider)' }}>

--- a/src/components/desktop/llm-chat/MessageBubble.tsx
+++ b/src/components/desktop/llm-chat/MessageBubble.tsx
@@ -116,7 +116,7 @@ function FileChangeCard({ change }: { change: FileChangePreview }) {
         onClick={() => setExpanded((value) => !value)}
         style={{ display: 'flex', alignItems: 'center', gap: 10, width: '100%', paddingTop: 10, paddingRight: 12, paddingBottom: 10, paddingLeft: 12, background: THEME_BG_CARD, border: '1px solid var(--t-panel-border)', borderRadius: 12, cursor: 'pointer', textAlign: 'left' }}
       >
-        <ChevronRight size={14} style={{ color: 'var(--t-text-secondary)', transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 160ms ease', flexShrink: 0 }} />
+        <ChevronRight size={14} style={{ color: 'var(--t-text-secondary)', transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 160ms cubic-bezier(0.22, 1, 0.36, 1)', flexShrink: 0 }} />
         <FileText size={14} style={{ color: 'var(--t-text-secondary)', flexShrink: 0 }} />
         <div style={{ minWidth: 0, flex: 1 }}>
           <div style={{ fontSize: 12, fontWeight: 700, color: 'var(--t-text)' }}>1 file changed</div>

--- a/src/components/desktop/repo-registry/shared.tsx
+++ b/src/components/desktop/repo-registry/shared.tsx
@@ -894,7 +894,7 @@ export function RepoActionButton({
         cursor: disabled ? 'not-allowed' : 'pointer',
         opacity: disabled ? 0.45 : 1,
         fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
-        transition: 'all 150ms cubic-bezier(0.32, 0.72, 0, 1)',
+        transition: 'all 150ms cubic-bezier(0.22, 1, 0.36, 1)',
       }}
     >
       {icon}

--- a/src/components/desktop/settings/OperatorDefaultsTab.tsx
+++ b/src/components/desktop/settings/OperatorDefaultsTab.tsx
@@ -271,7 +271,7 @@ function PickerMenu<T extends string>({ value, options, onChange, disabled, minW
           stroke="currentColor"
           strokeWidth={1.5}
           strokeLinecap="round"
-          style={{ flexShrink: 0, transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 160ms ease', color: RAMS_INK_QUIET }}
+          style={{ flexShrink: 0, transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 160ms cubic-bezier(0.22, 1, 0.36, 1)', color: RAMS_INK_QUIET }}
         >
           <polyline points="6 9 12 15 18 9" />
         </svg>

--- a/src/components/desktop/setup-wizard/atoms.tsx
+++ b/src/components/desktop/setup-wizard/atoms.tsx
@@ -36,7 +36,7 @@ export function AnimatedCheck({ delay = 0 }: { delay?: number }) {
       height: 20,
       borderRadius: '50%',
       background: visible ? '#22c55e' : 'rgba(34,197,94,0.15)',
-      transition: 'all 400ms cubic-bezier(0.34, 1.56, 0.64, 1)',
+      transition: 'all 400ms cubic-bezier(0.34, 1.36, 0.64, 1)',
       transform: visible ? 'scale(1)' : 'scale(0.5)',
       opacity: visible ? 1 : 0.3,
       flexShrink: 0,
@@ -130,7 +130,7 @@ export function StepDots({ total, current }: { total: number; current: number })
           background: i === current
             ? THEME_ACCENT
             : i < current ? THEME_ACCENT_SOFT_STRONG : THEME_DIVIDER,
-          transition: 'all 300ms cubic-bezier(0.34, 1.56, 0.64, 1)',
+          transition: 'all 300ms cubic-bezier(0.34, 1.36, 0.64, 1)',
         }} />
       ))}
     </div>
@@ -218,7 +218,7 @@ export function SetupWizardStepFrame({
             ? 'translateY(12px) scale(0.985)'
             : 'translateY(-12px) scale(0.985)'
           : 'translateY(0) scale(1)',
-        transition: 'opacity 220ms ease, transform 220ms cubic-bezier(0.34, 1.56, 0.64, 1)',
+        transition: 'opacity 220ms ease, transform 220ms cubic-bezier(0.34, 1.36, 0.64, 1)',
       }}
     >
       {children}

--- a/src/components/desktop/thoughts/mission-panel/IssueGroupList.tsx
+++ b/src/components/desktop/thoughts/mission-panel/IssueGroupList.tsx
@@ -67,7 +67,7 @@ export function IssueGroupList({
                 }}>
                   {group.issues.length}
                 </span>
-                <svg width={10} height={10} viewBox="0 0 10 10" fill="none" stroke="var(--t-text-muted)" strokeWidth="1.5" strokeLinecap="round" style={{ transform: collapsed ? 'rotate(-90deg)' : 'rotate(0deg)', transition: 'transform 150ms ease' }}>
+                <svg width={10} height={10} viewBox="0 0 10 10" fill="none" stroke="var(--t-text-muted)" strokeWidth="1.5" strokeLinecap="round" style={{ transform: collapsed ? 'rotate(-90deg)' : 'rotate(0deg)', transition: 'transform 150ms cubic-bezier(0.22, 1, 0.36, 1)' }}>
                   <path d="M2.5 3.5L5 6L7.5 3.5" />
                 </svg>
               </div>

--- a/src/components/desktop/thoughts/mission-panel/PacketCard.tsx
+++ b/src/components/desktop/thoughts/mission-panel/PacketCard.tsx
@@ -160,7 +160,7 @@ export function PacketCard({
           <span style={{ flexShrink: 0, fontSize: 9, fontWeight: 600, color: statusMeta.color, letterSpacing: '-0.01em' }}>
             {statusMeta.label}
           </span>
-          <svg width={10} height={10} viewBox="0 0 10 10" fill="none" stroke="var(--t-text-muted)" strokeWidth="1.5" strokeLinecap="round" style={{ flexShrink: 0, transform: isExpanded ? 'rotate(0deg)' : 'rotate(-90deg)', transition: 'transform 150ms ease' }}>
+          <svg width={10} height={10} viewBox="0 0 10 10" fill="none" stroke="var(--t-text-muted)" strokeWidth="1.5" strokeLinecap="round" style={{ flexShrink: 0, transform: isExpanded ? 'rotate(0deg)' : 'rotate(-90deg)', transition: 'transform 150ms cubic-bezier(0.22, 1, 0.36, 1)' }}>
             <path d="M2.5 3.5L5 6L7.5 3.5" />
           </svg>
         </button>

--- a/src/components/desktop/thoughts/mission-panel/RejectedFeedbackPanel.tsx
+++ b/src/components/desktop/thoughts/mission-panel/RejectedFeedbackPanel.tsx
@@ -144,7 +144,7 @@ export function RejectedFeedbackPanel({ packet }: RejectedFeedbackPanelProps) {
           letterSpacing: '-0.005em',
           outline: 'none',
           opacity: submitting ? 0.6 : 1,
-          transition: 'border-color 200ms cubic-bezier(0.4, 1.4, 0.6, 1)',
+          transition: 'border-color 200ms cubic-bezier(0.34, 1.36, 0.64, 1)',
         }}
         aria-label="Operator feedback for rerun"
       />
@@ -173,7 +173,7 @@ export function RejectedFeedbackPanel({ packet }: RejectedFeedbackPanelProps) {
             letterSpacing: '-0.01em',
             cursor: canSubmit ? 'pointer' : 'not-allowed',
             opacity: submitting ? 0.7 : 1,
-            transition: 'background 200ms cubic-bezier(0.4, 1.4, 0.6, 1), transform 150ms cubic-bezier(0.4, 1.4, 0.6, 1)',
+            transition: 'background 200ms cubic-bezier(0.34, 1.36, 0.64, 1), transform 150ms cubic-bezier(0.34, 1.36, 0.64, 1)',
             fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
           }}
           onMouseDown={(event) => {

--- a/src/components/desktop/timeline/TimelineDrilldown.tsx
+++ b/src/components/desktop/timeline/TimelineDrilldown.tsx
@@ -297,7 +297,7 @@ export function TimelineDrilldown({
         WebkitBackdropFilter: 'blur(28px) saturate(1.42)',
         display: 'flex',
         flexDirection: 'column',
-        animation: 'drillFadeIn 180ms cubic-bezier(0.32, 0.72, 0, 1)',
+        animation: 'drillFadeIn 180ms cubic-bezier(0.22, 1, 0.36, 1)',
       }}>
         <div
           style={{
@@ -418,7 +418,7 @@ export function TimelineDrilldown({
             overflow: 'hidden',
             display: 'flex',
             flexDirection: 'column',
-            animation: 'drillFadeIn 180ms cubic-bezier(0.32, 0.72, 0, 1)',
+            animation: 'drillFadeIn 180ms cubic-bezier(0.22, 1, 0.36, 1)',
           }}
         >
           <div
@@ -662,7 +662,7 @@ export function TimelineDrilldown({
             overflow: 'hidden',
             display: 'flex',
             flexDirection: 'column',
-            animation: 'drillFadeIn 180ms cubic-bezier(0.32, 0.72, 0, 1)',
+            animation: 'drillFadeIn 180ms cubic-bezier(0.22, 1, 0.36, 1)',
           }}
         >
           <div

--- a/src/components/desktop/workspace-terminal/OrchestratorTab.tsx
+++ b/src/components/desktop/workspace-terminal/OrchestratorTab.tsx
@@ -776,7 +776,7 @@ function OrchestratorTabInner({ tabId, active, repoPath, repoLabel }: Orchestrat
             display: 'flex',
             flexDirection: 'column',
             overflow: 'hidden',
-            transition: 'width 200ms ease, min-width 200ms ease',
+            transition: 'width 200ms cubic-bezier(0.22, 1, 0.36, 1), min-width 200ms cubic-bezier(0.22, 1, 0.36, 1)',
             flexShrink: 0,
             background: 'var(--t-chat-surface-bg, #ffffff)',
           }}

--- a/src/components/desktop/workspace-terminal/WorkspaceChatPane.tsx
+++ b/src/components/desktop/workspace-terminal/WorkspaceChatPane.tsx
@@ -140,7 +140,7 @@ function PacketHeaderCard({
             stroke="var(--t-text-faint)"
             strokeWidth={1.6}
             strokeLinecap="round"
-            style={{ flexShrink: 0, transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 160ms ease' }}
+            style={{ flexShrink: 0, transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 160ms cubic-bezier(0.22, 1, 0.36, 1)' }}
           >
             <path d="M2.5 3.5 L5 6 L7.5 3.5" />
           </svg>

--- a/src/components/mobile/AgentTranscriptSheet.tsx
+++ b/src/components/mobile/AgentTranscriptSheet.tsx
@@ -146,7 +146,7 @@ export const AgentTranscriptSheet = memo(function AgentTranscriptSheet({
     borderTopLeftRadius: 18,
     borderTopRightRadius: 18,
     transform: open ? 'translateY(0)' : 'translateY(100%)',
-    transition: 'transform 320ms cubic-bezier(0.32, 0.72, 0, 1)',
+    transition: 'transform 320ms cubic-bezier(0.22, 1, 0.36, 1)',
     display: 'flex',
     flexDirection: 'column',
     boxShadow: '0 -8px 32px rgba(0,0,0,0.18)',

--- a/src/components/mobile/ApprovalStack.tsx
+++ b/src/components/mobile/ApprovalStack.tsx
@@ -473,7 +473,7 @@ export function ApprovalStack({
                 fontSize: 16,
                 lineHeight: 1,
                 transform: resolvedExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
-                transition: 'transform 180ms ease',
+                transition: 'transform 180ms cubic-bezier(0.22, 1, 0.36, 1)',
               }}
             >
               ˅

--- a/src/components/mobile/ChatView.tsx
+++ b/src/components/mobile/ChatView.tsx
@@ -575,7 +575,7 @@ const PremiumCodeBlock = memo(function PremiumCodeBlock({
           <ChevronDown
             size={14}
             strokeWidth={2}
-            style={{ transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 180ms ease' }}
+            style={{ transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 180ms cubic-bezier(0.22, 1, 0.36, 1)' }}
           />
         </span>
       </button>
@@ -925,7 +925,7 @@ const MessageBubble = memo(function MessageBubble({
                       color: palette.tertiaryText,
                       flexShrink: 0,
                       transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
-                      transition: 'transform 180ms ease',
+                      transition: 'transform 180ms cubic-bezier(0.22, 1, 0.36, 1)',
                     }}
                   />
                 </div>

--- a/src/components/mobile/CodeBlock.tsx
+++ b/src/components/mobile/CodeBlock.tsx
@@ -173,7 +173,7 @@ export const CodeBlock = memo(function CodeBlock({ code, language }: CodeBlockPr
         createElement('span', {
           style: {
             fontSize: '0.6rem',
-            transition: 'transform 200ms ease',
+            transition: 'transform 200ms cubic-bezier(0.22, 1, 0.36, 1)',
             transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
           },
         }, '▼'),

--- a/src/components/mobile/ContextMenu.tsx
+++ b/src/components/mobile/ContextMenu.tsx
@@ -89,7 +89,7 @@ export const ContextMenu = memo(function ContextMenu({
           WebkitBackdropFilter: 'blur(40px) saturate(1.8)',
           boxShadow: '0 8px 32px rgba(0,0,0,0.14), 0 1px 4px rgba(0,0,0,0.06)',
           overflow: 'hidden',
-          animation: 'ctxScaleIn 200ms cubic-bezier(0.32, 0.72, 0, 1)',
+          animation: 'ctxScaleIn 200ms cubic-bezier(0.34, 1.36, 0.64, 1)',
           transformOrigin: `${x - safeX}px ${y < safeY ? 'bottom' : 'top'}`,
           padding: '6px 0',
         }}

--- a/src/components/mobile/MessageActions.tsx
+++ b/src/components/mobile/MessageActions.tsx
@@ -104,7 +104,7 @@ export const MessageActions = memo(function MessageActions({
         maxHeight: visible ? 36 : 0,
         opacity: visible ? 1 : 0,
         overflow: 'hidden',
-        transition: 'all 250ms cubic-bezier(0.32, 0.72, 0, 1)',
+        transition: 'all 250ms cubic-bezier(0.22, 1, 0.36, 1)',
         pointerEvents: visible ? 'auto' : 'none',
       }}
     >

--- a/src/components/mobile/MobileDiffViewer.tsx
+++ b/src/components/mobile/MobileDiffViewer.tsx
@@ -268,7 +268,7 @@ export const MobileDiffViewer = memo(function MobileDiffViewer({
     borderTopLeftRadius: 18,
     borderTopRightRadius: 18,
     transform: open ? 'translateY(0)' : 'translateY(100%)',
-    transition: 'transform 320ms cubic-bezier(0.32, 0.72, 0, 1)',
+    transition: 'transform 320ms cubic-bezier(0.22, 1, 0.36, 1)',
     display: 'flex',
     flexDirection: 'column',
     boxShadow: '0 -8px 32px rgba(0,0,0,0.18)',

--- a/src/components/mobile/MobileSearchSheet.tsx
+++ b/src/components/mobile/MobileSearchSheet.tsx
@@ -384,7 +384,7 @@ export function MobileSearchSheet({
         letterSpacing: MOBILE_BODY_TRACKING,
         display: 'flex',
         flexDirection: 'column',
-        animation: 'mobileSearchSheetIn 0.24s cubic-bezier(0.32, 0.72, 0, 1)',
+        animation: 'mobileSearchSheetIn 0.24s cubic-bezier(0.22, 1, 0.36, 1)',
       } as CSSProperties}
     >
       <style>{`

--- a/src/components/mobile/MobileSettingsSheet.tsx
+++ b/src/components/mobile/MobileSettingsSheet.tsx
@@ -294,7 +294,7 @@ export function MobileSettingsSheet({
         letterSpacing: MOBILE_BODY_TRACKING,
         display: 'flex',
         flexDirection: 'column',
-        animation: 'mobileSettingsSheetIn 0.28s cubic-bezier(0.32, 0.72, 0, 1)',
+        animation: 'mobileSettingsSheetIn 0.28s cubic-bezier(0.22, 1, 0.36, 1)',
       } as CSSProperties}
     >
       <style>{`

--- a/src/components/mobile/NotificationBanner.tsx
+++ b/src/components/mobile/NotificationBanner.tsx
@@ -91,7 +91,7 @@ function BannerCard({ notification, onDismiss, onTap }: {
           }
           setTimeout(onDismiss, 180);
         } else if (cardRef.current) {
-          cardRef.current.style.transition = 'transform 250ms cubic-bezier(0.32, 0.72, 0, 1), opacity 250ms ease';
+          cardRef.current.style.transition = 'transform 250ms cubic-bezier(0.22, 1, 0.36, 1), opacity 250ms ease';
           cardRef.current.style.transform = 'translate(0, 0)';
           cardRef.current.style.opacity = '1';
           // Clear transition after spring-back
@@ -117,7 +117,7 @@ function BannerCard({ notification, onDismiss, onTap }: {
         cursor: 'pointer',
         WebkitTapHighlightColor: 'transparent',
         transition: 'transform 200ms ease, opacity 200ms ease',
-        animation: 'bannerSlideDown 350ms cubic-bezier(0.32, 0.72, 0, 1)',
+        animation: 'bannerSlideDown 350ms cubic-bezier(0.22, 1, 0.36, 1)',
       }}
     >
       {/* Icon — small colored dot */}

--- a/src/components/mobile/OrchestratorView.tsx
+++ b/src/components/mobile/OrchestratorView.tsx
@@ -534,7 +534,7 @@ export function OrchestratorView({ onBack, hideHeader = false, refreshSignal = 0
               display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
               cursor: 'pointer', flexShrink: 0,
               WebkitTapHighlightColor: 'transparent',
-              transition: 'transform 180ms ease',
+              transition: 'transform 180ms cubic-bezier(0.22, 1, 0.36, 1)',
               transform: stripOpen ? 'rotate(0deg)' : 'rotate(180deg)',
               padding: 0,
             }}
@@ -591,7 +591,7 @@ export function OrchestratorView({ onBack, hideHeader = false, refreshSignal = 0
           style={{
             maxHeight: stripOpen ? 132 : 0,
             overflow: 'hidden',
-            transition: 'max-height 220ms cubic-bezier(0.32, 0.72, 0, 1)',
+            transition: 'max-height 220ms cubic-bezier(0.22, 1, 0.36, 1)',
           }}
           aria-hidden={!stripOpen}
         >

--- a/src/components/mobile/PageTransition.tsx
+++ b/src/components/mobile/PageTransition.tsx
@@ -16,7 +16,7 @@ export function PageTransition({ activeKey, children }: PageTransitionProps) {
     <div
       key={activeKey}
       style={{
-        animation: 'page-transition-in 280ms cubic-bezier(0.32, 0.72, 0, 1)',
+        animation: 'page-transition-in 280ms cubic-bezier(0.22, 1, 0.36, 1)',
       }}
     >
       <style>{`@keyframes page-transition-in { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }`}</style>

--- a/src/components/mobile/ProactiveSurface.tsx
+++ b/src/components/mobile/ProactiveSurface.tsx
@@ -49,7 +49,7 @@ const ProactiveCard = memo(function ProactiveCard({
       padding: '10px 12px', borderRadius: 14,
       background: `${item.color}06`,
       border: `1px solid ${item.color}15`,
-      animation: exiting ? 'proactiveExit 250ms ease forwards' : 'proactiveEnter 350ms cubic-bezier(0.32, 0.72, 0, 1)',
+      animation: exiting ? 'proactiveExit 250ms ease forwards' : 'proactiveEnter 350ms cubic-bezier(0.22, 1, 0.36, 1)',
       touchAction: 'manipulation',
     }}>
       {/* Icon */}

--- a/src/components/mobile/PullToRefresh.tsx
+++ b/src/components/mobile/PullToRefresh.tsx
@@ -43,7 +43,7 @@ export function PullToRefresh({
         transform: `translateX(-50%) translateY(${Math.max(pullDistance - 20, 0)}px)`,
         zIndex: 50,
         opacity: progress > 0.1 ? Math.min(progress * 1.5, 1) : 0,
-        transition: isPulling ? 'none' : 'all 300ms cubic-bezier(0.32, 0.72, 0, 1)',
+        transition: isPulling ? 'none' : 'all 300ms cubic-bezier(0.22, 1, 0.36, 1)',
         pointerEvents: 'none',
       }}>
         <div style={{
@@ -73,7 +73,7 @@ export function PullToRefresh({
               strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
               style={{
                 transform: `rotate(${progress * 180}deg)`,
-                transition: isPulling ? 'none' : 'transform 200ms ease',
+                transition: isPulling ? 'none' : 'transform 200ms cubic-bezier(0.22, 1, 0.36, 1)',
               }}>
               <line x1="12" y1="19" x2="12" y2="5" />
               <polyline points="5 12 12 5 19 12" />

--- a/src/components/mobile/ReferencePrimitives.tsx
+++ b/src/components/mobile/ReferencePrimitives.tsx
@@ -344,7 +344,7 @@ export function MobileActivitySummaryRow({
   const chevronStyle: CSSProperties = {
     color: palette.tertiary,
     transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
-    transition: 'transform 180ms ease',
+    transition: 'transform 180ms cubic-bezier(0.22, 1, 0.36, 1)',
   };
 
   return (

--- a/src/components/mobile/SessionInfoSheet.tsx
+++ b/src/components/mobile/SessionInfoSheet.tsx
@@ -150,7 +150,7 @@ function ContextBar({ percent }: { percent: number }) {
         height: '100%',
         borderRadius: 2,
         background: color,
-        transition: 'width 400ms cubic-bezier(0.32, 0.72, 0, 1), background 400ms ease',
+        transition: 'width 400ms cubic-bezier(0.22, 1, 0.36, 1), background 400ms ease',
       }} />
     </div>
   );
@@ -281,7 +281,7 @@ export const SessionInfoSheet = memo(function SessionInfoSheet({
   const prefersReducedMotion = typeof window !== 'undefined'
     && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
 
-  const springCurve = 'cubic-bezier(0.32, 0.72, 0, 1)';
+  const springCurve = 'cubic-bezier(0.22, 1, 0.36, 1)';
   const sheetTransition = prefersReducedMotion ? 'none' : `transform 400ms ${springCurve}`;
   const backdropTransition = prefersReducedMotion ? 'none' : 'opacity 300ms ease';
 

--- a/src/components/mobile/SessionPickerSheet.tsx
+++ b/src/components/mobile/SessionPickerSheet.tsx
@@ -208,7 +208,7 @@ function SectionHeader({
             justifyContent: 'center',
             color: colors.textSecondary,
             transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
-            transition: 'transform 220ms ease',
+            transition: 'transform 220ms cubic-bezier(0.22, 1, 0.36, 1)',
           }}
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
@@ -445,7 +445,7 @@ export const SessionPickerSheet = memo(function SessionPickerSheet({
           width: 'min(100dvw, 430px)',
           maxHeight: '78dvh',
           transform: open ? 'translate(-50%, 0)' : 'translate(-50%, 100%)',
-          transition: 'transform 220ms cubic-bezier(0.32, 0.72, 0, 1)',
+          transition: 'transform 220ms cubic-bezier(0.22, 1, 0.36, 1)',
           borderRadius: '20px 20px 0 0',
           background: 'rgba(30,28,26,0.95)',
           backdropFilter: 'blur(40px)',

--- a/src/components/mobile/SpeedDial.tsx
+++ b/src/components/mobile/SpeedDial.tsx
@@ -200,7 +200,7 @@ export const SpeedDialButton = memo(function SpeedDialButton({
           <span style={{
             display: 'block', width: 18, height: 1.5, borderRadius: 1,
             background: 'currentColor',
-            transition: 'all 250ms cubic-bezier(0.32, 0.72, 0, 1)',
+            transition: 'all 250ms cubic-bezier(0.22, 1, 0.36, 1)',
             transform: open ? 'translateY(5.25px) rotate(45deg)' : 'none',
           }} />
           <span style={{
@@ -212,7 +212,7 @@ export const SpeedDialButton = memo(function SpeedDialButton({
           <span style={{
             display: 'block', width: 16, height: 1.5, borderRadius: 1,
             background: 'currentColor',
-            transition: 'all 250ms cubic-bezier(0.32, 0.72, 0, 1)',
+            transition: 'all 250ms cubic-bezier(0.22, 1, 0.36, 1)',
             transform: open ? 'translateY(-5.25px) rotate(-45deg)' : 'none',
           }} />
         </div>

--- a/src/components/mobile/SwipeActions.tsx
+++ b/src/components/mobile/SwipeActions.tsx
@@ -174,7 +174,7 @@ export function SwipeActions({
           transform: `translate3d(${pinnedOffset}px, 0, 0)`,
           transition: swipe.swiping
             ? 'none'
-            : 'transform 220ms cubic-bezier(0.34, 1.56, 0.64, 1)',
+            : 'transform 220ms cubic-bezier(0.34, 1.36, 0.64, 1)',
           willChange: swipe.swiping ? 'transform' : undefined,
           // Hide swipe-revealed visuals during confirmation so the strip below
           // is the unambiguous next step.


### PR DESCRIPTION
## Summary

Audited every `cubic-bezier(...)` value and ad-hoc `transform/expand` `ms ease` pattern across `src/components/desktop` and `src/components/mobile`, snapping each to one of two canonical curves so motion reads as a single coherent system across the whole app.

- **Geometry / position / size** → `cubic-bezier(0.22, 1, 0.36, 1)` (iOS-grade ease-out)
- **Pop / spring / appear-disappear** → `cubic-bezier(0.34, 1.36, 0.64, 1)` (gentle overshoot)

77 transitions normalized across 55 files. No color/duration/structure changes — every changed line is just the curve.

### Replacements (cubic-bezier → canonical)

| Old curve | Count | Mapped to |
|-----------|-------|-----------|
| `cubic-bezier(0.32, 0.72, 0, 1)` | 32 | `cubic-bezier(0.22, 1, 0.36, 1)` (geometry) |
| `cubic-bezier(0.34, 1.56, 0.64, 1)` | 4 | `cubic-bezier(0.34, 1.36, 0.64, 1)` (pop, gentler) |
| `cubic-bezier(0.4, 1.4, 0.6, 1)` | 3 | `cubic-bezier(0.34, 1.36, 0.64, 1)` (pop) |

### Raw `ease` → canonical (interactive transforms only)

38 chevron rotates / expand-collapse / sidebar width transitions swapped from `ms ease` to `cubic-bezier(0.22, 1, 0.36, 1)` — these are the geometry-bearing transitions that should match the canonical curve. Background/color hover transitions left on `ease` (purposely out of scope; they don't carry motion characteristics).

### Notable per-file mappings

- `TitleBar.tsx:370` — `max-width 250ms` (search expand) → geometry
- `WorkspacesPanel.tsx:142,162,410` — chevron rotate, progress ring, max-height collapse → geometry
- `TimelineDrilldown.tsx:300/421/665` — `drillFadeIn` (translateY+scale keyframe) → geometry
- `setup-wizard/atoms.tsx:39,133,221` — pop/scale animations → softened pop
- `RejectedFeedbackPanel.tsx:147,176` — button transform/border → pop (canonicalized)
- `LiveOutput.tsx:112` — `diffCardSlideIn` (translateY) → geometry
- `cortex-task-board/constants.ts:6` — `CARD_TRANSITION` → geometry
- `mobile/SessionInfoSheet.tsx`, `MobileDiffViewer.tsx`, `AgentTranscriptSheet.tsx`, `SessionPickerSheet.tsx` — bottom-sheet `transform translateY` → geometry
- `mobile/ContextMenu.tsx:92` — `ctxScaleIn` (scale 0.85→1) → pop (correctly classified vs the previous geometry curve)
- `mobile/SwipeActions.tsx:177` — pop with overshoot → softened pop

Already-canonical curves left alone:
- `SessionPillContextMenu.tsx:104` (already pop)
- `UnifiedAgentsSidebar.tsx:31`, `SessionTileSurface.tsx:112` (already geometry)

## Test plan

- [x] `npx tsc --noEmit` returns 0 errors
- [ ] Visual smoke (chevron rotates, expand/collapse drawers, bottom-sheet entry, tile drag-and-drop, search expand) — motion should feel one notch tighter and more uniform; no other visible differences
- [ ] Midnight + light themes both look unchanged (no rgba surfaces touched — hard rule)