### PR TITLE
feat(cortex): living specs — directives auto-refresh with merge trailers (#769)

### DIFF
--- a/src/app/api/cortex/directives/route.ts
+++ b/src/app/api/cortex/directives/route.ts
@@ -16,6 +16,7 @@ import { NextResponse } from 'next/server';
 import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { getDataDir } from '@/lib/data-dir-migration';
+import { readAllDirectiveTrailers } from '@/lib/cortex/directive-merges';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -27,6 +28,8 @@ interface DirectiveSummary {
   repoName: string | null;
   priority: number | null;
   body: string;
+  /** #769 — last 3 trailer lines newest-first; empty until a merge appends one. */
+  recentMerges: string[];
 }
 
 const FRONT_MATTER_BOUNDARY = /^---\s*$/m;
@@ -41,7 +44,12 @@ function parseDirectiveFile(raw: string, fallbackId: string): DirectiveSummary |
   if (closingIndex < 0) return null;
 
   const front = afterFirst.slice(0, closingIndex);
-  const body = afterFirst.slice(closingIndex).replace(FRONT_MATTER_BOUNDARY, '').trim();
+  const rawBody = afterFirst.slice(closingIndex).replace(FRONT_MATTER_BOUNDARY, '').trim();
+  // #769 — Strip the `## Recent Merges` trailer so the body shown in the UI
+  // stays the operator-authored content. Trailer lines are surfaced via the
+  // separate `recentMerges` field so the recall card can render them with
+  // dedicated chrome.
+  const body = rawBody.replace(/\n*##\s+Recent Merges\b[\s\S]*$/, '').trim();
 
   const meta: Record<string, string> = {};
   for (const line of front.split('\n')) {
@@ -62,6 +70,7 @@ function parseDirectiveFile(raw: string, fallbackId: string): DirectiveSummary |
     repoName: meta.repoName?.trim() || null,
     priority: Number.isFinite(priorityNum) ? priorityNum : null,
     body,
+    recentMerges: [],
   };
 }
 
@@ -87,6 +96,14 @@ export async function GET() {
       } catch (error) {
         console.warn(`[cortex-directives] Failed to read ${name}:`, error);
       }
+    }
+
+    // #769 — Hydrate recent-merge trailers from the same markdown files.
+    // The helper re-reads the dir, but the cost is trivial (≤dozens of small
+    // files) and keeps the trailer logic colocated with the writer.
+    const trailerMap = readAllDirectiveTrailers(3);
+    for (const directive of directives) {
+      directive.recentMerges = trailerMap[directive.id] ?? [];
     }
 
     // Sort by priority desc (higher = more important), then title.

--- a/src/components/desktop/thoughts/recall-card/DirectiveRow.tsx
+++ b/src/components/desktop/thoughts/recall-card/DirectiveRow.tsx
@@ -13,6 +13,7 @@ import {
   Chevron,
   expandedSurfaceStyle,
   FONT_FAMILY,
+  MONO_FAMILY,
   rowChromeStyle,
   rowLabelStyle,
   rowValueStyle,
@@ -26,6 +27,47 @@ interface DirectiveRowProps {
   topDirective: DirectiveSummary | null;
   otherCount: number;
   allDirectives: DirectiveSummary[];
+}
+
+/**
+ * #769 — Living Specs render. Mono lines, muted ink, indented slightly.
+ * Tooltip on hover shows the full trailer line so the operator can read
+ * past the truncated tail without expanding into a viewer.
+ */
+function RecentMergesList({ lines }: { lines: string[] }) {
+  if (lines.length === 0) return null;
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        paddingLeft: 8,
+        borderLeftWidth: 2,
+        borderLeftStyle: 'solid',
+        borderLeftColor: 'var(--t-divider-subtle)',
+      }}
+    >
+      {lines.map((line, idx) => (
+        <div
+          key={`${idx}-${line.slice(0, 24)}`}
+          title={line}
+          style={{
+            fontFamily: MONO_FAMILY,
+            fontSize: 10,
+            lineHeight: 1.5,
+            color: 'var(--t-text-muted)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            letterSpacing: '-0.005em',
+          }}
+        >
+          {line}
+        </div>
+      ))}
+    </div>
+  );
 }
 
 export function DirectiveRow({
@@ -120,6 +162,7 @@ export function DirectiveRow({
               {topDirective.body}
             </div>
           ) : null}
+          <RecentMergesList lines={topDirective?.recentMerges ?? []} />
           {allDirectives.length > 1 ? (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
               {allDirectives.slice(0, 6).map((d) => (

--- a/src/components/desktop/thoughts/recall-card/shared.tsx
+++ b/src/components/desktop/thoughts/recall-card/shared.tsx
@@ -14,6 +14,14 @@ export interface DirectiveSummary {
   repoName: string | null;
   priority: number | null;
   body: string;
+  /**
+   * #769 — Last 3 merge-trailer lines surfaced under the directive title.
+   * Newest-first, raw markdown line including the leading `- ` bullet, e.g.
+   * `- 2026-04-29 [merged] feat(cortex): living specs (#769)`.
+   * Empty array when the directive has not yet matched a merged packet, or
+   * when `history: false` opts out.
+   */
+  recentMerges?: string[];
 }
 
 export interface RecentOutcome {

--- a/src/lib/cortex/directive-merges.ts
+++ b/src/lib/cortex/directive-merges.ts
@@ -1,0 +1,266 @@
+/**
+ * #769 — Living Specs.
+ *
+ * After a packet's PR merges, append a one-line trailer to each directive
+ * markdown file that matched the dispatch repo. The trailer accumulates
+ * evidence that a merge respected (or violated) the directive — directives
+ * stay human-authored, but each one carries a history of how the fleet
+ * acted on it.
+ *
+ * Storage:
+ *   ~/.o8/directives/<filename>.md
+ *
+ * Format (appended):
+ *   ## Recent Merges
+ *   - 2026-04-29 [merged] feat(orchestrator): packet title (#736)
+ *   - 2026-04-28 [violated] fix(workspaces): tighten filter (#735)
+ *
+ * Behaviour:
+ *   - Skip directives with `history: false` in front matter.
+ *   - Filter by repo using the same scope rules `build-context.ts` uses.
+ *   - Last 10 entries are kept; older ones are pruned in the same write.
+ *   - Append-only — never rewrite existing directive body content. The
+ *     `## Recent Merges` section is replaced with a fresh one each call;
+ *     everything above it is preserved verbatim.
+ *   - Helper never throws. A failure to update one directive is logged
+ *     and swallowed so a merge never rolls back over a markdown bug.
+ */
+
+import 'server-only';
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+
+import { getDataDir } from '@/lib/data-dir-migration';
+
+const MAX_TRAILER_ENTRIES = 10;
+const SECTION_HEADER = '## Recent Merges';
+const FRONT_MATTER_BOUNDARY = /^---\s*$/m;
+
+export interface DirectiveTrailerEntry {
+  /** ISO date YYYY-MM-DD. */
+  date: string;
+  /** `merged` for clean ships, `violated` when the review pass flagged a directive violation. */
+  status: 'merged' | 'violated';
+  /** Conventional-commit-style title (e.g. `feat(orchestrator): packet title`). */
+  title: string;
+  /** Optional GitHub issue/PR number to render as a `(#N)` suffix. */
+  issueNumber?: number | null;
+}
+
+interface DirectiveMeta {
+  id: string;
+  scope: string;
+  repoName: string | null;
+  history: boolean;
+}
+
+interface ParsedDirective {
+  meta: DirectiveMeta;
+  /** Raw front-matter block + body, stopping right before the `## Recent Merges` section. */
+  preserved: string;
+  /** Existing trailer lines, oldest first. */
+  trailerLines: string[];
+}
+
+/** Parse minimal front matter — just the keys we care about for filtering. */
+function parseFrontMatter(text: string, fallbackId: string): DirectiveMeta {
+  const result: DirectiveMeta = {
+    id: fallbackId,
+    scope: 'global',
+    repoName: null,
+    history: true,
+  };
+
+  if (!text.startsWith('---')) return result;
+
+  const afterFirst = text.slice(3).trimStart();
+  const closingIndex = afterFirst.search(FRONT_MATTER_BOUNDARY);
+  if (closingIndex < 0) return result;
+
+  const front = afterFirst.slice(0, closingIndex);
+  for (const line of front.split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx <= 0) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    if (!key) continue;
+    if (key === 'id') result.id = value || fallbackId;
+    else if (key === 'scope') result.scope = value || 'global';
+    else if (key === 'repoName') result.repoName = value || null;
+    else if (key === 'history') {
+      // Treat unquoted `false` / `no` / `0` as opt-out. Default = true.
+      const normalized = value.toLowerCase().replace(/['"`]/g, '');
+      if (normalized === 'false' || normalized === 'no' || normalized === '0') {
+        result.history = false;
+      }
+    }
+  }
+
+  return result;
+}
+
+function splitOnRecentMerges(text: string): { before: string; section: string | null } {
+  const re = new RegExp(`(^|\\n)${SECTION_HEADER}\\b[\\s\\S]*$`);
+  const match = text.match(re);
+  if (!match) return { before: text, section: null };
+  const idx = text.indexOf(match[0]);
+  const before = text.slice(0, idx);
+  const section = text.slice(idx + (match[1] === '\n' ? 1 : 0));
+  return { before, section };
+}
+
+function readTrailerLines(section: string | null): string[] {
+  if (!section) return [];
+  // Strip the header (and possibly leading newline) then collect `- ...` lines.
+  const body = section.replace(new RegExp(`^${SECTION_HEADER}\\s*\\n?`), '');
+  return body
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('- '));
+}
+
+function parseDirective(raw: string, fallbackId: string): ParsedDirective {
+  const text = raw.replace(/\r\n/g, '\n');
+  const meta = parseFrontMatter(text, fallbackId);
+  const { before, section } = splitOnRecentMerges(text);
+  const preserved = before.replace(/\s*$/, '\n');
+  const trailerLines = readTrailerLines(section);
+  return { meta, preserved, trailerLines };
+}
+
+function formatTrailerLine(entry: DirectiveTrailerEntry): string {
+  const issueSuffix =
+    typeof entry.issueNumber === 'number' && Number.isFinite(entry.issueNumber)
+      ? ` (#${entry.issueNumber})`
+      : '';
+  return `- ${entry.date} [${entry.status}] ${entry.title}${issueSuffix}`;
+}
+
+function renderRecentMergesSection(lines: string[]): string {
+  const trimmed = lines.slice(-MAX_TRAILER_ENTRIES);
+  return `${SECTION_HEADER}\n${trimmed.join('\n')}\n`;
+}
+
+function matchesRepoScope(meta: DirectiveMeta, repoPath: string): boolean {
+  const repoName = basename(repoPath).toLowerCase();
+  const scope = meta.scope.toLowerCase();
+  if (scope === 'global' || scope === '') return true;
+  const declared = (meta.repoName ?? '').toLowerCase();
+  if (declared && declared === repoName) return true;
+  if (scope === repoName) return true;
+  return false;
+}
+
+function listDirectiveFiles(): { name: string; path: string }[] {
+  try {
+    const dir = join(getDataDir(), 'directives');
+    if (!existsSync(dir)) return [];
+    return readdirSync(dir)
+      .filter((name) => name.endsWith('.md'))
+      .map((name) => ({ name, path: join(dir, name) }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Append a trailer entry to every directive matching the repo. Returns the
+ * list of directive ids that were updated so callers can log + surface
+ * the touch in telemetry. Never throws — per-file errors are logged.
+ */
+export function appendDirectiveTrailer({
+  repoPath,
+  entry,
+}: {
+  repoPath: string;
+  entry: DirectiveTrailerEntry;
+}): string[] {
+  if (!repoPath?.trim()) return [];
+  const updated: string[] = [];
+
+  const files = listDirectiveFiles();
+  if (files.length === 0) return [];
+
+  const newLine = formatTrailerLine(entry);
+
+  for (const file of files) {
+    try {
+      const raw = readFileSync(file.path, 'utf-8');
+      const fallbackId = file.name.replace(/\.md$/, '');
+      const parsed = parseDirective(raw, fallbackId);
+      if (!parsed.meta.history) continue;
+      if (!matchesRepoScope(parsed.meta, repoPath)) continue;
+
+      const merged = [...parsed.trailerLines, newLine];
+      const section = renderRecentMergesSection(merged);
+      const next = `${parsed.preserved}\n${section}`;
+
+      // Only write when the rendered output changes — avoids touching mtime
+      // for unrelated directives in the same dir.
+      if (next !== raw) {
+        writeFileSync(file.path, next, 'utf-8');
+      }
+      updated.push(parsed.meta.id);
+    } catch (error) {
+      console.warn(
+        `[directive-merges] Failed to append trailer to ${file.name}:`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+
+  return updated;
+}
+
+/**
+ * Read the latest N trailer lines for a directive id. Used by the API
+ * surface that powers the Recall Card. Returns the lines newest-first so
+ * the UI can render them top-down without sorting.
+ */
+export function readDirectiveTrailers(directiveId: string, limit = 3): string[] {
+  if (!directiveId?.trim()) return [];
+  try {
+    const files = listDirectiveFiles();
+    for (const file of files) {
+      const fallbackId = file.name.replace(/\.md$/, '');
+      const raw = readFileSync(file.path, 'utf-8');
+      const parsed = parseDirective(raw, fallbackId);
+      if (parsed.meta.id !== directiveId) continue;
+      // Stored chronologically (oldest first); reverse + slice for newest-N.
+      return parsed.trailerLines.slice(-limit).reverse();
+    }
+  } catch (error) {
+    console.warn(
+      `[directive-merges] Failed to read trailers for ${directiveId}:`,
+      error instanceof Error ? error.message : error,
+    );
+  }
+  return [];
+}
+
+/**
+ * Read the latest trailer lines for every directive on disk, keyed by
+ * directive id. Convenience for the API route so the recall-card surface
+ * resolves trailers for all rows in one pass.
+ */
+export function readAllDirectiveTrailers(limit = 3): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  try {
+    const files = listDirectiveFiles();
+    for (const file of files) {
+      try {
+        const fallbackId = file.name.replace(/\.md$/, '');
+        const raw = readFileSync(file.path, 'utf-8');
+        const parsed = parseDirective(raw, fallbackId);
+        const newest = parsed.trailerLines.slice(-limit).reverse();
+        if (newest.length > 0) out[parsed.meta.id] = newest;
+      } catch {
+        // skip unreadable files
+      }
+    }
+  } catch {
+    // dir missing — empty map is the right answer
+  }
+  return out;
+}

--- a/src/lib/orchestrator/operator-mission-service/merge.ts
+++ b/src/lib/orchestrator/operator-mission-service/merge.ts
@@ -1,4 +1,5 @@
 import { listApprovalsForContext } from '@/lib/approvals/store';
+import { appendDirectiveTrailer } from '@/lib/cortex/directive-merges';
 import { dispatch as dispatchLaneCommand } from '@/lib/lane/commands';
 import { buildPreviewForLane, type MergePreviewResult } from '@/lib/lane/preview-merge';
 import { archiveLane, findLaneByPacket } from '@/lib/lane/registry';
@@ -195,6 +196,38 @@ async function dispatchPacketMerge(
       console.log(
         '[worktree-cleanup]',
         `Post-merge cleanup skipped for lane ${lane.id} (packet ${packet.id}): reason=${cleanup.reason ?? 'unknown'}. Reconcile sweep will handle it.`,
+      );
+    }
+
+    // #769 — Living Specs. Append a one-line trailer to every directive
+    // matching this repo so each directive accumulates evidence of which
+    // merges respected (or, once #732 ships violation flags, violated)
+    // it. Best-effort — never roll back a successful merge over a markdown
+    // bug. `violated` is wired off `packet.review.approved === false`,
+    // matching the same flag that gates `[REJECTED]` in the outcomes block.
+    try {
+      const repoPath = packet.workspaceTargetPath?.trim() || lane.repoPath;
+      if (repoPath) {
+        const violated = packet.review?.approved === false;
+        const updated = appendDirectiveTrailer({
+          repoPath,
+          entry: {
+            date: new Date().toISOString().slice(0, 10),
+            status: violated ? 'violated' : 'merged',
+            title: packet.title,
+            issueNumber: packet.issue?.number ?? null,
+          },
+        });
+        if (updated.length > 0) {
+          console.log(
+            `[living-specs] Appended ${violated ? '[violated]' : '[merged]'} trailer to ${updated.length} directive${updated.length === 1 ? '' : 's'} for packet ${packet.id} (${updated.join(', ')})`,
+          );
+        }
+      }
+    } catch (error) {
+      console.warn(
+        `[living-specs] Trailer append failed for packet ${packet.id}:`,
+        error instanceof Error ? error.message : error,
       );
     }
   }


### PR DESCRIPTION
## Summary

Closes #769. After a packet merges, append a one-line trailer to every directive matching the repo so each directive accumulates evidence of which merges respected (or violated) it.

- New helper `src/lib/cortex/directive-merges.ts` — append-only writes, regex-based section replace, prunes to the last 10 entries, skips `history: false` opt-outs, creates the `## Recent Merges` section on first append.
- Hook lives in `src/lib/orchestrator/operator-mission-service/merge.ts` `dispatchPacketMerge`, immediately after `removeMergedWorktree` on a successful merge. Runs inside try/catch — never rolls back a merge over a markdown bug. Uses `packet.review?.approved === false` for the `[violated]` flag, matching the same gate as the `[REJECTED]` outcomes badge.
- `DirectiveRow.tsx` renders the latest 3 trailer lines newest-first under the directive body in the expanded recall-card surface — mono font, muted ink, indented with a left rule, `title` attribute for full-line tooltip.
- `/api/cortex/directives` strips the `## Recent Merges` section from the body field and surfaces it via a new `recentMerges: string[]` array (empty when the directive has not yet matched a merged packet, or when `history: false`).

## Test plan

- [x] Smoke test the helper against a temp directives dir — verified opt-out, repo-scope filter, section creation, prune to 10, `[merged]` vs `[violated]`.
- [x] Smoke test the API route — body excludes the trailer section, `recentMerges` returns newest-first.
- [x] `npx tsc --noEmit` passes.
- [x] Targeted `npx eslint` passes on touched files.
- [ ] After merging this PR and dispatching another packet, open the recall card on the next packet and confirm trailer lines render under the topDirective body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)