### PR TITLE
polish(updater): center-top placement + early surface (#712)

### DIFF
--- a/src/components/desktop/UpdateBanner.tsx
+++ b/src/components/desktop/UpdateBanner.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
-import { Download, RefreshCw } from './lucide-shims';
+import { useEffect, useState, useCallback, useRef } from 'react';
 
 interface UpdateInfo {
   version: string;
@@ -10,16 +9,29 @@ interface UpdateInfo {
 }
 
 const UPDATE_CHECK_INTERVAL = 30 * 60 * 1000; // 30 minutes
+const POP_CURVE = 'cubic-bezier(0.34, 1.36, 0.64, 1)';
+const SESSION_ANIM_KEY = 'o8:update-banner:animated';
+
 /**
- * UpdateBanner — shows a slim banner at the top of the dashboard when
- * a new version is available. On Tauri desktop, uses the native updater.
- * We intentionally skip browser-only update fetches in local/web mode to
- * avoid noisy CORS console failures against GitHub release assets.
+ * UpdateBanner — center-top sticky notification when a new version is
+ * available. On Tauri desktop, uses the native updater. We intentionally
+ * skip browser-only update fetches in local/web mode to avoid noisy CORS
+ * console failures against GitHub release assets.
+ *
+ * Placement: position-fixed, centered horizontally just below the 44px
+ * TitleBar. Solid paper surface (NOT glass — this is a notification, not
+ * chrome) with the brand orange LED indicator. Slides in with the canonical
+ * pop curve once per session via sessionStorage.
+ *
+ * Surface timing: the Tauri updater check fires on first mount with no
+ * artificial delay, so the banner can appear within the first second of
+ * webview boot rather than after the dashboard fully hydrates.
  */
 export function UpdateBanner() {
   const [update, setUpdate] = useState<UpdateInfo | null>(null);
-  const [dismissed, setDismissed] = useState(false);
   const [installing, setInstalling] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const animatedRef = useRef(false);
 
   const checkForUpdate = useCallback(async () => {
     try {
@@ -46,14 +58,45 @@ export function UpdateBanner() {
   }, []);
 
   useEffect(() => {
-    // Check on mount after a short delay (don't block initial render)
-    const initial = window.setTimeout(() => void checkForUpdate(), 5000);
+    // Read whether this session has already played the slide-in.
+    if (typeof window !== 'undefined') {
+      try {
+        animatedRef.current = window.sessionStorage.getItem(SESSION_ANIM_KEY) === '1';
+      } catch {
+        // sessionStorage can throw in private browsing — treat as fresh.
+      }
+    }
+
+    // Fire immediately so the banner can surface as soon as the Tauri
+    // updater resolves, not after the full dashboard hydration chain.
+    void checkForUpdate();
     const interval = window.setInterval(() => void checkForUpdate(), UPDATE_CHECK_INTERVAL);
     return () => {
-      window.clearTimeout(initial);
       window.clearInterval(interval);
     };
   }, [checkForUpdate]);
+
+  // Trigger the entrance transition on the next frame after the update
+  // payload arrives. Use rAF so the initial render commits the
+  // off-screen styles before we flip to the on-screen ones.
+  useEffect(() => {
+    if (!update) {
+      setMounted(false);
+      return;
+    }
+    let rafId: number | null = null;
+    rafId = window.requestAnimationFrame(() => {
+      setMounted(true);
+      try {
+        window.sessionStorage.setItem(SESSION_ANIM_KEY, '1');
+      } catch {
+        // ignore
+      }
+    });
+    return () => {
+      if (rafId !== null) window.cancelAnimationFrame(rafId);
+    };
+  }, [update]);
 
   const handleInstall = useCallback(async () => {
     if (typeof window !== 'undefined' && 'isTauri' in window && (window as { isTauri?: boolean }).isTauri) {
@@ -68,7 +111,7 @@ export function UpdateBanner() {
           await relaunch();
         }
       } catch (err) {
-        console.error('Update install failed:', err);
+        console.error('[update-banner] install failed:', err);
         setInstalling(false);
       }
     } else {
@@ -77,70 +120,90 @@ export function UpdateBanner() {
     }
   }, []);
 
-  if (!update || dismissed) return null;
+  if (!update) return null;
+
+  // If we already animated this session (e.g. component re-mounted after
+  // a tab change), skip the slide-in by starting in the mounted state.
+  const skipAnimation = animatedRef.current;
+  const isOnScreen = mounted || skipAnimation;
 
   return (
-    <div style={{
-      display: 'flex',
-      alignItems: 'center',
-      gap: 12,
-      padding: '8px 16px',
-      background: 'linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(124, 58, 237, 0.08))',
-      borderBottom: '1px solid rgba(37, 99, 235, 0.15)',
-      fontSize: 13,
-      color: 'var(--t-text)',
-      zIndex: 9100,
-    }}>
-      <Download size={14} style={{ color: '#2563eb', flexShrink: 0 }} />
-      <span style={{ flex: 1 }}>
-        <strong>o8 {update.version}</strong> is available
-        {update.notes ? ` — ${update.notes.slice(0, 80)}${update.notes.length > 80 ? '…' : ''}` : ''}
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        position: 'fixed',
+        top: 52,
+        left: '50%',
+        transform: isOnScreen
+          ? 'translate(-50%, 0)'
+          : 'translate(-50%, -16px)',
+        opacity: isOnScreen ? 1 : 0,
+        transition: skipAnimation
+          ? 'none'
+          : `transform 220ms ${POP_CURVE}, opacity 220ms ${POP_CURVE}`,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 14,
+        paddingTop: 10,
+        paddingRight: 12,
+        paddingBottom: 10,
+        paddingLeft: 16,
+        background: 'var(--t-chat-surface-bg)',
+        border: '1px solid var(--t-border)',
+        borderRadius: 12,
+        boxShadow: '0 12px 32px rgba(15, 23, 42, 0.16), 0 2px 6px rgba(15, 23, 42, 0.08)',
+        fontSize: 13,
+        color: 'var(--t-text)',
+        fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+        zIndex: 9100,
+        pointerEvents: 'auto',
+        maxWidth: 'min(560px, calc(100vw - 32px))',
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          background: '#FF5A1F',
+          boxShadow: '0 0 0 3px rgba(255, 90, 31, 0.18)',
+          flexShrink: 0,
+        }}
+      />
+      <span style={{ flex: 1, minWidth: 0, lineHeight: 1.3 }}>
+        <strong style={{ fontWeight: 600, color: 'var(--t-text)' }}>
+          Update available
+        </strong>
+        <span style={{ marginLeft: 8, color: 'var(--t-text-muted)', fontWeight: 400 }}>
+          o8 {update.version}
+        </span>
       </span>
       <button
         type="button"
         onClick={handleInstall}
         disabled={installing}
         style={{
-          padding: '4px 12px',
-          borderRadius: 8,
-          border: '1px solid rgba(37, 99, 235, 0.3)',
-          background: installing ? 'rgba(37, 99, 235, 0.04)' : 'rgba(37, 99, 235, 0.08)',
-          color: '#2563eb',
+          paddingTop: 6,
+          paddingRight: 14,
+          paddingBottom: 6,
+          paddingLeft: 14,
+          borderRadius: 10,
+          border: '1px solid var(--t-text)',
+          background: 'var(--t-text)',
+          color: 'var(--t-chat-surface-bg)',
+          fontFamily: 'inherit',
           fontSize: 12,
           fontWeight: 600,
+          letterSpacing: '-0.01em',
           cursor: installing ? 'wait' : 'pointer',
-          display: 'flex',
-          alignItems: 'center',
-          gap: 6,
+          opacity: installing ? 0.6 : 1,
+          whiteSpace: 'nowrap',
+          flexShrink: 0,
         }}
       >
-        {installing ? (
-          <>
-            <RefreshCw size={12} className="spin" />
-            Installing…
-          </>
-        ) : (
-          typeof window !== 'undefined' && 'isTauri' in window && (window as { isTauri?: boolean }).isTauri
-            ? 'Install & Restart'
-            : 'Download'
-        )}
-      </button>
-      <button
-        type="button"
-        onClick={() => setDismissed(true)}
-        style={{
-          padding: 4,
-          border: 'none',
-          background: 'transparent',
-          color: 'var(--t-text-muted)',
-          cursor: 'pointer',
-          borderRadius: 6,
-        }}
-        title="Dismiss"
-      >
-        <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
-          <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
-        </svg>
+        {installing ? 'Installing…' : 'Restart to update'}
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary

The UpdateBanner has been invisible across 8 ship cycles. Two root causes:

1. **Placement** — it rendered as a full-width strip at the top of the dashboard tree, top-left contrast was low against the chrome, and it bled into the TitleBar/ConnectionBanner area.
2. **Timing** — `checkForUpdate` was gated behind a `setTimeout(5000)` AND only fired after `DashboardInner` had fully hydrated (~15s post-launch). By the time it surfaced, the user had moved on.

## What changed

`src/components/desktop/UpdateBanner.tsx` — single-file change. No `dashboard/page.tsx` structural edits (the banner is `position: fixed` now, so its mount point doesn't affect placement).

- **Center-top sticky:** `position: fixed; top: 52px; left: 50%; transform: translateX(-50%)` — sits just below the 44px TitleBar, centered horizontally.
- **Rams aesthetic, no new tokens:** solid paper card (`var(--t-chat-surface-bg)`), 1px hairline border (`var(--t-border)`), 12px radius, soft shadow. Brand orange (`#FF5A1F`) as the status LED dot per DESIGN.md §01 (which already names UpdateBanner as the canonical example).
- **ONE CTA:** "Restart to update" — calls `result.downloadAndInstall()` then `relaunch()`, same Tauri flow as before. No dismiss button, no secondary actions.
- **Slide-in motion:** 220ms `cubic-bezier(0.34, 1.36, 0.64, 1)` on first appearance only. Tracked via `sessionStorage` so re-mounts (tab switches, hot reload) don't re-animate.
- **Early surface:** removed the 5s `setTimeout` — `checkForUpdate` fires immediately on first mount. Banner appears as soon as the Tauri updater resolves rather than after full dashboard hydration.

## Test plan

- [ ] Build signed (`npm run tauri:build:signed`), install over a previous version, confirm banner appears center-top within ~1s of launch
- [ ] Click "Restart to update" — verify download + install + relaunch flow works
- [ ] Theme: verify paper-card reads correctly in both light and midnight (uses tokens, not hardcoded rgba)
- [ ] Animation: only plays on first appearance per session (sessionStorage gate)
- [ ] Console: no errors from `[update-banner]` prefix on cold boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)