### PR TITLE
feat(cortex): auto-index registered repos at boot via codebase-memory-mcp (closes #741)

### DIFF
--- a/src/app/api/cortex/codebase-memory/route.ts
+++ b/src/app/api/cortex/codebase-memory/route.ts
@@ -1,0 +1,29 @@
+/**
+ * GET /api/cortex/codebase-memory
+ *
+ * Returns the live state of the codebase-memory boot indexer (#741, epic
+ * #738 Context Engine v2). The status-bar pill in #742's Recall card UI
+ * polls this to render the "Indexing 2/4 repos…" chip and to know when
+ * the index is ready for dispatch.
+ *
+ * Side-effect: also kicks the boot pass if it hasn't fired yet — the
+ * regular hook is /api/panel/status but the UI may render before that
+ * route gets hit, so we double-trigger here. Both are idempotent.
+ *
+ * Response shape: see IndexState in src/lib/codebase-memory/types.ts.
+ */
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import {
+  ensureCodebaseMemoryBootIndex,
+  getIndexState,
+} from '@/lib/codebase-memory/indexer';
+
+export async function GET() {
+  ensureCodebaseMemoryBootIndex();
+  const state = getIndexState();
+  return NextResponse.json(state);
+}

--- a/src/app/api/panel/status/route.ts
+++ b/src/app/api/panel/status/route.ts
@@ -1,6 +1,13 @@
 import { NextResponse } from 'next/server';
+import { ensureCodebaseMemoryBootIndex } from '@/lib/codebase-memory/indexer';
 
 export async function GET() {
+  // Tauri shell hits /api/panel/status as a liveness probe right after the
+  // bundled Node sidecar boots. Piggyback on that to kick the
+  // codebase-memory boot index pass (closes #741). Idempotent — fires once
+  // per server process. Runs in the background, never blocks the response.
+  ensureCodebaseMemoryBootIndex();
+
   return NextResponse.json({
     connected: false,
     gatewayUrl: null,

--- a/src/lib/codebase-memory/binary.ts
+++ b/src/lib/codebase-memory/binary.ts
@@ -1,0 +1,65 @@
+/**
+ * Resolve the codebase-memory-mcp binary path.
+ *
+ * Mirrors the resolution rules used by the Claude Desktop / Claude Code
+ * config generator (src/app/api/setup/mcp-config/route.ts):
+ *   1. process.env.O8_CODEBASE_MEMORY_BIN — set by the Tauri sidecar after
+ *      the cached binary is verified, OR after a fresh download finishes.
+ *   2. ~/.o8/bin/codebase-memory-mcp (.exe on Windows) — the deterministic
+ *      install location used by #739. We fall back to it because the env
+ *      var only inherits to children spawned AFTER the download completes,
+ *      which the Node sidecar usually isn't.
+ *
+ * Returns null when neither resolves to a real file. Callers MUST treat
+ * null as "feature unavailable" so cold first launch (binary still
+ * downloading) doesn't break the boot indexer.
+ */
+
+import 'server-only';
+
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const POLL_INTERVAL_MS = 1500;
+const DEFAULT_WAIT_TIMEOUT_MS = 60_000;
+
+export function resolveCodebaseMemoryBin(): string | null {
+  const fromEnv = process.env.O8_CODEBASE_MEMORY_BIN;
+  if (fromEnv && fromEnv.trim() && existsSync(fromEnv)) {
+    return fromEnv;
+  }
+
+  const home = process.env.HOME || process.env.USERPROFILE || homedir();
+  if (!home) return null;
+
+  const fileName =
+    process.platform === 'win32' ? 'codebase-memory-mcp.exe' : 'codebase-memory-mcp';
+  const deterministic = join(home, '.o8', 'bin', fileName);
+  if (existsSync(deterministic)) {
+    return deterministic;
+  }
+
+  return null;
+}
+
+/**
+ * Poll for the binary up to `timeoutMs`. Resolves with the path when found,
+ * or null if it never appears.
+ *
+ * The Tauri sidecar emits `codebase-memory:status` to the webview but we
+ * can't subscribe to that from server-side Node. Polling for the
+ * deterministic file path is equivalent and avoids any cross-process
+ * coordination.
+ */
+export async function waitForCodebaseMemoryBin(
+  timeoutMs = DEFAULT_WAIT_TIMEOUT_MS,
+): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const bin = resolveCodebaseMemoryBin();
+    if (bin) return bin;
+    await new Promise<void>((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  return resolveCodebaseMemoryBin();
+}

--- a/src/lib/codebase-memory/indexer.ts
+++ b/src/lib/codebase-memory/indexer.ts
@@ -1,0 +1,366 @@
+/**
+ * Boot indexer for codebase-memory-mcp.
+ *
+ * Closes #741 (epic #738 Context Engine v2). On o8 boot:
+ *   1. Wait for the codebase-memory-mcp binary (#739 download) to be ready.
+ *   2. Read ~/.o8/repos.json (the registry from src/lib/repos/registry.ts).
+ *   3. For each repo:
+ *      - Skip if HEAD matches the persisted last-indexed HEAD (cache hit).
+ *      - Skip + mark deferred if the repo on disk is > 500 MB.
+ *      - Otherwise queue an index_repository call. Concurrency capped at 2.
+ *   4. Persist the new HEAD on success so the next boot is a no-op.
+ *
+ * The boot pass is fire-and-forget: it returns immediately and runs in the
+ * background. Callers (status route, status-bar UI) read the live state via
+ * `getIndexState()`.
+ *
+ * Failure policy: every error is logged with the [codebase-memory] prefix
+ * and recorded on the per-repo entry. Nothing here can block the Next.js
+ * server boot or hard-crash the process.
+ */
+
+import 'server-only';
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { statSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { listRepos } from '@/lib/repos/registry';
+import type { RepoRegistryEntry } from '@/lib/repos/types';
+import { resolveCodebaseMemoryBin, waitForCodebaseMemoryBin } from './binary';
+import { callCodebaseMemoryTool } from './mcp-client';
+import { getRecordedHead, recordIndexedHead } from './state-store';
+import type { IndexState, RepoIndexEntry, RepoIndexStatus } from './types';
+
+const execFileAsync = promisify(execFile);
+
+/** Repos larger than this on disk are deferred to manual re-index. */
+const DEFAULT_MAX_REPO_SIZE_BYTES = 500 * 1024 * 1024;
+
+/** Concurrent index_repository calls — disk thrash guard. */
+const DEFAULT_INDEX_CONCURRENCY = 2;
+
+/** How long to wait for the binary on first boot before giving up. */
+const BINARY_WAIT_TIMEOUT_MS = 5 * 60_000;
+
+/** Tool exposed by codebase-memory-mcp (#738/#739). */
+const INDEX_TOOL_NAME = 'index_repository';
+
+/** Cap for the manual size walk so a giant node_modules doesn't stall boot. */
+const SIZE_WALK_ENTRY_CAP = 1500;
+
+// Live in-process state. Reset on server restart — that's fine since the
+// next boot pass repopulates it.
+const stateByRepoId = new Map<string, RepoIndexEntry>();
+let bootRan = false;
+let bootInFlight = false;
+
+function logInfo(msg: string, ...rest: unknown[]) {
+  console.log(`[codebase-memory] ${msg}`, ...rest);
+}
+function logWarn(msg: string, ...rest: unknown[]) {
+  console.warn(`[codebase-memory] ${msg}`, ...rest);
+}
+
+function setEntry(entry: RepoIndexEntry) {
+  stateByRepoId.set(entry.repoId, entry);
+}
+
+function patchEntry(repoId: string, patch: Partial<RepoIndexEntry>) {
+  const existing = stateByRepoId.get(repoId);
+  if (!existing) return;
+  setEntry({ ...existing, ...patch });
+}
+
+export function getIndexState(): IndexState {
+  const entries = Array.from(stateByRepoId.values()).sort((a, b) =>
+    a.repoName.localeCompare(b.repoName),
+  );
+  const inFlight = entries.some((e) => e.status === 'pending' || e.status === 'indexing');
+  return {
+    bootRan,
+    inFlight,
+    entries,
+  };
+}
+
+async function getCurrentHead(localPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('git', ['-C', localPath, 'rev-parse', 'HEAD'], {
+      maxBuffer: 64 * 1024,
+      timeout: 10_000,
+    });
+    const head = stdout.trim();
+    return head || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort repo size in bytes. We capped the recursion at
+ * SIZE_WALK_ENTRY_CAP to avoid spending boot time enumerating huge trees;
+ * past that cap we treat the repo as "definitely big" and defer it.
+ *
+ * Returns:
+ *   - bytes when fully measured under the cap
+ *   - null when measurement failed (treat as small/unknown — proceed)
+ *   - Number.POSITIVE_INFINITY when we hit the cap (treat as oversize)
+ */
+function measureRepoSize(localPath: string): number | null {
+  let total = 0;
+  let entriesSeen = 0;
+  const stack: string[] = [localPath];
+
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let dirents: ReturnType<typeof readdirSync>;
+    try {
+      dirents = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const dirent of dirents) {
+      entriesSeen += 1;
+      if (entriesSeen > SIZE_WALK_ENTRY_CAP) {
+        return Number.POSITIVE_INFINITY;
+      }
+      // Skip the usual giants — they exist in basically every repo.
+      if (
+        dirent.name === 'node_modules' ||
+        dirent.name === '.git' ||
+        dirent.name === 'target' ||
+        dirent.name === '.next' ||
+        dirent.name === 'dist'
+      ) {
+        // Approximate node_modules size by stating the directory once.
+        try {
+          const s = statSync(join(dir, dirent.name));
+          total += s.size;
+        } catch {
+          /* ignore */
+        }
+        continue;
+      }
+      const full = join(dir, dirent.name);
+      if (dirent.isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      try {
+        const s = statSync(full);
+        total += s.size;
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  return total;
+}
+
+interface RunIndexJobOpts {
+  binPath: string;
+  repo: RepoRegistryEntry;
+  maxSizeBytes: number;
+}
+
+async function runIndexJob({ binPath, repo, maxSizeBytes }: RunIndexJobOpts): Promise<void> {
+  const repoId = repo.id;
+
+  // Size guard. Defer oversize repos.
+  let sizeBytes: number | null = null;
+  try {
+    sizeBytes = measureRepoSize(repo.localPath);
+  } catch {
+    sizeBytes = null;
+  }
+  if (sizeBytes !== null && sizeBytes !== Number.POSITIVE_INFINITY) {
+    patchEntry(repoId, { sizeBytes });
+  }
+  if (sizeBytes !== null && sizeBytes > maxSizeBytes) {
+    logInfo(`deferring ${repo.name}: size ${Math.round(sizeBytes / (1024 * 1024))} MB > limit`);
+    patchEntry(repoId, {
+      status: 'deferred' satisfies RepoIndexStatus,
+      sizeBytes: sizeBytes === Number.POSITIVE_INFINITY ? null : sizeBytes,
+    });
+    return;
+  }
+
+  // HEAD-based cache check.
+  const currentHead = await getCurrentHead(repo.localPath);
+  if (!currentHead) {
+    logWarn(`skipping ${repo.name}: not a git repo or HEAD unresolved`);
+    patchEntry(repoId, { status: 'skipped' satisfies RepoIndexStatus });
+    return;
+  }
+  const recordedHead = getRecordedHead(repoId);
+  if (recordedHead && recordedHead === currentHead) {
+    logInfo(`cached ${repo.name}: HEAD ${currentHead.slice(0, 7)} unchanged`);
+    patchEntry(repoId, {
+      status: 'cached' satisfies RepoIndexStatus,
+      lastIndexedHead: currentHead,
+    });
+    return;
+  }
+
+  // Issue index_repository. cwd = repo root so the binary indexes the right tree.
+  patchEntry(repoId, { status: 'indexing' satisfies RepoIndexStatus });
+  logInfo(`indexing ${repo.name} (HEAD ${currentHead.slice(0, 7)})`);
+
+  const result = await callCodebaseMemoryTool({
+    binPath,
+    cwd: repo.localPath,
+    toolName: INDEX_TOOL_NAME,
+    args: { path: repo.localPath },
+  });
+
+  if (!result.ok) {
+    logWarn(`index failed for ${repo.name}: ${result.error}`);
+    patchEntry(repoId, {
+      status: 'error' satisfies RepoIndexStatus,
+      error: result.error,
+      durationMs: result.durationMs,
+    });
+    return;
+  }
+
+  recordIndexedHead(repoId, currentHead);
+  patchEntry(repoId, {
+    status: 'ready' satisfies RepoIndexStatus,
+    lastIndexedHead: currentHead,
+    lastIndexedAt: new Date().toISOString(),
+    error: null,
+    durationMs: result.durationMs,
+  });
+  logInfo(`indexed ${repo.name} in ${result.durationMs}ms`);
+}
+
+/**
+ * Drain the pending queue with bounded concurrency.
+ *
+ * Plain promise-pool. We don't pull in p-queue because the dep adds cost
+ * and this is fewer than 50 lines.
+ */
+async function runWithConcurrency(
+  jobs: Array<() => Promise<void>>,
+  concurrency: number,
+): Promise<void> {
+  const active = new Set<Promise<void>>();
+  for (const job of jobs) {
+    const run = job().catch((err: unknown) => {
+      logWarn('indexer worker threw:', err);
+    });
+    active.add(run);
+    void run.finally(() => active.delete(run));
+    if (active.size >= concurrency) {
+      await Promise.race(active);
+    }
+  }
+  await Promise.all(active);
+}
+
+export interface IndexAllOpts {
+  /** Override max repo size. Defaults to 500 MB. */
+  maxRepoSizeBytes?: number;
+  /** Override concurrency. Defaults to 2. */
+  concurrency?: number;
+  /** Override the binary-wait deadline. */
+  binaryWaitTimeoutMs?: number;
+}
+
+/**
+ * Run a single boot pass. Idempotent — concurrent calls share state.
+ * Resolves when every repo's index attempt has settled.
+ */
+export async function indexAllRepos(opts: IndexAllOpts = {}): Promise<IndexState> {
+  if (bootInFlight) {
+    return getIndexState();
+  }
+  bootInFlight = true;
+  bootRan = true;
+
+  const concurrency = opts.concurrency ?? DEFAULT_INDEX_CONCURRENCY;
+  const maxSizeBytes = opts.maxRepoSizeBytes ?? DEFAULT_MAX_REPO_SIZE_BYTES;
+  const waitMs = opts.binaryWaitTimeoutMs ?? BINARY_WAIT_TIMEOUT_MS;
+
+  try {
+    let repos: RepoRegistryEntry[];
+    try {
+      repos = await listRepos();
+    } catch (err) {
+      logWarn('failed to read repo registry:', err);
+      return getIndexState();
+    }
+
+    if (repos.length === 0) {
+      logInfo('no registered repos — boot pass is a no-op');
+      return getIndexState();
+    }
+
+    // Initialize state for each repo so the status endpoint has something
+    // to return immediately even before binary resolution.
+    for (const repo of repos) {
+      setEntry({
+        repoId: repo.id,
+        repoName: repo.name,
+        localPath: repo.localPath,
+        status: 'pending',
+      });
+    }
+
+    // Resolve binary; wait for #739's download if necessary.
+    let binPath = resolveCodebaseMemoryBin();
+    if (!binPath) {
+      logInfo('binary not yet available — waiting for #739 download');
+      binPath = await waitForCodebaseMemoryBin(waitMs);
+    }
+    if (!binPath) {
+      logWarn('binary unavailable after wait — marking all repos skipped');
+      for (const repo of repos) {
+        patchEntry(repo.id, {
+          status: 'skipped' satisfies RepoIndexStatus,
+          error: 'codebase-memory-mcp binary unavailable',
+        });
+      }
+      return getIndexState();
+    }
+
+    logInfo(`boot pass: ${repos.length} repos, binary at ${binPath}`);
+
+    const jobs: Array<() => Promise<void>> = repos.map(
+      (repo) => () => runIndexJob({ binPath: binPath!, repo, maxSizeBytes }),
+    );
+    await runWithConcurrency(jobs, concurrency);
+
+    const state = getIndexState();
+    const ready = state.entries.filter((e) => e.status === 'ready').length;
+    const cached = state.entries.filter((e) => e.status === 'cached').length;
+    const deferred = state.entries.filter((e) => e.status === 'deferred').length;
+    const errored = state.entries.filter((e) => e.status === 'error').length;
+    logInfo(
+      `boot pass complete: ${ready} indexed, ${cached} cached, ${deferred} deferred, ${errored} errored`,
+    );
+    return state;
+  } finally {
+    bootInFlight = false;
+  }
+}
+
+let bootHookFired = false;
+
+/**
+ * Idempotent boot trigger. Call from any route that the Tauri shell hits
+ * early (we use /api/panel/status). Spawns indexAllRepos on a microtask
+ * so the route handler returns immediately.
+ *
+ * Mirrors the `ensureBooted()` pattern in src/lib/skeleton/autoscan.ts.
+ */
+export function ensureCodebaseMemoryBootIndex(): void {
+  if (bootHookFired) return;
+  bootHookFired = true;
+  setImmediate(() => {
+    void indexAllRepos().catch((err: unknown) => {
+      logWarn('boot pass threw:', err);
+    });
+  });
+}

--- a/src/lib/codebase-memory/mcp-client.ts
+++ b/src/lib/codebase-memory/mcp-client.ts
@@ -1,0 +1,294 @@
+/**
+ * Minimal MCP-stdio JSON-RPC client for one-shot tool calls.
+ *
+ * Spawns a fresh codebase-memory-mcp child process, runs initialize +
+ * tools/call, then closes stdin so the child exits. We don't keep the
+ * child alive across calls — the boot indexer runs each repo serially
+ * (modulo the concurrency cap) and the binary's index step is the
+ * expensive part, not the spawn.
+ *
+ * Wire format mirrors src/lib/mcp/test-connection.ts. Both build on the
+ * MCP 2024-11-05 protocol with newline-delimited JSON-RPC frames.
+ */
+
+import 'server-only';
+
+import { spawn } from 'node:child_process';
+
+const INIT_TIMEOUT_MS = 10_000;
+const DEFAULT_CALL_TIMEOUT_MS = 5 * 60_000; // 5 min — large repos take time to index
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id: number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id?: number | string | null;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+export interface McpToolCallInput {
+  binPath: string;
+  cwd: string;
+  toolName: string;
+  args?: Record<string, unknown>;
+  /** Override timeout (ms) for the tools/call response. */
+  timeoutMs?: number;
+}
+
+export interface McpToolCallSuccess {
+  ok: true;
+  result: unknown;
+  durationMs: number;
+}
+
+export interface McpToolCallFailure {
+  ok: false;
+  error: string;
+  stderr?: string;
+  durationMs: number;
+}
+
+export type McpToolCallResult = McpToolCallSuccess | McpToolCallFailure;
+
+export async function callCodebaseMemoryTool(
+  input: McpToolCallInput,
+): Promise<McpToolCallResult> {
+  const started = Date.now();
+  const callTimeoutMs = input.timeoutMs ?? DEFAULT_CALL_TIMEOUT_MS;
+  let stderrBuf = '';
+
+  return new Promise<McpToolCallResult>((resolve) => {
+    let resolved = false;
+    let killed = false;
+    let child: ReturnType<typeof spawn> | null = null;
+
+    try {
+      child = spawn(input.binPath, [], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        cwd: input.cwd,
+        env: { ...process.env },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      resolve({
+        ok: false,
+        error: `Spawn failed — ${message}`,
+        durationMs: Date.now() - started,
+      });
+      return;
+    }
+
+    const finish = (result: McpToolCallResult) => {
+      if (resolved) return;
+      resolved = true;
+      if (child && !killed) {
+        killed = true;
+        try {
+          child.kill('SIGTERM');
+        } catch {
+          /* ignore */
+        }
+        setTimeout(() => {
+          if (child && !child.killed) {
+            try {
+              child.kill('SIGKILL');
+            } catch {
+              /* ignore */
+            }
+          }
+        }, 500);
+      }
+      resolve(result);
+    };
+
+    const timeout = setTimeout(() => {
+      finish({
+        ok: false,
+        error: `Timed out after ${callTimeoutMs}ms`,
+        stderr: stderrBuf || undefined,
+        durationMs: Date.now() - started,
+      });
+    }, callTimeoutMs);
+
+    child.on('error', (err) => {
+      clearTimeout(timeout);
+      finish({
+        ok: false,
+        error: `Process error — ${err.message}`,
+        stderr: stderrBuf || undefined,
+        durationMs: Date.now() - started,
+      });
+    });
+
+    child.on('exit', (code, signal) => {
+      if (resolved) return;
+      clearTimeout(timeout);
+      const hint = signal ? `signal ${signal}` : `exit code ${code ?? '?'}`;
+      finish({
+        ok: false,
+        error: `Process exited before tool call completed (${hint})`,
+        stderr: stderrBuf || undefined,
+        durationMs: Date.now() - started,
+      });
+    });
+
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderrBuf += chunk.toString('utf-8');
+      // Cap stderr buffer to avoid runaway memory.
+      if (stderrBuf.length > 8000) {
+        stderrBuf = stderrBuf.slice(-8000);
+      }
+    });
+
+    let stdoutBuf = '';
+    const pending = new Map<number, (resp: JsonRpcResponse) => void>();
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdoutBuf += chunk.toString('utf-8');
+      let nl = stdoutBuf.indexOf('\n');
+      while (nl !== -1) {
+        const line = stdoutBuf.slice(0, nl).trim();
+        stdoutBuf = stdoutBuf.slice(nl + 1);
+        nl = stdoutBuf.indexOf('\n');
+        if (!line) continue;
+        try {
+          const msg = JSON.parse(line) as JsonRpcResponse;
+          if (typeof msg.id === 'number' && pending.has(msg.id)) {
+            const handler = pending.get(msg.id)!;
+            pending.delete(msg.id);
+            handler(msg);
+          }
+        } catch {
+          // Notification or malformed — ignore.
+        }
+      }
+    });
+
+    const writeRequest = (req: JsonRpcRequest): boolean => {
+      if (!child?.stdin || child.stdin.destroyed) {
+        finish({
+          ok: false,
+          error: 'Child stdin closed before request was sent',
+          stderr: stderrBuf || undefined,
+          durationMs: Date.now() - started,
+        });
+        return false;
+      }
+      try {
+        child.stdin.write(`${JSON.stringify(req)}\n`);
+        return true;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        finish({
+          ok: false,
+          error: `Failed to write request — ${message}`,
+          stderr: stderrBuf || undefined,
+          durationMs: Date.now() - started,
+        });
+        return false;
+      }
+    };
+
+    const awaitResponse = (id: number, perRequestTimeoutMs?: number): Promise<JsonRpcResponse> =>
+      new Promise<JsonRpcResponse>((respResolve, respReject) => {
+        if (perRequestTimeoutMs) {
+          const t = setTimeout(() => {
+            pending.delete(id);
+            respReject(new Error(`Request id ${id} timed out`));
+          }, perRequestTimeoutMs);
+          pending.set(id, (resp) => {
+            clearTimeout(t);
+            respResolve(resp);
+          });
+        } else {
+          pending.set(id, respResolve);
+        }
+      });
+
+    // 1) initialize
+    if (
+      !writeRequest({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'o8-codebase-memory-indexer', version: '1.0.0' },
+        },
+      })
+    )
+      return;
+
+    void awaitResponse(1, INIT_TIMEOUT_MS)
+      .then((initResp) => {
+        if (initResp.error) {
+          finish({
+            ok: false,
+            error: `initialize failed — ${initResp.error.message}`,
+            stderr: stderrBuf || undefined,
+            durationMs: Date.now() - started,
+          });
+          return;
+        }
+
+        // Per spec: notify initialized.
+        writeRequest({ jsonrpc: '2.0', id: 2, method: 'notifications/initialized' });
+
+        // 2) tools/call
+        if (
+          !writeRequest({
+            jsonrpc: '2.0',
+            id: 3,
+            method: 'tools/call',
+            params: {
+              name: input.toolName,
+              arguments: input.args ?? {},
+            },
+          })
+        )
+          return;
+
+        void awaitResponse(3)
+          .then((callResp) => {
+            if (callResp.error) {
+              finish({
+                ok: false,
+                error: `${input.toolName} failed — ${callResp.error.message}`,
+                stderr: stderrBuf || undefined,
+                durationMs: Date.now() - started,
+              });
+              return;
+            }
+            clearTimeout(timeout);
+            finish({
+              ok: true,
+              result: callResp.result,
+              durationMs: Date.now() - started,
+            });
+          })
+          .catch((err: Error) => {
+            finish({
+              ok: false,
+              error: err.message,
+              stderr: stderrBuf || undefined,
+              durationMs: Date.now() - started,
+            });
+          });
+      })
+      .catch((err: Error) => {
+        finish({
+          ok: false,
+          error: err.message,
+          stderr: stderrBuf || undefined,
+          durationMs: Date.now() - started,
+        });
+      });
+  });
+}

--- a/src/lib/codebase-memory/state-store.ts
+++ b/src/lib/codebase-memory/state-store.ts
@@ -1,0 +1,68 @@
+/**
+ * Persisted last-indexed git HEAD per repo.
+ *
+ * Lives at <data-dir>/codebase-memory-state.json. The boot indexer reads
+ * this on startup, compares each repo's current HEAD against the recorded
+ * one, and skips re-indexing when they match. Writes happen after every
+ * successful index_repository call.
+ *
+ * Failures are swallowed — losing this state just means we re-index next
+ * boot, which is the conservative thing to do.
+ */
+
+import 'server-only';
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { getDataDir } from '@/lib/data-dir-migration';
+import type { PersistedIndexState } from './types';
+
+const STATE_FILE = 'codebase-memory-state.json';
+
+function statePath(): string {
+  return join(getDataDir(), STATE_FILE);
+}
+
+function emptyState(): PersistedIndexState {
+  return { version: 1, heads: {} };
+}
+
+export function readPersistedIndexState(): PersistedIndexState {
+  const path = statePath();
+  if (!existsSync(path)) return emptyState();
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<PersistedIndexState>;
+    if (!parsed || typeof parsed !== 'object' || !parsed.heads) return emptyState();
+    return { version: 1, heads: parsed.heads as PersistedIndexState['heads'] };
+  } catch {
+    return emptyState();
+  }
+}
+
+export function recordIndexedHead(
+  repoId: string,
+  head: string,
+  indexedAt: string = new Date().toISOString(),
+): void {
+  try {
+    const dir = getDataDir();
+    if (!existsSync(dir)) {
+      try {
+        mkdirSync(dir, { recursive: true });
+      } catch {
+        return;
+      }
+    }
+    const current = readPersistedIndexState();
+    current.heads[repoId] = { head, indexedAt };
+    writeFileSync(statePath(), `${JSON.stringify(current, null, 2)}\n`, 'utf-8');
+  } catch {
+    // Lossy on purpose — index will retry next boot.
+  }
+}
+
+export function getRecordedHead(repoId: string): string | null {
+  const state = readPersistedIndexState();
+  return state.heads[repoId]?.head ?? null;
+}

--- a/src/lib/codebase-memory/types.ts
+++ b/src/lib/codebase-memory/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Types for the codebase-memory boot indexer.
+ *
+ * Closes #741. The boot indexer reads ~/.o8/repos.json, spawns
+ * codebase-memory-mcp per repo, and calls index_repository so the
+ * Recall card (#742) has data available when the user dispatches.
+ */
+
+export type RepoIndexStatus =
+  | 'pending'      // queued, waiting for slot or binary
+  | 'indexing'    // index_repository in flight
+  | 'ready'       // indexed successfully (HEAD recorded)
+  | 'cached'      // skipped because HEAD unchanged
+  | 'deferred'    // size > limit, deferred to manual re-index
+  | 'skipped'     // binary unavailable / not a git repo / similar
+  | 'error';      // index_repository failed
+
+export interface RepoIndexEntry {
+  repoId: string;
+  repoName: string;
+  localPath: string;
+  status: RepoIndexStatus;
+  /** Last git HEAD we successfully indexed against. */
+  lastIndexedHead?: string | null;
+  /** Last successful index timestamp (ISO). */
+  lastIndexedAt?: string | null;
+  /** Most recent error message if status === 'error'. */
+  error?: string | null;
+  /** Repo size on disk in bytes (only set when measured). */
+  sizeBytes?: number | null;
+  /** Wall-clock duration of the last index_repository call. */
+  durationMs?: number | null;
+}
+
+export interface IndexState {
+  /** True when the boot pass has scheduled work for every repo. */
+  bootRan: boolean;
+  /** True while at least one repo is in 'pending' or 'indexing'. */
+  inFlight: boolean;
+  entries: RepoIndexEntry[];
+}
+
+/** Persisted shape at ~/.o8/codebase-memory-state.json. */
+export interface PersistedIndexState {
+  version: 1;
+  /** Map of repoId → last indexed git HEAD. */
+  heads: Record<string, { head: string; indexedAt: string }>;
+}


### PR DESCRIPTION
## Summary
- Boot indexer reads `~/.o8/repos.json` and runs `index_repository` against codebase-memory-mcp for each repo
- Background pass — never blocks Next.js boot or any route response
- Concurrency capped at 2, repos > 500 MB deferred, last-indexed HEAD cached so re-boots are no-ops
- Closes #741, third child of #738 (Context Engine v2). Builds on #739 (binary download) and #740 (.mcp.json registration)

## How it fires
`ensureCodebaseMemoryBootIndex()` is hooked into `GET /api/panel/status` — the liveness probe the Tauri shell hits right after the bundled Node sidecar starts. Idempotent (`bootHookFired` flag), runs on `setImmediate`. Also wired into the new status route as a safety-net so the Recall UI can trigger it.

## Files
- `src/lib/codebase-memory/types.ts` — `RepoIndexStatus`, `RepoIndexEntry`, `IndexState`, `PersistedIndexState`
- `src/lib/codebase-memory/binary.ts` — env-var + deterministic-path resolution + polling wait
- `src/lib/codebase-memory/state-store.ts` — `~/.o8/codebase-memory-state.json` reader/writer
- `src/lib/codebase-memory/mcp-client.ts` — MCP-stdio JSON-RPC client (mirrors `src/lib/mcp/test-connection.ts`)
- `src/lib/codebase-memory/indexer.ts` — `indexAllRepos()`, `getIndexState()`, `ensureCodebaseMemoryBootIndex()`
- `src/app/api/cortex/codebase-memory/route.ts` — `GET` returns live `IndexState` for #742's Recall card
- `src/app/api/panel/status/route.ts` — wires the boot trigger to the existing liveness route

## Hard-rules respected
- No changes to `src-tauri/*` (#739)
- No changes to `.mcp.json` (#740)
- No changes to `ThoughtsMissionPanel.tsx` (#742)
- No changes to `runtimes/registry.ts` (#743)
- No changes to `db/schema.ts`
- `npx tsc --noEmit` passes
- `npx eslint` clean
- Background indexing uses `setImmediate` — never blocks server boot

## Test plan
- [ ] Cold launch (no `~/.o8/bin/codebase-memory-mcp`): boot pass logs "binary not yet available — waiting", binary appears mid-wait, indexing fires
- [ ] Warm launch (binary cached, repos previously indexed): every repo logs "cached — HEAD unchanged"
- [ ] Modify a repo's HEAD, relaunch: that repo re-indexes, others stay cached
- [ ] Add a > 500 MB repo to the registry: logged "deferring … size > limit", marked `'deferred'`
- [ ] Empty registry (`~/.o8/repos.json` missing or `repos: []`): boot pass logs "no registered repos — boot pass is a no-op"
- [ ] `GET /api/cortex/codebase-memory` returns live `IndexState` JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)