### PR TITLE
fix(split-pane): persist AgentTileLayout pane widths to localStorage

### DIFF
--- a/src/components/desktop/workspace-terminal/AgentTileLayout.tsx
+++ b/src/components/desktop/workspace-terminal/AgentTileLayout.tsx
@@ -12,6 +12,14 @@ interface AgentTileLayoutProps {
 
 const DIVIDER_WIDTH = 4;
 const MIN_PANE_WIDTH = 280;
+const STORAGE_KEY = 'cortex-ide:agent-tile-widths';
+const PRUNE_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface StoredWidthEntry {
+  widths: number[];
+  updatedAt: number;
+}
+type StoredWidthMap = Record<string, StoredWidthEntry>;
 
 function evenWidths(count: number): number[] {
   if (count <= 0) return [];
@@ -20,6 +28,59 @@ function evenWidths(count: number): number[] {
   const sum = widths.reduce((total, value) => total + value, 0);
   widths[count - 1] = Number((widths[count - 1] + (100 - sum)).toFixed(2));
   return widths;
+}
+
+function hashSessions(sessions: string[]): string {
+  return sessions.slice().sort().join('|');
+}
+
+function loadStoredWidthMap(): StoredWidthMap {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return {};
+    const result: StoredWidthMap = {};
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!value || typeof value !== 'object') continue;
+      const candidate = value as { widths?: unknown; updatedAt?: unknown };
+      if (
+        Array.isArray(candidate.widths)
+        && candidate.widths.every((n) => typeof n === 'number' && Number.isFinite(n))
+        && typeof candidate.updatedAt === 'number'
+      ) {
+        result[key] = { widths: candidate.widths as number[], updatedAt: candidate.updatedAt };
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+function saveStoredWidthMap(hash: string, widths: number[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const map = loadStoredWidthMap();
+    const now = Date.now();
+    map[hash] = { widths, updatedAt: now };
+    for (const [key, entry] of Object.entries(map)) {
+      if (now - entry.updatedAt > PRUNE_AGE_MS) {
+        delete map[key];
+      }
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // localStorage may be full or disabled; silently ignore.
+  }
+}
+
+function readWidthsForHash(hash: string, count: number): number[] | null {
+  const map = loadStoredWidthMap();
+  const entry = map[hash];
+  if (entry && entry.widths.length === count) return entry.widths;
+  return null;
 }
 
 function cycleSession(sessions: string[], current: string | null, direction: 1 | -1): string | null {
@@ -36,10 +97,25 @@ export function AgentTileLayout({
   onCloseSession,
 }: AgentTileLayoutProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [storedWidths, setStoredWidths] = useState<number[]>(() => evenWidths(sessions.length));
+  const sessionsHash = useMemo(() => hashSessions(sessions), [sessions]);
+  const [storedWidths, setStoredWidths] = useState<number[]>(() => {
+    const persisted = readWidthsForHash(sessionsHash, sessions.length);
+    return persisted ?? evenWidths(sessions.length);
+  });
+  const lastHashRef = useRef<string>(sessionsHash);
   const [focusedSession, setFocusedSession] = useState<string | null>(sessions[0] ?? null);
   const [hoveredDivider, setHoveredDivider] = useState<number | null>(null);
   const [draggingDivider, setDraggingDivider] = useState<number | null>(null);
+
+  // When the session set changes (agent spawn/die), rehydrate widths for the
+  // new hash from localStorage if available, else fall back to even widths.
+  useEffect(() => {
+    if (lastHashRef.current === sessionsHash) return;
+    lastHashRef.current = sessionsHash;
+    const persisted = readWidthsForHash(sessionsHash, sessions.length);
+    setStoredWidths(persisted ?? evenWidths(sessions.length));
+  }, [sessionsHash, sessions.length]);
+
   const widths = useMemo(
     () => storedWidths.length === sessions.length ? storedWidths : evenWidths(sessions.length),
     [sessions.length, storedWidths],
@@ -100,6 +176,7 @@ export function AgentTileLayout({
     const startRight = startWidths[dividerIndex + 1] ?? 0;
     const pairTotal = startLeft + startRight;
     const minPercent = Math.min((MIN_PANE_WIDTH / availableWidth) * 100, pairTotal / 2);
+    let latestWidths = startWidths;
 
     setDraggingDivider(dividerIndex);
 
@@ -113,6 +190,7 @@ export function AgentTileLayout({
       const nextWidths = [...startWidths];
       nextWidths[dividerIndex] = Number(nextLeft.toFixed(2));
       nextWidths[dividerIndex + 1] = Number(nextRight.toFixed(2));
+      latestWidths = nextWidths;
       setStoredWidths(nextWidths);
     };
 
@@ -120,6 +198,11 @@ export function AgentTileLayout({
       setDraggingDivider(null);
       document.removeEventListener('mousemove', handleMove);
       document.removeEventListener('mouseup', handleUp);
+      // Persist final widths once the user releases the divider so layout
+      // survives unmount/remount and full app restarts.
+      if (latestWidths.length === sessions.length) {
+        saveStoredWidthMap(sessionsHash, latestWidths);
+      }
     };
 
     document.addEventListener('mousemove', handleMove);


### PR DESCRIPTION
## Summary
Closes the unmet acceptance criterion 3 of PR #663 — `AgentTileLayout` split-pane widths are now durable across component unmount, tab switch, and full app restart.

Before this change, drag-resized widths only lived in component `useState`, so any unmount (tab switch) or app restart wiped the layout back to evenly-distributed widths.

## What changed
- New localStorage key: **`cortex-ide:agent-tile-widths`**
- Storage shape: `Record<sessionsHash, { widths: number[]; updatedAt: number }>`
- **Session-set hash**: `sessions.slice().sort().join('|')` — different fleet compositions get different stored widths so cycling through agent sets doesn't bleed.
- **Hydration**: on mount and whenever the session-set hash changes (agent spawn/die), we read the matching entry. If its `widths.length === sessions.length`, we use it; otherwise we fall back to `evenWidths()`.
- **Persistence**: writes only fire on **mouseup** (resize end) inside `handleUp`, not on every mousemove — no thrashing during drag.
- **Prune policy**: each write removes entries older than 7 days (`PRUNE_AGE_MS = 7 * 24h`) so the key can't grow unbounded over many fleet compositions.

## Acceptance criteria covered
- [x] Width changes survive component unmount + remount within the same session
- [x] Width changes survive a full app restart (localStorage durable)
- [x] Different session-sets get different stored widths (no bleed)
- [x] Stale entries (>7 days) pruned on write
- [x] `npx tsc --noEmit` returns 0
- [x] No visual diff — pure persistence wiring

## Test plan
- [ ] Drag a divider in a 2-pane layout, switch tabs, return — widths preserved.
- [ ] Drag a divider, restart the app — widths preserved.
- [ ] Spawn a third agent so the session set changes — layout falls back to even widths for the new 3-pane hash.
- [ ] Kill that third agent so the original 2-pane hash returns — original drag widths restored.
- [ ] Inspect `localStorage.getItem('cortex-ide:agent-tile-widths')` — see hash → `{ widths, updatedAt }` map.