### PR TITLE
feat(tauri): dispatch popover redesign — glass card, draggable, runtime picker (#763)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "o8"
-version = "0.1.78"
+version = "0.1.79"
 dependencies = [
  "hex",
  "libc",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1605,13 +1605,51 @@ fn spawn_tray_badge_poller(app: AppHandle) {
 
 const POPOVER_LABEL: &str = "dispatch-popover";
 const POPOVER_WIDTH: f64 = 600.0;
-const POPOVER_HEIGHT: f64 = 80.0;
+const POPOVER_HEIGHT: f64 = 280.0;
+const POPOVER_STATE_FILE: &str = "popover-state.json";
 
-/// Open (or focus, if already open) the dispatch popover. Spotlight-style:
-/// horizontally centered, anchored at 25% from the top of the active monitor.
-/// Always-on-top, no decorations, frameless. Built on the dev URL when running
-/// `cargo tauri dev`, otherwise the bundled `tauri://localhost` scheme.
-/// Returns Ok(()) on success.
+/// Read the saved popover position from `~/.o8/popover-state.json`.
+/// Returns None when the file is missing, malformed, or contains values that
+/// don't fit on any plausible screen — in which case the open path falls back
+/// to the Spotlight-style top-center anchor.
+fn read_saved_popover_position() -> Option<(f64, f64)> {
+    let path = std::path::PathBuf::from(o8_data_dir()).join(POPOVER_STATE_FILE);
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let x = json.get("x")?.as_f64()?;
+    let y = json.get("y")?.as_f64()?;
+    // Reject obviously broken values — multi-monitor reconfigs sometimes save
+    // off-screen coordinates we can't recover from. Same defensive bounds as
+    // sanitize_window_state(), just looser.
+    if !x.is_finite() || !y.is_finite() { return None; }
+    if x < -10000.0 || x > 20000.0 || y < -10000.0 || y > 10000.0 { return None; }
+    Some((x, y))
+}
+
+/// Persist the popover position to `~/.o8/popover-state.json`. Called from
+/// the frontend after a drag finishes (via `save_dispatch_popover_position`).
+/// Best-effort: any IO error is logged and swallowed so the popover never
+/// becomes unusable just because a write failed.
+fn write_saved_popover_position(x: f64, y: f64) {
+    let dir = o8_data_dir();
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        log::warn!("[popover] mkdir {} failed: {}", dir, e);
+        return;
+    }
+    let path = std::path::PathBuf::from(&dir).join(POPOVER_STATE_FILE);
+    let payload = serde_json::json!({ "x": x, "y": y });
+    if let Err(e) = std::fs::write(&path, payload.to_string()) {
+        log::warn!("[popover] write {:?} failed: {}", path, e);
+    }
+}
+
+/// Open (or focus, if already open) the dispatch popover. Spotlight-style on
+/// first launch: horizontally centered, anchored at 25% from the top of the
+/// active monitor. Subsequent opens honor a position the user dragged the
+/// popover to (persisted to `~/.o8/popover-state.json`). Always-on-top, no
+/// decorations, frameless. Built on the dev URL when running `cargo tauri
+/// dev`, otherwise the bundled `tauri://localhost` scheme. Returns Ok(()) on
+/// success.
 fn open_dispatch_popover_impl(app: &AppHandle) -> Result<(), String> {
     // Compute Spotlight-style position on the primary monitor: horizontally
     // centered, 25% from the top. Falls back to .center() if monitor info is
@@ -1632,10 +1670,14 @@ fn open_dispatch_popover_impl(app: &AppHandle) -> Result<(), String> {
         _ => None,
     };
 
+    // Saved drag position wins over the Spotlight default — this is what
+    // makes the popover "remember where I put it" across summons.
+    let preferred_position = read_saved_popover_position().or(spotlight_position);
+
     if let Some(existing) = app.get_webview_window(POPOVER_LABEL) {
         let _ = existing.show();
         let _ = existing.set_focus();
-        if let Some((x, y)) = spotlight_position {
+        if let Some((x, y)) = preferred_position {
             let _ = existing.set_position(tauri::PhysicalPosition::new(x, y));
         } else {
             let _ = existing.center();
@@ -1666,7 +1708,7 @@ fn open_dispatch_popover_impl(app: &AppHandle) -> Result<(), String> {
         .visible(true)
         .skip_taskbar(true);
 
-    builder = if let Some((x, y)) = spotlight_position {
+    builder = if let Some((x, y)) = preferred_position {
         builder.position(x, y)
     } else {
         builder.center()
@@ -1696,6 +1738,15 @@ fn close_dispatch_popover(app: AppHandle) -> Result<(), String> {
         let _ = window.close();
     }
     Ok(())
+}
+
+/// Tauri command: persist the dispatch popover's last-known physical
+/// position. The popover frontend calls this after a drag finishes (mouseup
+/// on the header) so the next Cmd+Shift+O opens at the same spot. Coordinates
+/// are physical pixels relative to the primary monitor.
+#[tauri::command]
+fn save_dispatch_popover_position(x: f64, y: f64) {
+    write_saved_popover_position(x, y);
 }
 
 /// Tauri command: push an exact awaiting-review count to the tray badge.
@@ -1853,6 +1904,7 @@ pub fn run() {
             read_workspaces,
             open_dispatch_popover,
             close_dispatch_popover,
+            save_dispatch_popover_position,
             set_tray_badge,
             notify_review_ready,
             #[cfg(target_os = "macos")]

--- a/src/app/dispatch-popover/page.tsx
+++ b/src/app/dispatch-popover/page.tsx
@@ -1,8 +1,8 @@
 /**
- * /dispatch-popover — the 600x80 frameless popover summoned by Cmd+Shift+O
- * (issue #730). Renders DispatchPopover.tsx and inherits the dashboard's
- * ws-token via metadata so cross-origin auth works inside the secondary
- * Tauri webview.
+ * /dispatch-popover — the 600x280 glass-card popover summoned by Cmd+Shift+O
+ * (issues #730, #753, #763). Renders DispatchPopover.tsx and inherits the
+ * dashboard's ws-token via metadata so cross-origin auth works inside the
+ * secondary Tauri webview.
  */
 import type { Metadata } from 'next';
 import { getOrCreateWsToken } from '@/lib/ws-auth';

--- a/src/components/desktop/DispatchPopover.tsx
+++ b/src/components/desktop/DispatchPopover.tsx
@@ -1,25 +1,43 @@
 'use client';
 
 /**
- * DispatchPopover — the 600x80 frameless popover summoned by Cmd+Shift+O
- * (issue #730). Single text input. Press Enter to dispatch via the existing
- * `/api/orchestrator/create-mission` endpoint (which auto-dispatches because
- * the API defaults `dispatch=true`). Esc to close.
+ * DispatchPopover — the glass card summoned by Cmd+Shift+O (issues #730, #753, #763).
  *
- * Picks the most recently opened repo as the dispatch target. v1 trade-off:
- * we don't show a repo picker — that bloats the 80px height. Power users can
- * still dispatch via the main Orchestrator tab when they need a different
- * repo. Future iteration: tab-completion for repo names.
+ * Layout (600x280):
+ *   ┌─────────────────────────────────────────────┐
+ *   │ Dispatch a task          [drag handle]  [×] │  44px header
+ *   ├─────────────────────────────────────────────┤
+ *   │                                             │
+ *   │  What do you want done?                     │  textarea body
+ *   │                                             │
+ *   ├─────────────────────────────────────────────┤
+ *   │ [Codex] [Gemini] [openc.] · repo▾   Send ⌘↵│  48px footer
+ *   └─────────────────────────────────────────────┘
+ *
+ * Header is the entire drag region (`data-tauri-drag-region`). After a drag
+ * finishes we read the new physical position via Tauri's `onMoved` event and
+ * persist it via `save_dispatch_popover_position` so the next summons honors
+ * the saved spot. Esc closes without dispatching; ⌘+Enter dispatches.
+ *
+ * Dispatch is fire-and-forget: POST /api/orchestrator/create-mission with
+ * { repoPath, runtime, issues: [{title, body}] } then close the window. The
+ * orchestrator's WS lane events drive the awaiting-review notification on the
+ * main window, not this popover. Subcomponents live in `DispatchPopoverParts.tsx`
+ * to keep this file under the 800-line ceiling.
  */
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { V1_DISPATCH_RUNTIMES } from '@/lib/orchestrator/runtime-capabilities';
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+import {
+  ContextEnginePill,
+  DispatchBody,
+  DispatchFooter,
+  DispatchHeader,
+  ErrorRow,
+  type RepoEntry,
+} from './DispatchPopoverParts';
 
-interface RepoEntry {
-  id: string;
-  name: string;
-  localPath: string;
-  defaultBranch: string;
-  lastOpenedAt: string;
-}
+type CodebaseMemoryStatus = 'unknown' | 'downloading' | 'ready' | 'error';
 
 function readWsToken(): string {
   if (typeof document === 'undefined') return '';
@@ -28,61 +46,146 @@ function readWsToken(): string {
 
 function bearerHeaders(): Record<string, string> {
   const token = readWsToken();
-  const base: Record<string, string> = {
+  const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     Accept: 'application/json',
   };
-  if (token) base.Authorization = `Bearer ${token}`;
-  return base;
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
 }
 
-async function loadDefaultRepo(): Promise<RepoEntry | null> {
+async function loadRepos(): Promise<RepoEntry[]> {
   try {
     const res = await fetch('/api/panel/repos', { headers: bearerHeaders() });
-    if (!res.ok) return null;
+    if (!res.ok) return [];
     const json = await res.json().catch(() => null);
     const repos: RepoEntry[] = Array.isArray(json?.repos) ? json.repos : [];
-    if (repos.length === 0) return null;
-    // Most recently opened wins. lastOpenedAt is ISO; lex-sort works.
-    const sorted = [...repos].sort((a, b) => (b.lastOpenedAt ?? '').localeCompare(a.lastOpenedAt ?? ''));
-    return sorted[0] ?? null;
+    // Most-recently-opened first so the default selection is the active repo.
+    return [...repos].sort((a, b) => (b.lastOpenedAt ?? '').localeCompare(a.lastOpenedAt ?? ''));
+  } catch {
+    return [];
+  }
+}
+
+async function invokeTauri(
+  command: string,
+  payload?: Record<string, unknown>,
+): Promise<unknown> {
+  if (typeof window === 'undefined' || !('__TAURI_INTERNALS__' in window)) return null;
+  try {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return await invoke(command, payload);
   } catch {
     return null;
   }
 }
 
 async function closePopover(): Promise<void> {
-  // Cross fingers we're inside Tauri; in a non-Tauri preview context, just
-  // navigate the browser tab away.
-  try {
-    if (typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window) {
-      const { invoke } = await import('@tauri-apps/api/core');
-      await invoke('close_dispatch_popover');
-      return;
-    }
-  } catch {
-    // fall through
-  }
-  if (typeof window !== 'undefined') {
-    window.close();
-  }
+  const handled = await invokeTauri('close_dispatch_popover');
+  if (handled !== null) return;
+  if (typeof window !== 'undefined') window.close();
 }
 
 export default function DispatchPopover() {
-  const inputRef = useRef<HTMLInputElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const sendButtonRef = useRef<HTMLButtonElement | null>(null);
+  const runtimeButtonsRef = useRef<Array<HTMLButtonElement | null>>([]);
+  const repoButtonRef = useRef<HTMLButtonElement | null>(null);
+
   const [value, setValue] = useState('');
-  const [repo, setRepo] = useState<RepoEntry | null>(null);
+  const [repos, setRepos] = useState<RepoEntry[]>([]);
+  const [repoPath, setRepoPath] = useState<string | null>(null);
+  const [runtime, setRuntime] = useState<OrchestratorRuntime>('codex');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [repoPickerOpen, setRepoPickerOpen] = useState(false);
+  const [memoryStatus, setMemoryStatus] = useState<CodebaseMemoryStatus>('unknown');
 
+  const dispatchableRuntimes = useMemo<OrchestratorRuntime[]>(() => V1_DISPATCH_RUNTIMES, []);
+
+  // Mount: load repos, focus textarea.
   useEffect(() => {
-    void loadDefaultRepo().then((r) => setRepo(r));
-    const id = window.setTimeout(() => inputRef.current?.focus(), 30);
-    return () => window.clearTimeout(id);
+    let cancelled = false;
+    void loadRepos().then((list) => {
+      if (cancelled) return;
+      setRepos(list);
+      // Default to most-recently-opened repo (lastOpenedAt-sorted from loadRepos).
+      if (list.length > 0) setRepoPath(list[0].localPath);
+    });
+    const focusId = window.setTimeout(() => textareaRef.current?.focus(), 30);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(focusId);
+    };
   }, []);
 
-  // Esc closes immediately. We capture at window level because the input
-  // doesn't always have native Esc behavior under Tauri.
+  // Listen for the codebase-memory-mcp download status emitted by the Tauri
+  // sidecar on launch. Don't block dispatch — show an inline pill so the user
+  // knows the context engine isn't available for this packet.
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+    void (async () => {
+      if (typeof window === 'undefined' || !('__TAURI_INTERNALS__' in window)) return;
+      try {
+        const { listen } = await import('@tauri-apps/api/event');
+        const handle = await listen<string>('codebase-memory:status', (event) => {
+          const status = event.payload;
+          if (status === 'downloading' || status === 'ready' || status === 'error') {
+            setMemoryStatus(status);
+          }
+        });
+        if (cancelled) {
+          handle();
+        } else {
+          unlisten = handle;
+        }
+      } catch {
+        // Listener not available — leave status as 'unknown'.
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
+  }, []);
+
+  // Drag-end persistence: subscribe to the window's onMoved event and save the
+  // last position to ~/.o8/popover-state.json via the Rust command. Debounced
+  // to once-per-200ms because Tauri emits onMoved for every pixel of drag.
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+    let debounceId: number | null = null;
+    void (async () => {
+      if (typeof window === 'undefined' || !('__TAURI_INTERNALS__' in window)) return;
+      try {
+        const { getCurrentWindow } = await import('@tauri-apps/api/window');
+        const win = getCurrentWindow();
+        const handle = await win.onMoved(({ payload }) => {
+          if (debounceId !== null) window.clearTimeout(debounceId);
+          debounceId = window.setTimeout(() => {
+            void invokeTauri('save_dispatch_popover_position', { x: payload.x, y: payload.y });
+          }, 200);
+        });
+        if (cancelled) {
+          handle();
+        } else {
+          unlisten = handle;
+        }
+      } catch {
+        // Window API not available in non-Tauri contexts — drag persistence is a no-op.
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (debounceId !== null) window.clearTimeout(debounceId);
+      if (unlisten) unlisten();
+    };
+  }, []);
+
+  // Esc closes; we capture at window-level because the textarea sometimes
+  // swallows the keydown depending on the Tauri webview's focus state.
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -94,30 +197,10 @@ export default function DispatchPopover() {
     return () => window.removeEventListener('keydown', handler);
   }, []);
 
-  // Auto-close on blur — the popover should feel like a Spotlight prompt:
-  // click anywhere else, it goes away. We keep a ref-flag for `busy` so the
-  // handler can read the latest value (closure capture would freeze busy=false).
-  const busyRef = useRef(false);
-  useEffect(() => { busyRef.current = busy; }, [busy]);
-  useEffect(() => {
-    const handler = () => {
-      // Slight delay so submit's window.close beats this and we don't fire
-      // both close paths. Skip when a dispatch is in flight.
-      window.setTimeout(() => {
-        if (busyRef.current) return;
-        if (!document.hasFocus()) {
-          void closePopover();
-        }
-      }, 120);
-    };
-    window.addEventListener('blur', handler);
-    return () => window.removeEventListener('blur', handler);
-  }, []);
-
-  const submit = async () => {
+  const submit = useCallback(async () => {
     const trimmed = value.trim();
     if (!trimmed || busy) return;
-    if (!repo) {
+    if (!repoPath) {
       setError('No repo registered. Open one in the dashboard first.');
       return;
     }
@@ -128,7 +211,8 @@ export default function DispatchPopover() {
         method: 'POST',
         headers: bearerHeaders(),
         body: JSON.stringify({
-          repoPath: repo.localPath,
+          repoPath,
+          runtime,
           issues: [
             {
               number: Date.now(),
@@ -145,18 +229,26 @@ export default function DispatchPopover() {
         setBusy(false);
         return;
       }
-      // Mission created + auto-dispatched (the API defaults dispatch=true).
-      // Close immediately — the user can tab to o8 to monitor progress.
+      // Fire-and-forget: close immediately. The packet's awaiting_review
+      // notification is driven by the main window's WS lane handler.
       await closePopover();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Network error');
       setBusy(false);
     }
+  }, [busy, repoPath, runtime, value]);
+
+  const onTextareaKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // ⌘+Enter / Ctrl+Enter dispatches. Plain Enter inserts a newline (this is
+    // a textarea, not a single-line input, so the user can write multi-line tasks).
+    if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+      event.preventDefault();
+      void submit();
+    }
   };
 
-  const placeholder = repo
-    ? `Dispatch to ${repo.name} on ${repo.defaultBranch}…`
-    : 'Loading repo…';
+  const selectedRepo = repos.find((r) => r.localPath === repoPath) ?? null;
+  const memoryDownloading = memoryStatus === 'downloading';
 
   return (
     <div
@@ -165,91 +257,49 @@ export default function DispatchPopover() {
         inset: 0,
         display: 'flex',
         flexDirection: 'column',
-        backgroundColor: 'rgba(22, 25, 30, 0.92)',
-        backdropFilter: 'blur(24px) saturate(160%)',
-        WebkitBackdropFilter: 'blur(24px) saturate(160%)',
+        background: 'var(--t-panel)',
+        backdropFilter: 'blur(28px) saturate(170%)',
+        WebkitBackdropFilter: 'blur(28px) saturate(170%)',
         borderRadius: 14,
-        border: '1px solid rgba(255, 255, 255, 0.08)',
-        boxShadow: '0 24px 48px -12px rgba(0, 0, 0, 0.5)',
-        color: '#e8ecf2',
+        borderWidth: 1,
+        borderStyle: 'solid',
+        borderColor: 'var(--t-divider-subtle)',
+        boxShadow: '0 28px 56px -16px rgba(0, 0, 0, 0.42), 0 8px 16px -4px rgba(0, 0, 0, 0.18)',
+        color: 'var(--t-text)',
         fontFamily: '"Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, system-ui, sans-serif',
         overflow: 'hidden',
       }}
     >
-      <div
-        style={{
-          flex: 1,
-          display: 'flex',
-          alignItems: 'center',
-          paddingLeft: 18,
-          paddingRight: 18,
-          gap: 12,
+      <DispatchHeader busy={busy} onClose={() => void closePopover()} />
+      {memoryDownloading ? <ContextEnginePill /> : null}
+      <DispatchBody
+        textareaRef={textareaRef}
+        value={value}
+        busy={busy}
+        onChange={setValue}
+        onKeyDown={onTextareaKeyDown}
+      />
+      {error ? <ErrorRow message={error} /> : null}
+      <DispatchFooter
+        runtime={runtime}
+        runtimes={dispatchableRuntimes}
+        runtimeButtonsRef={runtimeButtonsRef}
+        onRuntimeChange={setRuntime}
+        repoButtonRef={repoButtonRef}
+        repoPickerOpen={repoPickerOpen}
+        onRepoPickerToggle={() => setRepoPickerOpen((o) => !o)}
+        onRepoPickerClose={() => setRepoPickerOpen(false)}
+        repos={repos}
+        selectedRepo={selectedRepo}
+        onRepoSelect={(localPath) => {
+          setRepoPath(localPath);
+          setRepoPickerOpen(false);
         }}
-      >
-        {/* Tiny brand glyph — square dot — matches the o8 design language. */}
-        <div
-          style={{
-            width: 8,
-            height: 8,
-            borderRadius: 2,
-            backgroundColor: busy ? '#f59e0b' : '#22c55e',
-            flexShrink: 0,
-            boxShadow: busy ? '0 0 12px rgba(245, 158, 11, 0.6)' : '0 0 12px rgba(34, 197, 94, 0.4)',
-          }}
-        />
-        <input
-          ref={inputRef}
-          value={value}
-          disabled={busy}
-          onChange={(event) => setValue(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter') {
-              event.preventDefault();
-              void submit();
-            }
-          }}
-          placeholder={placeholder}
-          autoFocus
-          spellCheck={false}
-          style={{
-            flex: 1,
-            background: 'transparent',
-            border: 'none',
-            outline: 'none',
-            color: '#ffffff',
-            fontSize: 17,
-            fontWeight: 400,
-            letterSpacing: '-0.01em',
-            fontFamily: 'inherit',
-          }}
-        />
-        <span
-          style={{
-            fontSize: 11,
-            color: 'rgba(232, 236, 242, 0.5)',
-            letterSpacing: '0.04em',
-            textTransform: 'uppercase',
-            flexShrink: 0,
-          }}
-        >
-          {busy ? 'Dispatching' : 'Enter'}
-        </span>
-      </div>
-      {error ? (
-        <div
-          style={{
-            paddingTop: 4,
-            paddingBottom: 8,
-            paddingLeft: 18,
-            paddingRight: 18,
-            fontSize: 11,
-            color: '#fca5a5',
-            letterSpacing: '-0.005em',
-          }}
-        >
-          {error}
-        </div>
-      ) : null}
+        sendButtonRef={sendButtonRef}
+        canSend={Boolean(value.trim()) && Boolean(repoPath) && !busy}
+        busy={busy}
+        onSend={() => void submit()}
+      />
     </div>
   );
 }

--- a/src/components/desktop/DispatchPopoverParts.tsx
+++ b/src/components/desktop/DispatchPopoverParts.tsx
@@ -1,0 +1,626 @@
+'use client';
+
+/**
+ * DispatchPopoverParts — header / body / footer / picker / send subcomponents
+ * for `DispatchPopover.tsx`. Split out so the popover host stays under the
+ * 800-line file ceiling. None of these are exported elsewhere — the popover
+ * is the only consumer.
+ */
+import { useEffect } from 'react';
+import { ORCHESTRATOR_RUNTIMES } from '@/lib/orchestrator/runtime-capabilities';
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+
+export interface RepoEntry {
+  id: string;
+  name: string;
+  localPath: string;
+  defaultBranch: string;
+  lastOpenedAt: string;
+}
+
+// Phosphor "X" path (regular weight, 256 viewBox).
+const PHOSPHOR_X_PATH =
+  'M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z';
+
+export function DispatchHeader({ busy, onClose }: { busy: boolean; onClose: () => void }) {
+  return (
+    <div
+      data-tauri-drag-region=""
+      style={{
+        height: 44,
+        flexShrink: 0,
+        display: 'flex',
+        alignItems: 'center',
+        paddingLeft: 16,
+        paddingRight: 8,
+        gap: 10,
+        borderBottomWidth: 1,
+        borderBottomStyle: 'solid',
+        borderBottomColor: 'var(--t-divider-subtle)',
+        // Header is the drag region — match the TitleBar pattern so any pixel
+        // that isn't a button drags the window.
+        WebkitAppRegion: 'drag',
+      } as React.CSSProperties}
+    >
+      <span
+        style={{
+          width: 7,
+          height: 7,
+          borderRadius: 2,
+          background: busy ? '#f59e0b' : '#22c55e',
+          flexShrink: 0,
+          boxShadow: busy
+            ? '0 0 10px rgba(245, 158, 11, 0.55)'
+            : '0 0 10px rgba(34, 197, 94, 0.4)',
+        }}
+      />
+      <span
+        style={{
+          fontSize: 13,
+          fontWeight: 600,
+          letterSpacing: '-0.005em',
+          color: 'var(--t-text)',
+        }}
+      >
+        Dispatch a task
+      </span>
+      <span
+        style={{
+          fontSize: 11,
+          color: 'var(--t-text-muted)',
+          letterSpacing: '0.02em',
+          marginLeft: 4,
+        }}
+      >
+        {busy ? 'Dispatching…' : 'one-shot packet'}
+      </span>
+      <div style={{ flex: 1 }} />
+      <button
+        type="button"
+        aria-label="Close popover"
+        data-no-drag=""
+        onClick={onClose}
+        style={{
+          WebkitAppRegion: 'no-drag',
+          width: 28,
+          height: 28,
+          borderRadius: 8,
+          borderWidth: 0,
+          background: 'transparent',
+          color: 'var(--t-text-muted)',
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          transition: 'background 120ms cubic-bezier(0.22, 1, 0.36, 1)',
+        } as React.CSSProperties}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.background = 'var(--t-divider-subtle)';
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.background = 'transparent';
+        }}
+      >
+        <svg width={14} height={14} viewBox="0 0 256 256" fill="currentColor" aria-hidden>
+          <path d={PHOSPHOR_X_PATH} />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+export function ContextEnginePill() {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        marginTop: 8,
+        marginRight: 14,
+        marginBottom: 0,
+        marginLeft: 14,
+        paddingTop: 6,
+        paddingRight: 10,
+        paddingBottom: 6,
+        paddingLeft: 10,
+        borderRadius: 8,
+        background: 'var(--t-input-bg)',
+        borderWidth: 1,
+        borderStyle: 'solid',
+        borderColor: 'var(--t-divider-subtle)',
+        fontSize: 11,
+        color: 'var(--t-text-muted)',
+        letterSpacing: '-0.005em',
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          borderWidth: 1.5,
+          borderStyle: 'solid',
+          borderColor: 'var(--t-text-muted)',
+          borderTopColor: 'transparent',
+          animation: 'dispatch-spinner 800ms linear infinite',
+        }}
+      />
+      <span>Setting up Context Engine — dispatch will skip context for this packet</span>
+      <style>{'@keyframes dispatch-spinner { to { transform: rotate(360deg); } }'}</style>
+    </div>
+  );
+}
+
+interface DispatchBodyProps {
+  textareaRef: React.MutableRefObject<HTMLTextAreaElement | null>;
+  value: string;
+  busy: boolean;
+  onChange: (next: string) => void;
+  onKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+}
+
+export function DispatchBody({ textareaRef, value, busy, onChange, onKeyDown }: DispatchBodyProps) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        paddingTop: 12,
+        paddingRight: 14,
+        paddingBottom: 8,
+        paddingLeft: 14,
+        minHeight: 0,
+      }}
+    >
+      <textarea
+        ref={textareaRef}
+        value={value}
+        disabled={busy}
+        onChange={(event) => onChange(event.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder="What do you want done?"
+        spellCheck={false}
+        autoFocus
+        style={{
+          flex: 1,
+          width: '100%',
+          minHeight: 0,
+          resize: 'none',
+          background: 'var(--t-input-bg)',
+          borderWidth: 1,
+          borderStyle: 'solid',
+          borderColor: 'var(--t-input-border)',
+          borderRadius: 10,
+          paddingTop: 10,
+          paddingRight: 12,
+          paddingBottom: 10,
+          paddingLeft: 12,
+          color: 'var(--t-text)',
+          fontFamily: 'inherit',
+          fontSize: 14,
+          lineHeight: 1.5,
+          letterSpacing: '-0.005em',
+          outline: 'none',
+        }}
+      />
+    </div>
+  );
+}
+
+export function ErrorRow({ message }: { message: string }) {
+  return (
+    <div
+      style={{
+        marginTop: 0,
+        marginRight: 14,
+        marginBottom: 4,
+        marginLeft: 14,
+        paddingTop: 4,
+        paddingBottom: 4,
+        fontSize: 11,
+        color: '#f87171',
+        letterSpacing: '-0.005em',
+      }}
+    >
+      {message}
+    </div>
+  );
+}
+
+interface DispatchFooterProps {
+  runtime: OrchestratorRuntime;
+  runtimes: OrchestratorRuntime[];
+  runtimeButtonsRef: React.MutableRefObject<Array<HTMLButtonElement | null>>;
+  onRuntimeChange: (next: OrchestratorRuntime) => void;
+  repoButtonRef: React.MutableRefObject<HTMLButtonElement | null>;
+  repoPickerOpen: boolean;
+  onRepoPickerToggle: () => void;
+  onRepoPickerClose: () => void;
+  repos: RepoEntry[];
+  selectedRepo: RepoEntry | null;
+  onRepoSelect: (localPath: string) => void;
+  sendButtonRef: React.MutableRefObject<HTMLButtonElement | null>;
+  canSend: boolean;
+  busy: boolean;
+  onSend: () => void;
+}
+
+export function DispatchFooter({
+  runtime,
+  runtimes,
+  runtimeButtonsRef,
+  onRuntimeChange,
+  repoButtonRef,
+  repoPickerOpen,
+  onRepoPickerToggle,
+  onRepoPickerClose,
+  repos,
+  selectedRepo,
+  onRepoSelect,
+  sendButtonRef,
+  canSend,
+  busy,
+  onSend,
+}: DispatchFooterProps) {
+  return (
+    <div
+      style={{
+        height: 48,
+        flexShrink: 0,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        paddingLeft: 12,
+        paddingRight: 12,
+        borderTopWidth: 1,
+        borderTopStyle: 'solid',
+        borderTopColor: 'var(--t-divider-subtle)',
+        position: 'relative',
+      }}
+    >
+      <RuntimeChips
+        runtime={runtime}
+        runtimes={runtimes}
+        runtimeButtonsRef={runtimeButtonsRef}
+        onChange={onRuntimeChange}
+      />
+      <RepoPicker
+        repoButtonRef={repoButtonRef}
+        open={repoPickerOpen}
+        onToggle={onRepoPickerToggle}
+        onClose={onRepoPickerClose}
+        repos={repos}
+        selectedRepo={selectedRepo}
+        onSelect={onRepoSelect}
+      />
+      <div style={{ flex: 1 }} />
+      <SendButton sendButtonRef={sendButtonRef} canSend={canSend} busy={busy} onClick={onSend} />
+    </div>
+  );
+}
+
+interface RuntimeChipsProps {
+  runtime: OrchestratorRuntime;
+  runtimes: OrchestratorRuntime[];
+  runtimeButtonsRef: React.MutableRefObject<Array<HTMLButtonElement | null>>;
+  onChange: (next: OrchestratorRuntime) => void;
+}
+
+function RuntimeChips({ runtime, runtimes, runtimeButtonsRef, onChange }: RuntimeChipsProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Runtime"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 4,
+        padding: 2,
+        background: 'var(--t-input-bg)',
+        borderRadius: 9,
+        borderWidth: 1,
+        borderStyle: 'solid',
+        borderColor: 'var(--t-divider-subtle)',
+      }}
+    >
+      {runtimes.map((id, index) => {
+        const meta = ORCHESTRATOR_RUNTIMES[id];
+        const active = id === runtime;
+        return (
+          <button
+            key={id}
+            ref={(el) => {
+              runtimeButtonsRef.current[index] = el;
+            }}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => onChange(id)}
+            title={meta.description}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              paddingTop: 4,
+              paddingRight: 9,
+              paddingBottom: 4,
+              paddingLeft: 8,
+              borderRadius: 7,
+              borderWidth: 0,
+              background: active ? 'var(--t-panel-solid, var(--t-panel))' : 'transparent',
+              boxShadow: active ? '0 1px 2px rgba(0, 0, 0, 0.18)' : 'none',
+              color: active ? 'var(--t-text)' : 'var(--t-text-muted)',
+              fontFamily: 'inherit',
+              fontSize: 11.5,
+              fontWeight: active ? 600 : 500,
+              letterSpacing: '-0.005em',
+              cursor: 'pointer',
+              transition: 'background 120ms cubic-bezier(0.22, 1, 0.36, 1)',
+            }}
+          >
+            <span
+              aria-hidden
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: '50%',
+                background: meta.accentColor,
+                flexShrink: 0,
+              }}
+            />
+            {meta.shortLabel}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+interface RepoPickerProps {
+  repoButtonRef: React.MutableRefObject<HTMLButtonElement | null>;
+  open: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  repos: RepoEntry[];
+  selectedRepo: RepoEntry | null;
+  onSelect: (localPath: string) => void;
+}
+
+function RepoPicker({
+  repoButtonRef,
+  open,
+  onToggle,
+  onClose,
+  repos,
+  selectedRepo,
+  onSelect,
+}: RepoPickerProps) {
+  // Close on outside click while popover is open. Scoped to the document so
+  // clicking outside the picker closes it; clicks inside don't bubble through
+  // to the document handler.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!target) return;
+      const popoverEl = document.getElementById('dispatch-repo-popover');
+      if (popoverEl && popoverEl.contains(target)) return;
+      if (repoButtonRef.current && repoButtonRef.current.contains(target)) return;
+      onClose();
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open, onClose, repoButtonRef]);
+
+  const label = selectedRepo ? selectedRepo.name : 'No repo';
+  return (
+    <div style={{ position: 'relative' }}>
+      <button
+        ref={repoButtonRef}
+        type="button"
+        onClick={onToggle}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        title={selectedRepo?.localPath ?? ''}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          paddingTop: 5,
+          paddingRight: 8,
+          paddingBottom: 5,
+          paddingLeft: 10,
+          borderRadius: 8,
+          borderWidth: 1,
+          borderStyle: 'solid',
+          borderColor: 'var(--t-divider-subtle)',
+          background: 'var(--t-input-bg)',
+          color: 'var(--t-text)',
+          fontFamily: 'inherit',
+          fontSize: 11.5,
+          fontWeight: 500,
+          letterSpacing: '-0.005em',
+          cursor: 'pointer',
+          maxWidth: 180,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {label}
+        </span>
+        <svg
+          width={9}
+          height={9}
+          viewBox="0 0 10 10"
+          fill="none"
+          stroke="var(--t-text-muted)"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          aria-hidden
+          style={{ flexShrink: 0, opacity: 0.6 }}
+        >
+          <path d="M2.5 3.5L5 6L7.5 3.5" />
+        </svg>
+      </button>
+      {open ? (
+        <div
+          id="dispatch-repo-popover"
+          role="listbox"
+          style={{
+            position: 'absolute',
+            bottom: 36,
+            left: 0,
+            zIndex: 50,
+            minWidth: 220,
+            maxWidth: 320,
+            maxHeight: 220,
+            overflowY: 'auto',
+            borderRadius: 10,
+            borderWidth: 1,
+            borderStyle: 'solid',
+            borderColor: 'var(--t-divider-subtle)',
+            background: 'var(--t-panel-solid, var(--t-panel))',
+            boxShadow: '0 12px 28px rgba(0, 0, 0, 0.22)',
+          }}
+        >
+          {repos.length === 0 ? (
+            <div
+              style={{
+                paddingTop: 10,
+                paddingRight: 12,
+                paddingBottom: 10,
+                paddingLeft: 12,
+                fontSize: 11.5,
+                color: 'var(--t-text-muted)',
+              }}
+            >
+              No repos registered. Open one in the dashboard first.
+            </div>
+          ) : (
+            repos.map((repo) => {
+              const active = repo.localPath === selectedRepo?.localPath;
+              return (
+                <button
+                  key={repo.id}
+                  type="button"
+                  role="option"
+                  aria-selected={active}
+                  onClick={() => onSelect(repo.localPath)}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    width: '100%',
+                    paddingTop: 8,
+                    paddingRight: 12,
+                    paddingBottom: 8,
+                    paddingLeft: 12,
+                    borderWidth: 0,
+                    background: active ? 'var(--t-accent-soft)' : 'transparent',
+                    color: 'var(--t-text)',
+                    fontFamily: 'inherit',
+                    fontSize: 11.5,
+                    fontWeight: active ? 600 : 500,
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    overflow: 'hidden',
+                  }}
+                  onMouseEnter={(e) => {
+                    if (!active) e.currentTarget.style.background = 'var(--t-panel-hover)';
+                  }}
+                  onMouseLeave={(e) => {
+                    if (!active) e.currentTarget.style.background = 'transparent';
+                  }}
+                >
+                  <span
+                    style={{
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      flex: 1,
+                    }}
+                  >
+                    {repo.name}
+                  </span>
+                  <span
+                    style={{
+                      fontFamily: '"SF Mono", Menlo, monospace',
+                      fontSize: 10,
+                      color: 'var(--t-text-muted)',
+                      flexShrink: 0,
+                    }}
+                  >
+                    {repo.defaultBranch}
+                  </span>
+                </button>
+              );
+            })
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+interface SendButtonProps {
+  sendButtonRef: React.MutableRefObject<HTMLButtonElement | null>;
+  canSend: boolean;
+  busy: boolean;
+  onClick: () => void;
+}
+
+function SendButton({ sendButtonRef, canSend, busy, onClick }: SendButtonProps) {
+  return (
+    <button
+      ref={sendButtonRef}
+      type="button"
+      onClick={onClick}
+      disabled={!canSend}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        paddingTop: 6,
+        paddingRight: 10,
+        paddingBottom: 6,
+        paddingLeft: 12,
+        borderRadius: 8,
+        borderWidth: 0,
+        background: canSend ? 'var(--t-accent)' : 'var(--t-input-bg)',
+        color: canSend ? '#ffffff' : 'var(--t-text-muted)',
+        fontFamily: 'inherit',
+        fontSize: 12,
+        fontWeight: 600,
+        letterSpacing: '-0.005em',
+        cursor: canSend ? 'pointer' : 'default',
+        opacity: canSend ? 1 : 0.7,
+        transition: 'opacity 120ms cubic-bezier(0.22, 1, 0.36, 1)',
+      }}
+    >
+      <span>{busy ? 'Sending…' : 'Send'}</span>
+      <span
+        aria-hidden
+        style={{
+          fontFamily: '"SF Mono", Menlo, monospace',
+          fontSize: 10,
+          fontWeight: 500,
+          opacity: 0.85,
+          letterSpacing: '0.02em',
+          paddingLeft: 4,
+          paddingRight: 4,
+          paddingTop: 1,
+          paddingBottom: 1,
+          borderRadius: 4,
+          background: canSend ? 'rgba(255, 255, 255, 0.22)' : 'transparent',
+        }}
+      >
+        ⌘↵
+      </span>
+    </button>
+  );
+}


### PR DESCRIPTION
Closes #763.

## Summary

- **Glass card** — 600x280 popover with header, textarea body, and footer. `var(--t-panel)` backdrop + vibrancy + 14px radius + drop shadow. All inline styles, palette tokens only.
- **Top-center anchor** — first launch snaps to Spotlight position (25% from top, horizontally centered on the active monitor). Subsequent summons honor saved drag position.
- **Draggable** — header (`data-tauri-drag-region`) is the drag handle. Frontend listens to Tauri's `onMoved` and persists to `~/.o8/popover-state.json` via a new `save_dispatch_popover_position` command, debounced 200ms.
- **Runtime picker** — 3-chip radiogroup (Codex / Gemini / opencode) using `V1_DISPATCH_RUNTIMES`. Repo picker is a custom popover above the button; outside-click closes it. No native `<select>` anywhere.
- **Dispatch flow** — ⌘+Enter posts to `/api/orchestrator/create-mission` with `{ repoPath, runtime, issues: [{title, body}] }` then closes the window. Fire-and-forget — main window's WS handler owns the awaiting-review notification. Esc closes without dispatch. Setting up Context Engine pill renders if `codebase-memory:status === downloading` but dispatch is still allowed.

## Files

- `src/components/desktop/DispatchPopover.tsx` — host (305 lines): state, lifecycle, dispatch.
- `src/components/desktop/DispatchPopoverParts.tsx` — header / body / footer / chips / picker / send button (626 lines).
- `src/app/dispatch-popover/page.tsx` — comment refresh only (still renders the component as-is).
- `src-tauri/src/lib.rs` — `POPOVER_HEIGHT` 80 → 280; `read_saved_popover_position` / `write_saved_popover_position` helpers; `open_dispatch_popover_impl` reads saved state with Spotlight fallback; new `save_dispatch_popover_position` Tauri command registered in `invoke_handler`.

## Test plan

- [ ] Cmd+Shift+O — popover flies in at top-center on first run.
- [ ] Drag by the header — popover moves; release; close; reopen — restores saved position.
- [ ] Type a one-liner + ⌘↵ — packet appears in Mission Control on the main window; popover closes.
- [ ] Click each runtime chip — switches runtime; visible state change.
- [ ] Click the repo dropdown — picker opens above; choose a repo; closes; click outside the open picker — closes.
- [ ] Esc — closes without dispatching.
- [ ] Light + midnight themes — glass tint reads correctly in both.
- [ ] `npx tsc --noEmit` clean.
- [ ] `cd src-tauri && cargo check --features dev-mcp-plugin` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)