### PR TITLE
feat(tauri): global-shortcut + notification + menu bar tray (closes #730 #731)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1568,6 +1568,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1718,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -2700,6 +2728,7 @@ dependencies = [
  "signal-hook",
  "tauri",
  "tauri-build",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
  "tauri-plugin-mcp",
  "tauri-plugin-notification",
@@ -4701,6 +4730,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424af23c7e88d05e4a1a6fc2c7be077912f8c76bd7900fd50aa2b7cbf5a2c405"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-log"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6538,6 +6582,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6575,6 +6636,12 @@ dependencies = [
  "libc",
  "quick-xml 0.30.0",
 ]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,8 @@ tauri-plugin-process = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-store = "2"
 tauri-plugin-window-state = "2"
+# Issue #730: Cmd+Shift+O global shortcut to summon the dispatch popover.
+tauri-plugin-global-shortcut = "2"
 # Optional: see [features].dev-mcp-plugin above. Relative path so clones can
 # opt in by placing the plugin repo next to cortex-ide.
 tauri-plugin-mcp = { path = "../../tauri-plugin-mcp", optional = true }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "o8 default capabilities",
-  "windows": ["main"],
+  "windows": ["main", "dispatch-popover"],
   "permissions": [
     "core:default",
     "core:event:default",
@@ -12,12 +12,21 @@
     "core:event:allow-emit-to",
     "core:window:allow-start-dragging",
     "core:window:allow-start-resize-dragging",
+    "core:window:allow-show",
+    "core:window:allow-hide",
+    "core:window:allow-close",
+    "core:window:allow-set-focus",
+    "core:webview:allow-create-webview-window",
     "shell:allow-open",
     "shell:allow-execute",
     "process:default",
     "notification:default",
     "store:default",
     "log:default",
-    "updater:default"
+    "updater:default",
+    "global-shortcut:default",
+    "global-shortcut:allow-register",
+    "global-shortcut:allow-unregister",
+    "global-shortcut:allow-is-registered"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,10 +3,12 @@ use serde::Serialize;
 use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 use tauri::{
-    menu::{Menu, MenuItem},
-    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    Emitter, Manager, RunEvent,
+    menu::{Menu, MenuItem, PredefinedMenuItem},
+    tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent},
+    AppHandle, Emitter, Manager, RunEvent, WebviewUrl, WebviewWindowBuilder,
 };
+use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
+use tauri_plugin_notification::NotificationExt;
 #[cfg(target_os = "macos")]
 use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
 #[cfg(target_os = "windows")]
@@ -1159,6 +1161,288 @@ fn read_workspaces() -> Result<serde_json::Value, String> {
     Ok(serde_json::json!({ "workspaces": workspaces }))
 }
 
+// ── Tray badge + native weapons (issues #730, #731) ──
+//
+// Three native macOS features that differentiate o8 from web/Electron rivals:
+//
+//   1. Cmd+Shift+O global shortcut → spawns a 600x80 always-on-top dispatch
+//      popover. Wired via tauri-plugin-global-shortcut.
+//
+//   2. Native notifications when a packet flips to `awaiting_review`. Fired
+//      from the frontend (which already holds the WS lane stream) via the
+//      `notify_review_ready` Tauri command. The macOS notification plugin
+//      doesn't expose action buttons natively (notify-rust limitation), so
+//      clicking the notification raises the app focused on the review card —
+//      "Approve / Reject" stay as in-app affordances for v1.
+//
+//   3. Menu bar tray with live "[N]" badge for pending reviews. The tray
+//      already exists; we now keep its title in sync by polling the lanes
+//      API every 5s. `set_tray_badge` is also exposed as a Tauri command so
+//      the frontend can push exact counts when WS lane events arrive (faster
+//      than waiting for the next poll tick).
+
+/// Shared handle to the menu bar tray icon. Stored once on `setup()` so
+/// background polls and frontend commands can update its title without
+/// re-creating the tray.
+fn tray_handle() -> &'static Mutex<Option<TrayIcon>> {
+    static HANDLE: OnceLock<Mutex<Option<TrayIcon>>> = OnceLock::new();
+    HANDLE.get_or_init(|| Mutex::new(None))
+}
+
+fn store_tray(tray: TrayIcon) {
+    if let Ok(mut guard) = tray_handle().lock() {
+        *guard = Some(tray);
+    }
+}
+
+/// Update the macOS menu bar tray title with a count badge. Hides the badge
+/// (sets to None) when count is 0 so the icon sits clean. macOS only — on
+/// other platforms `set_title` is a no-op, which is fine: we still update the
+/// tooltip elsewhere.
+fn apply_tray_badge(count: u32) {
+    let Ok(guard) = tray_handle().lock() else { return };
+    let Some(tray) = guard.as_ref() else { return };
+    let title = if count == 0 { None } else { Some(format!("[{}]", count)) };
+    if let Err(err) = tray.set_title(title.as_deref()) {
+        log::warn!("[tray-badge] set_title failed: {}", err);
+    }
+    // Tooltip mirrors the count so accessibility tools report it too.
+    let tooltip = if count == 0 {
+        "o8".to_string()
+    } else {
+        format!("o8 — {} awaiting review", count)
+    };
+    let _ = tray.set_tooltip(Some(tooltip));
+}
+
+/// Read a UTF-8 file from the o8 data dir, trimming whitespace. Used to pick
+/// up the dynamic API port and ws-token written by the sidecar.
+fn read_data_file(name: &str) -> Option<String> {
+    let path = format!("{}/{}", o8_data_dir(), name);
+    std::fs::read_to_string(&path).ok().map(|s| s.trim().to_string())
+}
+
+/// Resolve the API port the Next server is bound to. Mirrors the precedence
+/// in `src/lib/panel/api-port.ts` — env var first, on-disk file second,
+/// default 3001 last.
+fn resolve_api_port() -> u16 {
+    if let Ok(p) = std::env::var("O8_API_PORT") {
+        if let Ok(parsed) = p.parse() { return parsed; }
+    }
+    if let Some(raw) = read_data_file("api-port") {
+        if let Ok(parsed) = raw.parse() { return parsed; }
+    }
+    3001
+}
+
+/// Read the cross-origin auth token. Empty string if missing — the loopback
+/// origin path (which we use here) doesn't strictly need it but we send it
+/// when present so the request also works under future hardenings.
+fn resolve_ws_token() -> String {
+    read_data_file("ws-token").unwrap_or_default()
+}
+
+/// Background HTTP GET against the local Next server. Uses a raw TCP write so
+/// we don't pull in a new HTTP crate. The response body is small (lanes JSON,
+/// hundreds of bytes per active lane). Bounded read keeps us safe from a
+/// runaway server. Returns `None` on any error — callers fall back to the
+/// previous count.
+fn http_get_local(path: &str) -> Option<String> {
+    use std::io::{Read, Write};
+    use std::time::Duration;
+    let port = resolve_api_port();
+    let token = resolve_ws_token();
+    let addr = format!("127.0.0.1:{}", port);
+    let mut stream = std::net::TcpStream::connect_timeout(
+        &addr.parse().ok()?,
+        Duration::from_millis(750),
+    ).ok()?;
+    stream.set_read_timeout(Some(Duration::from_millis(1500))).ok();
+    stream.set_write_timeout(Some(Duration::from_millis(1500))).ok();
+    let auth = if token.is_empty() {
+        String::new()
+    } else {
+        format!("Authorization: Bearer {}\r\n", token)
+    };
+    let req = format!(
+        "GET {} HTTP/1.1\r\nHost: 127.0.0.1:{}\r\n{}Connection: close\r\nAccept: application/json\r\n\r\n",
+        path, port, auth
+    );
+    stream.write_all(req.as_bytes()).ok()?;
+    let mut buf = Vec::with_capacity(64 * 1024);
+    let mut chunk = [0u8; 4096];
+    loop {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(n) => {
+                buf.extend_from_slice(&chunk[..n]);
+                if buf.len() > 1024 * 1024 { break; } // 1 MiB cap
+            }
+            Err(_) => break,
+        }
+    }
+    let raw = String::from_utf8_lossy(&buf).to_string();
+    // Split off HTTP headers — body starts after the first \r\n\r\n.
+    let body_start = raw.find("\r\n\r\n").map(|i| i + 4).unwrap_or(0);
+    Some(raw[body_start..].to_string())
+}
+
+/// Count lanes whose status is `reviewing` (the user-facing "awaiting review"
+/// state). Falls back to 0 on any parse / network error — the badge just
+/// shows nothing rather than a stale value.
+fn count_awaiting_review() -> u32 {
+    let Some(body) = http_get_local("/api/lanes?active=true") else { return 0 };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) else { return 0 };
+    let Some(lanes) = json.get("lanes").and_then(|v| v.as_array()) else { return 0 };
+    lanes
+        .iter()
+        .filter(|lane| {
+            lane.get("status")
+                .and_then(|s| s.as_str())
+                .map(|s| s == "reviewing")
+                .unwrap_or(false)
+        })
+        .count() as u32
+}
+
+/// Spawn a long-lived background thread that polls the lanes API every 5s
+/// and pushes the awaiting-review count to the tray badge. Light enough to
+/// run continuously — one tiny HTTP request, no JSON deserialization beyond
+/// pulling out a status string per lane.
+fn spawn_tray_badge_poller(app: AppHandle) {
+    std::thread::spawn(move || {
+        let mut last_count: u32 = u32::MAX; // force first emit
+        loop {
+            let count = count_awaiting_review();
+            if count != last_count {
+                apply_tray_badge(count);
+                // Mirror to the frontend so any UI badge can stay synced
+                // without doing its own poll.
+                let _ = app.emit("tray-badge-changed", count);
+                last_count = count;
+            }
+            std::thread::sleep(std::time::Duration::from_secs(5));
+        }
+    });
+}
+
+// ── Cmd+Shift+O dispatch popover ──
+//
+// The popover is a secondary window labelled "dispatch-popover" loaded from
+// /dispatch-popover (a Next.js route that renders DispatchPopover.tsx). We
+// destroy it on Esc / submit so each invocation is a fresh window — simpler
+// than juggling visibility state across the global-shortcut callback and the
+// frontend.
+
+const POPOVER_LABEL: &str = "dispatch-popover";
+const POPOVER_WIDTH: f64 = 600.0;
+const POPOVER_HEIGHT: f64 = 80.0;
+
+/// Open (or focus, if already open) the dispatch popover. Centered on the
+/// active monitor, always-on-top, no decorations, frameless. Built on the
+/// dev URL when running `cargo tauri dev`, otherwise the bundled
+/// `tauri://localhost` scheme. Returns Ok(()) on success.
+fn open_dispatch_popover_impl(app: &AppHandle) -> Result<(), String> {
+    if let Some(existing) = app.get_webview_window(POPOVER_LABEL) {
+        let _ = existing.show();
+        let _ = existing.set_focus();
+        let _ = existing.center();
+        return Ok(());
+    }
+
+    // /dispatch-popover route. In dev (cargo tauri dev) we hit the Next dev
+    // server directly; in prod we use tauri://localhost which serves the
+    // static build out of out/frontend/.
+    let url = if cfg!(debug_assertions) {
+        let port = resolve_api_port();
+        let raw = format!("http://localhost:{}/dispatch-popover", port);
+        let parsed: tauri::Url = raw.parse().map_err(|e| format!("popover url parse: {}", e))?;
+        WebviewUrl::External(parsed)
+    } else {
+        WebviewUrl::App("dispatch-popover".into())
+    };
+
+    let mut builder = WebviewWindowBuilder::new(app, POPOVER_LABEL, url)
+        .title("Dispatch")
+        .inner_size(POPOVER_WIDTH, POPOVER_HEIGHT)
+        .resizable(false)
+        .always_on_top(true)
+        .decorations(false)
+        .transparent(true)
+        .focused(true)
+        .visible(true)
+        .skip_taskbar(true)
+        .center();
+
+    // visible_on_all_workspaces is critical for a global shortcut —
+    // otherwise the popover only shows on the workspace that owns the main
+    // window, defeating the "from anywhere" promise.
+    builder = builder.visible_on_all_workspaces(true);
+
+    builder.build().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Tauri command: open the popover. Called from frontend (e.g. a NavRail
+/// button) as well as from the global shortcut callback.
+#[tauri::command]
+fn open_dispatch_popover(app: AppHandle) -> Result<(), String> {
+    open_dispatch_popover_impl(&app)
+}
+
+/// Tauri command: close the popover. Called from the popover frontend on
+/// Esc / submit / blur.
+#[tauri::command]
+fn close_dispatch_popover(app: AppHandle) -> Result<(), String> {
+    if let Some(window) = app.get_webview_window(POPOVER_LABEL) {
+        let _ = window.close();
+    }
+    Ok(())
+}
+
+/// Tauri command: push an exact awaiting-review count to the tray badge.
+/// Frontend calls this when a WS lane event flips a packet's status, so the
+/// badge updates instantly instead of waiting for the 5s poll.
+#[tauri::command]
+fn set_tray_badge(count: u32) {
+    apply_tray_badge(count);
+}
+
+/// Tauri command: fire a native notification when a packet flips to
+/// awaiting_review. Frontend invokes this from the WS lane event handler.
+/// We also raise the tray badge by 0 (no-op for count) just to refresh the
+/// tooltip in case the poller hasn't ticked yet.
+#[tauri::command]
+fn notify_review_ready(
+    app: AppHandle,
+    title: String,
+    body: String,
+    packet_id: Option<String>,
+) -> Result<(), String> {
+    let display_title = if title.is_empty() { "Awaiting review".to_string() } else { title };
+    let display_body = if body.is_empty() {
+        "A packet is ready for review".to_string()
+    } else {
+        body
+    };
+    app.notification()
+        .builder()
+        .title(&display_title)
+        .body(&display_body)
+        .show()
+        .map_err(|e| e.to_string())?;
+    // Frontend can listen for this if it wants to scroll to the packet card
+    // when the notification is clicked. We can't intercept the click on
+    // macOS through the notify-rust path, but emitting here means anything
+    // listening on `notification-fired` knows the most recent packet.
+    let _ = app.emit("notification-fired", serde_json::json!({
+        "title": display_title,
+        "body": display_body,
+        "packetId": packet_id,
+    }));
+    Ok(())
+}
+
 // Sanity-bounds the saved window-state.json before tauri-plugin-window-state restores
 // from it. Multi-monitor reconfigs or virtual-desktop bugs can save dimensions like
 // 17000x2820 — wider than any real screen — and the plugin restores them blindly.
@@ -1194,6 +1478,12 @@ pub fn run() {
     // for ungraceful exits.
     install_shutdown_handlers();
 
+    // Cmd+Shift+O on macOS, Ctrl+Shift+O elsewhere. The global-shortcut
+    // plugin uses the same `Modifiers::SUPER` token for both Cmd (mac) and
+    // the Windows key — close enough for v1; we expose this constant so the
+    // handler and the registration match.
+    let dispatch_shortcut = Shortcut::new(Some(Modifiers::SUPER | Modifiers::SHIFT), Code::KeyO);
+
     #[allow(unused_mut)] // `mut` is needed only when `dev-mcp-plugin` feature is enabled
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_log::Builder::default()
@@ -1205,8 +1495,32 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_updater::Builder::new().build())
         // Auto-saves window size + position to the OS data dir on close and
-        // restores them on next launch. No config needed.
-        .plugin(tauri_plugin_window_state::Builder::default().build());
+        // restores them on next launch. The dispatch-popover is excluded —
+        // it's transient (Cmd+Shift+O summons + closes per use) and we don't
+        // want its 600x80 dimensions or position bleeding into anything.
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_filter(|label| label != POPOVER_LABEL)
+                .skip_initial_state(POPOVER_LABEL)
+                .build(),
+        )
+        // Cmd+Shift+O global shortcut (issue #730). Registered on `setup()`
+        // below so the AppHandle is available; the handler routes back into
+        // `open_dispatch_popover_impl()`.
+        .plugin(
+            tauri_plugin_global_shortcut::Builder::new()
+                .with_handler(move |app, shortcut, event| {
+                    if event.state() != ShortcutState::Pressed {
+                        return;
+                    }
+                    if shortcut == &dispatch_shortcut {
+                        if let Err(err) = open_dispatch_popover_impl(app) {
+                            log::warn!("[global-shortcut] open dispatch popover failed: {}", err);
+                        }
+                    }
+                })
+                .build(),
+        );
 
     // MCP plugin: exposes app to AI agents (screenshots, DOM, input simulation).
     // Optional dev-only feature. Requires a sibling checkout of tauri-plugin-mcp.
@@ -1239,26 +1553,43 @@ pub fn run() {
             read_git_status,
             read_approvals,
             read_workspaces,
+            open_dispatch_popover,
+            close_dispatch_popover,
+            set_tray_badge,
+            notify_review_ready,
             #[cfg(target_os = "macos")]
             master_key_get,
             #[cfg(target_os = "macos")]
             master_key_ensure,
         ])
-        .setup(|app| {
-            // ── System Tray ──
-            let show = MenuItem::with_id(app, "show", "Show Cortex IDE", true, None::<&str>)?;
-            let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
-            let menu = Menu::with_items(app, &[&show, &quit])?;
+        .setup(move |app| {
+            // ── System Tray (issue #731) ──
+            // Menu items: Show / Open Dispatch (Cmd+Shift+O) / Quit. The
+            // separator + "Open Dispatch" entry surfaces the global-shortcut
+            // feature so users discover it without reading docs.
+            let show = MenuItem::with_id(app, "show", "Show o8", true, None::<&str>)?;
+            let dispatch = MenuItem::with_id(app, "dispatch", "Quick Dispatch", true, Some("CmdOrCtrl+Shift+O"))?;
+            let separator = PredefinedMenuItem::separator(app)?;
+            let quit = MenuItem::with_id(app, "quit", "Quit o8", true, None::<&str>)?;
+            let menu = Menu::with_items(app, &[&show, &dispatch, &separator, &quit])?;
 
-            let _tray = TrayIconBuilder::new()
+            let tray = TrayIconBuilder::new()
                 .menu(&menu)
-                .tooltip("Cortex IDE")
+                // Show menu on left-click (default is right-click only on
+                // macOS) so the count-aware list is one click away.
+                .show_menu_on_left_click(false)
+                .tooltip("o8")
                 .on_menu_event(|app, event| {
                     match event.id.as_ref() {
                         "show" => {
                             if let Some(window) = app.get_webview_window("main") {
                                 let _ = window.show();
                                 let _ = window.set_focus();
+                            }
+                        }
+                        "dispatch" => {
+                            if let Err(err) = open_dispatch_popover_impl(app) {
+                                log::warn!("[tray] dispatch menu failed: {}", err);
                             }
                         }
                         "quit" => {
@@ -1282,6 +1613,30 @@ pub fn run() {
                     }
                 })
                 .build(app)?;
+            // Store the handle so background tasks (badge poller) and
+            // frontend commands can mutate the tray's title / tooltip.
+            store_tray(tray);
+
+            // ── Cmd+Shift+O global shortcut registration (issue #730) ──
+            // The handler is wired in the plugin Builder above; we just need
+            // to register the binding. macOS shows the accessibility prompt
+            // automatically on first registration; if the user denies, we
+            // log + carry on rather than blocking startup.
+            if let Err(err) = app.global_shortcut().register(dispatch_shortcut) {
+                log::warn!(
+                    "[global-shortcut] could not register Cmd+Shift+O: {} \
+                     (user may need to grant Accessibility permission)",
+                    err
+                );
+            } else {
+                log::info!("[global-shortcut] Cmd+Shift+O registered");
+            }
+
+            // ── Badge poller (issue #731) ──
+            // 5s tick keeps the tray title in sync with awaiting_review
+            // count without waiting on a frontend WS subscription. Cheap
+            // — one HTTP GET per tick, hits the same server as the panel.
+            spawn_tray_badge_poller(app.handle().clone());
 
             // ── Window Close → Hide to Tray ──
             let app_handle = app.handle().clone();

--- a/src/app/dispatch-popover/page.tsx
+++ b/src/app/dispatch-popover/page.tsx
@@ -1,0 +1,25 @@
+/**
+ * /dispatch-popover — the 600x80 frameless popover summoned by Cmd+Shift+O
+ * (issue #730). Renders DispatchPopover.tsx and inherits the dashboard's
+ * ws-token via metadata so cross-origin auth works inside the secondary
+ * Tauri webview.
+ */
+import type { Metadata } from 'next';
+import { getOrCreateWsToken } from '@/lib/ws-auth';
+import DispatchPopover from '@/components/desktop/DispatchPopover';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export function generateMetadata(): Metadata {
+  return {
+    title: 'o8 — Quick Dispatch',
+    other: {
+      'ws-token': getOrCreateWsToken(),
+    },
+  };
+}
+
+export default function DispatchPopoverPage() {
+  return <DispatchPopover />;
+}

--- a/src/components/desktop/DispatchPopover.tsx
+++ b/src/components/desktop/DispatchPopover.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+/**
+ * DispatchPopover — the 600x80 frameless popover summoned by Cmd+Shift+O
+ * (issue #730). Single text input. Press Enter to dispatch via the existing
+ * `/api/orchestrator/create-mission` endpoint (which auto-dispatches because
+ * the API defaults `dispatch=true`). Esc to close.
+ *
+ * Picks the most recently opened repo as the dispatch target. v1 trade-off:
+ * we don't show a repo picker — that bloats the 80px height. Power users can
+ * still dispatch via the main Orchestrator tab when they need a different
+ * repo. Future iteration: tab-completion for repo names.
+ */
+import { useEffect, useRef, useState } from 'react';
+
+interface RepoEntry {
+  id: string;
+  name: string;
+  localPath: string;
+  defaultBranch: string;
+  lastOpenedAt: string;
+}
+
+function readWsToken(): string {
+  if (typeof document === 'undefined') return '';
+  return document.querySelector('meta[name="ws-token"]')?.getAttribute('content') ?? '';
+}
+
+function bearerHeaders(): Record<string, string> {
+  const token = readWsToken();
+  const base: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  };
+  if (token) base.Authorization = `Bearer ${token}`;
+  return base;
+}
+
+async function loadDefaultRepo(): Promise<RepoEntry | null> {
+  try {
+    const res = await fetch('/api/panel/repos', { headers: bearerHeaders() });
+    if (!res.ok) return null;
+    const json = await res.json().catch(() => null);
+    const repos: RepoEntry[] = Array.isArray(json?.repos) ? json.repos : [];
+    if (repos.length === 0) return null;
+    // Most recently opened wins. lastOpenedAt is ISO; lex-sort works.
+    const sorted = [...repos].sort((a, b) => (b.lastOpenedAt ?? '').localeCompare(a.lastOpenedAt ?? ''));
+    return sorted[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function closePopover(): Promise<void> {
+  // Cross fingers we're inside Tauri; in a non-Tauri preview context, just
+  // navigate the browser tab away.
+  try {
+    if (typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window) {
+      const { invoke } = await import('@tauri-apps/api/core');
+      await invoke('close_dispatch_popover');
+      return;
+    }
+  } catch {
+    // fall through
+  }
+  if (typeof window !== 'undefined') {
+    window.close();
+  }
+}
+
+export default function DispatchPopover() {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [value, setValue] = useState('');
+  const [repo, setRepo] = useState<RepoEntry | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void loadDefaultRepo().then((r) => setRepo(r));
+    const id = window.setTimeout(() => inputRef.current?.focus(), 30);
+    return () => window.clearTimeout(id);
+  }, []);
+
+  // Esc closes immediately. We capture at window level because the input
+  // doesn't always have native Esc behavior under Tauri.
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        void closePopover();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  // Auto-close on blur — the popover should feel like a Spotlight prompt:
+  // click anywhere else, it goes away. We keep a ref-flag for `busy` so the
+  // handler can read the latest value (closure capture would freeze busy=false).
+  const busyRef = useRef(false);
+  useEffect(() => { busyRef.current = busy; }, [busy]);
+  useEffect(() => {
+    const handler = () => {
+      // Slight delay so submit's window.close beats this and we don't fire
+      // both close paths. Skip when a dispatch is in flight.
+      window.setTimeout(() => {
+        if (busyRef.current) return;
+        if (!document.hasFocus()) {
+          void closePopover();
+        }
+      }, 120);
+    };
+    window.addEventListener('blur', handler);
+    return () => window.removeEventListener('blur', handler);
+  }, []);
+
+  const submit = async () => {
+    const trimmed = value.trim();
+    if (!trimmed || busy) return;
+    if (!repo) {
+      setError('No repo registered. Open one in the dashboard first.');
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/orchestrator/create-mission', {
+        method: 'POST',
+        headers: bearerHeaders(),
+        body: JSON.stringify({
+          repoPath: repo.localPath,
+          issues: [
+            {
+              number: Date.now(),
+              title: trimmed.slice(0, 120),
+              body: trimmed,
+              url: '',
+            },
+          ],
+        }),
+      });
+      if (!res.ok) {
+        const txt = await res.text().catch(() => '');
+        setError(`Dispatch failed: ${res.status} ${txt.slice(0, 80)}`);
+        setBusy(false);
+        return;
+      }
+      // Mission created + auto-dispatched (the API defaults dispatch=true).
+      // Close immediately — the user can tab to o8 to monitor progress.
+      await closePopover();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Network error');
+      setBusy(false);
+    }
+  };
+
+  const placeholder = repo
+    ? `Dispatch to ${repo.name} on ${repo.defaultBranch}…`
+    : 'Loading repo…';
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: 'rgba(22, 25, 30, 0.92)',
+        backdropFilter: 'blur(24px) saturate(160%)',
+        WebkitBackdropFilter: 'blur(24px) saturate(160%)',
+        borderRadius: 14,
+        border: '1px solid rgba(255, 255, 255, 0.08)',
+        boxShadow: '0 24px 48px -12px rgba(0, 0, 0, 0.5)',
+        color: '#e8ecf2',
+        fontFamily: '"Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, system-ui, sans-serif',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          paddingLeft: 18,
+          paddingRight: 18,
+          gap: 12,
+        }}
+      >
+        {/* Tiny brand glyph — square dot — matches the o8 design language. */}
+        <div
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: 2,
+            backgroundColor: busy ? '#f59e0b' : '#22c55e',
+            flexShrink: 0,
+            boxShadow: busy ? '0 0 12px rgba(245, 158, 11, 0.6)' : '0 0 12px rgba(34, 197, 94, 0.4)',
+          }}
+        />
+        <input
+          ref={inputRef}
+          value={value}
+          disabled={busy}
+          onChange={(event) => setValue(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              void submit();
+            }
+          }}
+          placeholder={placeholder}
+          autoFocus
+          spellCheck={false}
+          style={{
+            flex: 1,
+            background: 'transparent',
+            border: 'none',
+            outline: 'none',
+            color: '#ffffff',
+            fontSize: 17,
+            fontWeight: 400,
+            letterSpacing: '-0.01em',
+            fontFamily: 'inherit',
+          }}
+        />
+        <span
+          style={{
+            fontSize: 11,
+            color: 'rgba(232, 236, 242, 0.5)',
+            letterSpacing: '0.04em',
+            textTransform: 'uppercase',
+            flexShrink: 0,
+          }}
+        >
+          {busy ? 'Dispatching' : 'Enter'}
+        </span>
+      </div>
+      {error ? (
+        <div
+          style={{
+            paddingTop: 4,
+            paddingBottom: 8,
+            paddingLeft: 18,
+            paddingRight: 18,
+            fontSize: 11,
+            color: '#fca5a5',
+            letterSpacing: '-0.005em',
+          }}
+        >
+          {error}
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Three native macOS weapons that differentiate o8 from web/Electron rivals — bundled because all three modify `src-tauri/src/lib.rs`, making parallel work impossible.

- **Cmd+Shift+O global shortcut** (#730) → frameless 600x80 always-on-top dispatch popover. Type once, press Enter, packet auto-dispatches via existing `/api/orchestrator/create-mission` flow. Esc / blur close.
- **Native notifications** for `awaiting_review` packets (#731) → `notify_review_ready` Tauri command fires `tauri-plugin-notification`; click raises the app focused on the review card.
- **Menu bar tray with live `[N]` badge** (#731) → 5s poller hits `/api/lanes?active=true`, updates `tray.set_title`. Frontend can push exact counts via `set_tray_badge` for instant WS-event-driven updates. Hidden when 0.

## What's wired vs stubbed

| Surface | State |
|---|---|
| Cmd+Shift+O global registration | wired — handler in plugin builder + `app.global_shortcut().register()` in setup |
| Dispatch popover spawn (Rust) | wired — `WebviewWindowBuilder` with always-on-top, transparent, no decorations |
| Dispatch popover frontend | wired — fetches latest repo, POSTs to `create-mission`, closes |
| Tray badge polling | wired — 5s tick, updates only on count change, emits `tray-badge-changed` event |
| Tray menu (Show / Quick Dispatch / Quit) | wired — Quick Dispatch opens popover |
| Native notification fire | wired — title + body via `tauri-plugin-notification` |
| Notification 3-button actions (Approve / Reject / Open) | **stubbed** — desktop notify-rust path doesn't expose actions through Tauri's shim. Click-to-raise works; in-app affordances stay. Follow-up issue recommended. |
| Per-packet right-click quick-actions on tray menu items | not in this PR — would require dynamic menu rebuild on each lane change; deferred. |

## Plugins added

- `tauri-plugin-global-shortcut = "2"` (new direct dep)
- `tauri-plugin-notification` was already in tree — newly *used* via `NotificationExt`

## Permissions added (`src-tauri/capabilities/default.json`)

- `global-shortcut:default`, `:allow-register`, `:allow-unregister`, `:allow-is-registered`
- `core:window:allow-show`, `:allow-hide`, `:allow-close`, `:allow-set-focus` — needed by the popover + tray for show/hide/close
- `core:webview:allow-create-webview-window` — needed to spawn the popover window
- `dispatch-popover` added to the windows allowlist alongside `main`

## Signed-build risks to flag

- **macOS Accessibility permission prompt on first Cmd+Shift+O.** `register()` logs and continues on denial; user re-grants via System Settings → Privacy & Security → Accessibility.
- **Notification permission prompt.** Tauri plugin defaults to `Granted`, but macOS still asks once on first `.show()`.
- **`cargo tauri dev` does not register global shortcuts on macOS** — sandboxed dev binary can't claim system hotkeys. Test by `npm run ship`.
- **Updater asset shape unchanged** — no signing key rotation needed.

## File count

5 files modified + 2 new = 7 total
- `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/capabilities/default.json`, `src-tauri/src/lib.rs`
- `src/app/dispatch-popover/page.tsx` (new), `src/components/desktop/DispatchPopover.tsx` (new)

## Verification

- `npx tsc --noEmit` — passes
- `cargo check --features dev-mcp-plugin` — passes
- `cargo check` (no features) — passes
- `cargo clippy` — only pre-existing warnings (4) at lines 36, 907, 912, 914 — none from this diff

## Test plan

- [ ] `npm run ship` — produce signed build with `dev-mcp-plugin` feature
- [ ] First launch — accept Accessibility permission prompt
- [ ] Press `Cmd+Shift+O` from outside the app (e.g. while focused on Slack)
- [ ] Verify 600x80 popover appears centered, always on top, focused
- [ ] Type "test packet from popover" → press Enter → popover closes, packet dispatches
- [ ] Verify packet appears in Mission Control with correct repo + title
- [ ] Press `Cmd+Shift+O` again, press Esc → popover closes without dispatching
- [ ] Press `Cmd+Shift+O` again, click outside the popover → closes via blur handler
- [ ] Trigger a packet to `reviewing` status → verify menu bar shows `[1]` within 5s
- [ ] Verify native notification fires (will need frontend hookup in a follow-up — backend command exists)
- [ ] Right-click tray icon → see Show o8 / Quick Dispatch / Quit
- [ ] Click "Quick Dispatch" → popover spawns

🤖 Generated with [Claude Code](https://claude.com/claude-code)