### PR TITLE
fix(workspaces): prune stale workspace records at the source (closes #750)

### DIFF
--- a/src/app/api/panel/branches/route.ts
+++ b/src/app/api/panel/branches/route.ts
@@ -108,6 +108,27 @@ export async function GET(req: NextRequest) {
         continue;
       }
 
+      // Claude harness sub-agent worktrees check out real feature branches
+      // (e.g. polish/hit-zone-approvals) into `.claude/worktrees/agent-XXX/`
+      // dirs that the harness creates per sub-agent run and never cleans up.
+      // The branch ref + worktree dir survive long after the sub-agent
+      // completes, leaking 30+ stale rows into the sidebar. Detect them by
+      // worktree-path convention (we already know it's a worktree from the
+      // git porcelain parse above) and skip — the user only ever wants to
+      // see worktrees they created via the o8 workspace flow, not the ones
+      // Claude's sub-agent feature spawned. Closes #750. The path check is
+      // a substring match because git reports paths verbatim from the
+      // porcelain output, including the repo's own basename — `endsWith`
+      // would miss nested cases. The active checkout (`isCurrent`) is
+      // never under .claude/worktrees/agent-* in practice but we preserve
+      // it defensively in case a power-user is daily-driving from one.
+      if (!isCurrent && isWt) {
+        const worktreePath = worktrees.get(trimmedName) ?? '';
+        if (worktreePath.includes('/.claude/worktrees/agent-')) {
+          continue;
+        }
+      }
+
       // Hide branches whose working diff vs default branch is empty — i.e.
       // every change on the branch already exists on default. Catches BOTH
       // fast-forward / regular merges AND squash merges (where the branch


### PR DESCRIPTION
## Root cause

The branch rail showed 30+ stale rows because the \`/api/panel/branches\` endpoint returns every branch ref whose worktree exists on disk, **regardless of whether the worktree was created by the user or by Claude Code's sub-agent harness**. Investigation found 38 sub-agent worktrees physically present at \`.claude/worktrees/agent-XXX/\`, each checked out to a real feature branch (\`polish/hit-zone-approvals\`, \`fix/sidecar-orphan-children-719\`, etc). Those worktrees are spawned by Claude's internal agent feature and never cleaned up — the branches accumulate forever as the user dispatches more agents.

The existing filter at line 107 of \`branches/route.ts\` only catches branches whose **name** starts with \`worktree-agent-*\` (an old convention). The current Claude harness checks out real feature branches into the agent path, so the name filter never matches.

## Why prior 4 attempts failed

All four prior attempts patched the symptom on the client side, in the \`visibleBranches\` filter inside \`RepoCardExpandedContent.tsx\`. But the root data was wrong, so any client filter could be defeated by:

| Attempt | Defeated by |
|---|---|
| 1. \`isWorktree && lastCommitUnix > 24h\` | Sub-agent worktrees have recent commits |
| 2. \`hasAgent\` (any record) | Agent records persist post-teardown — always true for any branch a Codex session ever touched, never true for Claude harness sub-agent branches |
| 3. \`agent.status in {running, reviewing, awaiting_review}\` | Status records aren't pruned, all say 'running' |
| 4. \`agent.lastActivityAt >= now - 5min\` | The \`agentsByBranch\` map builder leaves \`lastActivityAt\` undefined |
| 5 (current). \`agent.currentTask\` non-empty | Sub-agent worktrees have **no agent record at all** in \`agentsByBranch\` (workspaces API correctly filters them out by worktree-existence), so the filter SHOULD have hidden them. But the v0.1.71 build's bundled JS does not actually contain the latest filter code — verified by grepping the chunks for the v0.1.71 identifier strings. Even if the build had shipped correctly, the rail would still be 100% dependent on a client-side filter that's one bundle bug away from breaking again. |

## Fix

**Option B — root-fix the data source.** Patched \`/api/panel/branches/route.ts\` so it skips any worktree branch whose worktree path is under \`.claude/worktrees/agent-*\`. This is the convention Claude Code's sub-agent harness uses (\`locked claude agent agent-XXX\`). The filter:

- Only fires when \`isWt\` is true (we already know it's a worktree from the porcelain parse)
- Skips the active checkout (\`isCurrent\`) defensively in case a power-user is daily-driving from a sub-agent worktree
- Does NOT touch the o8 user-facing convention (\`.cortex-worktrees/\`) — those still surface in the rail

This kills the 30+ rows at the source, so the rail correctly shows only the active branch (\`main\`) plus any user-created worktrees.

## Verification

In the running app:
- Before: \`/api/panel/branches?path=~/cortex-ide\` returned **31 branches**
- After: returns **1** (just \`main\`)

To confirm in the UI:
1. \`npm run ship\` to build + auto-update
2. Reload the dashboard
3. Expand the \`cortex-ide\` card in the left sidebar
4. Only \`main\` should be visible — no Orchestrator/Assistant rows are blocked, and the disclosure (\`+ N idle\`) is gone because there are no stale rows to fold under it
5. Create a real worktree via the o8 workspace flow — it should appear correctly under \`.cortex-worktrees/\`

The v0.1.71 client filter (\`branchAgents.some((agent) => Boolean(agent.currentTask?.trim()))\`) is preserved as a defensive safety net — it correctly handles any other source of stale rows we haven't found yet, but it's no longer the only line of defense.

## Test plan

- [ ] \`npx tsc --noEmit\` passes (verified locally)
- [ ] Open dashboard, confirm cortex-ide card shows only \`main\` in branch rail
- [ ] Create a fresh user-facing worktree, confirm it appears under the rail
- [ ] Verify Orchestrator + Assistant tabs still work (they don't depend on this endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
