### PR TITLE
fix(settings): finish borderLeft sweep — Workers, Diagnostics, GitHub, ExternalMCP, shared

### DIFF
--- a/src/components/desktop/settings/DiagnosticsTab.tsx
+++ b/src/components/desktop/settings/DiagnosticsTab.tsx
@@ -207,14 +207,23 @@ export function DiagnosticsTab() {
       {error ? (
         <div style={{
           marginBottom: 28,
-          borderLeft: `2px solid #ef4444`,
-          paddingLeft: 14,
           paddingTop: 2,
           paddingBottom: 2,
           fontSize: 13,
           color: 'var(--t-text)',
           lineHeight: 1.55,
         }}>
+          <span style={{
+            fontFamily: MONO_FONT_STACK,
+            fontSize: 11,
+            fontWeight: 500,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            color: '#ef4444',
+            marginRight: 8,
+          }}>
+            [error]
+          </span>
           {error}
         </div>
       ) : null}
@@ -286,14 +295,23 @@ export function DiagnosticsTab() {
         {pruneError ? (
           <div style={{
             marginTop: 14,
-            borderLeft: `2px solid #ef4444`,
-            paddingLeft: 14,
             paddingTop: 2,
             paddingBottom: 2,
             fontSize: 13,
             color: 'var(--t-text)',
             lineHeight: 1.55,
           }}>
+            <span style={{
+              fontFamily: MONO_FONT_STACK,
+              fontSize: 11,
+              fontWeight: 500,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: '#ef4444',
+              marginRight: 8,
+            }}>
+              [error]
+            </span>
             {pruneError}
           </div>
         ) : null}
@@ -578,14 +596,23 @@ function ResetConfirmModal({
         {error ? (
           <div style={{
             marginBottom: 14,
-            borderLeft: `2px solid #ef4444`,
-            paddingLeft: 12,
             paddingTop: 2,
             paddingBottom: 2,
             fontSize: 12,
             color: 'var(--t-text)',
             lineHeight: 1.5,
           }}>
+            <span style={{
+              fontFamily: MONO_FONT_STACK,
+              fontSize: 11,
+              fontWeight: 500,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: '#ef4444',
+              marginRight: 8,
+            }}>
+              [error]
+            </span>
             {error}
           </div>
         ) : null}

--- a/src/components/desktop/settings/GitHubTab.tsx
+++ b/src/components/desktop/settings/GitHubTab.tsx
@@ -114,11 +114,20 @@ export function GitHubTab({
           color: 'var(--t-text-secondary)',
           fontFamily: APP_FONT_STACK,
           lineHeight: 1.5,
-          borderLeft: `2px solid ${RAMS_ACCENT}`,
-          paddingLeft: 12,
           paddingTop: 2,
           paddingBottom: 2,
         }}>
+          <span style={{
+            fontFamily: MONO_FONT_STACK,
+            fontSize: 11,
+            fontWeight: 500,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            color: RAMS_ACCENT,
+            marginRight: 8,
+          }}>
+            [note]
+          </span>
           {actionNote}
         </div>
       ) : null}

--- a/src/components/desktop/settings/WorkersTab.tsx
+++ b/src/components/desktop/settings/WorkersTab.tsx
@@ -252,14 +252,23 @@ export function WorkersTab() {
       {notice ? (
         <div style={{
           marginBottom: 28,
-          borderLeft: `2px solid #ef4444`,
-          paddingLeft: 14,
           paddingTop: 2,
           paddingBottom: 2,
           fontSize: 13,
           color: 'var(--t-text)',
           lineHeight: 1.55,
         }}>
+          <span style={{
+            fontFamily: MONO_FONT_STACK,
+            fontSize: 11,
+            fontWeight: 500,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            color: '#ef4444',
+            marginRight: 8,
+          }}>
+            [error]
+          </span>
           {notice}
         </div>
       ) : null}
@@ -300,13 +309,24 @@ export function WorkersTab() {
 
         {createdToken ? (
           <div style={{
-            borderLeft: `2px solid ${RAMS_ACCENT}`,
-            paddingLeft: 14,
             paddingTop: 12,
             paddingBottom: 12,
             marginBottom: 16,
           }}>
-            <FieldLabel>token created — copy now</FieldLabel>
+            <div style={{ marginBottom: 4 }}>
+              <span style={{
+                fontFamily: MONO_FONT_STACK,
+                fontSize: 11,
+                fontWeight: 500,
+                letterSpacing: '0.12em',
+                textTransform: 'uppercase',
+                color: RAMS_ACCENT,
+                marginRight: 8,
+              }}>
+                [active]
+              </span>
+              <FieldLabel>token created — copy now</FieldLabel>
+            </div>
             <div style={{
               fontSize: 12,
               color: 'var(--t-text-secondary)',
@@ -628,8 +648,6 @@ export function WorkersTab() {
 
         {restartRequired ? (
           <div style={{
-            borderLeft: `2px solid #f59e0b`,
-            paddingLeft: 14,
             paddingTop: 2,
             paddingBottom: 2,
             fontSize: 12,
@@ -637,6 +655,17 @@ export function WorkersTab() {
             lineHeight: 1.55,
             marginBottom: 14,
           }}>
+            <span style={{
+              fontFamily: MONO_FONT_STACK,
+              fontSize: 11,
+              fontWeight: 500,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: '#f59e0b',
+              marginRight: 8,
+            }}>
+              [warn]
+            </span>
             Restart o8 to {restartAction} remote runtime adapters. This session stays {remoteRuntimeRegistered ? 'loaded' : 'unloaded'} until restart.
           </div>
         ) : (

--- a/src/components/desktop/settings/mcp/ExternalMcpServersSection.tsx
+++ b/src/components/desktop/settings/mcp/ExternalMcpServersSection.tsx
@@ -306,24 +306,42 @@ export function ExternalMcpServersSection() {
 
         {note ? (
           <div style={{
-            borderLeft: `2px solid ${note.ok ? '#22c55e' : '#ef4444'}`,
-            paddingLeft: 12,
             fontSize: 12,
             color: note.ok ? '#15803d' : '#dc2626',
             lineHeight: 1.55,
           }}>
+            <span style={{
+              fontFamily: MONO_FONT_STACK,
+              fontSize: 11,
+              fontWeight: 500,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: note.ok ? '#22c55e' : '#ef4444',
+              marginRight: 8,
+            }}>
+              {note.ok ? '[ok]' : '[error]'}
+            </span>
             {note.message}
           </div>
         ) : null}
 
         {error ? (
           <div style={{
-            borderLeft: `2px solid #ef4444`,
-            paddingLeft: 12,
             fontSize: 12,
             color: '#dc2626',
             lineHeight: 1.55,
           }}>
+            <span style={{
+              fontFamily: MONO_FONT_STACK,
+              fontSize: 11,
+              fontWeight: 500,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: '#ef4444',
+              marginRight: 8,
+            }}>
+              [error]
+            </span>
             {error}
           </div>
         ) : null}

--- a/src/components/desktop/settings/shared.tsx
+++ b/src/components/desktop/settings/shared.tsx
@@ -247,20 +247,19 @@ export function TabButton({ label, icon, active, onClick, comingSoon = false }: 
         paddingLeft: 14,
         borderRadius: 0,
         border: 'none',
-        borderLeft: active ? `2px solid ${RAMS_ACCENT}` : '2px solid transparent',
         background: 'transparent',
-        color: active ? 'var(--t-text)' : 'var(--t-text-secondary)',
+        color: active ? RAMS_ACCENT : 'var(--t-text-secondary)',
         fontSize: 13,
         fontWeight: active ? 500 : 400,
         cursor: 'pointer',
         textAlign: 'left',
         fontFamily: APP_FONT_STACK,
         letterSpacing: '-0.01em',
-        transition: 'color 120ms, border-color 120ms',
+        transition: 'color 120ms',
         opacity: comingSoon && !active ? 0.55 : 1,
       }}
     >
-      <span style={{ flexShrink: 0, color: active ? 'var(--t-text)' : 'var(--t-text-muted)', display: 'inline-flex' }}>
+      <span style={{ flexShrink: 0, color: active ? RAMS_ACCENT : 'var(--t-text-muted)', display: 'inline-flex' }}>
         {icon}
       </span>
       <span style={{ flex: 1 }}>{label}</span>


### PR DESCRIPTION
## Summary

CLAUDE.md NEVER list bans borderLeft accents (Material Design pattern). #701 swept MCP + CloudWorkers; this PR finishes the remaining 10 violations across the settings tree.

All replacements follow the established pattern from a64cb86, cd9d0cb, 31b0a7f: bracketed mono prefix at the start of the content, color matching the prior border tone, no spread of layout.

## Files changed

| File:Line | Tone | Replacement |
|---|---|---|
| `DiagnosticsTab.tsx:210` | error (#ef4444) | `[error]` mono prefix |
| `DiagnosticsTab.tsx:289` | error (#ef4444) | `[error]` mono prefix |
| `DiagnosticsTab.tsx:581` | error (#ef4444) | `[error]` mono prefix |
| `WorkersTab.tsx:255` | error (#ef4444) | `[error]` mono prefix |
| `WorkersTab.tsx:303` | accent (RAMS_ACCENT) | `[active]` mono prefix |
| `WorkersTab.tsx:631` | warn (#f59e0b) | `[warn]` mono prefix |
| `GitHubTab.tsx:117` | accent (RAMS_ACCENT) | `[note]` mono prefix |
| `mcp/ExternalMcpServersSection.tsx:309` | ok/error (#22c55e/#ef4444) | `[ok]` / `[error]` mono prefix |
| `mcp/ExternalMcpServersSection.tsx:321` | error (#ef4444) | `[error]` mono prefix |
| `shared.tsx:250` (TabButton active) | accent (RAMS_ACCENT) | drop borderLeft, swap active text/icon to `RAMS_ACCENT` + `fontWeight: 500` |

## Verification

- `grep -rn 'borderLeft' src/components/desktop/settings/` → **0 matches**
- `npx tsc --noEmit` → **0 errors**
- 5 files modified, +105 / −23 lines

## Test plan

- [ ] Open Settings → Diagnostics, trigger an error, verify `[error]` mono prefix renders
- [ ] Open Settings → Workers, generate a token, verify `[active]` prefix on the highlight block
- [ ] Open Settings → Workers, toggle remote runtime flag, verify `[warn]` prefix on the restart notice
- [ ] Open Settings → Connectors (GitHub), trigger any action that surfaces a note, verify `[note]` prefix
- [ ] Open Settings → MCP, attempt to test/save an external MCP server with bad config, verify `[error]`/`[ok]` prefix
- [ ] Click through every Settings tab, verify the active TabButton uses orange accent text + medium weight (no left bar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)