### PR TITLE
fix(tabs): unique terminal labels (closes #708)

### DIFF
--- a/src/components/desktop/workspace-terminal/terminal-restore.ts
+++ b/src/components/desktop/workspace-terminal/terminal-restore.ts
@@ -12,6 +12,7 @@ import type {
   RegisteredRepo,
   TerminalTab,
 } from '@/components/desktop/workspace-terminal/types';
+import { nextTerminalLabel } from '@/components/desktop/workspace-terminal/terminal-tab-handlers';
 import {
   claimWorkspaceTabId,
 } from '@/components/desktop/workspace-terminal/utils';
@@ -91,6 +92,17 @@ export async function computeRestoredTabs(
     if (cancelled?.()) return null;
     const now = Date.now();
     const tabKind = savedTab.kind ?? 'terminal';
+
+    // Issue #708 — orchestrator tabs are never restored from persistence.
+    // The pinned Orchestrator is injected fresh by the migration effect in
+    // useWorkspaceTerminalController, so any persisted `kind: 'orchestrator'`
+    // entries are stale duplicates. Skipping them avoids two failure modes:
+    //   (a) duplicate Orchestrator tabs after restore;
+    //   (b) silent fallthrough to the default `terminal` branch below, which
+    //       would carry the "Orchestrator" label onto a real terminal tab.
+    if (tabKind === 'orchestrator') {
+      continue;
+    }
 
     if (tabKind === 'llm-chat') {
       const tabId = claimWorkspaceTabId('llm-chat', seenTabIds, savedTab.id);
@@ -240,6 +252,17 @@ export async function computeRestoredTabs(
       });
     }
     if (savedTab.id === saved.activeTabId) restoredActiveTabId = tabId;
+  }
+
+  // Issue #708 — backfill terminal tabs whose label was lost or inherited
+  // the literal string "Orchestrator" from an earlier persisted-orchestrator
+  // fallthrough. We assign each one the next available `Terminal N` label so
+  // the result never collides with an existing valid number.
+  for (const restored of restoredTabs) {
+    if (restored.kind !== 'terminal') continue;
+    const trimmed = restored.label?.trim() ?? '';
+    if (trimmed && trimmed !== 'Orchestrator') continue;
+    restored.label = nextTerminalLabel(restoredTabs);
   }
 
   const restoredActiveTab = restoredActiveTabId ? restoredTabs.find((tab) => tab.id === restoredActiveTabId) : null;

--- a/src/components/desktop/workspace-terminal/terminal-tab-handlers.ts
+++ b/src/components/desktop/workspace-terminal/terminal-tab-handlers.ts
@@ -33,18 +33,40 @@ export interface NewTerminalTabResult {
   cliCommand: string | null;
 }
 
+/**
+ * Issue #708 — pick the lowest unused `Terminal N` number among existing
+ * shell terminal tabs. Only labels matching `Terminal <integer>` participate;
+ * agent-named terminals (Claude Code, Codex, etc.) keep their own labels.
+ */
+export function nextTerminalLabel(tabs: TerminalTab[]): string {
+  const used = new Set<number>();
+  for (const tab of tabs) {
+    if (tab.kind !== 'terminal') continue;
+    const match = /^Terminal\s+(\d+)$/.exec(tab.label?.trim() ?? '');
+    if (match) used.add(Number(match[1]));
+  }
+  let n = 1;
+  while (used.has(n)) n += 1;
+  return `Terminal ${n}`;
+}
+
 export function computeNewTerminalTab(
   agentId: string,
   repo?: RegisteredRepo,
+  currentTabs: TerminalTab[] = [],
 ): NewTerminalTabResult {
   const agent = CLI_AGENTS.find((candidate) => candidate.id === agentId);
   if (!agent) return { newTab: null, activeTabId: '', cliCommand: null };
 
   const tabId = createWorkspaceTabId('terminal');
   const now = Date.now();
+  // Generic shell terminals get unique `Terminal N` labels; agent CLIs
+  // (Claude Code, Codex, OpenCode, Gemini CLI) keep their named labels so
+  // the user can tell at a glance which CLI is loaded.
+  const label = agentId === 'shell' ? nextTerminalLabel(currentTabs) : agent.label;
   const newTab: TerminalTab = {
     id: tabId,
-    label: agent.label,
+    label,
     kind: 'terminal',
     tmuxSession: null,
     cliAgent: agentId,
@@ -351,15 +373,15 @@ export function resolveRunCommandTarget(tabs: TerminalTab[]): RunCommandResult {
   if (pendingShell) {
     return { kind: 'pending-shell', pendingTabId: pendingShell.id };
   }
-  return { kind: 'new-tab', newTab: buildRunCommandTab() };
+  return { kind: 'new-tab', newTab: buildRunCommandTab(tabs) };
 }
 
-export function buildRunCommandTab(): TerminalTab {
+export function buildRunCommandTab(currentTabs: TerminalTab[] = []): TerminalTab {
   const nextTabId = createWorkspaceTabId('terminal');
   const now = Date.now();
   return {
     id: nextTabId,
-    label: 'Terminal',
+    label: nextTerminalLabel(currentTabs),
     kind: 'terminal',
     tmuxSession: null,
     cliAgent: 'shell',

--- a/src/components/desktop/workspace-terminal/useWorkspaceTerminalController.ts
+++ b/src/components/desktop/workspace-terminal/useWorkspaceTerminalController.ts
@@ -593,7 +593,8 @@ export function useWorkspaceTerminalController(
   }, []);
 
   const handleNewTab = useCallback((agentId: string, repo?: RegisteredRepo) => {
-    const result = computeNewTerminalTab(agentId, repo);
+    // Pass the current tabs so `Terminal N` numbering picks the next free slot.
+    const result = computeNewTerminalTab(agentId, repo, tabsRef.current);
     if (!result.newTab) return;
     if (result.cliCommand) {
       pendingCliCommands.current.set(result.newTab.id, result.cliCommand);


### PR DESCRIPTION
## Summary

Fresh launches of `/Applications/o8.app` showed three tab pills all labeled "Orchestrator". The first was the pinned default; tabs 2 and 3 were `kind: 'terminal'` tabs whose label said "Orchestrator" but content rendered a raw zsh prompt.

**Root cause:** `terminal-restore.ts` had no branch for `tabKind === 'orchestrator'`. Persisted orchestrator entries fell through to the default terminal branch (line 216), which uses `label: savedTab.label` — so the saved "Orchestrator" label rode onto a terminal tab while the kind silently became `terminal`. The migration effect in `useWorkspaceTerminalController` then injected a fresh real Orchestrator at index 0, leaving three "Orchestrator"-labeled tabs in the strip.

## Changes

- **`terminal-restore.ts`** — drop persisted `kind: 'orchestrator'` tabs at the top of the restore loop. The pinned Orchestrator is always injected fresh by the migration effect, so restored entries are stale duplicates.
- **`terminal-restore.ts`** — post-loop sweep relabels any restored `kind: 'terminal'` tab whose label is empty or `"Orchestrator"` to the next available `Terminal N` via `nextTerminalLabel`, so existing affected users get clean labels on first reload.
- **`terminal-tab-handlers.ts`** — new `nextTerminalLabel(tabs)` helper returns the lowest unused `Terminal N`. Wired into `computeNewTerminalTab` (shell path only) and `buildRunCommandTab`. Agent-named CLIs (Claude Code, Codex, OpenCode, Gemini CLI) keep their named labels.
- **`useWorkspaceTerminalController.ts`** — pass `tabsRef.current` into `computeNewTerminalTab` so the numbering function can see the existing set.

The pinned Orchestrator + Assistant tabs continue to be identified by `kind === 'orchestrator'` and `kind === 'llm-chat'` in the TabBar — never by label string — so they stay canonical.

## Note on TILE_LAYOUT_VERSION

The issue suggested driving the migration through `migrateNode()` in `lib/tiles/operations.ts`, but that file handles the tile-tree content kinds (the split-pane layout). The bug is in the **separate** persisted tab state (`~/.o8/terminal-states/<scope>.json`) which has its own `version: 1` field. The sweep in `terminal-restore.ts` is idempotent and self-heals on the next save, so no `TILE_LAYOUT_VERSION` bump is needed (and bumping it would unnecessarily reset everyone's split-pane layouts).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] No new lint warnings (4 pre-existing warnings on `main` unchanged)
- [x] Smoke-tested `nextTerminalLabel` against 8 cases (empty, single, gap, mixed kinds, etc.)
- [x] Smoke-tested the restore backfill against the user's exact repro (1 pinned + 2 mislabeled → `Orchestrator`, `Terminal 1`, `Terminal 2`)
- [ ] User reload test on installed app: persisted state with 3 "Orchestrator"-labeled tabs becomes 1 Orchestrator + Terminal 1 + Terminal 2
- [ ] Fresh user with no persisted state still sees only the two pinned tabs (Orchestrator + Assistant)
- [ ] Spawning a new shell terminal labels it `Terminal {next-free-N}`
- [ ] Spawning a Claude Code / Codex / OpenCode / Gemini CLI terminal still shows the agent's label

Closes #708