### PR TITLE
fix(settings): drop remaining borderLeft Material accents (MCP + CloudWorkers)

### DIFF
--- a/src/components/desktop/settings/CloudWorkersTab.tsx
+++ b/src/components/desktop/settings/CloudWorkersTab.tsx
@@ -177,14 +177,23 @@ export function CloudWorkersTab() {
       {notice ? (
         <div style={{
           marginBottom: 28,
-          borderLeft: `2px solid #ef4444`,
-          paddingLeft: 14,
           paddingTop: 2,
           paddingBottom: 2,
           fontSize: 13,
           color: 'var(--t-text)',
           lineHeight: 1.55,
         }}>
+          <span style={{
+            fontFamily: MONO_FONT_STACK,
+            fontSize: 11,
+            fontWeight: 500,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            color: '#ef4444',
+            marginRight: 8,
+          }}>
+            [error]
+          </span>
           {notice}
         </div>
       ) : null}
@@ -226,13 +235,24 @@ export function CloudWorkersTab() {
 
         {createdKey ? (
           <div style={{
-            borderLeft: `2px solid ${RAMS_ACCENT}`,
-            paddingLeft: 14,
             paddingTop: 12,
             paddingBottom: 12,
             marginBottom: 16,
           }}>
-            <FieldLabel>key generated — copy now</FieldLabel>
+            <div style={{ marginBottom: 4 }}>
+              <span style={{
+                fontFamily: MONO_FONT_STACK,
+                fontSize: 11,
+                fontWeight: 500,
+                letterSpacing: '0.12em',
+                textTransform: 'uppercase',
+                color: RAMS_ACCENT,
+                marginRight: 8,
+              }}>
+                [active]
+              </span>
+              <FieldLabel>key generated — copy now</FieldLabel>
+            </div>
             <div style={{
               fontSize: 12,
               color: 'var(--t-text-secondary)',

--- a/src/components/desktop/settings/MCPTab.tsx
+++ b/src/components/desktop/settings/MCPTab.tsx
@@ -361,11 +361,20 @@ export function MCPTab() {
           {d.nodeInstalled && d.codexInstalled && !d.ghInstalled ? (
             <div style={{
               marginTop: 14,
-              borderLeft: `2px solid ${RAMS_HAIRLINE_SOFT}`,
-              paddingLeft: 12,
             }}>
               <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--t-text)', marginBottom: 4 }}>
-                GitHub CLI not found (optional)
+                <span style={{
+                  fontFamily: MONO_FONT_STACK,
+                  fontSize: 11,
+                  fontWeight: 500,
+                  letterSpacing: '0.12em',
+                  textTransform: 'uppercase',
+                  color: RAMS_INK_QUIET,
+                  marginRight: 8,
+                }}>
+                  [optional]
+                </span>
+                GitHub CLI not found
               </div>
               <div style={{ color: 'var(--t-text-muted)', fontSize: 12, lineHeight: 1.55 }}>
                 Install with{' '}


### PR DESCRIPTION
## Summary

CLAUDE.md NEVER list bans `borderLeft` accents (Material Design). Three remaining violations swept from `src/components/desktop/settings/`. Matches the pattern already shipped in `OperatorDefaultsTab` (a64cb86) and the not-ready notice fix in `MCPTab` (cd9d0cb).

## Spot replacements

| File:Line | Tone | Old | New |
|---|---|---|---|
| `MCPTab.tsx:364` | hairline (optional notice) | `borderLeft: 2px solid ${RAMS_HAIRLINE_SOFT}` + `paddingLeft: 12` | `[OPTIONAL]` mono prefix in `RAMS_INK_QUIET` |
| `CloudWorkersTab.tsx:180` | error | `borderLeft: 2px solid #ef4444` + `paddingLeft: 14` | `[ERROR]` mono prefix in `#ef4444` |
| `CloudWorkersTab.tsx:229` | active (key generated success highlight) | `borderLeft: 2px solid ${RAMS_ACCENT}` + `paddingLeft: 14` | `[ACTIVE]` mono prefix in `RAMS_ACCENT`, paired with existing `FieldLabel` "key generated — copy now" |

Replacement primitive (consistent with OperatorDefaultsTab):

```tsx
<span style={{
  fontFamily: MONO_FONT_STACK,
  fontSize: 11,
  fontWeight: 500,
  letterSpacing: '0.12em',
  textTransform: 'uppercase',
  color: <SEMANTIC_COLOR>,
  marginRight: 8,
}}>
  [error] | [warn] | [active] | [optional]
</span>
```

`borderLeft` count in `src/components/desktop/settings/MCPTab.tsx` and `CloudWorkersTab.tsx` is now zero. Other settings files (WorkersTab, DiagnosticsTab, GitHubTab, mcp/ExternalMcpServersSection, shared) still carry `borderLeft` and are out of scope for this sweep.

## Test plan

- [x] `npx tsc --noEmit` returns 0
- [x] `grep -n borderLeft src/components/desktop/settings/MCPTab.tsx src/components/desktop/settings/CloudWorkersTab.tsx` returns no matches
- [ ] Visual: MCP tab in Settings → trigger Disclosure with `nodeInstalled && codexInstalled && !ghInstalled` to see the `[optional]` GitHub CLI line render
- [ ] Visual: Cloud Workers tab → fail a fetch to render `notice` and confirm `[error]` prefix replaces the red strip
- [ ] Visual: Cloud Workers tab → generate a key and confirm `[active]` prefix replaces the blue strip on the disclose-once panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)