### PR TITLE
fix(sidecar): reap orphan next/ws-server + stale tauri-mcp socket at boot (closes #776)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "o8"
-version = "0.1.80"
+version = "0.1.82"
 dependencies = [
  "hex",
  "libc",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -814,6 +814,235 @@ fn kill_tracked_children() {
     }
 }
 
+// ── Boot-time orphan reaper (issue #776) ──
+//
+// `probe_kill_port(3001/3002)` from #719/#728 only clears specific ports.
+// But orphans from prior crashes can squat on ANY port in our 3001-3050
+// range — and once they're listening on, say, 3003, our new sidecar quietly
+// picks 3004 and the user spends an hour debugging "why didn't my fix take
+// effect" before realizing the webview is hitting the wrong server.
+//
+// This reaper runs ONCE at boot, BEFORE the Tauri builder is constructed,
+// and:
+//   1. Enumerates every `next-server` and `ws-server` process via `pgrep`.
+//   2. Verifies o8 ownership via cwd substring + ppid==launchd (orphan
+//      signature). Active processes parented to a live `npm run dev` or
+//      another running sidecar are LEFT ALONE.
+//   3. SIGTERM with 2s grace, then SIGKILL anything still alive.
+//   4. Removes a stale `/tmp/tauri-mcp-o8-<user>.sock` if no live process
+//      holds it — fixes the "Socket ... is in use" crash on relaunch when
+//      the prior sidecar died without unbinding.
+//
+// We can't read other processes' env vars on macOS without root, so the
+// `O8_SIDECAR_PID` marker we set on our own children (see setup()) is best-
+// effort forward-compat — useful in `ps` output and on Linux/Windows where
+// /proc/<pid>/environ is readable.
+
+/// Fast PID enumeration via `pgrep -f <pattern>`. Returns Vec<u32> on success,
+/// empty Vec if pgrep is missing or finds nothing (both are non-fatal).
+#[cfg(unix)]
+fn pgrep_pids(pattern: &str) -> Vec<u32> {
+    let out = match Command::new("pgrep").args(["-f", pattern]).output() {
+        Ok(o) => o,
+        Err(_) => return Vec::new(),
+    };
+    // pgrep exits 1 when no match (stdout + stderr both empty) — not an error.
+    // A real failure produces something on stderr (e.g. permission denied).
+    if !out.status.success() && !out.stderr.is_empty() {
+        log::warn!(
+            "[orphan-reap] pgrep -f {:?} failed: {}",
+            pattern,
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+        return Vec::new();
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|s| s.trim().parse::<u32>().ok())
+        .filter(|pid| *pid != std::process::id())
+        .collect()
+}
+
+/// Best-effort cwd lookup via `lsof -p PID -a -d cwd -F n`. Returns the path
+/// or empty string. macOS lsof is part of the base system; Linux ships it on
+/// most distros. If lsof is missing we treat cwd as unknown and the candidate
+/// is rejected by the ownership filter (safer than a false-positive kill).
+#[cfg(unix)]
+fn process_cwd(pid: u32) -> String {
+    let out = match Command::new("lsof")
+        .args(["-p", &pid.to_string(), "-a", "-d", "cwd", "-F", "n"])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return String::new(),
+    };
+    // lsof -F n format: each record line starts with a single-char field
+    // marker; the cwd path is on a line starting with 'n'.
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .find_map(|l| l.strip_prefix('n').map(|s| s.to_string()))
+        .unwrap_or_default()
+}
+
+/// Parent PID via `ps -o ppid=`. Returns 0 on failure (treat as "unknown
+/// parent" — unsafe to assume orphan, so caller skips).
+#[cfg(unix)]
+fn process_ppid(pid: u32) -> u32 {
+    Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "ppid="])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .trim()
+                .parse::<u32>()
+                .ok()
+        })
+        .unwrap_or(0)
+}
+
+/// True if the cwd looks like an o8 install or checkout. We accept:
+///   - Any path containing `cortex-ide` (dev checkouts, worktrees)
+///   - Any path containing `.app/Contents/Resources/server` (installed app)
+///   - Any path ending in `/.o8` or containing `/o8/` (rebrand-friendly)
+///
+/// We deliberately do NOT match the bare token "o8" anywhere — too broad
+/// (matches user dirs like ~/projects/o8-experiment).
+#[cfg(unix)]
+fn cwd_looks_o8_owned(cwd: &str) -> bool {
+    if cwd.is_empty() {
+        return false;
+    }
+    cwd.contains("cortex-ide")
+        || cwd.contains(".app/Contents/Resources/server")
+        || cwd.contains("/.o8")
+        || cwd.contains("/o8.app/")
+}
+
+/// Send SIGTERM, wait up to 2s for the process to exit, then SIGKILL if
+/// still alive. `kill -0` is the standard "is this process alive" probe.
+#[cfg(unix)]
+fn term_then_kill(pid: u32) {
+    let _ = Command::new("kill").args(["-TERM", &pid.to_string()]).status();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(2000);
+    while std::time::Instant::now() < deadline {
+        let alive = Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !alive {
+            log::info!("[orphan-reap] pid={} exited after TERM", pid);
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    log::warn!("[orphan-reap] pid={} did not exit after 2s — sending KILL", pid);
+    let _ = Command::new("kill").args(["-KILL", &pid.to_string()]).status();
+}
+
+/// Clean a stale `/tmp/tauri-mcp-o8-<user>.sock` file. When the prior sidecar
+/// crashed without unbinding, the socket file lingers and the next launch's
+/// `tauri-plugin-mcp` plugin throws "Socket ... is in use by another instance".
+///
+/// We test "in-use" by attempting a Unix-domain stream connect to the socket.
+/// If a process is actually listening, connect() succeeds → we leave it alone
+/// (another live o8 instance owns it). If connect() fails with refused/no-such
+/// the file is dead → safe to unlink.
+#[cfg(unix)]
+fn clean_stale_tauri_mcp_socket() {
+    let user = std::env::var("USER").unwrap_or_else(|_| "default".into());
+    let sock_path = format!("/tmp/tauri-mcp-o8-{}.sock", user);
+    let path = std::path::Path::new(&sock_path);
+    if !path.exists() {
+        return;
+    }
+    // Best-effort liveness probe via UnixStream connect. A successful connect
+    // means somebody is listening — leave the socket alone.
+    use std::os::unix::net::UnixStream;
+    match UnixStream::connect(&sock_path) {
+        Ok(_) => {
+            log::info!(
+                "[orphan-reap] tauri-mcp socket at {} is live — leaving in place",
+                sock_path
+            );
+        }
+        Err(_) => {
+            // Connect refused / no listener — socket file is dead.
+            match std::fs::remove_file(&sock_path) {
+                Ok(()) => log::info!("[orphan-reap] removed stale tauri-mcp socket {}", sock_path),
+                Err(e) => log::warn!(
+                    "[orphan-reap] could not remove stale tauri-mcp socket {}: {}",
+                    sock_path, e
+                ),
+            }
+        }
+    }
+}
+
+/// Top-level orphan reaper. Called once from `pub fn run()` before the Tauri
+/// builder is constructed. No-ops on non-unix platforms.
+fn reap_o8_orphans() {
+    #[cfg(unix)]
+    {
+        // Patterns chosen to catch every shape o8 spawns its node children as.
+        // `next-server` is what Next.js renames the process title to after
+        // boot. `ws-server.mjs` and `ws-server.ts` cover the bundled and dev
+        // forms of our WebSocket multiplexer.
+        let patterns: &[&str] = &["next-server", "ws-server.mjs", "ws-server.ts"];
+        let mut candidates: Vec<u32> = Vec::new();
+        for p in patterns {
+            for pid in pgrep_pids(p) {
+                if !candidates.contains(&pid) {
+                    candidates.push(pid);
+                }
+            }
+        }
+
+        if candidates.is_empty() {
+            log::info!("[orphan-reap] no candidate next/ws-server processes found");
+        } else {
+            log::info!("[orphan-reap] candidates: {:?}", candidates);
+        }
+
+        for pid in candidates {
+            let ppid = process_ppid(pid);
+            let cwd = process_cwd(pid);
+
+            // Ownership filter — must look like an o8 install/checkout. This
+            // is the catastrophic-false-positive guard.
+            if !cwd_looks_o8_owned(&cwd) {
+                log::info!(
+                    "[orphan-reap] pid={} cwd={:?} not o8-owned — skipping",
+                    pid, cwd
+                );
+                continue;
+            }
+
+            // Orphan signal: parent reparented to launchd (pid 1). If the
+            // parent is still alive (a running terminal `npm run dev` or
+            // another live o8 sidecar), we leave it alone — the user is
+            // actively using it.
+            if ppid != 1 {
+                log::info!(
+                    "[orphan-reap] pid={} ppid={} is actively parented (cwd={:?}) — skipping",
+                    pid, ppid, cwd
+                );
+                continue;
+            }
+
+            log::info!(
+                "[orphan-reap] reaping orphan pid={} ppid=1 cwd={:?}",
+                pid, cwd
+            );
+            term_then_kill(pid);
+        }
+
+        clean_stale_tauri_mcp_socket();
+    }
+}
+
 // ── Child process log capture ──
 //
 // The bundled Next.js server and WS server each get their own log file
@@ -1827,6 +2056,15 @@ pub fn run() {
     // for ungraceful exits.
     install_shutdown_handlers();
 
+    // ── Boot-time orphan reaper (issue #776) ──
+    // Reap stale `next-server` / `ws-server` processes from prior crashes
+    // (reparented to launchd) and remove a stale `/tmp/tauri-mcp-o8-<user>.sock`
+    // BEFORE the Tauri builder is constructed — the `tauri-plugin-mcp` plugin
+    // binds the socket during builder setup and throws if the file lingers.
+    // Wider net than `probe_kill_port` from #719: hits orphans on any port,
+    // not just 3001/3002.
+    reap_o8_orphans();
+
     // Cmd+Shift+O on macOS, Ctrl+Shift+O elsewhere. The global-shortcut
     // plugin uses the same `Modifiers::SUPER` token for both Cmd (mac) and
     // the Windows key — close enough for v1; we expose this constant so the
@@ -2136,7 +2374,13 @@ pub fn run() {
                     .env("O8_NODE_BIN", &node_bin)
                     .env("O8_API_PORT", api_port.to_string())
                     .env("O8_WS_PORT", ws_port.to_string())
-                    .env("WS_PORT", ws_port.to_string());
+                    .env("WS_PORT", ws_port.to_string())
+                    // Issue #776: marker so future sidecar boots can identify
+                    // this child as an o8 sibling. macOS doesn't let us read
+                    // env vars of other processes without root, so this is
+                    // best-effort forward-compat for Linux/Windows /proc and
+                    // human-readable in `ps -E` from the same user.
+                    .env("O8_SIDECAR_PID", std::process::id().to_string());
                 if has_bundled_mcp {
                     server_cmd.env("O8_BUNDLED_MCP_DIR", &server_dir);
                     server_cmd.env("O8_BUNDLED_MCP_PATH", &bundled_operator_mcp);
@@ -2184,6 +2428,8 @@ pub fn run() {
                         .env("O8_NODE_BIN", &node_bin)
                         .env("WS_PORT", ws_port.to_string())
                         .env("NEXT_ORIGIN", format!("http://127.0.0.1:{}", api_port))
+                        // Issue #776: same sidecar marker as the next-server child.
+                        .env("O8_SIDECAR_PID", std::process::id().to_string())
                         .stdout(child_stdio(ws_log.as_ref()))
                         .stderr(child_stdio(ws_log.as_ref()))
                         .spawn()


### PR DESCRIPTION
## Summary

Closes #776. Boot-time reaper in `src-tauri/src/lib.rs` that runs once before the Tauri builder is constructed — wider net than `probe_kill_port` from #719/#728, plus stale-socket cleanup.

## What it does

1. **Enumerate orphan candidates** via `pgrep -f` against `next-server`, `ws-server.mjs`, `ws-server.ts`. Skips our own PID.
2. **Verify o8 ownership** via cwd substring lookup with `lsof -p PID -a -d cwd -F n`. Accepted patterns: `cortex-ide`, `.app/Contents/Resources/server`, `/.o8`, `/o8.app/`. Bare `o8` is rejected (too broad — would match user dirs like `~/projects/o8-experiment`).
3. **Confirm orphan signature** via `ps -o ppid=`. Only `ppid == 1` (reparented to launchd) is reaped. A live `npm run dev` parent or another running o8 sidecar is left alone.
4. **Kill ladder**: `SIGTERM`, poll `kill -0` every 100ms for up to 2s, then `SIGKILL` if still alive.
5. **Stale socket cleanup**: at `/tmp/tauri-mcp-o8-<user>.sock`. Probe with `UnixStream::connect` — if it succeeds, a live process owns it (leave alone). If it fails, the file is dead and `std::fs::remove_file` unlinks it. Fixes the `Socket ... is in use by another instance` crash from `tauri-plugin-mcp` on relaunch when a prior sidecar died without unbinding.
6. **Forward-compat breadcrumb**: own children spawn with `O8_SIDECAR_PID=<self_pid>`. macOS won't let us read other-process env without root, but Linux /proc and same-user ps can see it.

## Detection method

`pgrep -f` for the process-title patterns, then per-PID cwd lookup via `lsof`. Both are base-system tools on macOS and ship on every reasonable Linux distro. Falls back to "skip" if either is missing — no false-positive kills.

## Ownership filter

Two-condition AND:
- cwd contains an o8-shaped path substring (see list above)
- ppid is exactly 1 (launchd)

If either is false, the candidate is skipped. The cwd filter is the catastrophic-false-positive guard — combined with ppid==1 it's hard to construct a false positive.

## Edge cases

- **User has a project dir literally named `cortex-ide` running their own next-server**: would only get reaped if their next-server was reparented to launchd (ppid==1). A live `next dev` in a terminal has ppid=npm/zsh, not launchd. Safe.
- **`pgrep` or `lsof` missing**: helper returns empty / unknown cwd, candidate skipped, reaper no-ops cleanly.
- **Live o8 instance running on another port**: its children have ppid = sidecar's running PID (alive), so they're skipped. The new sidecar's `probe_kill_port(3001)` from #719 still kills the active one in second-instance scenarios — that's the existing belt for "second copy launching over first".
- **First deploy of this fix**: orphans from prior versions don't have `O8_SIDECAR_PID` set. The cwd+ppid filter catches them anyway — env marker is forward-compat only.

## Compile checks

- `cd src-tauri && cargo check --features dev-mcp-plugin` → passes
- `cargo clippy --features dev-mcp-plugin --no-deps` → 6 pre-existing warnings, zero new ones from this PR

## Test plan

- [ ] Force-quit production o8.app to leave next-server / ws-server reparented to launchd
- [ ] Verify `pgrep -af next-server` shows orphan(s)
- [ ] Launch fresh o8.app
- [ ] Verify Console.app log shows `[orphan-reap]` lines reaping the orphans
- [ ] Verify `pgrep -af next-server` shows exactly 1 PID (the new child)
- [ ] Repeat 5x — every launch ends with a single child + fresh socket
- [ ] Pre-create stale socket: `touch /tmp/tauri-mcp-o8-$USER.sock` after killing o8 → relaunch, verify no `Socket ... is in use` crash
- [ ] Living Specs hook (#770) fires on a real merge instead of being silently shadowed by a stale orphan

🤖 Generated with [Claude Code](https://claude.com/claude-code)