### PR TITLE
feat(mobile): DevHostFrame iframe with URL bar + LAN host discovery (closes #781)

### DIFF
--- a/src/app/api/panel/lan-host/route.ts
+++ b/src/app/api/panel/lan-host/route.ts
@@ -1,0 +1,136 @@
+/**
+ * LAN host discovery for the mobile DevHostFrame.
+ *
+ * Returns the first non-loopback IPv4 address in a private RFC1918 range
+ * (10/8, 172.16/12, 192.168/16) and the list of LAN-reachable dev ports.
+ *
+ * Used by the right-side iframe in the mobile landscape split shell to
+ * default the URL bar to `http://{lanIp}:{focusedPort}` so the user can
+ * reach their localhost dev server from their phone over the same network.
+ *
+ * Gated under `/api/panel/*` middleware (loopback or ws-token bearer).
+ */
+
+export const dynamic = 'force-dynamic';
+
+import os from 'node:os';
+import { NextResponse } from 'next/server';
+
+interface LanHostResponse {
+  lanIp: string | null;
+  ports: number[];
+}
+
+/**
+ * Pick the first non-loopback IPv4 in 10/8, 172.16/12, or 192.168/16.
+ *
+ * The order of preference matches what people actually see at home/office:
+ *   - 192.168.x.x (most home routers)
+ *   - 10.x.x.x (some corporate networks, Tailscale CGNAT)
+ *   - 172.16-31.x.x (Docker/some corporate networks)
+ *
+ * We sort interface names so "en0" beats "utun*" tunnels — the user's
+ * physical Wi-Fi/Ethernet is what their phone can actually reach.
+ */
+function pickLanIp(): string | null {
+  const ifaces = os.networkInterfaces();
+  const candidates: { iface: string; address: string; rank: number }[] = [];
+
+  for (const [name, addrs] of Object.entries(ifaces)) {
+    if (!addrs) continue;
+    for (const addr of addrs) {
+      if (addr.family !== 'IPv4') continue;
+      if (addr.internal) continue;
+      const ip = addr.address;
+      const rank = privateRangeRank(ip);
+      if (rank === 0) continue;
+      candidates.push({ iface: name, address: ip, rank });
+    }
+  }
+
+  if (candidates.length === 0) return null;
+
+  // Sort: highest rank first (192.168 > 10 > 172.16), then by interface
+  // name (en* before utun*) so VPN tunnels lose to physical interfaces.
+  candidates.sort((a, b) => {
+    if (b.rank !== a.rank) return b.rank - a.rank;
+    return interfacePriority(a.iface) - interfacePriority(b.iface);
+  });
+
+  return candidates[0].address;
+}
+
+function privateRangeRank(ip: string): number {
+  // 192.168.0.0/16 — home routers, return highest rank.
+  if (ip.startsWith('192.168.')) return 3;
+  // 10.0.0.0/8 — many corporate networks, also Tailscale's 100.64/10 sits
+  // in CGNAT but starts with "100." so it falls through naturally.
+  if (ip.startsWith('10.')) return 2;
+  // 172.16.0.0/12 — second octet must be 16-31.
+  if (ip.startsWith('172.')) {
+    const parts = ip.split('.');
+    if (parts.length < 2) return 0;
+    const second = parseInt(parts[1], 10);
+    if (Number.isFinite(second) && second >= 16 && second <= 31) return 1;
+  }
+  return 0;
+}
+
+function interfacePriority(name: string): number {
+  // Lower = preferred. Physical interfaces beat tunnels.
+  if (name.startsWith('en')) return 0;
+  if (name.startsWith('eth')) return 0;
+  if (name.startsWith('wl')) return 1;
+  if (name.startsWith('bridge')) return 5;
+  if (name.startsWith('utun')) return 8;
+  if (name.startsWith('tun')) return 8;
+  return 4;
+}
+
+/**
+ * Read LAN-reachable dev ports by reusing the same scan that powers the
+ * desktop port-hover popover. We skip the full HTTP roundtrip and call
+ * lsof directly here — the panel/ports route already does this and the
+ * extra HTTP call from a server route to itself just doubles the work.
+ *
+ * For v1 we keep the scan minimal: any registered repo's listening port
+ * counts. The DevHostFrame uses these as typeahead suggestions, not as
+ * a strict whitelist.
+ */
+async function scanDevPorts(): Promise<number[]> {
+  // Lazy-import the panel ports scanner — fall back gracefully if the
+  // route module shape changes; an empty list is a valid response.
+  try {
+    // The panel/ports route holds an internal cache, but it's not exported.
+    // For now, do a thin lsof scan inline. If this ever grows we can extract
+    // a shared helper — single use-case here.
+    const { execSync } = await import('node:child_process');
+    const raw = execSync(
+      'lsof -i -P -n -sTCP:LISTEN -F pn 2>/dev/null',
+      { encoding: 'utf-8', timeout: 3000 },
+    ).trim();
+
+    const ports = new Set<number>();
+    for (const line of raw.split('\n')) {
+      if (!line.startsWith('n')) continue;
+      const match = line.match(/:(\d+)$/);
+      if (!match) continue;
+      const port = parseInt(match[1], 10);
+      if (!Number.isFinite(port)) continue;
+      // Skip well-known system ports — phone won't want to browse SSH.
+      if (port < 1024) continue;
+      // Skip mDNS/system-ish ranges that aren't dev servers.
+      if (port === 5000 || port === 5353 || port === 7000) continue;
+      ports.add(port);
+    }
+    return [...ports].sort((a, b) => a - b);
+  } catch {
+    return [];
+  }
+}
+
+export async function GET(): Promise<NextResponse<LanHostResponse>> {
+  const lanIp = pickLanIp();
+  const ports = await scanDevPorts();
+  return NextResponse.json({ lanIp, ports });
+}

--- a/src/components/mobile-split-shell/DevHostFrame.tsx
+++ b/src/components/mobile-split-shell/DevHostFrame.tsx
@@ -1,0 +1,793 @@
+'use client';
+
+/**
+ * DevHostFrame — the right-side iframe in the mobile landscape split shell.
+ *
+ * Renders the user's LAN dev server (e.g. http://192.168.1.42:3001) inside
+ * an iframe with a Safari-quality URL bar above it. Address typeahead pulls
+ * from /api/panel/ports + /api/panel/lan-host so the user can jump to any
+ * registered repo's dev port. Sites that block embedding (X-Frame-Options
+ * DENY, strict CSP) fall back to a clear "blocked" empty state with an
+ * external-open link.
+ *
+ * iOS PWA caveat: if o8 itself is served https://, Safari blocks mixed-
+ * content http:// iframes silently. The empty state surfaces this so the
+ * user knows to either run o8 over http://lan-ip or wait for the v2
+ * mkcert proxy.
+ *
+ * Owned by the mobile-dev-host-frame agent. The split-shell layout
+ * (#779) imports this component and mounts it in the right pane.
+ */
+
+import {
+  forwardRef,
+  memo,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+/* ── Phosphor SVG path data (regular weight, 256×256 viewBox) ───────────── */
+/* Inlined per repo policy: no React icon components in the Tauri webview.   */
+const PHOSPHOR_PATHS = {
+  CaretLeft:
+    'M165.66,202.34a8,8,0,0,1-11.32,11.32l-80-80a8,8,0,0,1,0-11.32l80-80a8,8,0,0,1,11.32,11.32L91.31,128Z',
+  CaretRight:
+    'M181.66,133.66l-80,80a8,8,0,0,1-11.32-11.32L164.69,128,90.34,53.66a8,8,0,0,1,11.32-11.32l80,80A8,8,0,0,1,181.66,133.66Z',
+  ArrowClockwise:
+    'M240,56v48a8,8,0,0,1-8,8H184a8,8,0,0,1,0-16H211.4L184.81,71.64l-.25-.24a80,80,0,1,0-1.67,114.78,8,8,0,0,1,11,11.63A95.44,95.44,0,0,1,128,224h-1.32A96,96,0,1,1,195.75,60L224,85.8V56a8,8,0,1,1,16,0Z',
+  ArrowSquareOut:
+    'M200,64V168a8,8,0,0,1-16,0V83.31L69.66,197.66a8,8,0,0,1-11.32-11.32L172.69,72H88a8,8,0,0,1,0-16H192A8,8,0,0,1,200,64Z',
+  WarningCircle:
+    'M128,24A104,104,0,1,0,232,128,104.13,104.13,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm-8-80V80a8,8,0,0,1,16,0v56a8,8,0,0,1-16,0Zm20,36a12,12,0,1,1-12-12A12,12,0,0,1,140,172Z',
+} as const;
+
+/* ── Public API ─────────────────────────────────────────────────────────── */
+
+export interface DevHostFrameHandle {
+  back(): void;
+  forward(): void;
+  reload(): void;
+}
+
+export interface DevHostFrameProps {
+  initialUrl?: string;
+  onUrlChange?(url: string): void;
+}
+
+/* ── Internals ──────────────────────────────────────────────────────────── */
+
+const MONO_FAMILY = '"SF Mono", Menlo, ui-monospace, monospace';
+const SANS_FAMILY = '"Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, system-ui, sans-serif';
+const HOSTILE_TIMEOUT_MS = 4_000;
+
+interface PortsResponse {
+  ports?: { port: number; repo: string | null }[];
+  groups?: { repo: string; ports: number[] }[];
+}
+
+interface LanHostResponse {
+  lanIp: string | null;
+  ports: number[];
+}
+
+interface Suggestion {
+  url: string;
+  label: string;
+  hint?: string;
+}
+
+/**
+ * URLs we consider trustworthy for an iframe. Public sites usually block
+ * embedding — for those we let the 4s onload timer fire the empty state.
+ * Local dev hosts almost always allow embedding (or the user controls
+ * them) — for those we skip the timer entirely so the empty state never
+ * misfires while a heavy bundle loads.
+ */
+function isLocalDevHost(rawUrl: string): boolean {
+  let host: string;
+  try {
+    host = new URL(rawUrl).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  if (host === 'localhost' || host.endsWith('.localhost')) return true;
+  if (host.endsWith('.local')) return true;
+  if (host === '127.0.0.1' || host.startsWith('127.')) return true;
+  if (host.startsWith('192.168.')) return true;
+  if (host.startsWith('10.')) return true;
+  if (host.startsWith('172.')) {
+    const parts = host.split('.');
+    const second = parts.length >= 2 ? parseInt(parts[1], 10) : NaN;
+    if (Number.isFinite(second) && second >= 16 && second <= 31) return true;
+  }
+  return false;
+}
+
+function isHttpUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value.trim());
+}
+
+function isMixedContentBlocked(url: string): boolean {
+  if (typeof window === 'undefined') return false;
+  if (window.location.protocol !== 'https:') return false;
+  return /^http:\/\//i.test(url);
+}
+
+/* ── Component ──────────────────────────────────────────────────────────── */
+
+export const DevHostFrame = memo(
+  forwardRef<DevHostFrameHandle, DevHostFrameProps>(function DevHostFrame(
+    { initialUrl, onUrlChange },
+    ref,
+  ) {
+    const iframeRef = useRef<HTMLIFrameElement | null>(null);
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const hostileTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const [committedUrl, setCommittedUrl] = useState<string>(initialUrl ?? '');
+    const [draftUrl, setDraftUrl] = useState<string>(initialUrl ?? '');
+    const [showSuggestions, setShowSuggestions] = useState<boolean>(false);
+    const [loadState, setLoadState] = useState<'idle' | 'loading' | 'ok' | 'blocked' | 'mixed'>(
+      initialUrl ? 'loading' : 'idle',
+    );
+    const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+    const [bootDefault, setBootDefault] = useState<{ url: string; lanIp: string | null } | null>(
+      null,
+    );
+
+    /* ── Fetch typeahead data once on mount ─────────────────────────────── */
+    useEffect(() => {
+      let cancelled = false;
+      (async () => {
+        try {
+          const [portsRes, lanRes] = await Promise.all([
+            fetch('/api/panel/ports').then((r) => (r.ok ? (r.json() as Promise<PortsResponse>) : null)),
+            fetch('/api/panel/lan-host').then((r) =>
+              r.ok ? (r.json() as Promise<LanHostResponse>) : null,
+            ),
+          ]);
+          if (cancelled) return;
+
+          const lanIp = lanRes?.lanIp ?? null;
+          const items: Suggestion[] = [];
+          const seenUrls = new Set<string>();
+
+          // Per-repo group entries first — these are the labelled
+          // "this repo's dev server" shortcuts.
+          if (portsRes?.groups) {
+            for (const group of portsRes.groups) {
+              for (const port of group.ports) {
+                const url = `http://${lanIp ?? 'localhost'}:${port}`;
+                if (seenUrls.has(url)) continue;
+                seenUrls.add(url);
+                items.push({
+                  url,
+                  label: `${group.repo}:${port}`,
+                  hint: lanIp ? `${lanIp}:${port}` : `localhost:${port}`,
+                });
+              }
+            }
+          }
+
+          // Fall through to any LAN ports the panel scan didn't tag with
+          // a repo — still useful as bare endpoints.
+          const fallbackPorts = lanRes?.ports ?? [];
+          for (const port of fallbackPorts) {
+            const url = `http://${lanIp ?? 'localhost'}:${port}`;
+            if (seenUrls.has(url)) continue;
+            seenUrls.add(url);
+            items.push({
+              url,
+              label: `localhost:${port}`,
+              hint: lanIp ? `${lanIp}:${port}` : undefined,
+            });
+          }
+
+          setSuggestions(items);
+
+          // Default URL = first repo-tagged port over LAN if we have one.
+          if (!initialUrl && items.length > 0) {
+            setBootDefault({ url: items[0].url, lanIp });
+            setCommittedUrl(items[0].url);
+            setDraftUrl(items[0].url);
+            setLoadState('loading');
+            onUrlChange?.(items[0].url);
+          } else if (!initialUrl) {
+            setBootDefault({ url: '', lanIp });
+          }
+        } catch {
+          // Typeahead is best-effort — keep going with a blank URL bar.
+          if (!cancelled) setBootDefault({ url: '', lanIp: null });
+        }
+      })();
+
+      return () => {
+        cancelled = true;
+      };
+      // We intentionally only run this once on mount.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    /* ── Imperative handle for parent split-shell controls ──────────────── */
+    useImperativeHandle(
+      ref,
+      () => ({
+        back: () => {
+          try {
+            iframeRef.current?.contentWindow?.history.back();
+          } catch {
+            /* cross-origin frames throw — silent no-op */
+          }
+        },
+        forward: () => {
+          try {
+            iframeRef.current?.contentWindow?.history.forward();
+          } catch {
+            /* cross-origin frames throw — silent no-op */
+          }
+        },
+        reload: () => {
+          if (!committedUrl) return;
+          // Force re-mount by toggling state; iframe.location.reload() also
+          // throws on cross-origin frames, so we re-set the src instead.
+          setLoadState('loading');
+          if (iframeRef.current) {
+            iframeRef.current.src = committedUrl;
+          }
+          armHostileTimer(committedUrl);
+        },
+      }),
+      // armHostileTimer is stable via useCallback below.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [committedUrl],
+    );
+
+    /* ── 4-second hostile-iframe detector ───────────────────────────────── */
+    const clearHostileTimer = useCallback(() => {
+      if (hostileTimerRef.current) {
+        clearTimeout(hostileTimerRef.current);
+        hostileTimerRef.current = null;
+      }
+    }, []);
+
+    const armHostileTimer = useCallback(
+      (url: string) => {
+        clearHostileTimer();
+        // Skip the timer entirely for known-good local dev hosts. They
+        // can take >4s to first-paint while a Webpack/Next bundle compiles.
+        if (isLocalDevHost(url)) return;
+        hostileTimerRef.current = setTimeout(() => {
+          // If we still haven't seen onload, assume the site refused embedding.
+          setLoadState((prev) => (prev === 'loading' ? 'blocked' : prev));
+        }, HOSTILE_TIMEOUT_MS);
+      },
+      [clearHostileTimer],
+    );
+
+    /* ── Commit a URL: validate, set src, arm hostile timer ─────────────── */
+    const commitUrl = useCallback(
+      (raw: string) => {
+        const trimmed = raw.trim();
+        if (!trimmed) return;
+        if (!isHttpUrl(trimmed)) {
+          // Treat raw "192.168.1.42:3001" as http://192.168.1.42:3001
+          const fallback = `http://${trimmed.replace(/^\/+/, '')}`;
+          if (!isHttpUrl(fallback)) return;
+          return commitUrl(fallback);
+        }
+        if (isMixedContentBlocked(trimmed)) {
+          setCommittedUrl(trimmed);
+          setLoadState('mixed');
+          onUrlChange?.(trimmed);
+          return;
+        }
+        setCommittedUrl(trimmed);
+        setDraftUrl(trimmed);
+        setShowSuggestions(false);
+        setLoadState('loading');
+        armHostileTimer(trimmed);
+        onUrlChange?.(trimmed);
+      },
+      [armHostileTimer, onUrlChange],
+    );
+
+    /* ── Initial URL → arm timer on first paint ─────────────────────────── */
+    useEffect(() => {
+      if (committedUrl && loadState === 'loading') {
+        armHostileTimer(committedUrl);
+      }
+      return clearHostileTimer;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [committedUrl]);
+
+    /* ── Iframe load handlers ───────────────────────────────────────────── */
+    const onIframeLoad = useCallback(() => {
+      clearHostileTimer();
+      // contentDocument is null for cross-origin iframes — that's normal,
+      // not a sign of blocking. Just trust the onload event firing.
+      setLoadState('ok');
+    }, [clearHostileTimer]);
+
+    const onIframeError = useCallback(() => {
+      clearHostileTimer();
+      setLoadState('blocked');
+    }, [clearHostileTimer]);
+
+    /* ── URL bar interactions ───────────────────────────────────────────── */
+    const onSubmit = useCallback(
+      (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        commitUrl(draftUrl);
+      },
+      [commitUrl, draftUrl],
+    );
+
+    const onClickSuggestion = useCallback(
+      (item: Suggestion) => {
+        commitUrl(item.url);
+        inputRef.current?.blur();
+      },
+      [commitUrl],
+    );
+
+    /* ── Filtered typeahead based on current draft ──────────────────────── */
+    const visibleSuggestions = useMemo(() => {
+      if (!showSuggestions) return [] as Suggestion[];
+      const q = draftUrl.trim().toLowerCase();
+      if (!q) return suggestions;
+      return suggestions.filter(
+        (s) =>
+          s.url.toLowerCase().includes(q) ||
+          s.label.toLowerCase().includes(q) ||
+          (s.hint?.toLowerCase().includes(q) ?? false),
+      );
+    }, [draftUrl, showSuggestions, suggestions]);
+
+    /* ── Render ─────────────────────────────────────────────────────────── */
+    return (
+      <div
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          minHeight: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          background: 'var(--t-bg)',
+          fontFamily: SANS_FAMILY,
+          color: 'var(--t-text)',
+          overscrollBehavior: 'contain',
+        }}
+      >
+        {/* ── URL bar ─────────────────────────────────────────────────── */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            paddingTop: 'max(8px, env(safe-area-inset-top))',
+            paddingBottom: 8,
+            paddingLeft: 'max(10px, env(safe-area-inset-left))',
+            paddingRight: 'max(10px, env(safe-area-inset-right))',
+            background: 'var(--t-panel)',
+            borderBottom: '1px solid var(--t-panel-border)',
+            backdropFilter: 'blur(20px) saturate(180%)',
+            WebkitBackdropFilter: 'blur(20px) saturate(180%)',
+            flexShrink: 0,
+            zIndex: 2,
+          }}
+        >
+          <NavButton
+            label="Back"
+            onClick={() => {
+              try {
+                iframeRef.current?.contentWindow?.history.back();
+              } catch {
+                /* no-op */
+              }
+            }}
+            iconPath={PHOSPHOR_PATHS.CaretLeft}
+          />
+          <NavButton
+            label="Forward"
+            onClick={() => {
+              try {
+                iframeRef.current?.contentWindow?.history.forward();
+              } catch {
+                /* no-op */
+              }
+            }}
+            iconPath={PHOSPHOR_PATHS.CaretRight}
+          />
+          <NavButton
+            label="Reload"
+            onClick={() => {
+              if (!committedUrl) return;
+              setLoadState('loading');
+              if (iframeRef.current) iframeRef.current.src = committedUrl;
+              armHostileTimer(committedUrl);
+            }}
+            iconPath={PHOSPHOR_PATHS.ArrowClockwise}
+          />
+
+          <form onSubmit={onSubmit} style={{ flex: 1, minWidth: 0, position: 'relative' }}>
+            <input
+              ref={inputRef}
+              type="url"
+              inputMode="url"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
+              placeholder={
+                bootDefault?.lanIp
+                  ? `http://${bootDefault.lanIp}:port`
+                  : 'Type a dev host URL'
+              }
+              value={draftUrl}
+              onChange={(e) => {
+                setDraftUrl(e.target.value);
+                setShowSuggestions(true);
+              }}
+              onFocus={() => setShowSuggestions(true)}
+              onBlur={() => {
+                // Delay so a tap on a suggestion still fires.
+                window.setTimeout(() => setShowSuggestions(false), 120);
+              }}
+              style={{
+                width: '100%',
+                padding: '8px 12px',
+                borderRadius: 10,
+                border: '1px solid var(--t-panel-border)',
+                background: 'var(--t-input-bg)',
+                color: 'var(--t-text)',
+                fontFamily: MONO_FAMILY,
+                fontSize: 13,
+                lineHeight: '20px',
+                outline: 'none',
+                boxSizing: 'border-box',
+                WebkitAppearance: 'none',
+                appearance: 'none',
+              }}
+            />
+            {visibleSuggestions.length > 0 ? (
+              <ul
+                role="listbox"
+                style={{
+                  position: 'absolute',
+                  top: 'calc(100% + 6px)',
+                  left: 0,
+                  right: 0,
+                  margin: 0,
+                  padding: 4,
+                  listStyle: 'none',
+                  background: 'var(--t-panel-solid)',
+                  border: '1px solid var(--t-panel-border)',
+                  borderRadius: 12,
+                  boxShadow: 'var(--t-panel-shadow)',
+                  maxHeight: 240,
+                  overflowY: 'auto',
+                  zIndex: 5,
+                  backdropFilter: 'blur(24px) saturate(180%)',
+                  WebkitBackdropFilter: 'blur(24px) saturate(180%)',
+                }}
+              >
+                {visibleSuggestions.map((item) => (
+                  <li key={item.url}>
+                    <button
+                      type="button"
+                      onMouseDown={(e) => {
+                        // Prevent the input from blurring before the click fires.
+                        e.preventDefault();
+                      }}
+                      onClick={() => onClickSuggestion(item)}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'baseline',
+                        gap: 8,
+                        width: '100%',
+                        padding: '10px 12px',
+                        minHeight: 44,
+                        border: 'none',
+                        background: 'transparent',
+                        color: 'var(--t-text)',
+                        textAlign: 'left',
+                        borderRadius: 8,
+                        cursor: 'pointer',
+                        fontFamily: SANS_FAMILY,
+                      }}
+                    >
+                      <span style={{ fontSize: 13, fontWeight: 500 }}>{item.label}</span>
+                      <span
+                        style={{
+                          fontFamily: MONO_FAMILY,
+                          fontSize: 11,
+                          color: 'var(--t-text-muted)',
+                          marginLeft: 'auto',
+                        }}
+                      >
+                        {item.hint ?? item.url.replace(/^https?:\/\//, '')}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </form>
+        </div>
+
+        {/* ── Iframe / empty states ──────────────────────────────────── */}
+        <div
+          style={{
+            flex: 1,
+            minHeight: 0,
+            position: 'relative',
+            background: 'var(--t-bg)',
+          }}
+        >
+          {loadState === 'idle' && !committedUrl ? (
+            <IdleState lanIp={bootDefault?.lanIp ?? null} />
+          ) : loadState === 'blocked' ? (
+            <BlockedState
+              url={committedUrl}
+              kind="frame"
+              onRetry={() => {
+                setLoadState('loading');
+                if (iframeRef.current) iframeRef.current.src = committedUrl;
+                armHostileTimer(committedUrl);
+              }}
+            />
+          ) : loadState === 'mixed' ? (
+            <BlockedState url={committedUrl} kind="mixed" onRetry={null} />
+          ) : null}
+
+          {committedUrl && loadState !== 'mixed' ? (
+            <iframe
+              ref={iframeRef}
+              src={committedUrl}
+              title="Dev host preview"
+              onLoad={onIframeLoad}
+              onError={onIframeError}
+              sandbox="allow-scripts allow-same-origin allow-forms"
+              referrerPolicy="no-referrer"
+              allow="clipboard-read; clipboard-write"
+              style={{
+                position: 'absolute',
+                inset: 0,
+                width: '100%',
+                height: '100%',
+                border: 'none',
+                background: 'var(--t-bg)',
+                // Keep the iframe in the DOM during 'blocked' so retry just
+                // toggles state, but visually hide it under the empty state.
+                visibility: loadState === 'blocked' ? 'hidden' : 'visible',
+              }}
+            />
+          ) : null}
+        </div>
+      </div>
+    );
+  }),
+);
+
+DevHostFrame.displayName = 'DevHostFrame';
+
+/* ── Subcomponents ─────────────────────────────────────────────────────── */
+
+interface NavButtonProps {
+  label: string;
+  iconPath: string;
+  onClick(): void;
+}
+
+function NavButton({ label, iconPath, onClick }: NavButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onClick}
+      style={{
+        width: 36,
+        height: 36,
+        minWidth: 36,
+        flexShrink: 0,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        border: '1px solid var(--t-panel-border)',
+        background: 'var(--t-panel-translucent)',
+        color: 'var(--t-text-secondary)',
+        borderRadius: 10,
+        cursor: 'pointer',
+        padding: 0,
+      }}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={16}
+        height={16}
+        fill="currentColor"
+        viewBox="0 0 256 256"
+        style={{ display: 'block', flexShrink: 0 }}
+      >
+        <path d={iconPath} />
+      </svg>
+    </button>
+  );
+}
+
+interface BlockedStateProps {
+  url: string;
+  kind: 'frame' | 'mixed';
+  onRetry: (() => void) | null;
+}
+
+function BlockedState({ url, kind, onRetry }: BlockedStateProps) {
+  const title =
+    kind === 'mixed'
+      ? 'Mixed-content blocked by iOS'
+      : 'This site blocks embedding';
+  const detail =
+    kind === 'mixed'
+      ? 'Safari refuses to load http:// inside an https:// app. Serve o8 over http:// from your dev box, or wait for the v2 mkcert proxy.'
+      : 'The site set X-Frame-Options or a strict CSP. Open it externally to view it.';
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 'max(24px, env(safe-area-inset-bottom))',
+        textAlign: 'center',
+        gap: 14,
+        zIndex: 1,
+      }}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={32}
+        height={32}
+        viewBox="0 0 256 256"
+        fill="var(--t-text-muted)"
+        style={{ opacity: 0.7 }}
+      >
+        <path d={PHOSPHOR_PATHS.WarningCircle} />
+      </svg>
+      <div
+        style={{
+          fontFamily: SANS_FAMILY,
+          fontSize: 15,
+          fontWeight: 600,
+          color: 'var(--t-text)',
+        }}
+      >
+        {title}
+      </div>
+      <div
+        style={{
+          fontFamily: SANS_FAMILY,
+          fontSize: 13,
+          lineHeight: 1.4,
+          color: 'var(--t-text-secondary)',
+          maxWidth: 360,
+        }}
+      >
+        {detail}
+      </div>
+      <div
+        style={{
+          fontFamily: MONO_FAMILY,
+          fontSize: 11,
+          color: 'var(--t-text-muted)',
+          maxWidth: '100%',
+          overflowWrap: 'anywhere',
+          padding: '6px 10px',
+          background: 'var(--t-bg-card)',
+          borderRadius: 8,
+          border: '1px solid var(--t-panel-border)',
+        }}
+      >
+        {url || '—'}
+      </div>
+      <div style={{ display: 'flex', gap: 8 }}>
+        {onRetry ? (
+          <button
+            type="button"
+            onClick={onRetry}
+            style={{
+              padding: '8px 14px',
+              minHeight: 36,
+              borderRadius: 10,
+              border: '1px solid var(--t-panel-border)',
+              background: 'var(--t-panel-translucent)',
+              color: 'var(--t-text)',
+              fontFamily: SANS_FAMILY,
+              fontSize: 13,
+              cursor: 'pointer',
+            }}
+          >
+            Try again
+          </button>
+        ) : null}
+        {url ? (
+          <a
+            href={url}
+            target="_blank"
+            rel="noreferrer noopener"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '8px 14px',
+              minHeight: 36,
+              borderRadius: 10,
+              border: '1px solid var(--t-panel-border)',
+              background: 'var(--t-panel-active)',
+              color: 'var(--t-text)',
+              fontFamily: SANS_FAMILY,
+              fontSize: 13,
+              textDecoration: 'none',
+            }}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width={14}
+              height={14}
+              fill="currentColor"
+              viewBox="0 0 256 256"
+            >
+              <path d={PHOSPHOR_PATHS.ArrowSquareOut} />
+            </svg>
+            Open externally
+          </a>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function IdleState({ lanIp }: { lanIp: string | null }) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+        textAlign: 'center',
+        gap: 8,
+      }}
+    >
+      <div
+        style={{
+          fontFamily: SANS_FAMILY,
+          fontSize: 14,
+          color: 'var(--t-text-secondary)',
+        }}
+      >
+        Type a URL above to load your dev server.
+      </div>
+      {lanIp ? (
+        <div
+          style={{
+            fontFamily: MONO_FAMILY,
+            fontSize: 12,
+            color: 'var(--t-text-muted)',
+          }}
+        >
+          LAN host: {lanIp}
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `DevHostFrame` for the mobile-split-shell right pane: iframe + Safari-style URL bar with custom address input, back/forward/reload (Phosphor SVG, no React icons), and port-aware typeahead pulled from `/api/panel/ports` + a new `/api/panel/lan-host` endpoint.
- New gated `GET /api/panel/lan-host` enumerates `os.networkInterfaces()` and returns the first non-loopback IPv4 in 192.168/16 → 10/8 → 172.16/12 (physical interfaces beat VPN tunnels), plus a deduped list of LAN-reachable dev ports via `lsof`.
- Iframe-hostile detection: 4s onload watchdog flips to a "This site blocks embedding" empty state with the URL + an external-open link. Whitelisted dev hosts (`localhost`, `127.`, `10.`, `172.16-31.`, `192.168.`, `*.local`, `*.localhost`) skip the timer entirely so heavy local bundles never misfire it.
- iOS PWA mixed-content guard: when the parent shell is on `https://` and the user types `http://192.168.x.x:3001`, we render a dedicated empty state explaining the Safari restriction (run o8 over `http://` from the dev box, or wait for the v2 mkcert proxy) instead of letting the request silently disappear.
- `forwardRef` exposes `back()`/`forward()`/`reload()` for the parent split-shell to drive (#779) — uses `iframe.contentWindow.history` and re-`src=`-on-reload because cross-origin frames throw on `location.reload()`.

## Implementation notes
- File ownership respected: only `src/components/mobile-split-shell/DevHostFrame.tsx` (793 lines, under 800 ceiling) and `src/app/api/panel/lan-host/route.ts` (136 lines). Did not touch `MobileSplitShell.tsx`, `landscape-controller.ts`, status-bar, push-url route, or any desktop component.
- Inline styles only, palette tokens (`var(--t-panel)` / `--t-input-bg` / `--t-text-muted` / `--t-panel-translucent` / etc.) — no hardcoded rgba whites or grays.
- Plus Jakarta Sans for chrome, `"SF Mono", Menlo, ui-monospace, monospace` for the URL input + suggestion hints + URL display in empty states (the codebase doesn't define a `--font-mono` CSS var; matched `MOBILE_CODE_FONT_FAMILY` from `ChatView.tsx`).
- iframe attrs: `sandbox="allow-scripts allow-same-origin allow-forms"`, `referrerpolicy="no-referrer"`, `allow="clipboard-read; clipboard-write"`.
- iOS-safe: `safe-area-inset-*` on URL bar padding + empty state, `100%` height with `min-height: 0` for the iframe container, `overscroll-behavior: contain` to keep the iframe from rubber-banding the parent shell.
- Endpoint sits under existing `/api/panel/*` middleware gate — loopback or `Authorization: Bearer <ws-token>`.

## Test plan
- [ ] On phone in landscape (after #779 lands and mounts the component), URL bar prefills to first repo-tagged LAN port → page loads → can interact with localhost dev server.
- [ ] Typing `https://github.com` in the URL bar → 4s timeout fires → "This site blocks embedding" empty state with the URL + Open externally link.
- [ ] Typing `192.168.1.42:3001` (no scheme) → auto-prefixed to `http://` → iframe loads.
- [ ] On https:// PWA host, typing `http://192.168.x.x:3001` → mixed-content empty state (no silent failure).
- [ ] Typeahead: focus URL input → suggestions list shows `${repo}:${port}` rows → click row → iframe.src updates.
- [ ] `GET /api/panel/lan-host` from loopback returns `{ lanIp, ports }`; cross-origin without bearer token returns 401.
- [ ] Imperative `ref.current.back()/forward()/reload()` cycle iframe history without console errors on cross-origin frames.

## Followup for #779
The split shell should `import { DevHostFrame, type DevHostFrameHandle } from '@/components/mobile-split-shell/DevHostFrame'`, mount it in the right pane with a `ref` so its toolbar can wire back/forward/reload, and pass `initialUrl` if the user has set one in settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)