### PR TITLE
fix(updater): mirror release artifacts to public hurttlocker/o8 repo

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -26,6 +26,7 @@ import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 
 const REPO = 'hurttlocker/cortex-ide';
+const PUBLIC_MIRROR = 'hurttlocker/o8';
 const root = process.cwd();
 
 const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
@@ -48,7 +49,10 @@ for (const path of [DMG, APP_TAR, APP_SIG]) {
 
 const signature = readFileSync(APP_SIG, 'utf8').trim();
 const pubDate = new Date().toISOString();
-const downloadBase = `https://github.com/${REPO}/releases/download/${tag}`;
+// Point latest.json download URLs at the PUBLIC MIRROR so the Tauri updater
+// can fetch artifacts anonymously. The private repo (REPO) returns 404 for
+// anonymous download requests even when the release is published.
+const downloadBase = `https://github.com/${PUBLIC_MIRROR}/releases/download/${tag}`;
 
 // Same signed binary works on x86_64 natively and aarch64 under Rosetta, so
 // point both platforms at the same artifact until a native arm64 runner
@@ -107,5 +111,43 @@ if (releaseExists) {
 }
 
 console.log(`[release] published ${tag}`);
+
+// Mirror artifacts to the public repo so the Tauri updater can fetch
+// latest.json + the .app.tar.gz anonymously. The private REPO is the source
+// of truth for code + full release notes; PUBLIC_MIRROR only carries the
+// updater payload. Failures here are logged but non-fatal — the private
+// publish above already succeeded.
+const mirrorNotes = `Auto-update artifacts for o8 ${tag}. See https://github.com/${REPO}/releases/tag/${tag} for details.`;
+
+try {
+  let mirrorExists = false;
+  try {
+    execFileSync('gh', ['release', 'view', tag, '-R', PUBLIC_MIRROR], { stdio: 'pipe' });
+    mirrorExists = true;
+  } catch {}
+
+  if (mirrorExists) {
+    console.log(`[release-mirror] ${tag} already exists on ${PUBLIC_MIRROR} — replacing assets`);
+    execFileSync('gh', [
+      'release', 'upload', tag, ...uploadArgs,
+      '--clobber',
+      '-R', PUBLIC_MIRROR,
+    ], { stdio: 'inherit' });
+  } else {
+    console.log(`[release-mirror] creating ${tag} on ${PUBLIC_MIRROR}`);
+    execFileSync('gh', [
+      'release', 'create', tag, ...uploadArgs,
+      '--title', `o8 ${tag}`,
+      '--notes', mirrorNotes,
+      '-R', PUBLIC_MIRROR,
+    ], { stdio: 'inherit' });
+  }
+
+  console.log(`[release-mirror] mirrored ${tag} to ${PUBLIC_MIRROR}`);
+} catch (err) {
+  console.error(`[release-mirror] failed to mirror ${tag} to ${PUBLIC_MIRROR}:`, err?.message ?? err);
+  console.error(`[release-mirror] private publish above is unaffected — auto-update will not pick up this version until the mirror succeeds`);
+}
+
 console.log(`[release] the installed o8.app will pick up the update on next launch`);
 console.log(`[release] (or within 30 min via the UpdateBanner poll).`);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -60,7 +60,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://github.com/hurttlocker/cortex-ide/releases/latest/download/latest.json"
+        "https://github.com/hurttlocker/o8/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDg2NTIxQTI4MjkyODVGQTcKUldTblh5Z3BLQnBTaHI4VWFFM1VMVG1ZTU0wOExQQmRiYlZyZUJ3UExSUWVyRFpvcFNKQkZ4Uy8K"
     }


### PR DESCRIPTION
## Bug

The Tauri auto-update banner has never fired in production. Confirmed root cause: `hurttlocker/cortex-ide` is a **private** repo, and GitHub returns **404 for anonymous downloads of private-repo release assets** — including `latest.json`. Verified live:

```
$ curl https://github.com/hurttlocker/cortex-ide/releases/download/v0.1.46/latest.json
404
```

Same for the `.dmg`, `.sig`, and `.app.tar.gz`, even though `gh release view v0.1.46` lists them. The Tauri updater client has no auth, so it silently no-ops every poll.

## Fix

Dual-publish on every ship. `hurttlocker/cortex-ide` (private) stays the source of truth — full changelog, code, signed artifacts. `hurttlocker/o8` (public) gets a parallel release with the same 4 artifacts so the Tauri client can fetch `latest.json` + the `.app.tar.gz` anonymously.

### Flow

1. Build via `npm run ship` as today.
2. `scripts/release.mjs` publishes `vX.Y.Z` to `hurttlocker/cortex-ide` (existing path, unchanged).
3. `scripts/release.mjs` then creates (or clobbers) `vX.Y.Z` on `hurttlocker/o8` and uploads all 4 assets there.
4. The Tauri updater endpoint in `tauri.conf.json` now points at the public mirror, so the installed app fetches `https://github.com/hurttlocker/o8/releases/latest/download/latest.json` (anonymous, returns 200).
5. `latest.json` itself contains `platform[].url` values pointing back at `hurttlocker/o8/releases/download/<tag>/o8.app.tar.gz`, so the actual binary download also stays in public-mirror land.
6. Mirror failures are logged with `[release-mirror]` prefix but do **not** fail the whole ship — the private publish is the source of truth.

### Assets pushed to the mirror (per release)

- `latest.json` — updater manifest (~1.2 KB)
- `o8.app.tar.gz` — signed update payload (~41 MB)
- `o8.app.tar.gz.sig` — minisign signature (~400 B)
- `o8_<VERSION>_x64.dmg` — DMG installer (~40 MB)

The minisign signature is unchanged — same key (`~/.tauri/cortex-ide.key`), same pubkey embedded in `tauri.conf.json`, so the installed app's signature verification works without re-signing existing releases.

### v0.1.46 backfill

Not handled here. The orchestrator will manually backfill the v0.1.46 artifacts to `hurttlocker/o8` so the currently-installed app sees a valid `latest.json` immediately. The **next ship (v0.1.47+) is the first full dual-publish**.

## Files changed

- `scripts/release.mjs` — added `PUBLIC_MIRROR` constant, repointed `downloadBase` (which feeds `latest.json` URLs) at the public mirror, and added a mirror-publish block after the private publish that mirrors `gh release view → upload --clobber` if the mirror release exists or `gh release create` if not. All mirror output uses the `[release-mirror]` log prefix.
- `src-tauri/tauri.conf.json` — `plugins.updater.endpoints` flipped from `hurttlocker/cortex-ide` → `hurttlocker/o8`.

## Verification

- `node --check scripts/release.mjs` — passes
- `npx tsc --noEmit` — passes (0 errors)
- No new dependencies, no new abstractions, 2 files modified.