### PR TITLE
fix(tabs): apply tab dedupe across all restore paths (closes #713)

### DIFF
--- a/src/app/api/panel/terminal-state/route.ts
+++ b/src/app/api/panel/terminal-state/route.ts
@@ -4,7 +4,11 @@ import { NextResponse } from 'next/server';
 import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, statSync } from 'fs';
 import path from 'path';
 import { listRepos } from '@/lib/repos/registry';
-import { buildRepoStateScope } from '@/lib/terminal/tab-state';
+import {
+  buildRepoStateScope,
+  sanitizePersistedState,
+  type PersistedTabState,
+} from '@/lib/terminal/tab-state';
 
 const HOME = process.env.HOME ?? '/tmp';
 const STATE_DIR = path.join(HOME, '.o8');
@@ -18,6 +22,46 @@ function sanitizeScope(rawScope: string | null) {
 
 function getStateFile(scope: string) {
   return path.join(STATE_SCOPE_DIR, `${scope}.json`);
+}
+
+type StateFilePayload = Record<string, unknown>;
+
+/**
+ * Read a persisted-state file, apply the issue #713 sanitizer (drop stale
+ * `kind: 'orchestrator'` entries + relabel `kind: 'terminal'` tabs whose
+ * label is "Orchestrator"), and write the corrected payload back to disk
+ * whenever the sanitizer mutated anything. This is the migration step —
+ * once any client touches the file, it heals permanently.
+ *
+ * Returns the sanitized payload (or the original parsed JSON if it didn't
+ * have the persisted shape). On any IO error or non-object payload, returns
+ * null.
+ */
+function readAndSanitizeStateFile(filePath: string): StateFilePayload | null {
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, 'utf-8')) as unknown;
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+    const obj = parsed as StateFilePayload;
+    if (obj.version !== 1 || !Array.isArray(obj.tabs)) {
+      return obj;
+    }
+    const state = obj as unknown as PersistedTabState;
+    const { state: sanitized, mutated } = sanitizePersistedState(state);
+    if (mutated) {
+      try {
+        writeFileSync(filePath, JSON.stringify(sanitized, null, 2));
+        console.log(`[terminal-state] sanitized stale orchestrator/terminal labels in ${path.basename(filePath)}`);
+      } catch {
+        // Sanitized in-memory copy still wins for this response; the next
+        // save will rewrite the file anyway.
+      }
+    }
+    return sanitized as unknown as StateFilePayload;
+  } catch {
+    return null;
+  }
 }
 
 function normalizeScopePath(value?: string | null) {
@@ -100,13 +144,14 @@ function findLatestRepoState(repoPath: string, excludeFile?: string | null) {
         return null;
       }
       try {
-        const parsed = JSON.parse(readFileSync(fullPath, 'utf-8'));
+        const parsed = readAndSanitizeStateFile(fullPath);
+        if (!parsed) return null;
         const stats = repoStateStats(parsed, repoPath);
         if (stats.matchingCount === 0) {
           return null;
         }
-        const savedAt = typeof parsed?.savedAt === 'string'
-          ? Date.parse(parsed.savedAt)
+        const savedAt = typeof (parsed as { savedAt?: string })?.savedAt === 'string'
+          ? Date.parse((parsed as { savedAt: string }).savedAt)
           : statSync(fullPath).mtimeMs;
         return {
           matchingCount: stats.matchingCount,
@@ -117,7 +162,7 @@ function findLatestRepoState(repoPath: string, excludeFile?: string | null) {
         return null;
       }
     })
-    .filter((entry): entry is { matchingCount: number; savedAt: number; data: unknown } => Boolean(entry))
+    .filter((entry): entry is { matchingCount: number; savedAt: number; data: StateFilePayload } => Boolean(entry))
     .sort((a, b) => {
       if (b.matchingCount !== a.matchingCount) return b.matchingCount - a.matchingCount;
       return b.savedAt - a.savedAt;
@@ -139,13 +184,16 @@ function findLatestNonEmptyState(excludeFile?: string | null) {
         return null;
       }
       try {
-        const parsed = JSON.parse(readFileSync(fullPath, 'utf-8'));
-        const tabs = Array.isArray(parsed?.tabs) ? parsed.tabs : [];
+        const parsed = readAndSanitizeStateFile(fullPath);
+        if (!parsed) return null;
+        const tabs = Array.isArray((parsed as { tabs?: unknown[] })?.tabs)
+          ? (parsed as { tabs: unknown[] }).tabs
+          : [];
         if (tabs.length === 0) {
           return null;
         }
-        const savedAt = typeof parsed?.savedAt === 'string'
-          ? Date.parse(parsed.savedAt)
+        const savedAt = typeof (parsed as { savedAt?: string })?.savedAt === 'string'
+          ? Date.parse((parsed as { savedAt: string }).savedAt)
           : statSync(fullPath).mtimeMs;
         return {
           savedAt: Number.isFinite(savedAt) ? savedAt : statSync(fullPath).mtimeMs,
@@ -155,7 +203,7 @@ function findLatestNonEmptyState(excludeFile?: string | null) {
         return null;
       }
     })
-    .filter((entry): entry is { savedAt: number; data: unknown } => Boolean(entry))
+    .filter((entry): entry is { savedAt: number; data: StateFilePayload } => Boolean(entry))
     .sort((a, b) => b.savedAt - a.savedAt);
 
   return candidates[0]?.data ?? null;
@@ -174,7 +222,8 @@ export async function GET(request: Request) {
     const stateFile = getStateFile(scope);
 
     if (existsSync(stateFile)) {
-      const data = filterStateToRegisteredRepos(JSON.parse(readFileSync(stateFile, 'utf-8')), repoRoots);
+      const sanitizedFile = readAndSanitizeStateFile(stateFile);
+      const data = sanitizedFile ? filterStateToRegisteredRepos(sanitizedFile, repoRoots) : null;
       if (!data) {
         return NextResponse.json(null, { status: 404 });
       }
@@ -189,7 +238,8 @@ export async function GET(request: Request) {
         if (canonicalScope && canonicalScope !== scope) {
           const canonicalFile = getStateFile(canonicalScope);
           if (existsSync(canonicalFile)) {
-            const canonicalData = filterStateToRegisteredRepos(JSON.parse(readFileSync(canonicalFile, 'utf-8')), repoRoots);
+            const canonicalSanitized = readAndSanitizeStateFile(canonicalFile);
+            const canonicalData = canonicalSanitized ? filterStateToRegisteredRepos(canonicalSanitized, repoRoots) : null;
             if (canonicalData) {
               return NextResponse.json(canonicalData);
             }
@@ -214,7 +264,8 @@ export async function GET(request: Request) {
     }
 
     if (scope === 'tile-root' && existsSync(LEGACY_STATE_FILE)) {
-      const data = filterStateToRegisteredRepos(JSON.parse(readFileSync(LEGACY_STATE_FILE, 'utf-8')), repoRoots);
+      const sanitizedLegacy = readAndSanitizeStateFile(LEGACY_STATE_FILE);
+      const data = sanitizedLegacy ? filterStateToRegisteredRepos(sanitizedLegacy, repoRoots) : null;
       if (!data) {
         return NextResponse.json(null, { status: 404 });
       }
@@ -245,14 +296,33 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
   try {
     const scope = sanitizeScope(new URL(request.url).searchParams.get('scope'));
-    const state = await request.json();
+    const incoming = await request.json();
+    // Issue #713 — server-side scrub on every save. The client also
+    // sanitizes (via `saveTabState` in lib/terminal/tab-state.ts), but a
+    // stale or older client could still POST a payload with `kind:
+    // 'orchestrator'` entries or "Orchestrator"-labeled terminals. Catching
+    // it here means the file on disk is always clean regardless of who
+    // wrote it.
+    let payload = incoming;
+    if (
+      incoming
+      && typeof incoming === 'object'
+      && (incoming as { version?: number }).version === 1
+      && Array.isArray((incoming as { tabs?: unknown }).tabs)
+    ) {
+      const { state: sanitized, mutated } = sanitizePersistedState(incoming as PersistedTabState);
+      if (mutated) {
+        console.log('[terminal-state] sanitized stale orchestrator/terminal labels in POST payload');
+        payload = sanitized;
+      }
+    }
     if (!existsSync(STATE_DIR)) {
       mkdirSync(STATE_DIR, { recursive: true });
     }
     if (!existsSync(STATE_SCOPE_DIR)) {
       mkdirSync(STATE_SCOPE_DIR, { recursive: true });
     }
-    const serialized = JSON.stringify(state, null, 2);
+    const serialized = JSON.stringify(payload, null, 2);
     writeFileSync(getStateFile(scope), serialized);
     if (scope === 'tile-root') {
       writeFileSync(LEGACY_STATE_FILE, serialized);

--- a/src/components/desktop/workspace-terminal/useWorkspaceTerminalController.ts
+++ b/src/components/desktop/workspace-terminal/useWorkspaceTerminalController.ts
@@ -467,20 +467,38 @@ export function useWorkspaceTerminalController(
     }
   }, [sendTerminalAttach, termWsConnected]);
 
-  // Migration: if restored state is missing an Orchestrator tab, inject one
-  // at the front. Ensures existing users get the new tab automatically and
-  // don't have to manually add it.
+  // Migration: ensure exactly one Orchestrator tab exists at the front. This
+  // covers two cases:
+  //   (a) restored state missing an Orchestrator entirely → inject a fresh one
+  //       so existing users get the new tab automatically.
+  //   (b) restored state with multiple stale Orchestrator entries (issue
+  //       #708 / #713) → keep only the first and drop the duplicates so the
+  //       user never sees three "Orchestrator" tabs.
+  // Idempotent — when there's exactly one Orchestrator at index 0 and no
+  // duplicates, this effect is a no-op.
   useEffect(() => {
     if (defaultTab !== 'llm-chat') return;
     if (tabs.length === 0) return;
-    const hasOrchestrator = tabs.some((tab) => tab.kind === 'orchestrator');
-    if (hasOrchestrator) return;
-    const orchestratorTab = createDefaultOrchestratorTab();
-    const nextTabs = [orchestratorTab, ...tabs];
+    const orchestratorTabs = tabs.filter((tab) => tab.kind === 'orchestrator');
+    const nonOrchestratorTabs = tabs.filter((tab) => tab.kind !== 'orchestrator');
+
+    if (orchestratorTabs.length === 1 && tabs[0]?.kind === 'orchestrator') {
+      return; // Already canonical.
+    }
+
+    const pinnedOrchestrator = orchestratorTabs[0] ?? createDefaultOrchestratorTab();
+    const nextTabs = [pinnedOrchestrator, ...nonOrchestratorTabs];
     tabsRef.current = nextTabs;
     setTabs(nextTabs);
-    // Don't steal focus from whatever the user was on — just inject the tab.
-  }, [createDefaultOrchestratorTab, defaultTab, tabs]);
+    // If the active tab was a duplicate orchestrator we just dropped, keep
+    // the surviving pinned orchestrator active. Otherwise leave the pointer
+    // alone so we don't steal focus.
+    const droppedActive = orchestratorTabs.length > 1
+      && orchestratorTabs.slice(1).some((tab) => tab.id === activeTabId);
+    if (droppedActive) {
+      setActiveTabId(pinnedOrchestrator.id);
+    }
+  }, [activeTabId, createDefaultOrchestratorTab, defaultTab, tabs]);
 
   const handleSessionCreated = useCallback((sessionName: string, requestId?: string) => {
     const directTabId = requestId ? pendingRequestRef.current.get(requestId) : undefined;

--- a/src/lib/terminal/tab-state.ts
+++ b/src/lib/terminal/tab-state.ts
@@ -78,6 +78,106 @@ function isPinnedKind(kind: PersistedTab['kind']): boolean {
 }
 
 /**
+ * Pick the next available "Terminal N" label given an existing list of
+ * persisted tabs. Mirrors `nextTerminalLabel` from
+ * `workspace-terminal/terminal-tab-handlers.ts` so server-side sanitization
+ * (in the API route) can run without importing client-only modules.
+ */
+function nextPersistedTerminalLabel(tabs: PersistedTab[]): string {
+  const used = new Set<number>();
+  for (const tab of tabs) {
+    if ((tab.kind ?? 'terminal') !== 'terminal') continue;
+    const match = /^Terminal\s+(\d+)$/.exec(tab.label?.trim() ?? '');
+    if (match) used.add(Number(match[1]));
+  }
+  let n = 1;
+  while (used.has(n)) n += 1;
+  return `Terminal ${n}`;
+}
+
+/**
+ * Sanitize a persisted tab list:
+ *
+ *   1. Keep at most ONE `kind: 'orchestrator'` entry, and only if it sits at
+ *      index 0. Any extra orchestrator entries (or one in a non-leading
+ *      position) get dropped — the controller's migration effect always
+ *      ensures a single pinned orchestrator at the front, so anything else
+ *      is a stale duplicate from older builds.
+ *   2. Relabel surviving `kind: 'terminal'` tabs whose label is empty or the
+ *      literal string "Orchestrator" to the next free `Terminal N`. Existing
+ *      affected users were left with mislabeled terminal tabs after the
+ *      pre-#709 fallthrough; this scrub corrects them in-place.
+ *
+ * Idempotent — applying it twice is a no-op. Runs on BOTH the load path
+ * (server route + client `loadTabState`) and the save path (`saveTabState`)
+ * so a stale persisted file gets corrected even if the load path returns
+ * early before reaching `computeRestoredTabs`. Issue #713.
+ */
+export function sanitizePersistedTabs(tabs: PersistedTab[]): { tabs: PersistedTab[]; mutated: boolean } {
+  if (!Array.isArray(tabs) || tabs.length === 0) return { tabs, mutated: false };
+
+  let mutated = false;
+  const survivors: PersistedTab[] = [];
+  let keptOrchestrator = false;
+  for (let i = 0; i < tabs.length; i += 1) {
+    const tab = tabs[i];
+    const kind = tab.kind ?? 'terminal';
+    if (kind === 'orchestrator') {
+      // Only keep the very first orchestrator, AND only if it's at index 0.
+      // An orchestrator entry at a later index is treated as stale because
+      // the controller always pins it to the front; preserving it would
+      // re-introduce duplicate-tab UI bugs.
+      if (i === 0 && !keptOrchestrator) {
+        keptOrchestrator = true;
+        survivors.push(tab);
+      } else {
+        mutated = true;
+      }
+      continue;
+    }
+    survivors.push(tab);
+  }
+
+  // Second pass: relabel terminal tabs whose label was lost or carried
+  // "Orchestrator" forward from the legacy fallthrough. Walk the surviving
+  // list and assign each affected entry the next available `Terminal N`
+  // among the survivors. We mutate copies, never the original objects.
+  const result: PersistedTab[] = [];
+  for (const tab of survivors) {
+    const kind = tab.kind ?? 'terminal';
+    if (kind !== 'terminal') {
+      result.push(tab);
+      continue;
+    }
+    const label = tab.label?.trim() ?? '';
+    if (label && label !== 'Orchestrator') {
+      result.push(tab);
+      continue;
+    }
+    mutated = true;
+    result.push({ ...tab, label: nextPersistedTerminalLabel(result) });
+  }
+
+  return { tabs: result, mutated };
+}
+
+/**
+ * Sanitize the full persisted state (tabs + activeTabId). If sanitization
+ * dropped the previously-active tab, picks the first surviving tab as the
+ * new active tab. Idempotent.
+ */
+export function sanitizePersistedState(state: PersistedTabState): { state: PersistedTabState; mutated: boolean } {
+  const { tabs, mutated } = sanitizePersistedTabs(state.tabs);
+  if (!mutated) return { state, mutated: false };
+  const activeStillThere = tabs.some((tab) => tab.id === state.activeTabId);
+  const nextActiveTabId = activeStillThere ? state.activeTabId : (tabs[0]?.id ?? '');
+  return {
+    state: { ...state, tabs, activeTabId: nextActiveTabId },
+    mutated: true,
+  };
+}
+
+/**
  * A tab is "clearly dead" if it carries no signal of live work. Conservative —
  * we'd rather keep something stale than drop an in-flight mission. Returns
  * `true` only for the obvious zombies.
@@ -255,13 +355,19 @@ function buildStatePath(scope: string, repoPath?: string | null) {
 /** Save tab state to server */
 export async function saveTabState(state: PersistedTabState, scope = 'tile-root'): Promise<void> {
   try {
-    const beforeCount = state.tabs.length;
-    const { tabs: prunedTabs, dropped } = pruneTabs(state.tabs, state.activeTabId);
+    // Issue #713 — scrub stale orchestrator entries + mislabeled terminals
+    // BEFORE pruning so the prune-survivor pass sees corrected labels.
+    const { state: sanitized, mutated: sanitizeMutated } = sanitizePersistedState(state);
+    if (sanitizeMutated) {
+      console.log('[tab-state] sanitized stale orchestrator/terminal labels on save');
+    }
+    const beforeCount = sanitized.tabs.length;
+    const { tabs: prunedTabs, dropped } = pruneTabs(sanitized.tabs, sanitized.activeTabId);
     if (dropped > 0) {
       console.log(`[tab-state] pruned ${dropped} tabs on save (was ${beforeCount}, now ${prunedTabs.length})`);
     }
-    const persisted: PersistedTabState = dropped > 0
-      ? { ...state, tabs: prunedTabs }
+    const persisted: PersistedTabState = dropped > 0 || sanitizeMutated
+      ? { ...sanitized, tabs: prunedTabs }
       : state;
     await fetch(buildStatePath(scope), {
       method: 'POST',
@@ -282,13 +388,21 @@ export async function loadTabState(scope = 'tile-root', repoPath?: string | null
     if (data.version !== 1) return null;
     const state = data as PersistedTabState;
     if (!Array.isArray(state.tabs) || state.tabs.length === 0) return state;
-    const beforeCount = state.tabs.length;
-    const { tabs: prunedTabs, dropped } = pruneTabs(state.tabs, state.activeTabId);
+    // Issue #713 — sanitize FIRST so the prune phase + downstream
+    // computeRestoredTabs both see corrected labels. Defensive: even if the
+    // server-side route already applied the same sanitizer, this is
+    // idempotent and a no-op when the data is clean.
+    const { state: sanitized, mutated: sanitizeMutated } = sanitizePersistedState(state);
+    if (sanitizeMutated) {
+      console.log('[tab-state] sanitized stale orchestrator/terminal labels on load');
+    }
+    const beforeCount = sanitized.tabs.length;
+    const { tabs: prunedTabs, dropped } = pruneTabs(sanitized.tabs, sanitized.activeTabId);
     if (dropped > 0) {
       console.log(`[tab-state] pruned ${dropped} tabs on load (was ${beforeCount}, now ${prunedTabs.length})`);
-      return { ...state, tabs: prunedTabs };
+      return { ...sanitized, tabs: prunedTabs };
     }
-    return state;
+    return sanitizeMutated ? sanitized : state;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

The #709 fix only ran inside `computeRestoredTabs` on the client. It missed the disk file itself, the fallback read paths in the API route, and the migration effect couldn't dedupe — so users with broken persisted state (e.g. three "Orchestrator"-labeled tabs) kept seeing the bug after force-installing v0.1.61.

This PR puts the same drop-stale-orchestrator + relabel-terminal-with-Orch-label logic in the four places that matter so the file gets healed on first read, regardless of which code path opens it.

## Changes

- **`lib/terminal/tab-state.ts`** — new `sanitizePersistedTabs` + `sanitizePersistedState` helpers. Keep at most one `kind: 'orchestrator'` (only at index 0) and relabel surviving `kind: 'terminal'` tabs labeled "Orchestrator" to the next free `Terminal N`. Idempotent. Both `loadTabState` and `saveTabState` now apply it.

- **`app/api/panel/terminal-state/route.ts`** — new `readAndSanitizeStateFile` that reads, sanitizes, AND writes back to disk whenever the sanitizer mutated anything. Wired into every read path (primary file, canonical-scope redirect, legacy file, latest-non-empty fallback, latest-repo fallback). POST handler also sanitizes incoming payloads. This is the one-time migration step — any stale file heals on first GET.

- **`useWorkspaceTerminalController.ts`** — migration effect hardened: instead of "inject if missing", it keeps exactly one Orchestrator at index 0 and drops any duplicates. Idempotent.

The original `computeRestoredTabs` fix from #709 stays in place as defense-in-depth at the React state layer.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Smoke-tested against user's reported broken state (3-orch from #708, 2-orch + terminal-with-Orch from #713) — sanitizes cleanly and is idempotent on re-application
- [x] Smoke-tested against clean states (Orch+Assistant, Terminal-only, Chat-only, Empty) — sanitizer is a no-op
- [x] `computeRestoredTabs` still emits correct labels on the user's 3-orch input (Terminal 1 + Terminal 2)
- [ ] Install build, relaunch with stale file on disk, verify no duplicate Orchestrator tabs visible
- [ ] Verify the on-disk file gets healed (orchestrator-kind entries dropped, terminal-with-Orch-label relabeled) on first launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)