### PR TITLE
fix(workspaces): show only active work in branch rail (idle worktrees collapse to disclosure)

### DIFF
--- a/src/components/desktop/repo-registry/RepoCardExpandedContent.tsx
+++ b/src/components/desktop/repo-registry/RepoCardExpandedContent.tsx
@@ -96,23 +96,30 @@ function RepoCardExpandedContentBase({
     )),
     [orchestratorPackets, repo.localPath],
   );
+  // Active-work-only visibility rule (#workspace-prune-v2):
+  // Show current branch, anything an agent is on, anything a packet targets,
+  // and worktrees with a commit in the last 24h that aren't flagged stale.
+  // Everything else (idle worktrees, plain non-current branches) collapses
+  // under the "+ N idle" disclosure below — the rail is not a branch picker.
   const visibleBranches = useMemo(
-    () => branches.filter((branch) => {
-      const branchAgents = agentsByBranch?.get(branch.name) ?? [];
-      const hasAgent = Boolean(branchAgents.length);
-      const isPacketTarget = repoScopedPackets.some((packet) => packet.branchTarget.trim() === branch.name);
-      return (
-        branch.isWorktree
-        || !branch.current
-        || hasAgent
-        || isPacketTarget
-        || (branch.current && repoScopedPackets.some((packet) => packet.branchTarget.trim() === '' || packet.branchTarget.trim() === branch.name))
-      );
-    }),
+    () => {
+      const ACTIVE_WINDOW_MS = 24 * 60 * 60 * 1000;
+      const cutoff = Date.now() - ACTIVE_WINDOW_MS;
+      return branches.filter((branch) => {
+        if (branch.current) return true;
+        const branchAgents = agentsByBranch?.get(branch.name) ?? [];
+        const hasAgent = Boolean(branchAgents.length);
+        if (hasAgent) return true;
+        const isPacketTarget = repoScopedPackets.some((packet) => packet.branchTarget.trim() === branch.name);
+        if (isPacketTarget) return true;
+        if (branch.isWorktree && !branch.isStale && branch.lastCommitUnix > cutoff) return true;
+        return false;
+      });
+    },
     [agentsByBranch, branches, repoScopedPackets],
   );
   const hiddenBranchCount = useMemo(
-    () => branches.filter((branch) => branch.isWorktree && !visibleBranches.some((visibleBranch) => visibleBranch.name === branch.name)).length,
+    () => branches.length - visibleBranches.length,
     [branches, visibleBranches],
   );
   const unmatchedRepoPackets = useMemo(
@@ -576,7 +583,7 @@ function RepoCardExpandedContentBase({
                 target.style.background = 'transparent';
               }}
             >
-              + {hiddenBranchCount} worktree{hiddenBranchCount !== 1 ? 's' : ''}
+              + {hiddenBranchCount} idle
             </button>
           ) : null}
           <button


### PR DESCRIPTION
## Summary

User flagged the left-rail showing 30+ idle branches: "if these agents are stale and the work is completed I think they should go into an archive or something, just sitting like this is bad UI… we are forcing users to use the orchestrator. We need active work only."

The visibility rule in `RepoCardExpandedContent.tsx` was overly inclusive — it showed every worktree and every non-current branch, so the disclosure ("+ N worktrees") never triggered. New rule scopes to current / active-agent / packet / recently-active worktrees; idle work folds under the existing disclosure.

## What changed

- **Visible by default**: current branch (always), branches with running agents, packet targets, and worktrees whose `lastCommitUnix` is within the last 24h AND not `isStale`.
- **Hidden** (rolls into the existing "+ N idle" disclosure): stale worktrees, idle (>24h) worktrees, and non-current branches that aren't worktrees and have no agent/packet — the rail isn't a branch picker.
- Disclosure label renamed `worktree(s)` -> `idle` since it now covers all idle work, not just worktrees. `hiddenBranchCount` derives directly from `branches.length - visibleBranches.length` so the count stays in sync with whatever the visibility rule decides.

Reuses existing `BranchInfo` fields (`isStale`, `lastCommitUnix`) — no new data fetch, no new visual surface, just gated visibility. File goes from 725 -> 731 lines (well under the 800 ceiling).

## Test plan

- [ ] Open the workspaces panel on a repo with many stale worktrees — only the current branch + any active agents/packets show; everything else collapses behind "+ N idle".
- [ ] Click "+ N idle" — full list expands as before.
- [ ] Worktree with a commit in the last 24h (and `isStale: false`) stays visible without an agent attached.
- [ ] Branch with an attached agent stays visible regardless of commit age.
- [ ] Branch matching an open packet's `branchTarget` stays visible regardless of commit age.
- [ ] `npx tsc --noEmit` passes (verified locally).