### PR TITLE
fix(tabs): make orchestrator bootstrap idempotent on remount (closes #714)

### DIFF
--- a/src/components/desktop/workspace-terminal/terminal-restore.ts
+++ b/src/components/desktop/workspace-terminal/terminal-restore.ts
@@ -100,7 +100,16 @@ export async function computeRestoredTabs(
     //   (a) duplicate Orchestrator tabs after restore;
     //   (b) silent fallthrough to the default `terminal` branch below, which
     //       would carry the "Orchestrator" label onto a real terminal tab.
-    if (tabKind === 'orchestrator') {
+    //
+    // Issue #714 — also skip any tab whose ID begins with `orchestrator-`,
+    // regardless of its persisted `kind`. The `orchestrator-` prefix is only
+    // ever produced by `createWorkspaceTabId('orchestrator')`, so a saved tab
+    // with that prefix was originally an orchestrator. If a downstream code
+    // path mutated its `kind` to `terminal` (the disk artifact that triggered
+    // #714), it is still a zombie that the migration effect will replace —
+    // resurrecting it as a real terminal would produce the duplicate-tab
+    // symptom on every controller remount.
+    if (tabKind === 'orchestrator' || (savedTab.id ?? '').startsWith('orchestrator-')) {
       continue;
     }
 

--- a/src/components/desktop/workspace-terminal/terminal-tab-handlers.ts
+++ b/src/components/desktop/workspace-terminal/terminal-tab-handlers.ts
@@ -306,8 +306,16 @@ export function buildHistoryChatTab(
 /* ------------------------------------------------------------------ */
 
 export function serializeTabsForPersistence(currentTabs: TerminalTab[]) {
+  // Issue #714 — strip zombies before they hit disk:
+  //   - canvas:ci tabs (legacy, never persisted)
+  //   - orchestrator-prefixed tabs whose `kind` was mutated away from
+  //     'orchestrator' (the disk artifact that triggered #714). These are
+  //     stale stubs that the migration effect will replace on next mount;
+  //     persisting them resurrects them as fake "Orchestrator"-labeled
+  //     terminals across remounts.
   return currentTabs
     .filter((tab) => !(tab.kind === 'canvas' && tab.canvasTab?.kind === 'ci'))
+    .filter((tab) => !(tab.kind !== 'orchestrator' && tab.id.startsWith('orchestrator-')))
     .map((tab) => ({
       id: tab.id,
       label: tab.label,

--- a/src/components/desktop/workspace-terminal/useWorkspaceTerminalController.ts
+++ b/src/components/desktop/workspace-terminal/useWorkspaceTerminalController.ts
@@ -470,15 +470,28 @@ export function useWorkspaceTerminalController(
   // Migration: if restored state is missing an Orchestrator tab, inject one
   // at the front. Ensures existing users get the new tab automatically and
   // don't have to manually add it.
+  //
+  // Issue #714 — this effect MUST be idempotent against any remount (theme
+  // switch, HMR, parent re-render that unmounts TileContainer, etc.). The
+  // contract: never produce a duplicate orchestrator. Two layers of dedup:
+  //   1. State-side: bail if `tabs` already has an orchestrator-kind tab.
+  //   2. Ref-side: also bail if `tabsRef.current` has one. Covers the window
+  //      where another setTabs has scheduled an update we haven't rendered.
+  // Setting via the functional updater form gives us a third guard against
+  // batched / out-of-order state writes that could otherwise stack two
+  // injectors onto the same base.
   useEffect(() => {
     if (defaultTab !== 'llm-chat') return;
     if (tabs.length === 0) return;
-    const hasOrchestrator = tabs.some((tab) => tab.kind === 'orchestrator');
-    if (hasOrchestrator) return;
-    const orchestratorTab = createDefaultOrchestratorTab();
-    const nextTabs = [orchestratorTab, ...tabs];
-    tabsRef.current = nextTabs;
-    setTabs(nextTabs);
+    if (tabs.some((tab) => tab.kind === 'orchestrator')) return;
+    if (tabsRef.current.some((tab) => tab.kind === 'orchestrator')) return;
+    setTabs((previous) => {
+      if (previous.some((tab) => tab.kind === 'orchestrator')) return previous;
+      const orchestratorTab = createDefaultOrchestratorTab();
+      const nextTabs = [orchestratorTab, ...previous];
+      tabsRef.current = nextTabs;
+      return nextTabs;
+    });
     // Don't steal focus from whatever the user was on — just inject the tab.
   }, [createDefaultOrchestratorTab, defaultTab, tabs]);
 


### PR DESCRIPTION
## Summary

- **Root cause**: a zombie tab on disk — a saved entry whose `id` started with `orchestrator-` (so it was originally an orchestrator-kind tab) but whose `kind` had been mutated to `terminal` somewhere upstream. The #708 skip rule only matched on `kind === 'orchestrator'`, so the zombie fell through to the default terminal branch in `computeRestoredTabs` and was resurrected as a fake "Orchestrator"-labeled terminal on every controller remount (e.g. when navigating Settings → workspace after a theme switch).
- **Fix**: three layers of dedup so this can't recur — restore-side skip on `orchestrator-` prefix, controller-side rock-solid bootstrap idempotency (state + ref + functional-updater guards), persistence-side filter that strips `orchestrator-`-prefixed non-orchestrator zombies before they hit disk.
- **Confirmed**: `ThemeProvider` does not unmount any subtree on theme change — it only writes CSS vars on `<html>` and persists to localStorage. The remount that triggered #714 was actually the `activeNavSection !== 'settings'` conditional around `<TileContainer>` in `dashboard/page.tsx`, but the bootstrap contract is now strong enough that any cause of remount is safe.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally — clean)
- [ ] Open o8 with the existing `~/.o8/terminal-states/tile-root.json`. Tabs should be `Orchestrator | Assistant`, no duplicate.
- [ ] Settings → Appearance → toggle Light/Midnight a few times. Navigate back to workspace. Tabs should still be `Orchestrator | Assistant`, no duplicate "Orchestrator" terminal.
- [ ] Repeat with a fresh data dir (`CORTEX_IDE_DATA_DIR=$(mktemp -d) ...`) — should still bootstrap exactly two tabs and no duplicate.
- [ ] Manually corrupt the persisted file (`kind: 'terminal'` with `id: 'orchestrator-...'` and `label: 'Orchestrator'`), relaunch — the zombie should be skipped on restore, and on next save the file should no longer contain the bad entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)