### PR TITLE
feat(context-engine): editable packet spec.md feeds live orchestrator context (closes #773)

### DIFF
--- a/src/app/api/orchestrator/packet-spec/route.ts
+++ b/src/app/api/orchestrator/packet-spec/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest } from 'next/server';
+import { readPacketSpec, writePacketSpec } from '@/lib/orchestrator/packet-spec';
+import { requirePanelAuth } from '@/lib/panel/auth';
+import { asRecord, operatorError, operatorSuccess, parseJsonBody } from '../_utils';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const PACKET_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+function readPacketId(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return PACKET_ID_PATTERN.test(trimmed) ? trimmed : null;
+}
+
+export async function GET(request: NextRequest) {
+  const denied = requirePanelAuth(request);
+  if (denied) return denied;
+
+  const packetId = readPacketId(request.nextUrl.searchParams.get('packetId'));
+  if (!packetId) {
+    return operatorError('invalid_request', 'packetId is required.', 400);
+  }
+
+  try {
+    const record = await readPacketSpec(packetId);
+    return operatorSuccess(record);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to read packet spec.';
+    return operatorError('read_failed', message, 500, error);
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const denied = requirePanelAuth(request);
+  if (denied) return denied;
+
+  const body = await parseJsonBody(request);
+  const record = asRecord(body);
+  if (!record) {
+    return operatorError('invalid_request', 'Invalid JSON body.', 400);
+  }
+
+  const packetId = readPacketId(record.packetId);
+  if (!packetId) {
+    return operatorError('invalid_request', 'packetId is required.', 400);
+  }
+
+  const content = typeof record.content === 'string' ? record.content : '';
+  try {
+    const result = await writePacketSpec(packetId, content);
+    return operatorSuccess(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to write packet spec.';
+    return operatorError('write_failed', message, 500, error);
+  }
+}

--- a/src/components/desktop/thoughts/mission-panel/PacketCard.tsx
+++ b/src/components/desktop/thoughts/mission-panel/PacketCard.tsx
@@ -13,6 +13,7 @@ import type { EditingField, ReviewPanelState } from './types';
 import { PacketMetaRows } from './PacketMetaRows';
 import { PacketReviewCard } from './PacketReviewCard';
 import { PacketReviewPanel } from './PacketReviewPanel';
+import { PacketSpecEditor } from './PacketSpecEditor';
 import { RejectedFeedbackPanel } from './RejectedFeedbackPanel';
 
 interface PacketCardProps {
@@ -213,6 +214,11 @@ export function PacketCard({
 
           {/* #742 — Context Recall Card (Directive / Recent Outcomes / Symbol Graph). */}
           <ContextRecallCard packet={packet} repoName={targetRepoName} />
+
+          {/* #773 — Editable spec.md. The orchestrator re-reads the latest
+              spec at dispatch time so each NEW launch sees the operator's
+              current intent. In-flight agents are not steered. */}
+          <PacketSpecEditor packetId={packet.id} />
 
           {/* #615 — DETAILS row (read-only popover trigger). */}
           <div

--- a/src/components/desktop/thoughts/mission-panel/PacketSpecEditor.tsx
+++ b/src/components/desktop/thoughts/mission-panel/PacketSpecEditor.tsx
@@ -1,0 +1,388 @@
+'use client';
+
+/**
+ * #773 — Editable packet spec.md (the "live spec").
+ *
+ * Renders inside the expanded packet card as an Issues-style row labelled
+ * SPEC. Click to expand: shows the saved markdown body in a monospace
+ * read pane with an EDIT button. Editing swaps to a textarea + Save / Cancel.
+ *
+ * The orchestrator re-reads the spec at dispatch time (see
+ * `lib/orchestrator/packet-prompt.ts`) so a NEW launch picks up the latest
+ * content. In-flight agents are not steered — that's the governance moat
+ * vs. Augment Intent's auto-merge model.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Chevron,
+  expandedSurfaceStyle,
+  FONT_FAMILY,
+  formatRelative,
+  MONO_FAMILY,
+  rowChromeStyle,
+  rowLabelStyle,
+  rowValueStyle,
+} from '@/components/desktop/thoughts/recall-card/shared';
+
+interface PacketSpecEditorProps {
+  packetId: string;
+}
+
+interface SpecState {
+  loading: boolean;
+  content: string;
+  updatedAt: string | null;
+  error: string | null;
+}
+
+const PLACEHOLDER = `# Goal\n\nWhat are we trying to do?\n\n# Constraints\n\n- \n\n# Tasks\n\n- [ ] \n\n# Acceptance\n\n- [ ] \n`;
+
+export function PacketSpecEditor({ packetId }: PacketSpecEditorProps) {
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [state, setState] = useState<SpecState>({
+    loading: true,
+    content: '',
+    updatedAt: null,
+    error: null,
+  });
+
+  // Bump on save; the cheap re-fetch on the GET endpoint keeps us in sync
+  // with any out-of-band writes (e.g. an agent-proposed update once that
+  // surface lands).
+  const [refreshTick, setRefreshTick] = useState(0);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Always keep the spec in sync. The first fetch fires on mount; subsequent
+  // fetches fire when the operator clicks Save or when refreshTick bumps.
+  useEffect(() => {
+    let cancelled = false;
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+    fetch(`/api/orchestrator/packet-spec?packetId=${encodeURIComponent(packetId)}`, {
+      method: 'GET',
+      credentials: 'same-origin',
+    })
+      .then(async (response) => {
+        if (cancelled) return;
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const payload = await response.json() as { ok?: boolean; result?: { content?: string; updatedAt?: string | null } };
+        if (!payload.ok || !payload.result) {
+          throw new Error('Invalid response.');
+        }
+        setState({
+          loading: false,
+          content: typeof payload.result.content === 'string' ? payload.result.content : '',
+          updatedAt: payload.result.updatedAt ?? null,
+          error: null,
+        });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : 'Unable to load spec.';
+        setState({ loading: false, content: '', updatedAt: null, error: message });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [packetId, refreshTick]);
+
+  const beginEdit = useCallback(() => {
+    setDraft(state.content || PLACEHOLDER);
+    setEditing(true);
+    // Focus next tick so the textarea is mounted.
+    requestAnimationFrame(() => {
+      const node = textareaRef.current;
+      if (node) {
+        node.focus();
+        node.setSelectionRange(node.value.length, node.value.length);
+      }
+    });
+  }, [state.content]);
+
+  const cancelEdit = useCallback(() => {
+    setEditing(false);
+    setDraft('');
+  }, []);
+
+  const save = useCallback(async () => {
+    if (saving) return;
+    setSaving(true);
+    try {
+      const response = await fetch('/api/orchestrator/packet-spec', {
+        method: 'PUT',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ packetId, content: draft }),
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const payload = await response.json() as { ok?: boolean; result?: { updatedAt?: string }; error?: { message?: string } };
+      if (!payload.ok) {
+        throw new Error(payload.error?.message || 'Save failed.');
+      }
+      setEditing(false);
+      setRefreshTick((tick) => tick + 1);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Save failed.';
+      setState((prev) => ({ ...prev, error: message }));
+    } finally {
+      setSaving(false);
+    }
+  }, [draft, packetId, saving]);
+
+  const hasContent = state.content.trim().length > 0;
+  const collapsedValue = state.loading
+    ? 'Loading...'
+    : hasContent
+      ? firstNonEmptyLine(state.content)
+      : 'No spec yet — click to add operator intent';
+
+  return (
+    <div
+      data-packet-row
+      style={{
+        borderTopWidth: 1,
+        borderTopStyle: 'solid',
+        borderTopColor: 'var(--t-divider-subtle)',
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        style={{
+          ...rowChromeStyle,
+          background: open ? 'var(--t-divider-subtle)' : 'transparent',
+        }}
+        onMouseEnter={(e) => {
+          if (!open) e.currentTarget.style.background = 'var(--t-divider-subtle)';
+        }}
+        onMouseLeave={(e) => {
+          if (!open) e.currentTarget.style.background = 'transparent';
+        }}
+      >
+        <span style={rowLabelStyle}>spec</span>
+        <span
+          style={{
+            ...rowValueStyle,
+            color: hasContent ? 'var(--t-text)' : 'var(--t-text-muted)',
+          }}
+        >
+          {collapsedValue}
+        </span>
+        {state.updatedAt ? (
+          <span
+            style={{
+              fontSize: 9.5,
+              color: 'var(--t-text-faint)',
+              fontFamily: FONT_FAMILY,
+              flexShrink: 0,
+              letterSpacing: '-0.005em',
+            }}
+          >
+            Updated {formatRelative(state.updatedAt)}
+          </span>
+        ) : null}
+        <Chevron open={open} />
+      </button>
+
+      {open ? (
+        <div
+          style={{
+            ...expandedSurfaceStyle,
+            paddingLeft: 10,
+            paddingRight: 10,
+            paddingTop: 8,
+            paddingBottom: 10,
+            gap: 8,
+          }}
+        >
+          {state.error ? (
+            <div
+              style={{
+                fontFamily: FONT_FAMILY,
+                fontSize: 11,
+                color: '#b91c1c',
+              }}
+            >
+              {state.error}
+            </div>
+          ) : null}
+
+          {editing ? (
+            <>
+              <textarea
+                ref={textareaRef}
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                spellCheck={false}
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') {
+                    e.preventDefault();
+                    cancelEdit();
+                  }
+                  if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    void save();
+                  }
+                }}
+                style={{
+                  width: '100%',
+                  minHeight: 200,
+                  resize: 'vertical',
+                  fontFamily: MONO_FAMILY,
+                  fontSize: 11.5,
+                  lineHeight: 1.55,
+                  color: 'var(--t-text)',
+                  background: 'var(--t-input-bg, rgba(15, 23, 42, 0.04))',
+                  borderWidth: 1,
+                  borderStyle: 'solid',
+                  borderColor: 'var(--t-divider)',
+                  borderRadius: 8,
+                  paddingTop: 8,
+                  paddingRight: 10,
+                  paddingBottom: 8,
+                  paddingLeft: 10,
+                  outline: 'none',
+                  letterSpacing: '-0.005em',
+                }}
+              />
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <button
+                  type="button"
+                  onClick={() => void save()}
+                  disabled={saving}
+                  style={{
+                    borderWidth: 0,
+                    background: '#2563eb',
+                    color: '#fff',
+                    paddingTop: 4,
+                    paddingRight: 10,
+                    paddingBottom: 4,
+                    paddingLeft: 10,
+                    borderRadius: 6,
+                    fontSize: 10.5,
+                    fontWeight: 700,
+                    cursor: saving ? 'wait' : 'pointer',
+                    opacity: saving ? 0.7 : 1,
+                    fontFamily: FONT_FAMILY,
+                    letterSpacing: '-0.01em',
+                  }}
+                >
+                  {saving ? 'Saving...' : 'Save'}
+                </button>
+                <button
+                  type="button"
+                  onClick={cancelEdit}
+                  disabled={saving}
+                  style={{
+                    borderWidth: 0,
+                    background: 'transparent',
+                    color: 'var(--t-text-muted)',
+                    paddingTop: 4,
+                    paddingRight: 8,
+                    paddingBottom: 4,
+                    paddingLeft: 8,
+                    borderRadius: 6,
+                    fontSize: 10.5,
+                    fontWeight: 600,
+                    cursor: saving ? 'wait' : 'pointer',
+                    fontFamily: FONT_FAMILY,
+                  }}
+                >
+                  Cancel
+                </button>
+                <span
+                  style={{
+                    fontFamily: FONT_FAMILY,
+                    fontSize: 9.5,
+                    color: 'var(--t-text-faint)',
+                    marginLeft: 'auto',
+                    letterSpacing: '-0.005em',
+                  }}
+                >
+                  Cmd/Ctrl + Enter to save · Esc to cancel
+                </span>
+              </div>
+            </>
+          ) : (
+            <>
+              {hasContent ? (
+                <pre
+                  style={{
+                    margin: 0,
+                    fontFamily: MONO_FAMILY,
+                    fontSize: 11.5,
+                    lineHeight: 1.55,
+                    color: 'var(--t-text)',
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                    letterSpacing: '-0.005em',
+                  }}
+                >
+                  {state.content}
+                </pre>
+              ) : (
+                <div
+                  style={{
+                    fontFamily: FONT_FAMILY,
+                    fontSize: 11,
+                    color: 'var(--t-text-muted)',
+                    lineHeight: 1.5,
+                  }}
+                >
+                  Add an editable spec for this packet — the orchestrator re-reads it on every dispatch so the agent always sees your current intent. In-flight agents keep their original prompt; only the next launch picks up edits.
+                </div>
+              )}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <button
+                  type="button"
+                  onClick={beginEdit}
+                  style={{
+                    borderWidth: 0,
+                    background: hasContent ? 'transparent' : '#2563eb',
+                    color: hasContent ? '#2563eb' : '#fff',
+                    paddingTop: 4,
+                    paddingRight: 10,
+                    paddingBottom: 4,
+                    paddingLeft: 10,
+                    borderRadius: 6,
+                    fontSize: 10.5,
+                    fontWeight: 700,
+                    cursor: 'pointer',
+                    fontFamily: FONT_FAMILY,
+                    letterSpacing: '-0.01em',
+                  }}
+                  onMouseEnter={(e) => {
+                    if (hasContent) e.currentTarget.style.background = 'rgba(37, 99, 235, 0.08)';
+                  }}
+                  onMouseLeave={(e) => {
+                    if (hasContent) e.currentTarget.style.background = 'transparent';
+                  }}
+                >
+                  {hasContent ? 'Edit' : 'Add spec'}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function firstNonEmptyLine(content: string): string {
+  for (const raw of content.split('\n')) {
+    const trimmed = raw.trim().replace(/^#+\s*/, '');
+    if (trimmed) {
+      return trimmed.length > 80 ? `${trimmed.slice(0, 77)}...` : trimmed;
+    }
+  }
+  return 'Empty spec';
+}

--- a/src/lib/orchestrator/packet-prompt.ts
+++ b/src/lib/orchestrator/packet-prompt.ts
@@ -4,6 +4,7 @@ import { renderReadBudgetSections } from '@/lib/dispatch/read-budget';
 import { getTopRulesForPacket, readRepoScopedRules } from '@/lib/dispatch/rules-store';
 import { readAttemptLearnings, type AttemptLearning } from '@/lib/orchestrator/attempt-log';
 import { readPacketCompletionContext } from '@/lib/orchestrator/context-relay';
+import { buildPacketSpecPromptSection } from '@/lib/orchestrator/packet-spec';
 import { buildPacketSelfReviewInstructions } from '@/lib/orchestrator/self-review';
 import type { OrchestratorPacket, PacketContext } from '@/lib/orchestrator/types';
 import { truncateText } from '@/lib/util/text';
@@ -255,8 +256,16 @@ export async function buildPacketPrompt(
           .join('\n\n'),
       })
     : '';
+  // #773 — Live spec injection. The operator can edit a per-packet spec in
+  // the Mission panel; we re-read it here so each NEW dispatch gets the
+  // current content. Running agents are not steered — only the next launch
+  // (or rerun) sees an edited spec. Returns null when no spec exists.
+  const livePacketSpec = await buildPacketSpecPromptSection(packet.id);
   if (contextBlock) {
     console.log(`[context-injection] Prepended <context> block for packet ${packet.id} (${contextBlock.length} chars)`);
+  }
+  if (livePacketSpec) {
+    console.log(`[packet-spec] Injected live spec for packet ${packet.id} (${livePacketSpec.length} chars)`);
   }
   if (dependencySections.length > 0) {
     console.log(`[context-relay] Injected dependency context for packet ${packet.id}`);
@@ -284,6 +293,7 @@ export async function buildPacketPrompt(
     contextBlock || null,
     `Packet: ${packet.title}`,
     packet.summary ? `Summary: ${packet.summary}` : null,
+    livePacketSpec,
     packet.branchTarget ? `Branch target: ${packet.branchTarget}` : null,
     packet.dependencyLabels.length > 0 ? `Dependencies: ${packet.dependencyLabels.join(', ')}` : null,
     dependencySections.length > 0 ? 'Dependency handoff context:' : null,

--- a/src/lib/orchestrator/packet-spec.ts
+++ b/src/lib/orchestrator/packet-spec.ts
@@ -1,0 +1,114 @@
+/**
+ * Packet spec storage — closes #773.
+ *
+ * Each packet can have a free-form `spec.md` document the operator edits
+ * inline in the Mission panel. The orchestrator re-reads the file at dispatch
+ * time so the agent always sees the *current* content, not whatever was
+ * captured when the packet was created. This is the visible UI for
+ * Augment Intent's "living spec" pattern, with o8's governance moat:
+ * edits never reach an in-flight agent — only NEW dispatches pick them up.
+ *
+ * Storage: `<dataDir>/packet-specs/<packet-id>.md`. One file per packet, no
+ * SQLite migration. Durable across restarts because the data dir survives the
+ * app cycle. Returning JSON is intentional (vs raw .md) so the API can carry
+ * `updatedAt` alongside the content without parsing front-matter.
+ */
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { getDataDir } from '@/lib/data-dir-migration';
+
+const SPEC_DIR_NAME = 'packet-specs';
+const MAX_SPEC_BYTES = 64 * 1024; // 64 KB. A spec longer than this should be a doc, not a packet brief.
+const PACKET_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+export interface PacketSpecRecord {
+  /** Markdown body the operator typed. Empty string when no spec exists. */
+  content: string;
+  /** ISO timestamp of the most recent successful write, or null if no spec exists. */
+  updatedAt: string | null;
+}
+
+function getSpecDir(): string {
+  return join(getDataDir(), SPEC_DIR_NAME);
+}
+
+function getSpecPath(packetId: string): string {
+  if (!PACKET_ID_PATTERN.test(packetId)) {
+    throw new Error('Invalid packet id.');
+  }
+  return join(getSpecDir(), `${packetId}.md`);
+}
+
+/**
+ * Read the spec for a packet. Returns an empty record (`content=''`,
+ * `updatedAt=null`) when the file doesn't exist — callers shouldn't need to
+ * handle ENOENT manually.
+ */
+export async function readPacketSpec(packetId: string): Promise<PacketSpecRecord> {
+  const path = getSpecPath(packetId);
+  try {
+    const [content, info] = await Promise.all([
+      readFile(path, 'utf8'),
+      stat(path),
+    ]);
+    return {
+      content,
+      updatedAt: info.mtime.toISOString(),
+    };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      return { content: '', updatedAt: null };
+    }
+    throw error;
+  }
+}
+
+/**
+ * Write the spec for a packet. Trims trailing whitespace and creates the
+ * parent directory on first use. Returns the new `updatedAt` so the UI can
+ * render the "Updated Xs ago" stamp without re-reading the file.
+ */
+export async function writePacketSpec(
+  packetId: string,
+  content: string,
+): Promise<{ updatedAt: string }> {
+  const path = getSpecPath(packetId);
+  const normalized = typeof content === 'string' ? content.replace(/\s+$/u, '') : '';
+  if (Buffer.byteLength(normalized, 'utf8') > MAX_SPEC_BYTES) {
+    throw new Error(`Spec exceeds ${MAX_SPEC_BYTES} bytes — break into linked docs.`);
+  }
+
+  await mkdir(getSpecDir(), { recursive: true });
+  await writeFile(path, normalized, 'utf8');
+  const info = await stat(path);
+  return { updatedAt: info.mtime.toISOString() };
+}
+
+/**
+ * Build the prompt-side <spec> block. Returns null when no spec exists or the
+ * stored body is whitespace-only — `buildPacketPrompt` filters falsy entries
+ * before joining, so a null short-circuits cleanly.
+ *
+ * The wrapper labels the section explicitly so weaker models can scope-check
+ * the request against the operator's intent. Truncation is intentional: a
+ * 64 KB spec would dwarf the packet brief; we cap at 8 KB for the prompt
+ * window. Operators with longer specs see a "...truncated" footer.
+ */
+const PROMPT_SPEC_LIMIT = 8_192;
+export async function buildPacketSpecPromptSection(packetId: string): Promise<string | null> {
+  const record = await readPacketSpec(packetId);
+  const body = record.content.trim();
+  if (!body) {
+    return null;
+  }
+
+  const truncated = body.length > PROMPT_SPEC_LIMIT
+    ? `${body.slice(0, PROMPT_SPEC_LIMIT)}\n\n[...spec truncated; full content visible in o8 UI]`
+    : body;
+
+  return [
+    'Live spec (editable in the Mission panel — this is the operator\'s current intent):',
+    truncated,
+  ].join('\n');
+}


### PR DESCRIPTION
## Summary
- Each expanded packet card in the Mission panel renders a new SPEC row. Operators edit a free-form markdown body inline; the orchestrator re-reads it at dispatch time so each NEW launch sees the operator's current intent.
- In-flight agents keep their original prompt — only the next launch (or rerun) picks up edits. That's the governance moat vs. Augment Intent's auto-merge model.
- Storage: `<dataDir>/packet-specs/<packet-id>.md`. No SQLite migration; pure file-per-packet for durability.
- API: `GET` and `PUT /api/orchestrator/packet-spec`, gated through the existing `/api/orchestrator/*` middleware (loopback + ws-token).
- Dispatch: `buildPacketPrompt` prepends a "Live spec" block when present, falsy returns short-circuit through the existing `.filter(Boolean)` pipeline.

## Files
- `src/lib/orchestrator/packet-spec.ts` — read/write helpers + prompt builder.
- `src/app/api/orchestrator/packet-spec/route.ts` — gated GET/PUT.
- `src/components/desktop/thoughts/mission-panel/PacketSpecEditor.tsx` — Issues-style row + textarea editor.
- `src/components/desktop/thoughts/mission-panel/PacketCard.tsx` — mounts the editor under the Context Recall Card.
- `src/lib/orchestrator/packet-prompt.ts` — injects the live spec into the dispatch prompt.

## Demo flow
1. Expand a packet in Mission Control. A SPEC row appears below DIRECTIVE / OUTCOMES / SYMBOLS.
2. Click the row, click "Add spec", type intent (the placeholder seeds Goal / Constraints / Tasks / Acceptance).
3. Save. The "Updated Xs ago" stamp appears immediately.
4. Launch the packet — `[packet-spec] Injected live spec for packet ...` logs in the server console; the agent's prompt now opens with the live content.
5. While the agent runs, edit the spec again. Save. The next dispatch picks it up; the running agent does not.

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] ESLint passes on the touched files
- [ ] Open a fresh packet, no spec — placeholder copy + "Add spec" button render
- [ ] Save a spec, observe `Updated Xs ago` and `cmd+enter` shortcut
- [ ] Re-launch the packet, confirm the prompt log line + agent transcript shows the new content
- [ ] Edit while agent is running, confirm the running agent's prompt is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)