### PR TITLE
feat(orchestrator): packet review card 3-pane (closes #729)

### DIFF
--- a/src/app/api/cortex/directives/route.ts
+++ b/src/app/api/cortex/directives/route.ts
@@ -1,0 +1,107 @@
+/**
+ * GET /api/cortex/directives
+ *
+ * Lists directive markdown files from the data dir's `directives/` folder.
+ * Each file has YAML-like front matter: id, title, scope, repoName, priority,
+ * created, updated. The body below the second `---` is the directive text.
+ *
+ * Response:
+ *   { directives: Array<{ id, title, scope, repoName?, priority?, body }> }
+ *
+ * Surface — Packet Review Card (#729) lists directive titles in its SPEC
+ * pane. Read-only.
+ */
+
+import { NextResponse } from 'next/server';
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { getDataDir } from '@/lib/data-dir-migration';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface DirectiveSummary {
+  id: string;
+  title: string;
+  scope: string;
+  repoName: string | null;
+  priority: number | null;
+  body: string;
+}
+
+const FRONT_MATTER_BOUNDARY = /^---\s*$/m;
+
+function parseDirectiveFile(raw: string, fallbackId: string): DirectiveSummary | null {
+  const text = raw.replace(/\r\n/g, '\n').trim();
+  if (!text.startsWith('---')) return null;
+
+  // Strip leading ---, find next ---
+  const afterFirst = text.slice(3).trimStart();
+  const closingIndex = afterFirst.search(FRONT_MATTER_BOUNDARY);
+  if (closingIndex < 0) return null;
+
+  const front = afterFirst.slice(0, closingIndex);
+  const body = afterFirst.slice(closingIndex).replace(FRONT_MATTER_BOUNDARY, '').trim();
+
+  const meta: Record<string, string> = {};
+  for (const line of front.split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx <= 0) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    if (key) meta[key] = value;
+  }
+
+  const priorityRaw = meta.priority;
+  const priorityNum = priorityRaw ? Number.parseInt(priorityRaw, 10) : NaN;
+
+  return {
+    id: meta.id?.trim() || fallbackId,
+    title: meta.title?.trim() || fallbackId,
+    scope: meta.scope?.trim() || 'global',
+    repoName: meta.repoName?.trim() || null,
+    priority: Number.isFinite(priorityNum) ? priorityNum : null,
+    body,
+  };
+}
+
+export async function GET() {
+  try {
+    const dataDir = getDataDir();
+    const directivesDir = join(dataDir, 'directives');
+
+    if (!existsSync(directivesDir)) {
+      return NextResponse.json({ directives: [] }, {
+        headers: { 'Cache-Control': 'no-store, max-age=0' },
+      });
+    }
+
+    const entries = readdirSync(directivesDir).filter((name) => name.endsWith('.md'));
+    const directives: DirectiveSummary[] = [];
+    for (const name of entries) {
+      try {
+        const raw = readFileSync(join(directivesDir, name), 'utf-8');
+        const fallbackId = name.replace(/\.md$/, '');
+        const parsed = parseDirectiveFile(raw, fallbackId);
+        if (parsed) directives.push(parsed);
+      } catch (error) {
+        console.warn(`[cortex-directives] Failed to read ${name}:`, error);
+      }
+    }
+
+    // Sort by priority desc (higher = more important), then title.
+    directives.sort((a, b) => {
+      const ap = a.priority ?? 0;
+      const bp = b.priority ?? 0;
+      if (ap !== bp) return bp - ap;
+      return a.title.localeCompare(b.title);
+    });
+
+    return NextResponse.json({ directives }, {
+      headers: { 'Cache-Control': 'no-store, max-age=0' },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to load directives.';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/desktop/thoughts/mission-panel/PacketCard.tsx
+++ b/src/components/desktop/thoughts/mission-panel/PacketCard.tsx
@@ -10,6 +10,7 @@ import { PacketActionStrip } from '@/components/desktop/thoughts/PacketActionStr
 import { PacketDetailsPopover } from '@/components/desktop/thoughts/PacketDetailsPopover';
 import type { EditingField, ReviewPanelState } from './types';
 import { PacketMetaRows } from './PacketMetaRows';
+import { PacketReviewCard } from './PacketReviewCard';
 import { PacketReviewPanel } from './PacketReviewPanel';
 import { RejectedFeedbackPanel } from './RejectedFeedbackPanel';
 
@@ -70,6 +71,11 @@ export function PacketCard({
     packet.status === 'awaiting_review'
     || (packet.status === 'blocked' && packet.blockedReason === 'Awaiting operator input')
   );
+  // #729 — Hero review surface for `awaiting_review` packets. The lighter
+  // PacketReviewPanel still owns the `blocked + Awaiting operator input` case
+  // (where the orchestrator hasn't moved the packet to awaiting_review yet but
+  // is gated on operator input).
+  const showHeroReviewCard = Boolean(packet.lane?.laneId) && packet.status === 'awaiting_review';
   // #662 — Rejected packets get a one-click rerun-with-feedback panel.
   // Detect via packet.review?.approved === false rather than packet.status,
   // since submitPacketReview leaves status untouched.
@@ -513,7 +519,12 @@ export function PacketCard({
             )}
           </div>
 
-          {showReviewSection ? (
+          {showHeroReviewCard ? (
+            <PacketReviewCard
+              packet={packet}
+              reviewState={reviewState}
+            />
+          ) : showReviewSection ? (
             <PacketReviewPanel
               packet={packet}
               reviewState={reviewState}
@@ -529,7 +540,7 @@ export function PacketCard({
                 paddingRight: 10,
                 paddingBottom: 10,
                 paddingLeft: 10,
-                borderTopWidth: showReviewSection ? 0 : 1,
+                borderTopWidth: showReviewSection || showHeroReviewCard ? 0 : 1,
                 borderTopStyle: 'solid',
                 borderTopColor: 'var(--t-divider-subtle)',
               }}

--- a/src/components/desktop/thoughts/mission-panel/PacketReviewCard.tsx
+++ b/src/components/desktop/thoughts/mission-panel/PacketReviewCard.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import { DiffPane } from './review-card/DiffPane';
+import { ReviewPane } from './review-card/ReviewPane';
+import { SpecPane } from './review-card/SpecPane';
+import {
+  DiffPayload,
+  DirectiveSummary,
+  PANE_BORDER_COLOR,
+} from './review-card/shared';
+import type { ReviewPanelState } from './types';
+
+/**
+ * #729 — Packet Review Card.
+ *
+ * The hero feature: 3-pane review surface that replaces the lighter-weight
+ * PacketReviewPanel for packets in `awaiting_review`.
+ *
+ * Layout:
+ *   ┌─────────────┬─────────────┬─────────────┐
+ *   │ SPEC +      │ DIFF        │ REVIEW      │
+ *   │ Directives  │ (file tree, │ (verdict,   │
+ *   │             │  unified)   │  concerns,  │
+ *   │             │             │  actions)   │
+ *   └─────────────┴─────────────┴─────────────┘
+ *
+ * All endpoints are existing. We add no new visual primitives — just rgba+
+ * palette tokens already in the design system.
+ */
+interface PacketReviewCardProps {
+  packet: OrchestratorPacket;
+  reviewState: ReviewPanelState | null;
+  onActionComplete?: () => void;
+}
+
+export function PacketReviewCard({ packet, reviewState, onActionComplete }: PacketReviewCardProps) {
+  const [directives, setDirectives] = useState<DirectiveSummary[] | null>(null);
+  const [directivesError, setDirectivesError] = useState<string | null>(null);
+  const [diff, setDiff] = useState<DiffPayload | null>(null);
+  const [diffLoading, setDiffLoading] = useState(false);
+  const [diffError, setDiffError] = useState<string | null>(null);
+
+  const worktreePath = reviewState?.worktreePath ?? packet.lane?.worktreePath ?? null;
+  const baseBranchHint = packet.branchTarget && packet.branchTarget.trim() ? packet.branchTarget : null;
+
+  // Load directives once on mount.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await fetch('/api/cortex/directives', { cache: 'no-store' });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const payload = await response.json() as { directives?: DirectiveSummary[] };
+        if (cancelled) return;
+        setDirectives(payload.directives ?? []);
+      } catch (error) {
+        if (cancelled) return;
+        setDirectivesError(error instanceof Error ? error.message : 'Unable to load directives.');
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // Load diff when worktreePath becomes known.
+  useEffect(() => {
+    if (!worktreePath) {
+      setDiff(null);
+      setDiffLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setDiffLoading(true);
+    setDiffError(null);
+    (async () => {
+      try {
+        const params = new URLSearchParams({ worktreePath });
+        if (baseBranchHint) params.set('baseBranch', baseBranchHint);
+        const response = await fetch(`/api/worktrees/diff?${params.toString()}`, { cache: 'no-store' });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const payload = await response.json() as DiffPayload & { error?: string };
+        if (cancelled) return;
+        if (payload.error) {
+          setDiffError(payload.error);
+          setDiff(null);
+        } else {
+          setDiff(payload);
+        }
+      } catch (error) {
+        if (cancelled) return;
+        setDiffError(error instanceof Error ? error.message : 'Unable to load diff.');
+      } finally {
+        if (!cancelled) setDiffLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [worktreePath, baseBranchHint, packet.id]);
+
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'row',
+      gap: 0,
+      paddingTop: 0,
+      paddingRight: 0,
+      paddingBottom: 0,
+      paddingLeft: 0,
+      borderTopWidth: 1,
+      borderTopStyle: 'solid',
+      borderTopColor: PANE_BORDER_COLOR,
+      background: 'var(--t-panel)',
+    }}>
+      <div style={{ flex: 1, minWidth: 0, borderRightWidth: 1, borderRightStyle: 'solid', borderRightColor: PANE_BORDER_COLOR }}>
+        <SpecPane packet={packet} directives={directives} directivesError={directivesError} />
+      </div>
+      <div style={{ flex: 1, minWidth: 0, borderRightWidth: 1, borderRightStyle: 'solid', borderRightColor: PANE_BORDER_COLOR }}>
+        <DiffPane packet={packet} reviewState={reviewState} diff={diff} diffLoading={diffLoading} diffError={diffError} />
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <ReviewPane packet={packet} onActionComplete={onActionComplete} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/desktop/thoughts/mission-panel/review-card/DiffPane.tsx
+++ b/src/components/desktop/thoughts/mission-panel/review-card/DiffPane.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import { parseGitDiff } from '@/lib/worktree/diff-parser';
+import type { ReviewPanelState } from '../types';
+import {
+  DiffPayload,
+  FONT_FAMILY,
+  MONO_FAMILY,
+  ParsedFileDiff,
+  paneLabelStyle,
+  paneStyle,
+} from './shared';
+
+/**
+ * #729 — DIFF pane: file tree with +/- totals + per-file unified diff with
+ * hunk-level expansion.
+ */
+function toFileDiffs(rawDiff: string): ParsedFileDiff[] {
+  const sections = parseGitDiff(rawDiff);
+  return sections.map((section) => {
+    let additions = 0;
+    let deletions = 0;
+    for (const line of section.patch.split('\n')) {
+      if (line.startsWith('+++') || line.startsWith('---')) continue;
+      if (line.startsWith('+')) additions += 1;
+      else if (line.startsWith('-')) deletions += 1;
+    }
+    return { path: section.path, additions, deletions, patch: section.patch, status: section.status };
+  });
+}
+
+export function DiffPane({ packet, reviewState, diff, diffLoading, diffError }: {
+  packet: OrchestratorPacket;
+  reviewState: ReviewPanelState | null;
+  diff: DiffPayload | null;
+  diffLoading: boolean;
+  diffError: string | null;
+}) {
+  const [expandedFiles, setExpandedFiles] = useState<Record<string, boolean>>({});
+  const fileDiffs = useMemo(() => diff ? toFileDiffs(diff.diff) : [], [diff]);
+  const toggleFile = useCallback((path: string) => {
+    setExpandedFiles((current) => ({ ...current, [path]: !current[path] }));
+  }, []);
+
+  // Fall back to reviewState file list when raw diff is in flight.
+  const fallbackFiles = (reviewState?.snapshot?.changedFiles ?? []).map((file) => ({
+    path: file.path,
+    additions: file.additions ?? 0,
+    deletions: file.deletions ?? 0,
+    patch: '',
+    status: 'M' as ParsedFileDiff['status'],
+  }));
+  const filesToRender = fileDiffs.length > 0 ? fileDiffs : fallbackFiles;
+
+  return (
+    <div style={paneStyle()}>
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 8 }}>
+        <div style={paneLabelStyle()}>DIFF</div>
+        {diff ? (
+          <div style={{
+            fontSize: 10,
+            color: 'var(--t-text-muted)',
+            fontFamily: MONO_FAMILY,
+          }}>
+            <span style={{ color: '#16a34a' }}>+{diff.additions}</span>
+            {' '}
+            <span style={{ color: '#dc2626' }}>-{diff.deletions}</span>
+            {' '}
+            <span>· {diff.fileCount} files</span>
+          </div>
+        ) : null}
+      </div>
+
+      {diffLoading ? (
+        <div style={{ fontSize: 10.5, color: 'var(--t-text-muted)', fontFamily: FONT_FAMILY }}>
+          Loading diff…
+        </div>
+      ) : null}
+
+      {diffError ? (
+        <div style={{ fontSize: 10.5, color: '#b91c1c', fontFamily: FONT_FAMILY }}>
+          {diffError}
+        </div>
+      ) : null}
+
+      {!diffLoading && !diffError && filesToRender.length === 0 ? (
+        <div style={{ fontSize: 10.5, color: 'var(--t-text-muted)', fontFamily: FONT_FAMILY }}>
+          Working tree clean.
+        </div>
+      ) : null}
+
+      {filesToRender.length > 0 ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          {filesToRender.map((file) => {
+            const isExpanded = expandedFiles[file.path] === true;
+            const canExpand = file.patch.length > 0;
+            return (
+              <div
+                key={`${packet.id}:${file.path}`}
+                style={{
+                  borderRadius: 8,
+                  borderWidth: 1,
+                  borderStyle: 'solid',
+                  borderColor: 'rgba(148, 163, 184, 0.16)',
+                  background: 'rgba(148, 163, 184, 0.06)',
+                  overflow: 'hidden',
+                }}
+              >
+                <button
+                  type="button"
+                  onClick={canExpand ? () => toggleFile(file.path) : undefined}
+                  disabled={!canExpand}
+                  style={{
+                    width: '100%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    paddingTop: 5,
+                    paddingRight: 8,
+                    paddingBottom: 5,
+                    paddingLeft: 8,
+                    borderWidth: 0,
+                    background: 'transparent',
+                    cursor: canExpand ? 'pointer' : 'default',
+                    textAlign: 'left',
+                    fontFamily: FONT_FAMILY,
+                  }}
+                >
+                  {canExpand ? (
+                    <svg width={9} height={9} viewBox="0 0 10 10" fill="none" stroke="var(--t-text-muted)" strokeWidth="1.5" strokeLinecap="round" style={{ flexShrink: 0, transform: isExpanded ? 'rotate(0deg)' : 'rotate(-90deg)', transition: 'transform 120ms cubic-bezier(0.22, 1, 0.36, 1)' }}>
+                      <path d="M2.5 3.5L5 6L7.5 3.5" />
+                    </svg>
+                  ) : <span style={{ width: 9, flexShrink: 0 }} />}
+                  <span style={{
+                    flex: 1,
+                    minWidth: 0,
+                    fontSize: 10.5,
+                    color: 'var(--t-text)',
+                    fontFamily: MONO_FAMILY,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}>
+                    {file.path}
+                  </span>
+                  <span style={{
+                    flexShrink: 0,
+                    fontSize: 10,
+                    fontWeight: 700,
+                    fontFamily: MONO_FAMILY,
+                    display: 'inline-flex',
+                    gap: 6,
+                  }}>
+                    <span style={{ color: '#16a34a' }}>+{file.additions}</span>
+                    <span style={{ color: '#dc2626' }}>-{file.deletions}</span>
+                  </span>
+                </button>
+                {isExpanded && file.patch ? (
+                  <pre style={{
+                    margin: 0,
+                    paddingTop: 6,
+                    paddingRight: 10,
+                    paddingBottom: 6,
+                    paddingLeft: 10,
+                    fontSize: 10,
+                    fontFamily: MONO_FAMILY,
+                    color: 'var(--t-text)',
+                    background: 'var(--t-bg)',
+                    borderTopWidth: 1,
+                    borderTopStyle: 'solid',
+                    borderTopColor: 'rgba(148, 163, 184, 0.12)',
+                    overflowX: 'auto',
+                    whiteSpace: 'pre',
+                    lineHeight: 1.5,
+                  }}>
+                    {file.patch.split('\n').map((line, idx) => {
+                      let color = 'var(--t-text-secondary)';
+                      if (line.startsWith('+') && !line.startsWith('+++')) color = '#16a34a';
+                      else if (line.startsWith('-') && !line.startsWith('---')) color = '#dc2626';
+                      else if (line.startsWith('@@')) color = '#7c3aed';
+                      return (
+                        <div key={idx} style={{ color, whiteSpace: 'pre' }}>
+                          {line || ' '}
+                        </div>
+                      );
+                    })}
+                  </pre>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/desktop/thoughts/mission-panel/review-card/ReviewPane.tsx
+++ b/src/components/desktop/thoughts/mission-panel/review-card/ReviewPane.tsx
@@ -1,0 +1,356 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import {
+  buildConcerns,
+  Concern,
+  deriveVerdict,
+  FONT_FAMILY,
+  paneLabelStyle,
+  paneStyle,
+  verdictTone,
+} from './shared';
+
+/**
+ * #729 — REVIEW pane: verdict pill + concerns list + 3 action buttons.
+ *
+ * Buttons wire to existing endpoints:
+ *   Merge          → /api/orchestrator/merge        (approveAndMergePacket)
+ *   Re-spec        → /api/orchestrator/rerun-with-feedback
+ *   Kill packet    → /api/orchestrator/reset-packet (clearWorktree=true)
+ */
+function ConcernRow({ concern }: { concern: Concern }) {
+  const tone = concern.category === 'mechanical'
+    ? { color: '#b91c1c', bg: 'rgba(239, 68, 68, 0.06)', border: 'rgba(239, 68, 68, 0.18)' }
+    : concern.category === 'edge-cases'
+      ? { color: '#b45309', bg: 'rgba(245, 158, 11, 0.08)', border: 'rgba(245, 158, 11, 0.22)' }
+      : concern.category === 'read-budget'
+        ? { color: '#2563eb', bg: 'rgba(37, 99, 235, 0.06)', border: 'rgba(37, 99, 235, 0.18)' }
+        : { color: 'var(--t-text-secondary)', bg: 'rgba(148, 163, 184, 0.06)', border: 'rgba(148, 163, 184, 0.16)' };
+  return (
+    <div style={{
+      paddingTop: 5,
+      paddingRight: 8,
+      paddingBottom: 5,
+      paddingLeft: 8,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderStyle: 'solid',
+      borderColor: tone.border,
+      background: tone.bg,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 2,
+    }}>
+      <span style={{ fontSize: 10, fontWeight: 700, color: tone.color, fontFamily: FONT_FAMILY, letterSpacing: '-0.005em' }}>
+        {concern.label}
+      </span>
+      <span style={{ fontSize: 10.5, color: 'var(--t-text-secondary)', fontFamily: FONT_FAMILY, lineHeight: 1.4 }}>
+        {concern.detail}
+      </span>
+    </div>
+  );
+}
+
+export function ReviewPane({ packet, onActionComplete }: {
+  packet: OrchestratorPacket;
+  onActionComplete?: () => void;
+}) {
+  const verdict = deriveVerdict(packet);
+  const tone = verdictTone(verdict);
+  const concerns = useMemo(() => buildConcerns(packet), [packet]);
+
+  const [busy, setBusy] = useState<'merge' | 'respec' | 'kill' | null>(null);
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const [feedback, setFeedback] = useState('');
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionNote, setActionNote] = useState<string | null>(null);
+
+  const reviewSummary = packet.review?.summary?.trim() ?? '';
+
+  const callAction = useCallback(async (
+    kind: 'merge' | 'respec' | 'kill',
+    body: Record<string, unknown>,
+    endpoint: string,
+  ) => {
+    setBusy(kind);
+    setActionError(null);
+    setActionNote(null);
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const payload = await response.json().catch(() => null) as {
+        ok?: boolean;
+        result?: { note?: string };
+        error?: { message?: string };
+      } | null;
+      if (!response.ok || !payload?.ok) {
+        throw new Error(payload?.error?.message ?? `Unable to ${kind} packet.`);
+      }
+      setActionNote(payload.result?.note ?? null);
+      onActionComplete?.();
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : `Unable to ${kind} packet.`);
+    } finally {
+      setBusy(null);
+    }
+  }, [onActionComplete]);
+
+  const onMerge = useCallback(() => {
+    void callAction('merge', { packetId: packet.id }, '/api/orchestrator/merge');
+  }, [callAction, packet.id]);
+
+  const onKill = useCallback(() => {
+    void callAction('kill', { packetId: packet.id, clearWorktree: true, reason: 'Killed via review card.' }, '/api/orchestrator/reset-packet');
+  }, [callAction, packet.id]);
+
+  const onSubmitFeedback = useCallback(() => {
+    const trimmed = feedback.trim();
+    if (!trimmed) return;
+    void callAction('respec', { packetId: packet.id, feedback: trimmed }, '/api/orchestrator/rerun-with-feedback')
+      .then(() => {
+        setFeedback('');
+        setFeedbackOpen(false);
+      });
+  }, [callAction, feedback, packet.id]);
+
+  return (
+    <div style={paneStyle()}>
+      <div style={paneLabelStyle()}>REVIEW</div>
+
+      <div style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        alignSelf: 'flex-start',
+        gap: 6,
+        paddingTop: 4,
+        paddingRight: 10,
+        paddingBottom: 4,
+        paddingLeft: 10,
+        borderRadius: 999,
+        background: tone.background,
+        borderWidth: 1,
+        borderStyle: 'solid',
+        borderColor: tone.border,
+        color: tone.color,
+        fontSize: 11,
+        fontWeight: 800,
+        letterSpacing: '0.06em',
+        fontFamily: FONT_FAMILY,
+      }}>
+        {tone.label}
+      </div>
+
+      {reviewSummary ? (
+        <div style={{
+          fontSize: 11,
+          color: 'var(--t-text-secondary)',
+          lineHeight: 1.5,
+          whiteSpace: 'pre-wrap',
+          fontFamily: FONT_FAMILY,
+        }}>
+          {reviewSummary}
+        </div>
+      ) : null}
+
+      {concerns.length === 0 ? (
+        <div style={{ fontSize: 10.5, color: 'var(--t-text-muted)', fontFamily: FONT_FAMILY }}>
+          No concerns surfaced.
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          {concerns.map((concern, idx) => (
+            <ConcernRow key={`${concern.category}:${idx}`} concern={concern} />
+          ))}
+        </div>
+      )}
+
+      {actionError ? (
+        <div style={{
+          fontSize: 10.5,
+          color: '#b91c1c',
+          paddingTop: 5,
+          paddingRight: 8,
+          paddingBottom: 5,
+          paddingLeft: 8,
+          borderRadius: 6,
+          background: 'rgba(239, 68, 68, 0.06)',
+          borderWidth: 1,
+          borderStyle: 'solid',
+          borderColor: 'rgba(239, 68, 68, 0.18)',
+          fontFamily: FONT_FAMILY,
+        }}>
+          {actionError}
+        </div>
+      ) : null}
+
+      {actionNote ? (
+        <div style={{
+          fontSize: 10.5,
+          color: 'var(--t-text-secondary)',
+          fontFamily: FONT_FAMILY,
+        }}>
+          {actionNote}
+        </div>
+      ) : null}
+
+      {feedbackOpen ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <textarea
+            value={feedback}
+            onChange={(e) => setFeedback(e.target.value)}
+            placeholder="What needs to change? Be specific — this prepends to the original prompt."
+            disabled={busy === 'respec'}
+            style={{
+              width: '100%',
+              minHeight: 70,
+              maxHeight: 160,
+              resize: 'vertical',
+              borderRadius: 8,
+              borderWidth: 1,
+              borderStyle: 'solid',
+              borderColor: 'var(--t-panel-border)',
+              background: 'var(--t-input-bg, var(--t-panel))',
+              color: 'var(--t-text)',
+              paddingTop: 6,
+              paddingRight: 8,
+              paddingBottom: 6,
+              paddingLeft: 8,
+              fontSize: 11,
+              fontFamily: FONT_FAMILY,
+              outline: 'none',
+            }}
+          />
+          <div style={{ display: 'flex', gap: 6 }}>
+            <button
+              type="button"
+              onClick={onSubmitFeedback}
+              disabled={!feedback.trim() || busy === 'respec'}
+              style={{
+                paddingTop: 5,
+                paddingRight: 10,
+                paddingBottom: 5,
+                paddingLeft: 10,
+                borderRadius: 8,
+                borderWidth: 1,
+                borderStyle: 'solid',
+                borderColor: 'rgba(245, 158, 11, 0.36)',
+                background: 'rgba(245, 158, 11, 0.14)',
+                color: '#b45309',
+                fontSize: 10.5,
+                fontWeight: 700,
+                cursor: !feedback.trim() || busy === 'respec' ? 'not-allowed' : 'pointer',
+                opacity: !feedback.trim() || busy === 'respec' ? 0.5 : 1,
+                fontFamily: FONT_FAMILY,
+              }}
+            >
+              {busy === 'respec' ? 'Submitting…' : 'Submit feedback'}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setFeedbackOpen(false); setFeedback(''); }}
+              disabled={busy === 'respec'}
+              style={{
+                paddingTop: 5,
+                paddingRight: 10,
+                paddingBottom: 5,
+                paddingLeft: 10,
+                borderRadius: 8,
+                borderWidth: 1,
+                borderStyle: 'solid',
+                borderColor: 'var(--t-panel-border)',
+                background: 'transparent',
+                color: 'var(--t-text-muted)',
+                fontSize: 10.5,
+                fontWeight: 600,
+                cursor: 'pointer',
+                fontFamily: FONT_FAMILY,
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, paddingTop: 4 }}>
+          <button
+            type="button"
+            onClick={onMerge}
+            disabled={busy !== null}
+            style={{
+              paddingTop: 6,
+              paddingRight: 12,
+              paddingBottom: 6,
+              paddingLeft: 12,
+              borderRadius: 10,
+              borderWidth: 1,
+              borderStyle: 'solid',
+              borderColor: 'rgba(34, 197, 94, 0.36)',
+              background: 'rgba(34, 197, 94, 0.14)',
+              color: '#15803d',
+              fontSize: 11,
+              fontWeight: 700,
+              cursor: busy !== null ? 'not-allowed' : 'pointer',
+              opacity: busy !== null ? 0.5 : 1,
+              fontFamily: FONT_FAMILY,
+            }}
+          >
+            {busy === 'merge' ? 'Merging…' : 'Merge'}
+          </button>
+          <button
+            type="button"
+            onClick={() => setFeedbackOpen(true)}
+            disabled={busy !== null}
+            style={{
+              paddingTop: 6,
+              paddingRight: 12,
+              paddingBottom: 6,
+              paddingLeft: 12,
+              borderRadius: 10,
+              borderWidth: 1,
+              borderStyle: 'solid',
+              borderColor: 'rgba(245, 158, 11, 0.36)',
+              background: 'rgba(245, 158, 11, 0.10)',
+              color: '#b45309',
+              fontSize: 11,
+              fontWeight: 700,
+              cursor: busy !== null ? 'not-allowed' : 'pointer',
+              opacity: busy !== null ? 0.5 : 1,
+              fontFamily: FONT_FAMILY,
+            }}
+          >
+            Re-spec with fixes
+          </button>
+          <button
+            type="button"
+            onClick={onKill}
+            disabled={busy !== null}
+            style={{
+              paddingTop: 6,
+              paddingRight: 12,
+              paddingBottom: 6,
+              paddingLeft: 12,
+              borderRadius: 10,
+              borderWidth: 1,
+              borderStyle: 'solid',
+              borderColor: 'rgba(239, 68, 68, 0.32)',
+              background: 'rgba(239, 68, 68, 0.08)',
+              color: '#b91c1c',
+              fontSize: 11,
+              fontWeight: 700,
+              cursor: busy !== null ? 'not-allowed' : 'pointer',
+              opacity: busy !== null ? 0.5 : 1,
+              fontFamily: FONT_FAMILY,
+            }}
+          >
+            {busy === 'kill' ? 'Killing…' : 'Kill packet'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/desktop/thoughts/mission-panel/review-card/SpecPane.tsx
+++ b/src/components/desktop/thoughts/mission-panel/review-card/SpecPane.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import {
+  DirectiveSummary,
+  FONT_FAMILY,
+  PANE_BORDER_COLOR,
+  paneLabelStyle,
+  paneStyle,
+} from './shared';
+
+/**
+ * #729 — SPEC pane: issue title/body + directives invoked.
+ */
+export function SpecPane({ packet, directives, directivesError }: {
+  packet: OrchestratorPacket;
+  directives: DirectiveSummary[] | null;
+  directivesError: string | null;
+}) {
+  const issueBody = packet.issue?.body?.trim() ?? '';
+  const issueNumber = packet.issue?.number ?? null;
+  const issueUrl = packet.issue?.url ?? null;
+
+  return (
+    <div style={paneStyle()}>
+      <div style={paneLabelStyle()}>SPEC</div>
+      <div style={{
+        fontSize: 12.5,
+        fontWeight: 700,
+        color: 'var(--t-text)',
+        letterSpacing: '-0.01em',
+        lineHeight: 1.35,
+        fontFamily: FONT_FAMILY,
+      }}>
+        {issueNumber ? `#${issueNumber} — ` : ''}{packet.title}
+      </div>
+      {issueUrl ? (
+        <a
+          href={issueUrl}
+          target="_blank"
+          rel="noreferrer"
+          style={{
+            fontSize: 10.5,
+            color: '#2563eb',
+            textDecoration: 'none',
+            fontFamily: FONT_FAMILY,
+            wordBreak: 'break-all',
+          }}
+        >
+          {issueUrl}
+        </a>
+      ) : null}
+      {issueBody ? (
+        <div style={{
+          fontSize: 11,
+          color: 'var(--t-text-secondary)',
+          lineHeight: 1.5,
+          whiteSpace: 'pre-wrap',
+          fontFamily: FONT_FAMILY,
+          paddingTop: 4,
+          paddingBottom: 4,
+          maxHeight: 160,
+          overflowY: 'auto',
+          borderTopWidth: 1,
+          borderTopStyle: 'solid',
+          borderTopColor: PANE_BORDER_COLOR,
+          borderBottomWidth: 1,
+          borderBottomStyle: 'solid',
+          borderBottomColor: PANE_BORDER_COLOR,
+        }}>
+          {issueBody}
+        </div>
+      ) : packet.summary ? (
+        <div style={{
+          fontSize: 11,
+          color: 'var(--t-text-secondary)',
+          lineHeight: 1.5,
+          whiteSpace: 'pre-wrap',
+          fontFamily: FONT_FAMILY,
+        }}>
+          {packet.summary}
+        </div>
+      ) : null}
+
+      <div style={{ ...paneLabelStyle(), paddingTop: 6 }}>Directives invoked</div>
+      {directivesError ? (
+        <div style={{ fontSize: 10.5, color: '#b91c1c', fontFamily: FONT_FAMILY }}>
+          {directivesError}
+        </div>
+      ) : !directives ? (
+        <div style={{ fontSize: 10.5, color: 'var(--t-text-muted)', fontFamily: FONT_FAMILY }}>
+          Loading directives…
+        </div>
+      ) : directives.length === 0 ? (
+        <div style={{ fontSize: 10.5, color: 'var(--t-text-muted)', fontFamily: FONT_FAMILY }}>
+          No directives configured.
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          {directives.map((directive) => (
+            <div
+              key={directive.id}
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 8,
+                paddingTop: 5,
+                paddingRight: 7,
+                paddingBottom: 5,
+                paddingLeft: 7,
+                borderRadius: 8,
+                background: 'rgba(148, 163, 184, 0.08)',
+                borderWidth: 1,
+                borderStyle: 'solid',
+                borderColor: 'rgba(148, 163, 184, 0.16)',
+              }}
+            >
+              <span style={{
+                flexShrink: 0,
+                fontSize: 9,
+                fontWeight: 700,
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+                color: directive.scope === 'global' ? '#2563eb' : 'var(--t-text-muted)',
+                paddingTop: 2,
+                fontFamily: FONT_FAMILY,
+              }}>
+                {directive.scope}
+              </span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{
+                  fontSize: 11,
+                  fontWeight: 600,
+                  color: 'var(--t-text)',
+                  fontFamily: FONT_FAMILY,
+                  lineHeight: 1.35,
+                }}>
+                  {directive.title}
+                </div>
+                {directive.body ? (
+                  <div style={{
+                    fontSize: 10,
+                    color: 'var(--t-text-muted)',
+                    fontFamily: FONT_FAMILY,
+                    lineHeight: 1.4,
+                    marginTop: 2,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    display: '-webkit-box',
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: 'vertical',
+                  } as React.CSSProperties}>
+                    {directive.body}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/desktop/thoughts/mission-panel/review-card/shared.ts
+++ b/src/components/desktop/thoughts/mission-panel/review-card/shared.ts
@@ -1,0 +1,125 @@
+/**
+ * #729 — Shared types + style tokens for the Packet Review Card panes.
+ */
+
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+
+export type Verdict = 'merge' | 'respec' | 'kill' | 'pending';
+
+export interface DirectiveSummary {
+  id: string;
+  title: string;
+  scope: string;
+  repoName: string | null;
+  priority: number | null;
+  body: string;
+}
+
+export interface DiffPayload {
+  diff: string;
+  additions: number;
+  deletions: number;
+  fileCount: number;
+  baseBranch: string | null;
+}
+
+export interface ParsedFileDiff {
+  path: string;
+  additions: number;
+  deletions: number;
+  patch: string;
+  status: 'A' | 'M' | 'D' | 'R';
+}
+
+export interface Concern {
+  category: 'read-budget' | 'edge-cases' | 'mechanical' | 'review';
+  label: string;
+  detail: string;
+}
+
+export const PANE_BORDER_COLOR = 'var(--t-divider-subtle)';
+export const LABEL_COLOR = 'var(--t-text-muted)';
+export const FONT_FAMILY = '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif';
+export const MONO_FAMILY = 'var(--font-mono, "SF Mono", Menlo, monospace)';
+
+export function deriveVerdict(packet: OrchestratorPacket): Verdict {
+  if (packet.review) return packet.review.approved ? 'merge' : 'respec';
+  return 'pending';
+}
+
+export function verdictTone(verdict: Verdict) {
+  switch (verdict) {
+    case 'merge':
+      return { label: 'MERGE', color: '#15803d', background: 'rgba(34, 197, 94, 0.12)', border: 'rgba(34, 197, 94, 0.32)' };
+    case 'respec':
+      return { label: 'RE-SPEC', color: '#b45309', background: 'rgba(245, 158, 11, 0.14)', border: 'rgba(245, 158, 11, 0.36)' };
+    case 'kill':
+      return { label: 'KILL', color: '#b91c1c', background: 'rgba(239, 68, 68, 0.12)', border: 'rgba(239, 68, 68, 0.32)' };
+    default:
+      return { label: 'PENDING', color: 'var(--t-text-muted)', background: 'rgba(148, 163, 184, 0.12)', border: 'rgba(148, 163, 184, 0.28)' };
+  }
+}
+
+export function paneStyle(): React.CSSProperties {
+  return {
+    flex: 1,
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8,
+    paddingTop: 10,
+    paddingRight: 11,
+    paddingBottom: 10,
+    paddingLeft: 11,
+    minHeight: 280,
+    maxHeight: 460,
+    overflowY: 'auto',
+  };
+}
+
+export function paneLabelStyle(): React.CSSProperties {
+  return {
+    fontSize: 9,
+    fontWeight: 700,
+    textTransform: 'uppercase',
+    letterSpacing: '0.08em',
+    color: LABEL_COLOR,
+    fontFamily: FONT_FAMILY,
+  };
+}
+
+export function buildConcerns(packet: OrchestratorPacket): Concern[] {
+  const out: Concern[] = [];
+
+  if (packet.readBudget) {
+    const reads = packet.readBudget.requiredReads.length;
+    if (reads > 0) {
+      out.push({
+        category: 'read-budget',
+        label: 'Read budget',
+        detail: `Required ${packet.readBudget.minToolCalls} read-only call(s) across ${reads} surface file(s).`,
+      });
+    }
+  }
+
+  if (packet.edgeCaseSites && packet.edgeCaseSites.length > 0) {
+    const top = packet.edgeCaseSites[0];
+    out.push({
+      category: 'edge-cases',
+      label: 'Edge cases flagged',
+      detail: `${packet.edgeCaseSites.length} site(s) including ${top.location}.`,
+    });
+  }
+
+  if (packet.review?.findings) {
+    for (const finding of packet.review.findings.slice(0, 5)) {
+      out.push({
+        category: finding.severity === 'high' ? 'mechanical' : 'review',
+        label: finding.file,
+        detail: finding.description,
+      });
+    }
+  }
+
+  return out;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -119,6 +119,9 @@ const GATED_PREFIXES = [
   '/api/claude-code/',
   '/api/codex/',
   '/api/operator/',
+  // Cortex memory/directive surface — local-only by design. Even read-only
+  // endpoints leak operator preferences and repo names; gate them too.
+  '/api/cortex/',
   // Setup routes are gated too — GET is allowlisted above, POST needs loopback
   // or a token (so an evil cross-origin page can't POST to /api/setup/claude-desktop
   // and silently write to the user's Claude config).


### PR DESCRIPTION
## Summary

- 3-pane Packet Review Card — SPEC + Directives | DIFF | REVIEW — renders inline on `awaiting_review` packets
- Reuses existing endpoints (`/api/orchestrator/merge`, `/api/orchestrator/rerun-with-feedback`, `/api/orchestrator/reset-packet`, `/api/worktrees/diff`)
- New `GET /api/cortex/directives` reads `~/.o8/directives/*.md` (front-matter parser)

## Wiring

| Surface | Wired vs Stubbed |
|---|---|
| SPEC pane (issue title + body + URL) | wired |
| Directives list (priority-sorted) | wired (new `/api/cortex/directives`) |
| DIFF pane (file tree + +/- + per-file unified) | wired (`/api/worktrees/diff` + `parseGitDiff`) |
| REVIEW verdict pill | derived from `packet.review.approved` |
| Concerns rows (read-budget / edge-cases / mechanical) | renders from `packet.readBudget` / `packet.edgeCaseSites` / `packet.review.findings` — actual detection lives in #732/#733 |
| Merge button | wired to `approveAndMergePacket` via `/api/orchestrator/merge` |
| Re-spec with fixes | wired to `rerunWithFeedback` via `/api/orchestrator/rerun-with-feedback` |
| Kill packet | wired to `resetPacket(clearWorktree=true)` via `/api/orchestrator/reset-packet` |

## Decomposition

`PacketReviewCard.tsx` is the orchestrator (129 lines). Panes split into `review-card/SpecPane.tsx`, `DiffPane.tsx`, `ReviewPane.tsx`, plus `shared.ts` for tokens/types — all under the 800-line ceiling.

## Test plan

- [ ] Open a packet in `awaiting_review` — 3 panes render inline when expanded
- [ ] Directives populate from `~/.o8/directives/`
- [ ] Each file row in DIFF expands to per-file unified hunks (+/- coloured)
- [ ] Verdict pill reflects `packet.review.approved` state
- [ ] Merge / Kill / Re-spec hit their endpoints (network tab)
- [ ] `npx tsc --noEmit` passes
- [ ] No CSS classes / no native `<select>`s / no react-icon imports

Generated with [Claude Code](https://claude.com/claude-code)
