### PR TITLE
feat(mission-control): status-grouped lanes (closes #772)

### DIFF
--- a/src/components/desktop/thoughts/ThoughtsMissionPanel.tsx
+++ b/src/components/desktop/thoughts/ThoughtsMissionPanel.tsx
@@ -26,6 +26,7 @@ import {
 } from './mission-panel/branchTarget';
 import { IssueGroupList } from './mission-panel/IssueGroupList';
 import { PacketCard } from './mission-panel/PacketCard';
+import { StatusGroupedLanes } from './mission-panel/StatusGroupedLanes';
 
 // #517 — Rough per-run cost estimate used only for the fan-out gate warning.
 // Not meant to be accurate — it just reminds the operator that running 3+
@@ -421,7 +422,60 @@ export function ThoughtsMissionPanel({
     }
   }, []);
 
+  // #517 — Tracked outside the renderPacket closure so the dedupe set is
+  // shared across all section traversals in StatusGroupedLanes. Recreated
+  // every parent render so it resets cleanly between re-renders. Plain
+  // const (not useCallback) so the Set never gets stale between renders.
   const renderedComparisonGroupIds = new Set<string>();
+
+  const renderPacket = (packet: OrchestratorPacket) => {
+    // Comparison-group siblings: render ONE ComparisonCard at the first
+    // sibling's position, return null for the rest.
+    if (packet.comparisonGroupId) {
+      if (renderedComparisonGroupIds.has(packet.comparisonGroupId)) {
+        return null;
+      }
+      renderedComparisonGroupIds.add(packet.comparisonGroupId);
+      const groupPackets = comparisonGroups.get(packet.comparisonGroupId) ?? [packet];
+      return (
+        <ComparisonCard
+          key={`cmp-${packet.comparisonGroupId}`}
+          groupId={packet.comparisonGroupId}
+          packets={groupPackets}
+          onPickWinner={handlePickComparisonWinner}
+        />
+      );
+    }
+
+    const isExpanded = expandedPacketId === packet.id;
+    const reviewState = reviewStateByPacketId[packet.id] ?? null;
+    return (
+      <PacketCard
+        key={packet.id}
+        packet={packet}
+        allPackets={missionState.packets}
+        isExpanded={isExpanded}
+        onToggleExpanded={() => setExpandedPacketId(isExpanded ? null : packet.id)}
+        editingField={editingField}
+        onEditingFieldChange={setEditingField}
+        workspaceTargets={workspaceTargets}
+        repoRemoteUrlByPath={repoRemoteUrlByPath}
+        reviewState={reviewState}
+        onPatch={(updater) => patchPacket(packet.id, updater)}
+        onLaunch={() => { void handleLaunchPacket(packet); }}
+        onFocus={() => handleFocusPacket(packet)}
+        onDelete={() => {
+          updateMissionState((current) => ({
+            ...current,
+            packets: current.packets.filter((p) => p.id !== packet.id),
+          }));
+        }}
+        onReviewAction={(verb) => { void handleReviewAction(packet, verb); }}
+        onToggleShowAllFiles={() => updateReviewState(packet.id, (current) => ({ ...current, showAllFiles: !current.showAllFiles }))}
+        onResume={() => handleResumePacket(packet)}
+      />
+    );
+  };
 
   useEffect(() => {
     if (!open || !visible || !expandedPacketId) return;
@@ -686,54 +740,10 @@ export function ThoughtsMissionPanel({
         </div>
       ) : null}
 
-      {missionState.packets.map((packet) => {
-        // #517 — Route comparison-group packets through ComparisonCard. Render
-        // ONE card per groupId (at the first sibling's position), skip the rest.
-        if (packet.comparisonGroupId) {
-          if (renderedComparisonGroupIds.has(packet.comparisonGroupId)) {
-            return null;
-          }
-          renderedComparisonGroupIds.add(packet.comparisonGroupId);
-          const groupPackets = comparisonGroups.get(packet.comparisonGroupId) ?? [packet];
-          return (
-            <ComparisonCard
-              key={`cmp-${packet.comparisonGroupId}`}
-              groupId={packet.comparisonGroupId}
-              packets={groupPackets}
-              onPickWinner={handlePickComparisonWinner}
-            />
-          );
-        }
-
-        const isExpanded = expandedPacketId === packet.id;
-        const reviewState = reviewStateByPacketId[packet.id] ?? null;
-        return (
-          <PacketCard
-            key={packet.id}
-            packet={packet}
-            allPackets={missionState.packets}
-            isExpanded={isExpanded}
-            onToggleExpanded={() => setExpandedPacketId(isExpanded ? null : packet.id)}
-            editingField={editingField}
-            onEditingFieldChange={setEditingField}
-            workspaceTargets={workspaceTargets}
-            repoRemoteUrlByPath={repoRemoteUrlByPath}
-            reviewState={reviewState}
-            onPatch={(updater) => patchPacket(packet.id, updater)}
-            onLaunch={() => { void handleLaunchPacket(packet); }}
-            onFocus={() => handleFocusPacket(packet)}
-            onDelete={() => {
-              updateMissionState((current) => ({
-                ...current,
-                packets: current.packets.filter((p) => p.id !== packet.id),
-              }));
-            }}
-            onReviewAction={(verb) => { void handleReviewAction(packet, verb); }}
-            onToggleShowAllFiles={() => updateReviewState(packet.id, (current) => ({ ...current, showAllFiles: !current.showAllFiles }))}
-            onResume={() => handleResumePacket(packet)}
-          />
-        );
-      })}
+      {/* #772 — Status-grouped sectioned list. Empty groups collapse, so
+          the operator never sees `DONE · 0` headers. Each section's
+          open/closed state persists per-status to localStorage. */}
+      <StatusGroupedLanes packets={missionState.packets} renderPacket={renderPacket} />
     </div>
   );
 }

--- a/src/components/desktop/thoughts/mission-panel/StatusGroupedLanes.tsx
+++ b/src/components/desktop/thoughts/mission-panel/StatusGroupedLanes.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+// #772 — Linear-style sectioned packet list for Mission Control.
+// Wraps the packet render output in collapsible status sections. Pure
+// presentation: takes a renderPacket callback so the parent Mission panel
+// keeps owning PacketCard / ComparisonCard wiring.
+
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import {
+  PACKET_GROUP_ORDER,
+  groupPacketsByStatus,
+  type PacketGroupId,
+} from './groupPackets';
+
+const GROUP_OPEN_LS_PREFIX = 'cortex-ide:mission:group-open:';
+
+function readPersistedOpen(id: PacketGroupId, fallback: boolean): boolean {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const raw = window.localStorage.getItem(`${GROUP_OPEN_LS_PREFIX}${id}`);
+    if (raw === null) return fallback;
+    return raw === '1';
+  } catch {
+    return fallback;
+  }
+}
+
+function writePersistedOpen(id: PacketGroupId, open: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(`${GROUP_OPEN_LS_PREFIX}${id}`, open ? '1' : '0');
+  } catch {
+    // localStorage write failed — not a problem, next session falls back to default.
+  }
+}
+
+interface StatusGroupedLanesProps {
+  packets: OrchestratorPacket[];
+  /**
+   * Render-prop for each packet. Returning `null` skips the row — the parent
+   * uses this to dedupe comparison-group siblings. Skipped rows are NOT
+   * counted toward the section header, since the rendered ComparisonCard
+   * appears at the position of the first sibling and counts as one row.
+   */
+  renderPacket: (packet: OrchestratorPacket) => ReactNode;
+}
+
+/**
+ * Renders packets grouped by status. Empty sections are skipped entirely
+ * so the operator never sees `DONE · 0` headers. Open/closed state is
+ * persisted to localStorage per-group key.
+ */
+export function StatusGroupedLanes({ packets, renderPacket }: StatusGroupedLanesProps) {
+  // Initialise open state per group from localStorage, falling back to the
+  // default in PACKET_GROUP_ORDER. Done once at mount — toggling persists
+  // back via the click handler.
+  const [openByGroup, setOpenByGroup] = useState<Record<PacketGroupId, boolean>>(() => {
+    const seed = {} as Record<PacketGroupId, boolean>;
+    for (const def of PACKET_GROUP_ORDER) {
+      seed[def.id] = readPersistedOpen(def.id, def.defaultOpen);
+    }
+    return seed;
+  });
+
+  // Cross-tab sync: if another window flips a group, mirror it here.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const onStorage = (event: StorageEvent) => {
+      if (!event.key || !event.key.startsWith(GROUP_OPEN_LS_PREFIX)) return;
+      const id = event.key.slice(GROUP_OPEN_LS_PREFIX.length) as PacketGroupId;
+      const def = PACKET_GROUP_ORDER.find((d) => d.id === id);
+      if (!def) return;
+      const next = event.newValue === '1' ? true : event.newValue === '0' ? false : def.defaultOpen;
+      setOpenByGroup((prev) => (prev[id] === next ? prev : { ...prev, [id]: next }));
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  const toggleGroup = useCallback((id: PacketGroupId) => {
+    setOpenByGroup((prev) => {
+      const next = !prev[id];
+      writePersistedOpen(id, next);
+      return { ...prev, [id]: next };
+    });
+  }, []);
+
+  const grouped = groupPacketsByStatus(packets);
+
+  return (
+    <>
+      {PACKET_GROUP_ORDER.map((def) => {
+        const groupPackets = grouped[def.id];
+        // Empty sections collapse — never render a `DONE · 0` header.
+        if (groupPackets.length === 0) return null;
+
+        // Render the packet rows once so we can count "visible" rows for
+        // the header badge. A child returning null (e.g. a comparison-group
+        // sibling already rendered above) doesn't count toward the badge.
+        const renderedRows: ReactNode[] = [];
+        let visibleCount = 0;
+        for (const packet of groupPackets) {
+          const node = renderPacket(packet);
+          if (node === null || node === undefined || node === false) continue;
+          renderedRows.push(node);
+          visibleCount += 1;
+        }
+        // Edge case: every packet in this group was deduped (e.g. a
+        // comparison group whose representative was rendered in another
+        // section). Treat as empty.
+        if (visibleCount === 0) return null;
+
+        const open = openByGroup[def.id];
+        return (
+          <div key={def.id} style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+            <button
+              type="button"
+              onClick={() => toggleGroup(def.id)}
+              aria-expanded={open}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                height: 28,
+                paddingTop: 0,
+                paddingRight: 8,
+                paddingBottom: 0,
+                paddingLeft: 8,
+                border: 'none',
+                background: 'transparent',
+                cursor: 'pointer',
+                position: 'sticky',
+                top: 0,
+                zIndex: 1,
+                fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+              }}
+            >
+              <span
+                style={{
+                  fontSize: 11,
+                  fontWeight: 600,
+                  textTransform: 'uppercase' as const,
+                  letterSpacing: '0.05em',
+                  color: 'var(--t-text-muted)',
+                }}
+              >
+                {def.label}
+              </span>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <span
+                  style={{
+                    paddingTop: 1,
+                    paddingRight: 6,
+                    paddingBottom: 1,
+                    paddingLeft: 6,
+                    borderRadius: 999,
+                    background: 'var(--t-divider-subtle)',
+                    color: 'var(--t-text-secondary)',
+                    fontSize: 10,
+                    fontWeight: 700,
+                    fontFamily: 'var(--font-mono, "SF Mono", Menlo, monospace)',
+                    fontVariantNumeric: 'tabular-nums',
+                  }}
+                >
+                  {visibleCount}
+                </span>
+                <svg
+                  width={10}
+                  height={10}
+                  viewBox="0 0 10 10"
+                  fill="none"
+                  stroke="var(--t-text-muted)"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  style={{
+                    transform: open ? 'rotate(0deg)' : 'rotate(-90deg)',
+                    transition: 'transform 150ms cubic-bezier(0.22, 1, 0.36, 1)',
+                  }}
+                >
+                  <path d="M2.5 3.5L5 6L7.5 3.5" />
+                </svg>
+              </div>
+            </button>
+            {open ? (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                {renderedRows}
+              </div>
+            ) : null}
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/src/components/desktop/thoughts/mission-panel/groupPackets.ts
+++ b/src/components/desktop/thoughts/mission-panel/groupPackets.ts
@@ -1,0 +1,104 @@
+// #772 — Pure render-time grouping for Mission Control packets.
+// Maps each OrchestratorPacket onto one of six fixed status buckets so the
+// Mission panel can render Linear-style sectioned lists without touching
+// the data layer.
+
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+
+export type PacketGroupId =
+  | 'in_progress'
+  | 'in_review'
+  | 'backlog'
+  | 'done'
+  | 'cancelled'
+  | 'archived';
+
+export interface PacketGroupDef {
+  id: PacketGroupId;
+  /** Uppercase Rams-style label rendered in the section header. */
+  label: string;
+  /** Whether the section should default to expanded on first render. */
+  defaultOpen: boolean;
+}
+
+/**
+ * Fixed display order — matches the spec on #772.
+ * In Progress → In Review → Backlog → Done → Cancelled → Archived.
+ *
+ * In Progress + In Review default to expanded. Backlog/Done/Cancelled/Archived
+ * default to collapsed so the visible operator pipeline stays focused on
+ * "what's actively flowing" without dropping context for completed work.
+ */
+export const PACKET_GROUP_ORDER: readonly PacketGroupDef[] = [
+  { id: 'in_progress', label: 'In Progress', defaultOpen: true },
+  { id: 'in_review', label: 'In Review', defaultOpen: true },
+  { id: 'backlog', label: 'Backlog', defaultOpen: false },
+  { id: 'done', label: 'Done', defaultOpen: false },
+  { id: 'cancelled', label: 'Cancelled', defaultOpen: false },
+  { id: 'archived', label: 'Archived', defaultOpen: false },
+];
+
+/**
+ * Bucket a single packet onto a status group.
+ *
+ * Mapping rules (derived from existing OrchestratorPacketStatus + flags):
+ * - Archived bucket wins first — `archivedAt` set OR `status === 'archived'`
+ *   means the operator manually archived the row.
+ * - Done — `status === 'released'` OR `releaseState === 'released'`.
+ *   Released = merged. The display layer in `lib/orchestrator/display.ts`
+ *   already labels this state "Completed", which we surface as Done.
+ * - In Review — `status === 'awaiting_review'`. The packet has a worktree
+ *   diff waiting on the human merge gate.
+ * - Backlog — `queueState === 'draft'` AND no lane binding yet. These are
+ *   packets the operator has scoped but not dispatched.
+ * - In Progress — everything live: queued/launching/running/idle (lane
+ *   spawned) + recovering/failed/blocked. Failed/blocked stay visible at
+ *   the top because the operator needs to act on them, not because the
+ *   work is "in progress" in the strict sense.
+ *
+ * Cancelled is currently never assigned — packets don't carry a
+ * `cancelled` status today, and the issue (#772) said "No new data model".
+ * The bucket exists so the section header renders consistently the moment
+ * a future cancellation flow lands. Empty sections collapse, so it stays
+ * hidden until then.
+ */
+export function classifyPacketGroup(packet: OrchestratorPacket): PacketGroupId {
+  if (packet.archivedAt || packet.status === 'archived') {
+    return 'archived';
+  }
+  if (packet.status === 'released' || packet.releaseState === 'released') {
+    return 'done';
+  }
+  if (packet.status === 'awaiting_review') {
+    return 'in_review';
+  }
+  if (packet.queueState === 'draft' && !packet.lane?.laneId) {
+    return 'backlog';
+  }
+  return 'in_progress';
+}
+
+/**
+ * Group an ordered list of packets into the fixed six-bucket layout.
+ * Preserves input order within each bucket so operators see packets in
+ * the same sequence the parent Mission panel feeds them.
+ *
+ * Comparison-group siblings are passed through unchanged — the caller
+ * still dedupes them at render time via `comparisonGroupId`.
+ */
+export function groupPacketsByStatus(
+  packets: readonly OrchestratorPacket[],
+): Record<PacketGroupId, OrchestratorPacket[]> {
+  const result: Record<PacketGroupId, OrchestratorPacket[]> = {
+    in_progress: [],
+    in_review: [],
+    backlog: [],
+    done: [],
+    cancelled: [],
+    archived: [],
+  };
+  for (const packet of packets) {
+    result[classifyPacketGroup(packet)].push(packet);
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- Linear-style sectioned packet list — six fixed groups (In Progress / In Review / Backlog / Done / Cancelled / Archived) — replaces the flat packet list in Mission Control.
- Pure render-time grouping. No `lanes` schema changes, no new packet status. Mapping is derived from existing fields (`archivedAt`, `status`, `releaseState`, `queueState`, `lane?.laneId`).
- Empty groups collapse entirely (no `DONE · 0` headers). Per-group open/closed state persists to localStorage at `cortex-ide:mission:group-open:<status>`.

## Where the grouping lives
- `src/components/desktop/thoughts/mission-panel/groupPackets.ts` — `classifyPacketGroup(packet)` + `groupPacketsByStatus(packets)` + the canonical `PACKET_GROUP_ORDER` (defines label + default open state per group).
- `src/components/desktop/thoughts/mission-panel/StatusGroupedLanes.tsx` — section renderer with collapse state, localStorage persistence, cross-tab sync via `storage` event, and a render-prop API so `ThoughtsMissionPanel` keeps owning `PacketCard` / `ComparisonCard` wiring.
- `src/components/desktop/thoughts/ThoughtsMissionPanel.tsx` — the flat `missionState.packets.map(...)` block was extracted into a `renderPacket` callback and the map replaced with `<StatusGroupedLanes packets={...} renderPacket={renderPacket} />`. Comparison-group dedupe `Set` is still tracked at the parent level so multiple section traversals share it.

## Status mapping
- **Archived** — `archivedAt` set OR `status === 'archived'` (manual user action).
- **Done** — `status === 'released'` OR `releaseState === 'released'` (merged).
- **In Review** — `status === 'awaiting_review'`.
- **Backlog** — `queueState === 'draft'` AND no `lane.laneId` (created but not yet dispatched).
- **In Progress** — everything else live (queued/launching/running/idle/recovering/failed/blocked).
- **Cancelled** — never assigned today (no `cancelled` status exists). Section header stays hidden because empty groups collapse; bucket is in place for the eventual cancel flow.

## Section header treatment
- Uppercase Rams-style label in `var(--t-text-muted)` (`fontSize: 11`, `fontWeight: 600`, `letterSpacing: 0.05em`).
- Mono-flavored count badge (`fontFamily: var(--font-mono)`, `fontVariantNumeric: 'tabular-nums'`) inside a pill against `var(--t-divider-subtle)` — matches the existing `IssueGroupList` pattern for visual harmony.
- Chevron rotates `0deg` open / `-90deg` closed with the same 150ms cubic-bezier curve used elsewhere in the panel.
- Sticky `top: 0` so headers pin above their rows during scroll.

## Empty-section behavior
- Renderer counts visible rows after invoking `renderPacket` (a `null` return — e.g. an already-rendered comparison sibling — does NOT count). Sections with 0 visible rows skip rendering entirely. So `Cancelled` is invisible, and `Done` only appears once a packet ships.

## Defaults (per #772 acceptance criteria)
- In Progress + In Review default OPEN.
- Backlog / Done / Cancelled / Archived default CLOSED.

## Caveats
- Comparison cards (`#517` best-of-n) keep their dedupe contract — the `renderedComparisonGroupIds` Set is allocated once per parent render so all section passes share it. No cross-section duplication.
- Cross-tab sync via the `storage` event keeps multiple Mission panels in agreement when an operator toggles a section.
- File ceiling respected: `ThoughtsMissionPanel.tsx` 749 lines, `StatusGroupedLanes.tsx` 195 lines, `groupPackets.ts` 104 lines.

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally).
- [ ] `npx eslint` on the three changed/added files passes (verified locally).
- [ ] Visual: open Mission Control with mixed packets — verify all six labels render in fixed order, empty groups hide.
- [ ] Visual: collapse a section, reload the app — collapse state persists.
- [ ] Visual: dispatch a backlog packet — packet jumps from Backlog to In Progress.
- [ ] Visual: approve_and_merge a packet — packet jumps to Done.
- [ ] Visual: comparison group still renders ONE ComparisonCard inside its section, not duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)