### PR TITLE
fix(changes-panel): watch .git for live refresh on external commit

### DIFF
--- a/src/app/api/panel/git-watch/route.ts
+++ b/src/app/api/panel/git-watch/route.ts
@@ -1,0 +1,153 @@
+/**
+ * SSE endpoint that watches a workspace's `.git/HEAD` and `.git/index` files
+ * and emits a `changed` event whenever either is touched.
+ *
+ * Used by the right-side Changes panel to refresh after `git commit` runs in
+ * any terminal (embedded or external). Avoids tight polling — the watcher is
+ * filesystem-driven and only fires on real git activity.
+ *
+ * Watches HEAD (branch refs / detached state) and index (staged files) so we
+ * catch every commit, checkout, reset, stash, etc. Debounced 200ms to coalesce
+ * the multi-write burst that git emits per command.
+ */
+
+import { NextRequest } from 'next/server';
+import { existsSync, watch, type FSWatcher } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const DEBOUNCE_MS = 200;
+const PING_INTERVAL_MS = 25_000;
+
+function resolveWorkspace(input: string): string {
+  if (input.startsWith('~')) {
+    return input.replace('~', homedir());
+  }
+  return input;
+}
+
+export async function GET(request: NextRequest) {
+  const workspaceParam = request.nextUrl.searchParams.get('workspace')?.trim();
+  if (!workspaceParam) {
+    return new Response(JSON.stringify({ error: 'workspace is required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const workspace = resolveWorkspace(workspaceParam);
+  const gitDir = join(workspace, '.git');
+  const headPath = join(gitDir, 'HEAD');
+  const indexPath = join(gitDir, 'index');
+
+  if (!existsSync(gitDir)) {
+    return new Response(JSON.stringify({ error: 'workspace is not a git repo' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const encoder = new TextEncoder();
+  let pingTimer: ReturnType<typeof setInterval> | null = null;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  const watchers: FSWatcher[] = [];
+  let closed = false;
+
+  const readable = new ReadableStream({
+    start(controller) {
+      const send = (event: string, data: unknown) => {
+        if (closed) return;
+        try {
+          controller.enqueue(
+            encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`),
+          );
+        } catch {
+          // stream closed mid-send — ignore
+        }
+      };
+
+      send('connected', { workspace, ts: Date.now() });
+
+      const scheduleEmit = () => {
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+          send('changed', { ts: Date.now() });
+        }, DEBOUNCE_MS);
+      };
+
+      const attach = (target: string) => {
+        if (!existsSync(target)) return;
+        try {
+          const watcher = watch(target, () => {
+            scheduleEmit();
+          });
+          watcher.on('error', () => {
+            // Single-file watch can drop on rename/atomic write — ignore;
+            // the .git dir watch below catches the recreation.
+          });
+          watchers.push(watcher);
+        } catch {
+          // Best-effort. If watch fails the panel still has its manual refresh.
+        }
+      };
+
+      attach(headPath);
+      attach(indexPath);
+
+      // Watch the .git directory itself — git often replaces HEAD/index via
+      // atomic rename (write to .lock, rename over). The single-file watcher
+      // can lose its target on rename, so we keep the dir-level watch as a
+      // backstop and re-emit when HEAD or index changes name.
+      try {
+        const dirWatcher = watch(gitDir, (_eventType, fileName) => {
+          const name = fileName?.toString();
+          if (name === 'HEAD' || name === 'index') {
+            scheduleEmit();
+          }
+        });
+        dirWatcher.on('error', () => { /* ignore */ });
+        watchers.push(dirWatcher);
+      } catch {
+        // ignore
+      }
+
+      pingTimer = setInterval(() => {
+        if (closed) return;
+        try {
+          controller.enqueue(
+            encoder.encode(`event: ping\ndata: ${JSON.stringify({ ts: Date.now() })}\n\n`),
+          );
+        } catch {
+          // ignore stream closure races
+        }
+      }, PING_INTERVAL_MS);
+    },
+    cancel() {
+      closed = true;
+      if (pingTimer) {
+        clearInterval(pingTimer);
+        pingTimer = null;
+      }
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
+      for (const watcher of watchers) {
+        try { watcher.close(); } catch { /* ignore */ }
+      }
+      watchers.length = 0;
+    },
+  });
+
+  return new Response(readable, {
+    headers: {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  });
+}

--- a/src/components/desktop/O8ChangesPane.tsx
+++ b/src/components/desktop/O8ChangesPane.tsx
@@ -223,6 +223,35 @@ export const O8ChangesPane = memo(function O8ChangesPane({ repoPath, repoSlug, i
     void fetchChanges();
   }, [fetchChanges]);
 
+  // Live refresh: subscribe to filesystem events on `.git/HEAD` and `.git/index`
+  // so the panel reflects external `git commit`s within ~250ms (200ms server
+  // debounce + RTT). No tight polling — server-side fs.watch drives this.
+  // Keep `fetchChanges` in a ref so the EventSource only reconnects when the
+  // repo path changes, not on every filter toggle.
+  const fetchChangesRef = useRef(fetchChanges);
+  useEffect(() => { fetchChangesRef.current = fetchChanges; }, [fetchChanges]);
+
+  useEffect(() => {
+    if (!repoPath) return;
+    if (typeof window === 'undefined' || typeof EventSource === 'undefined') return;
+
+    const url = `/api/panel/git-watch?workspace=${encodeURIComponent(repoPath)}`;
+    let source: EventSource | null = null;
+    try {
+      source = new EventSource(url);
+    } catch {
+      return;
+    }
+
+    const handleChanged = () => { void fetchChangesRef.current(); };
+    source.addEventListener('changed', handleChanged);
+
+    return () => {
+      source?.removeEventListener('changed', handleChanged);
+      source?.close();
+    };
+  }, [repoPath]);
+
   useEffect(() => {
     setExpandedFile(null);
     setExpandedDiff(null);


### PR DESCRIPTION
## Where the bug was

The right-side Changes panel (`src/components/desktop/O8ChangesPane.tsx`) only refetched `git status` on initial mount and on filter/repo changes. When a user ran `git commit` from the embedded terminal or any external terminal, the panel kept showing the freshly-committed files as Uncommitted with their original additions/deletions counts until the user manually clicked the refresh button or restarted the app. Closes #698.

This was not a regression from PR #691 — `O8ChangesPane` had no polling at all, so #691's interval-widening sweep didn't touch it. The pane simply had no live-refresh mechanism.

## What watcher was added

A small server-side SSE endpoint at `/api/panel/git-watch?workspace=<path>` that runs `node:fs.watch` on the workspace's `.git/HEAD`, `.git/index`, and the `.git` directory itself, debounced 200ms to coalesce git's multi-write burst per command. The endpoint inherits the existing loopback + ws-token gate from `src/middleware.ts` (it's under `/api/panel/`).

The Changes panel opens an `EventSource` keyed on `repoPath` and refetches on every `changed` event. `fetchChanges` is stored in a ref so the EventSource only reconnects when the repo path changes — toggling the filter dropdown does not rebuild the connection.

## Files that trigger refresh

- `<workspace>/.git/HEAD` — picks up branch checkouts, detached-HEAD moves, commits that move the current ref
- `<workspace>/.git/index` — picks up `git add`, `git reset`, staging changes
- `<workspace>/.git/` directory watch — backstop for git's atomic-rename pattern (write to `.lock`, rename over). Only re-emits when the renamed file is `HEAD` or `index`.

This catches every commit, checkout, reset, and stash from any source — embedded PTY, external terminal, IDE, or another agent — within ~250ms (200ms server debounce + RTT).

## How polling churn was avoided

- **No `setInterval`.** The watcher is purely `fs.watch`-driven and only fires on real git activity.
- **No client-side timer.** EventSource is one persistent connection per repo, with a 25s server-side ping for proxy keepalive.
- **Debounced server-side**, so the ~3-5 file writes git makes per command emit a single `changed` event to the client.
- **Connection is keyed on `repoPath` only**, not on filter — switching the filter does not rebuild the connection.

The 5-minute fallback poll in the sibling `ChangesTab.tsx` (`src/components/desktop/workspace-side-panel/ChangesTab.tsx`) was left alone — different surface, different data hook, out of scope for this fix.

## Test plan

- [x] `npx tsc --noEmit` passes (exit 0)
- [ ] In the prod app: edit a file, commit from embedded terminal, verify panel shows clean state within 2s
- [ ] Same flow but commit from an external terminal (iTerm, separate `git` invocation), verify panel updates
- [ ] `git checkout -b feature` in terminal, verify panel reacts (HEAD changed)
- [ ] Open the panel for ~10 minutes idle, verify no fetch storm in network tab and EventSource ping fires every 25s

🤖 Generated with [Claude Code](https://claude.com/claude-code)