### PR TITLE
feat(orchestrator): suggested-reply chips under Coordinator messages (#771)

### DIFF
--- a/src/app/api/v2/chat/suggestions/route.ts
+++ b/src/app/api/v2/chat/suggestions/route.ts
@@ -1,0 +1,143 @@
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/v2/chat/suggestions
+ *
+ * Closes #771 — Augment Intent-style suggested-reply chips.
+ *
+ * Given the last assistant message + a small slice of prior context, returns
+ * 0–3 short suggested user replies. Calls Gemini 2.5 Flash directly (the same
+ * cheap free path used by `/api/mobile/enhance`).
+ *
+ * Empty array means "no useful suggestions" — the UI hides the chip row.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { sanitizeErrorMessage } from '@/lib/api/error-format';
+
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY ?? process.env.GOOGLE_AI_API_KEY ?? '';
+const GEMINI_MODEL = 'gemini-2.5-flash';
+
+const SYSTEM_PROMPT = `You generate short suggested-reply chips for the next user turn in a coding assistant chat. The user is an engineer talking to an orchestrator AI.
+
+Rules:
+- Output STRICT JSON: { "suggestions": string[] }. No prose, no code fences.
+- 0 to 3 suggestions, max. Prefer 2-3 when the assistant asked a question or proposed an action; prefer 0 when the assistant is mid-thought, mid-tool-call, or just acknowledging.
+- Each suggestion is what the USER would say next. First-person, short (3-7 words), action-oriented.
+- Cover distinct intents: an approval/yes path, a concern/pushback, and a clarifying question. Vary across the trio.
+- Never echo the assistant. Never quote. No emoji. No trailing punctuation other than question marks.
+- If the assistant message is just a status update (e.g., "Working on it…", "Reading file X"), return { "suggestions": [] }.`;
+
+interface SuggestionRequest {
+  messageId: string;
+  assistantText: string;
+  // Optional small slice of prior turns for context (most-recent-last).
+  recentContext?: { role: string; text: string }[];
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function buildContextBlock(recent: SuggestionRequest['recentContext']): string {
+  if (!recent || recent.length === 0) return '';
+  const lines = recent.slice(-4).map((entry) => {
+    const role = entry.role === 'assistant' ? 'Assistant' : entry.role === 'user' ? 'User' : null;
+    if (!role) return null;
+    const text = String(entry.text ?? '').trim().slice(0, 600);
+    if (!text) return null;
+    return `${role}: ${text}`;
+  }).filter((line): line is string => Boolean(line));
+  return lines.length > 0 ? `\n\nRecent turns:\n${lines.join('\n')}` : '';
+}
+
+function parseSuggestions(raw: string): string[] {
+  if (!raw) return [];
+  // Strip code fences if Gemini ignored the instruction.
+  const cleaned = raw.replace(/^\s*```(?:json)?/i, '').replace(/```\s*$/, '').trim();
+  try {
+    const parsed = JSON.parse(cleaned) as unknown;
+    if (parsed && typeof parsed === 'object' && Array.isArray((parsed as { suggestions?: unknown }).suggestions)) {
+      const list = (parsed as { suggestions: unknown[] }).suggestions
+        .filter(isString)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0 && s.length <= 80);
+      // Dedupe while preserving order.
+      const seen = new Set<string>();
+      const deduped = list.filter((s) => {
+        const key = s.toLowerCase();
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+      return deduped.slice(0, 3);
+    }
+  } catch {
+    return [];
+  }
+  return [];
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json() as Partial<SuggestionRequest>;
+    const messageId = isString(body.messageId) ? body.messageId : null;
+    const assistantText = isString(body.assistantText) ? body.assistantText.trim() : '';
+
+    if (!messageId) {
+      return NextResponse.json({ error: 'messageId required' }, { status: 400 });
+    }
+    if (assistantText.length < 12) {
+      return NextResponse.json({ messageId, suggestions: [] });
+    }
+
+    if (!GEMINI_API_KEY) {
+      // No key — silent empty response (the UI just hides the chip row).
+      return NextResponse.json({ messageId, suggestions: [] });
+    }
+
+    const truncated = assistantText.length > 4000 ? `${assistantText.slice(0, 4000)}…` : assistantText;
+    const contextBlock = buildContextBlock(body.recentContext);
+    const userPrompt = `Assistant just said:\n"""\n${truncated}\n"""${contextBlock}\n\nReturn the JSON now.`;
+
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${GEMINI_API_KEY}`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 8_000);
+
+    let res: globalThis.Response;
+    try {
+      res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          system_instruction: { parts: [{ text: SYSTEM_PROMPT }] },
+          contents: [{ parts: [{ text: userPrompt }] }],
+          generationConfig: {
+            temperature: 0.4,
+            maxOutputTokens: 200,
+            responseMimeType: 'application/json',
+          },
+        }),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!res.ok) {
+      console.log('[suggested-replies] Gemini error', res.status);
+      return NextResponse.json({ messageId, suggestions: [] });
+    }
+
+    const data = await res.json();
+    const raw = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+    const suggestions = parseSuggestions(typeof raw === 'string' ? raw : '');
+
+    return NextResponse.json({ messageId, suggestions });
+  } catch (err) {
+    console.log('[suggested-replies] error', err);
+    return NextResponse.json(
+      { error: sanitizeErrorMessage(err, 'Internal error'), suggestions: [] },
+      { status: 200 },
+    );
+  }
+}

--- a/src/components/desktop/thoughts/SuggestedReplies.tsx
+++ b/src/components/desktop/thoughts/SuggestedReplies.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+/**
+ * SuggestedReplies — Augment Intent-style chip row under an assistant message.
+ *
+ * Pure component. The parent owns the chip strings + dismissed/cached state;
+ * this just renders + reports clicks.
+ *
+ * Closes #771.
+ */
+import { useState, useSyncExternalStore } from 'react';
+
+interface SuggestedRepliesProps {
+  chips: string[];
+  disabled?: boolean;
+  onSelect: (chip: string) => void;
+  onDismiss: () => void;
+}
+
+// Rams "one orange" — matches the orchestrator accent already used in ThoughtsChatPanel
+// (line ~661, activeTargetColor for orchestrator mode). Hardcoded because the global
+// `--t-accent` is the blue product accent, and the design language calls for the
+// single orange ink for Coordinator surfaces.
+const ORCHESTRATOR_ACCENT = '#e07a3a';
+
+const CLOSE_PATH = 'M208,202.74,121.26,116a8,8,0,0,0-11.32,0L24.2,202.74a8,8,0,0,0,11.31,11.32L116,133.59l80.49,80.47a8,8,0,0,0,11.31-11.32Z';
+
+function subscribeReducedMotion(callback: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+  try {
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    media.addEventListener('change', callback);
+    return () => media.removeEventListener('change', callback);
+  } catch {
+    return () => {};
+  }
+}
+
+function getReducedMotion(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  } catch {
+    return false;
+  }
+}
+
+function getReducedMotionServerSnapshot(): boolean {
+  return false;
+}
+
+export function SuggestedReplies({ chips, disabled = false, onSelect, onDismiss }: SuggestedRepliesProps) {
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const [dismissHover, setDismissHover] = useState(false);
+  const reduceMotion = useSyncExternalStore(subscribeReducedMotion, getReducedMotion, getReducedMotionServerSnapshot);
+
+  if (chips.length === 0) return null;
+
+  const filteredChips = chips.filter((chip) => chip.trim().length > 0);
+  if (filteredChips.length === 0) return null;
+
+  return (
+    <div
+      role="group"
+      aria-label="Suggested replies"
+      style={{
+        alignSelf: 'flex-start',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        flexWrap: 'wrap',
+        marginTop: 4,
+        marginLeft: 2,
+        opacity: disabled ? 0.45 : 1,
+        transition: reduceMotion ? 'none' : 'opacity 160ms ease',
+      }}
+    >
+      {filteredChips.map((chip, index) => {
+        const isHovered = !disabled && hoveredIndex === index;
+        return (
+          <button
+            key={`${chip}-${index}`}
+            type="button"
+            disabled={disabled}
+            onClick={() => {
+              if (disabled) return;
+              onSelect(chip);
+            }}
+            onMouseEnter={() => setHoveredIndex(index)}
+            onMouseLeave={() => setHoveredIndex((current) => (current === index ? null : current))}
+            style={{
+              appearance: 'none',
+              cursor: disabled ? 'default' : 'pointer',
+              display: 'inline-flex',
+              alignItems: 'center',
+              fontFamily: '"Plus Jakarta Sans", system-ui, sans-serif',
+              fontSize: 12,
+              fontWeight: 500,
+              letterSpacing: '-0.01em',
+              lineHeight: 1.2,
+              paddingTop: 5,
+              paddingRight: 10,
+              paddingBottom: 5,
+              paddingLeft: 10,
+              borderRadius: 999,
+              borderTopWidth: 1,
+              borderRightWidth: 1,
+              borderBottomWidth: 1,
+              borderLeftWidth: 1,
+              borderTopStyle: 'solid',
+              borderRightStyle: 'solid',
+              borderBottomStyle: 'solid',
+              borderLeftStyle: 'solid',
+              borderTopColor: isHovered ? ORCHESTRATOR_ACCENT : 'var(--t-divider-subtle, rgba(0,0,0,0.08))',
+              borderRightColor: isHovered ? ORCHESTRATOR_ACCENT : 'var(--t-divider-subtle, rgba(0,0,0,0.08))',
+              borderBottomColor: isHovered ? ORCHESTRATOR_ACCENT : 'var(--t-divider-subtle, rgba(0,0,0,0.08))',
+              borderLeftColor: isHovered ? ORCHESTRATOR_ACCENT : 'var(--t-divider-subtle, rgba(0,0,0,0.08))',
+              background: isHovered ? 'var(--t-panel-hover, rgba(0,0,0,0.04))' : 'transparent',
+              color: isHovered ? ORCHESTRATOR_ACCENT : 'var(--t-text-secondary, var(--t-text, #5b6475))',
+              transition: reduceMotion ? 'none' : 'border-color 140ms ease, background 140ms ease, color 140ms ease',
+              maxWidth: 280,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {chip}
+          </button>
+        );
+      })}
+
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => {
+          if (disabled) return;
+          onDismiss();
+        }}
+        onMouseEnter={() => setDismissHover(true)}
+        onMouseLeave={() => setDismissHover(false)}
+        aria-label="Dismiss suggested replies"
+        style={{
+          appearance: 'none',
+          cursor: disabled ? 'default' : 'pointer',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 22,
+          height: 22,
+          borderRadius: 999,
+          borderTopWidth: 0,
+          borderRightWidth: 0,
+          borderBottomWidth: 0,
+          borderLeftWidth: 0,
+          background: dismissHover && !disabled ? 'var(--t-panel-hover, rgba(0,0,0,0.06))' : 'transparent',
+          color: dismissHover && !disabled
+            ? 'var(--t-text, #111827)'
+            : 'var(--t-text-tertiary, var(--t-text-secondary, #9ca3af))',
+          transition: reduceMotion ? 'none' : 'background 120ms ease, color 120ms ease',
+          padding: 0,
+        }}
+      >
+        <svg width={11} height={11} viewBox="0 0 256 256" fill="currentColor" aria-hidden="true">
+          <path d={CLOSE_PATH} />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
+++ b/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
@@ -46,6 +46,7 @@ import { ThreadExportButton } from './chat-panel/ThreadExportButton';
 import { useClearCommand } from './chat-panel/useClearCommand';
 import { useOrchestratorReloadNotice } from './chat-panel/useOrchestratorReloadNotice';
 import { usePersistChatThread } from './chat-panel/usePersistChatThread';
+import { useSuggestedReplies } from './chat-panel/useSuggestedReplies';
 import type {
   ThoughtsChatPanelChromeState,
   ThoughtsChatPanelHandle,
@@ -659,6 +660,18 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
   const hasAssistantActivity = displayMessages.some((message) => message.role !== 'user');
   const activeTargetLabel = isOrchestratorMode ? 'Claude Code' : (targetAgent?.name ?? orchestratorRuntimeTone(preferredRuntime).label);
   const activeTargetColor = isOrchestratorMode ? '#e07a3a' : (targetAgent?.color ?? orchestratorRuntimeTone(preferredRuntime).color);
+  // #771 — Augment Intent-style chip row under the last assistant message.
+  // Only fires in orchestrator mode; CLI lanes still steer via the composer.
+  const {
+    lastAssistantId: suggestedReplyMessageId,
+    chipsForLastAssistant,
+    dismissChips: dismissSuggestedReplies,
+  } = useSuggestedReplies({
+    enabled: isOrchestratorMode,
+    messages: displayMessages,
+    isStreaming: displayWaiting,
+  });
+
   // Memoize so a render triggered by composer state (input typing) doesn't
   // hand ChatMessageList a fresh `topContent` ref each keystroke.
   const transcriptTopContent = useMemo(() => displayPlanText ? (
@@ -960,6 +973,10 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
         emptyStateFallback={fallbackEmptyState}
         topContent={transcriptTopContent}
         isOrchestratorMode={isOrchestratorMode}
+        suggestedReplyMessageId={suggestedReplyMessageId}
+        suggestedReplies={chipsForLastAssistant}
+        onSelectSuggestion={(chip) => { sendNow(chip); }}
+        onDismissSuggestions={dismissSuggestedReplies}
       />
 
       <ChatToastStack

--- a/src/components/desktop/thoughts/chat-panel/ChatMessageList.tsx
+++ b/src/components/desktop/thoughts/chat-panel/ChatMessageList.tsx
@@ -2,6 +2,7 @@
 
 import { forwardRef } from 'react';
 import { DesktopAgentMessage } from '../../DesktopAgentMessage';
+import { SuggestedReplies } from '../SuggestedReplies';
 import type { MobileTranscriptEntry } from '@/lib/mobile/types';
 
 interface ChatMessageListProps {
@@ -22,6 +23,13 @@ interface ChatMessageListProps {
   // Duplicating the inline "is thinking…" bubble here makes the chat feel
   // noisy during tool-heavy turns. CLI lane panels still need the bubble.
   isOrchestratorMode?: boolean;
+  // Suggested-reply chips (#771). The parent owns the cache + Gemini fetch and
+  // hands us the chip strings for the last assistant message. We render them
+  // under that message; click → onSelectSuggestion(text); X → onDismissSuggestions.
+  suggestedReplyMessageId?: string | null;
+  suggestedReplies?: string[];
+  onSelectSuggestion?: (chip: string) => void;
+  onDismissSuggestions?: () => void;
 }
 
 export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(function ChatMessageList({
@@ -38,7 +46,18 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
   emptyStateFallback,
   topContent,
   isOrchestratorMode = false,
+  suggestedReplyMessageId,
+  suggestedReplies,
+  onSelectSuggestion,
+  onDismissSuggestions,
 }, chatEndRef) {
+  const hasSuggestedReplies = Boolean(
+    suggestedReplyMessageId
+    && suggestedReplies
+    && suggestedReplies.length > 0
+    && onSelectSuggestion
+    && onDismissSuggestions,
+  );
   const showEmptyWithOverride = displayMessages.length === 0 && !displayWaiting && emptyStateOverride;
   const showEmptyWithFallback = displayMessages.length === 0 && !displayWaiting && !emptyStateOverride;
   const isCompacting = displayWaiting && displayMessages.length > 0 &&
@@ -76,6 +95,15 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
           repoPath={repoPath}
         />
       ))}
+
+      {hasSuggestedReplies && suggestedReplies && onSelectSuggestion && onDismissSuggestions ? (
+        <SuggestedReplies
+          chips={suggestedReplies}
+          disabled={displayWaiting}
+          onSelect={onSelectSuggestion}
+          onDismiss={onDismissSuggestions}
+        />
+      ) : null}
 
       {isCompacting ? (
         <div style={{

--- a/src/components/desktop/thoughts/chat-panel/useSuggestedReplies.ts
+++ b/src/components/desktop/thoughts/chat-panel/useSuggestedReplies.ts
@@ -1,0 +1,149 @@
+'use client';
+
+/**
+ * useSuggestedReplies — manages the per-message chip cache + Gemini fetch.
+ *
+ * One in-flight fetch at a time. Cached by message id so re-renders don't
+ * re-fetch. Dismissals are sticky for the lifetime of the thread.
+ *
+ * Closes #771.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { MobileTranscriptEntry } from '@/lib/mobile/types';
+
+interface UseSuggestedRepliesOptions {
+  /** Whether the chat is currently in orchestrator mode (chips only show here). */
+  enabled: boolean;
+  /** Live transcript. The hook watches the LAST assistant message. */
+  messages: MobileTranscriptEntry[];
+  /** True while the orchestrator is streaming — chips become disabled. */
+  isStreaming: boolean;
+}
+
+interface SuggestionsResponse {
+  messageId?: string;
+  suggestions?: unknown;
+}
+
+const MAX_CONTEXT_TURNS = 4;
+const MIN_ASSISTANT_LEN = 12;
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((s) => typeof s === 'string');
+}
+
+export function useSuggestedReplies({ enabled, messages, isStreaming }: UseSuggestedRepliesOptions) {
+  const [chipsByMessage, setChipsByMessage] = useState<Map<string, string[]>>(new Map());
+  const [dismissedMessages, setDismissedMessages] = useState<Set<string>>(new Set());
+  const inflightRef = useRef<Set<string>>(new Set());
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Identify the last assistant message; that's the only one we ever attach
+  // chips to. Chips on older assistant messages aren't useful and would be
+  // noisy.
+  const lastAssistantId = useMemo(() => {
+    if (!enabled) return null;
+    for (let i = messages.length - 1; i >= 0; i -= 1) {
+      const entry = messages[i];
+      if (entry?.role === 'assistant' && (entry.text ?? '').trim().length > 0) {
+        return entry.id;
+      }
+    }
+    return null;
+  }, [enabled, messages]);
+
+  // Fetch chips for the current last assistant when needed.
+  useEffect(() => {
+    if (!enabled || !lastAssistantId || isStreaming) return;
+    if (chipsByMessage.has(lastAssistantId)) return;
+    if (dismissedMessages.has(lastAssistantId)) return;
+    if (inflightRef.current.has(lastAssistantId)) return;
+
+    const target = messages.find((m) => m.id === lastAssistantId);
+    if (!target) return;
+    const assistantText = (target.text ?? '').trim();
+    if (assistantText.length < MIN_ASSISTANT_LEN) return;
+
+    // Build a small recent-context window (the most recent N entries before
+    // the target message). Stripped to plain {role, text} so we don't ship
+    // tool-call payloads to the suggestion endpoint.
+    const targetIndex = messages.findIndex((m) => m.id === lastAssistantId);
+    const window = targetIndex >= 0
+      ? messages
+          .slice(Math.max(0, targetIndex - MAX_CONTEXT_TURNS), targetIndex)
+          .filter((m) => m.role === 'user' || m.role === 'assistant')
+          .map((m) => ({ role: m.role, text: (m.text ?? '').trim() }))
+          .filter((m) => m.text.length > 0)
+      : [];
+
+    inflightRef.current.add(lastAssistantId);
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    void (async () => {
+      try {
+        const res = await fetch('/api/v2/chat/suggestions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            messageId: lastAssistantId,
+            assistantText,
+            recentContext: window,
+          }),
+          signal: controller.signal,
+        });
+        if (!res.ok) return;
+        const data = await res.json() as SuggestionsResponse;
+        const suggestions = isStringArray(data.suggestions) ? data.suggestions : [];
+        setChipsByMessage((prev) => {
+          const next = new Map(prev);
+          next.set(lastAssistantId, suggestions);
+          return next;
+        });
+      } catch {
+        // Network/abort — leave the cache empty so we may retry on next render
+        // if the message is still the last one. inflight cleanup below ensures
+        // we don't permanently block.
+      } finally {
+        inflightRef.current.delete(lastAssistantId);
+      }
+    })();
+
+    return () => {
+      controller.abort();
+    };
+  }, [chipsByMessage, dismissedMessages, enabled, isStreaming, lastAssistantId, messages]);
+
+  // When messages collapse to nothing (e.g. reset/clear), drop caches so a new
+  // thread starts clean.
+  useEffect(() => {
+    if (messages.length === 0) {
+      setChipsByMessage((prev) => (prev.size === 0 ? prev : new Map()));
+      setDismissedMessages((prev) => (prev.size === 0 ? prev : new Set()));
+      inflightRef.current.clear();
+    }
+  }, [messages.length]);
+
+  const chipsForLastAssistant = useMemo(() => {
+    if (!enabled || !lastAssistantId) return [];
+    if (dismissedMessages.has(lastAssistantId)) return [];
+    return chipsByMessage.get(lastAssistantId) ?? [];
+  }, [chipsByMessage, dismissedMessages, enabled, lastAssistantId]);
+
+  const dismissChips = useCallback(() => {
+    if (!lastAssistantId) return;
+    setDismissedMessages((prev) => {
+      if (prev.has(lastAssistantId)) return prev;
+      const next = new Set(prev);
+      next.add(lastAssistantId);
+      return next;
+    });
+  }, [lastAssistantId]);
+
+  return {
+    lastAssistantId,
+    chipsForLastAssistant,
+    dismissChips,
+  };
+}


### PR DESCRIPTION
Closes #771.

## Summary

- Adds an Augment Intent-style chip row under the last Coordinator (orchestrator) message in `ThoughtsChatPanel`. Each chip is a short first-person suggestion for the user's next turn (approval, concern, clarifying question).
- Chips are generated by a small follow-up Gemini 2.5 Flash call on the same tick the assistant finishes streaming, scoped to orchestrator mode only. Tap routes through `sendNow()` so the chip text becomes the next user message; X dismisses the row.
- New POST `/api/v2/chat/suggestions` returns 0–3 short strings via strict JSON; empty array is valid and hides the row. Fails silent (returns `[]`) when `GEMINI_API_KEY` is unset or the upstream errors.

## Files

- `src/app/api/v2/chat/suggestions/route.ts` (new, 143 lines) — Gemini Flash endpoint, mirrors the `/api/mobile/enhance` pattern.
- `src/components/desktop/thoughts/SuggestedReplies.tsx` (new, 169 lines) — pure render: pill chips, Plus Jakarta Sans 12/500, muted ink, orange (`#e07a3a`) on hover, X dismiss button.
- `src/components/desktop/thoughts/chat-panel/useSuggestedReplies.ts` (new, 149 lines) — per-message cache + Gemini fetch, scoped to orchestrator mode and the last assistant message only.
- `src/components/desktop/thoughts/chat-panel/ChatMessageList.tsx` (+28 lines) — renders the chip row as a sibling between the messages map and the compaction/thinking blocks.
- `src/components/desktop/thoughts/ThoughtsChatPanel.tsx` (+17 lines) — calls `useSuggestedReplies`, wires props into `ChatMessageList`.

## Test plan

- [ ] Open the Orchestrator tab, send a message that asks a question — chips appear under the response within ~1s.
- [ ] Click a chip — its text is sent as the next user message and the chip row disappears.
- [ ] Click the X — chips for that message vanish and stay hidden when the transcript scrolls.
- [ ] While the orchestrator is streaming, the visible chips fade to disabled and don't react to clicks.
- [ ] Run with `GEMINI_API_KEY` unset — no chips ever appear, no console error.
- [ ] Switch to a CLI lane (Codex/Claude Code), send a message — chips never appear under those responses.
- [ ] In a thread that already has chips, run `/clear` — chip cache resets cleanly with the new thread.
- [ ] System with `prefers-reduced-motion: reduce` — chips appear without any entrance animation, hover transitions disabled.

## Caveats

- The orange accent (`#e07a3a`) is hardcoded in `SuggestedReplies.tsx` because the global `--t-accent` is the blue product accent. Comment in the file calls this out and points at the matching `activeTargetColor` in `ThoughtsChatPanel`.
- `ThoughtsChatPanel.tsx` was already at 1004 lines (over the 800-line ceiling). My change adds 17 bounded lines (a hook destructure + 4 prop wires); the heavy logic lives in the new 149-line `useSuggestedReplies` hook. A standalone decomposition pass on this file is out of scope for #771.
- One inflight fetch at a time, keyed on the assistant message id. If the network aborts (component unmount, faster turn), the next render with the same `lastAssistantId` retries automatically.

Generated with [Claude Code](https://claude.com/claude-code)