### PR TITLE
feat(cortex): demo polish — seed directives + record-ready state (closes #744)

### DIFF
--- a/examples/directives/README.md
+++ b/examples/directives/README.md
@@ -1,0 +1,24 @@
+# Seed directives
+
+Bundled directive markdown files copied to `~/.o8/directives/` on first launch
+(or whenever `scripts/seed-demo-state.mjs` runs). Each file has YAML-style
+front matter — see `src/app/api/cortex/directives/route.ts` for the parser.
+
+Front-matter fields:
+
+| key       | required | meaning                                                    |
+| --------- | -------- | ---------------------------------------------------------- |
+| `id`      | yes      | Stable, deterministic. Used for dedupe on re-seed.         |
+| `title`   | yes      | One-line summary surfaced in the Recall Card chip.         |
+| `scope`   | yes      | `global` or a repo name (e.g. `repo` + `repoName: foo`).   |
+| `repoName`| no       | Required when `scope` is repo-specific.                    |
+| `priority`| no       | Higher = more important. Recall Card sorts desc.           |
+| `created` | yes      | ISO timestamp.                                             |
+| `updated` | yes      | ISO timestamp.                                             |
+
+Body text lives below the second `---` and is the directive content the
+orchestrator injects into dispatch packets.
+
+The seed files use stable `id`s prefixed with `seed-` so re-running the
+seeding script never duplicates them — the script skips any file whose `id`
+already exists in the data dir.

--- a/examples/directives/seed-cortex-ide-800-line-ceiling.md
+++ b/examples/directives/seed-cortex-ide-800-line-ceiling.md
@@ -1,0 +1,11 @@
+---
+id: seed-cortex-ide-800-line-ceiling
+title: 800-line file ceiling — decompose before adding
+scope: repo
+repoName: cortex-ide
+priority: 8
+created: 2026-04-28T00:00:00.000Z
+updated: 2026-04-28T00:00:00.000Z
+---
+
+Files must stay under 800 lines. If your change would push past 800, decompose first: extract helpers, hooks, sub-components, or modules before adding new logic. Layout orchestrators (`src/app/dashboard/page.tsx`) and multiplexers (`src/ws-server.ts`) are explicitly waived. The recall-card sub-components and packet-review-card panes are good examples of the decomposition pattern.

--- a/examples/directives/seed-cortex-ide-glass-chrome-preserved.md
+++ b/examples/directives/seed-cortex-ide-glass-chrome-preserved.md
@@ -1,0 +1,11 @@
+---
+id: seed-cortex-ide-glass-chrome-preserved
+title: Don't kill glass transparency on chrome surfaces
+scope: repo
+repoName: cortex-ide
+priority: 6
+created: 2026-04-28T00:00:00.000Z
+updated: 2026-04-28T00:00:00.000Z
+---
+
+Low-opacity rgba whites are intentional — they're the glass tint over the macOS vibrancy backdrop. Never blanket-replace them with solid palette tokens during a refactor; that collapses the chrome into opaque blobs and loses the depth. Workspace, chat, and terminal surfaces are pinned to solid colors on purpose; the surrounding chrome is glass on purpose. Verify visually before mass-rewriting any rgba.

--- a/examples/directives/seed-cortex-ide-inline-styles-only.md
+++ b/examples/directives/seed-cortex-ide-inline-styles-only.md
@@ -1,0 +1,11 @@
+---
+id: seed-cortex-ide-inline-styles-only
+title: Inline styles only — no CSS classes anywhere
+scope: repo
+repoName: cortex-ide
+priority: 9
+created: 2026-04-28T00:00:00.000Z
+updated: 2026-04-28T00:00:00.000Z
+---
+
+All styling lives in `style={{ }}` props on JSX. Never use CSS class names, stylesheets, or CSS modules. iOS Safari and the Tauri webview have shipped reliability issues with class-based styling — this is a permanent rule, not a stylistic preference. Use `as React.CSSProperties` when assigning vendor-prefixed or non-standard CSS properties.

--- a/examples/directives/seed-cortex-ide-no-native-form-controls-in-packets.md
+++ b/examples/directives/seed-cortex-ide-no-native-form-controls-in-packets.md
@@ -1,0 +1,11 @@
+---
+id: seed-cortex-ide-no-native-form-controls-in-packets
+title: No native select / input inside packet cards
+scope: repo
+repoName: cortex-ide
+priority: 7
+created: 2026-04-28T00:00:00.000Z
+updated: 2026-04-28T00:00:00.000Z
+---
+
+Packet metadata rows in Mission Control use Issues-style clickable rows: uppercase label, value, chevron, click to inline-edit (textarea/input) or open a floating popover. Native `<select>` and `<input>` controls render as chunky bubbles that break the density. See `ThoughtsMissionPanel` and the `packet-meta-rows` pattern — copy that, never reach for a raw form control.

--- a/examples/directives/seed-cortex-ide-palette-vars.md
+++ b/examples/directives/seed-cortex-ide-palette-vars.md
@@ -1,0 +1,11 @@
+---
+id: seed-cortex-ide-palette-vars
+title: Use palette CSS vars, never hardcoded rgba for surfaces
+scope: repo
+repoName: cortex-ide
+priority: 10
+created: 2026-04-28T00:00:00.000Z
+updated: 2026-04-28T00:00:00.000Z
+---
+
+Never hardcode rgba colors for chrome surfaces. Use `var(--t-bg-card)`, `var(--t-panel)`, `var(--t-input-bg)`, `var(--t-divider-subtle)`, etc. A hardcoded `rgba(255,255,255,0.56)` renders as a giant light-gray blob in midnight theme — see commit 929ffdf. The CSS variable system has 60+ tokens per theme; reach for one before writing a literal color.

--- a/examples/directives/seed-cortex-ide-phosphor-svg-only.md
+++ b/examples/directives/seed-cortex-ide-phosphor-svg-only.md
@@ -1,0 +1,11 @@
+---
+id: seed-cortex-ide-phosphor-svg-only
+title: Phosphor raw SVG only — no React icon components
+scope: repo
+repoName: cortex-ide
+priority: 9
+created: 2026-04-28T00:00:00.000Z
+updated: 2026-04-28T00:00:00.000Z
+---
+
+Never use `@phosphor-icons/react` or `lucide-react` component imports — neither renders correctly in the Tauri webview. Extract SVG path data from `@phosphor-icons/react/dist/defs/` and use raw `<svg>` elements with inline styles. For trivial actions (plus, minus, chevron) prefer HTML entities. The shim system in `src/lib/icons/` covers 85 icons; check there before adding a new one.

--- a/examples/directives/seed-global-surgical-changes.md
+++ b/examples/directives/seed-global-surgical-changes.md
@@ -1,0 +1,10 @@
+---
+id: seed-global-surgical-changes
+title: Surgical changes — don't refactor adjacent code
+scope: global
+priority: 7
+created: 2026-04-28T00:00:00.000Z
+updated: 2026-04-28T00:00:00.000Z
+---
+
+Every changed line must trace back to the request. Don't "improve" adjacent code, comments, or formatting. Don't refactor what isn't broken. Match existing style even if you'd write it differently. If you notice unrelated dead code or a tempting refactor, mention it — don't silently delete or rewrite it. Drift in unrelated areas is the #1 source of bad reviews.

--- a/examples/directives/seed-global-typecheck-before-commit.md
+++ b/examples/directives/seed-global-typecheck-before-commit.md
@@ -1,0 +1,10 @@
+---
+id: seed-global-typecheck-before-commit
+title: Always typecheck before commit
+scope: global
+priority: 8
+created: 2026-04-28T00:00:00.000Z
+updated: 2026-04-28T00:00:00.000Z
+---
+
+Run `npx tsc --noEmit` before every commit. CI will catch regressions but local checks save the round-trip and reviewer time. For Next.js repos prefer `npm run typecheck` (clears the typegen cache before checking). No exceptions on shared codebases — a broken typecheck blocks the whole team.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "typecheck": "rm -rf .next/types .next/dev/types && next typegen && tsc --noEmit",
     "rule-check": "tsx scripts/rule-check.ts",
     "smoke": "node scripts/smoke.mjs",
+    "seed:demo": "node scripts/seed-demo-state.mjs",
     "worker:build": "node scripts/build-worker.mjs",
     "worker:dev": "tsx scripts/worker/index.ts",
     "research:session": "tsx scripts/research/run-cortex-autoresearch.ts --trigger on-demand --max-loops 1",

--- a/scripts/seed-demo-state.mjs
+++ b/scripts/seed-demo-state.mjs
@@ -1,0 +1,441 @@
+#!/usr/bin/env node
+/**
+ * Demo state seeder — populates a clean install with everything the Context
+ * Engine needs to look impressive on first launch (#744, the YC demo polish).
+ *
+ * Two effects, both idempotent:
+ *
+ *   1. Copies any `examples/directives/*.md` not already present in
+ *      `~/.o8/directives/` (matched by the front-matter `id`). Lets us ship
+ *      a curated default set without overwriting user-authored directives.
+ *
+ *   2. Inserts a realistic mix of `session_outcomes` rows for the cortex-ide
+ *      repo (default; configurable via `--repo-path=...`). Skipped if the
+ *      target repo already has >= MIN_OUTCOMES rows so re-runs don't pile
+ *      on top of real data.
+ *
+ * Usage:
+ *
+ *   node scripts/seed-demo-state.mjs                 # seed cortex-ide repo
+ *   node scripts/seed-demo-state.mjs --repo-path=/abs/path/to/repo
+ *   node scripts/seed-demo-state.mjs --force-outcomes   # re-seed even if rows exist
+ *   node scripts/seed-demo-state.mjs --directives-only
+ *   node scripts/seed-demo-state.mjs --outcomes-only
+ *
+ * Safe to call from npm postinstall, dev runner, or by hand. Never destroys
+ * existing data — if you need to start clean, delete `~/.o8/cortex-ide.db`
+ * and the `~/.o8/directives/` dir manually first.
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, copyFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ── Config ──────────────────────────────────────────────────────────────
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, '..');
+const SEED_DIRECTIVE_DIR = join(REPO_ROOT, 'examples', 'directives');
+
+function getDataDir() {
+  return process.env.O8_DATA_DIR
+    || process.env.CORTEX_IDE_DATA_DIR
+    || join(homedir(), '.o8');
+}
+
+function getDbPath() {
+  return process.env.CORTEX_IDE_DB_PATH || join(getDataDir(), 'cortex-ide.db');
+}
+
+function getDirectivesDir() {
+  return join(getDataDir(), 'directives');
+}
+
+const DEFAULT_REPO_PATH = join(homedir(), 'cortex-ide');
+const MIN_OUTCOMES = 5;
+
+// ── CLI ─────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+let repoPath = DEFAULT_REPO_PATH;
+let forceOutcomes = false;
+let directivesOnly = false;
+let outcomesOnly = false;
+
+for (const arg of args) {
+  if (arg.startsWith('--repo-path=')) {
+    repoPath = arg.slice('--repo-path='.length);
+  } else if (arg === '--force-outcomes') {
+    forceOutcomes = true;
+  } else if (arg === '--directives-only') {
+    directivesOnly = true;
+  } else if (arg === '--outcomes-only') {
+    outcomesOnly = true;
+  } else if (arg === '--help' || arg === '-h') {
+    console.log([
+      'Usage: node scripts/seed-demo-state.mjs [options]',
+      '',
+      'Options:',
+      '  --repo-path=<abs>       Repo to seed outcomes for (default: ~/cortex-ide)',
+      '  --force-outcomes        Re-seed outcomes even if rows already exist',
+      '  --directives-only       Skip the outcomes seed',
+      '  --outcomes-only         Skip the directives seed',
+      '  -h, --help              Show this help',
+    ].join('\n'));
+    process.exit(0);
+  } else {
+    console.warn(`[seed-demo-state] Ignoring unknown arg: ${arg}`);
+  }
+}
+
+// ── Directives ──────────────────────────────────────────────────────────
+
+const FRONT_MATTER_BOUNDARY = /^---\s*$/m;
+
+function parseDirectiveId(raw) {
+  const text = raw.replace(/\r\n/g, '\n').trim();
+  if (!text.startsWith('---')) return null;
+  const afterFirst = text.slice(3).trimStart();
+  const closingIndex = afterFirst.search(FRONT_MATTER_BOUNDARY);
+  if (closingIndex < 0) return null;
+  const front = afterFirst.slice(0, closingIndex);
+  for (const line of front.split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx <= 0) continue;
+    const key = line.slice(0, idx).trim();
+    if (key === 'id') return line.slice(idx + 1).trim();
+  }
+  return null;
+}
+
+function collectExistingDirectiveIds(dir) {
+  if (!existsSync(dir)) return new Set();
+  const ids = new Set();
+  for (const name of readdirSync(dir)) {
+    if (!name.endsWith('.md')) continue;
+    try {
+      const raw = readFileSync(join(dir, name), 'utf-8');
+      const id = parseDirectiveId(raw);
+      if (id) ids.add(id);
+    } catch {
+      // Ignore unreadable files — never block the seed on a parse error.
+    }
+  }
+  return ids;
+}
+
+function seedDirectives() {
+  if (!existsSync(SEED_DIRECTIVE_DIR)) {
+    console.log(`[seed-demo-state] No seed dir at ${SEED_DIRECTIVE_DIR}; skipping directive seed.`);
+    return { copied: 0, skipped: 0 };
+  }
+
+  const targetDir = getDirectivesDir();
+  if (!existsSync(targetDir)) mkdirSync(targetDir, { recursive: true });
+
+  const existingIds = collectExistingDirectiveIds(targetDir);
+  let copied = 0;
+  let skipped = 0;
+
+  for (const name of readdirSync(SEED_DIRECTIVE_DIR)) {
+    if (!name.endsWith('.md')) continue;
+    const src = join(SEED_DIRECTIVE_DIR, name);
+    let raw = '';
+    try {
+      raw = readFileSync(src, 'utf-8');
+    } catch {
+      continue;
+    }
+    const id = parseDirectiveId(raw);
+    if (!id) {
+      console.warn(`[seed-demo-state] ${name} has no id in front matter; skipping.`);
+      continue;
+    }
+    if (existingIds.has(id)) {
+      skipped++;
+      continue;
+    }
+    const dest = join(targetDir, name);
+    if (existsSync(dest)) {
+      // Same filename, different id — let user-managed file win.
+      skipped++;
+      continue;
+    }
+    copyFileSync(src, dest);
+    copied++;
+  }
+
+  console.log(`[seed-demo-state] Directives: copied ${copied}, skipped ${skipped} (already present).`);
+  return { copied, skipped };
+}
+
+// ── Outcomes ────────────────────────────────────────────────────────────
+
+/**
+ * Realistic-looking session outcomes for a cortex-ide demo. All branch /
+ * summary text is drawn from real recent merges so the Recall Card surfaces
+ * believable history instead of placeholder gibberish.
+ *
+ * Mix is intentional:
+ *   - 6 succeeded + reviewApproved=1 (clean merges)
+ *   - 1 succeeded + reviewApproved=0 (rejected after review)
+ *   - 1 partial (incomplete pass — orchestrator decomposed and retried)
+ *   - 1 failed (genuine engine failure)
+ *
+ * Runtimes are spread across codex / gemini / opencode to show the fleet
+ * isn't single-runtime. Costs and durations are inside plausible bands.
+ */
+const DEMO_OUTCOMES = [
+  {
+    branch: 'feat/recall-card-742',
+    runtime: 'codex',
+    outcome: 'succeeded',
+    reviewApproved: 1,
+    summary: 'Built the 3-row Context Recall Card hero — directives, recent outcomes, symbol graph — sandwiched into ThoughtsMissionPanel.',
+    durationMin: 14,
+    costUsd: 0.42,
+    model: 'gpt-5.4-xhigh',
+    daysAgo: 1,
+    findings: 0,
+  },
+  {
+    branch: 'feat/dispatch-context-injection-743',
+    runtime: 'codex',
+    outcome: 'succeeded',
+    reviewApproved: 1,
+    summary: 'Injected <context> block into packet bodies on dispatch — directives + outcomes + symbol graph with a 4000-char budget.',
+    durationMin: 11,
+    costUsd: 0.31,
+    model: 'gpt-5.4-xhigh',
+    daysAgo: 1,
+    findings: 0,
+  },
+  {
+    branch: 'feat/auto-index-repos-741',
+    runtime: 'gemini',
+    outcome: 'succeeded',
+    reviewApproved: 1,
+    summary: 'Auto-index every registered repo at boot via codebase-memory-mcp; surfaces an indexing chip on the first dispatch after a cold start.',
+    durationMin: 9,
+    costUsd: 0.08,
+    model: 'gemini-2.5-pro',
+    daysAgo: 2,
+    findings: 1,
+  },
+  {
+    branch: 'feat/mcp-register-codebase-memory-740',
+    runtime: 'codex',
+    outcome: 'succeeded',
+    reviewApproved: 1,
+    summary: 'Registered codebase-memory-mcp in .mcp.json + setup generator so a fresh install picks up the binary the first time the operator hits Recall.',
+    durationMin: 7,
+    costUsd: 0.18,
+    model: 'gpt-5.4-xhigh',
+    daysAgo: 2,
+    findings: 0,
+  },
+  {
+    branch: 'feat/codebase-memory-runtime-download-755',
+    runtime: 'codex',
+    outcome: 'succeeded',
+    reviewApproved: 1,
+    summary: 'Runtime-download codebase-memory-mcp on first launch — pull from GitHub Releases, verify checksum, drop into ~/.o8/bin so first-run is hands-off.',
+    durationMin: 13,
+    costUsd: 0.34,
+    model: 'gpt-5.4-xhigh',
+    daysAgo: 3,
+    findings: 0,
+  },
+  {
+    branch: 'fix/dispatch-popover-placement-752',
+    runtime: 'gemini',
+    outcome: 'succeeded',
+    reviewApproved: 1,
+    summary: 'Anchored Cmd+Shift+O popover at top-center of the active screen so multi-monitor setups stop opening off-screen on the wrong display.',
+    durationMin: 6,
+    costUsd: 0.05,
+    model: 'gemini-2.5-pro',
+    daysAgo: 4,
+    findings: 0,
+  },
+  {
+    branch: 'polish/orchestrator-empty-state-copy',
+    runtime: 'opencode',
+    outcome: 'succeeded',
+    reviewApproved: 0,
+    summary: 'Rewrote the orchestrator empty-state copy and quick-action card layout. Reviewer flagged the new copy as off-brand vs the locked design language.',
+    durationMin: 8,
+    costUsd: 0.04,
+    model: 'opencode/gpt-5-nano',
+    daysAgo: 5,
+    findings: 3,
+  },
+  {
+    branch: 'feat/packet-meta-rows-restyle',
+    runtime: 'codex',
+    outcome: 'partial',
+    reviewApproved: null,
+    summary: 'Started restyling packet metadata as Issues-style rows. Branch + repo rows landed cleanly; runtime + summary rows still using a native select that will need a popover follow-up.',
+    durationMin: 22,
+    costUsd: 0.51,
+    model: 'gpt-5.4-xhigh',
+    daysAgo: 6,
+    findings: 2,
+  },
+  {
+    branch: 'fix/midnight-blob-rgba-sweep',
+    runtime: 'gemini',
+    outcome: 'failed',
+    reviewApproved: null,
+    summary: 'Tried to swap hardcoded rgba whites for palette vars in the chrome surfaces. Pass collapsed glass into solid blobs across NavRail, status bar, and command palette — reverted before merge.',
+    durationMin: 19,
+    costUsd: 0.12,
+    model: 'gemini-2.5-pro',
+    daysAgo: 7,
+    findings: 5,
+  },
+  {
+    branch: 'feat/recall-card-symbol-graph-row',
+    runtime: 'codex',
+    outcome: 'succeeded',
+    reviewApproved: 1,
+    summary: 'Added the Symbol Graph row to the Context Recall Card — debounced trace_path call against codebase-memory-mcp, gracefully hides when the index is still building.',
+    durationMin: 16,
+    costUsd: 0.39,
+    model: 'gpt-5.4-xhigh',
+    daysAgo: 8,
+    findings: 0,
+  },
+];
+
+function makeOutcomeId(repoPath, daysAgo, runtime, branch) {
+  // Deterministic id so re-runs don't pile up duplicate rows. Branch slug is
+  // included so two same-day same-runtime outcomes don't collide.
+  const repoSlug = repoPath.replace(/[^A-Za-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  const branchSlug = branch.replace(/[^A-Za-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40);
+  return `seed-${repoSlug}-${daysAgo}d-${runtime}-${branchSlug}`;
+}
+
+function isoDaysAgo(days, jitterMinutes = 0) {
+  const ms = Date.now() - days * 24 * 60 * 60 * 1000 + jitterMinutes * 60 * 1000;
+  return new Date(ms).toISOString();
+}
+
+async function seedOutcomes(repoPath) {
+  const dbPath = getDbPath();
+  if (!existsSync(dbPath)) {
+    console.log(`[seed-demo-state] DB not yet initialized at ${dbPath}.`);
+    console.log('[seed-demo-state] Launch o8 once to create it, then re-run this script.');
+    return { inserted: 0, skipped: 0 };
+  }
+
+  let Database;
+  try {
+    ({ default: Database } = await import('better-sqlite3'));
+  } catch (error) {
+    console.error('[seed-demo-state] better-sqlite3 not available — run `npm install` first.');
+    console.error(error.message);
+    return { inserted: 0, skipped: 0 };
+  }
+
+  const sqlite = new Database(dbPath);
+  sqlite.pragma('journal_mode = WAL');
+  sqlite.pragma('busy_timeout = 5000');
+
+  // Confirm the table exists before we start writing.
+  const tableExists = sqlite
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='session_outcomes';")
+    .get();
+  if (!tableExists) {
+    console.log('[seed-demo-state] session_outcomes table not found — DB schema not migrated yet.');
+    console.log('[seed-demo-state] Launch o8 once so the schema lands, then re-run.');
+    sqlite.close();
+    return { inserted: 0, skipped: 0 };
+  }
+
+  const existingCount = sqlite
+    .prepare('SELECT COUNT(*) as count FROM session_outcomes WHERE repo_path = ?')
+    .get(repoPath);
+  const existing = existingCount?.count ?? 0;
+
+  if (existing >= MIN_OUTCOMES && !forceOutcomes) {
+    console.log(
+      `[seed-demo-state] Outcomes: ${repoPath} already has ${existing} rows (>= ${MIN_OUTCOMES}); skipping. Pass --force-outcomes to re-seed.`,
+    );
+    sqlite.close();
+    return { inserted: 0, skipped: DEMO_OUTCOMES.length };
+  }
+
+  const insertStmt = sqlite.prepare(`
+    INSERT OR REPLACE INTO session_outcomes (
+      id, repo_path, branch, runtime, session_key, lane_id, packet_id,
+      outcome, summary, attempts, retry_history_json, duration_ms,
+      total_tokens, cost_usd, model, patterns_json, conflict_zones_json,
+      changed_files_json, review_approved, review_findings_count,
+      transcript_path, started_at, completed_at, created_at, plan_text
+    ) VALUES (
+      @id, @repo_path, @branch, @runtime, NULL, NULL, NULL,
+      @outcome, @summary, 1, '[]', @duration_ms,
+      @total_tokens, @cost_usd, @model, '[]', '[]',
+      '[]', @review_approved, @review_findings_count,
+      NULL, @started_at, @completed_at, datetime('now'), NULL
+    )
+  `);
+
+  let inserted = 0;
+  const tx = sqlite.transaction(() => {
+    for (const row of DEMO_OUTCOMES) {
+      const durationMs = row.durationMin * 60 * 1000;
+      const completed = isoDaysAgo(row.daysAgo, 0);
+      const started = isoDaysAgo(row.daysAgo, -row.durationMin);
+      const id = makeOutcomeId(repoPath, row.daysAgo, row.runtime, row.branch);
+      insertStmt.run({
+        id,
+        repo_path: repoPath,
+        branch: row.branch,
+        runtime: row.runtime,
+        outcome: row.outcome,
+        summary: row.summary,
+        duration_ms: durationMs,
+        total_tokens: Math.round(row.costUsd * 80_000),
+        cost_usd: row.costUsd,
+        model: row.model,
+        review_approved: row.reviewApproved,
+        review_findings_count: row.findings,
+        started_at: started,
+        completed_at: completed,
+      });
+      inserted++;
+    }
+  });
+  tx();
+  sqlite.close();
+
+  console.log(
+    `[seed-demo-state] Outcomes: inserted ${inserted} rows for ${repoPath} (had ${existing} before).`,
+  );
+  return { inserted, skipped: 0 };
+}
+
+// ── Main ────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log(`[seed-demo-state] Data dir: ${getDataDir()}`);
+  console.log(`[seed-demo-state] DB path:  ${getDbPath()}`);
+  console.log(`[seed-demo-state] Repo:     ${repoPath}`);
+
+  if (!outcomesOnly) {
+    seedDirectives();
+  }
+  if (!directivesOnly) {
+    await seedOutcomes(repoPath);
+  }
+
+  console.log('[seed-demo-state] Done.');
+}
+
+main().catch((error) => {
+  console.error('[seed-demo-state] Failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Final link in the Context Engine v2 chain (#739 → #743). Ships a curated set of high-signal directive examples plus a one-shot seed script so the Recall Card has interesting data to surface during the YC pitch demo on May 4.

- `examples/directives/` — 8 bundled directive markdown files. 6 repo-scoped to cortex-ide (palette CSS vars, Phosphor raw SVG, inline styles, 800-line ceiling, no native form controls in packets, glass chrome preserved); 2 global (always typecheck before commit, surgical changes). Stable `seed-*` ids so re-runs never duplicate.
- `scripts/seed-demo-state.mjs` — idempotent seeder. Copies any directive with a new id into `~/.o8/directives/`, then inserts 10 realistic `session_outcomes` rows for the cortex-ide repo (mix of `succeeded` / `partial` / `failed` / rejected; codex / gemini / opencode runtimes; real branch names + summaries drawn from recent merge history). Skips outcomes when the target repo already has >= 5 rows; `--force-outcomes` re-seeds.
- `package.json` — adds `npm run seed:demo` for muscle memory.

## What this fixes for the demo

Before this PR the local DB had **2 outcomes total**, both old failures with truncated transcript paths in their summary text. The Recall Card's RECENT OUTCOMES row would have rendered "rejected | something webview tool family…" — useless on camera. After this PR there are 12 outcomes, the top three (most recent merges) render as clean `[merged]` rows for `feat/dispatch-context-injection-743`, `feat/recall-card-742`, and `feat/auto-index-repos-741` — exactly the prior links of the Context Engine chain Marquise will already be talking about.

## Acceptance criteria

- [x] Demo repo selected: `cortex-ide` (already in `~/.o8/repos.json`)
- [x] At least 1 directive seeded with high recall value — 8 seeded, top is "Use palette CSS vars, never hardcoded rgba for surfaces" (priority 10, repo-scoped to cortex-ide)
- [x] `session_outcomes` table has at least 5 entries for the demo repo, mix of merge / rework — 12 total, mix of succeeded / partial / failed
- [x] `npx tsc --noEmit` passes

## Test plan

- [x] `node scripts/seed-demo-state.mjs` runs cleanly on first invocation (8 directives copied, 10 outcomes inserted)
- [x] Re-running is idempotent (8 directives skipped as already present, outcomes skipped because >= 5 rows already exist)
- [x] `--force-outcomes` re-seeds (id collision check via the unique branch slug)
- [x] `GET /api/cortex/directives` returns 14 entries sorted by priority desc
- [x] `GET /api/cortex/recent-outcomes?repoPath=~/cortex-ide&limit=3` returns the three most recent seeded merges
- [x] No files from #742 (recall card) or #743 (context injection) modified

## Hard rules followed

- No touches to engine plumbing (`src-tauri/*`, `.mcp.json`, `lib/codebase-memory/*`)
- No touches to `runtimes/registry.ts` or `orchestrator/*`
- Only files added: `examples/directives/*.md`, `scripts/seed-demo-state.mjs`. Only file modified: `package.json` (one line added)

closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)
