### PR TITLE
feat(mcp): vendor codebase-memory-mcp into Tauri sidecar (closes #739)

### DIFF
--- a/docs/codebase-memory-build.md
+++ b/docs/codebase-memory-build.md
@@ -1,0 +1,68 @@
+# Vendoring `codebase-memory-mcp` (issue #739)
+
+The Context Engine v2 (epic #738) ships the static `codebase-memory-mcp` binary inside the o8 Tauri bundle so the production app can index repos and answer recall queries without a separate install step. This doc explains how the binary gets vendored, how to upgrade the pin, and the size trade-off the orchestrator should be aware of.
+
+## Source
+
+- Upstream: [DeusData/codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp) (MIT)
+- Pinned version: `v0.6.0` (see `scripts/fetch-codebase-memory.mjs` `CMM_VERSION`)
+- Distribution: prebuilt static binaries on the GitHub release page, four targets — `darwin-amd64`, `darwin-arm64`, `linux-amd64`, `linux-arm64`, plus a `windows-amd64` zip.
+
+## How it ends up in the bundle
+
+1. `npm run tauri:prebuild` runs `scripts/tauri-export.mjs`.
+2. After the Next.js + MCP server bundles compile, the script invokes `node scripts/fetch-codebase-memory.mjs`.
+3. The fetch script detects the host platform (`process.platform` + `process.arch`), downloads the matching tarball/zip from `github.com/DeusData/codebase-memory-mcp/releases/v0.6.0`, verifies the SHA-256 against the pinned checksum, extracts the binary, and writes it to `out/server/codebase-memory-mcp` (or `.exe` on Windows).
+4. A sentinel file `out/server/.codebase-memory-mcp.version` marks the version + asset combo so reruns short-circuit.
+5. Tauri's `bundle.resources` config (`tauri.conf.json` already maps `out/server/` → `Contents/Resources/server/`) ships the binary alongside the Node servers — no `tauri.conf.json` change required.
+6. At launch, `src-tauri/src/lib.rs` looks for `<resource_dir>/server/codebase-memory-mcp{.exe}`. If found, it sets `O8_CODEBASE_MEMORY_BIN` on the spawned Next.js server's environment (and on the parent's env so any later child inherits it).
+
+## Why a fetch script instead of committing the binary
+
+Each architecture's binary is ~161 MB uncompressed. Committing all four (or even one) would either bloat every clone or push us into Git LFS storage costs. The fetch script keeps the repo clean and only ever materializes the binary for the current build host.
+
+The fetch is **non-fatal** — if the runner is offline, the prebuild logs a warning and continues. The Tauri sidecar treats a missing binary as "feature unavailable" rather than a startup error, so a bundle without the binary still boots; it just can't serve the codebase-memory MCP tools.
+
+## Bundle size impact
+
+| Metric | Before | After (single arch) | Delta |
+|---|---|---|---|
+| Compressed installer (`.app.tar.gz`) | ~41 MB | ~69 MB | +28 MB |
+| Installed `.app` on disk | ~148 MB | ~309 MB | +161 MB |
+
+This **exceeds** the issue's stated `<30 MB` delta target on disk. The compressed download delta is in the same neighborhood as the issue's estimate (the binary compresses 5.7×). Two follow-up paths if the disk delta becomes a problem:
+
+1. **Move to runtime download**: drop the build-time fetch and have the Tauri sidecar download the binary into `~/.cortex-ide/codebase-memory-mcp/<version>/` on first launch. Zero installer delta, costs the user a one-time ~28 MB network pull.
+2. **Trim the binary**: the upstream binary is ~161 MB because it ships tree-sitter parsers for 66 languages plus a UI bundle. A custom build with a slimmed parser set would shrink the binary substantially. See upstream `Makefile` for the parser feature flags.
+
+Both are out of scope for #739 — flagged here so the orchestrator can revisit if needed.
+
+## Cross-compile fallback (when upstream lacks a target)
+
+Upstream currently ships all four targets, so nothing to do. If a future release drops a target (e.g. drops `darwin-arm64` prebuilts), build from source:
+
+```bash
+git clone https://github.com/DeusData/codebase-memory-mcp.git
+cd codebase-memory-mcp
+git checkout v0.6.0
+# Toolchain assumed: Go 1.22+. Adjust if upstream changes language.
+GOOS=darwin GOARCH=arm64 make build
+# Produces ./codebase-memory-mcp — copy into the o8 repo's out/server/
+```
+
+If we ever cross-compile, replace the corresponding entry in `CHECKSUMS` in `scripts/fetch-codebase-memory.mjs` with a SHA pinned against the artifact you produced (and keep that artifact in a private bucket the build host can reach).
+
+## Upgrade procedure
+
+1. Pick a new release on the upstream repo.
+2. Bump `CMM_VERSION` in `scripts/fetch-codebase-memory.mjs`.
+3. Pull the new `checksums.txt` from that release and replace the `CHECKSUMS` map entries.
+4. `rm -rf out` and rerun `npm run tauri:prebuild` to confirm the fetch + extraction still works.
+5. Run `cd src-tauri && cargo check --features dev-mcp-plugin` to make sure the Rust side compiles.
+6. Smoke test the binary: `out/server/codebase-memory-mcp --version` should print the new version.
+7. Note any new MCP tools / behaviour changes in the upgrade PR.
+
+## What downstream issues need
+
+- **#740 (`.mcp.json` registration)**: read `process.env.O8_CODEBASE_MEMORY_BIN`. If set, register an MCP server entry pointing the `command` field at that path (no args). If unset, omit the entry.
+- **#742 (recall card)** + **#743 (dispatch injection)**: same pattern — gate on `O8_CODEBASE_MEMORY_BIN` being defined.

--- a/scripts/fetch-codebase-memory.mjs
+++ b/scripts/fetch-codebase-memory.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * Fetch the matching-arch `codebase-memory-mcp` static binary from the
+ * upstream DeusData release and drop it into out/server/ so it ships as
+ * a Tauri bundle resource alongside the Node MCP servers.
+ *
+ * Why fetch instead of commit:
+ *   The binary is ~161 MB uncompressed × 4 architectures = >640 MB. That
+ *   would balloon every clone and make Git LFS storage cost dominate. This
+ *   script pulls only the binary that matches the build host so each
+ *   installer carries exactly one architecture's binary.
+ *
+ * Idempotency:
+ *   Writes a sentinel file `out/server/.codebase-memory-mcp.version` so
+ *   reruns skip the download when the version + arch already match.
+ *
+ * Failure mode:
+ *   Non-fatal — if the network fetch fails the script logs and exits 0
+ *   without writing the binary. The Tauri sidecar treats a missing binary
+ *   as "feature unavailable" rather than a startup blocker.
+ *
+ * Pin: bump CMM_VERSION to upgrade. checksums baked in below come from
+ *      the upstream release `checksums.txt` for that tag.
+ */
+import { mkdirSync, existsSync, writeFileSync, readFileSync, statSync, chmodSync, createWriteStream, rmSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { pipeline } from 'stream/promises';
+import { createHash } from 'crypto';
+import { execSync } from 'child_process';
+import { tmpdir } from 'os';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+const out = join(root, 'out', 'server');
+
+// ── Version pin ────────────────────────────────────────────────────
+// Bump this and the matching checksums entry to upgrade. See
+// docs/codebase-memory-build.md for the upgrade procedure.
+const CMM_VERSION = '0.6.0';
+const CMM_REPO = 'DeusData/codebase-memory-mcp';
+
+// SHA-256 from the upstream release `checksums.txt`. We pin these here
+// so a tampered release artifact gets caught at build time even if the
+// download succeeds.
+const CHECKSUMS = {
+  'codebase-memory-mcp-darwin-amd64.tar.gz': 'a4d09d97fe1f47e1a0a23309bc34d9937f74c61950bed3259f9576800cc78727',
+  'codebase-memory-mcp-darwin-arm64.tar.gz': 'a1d3f8a4c353ab94ea8fe1fb60159758020f2f256c9652699a0bd6725189a439',
+  'codebase-memory-mcp-linux-amd64.tar.gz': '0dfd70f73337219925f3ec6a572fe776dbbe1c4c8c6ab546ab214fe16e56a426',
+  'codebase-memory-mcp-linux-arm64.tar.gz': 'f1fad27262fe7af4a356af128e43942355cb2189491079b6790ecc5ae3af069c',
+  'codebase-memory-mcp-windows-amd64.zip': 'da3d7d7bd6f687b697145457ff9d113ecf6daffe173d236457a43223e89a5e9c',
+};
+
+// ── Platform detection ─────────────────────────────────────────────
+function detectAsset() {
+  const platform = process.platform; // 'darwin' | 'linux' | 'win32'
+  const arch = process.arch;         // 'x64' | 'arm64'
+  if (platform === 'darwin' && arch === 'x64')   return { name: 'codebase-memory-mcp-darwin-amd64.tar.gz', binary: 'codebase-memory-mcp', isZip: false };
+  if (platform === 'darwin' && arch === 'arm64') return { name: 'codebase-memory-mcp-darwin-arm64.tar.gz', binary: 'codebase-memory-mcp', isZip: false };
+  if (platform === 'linux'  && arch === 'x64')   return { name: 'codebase-memory-mcp-linux-amd64.tar.gz',  binary: 'codebase-memory-mcp', isZip: false };
+  if (platform === 'linux'  && arch === 'arm64') return { name: 'codebase-memory-mcp-linux-arm64.tar.gz',  binary: 'codebase-memory-mcp', isZip: false };
+  if (platform === 'win32'  && arch === 'x64')   return { name: 'codebase-memory-mcp-windows-amd64.zip',   binary: 'codebase-memory-mcp.exe', isZip: true };
+  return null;
+}
+
+// ── Idempotency check ──────────────────────────────────────────────
+function alreadyFetched(binaryPath, sentinelPath, expectedTag) {
+  if (!existsSync(binaryPath) || !existsSync(sentinelPath)) return false;
+  try {
+    const tag = readFileSync(sentinelPath, 'utf-8').trim();
+    return tag === expectedTag;
+  } catch {
+    return false;
+  }
+}
+
+// ── Download with redirect support ─────────────────────────────────
+async function download(url, dest) {
+  // GitHub release URLs redirect to S3. Node 22+ follows redirects in
+  // fetch() automatically.
+  const res = await fetch(url, { redirect: 'follow' });
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  const stream = createWriteStream(dest);
+  await pipeline(res.body, stream);
+}
+
+// ── SHA-256 verification ───────────────────────────────────────────
+function sha256(filePath) {
+  const hash = createHash('sha256');
+  hash.update(readFileSync(filePath));
+  return hash.digest('hex');
+}
+
+// ── Extract (tar.gz or zip) ────────────────────────────────────────
+function extract(archivePath, outDir, isZip) {
+  if (isZip) {
+    // unzip is preinstalled on macOS/Linux; on Windows the build runner
+    // ships PowerShell which has Expand-Archive. Use unzip first.
+    try {
+      execSync(`unzip -o "${archivePath}" -d "${outDir}"`, { stdio: 'pipe' });
+    } catch {
+      execSync(`powershell -NoProfile -Command "Expand-Archive -Force -Path '${archivePath}' -DestinationPath '${outDir}'"`, { stdio: 'pipe' });
+    }
+  } else {
+    execSync(`tar -xzf "${archivePath}" -C "${outDir}"`, { stdio: 'pipe' });
+  }
+}
+
+// ── Main ───────────────────────────────────────────────────────────
+async function main() {
+  const asset = detectAsset();
+  if (!asset) {
+    console.warn(`[codebase-memory] unsupported host ${process.platform}/${process.arch} — skipping`);
+    return;
+  }
+
+  const expectedSha = CHECKSUMS[asset.name];
+  if (!expectedSha) {
+    console.warn(`[codebase-memory] no checksum pinned for ${asset.name} — skipping`);
+    return;
+  }
+
+  if (!existsSync(out)) mkdirSync(out, { recursive: true });
+
+  const binaryPath = join(out, asset.binary);
+  const sentinelPath = join(out, '.codebase-memory-mcp.version');
+  const expectedTag = `${CMM_VERSION}-${asset.name}`;
+
+  if (alreadyFetched(binaryPath, sentinelPath, expectedTag)) {
+    console.log(`[codebase-memory] cached: ${asset.binary} v${CMM_VERSION}`);
+    return;
+  }
+
+  const url = `https://github.com/${CMM_REPO}/releases/download/v${CMM_VERSION}/${asset.name}`;
+  const tmpDir = join(tmpdir(), `o8-cmm-${process.pid}`);
+  mkdirSync(tmpDir, { recursive: true });
+  const archivePath = join(tmpDir, asset.name);
+
+  try {
+    console.log(`[codebase-memory] fetching ${asset.name} v${CMM_VERSION}…`);
+    await download(url, archivePath);
+
+    const actual = sha256(archivePath);
+    if (actual !== expectedSha) {
+      throw new Error(`sha256 mismatch: expected ${expectedSha}, got ${actual}`);
+    }
+
+    extract(archivePath, tmpDir, asset.isZip);
+
+    const extractedBinary = join(tmpDir, asset.binary);
+    if (!existsSync(extractedBinary)) {
+      throw new Error(`binary not found in archive at ${extractedBinary}`);
+    }
+
+    // Move into out/server. Use cp for cross-fs safety.
+    execSync(`cp "${extractedBinary}" "${binaryPath}"`, { stdio: 'pipe' });
+    if (process.platform !== 'win32') chmodSync(binaryPath, 0o755);
+    writeFileSync(sentinelPath, expectedTag);
+
+    const sizeMB = (statSync(binaryPath).size / (1024 * 1024)).toFixed(1);
+    console.log(`[codebase-memory] installed ${asset.binary} v${CMM_VERSION} (${sizeMB} MB)`);
+  } catch (err) {
+    // Non-fatal: warn and continue. The Tauri sidecar treats a missing
+    // binary as "feature unavailable" — production builds without
+    // network access should still succeed.
+    console.warn(`[codebase-memory] fetch failed (non-fatal): ${err.message}`);
+  } finally {
+    // Best-effort tmp cleanup.
+    try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+  }
+}
+
+main().catch((e) => {
+  // Catch-all guard so the script never blocks the wider prebuild.
+  console.warn(`[codebase-memory] unexpected error (non-fatal): ${e.message}`);
+});

--- a/scripts/tauri-export.mjs
+++ b/scripts/tauri-export.mjs
@@ -402,6 +402,17 @@ for (const bundle of REQUIRED_BUNDLES) {
   }
 }
 
+// ── Fetch codebase-memory-mcp static binary (issue #739) ──
+// Pulls the matching-arch prebuilt from the upstream DeusData release into
+// out/server/. Non-fatal: if the network is unreachable, the bundle ships
+// without it and the Tauri sidecar treats the binary as optional. The fetch
+// script is idempotent — second runs hit the cache via the version sentinel.
+try {
+  execSync('node scripts/fetch-codebase-memory.mjs', { cwd: root, stdio: 'inherit' });
+} catch (e) {
+  console.warn('⚠️  fetch-codebase-memory.mjs failed (non-fatal):', e.message);
+}
+
 const size = execSync(`du -sh "${server}" 2>/dev/null`).toString().trim().split('\\t')[0];
 console.log('\\n✅ Export complete');
 console.log(`   frontend/ → loader HTML`);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "o8"
-version = "0.1.72"
+version = "0.1.73"
 dependencies = [
  "libc",
  "log",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1789,6 +1789,25 @@ pub fn run() {
                     log::info!("Bundled MCP scripts at {:?}", server_dir);
                 }
 
+                // Issue #739: Vendored codebase-memory-mcp static binary.
+                // Fetched at build time by scripts/fetch-codebase-memory.mjs
+                // and dropped into out/server/. Setting the env var lets the
+                // Next server, ws-server, and #740's MCP registration logic
+                // resolve the binary path without re-probing the filesystem.
+                // Missing binary = feature unavailable, not a startup error.
+                let codebase_memory_bin_name = if cfg!(target_os = "windows") {
+                    "codebase-memory-mcp.exe"
+                } else {
+                    "codebase-memory-mcp"
+                };
+                let codebase_memory_bin = server_dir.join(codebase_memory_bin_name);
+                let has_codebase_memory_bin = codebase_memory_bin.exists();
+                if has_codebase_memory_bin {
+                    log::info!("Bundled codebase-memory-mcp at {:?}", codebase_memory_bin);
+                } else {
+                    log::info!("codebase-memory-mcp binary not bundled — feature unavailable");
+                }
+
                 // Open per-server log files before spawning so stdout/stderr
                 // can be wired directly. Rotated to .prev on each boot.
                 let next_log = open_child_log("next-server.log");
@@ -1809,6 +1828,14 @@ pub fn run() {
                 if has_bundled_mcp {
                     server_cmd.env("O8_BUNDLED_MCP_DIR", &server_dir);
                     server_cmd.env("O8_BUNDLED_MCP_PATH", &bundled_operator_mcp);
+                }
+                if has_codebase_memory_bin {
+                    server_cmd.env("O8_CODEBASE_MEMORY_BIN", &codebase_memory_bin);
+                    // Also persist to the parent process env so any future
+                    // child spawned by the orchestrator or MCP servers picks
+                    // it up without us threading the path through every call
+                    // site. Mirrors the O8_NODE_BIN pattern above.
+                    std::env::set_var("O8_CODEBASE_MEMORY_BIN", &codebase_memory_bin);
                 }
                 match server_cmd
                     .stdout(child_stdio(next_log.as_ref()))


### PR DESCRIPTION
Closes #739. First child in the strict-sequential YC-prep Context Engine v2 chain (#738).

## Approach: Option B (real binary) via build-time fetch + single-arch ship

The issue offered two paths — write a thin Node MCP server (Option A) or vendor the real `DeusData/codebase-memory-mcp` static binary (Option B). The issue body strongly implies Option B (\"the codebase-memory-mcp static binary\", \"~15 MB\", `bundle.externalBin` references), so I went with the real binary.

Within Option B I picked **build-time fetch** over committing the binaries:

- Each architecture's binary is **~161 MB uncompressed**. Committing all four to LFS would push >640 MB through every clone and dominate LFS storage cost.
- A fetch script materializes only the matching-host binary into `out/server/` during `npm run tauri:prebuild`, so each installer carries exactly one architecture.
- SHA-256 checksums are pinned in the script and verified after download — tampered upstream artifacts get caught at build time.
- Fetch is non-fatal: offline runners log a warning and ship without the binary, and the Tauri sidecar treats a missing binary as \"feature unavailable\" rather than a startup error.

## What changed

- `scripts/fetch-codebase-memory.mjs` — new. Detects host platform, downloads + verifies + extracts, idempotent via a sentinel file.
- `scripts/tauri-export.mjs` — invokes the fetch script after the rest of the bundle is built.
- `src-tauri/src/lib.rs` — looks for `<resource_dir>/server/codebase-memory-mcp{.exe}`. If found, exports `O8_CODEBASE_MEMORY_BIN` to spawned children and to the parent process env (so any later child inherits it, mirroring the `O8_NODE_BIN` pattern).
- `docs/codebase-memory-build.md` — new. Documents the source, version pin, upgrade procedure, cross-compile fallback, size trade-off, and what downstream issues need.

No `tauri.conf.json` change required — the existing `bundle.resources` mapping (`out/server/` → `Contents/Resources/server/`) already ships everything in `out/server/`.

## Bundle size delta — flagging clearly

| Metric | Before | After (single arch) | Delta |
|---|---|---|---|
| Compressed installer (`.app.tar.gz`) | ~41 MB | ~69 MB | **+28 MB** |
| Installed `.app` on disk | ~148 MB | ~309 MB | **+161 MB** |

**This blows past the issue's `<30 MB` on-disk target and the user's ~220 MB total budget.** The issue body assumed ~15 MB; the real binary is ~161 MB because it ships tree-sitter parsers for 66 languages plus a UI bundle.

Two follow-up paths if disk delta turns into a blocker:

1. **Runtime download** — drop the build-time fetch, have the sidecar pull the binary into `~/.cortex-ide/codebase-memory-mcp/<version>/` on first launch. Zero installer delta, costs the user a one-time ~28 MB network pull. ~30 lines of Rust.
2. **Slimmed binary** — custom build with a reduced parser set. Out of scope for this issue but tracked in `docs/codebase-memory-build.md`.

Both are out of scope for #739 — flagged for orchestrator decision.

## Verification

- `npx tsc --noEmit` ✓ clean
- `cd src-tauri && cargo check --features dev-mcp-plugin` ✓ clean
- `node scripts/fetch-codebase-memory.mjs` ✓ first run downloads + extracts + writes binary, second run hits cache
- `out/server/codebase-memory-mcp --version` ✓ prints `codebase-memory-mcp 0.6.0` (verified on darwin-amd64)
- `cargo tauri build` not run locally (long-running + needs signing key); CI gate is the build trigger.

## Lifecycle / spawn behavior

The binary is **not auto-spawned** by `lib.rs` — that's #740's job. Today the sidecar just sets `O8_CODEBASE_MEMORY_BIN` so child processes can find the binary. When #740 wires up `.mcp.json` registration the Claude Code session will spawn it on demand and tear it down via the standard MCP stdio close pattern. The existing `register_child` / `kill_tracked_children` flow in `lib.rs` already handles SIGTERM/SIGINT cleanup for any future direct spawns.

## What #740 (next in chain) needs

- **Read `process.env.O8_CODEBASE_MEMORY_BIN`** at runtime. If set, register an MCP server entry in `.mcp.json` (or wherever the registration logic lives) with `command` pointing at that path and no args (the binary defaults to MCP-stdio mode when invoked bare).
- **If unset**, omit the entry entirely. Don't error.
- **Working directory** for the spawned binary should be the user's repo root — it indexes whatever directory it's invoked from. The orchestrator session already passes a `cwd` per session.

## Files touched

- `scripts/fetch-codebase-memory.mjs` (new)
- `scripts/tauri-export.mjs`
- `src-tauri/src/lib.rs`
- `src-tauri/Cargo.lock` (pre-existing version sync from main)
- `docs/codebase-memory-build.md` (new)

## Caveats / risks

- **Size delta** is the headline. See above — orchestrator decides whether to ship as-is or pivot to runtime download.
- **CI build hosts must have network access** to `github.com/DeusData/codebase-memory-mcp/releases`. If a network-restricted runner is added later, switch to runtime download.
- **Upstream pin is v0.6.0**. Bump procedure in `docs/codebase-memory-build.md` — mainly bump `CMM_VERSION` and refresh the `CHECKSUMS` map.
- **Windows** path is wired (`.exe` extension, zip extraction via `unzip` / `Expand-Archive`) but **not smoke-tested on a Windows host** — only macOS x64 verified end-to-end here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)