### PR TITLE
feat(workspaces): hover-reveal trash + confirm-strip + git branch -D (#720)

### DIFF
--- a/src/app/api/panel/branches/route.ts
+++ b/src/app/api/panel/branches/route.ts
@@ -191,10 +191,15 @@ export async function GET(req: NextRequest) {
 }
 
 // ── DELETE: Remove branch (+ worktree if applicable) ──
+//
+// Local-only by default. The sidebar prune UI never deletes the remote ref —
+// pass `deleteRemote: true` only when the caller explicitly opts in (a future
+// "delete remote too" toggle). See #720 for the rationale: the prune gesture
+// is for tidying the local sidebar, not for force-publishing branch removal.
 export async function DELETE(req: NextRequest) {
   try {
-    const body = await req.json() as { path: string; branch: string; force?: boolean };
-    const { path: repoPath, branch, force } = body;
+    const body = await req.json() as { path: string; branch: string; force?: boolean; deleteRemote?: boolean };
+    const { path: repoPath, branch, force, deleteRemote } = body;
 
     if (!repoPath || !branch) {
       return NextResponse.json({ error: 'path and branch required' }, { status: 400 });
@@ -235,15 +240,19 @@ export async function DELETE(req: NextRequest) {
       timeout: 5000,
     });
 
-    // Try to delete remote branch too
+    // Optionally delete the remote branch — opt-in only. Local prune does not
+    // touch origin so a YC-reviewer-style "tidy my sidebar" click can't
+    // accidentally drop a remote ref another collaborator is depending on.
     let remoteDeleted = false;
-    try {
-      execSync(`git -C "${repoPath}" push origin --delete "${branch}" 2>/dev/null`, {
-        encoding: 'utf-8',
-        timeout: 10000,
-      });
-      remoteDeleted = true;
-    } catch { /* no remote branch or no permission */ }
+    if (deleteRemote) {
+      try {
+        execSync(`git -C "${repoPath}" push origin --delete "${branch}" 2>/dev/null`, {
+          encoding: 'utf-8',
+          timeout: 10000,
+        });
+        remoteDeleted = true;
+      } catch { /* no remote branch or no permission */ }
+    }
 
     return NextResponse.json({
       deleted: branch,

--- a/src/components/desktop/repo-registry/RepoBranchRow.tsx
+++ b/src/components/desktop/repo-registry/RepoBranchRow.tsx
@@ -492,7 +492,11 @@ function RepoBranchRowBase({
               color: 'var(--t-text-faint)',
               cursor: 'pointer',
               opacity: rowHovered ? 1 : 0,
-              transition: 'opacity 120ms cubic-bezier(0.22, 1, 0.36, 1), color 120ms cubic-bezier(0.22, 1, 0.36, 1)',
+              // Pop curve for the hover-reveal — matches SessionPillContextMenu,
+              // RejectedFeedbackPanel, setup-wizard atoms. Subtle overshoot so
+              // the trash icon "appears" rather than fades, signalling that the
+              // affordance is intentional and clickable. (#720)
+              transition: 'opacity 220ms cubic-bezier(0.34, 1.36, 0.64, 1), color 120ms cubic-bezier(0.22, 1, 0.36, 1)',
             }}
             onMouseEnter={(event) => {
               (event.currentTarget as HTMLButtonElement).style.color = '#c97070';


### PR DESCRIPTION
## Summary

- The hover-reveal trash + confirm strip + `handleDeleteBranch` flow already existed in `RepoBranchRow.tsx`. The audit found two things blocking the YC-reviewer-grade polish: the DELETE endpoint silently force-deleted the remote branch on every click, and the trash hover-reveal used the smooth ease curve instead of the established pop curve.
- DELETE `/api/panel/branches` is now local-only by default. Pass `deleteRemote: true` to restore the prior behavior (no caller does today; future "delete remote too" toggle goes here).
- Trash hover-reveal swapped to `cubic-bezier(0.34, 1.36, 0.64, 1)` — same curve as `SessionPillContextMenu`, `RejectedFeedbackPanel`, and the setup-wizard atoms. Subtle overshoot so the affordance reads as appearing, not fading.

Closes #720.

## Test plan

- [ ] Hover a workspace branch row in the left sidebar — trash icon pops in (overshoot is barely perceptible, just enough to feel intentional).
- [ ] Click trash → inline confirm strip ("Delete branch X? Cancel / Delete") appears below the row.
- [ ] Click Delete on a fully-merged branch → row disappears, branch list refreshes, `git branch -d <name>` ran on disk.
- [ ] Click Delete on an unmerged branch → first call returns 409 with `canForce: true`, the row's `branchDeleteConfirm` strip appears with "Force delete / Cancel". Click Force delete → branch is removed via `git branch -D`.
- [ ] After delete, run `git branch -r` on the repo — the `origin/<name>` ref is still there (no automatic remote prune).
- [ ] Worktree-attached branches: trash → clean up via the existing worktree cleanup path.
- [ ] Current branch + main/master/develop: trash icon does not render (protected, gated by `branch.current === false && branch.name !== repo.defaultBranch`).
- [ ] `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)