### PR TITLE
feat(mobile): long-press port chip pushes URL to connected phone (closes #782)

### DIFF
--- a/src/app/api/mobile/push-url/route.ts
+++ b/src/app/api/mobile/push-url/route.ts
@@ -1,0 +1,170 @@
+/**
+ * POST /api/mobile/push-url
+ *
+ * Long-press a port chip on the desktop status bar, click "Send to mobile",
+ * and the URL is fanned out to every connected mobile client over WS. The
+ * mobile-split-shell listener consumes the broadcast and re-points the
+ * DevHostFrame iframe to the new URL.
+ *
+ * Issue: https://github.com/hurttlocker/cortex-ide/issues/782
+ *
+ * Body:
+ *   { url: string, sourceRepoId?: string | null }
+ *
+ * The URL is validated server-side: only LAN-style hosts are accepted
+ * (loopback, RFC1918 private ranges, *.local / *.localhost). Anything else
+ * is rejected with a 400 so a malicious caller can't push arbitrary
+ * external pages onto a phone. The middleware additionally gates this
+ * route on loopback / bearer token.
+ *
+ * On success, the WS server fans out a `mobile-dev-host` / `url-push`
+ * event with payload `{ url, sentAt, sourceRepoId }`.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getOrCreateWsToken } from '@/lib/ws-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const REALTIME_INTERNAL_ORIGIN =
+  process.env.CORTEX_REALTIME_INTERNAL_ORIGIN ?? 'http://127.0.0.1:3002';
+const REALTIME_INTERNAL_TIMEOUT_MS = 2_500;
+
+/**
+ * Returns true when the URL points at a host the user could plausibly be
+ * dev-running on the same LAN. Defense-in-depth — even an authorized
+ * caller cannot push https://example.com onto the phone.
+ *
+ * Allowed:
+ *   - http(s)://localhost(:port)
+ *   - http(s)://127.0.0.1(:port)
+ *   - http(s)://10.x.x.x(:port)
+ *   - http(s)://172.16.x.x – 172.31.x.x(:port)
+ *   - http(s)://192.168.x.x(:port)
+ *   - http(s)://*.local or *.localhost (mDNS / dev hostnames)
+ *   - http(s)://[::1] (IPv6 loopback)
+ */
+export function isLanDevHost(rawUrl: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return false;
+  }
+
+  // URL hostname keeps the brackets for IPv6 (e.g. "[::1]"). Normalize so
+  // the loopback check below works for both shapes.
+  const rawHost = parsed.hostname.toLowerCase();
+  const host = rawHost.startsWith('[') && rawHost.endsWith(']')
+    ? rawHost.slice(1, -1)
+    : rawHost;
+
+  // mDNS / dev hostnames.
+  if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.local')) {
+    return true;
+  }
+
+  // IPv6 loopback (after stripping brackets).
+  if (host === '::1') return true;
+
+  // Plain loopback v4.
+  if (host === '127.0.0.1' || host.startsWith('127.')) return true;
+
+  // RFC1918 — private LAN ranges.
+  if (host.startsWith('10.')) return true;
+  if (host.startsWith('192.168.')) return true;
+
+  if (host.startsWith('172.')) {
+    const parts = host.split('.');
+    if (parts.length === 4) {
+      const second = Number.parseInt(parts[1], 10);
+      if (Number.isFinite(second) && second >= 16 && second <= 31) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+interface PushUrlBody {
+  url?: string;
+  sourceRepoId?: string | null;
+}
+
+export async function POST(req: NextRequest) {
+  let body: PushUrlBody;
+  try {
+    body = (await req.json()) as PushUrlBody;
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: 'Invalid JSON body.' },
+      { status: 400 },
+    );
+  }
+
+  const url = typeof body.url === 'string' ? body.url.trim() : '';
+  if (!url) {
+    return NextResponse.json(
+      { ok: false, error: 'url is required.' },
+      { status: 400 },
+    );
+  }
+
+  if (!isLanDevHost(url)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          'Only LAN dev hosts can be pushed. Allowed: localhost, 127.0.0.1, 10.x, 172.16-31.x, 192.168.x, *.local, *.localhost.',
+      },
+      { status: 400 },
+    );
+  }
+
+  const sourceRepoId =
+    typeof body.sourceRepoId === 'string' && body.sourceRepoId.trim()
+      ? body.sourceRepoId.trim()
+      : null;
+  const sentAt = new Date().toISOString();
+
+  try {
+    const response = await fetch(`${REALTIME_INTERNAL_ORIGIN}/internal/mobile-url-push`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${getOrCreateWsToken()}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ url, sourceRepoId, sentAt }),
+      signal: AbortSignal.timeout(REALTIME_INTERNAL_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      console.error('[mobile/push-url] ws-server rejected push', response.status, detail);
+      return NextResponse.json(
+        { ok: false, error: 'Failed to broadcast URL to mobile clients.' },
+        { status: 502 },
+      );
+    }
+
+    const payload = (await response.json().catch(() => null)) as
+      | { ok?: boolean; recipients?: number }
+      | null;
+    const recipients =
+      payload && typeof payload.recipients === 'number' ? payload.recipients : 0;
+
+    return NextResponse.json({ ok: true, recipients, sentAt, url });
+  } catch (error) {
+    console.error('[mobile/push-url] internal fetch failed', error);
+    return NextResponse.json(
+      { ok: false, error: 'Realtime bridge unavailable.' },
+      { status: 502 },
+    );
+  }
+}

--- a/src/components/desktop/DesktopStatusBar.tsx
+++ b/src/components/desktop/DesktopStatusBar.tsx
@@ -17,7 +17,7 @@
 
 import { memo, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { GitBranch } from './lucide-shims';
+import { ChevronRight, Copy, GitBranch, Send } from './lucide-shims';
 import { ChartBar, FolderPlus, GearSix, WarningCircle } from '@phosphor-icons/react';
 import { ChromeButton } from './chrome/ChromeButton';
 import { formatBranchDisplayName } from './repo-registry/shared';
@@ -53,13 +53,28 @@ function portLabel(port: number): string {
  * Inline footer-anchored version of the old NavRail PortsFooter — polls the
  * same `/api/panel/ports` endpoint and refreshes on agent-lifecycle events.
  * The popover opens upward from the footer button.
+ *
+ * Long-press / right-click on a port row swaps the popover to an action
+ * panel with "Send to mobile" + "Copy URL" buttons (#782). Long-press
+ * threshold is 500ms (matches mobile haptic conventions).
  */
+const LONG_PRESS_MS = 500;
+
+type ActionTarget = { port: number; url: string; repo: string };
+type ActionToast = { tone: 'success' | 'error'; message: string } | null;
+
 function FooterPorts({ onPortPreview }: { onPortPreview?: DesktopStatusBarProps['onPortPreview'] }) {
   const [groups, setGroups] = useState<PortGroup[]>([]);
   const [total, setTotal] = useState(0);
   const [open, setOpen] = useState(false);
   const [popoverLeft, setPopoverLeft] = useState(120);
+  const [actionTarget, setActionTarget] = useState<ActionTarget | null>(null);
+  const [actionToast, setActionToast] = useState<ActionToast>(null);
+  const [sending, setSending] = useState(false);
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressFiredRef = useRef(false);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const anchorRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -85,6 +100,77 @@ function FooterPorts({ onPortPreview }: { onPortPreview?: DesktopStatusBarProps[
     };
   }, []);
 
+  useEffect(() => {
+    return () => {
+      if (longPressTimer.current) clearTimeout(longPressTimer.current);
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+    };
+  }, []);
+
+  const showActionToast = (toast: ActionToast) => {
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    setActionToast(toast);
+    if (toast) {
+      toastTimer.current = setTimeout(() => setActionToast(null), 2400);
+    }
+  };
+
+  const enterActionMode = (target: ActionTarget) => {
+    longPressFiredRef.current = true;
+    setActionTarget(target);
+    setActionToast(null);
+  };
+
+  const exitActionMode = () => {
+    setActionTarget(null);
+    setSending(false);
+  };
+
+  const sendToMobile = async (target: ActionTarget) => {
+    if (sending) return;
+    setSending(true);
+    try {
+      const response = await fetch('/api/mobile/push-url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: target.url, sourceRepoId: target.repo || null }),
+      });
+      const payload = (await response.json().catch(() => null)) as
+        | { ok?: boolean; recipients?: number; error?: string }
+        | null;
+      if (response.ok && payload?.ok) {
+        const recipients = typeof payload.recipients === 'number' ? payload.recipients : 0;
+        showActionToast(
+          recipients > 0
+            ? { tone: 'success', message: 'Sent to mobile' }
+            : { tone: 'error', message: 'No phone connected' },
+        );
+      } else {
+        const message = typeof payload?.error === 'string' && payload.error
+          ? payload.error
+          : 'Send failed';
+        showActionToast({ tone: 'error', message });
+      }
+    } catch {
+      showActionToast({ tone: 'error', message: 'Send failed' });
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const copyUrl = async (target: ActionTarget) => {
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(target.url);
+        showActionToast({ tone: 'success', message: 'Copied' });
+      } else {
+        showActionToast({ tone: 'error', message: 'Clipboard unavailable' });
+      }
+    } catch {
+      showActionToast({ tone: 'error', message: 'Copy failed' });
+    }
+  };
+
   if (total === 0) return null;
 
   const showPopover = () => {
@@ -96,7 +182,10 @@ function FooterPorts({ onPortPreview }: { onPortPreview?: DesktopStatusBarProps[
     setOpen(true);
   };
   const scheduleHide = () => {
-    hideTimer.current = setTimeout(() => setOpen(false), 200);
+    hideTimer.current = setTimeout(() => {
+      setOpen(false);
+      exitActionMode();
+    }, 200);
   };
 
   const ariaLabel = `${total} active port${total === 1 ? '' : 's'}`;
@@ -167,11 +256,62 @@ function FooterPorts({ onPortPreview }: { onPortPreview?: DesktopStatusBarProps[
           >
             {total} active port{total === 1 ? '' : 's'}
           </div>
-          {allPorts.map(({ port, repo }) => (
+          {actionTarget ? (
+            <PortActionPanel
+              target={actionTarget}
+              sending={sending}
+              toast={actionToast}
+              onSend={() => sendToMobile(actionTarget)}
+              onCopy={() => copyUrl(actionTarget)}
+              onBack={exitActionMode}
+            />
+          ) : null}
+          {!actionTarget && allPorts.map(({ port, repo }) => (
             <button
               key={`${repo}-${port}`}
               type="button"
+              onContextMenu={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                if (longPressTimer.current) {
+                  clearTimeout(longPressTimer.current);
+                  longPressTimer.current = null;
+                }
+                enterActionMode({ port, url: `http://localhost:${port}`, repo });
+              }}
+              onPointerDown={(event) => {
+                if (event.pointerType === 'mouse' && event.button !== 0) return;
+                longPressFiredRef.current = false;
+                if (longPressTimer.current) clearTimeout(longPressTimer.current);
+                longPressTimer.current = setTimeout(() => {
+                  longPressTimer.current = null;
+                  enterActionMode({ port, url: `http://localhost:${port}`, repo });
+                }, LONG_PRESS_MS);
+              }}
+              onPointerUp={() => {
+                if (longPressTimer.current) {
+                  clearTimeout(longPressTimer.current);
+                  longPressTimer.current = null;
+                }
+              }}
+              onPointerLeave={() => {
+                if (longPressTimer.current) {
+                  clearTimeout(longPressTimer.current);
+                  longPressTimer.current = null;
+                }
+              }}
+              onPointerCancel={() => {
+                if (longPressTimer.current) {
+                  clearTimeout(longPressTimer.current);
+                  longPressTimer.current = null;
+                }
+              }}
               onClick={() => {
+                // Long-press already opened the action panel — don't also navigate.
+                if (longPressFiredRef.current) {
+                  longPressFiredRef.current = false;
+                  return;
+                }
                 setOpen(false);
                 const url = `http://localhost:${port}`;
                 if (onPortPreview) {
@@ -198,7 +338,10 @@ function FooterPorts({ onPortPreview }: { onPortPreview?: DesktopStatusBarProps[
                 cursor: 'pointer',
                 textAlign: 'left',
                 fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+                userSelect: 'none',
+                WebkitUserSelect: 'none',
               }}
+              title="Click to preview · Long-press or right-click for actions"
               onMouseEnter={(event) => { event.currentTarget.style.background = 'var(--t-panel-hover)'; }}
               onMouseLeave={(event) => { event.currentTarget.style.background = 'transparent'; }}
             >
@@ -226,6 +369,167 @@ function FooterPorts({ onPortPreview }: { onPortPreview?: DesktopStatusBarProps[
           ))}
         </div>,
         document.body,
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Action panel shown inside the ports popover after a long-press / right-click
+ * on a port row. Two actions: send the dev-host URL to the connected mobile
+ * client (#782) or copy the URL to the clipboard. The inline toast clears
+ * itself after ~2.4s.
+ */
+function PortActionPanel({
+  target,
+  sending,
+  toast,
+  onSend,
+  onCopy,
+  onBack,
+}: {
+  target: ActionTarget;
+  sending: boolean;
+  toast: ActionToast;
+  onSend: () => void;
+  onCopy: () => void;
+  onBack: () => void;
+}) {
+  const headerStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+    paddingTop: 4,
+    paddingRight: 6,
+    paddingBottom: 6,
+    paddingLeft: 6,
+    fontSize: 11,
+    fontWeight: 600,
+    color: 'var(--t-text-faint)',
+    letterSpacing: '-0.01em',
+  } as const;
+
+  const actionRowStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    width: '100%',
+    paddingTop: 7,
+    paddingRight: 8,
+    paddingBottom: 7,
+    paddingLeft: 8,
+    borderWidth: 0,
+    borderRadius: 6,
+    background: 'transparent',
+    color: 'var(--t-text)',
+    fontSize: 12,
+    fontWeight: 500,
+    cursor: 'pointer',
+    textAlign: 'left' as const,
+    fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+  };
+
+  const toastTone = toast?.tone === 'success' ? '#16a34a' : '#dc2626';
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <div style={headerStyle}>
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Back to port list"
+          title="Back"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 18,
+            height: 18,
+            borderRadius: 4,
+            borderWidth: 0,
+            background: 'transparent',
+            color: 'var(--t-text-faint)',
+            cursor: 'pointer',
+            transform: 'scaleX(-1)',
+          }}
+          onMouseEnter={(event) => { event.currentTarget.style.background = 'var(--t-panel-hover)'; }}
+          onMouseLeave={(event) => { event.currentTarget.style.background = 'transparent'; }}
+        >
+          <ChevronRight size={11} strokeWidth={2} />
+        </button>
+        <span style={{ flex: 1 }}>{portLabel(target.port)}</span>
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 600,
+            color: 'var(--t-text-faint)',
+            fontFamily: '"SF Mono", ui-monospace, monospace',
+          }}
+        >
+          :{target.port}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={onSend}
+        disabled={sending}
+        style={{
+          ...actionRowStyle,
+          opacity: sending ? 0.6 : 1,
+          cursor: sending ? 'progress' : 'pointer',
+        }}
+        onMouseEnter={(event) => {
+          if (!sending) event.currentTarget.style.background = 'var(--t-panel-hover)';
+        }}
+        onMouseLeave={(event) => { event.currentTarget.style.background = 'transparent'; }}
+      >
+        <Send size={12} strokeWidth={1.8} />
+        <span style={{ flex: 1 }}>{sending ? 'Sending…' : 'Send to mobile'}</span>
+      </button>
+      <button
+        type="button"
+        onClick={onCopy}
+        style={actionRowStyle}
+        onMouseEnter={(event) => { event.currentTarget.style.background = 'var(--t-panel-hover)'; }}
+        onMouseLeave={(event) => { event.currentTarget.style.background = 'transparent'; }}
+      >
+        <Copy size={12} strokeWidth={1.8} />
+        <span style={{ flex: 1 }}>Copy URL</span>
+      </button>
+      <div
+        style={{
+          paddingTop: 4,
+          paddingRight: 8,
+          paddingBottom: 4,
+          paddingLeft: 8,
+          fontSize: 10,
+          fontWeight: 500,
+          color: 'var(--t-text-faint)',
+          fontFamily: '"SF Mono", ui-monospace, monospace',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {target.url}
+      </div>
+      {toast ? (
+        <div
+          role="status"
+          style={{
+            paddingTop: 6,
+            paddingRight: 8,
+            paddingBottom: 6,
+            paddingLeft: 8,
+            marginTop: 2,
+            fontSize: 11,
+            fontWeight: 600,
+            color: toastTone,
+            letterSpacing: '-0.01em',
+          }}
+        >
+          {toast.message}
+        </div>
       ) : null}
     </div>
   );

--- a/src/components/mobile-split-shell/url-push-listener.ts
+++ b/src/components/mobile-split-shell/url-push-listener.ts
@@ -1,0 +1,204 @@
+/**
+ * Mobile dev-host URL-push listener.
+ *
+ * Subscribes to the `mobile-dev-host` WS channel (broadcast from
+ * `/api/mobile/push-url` via the ws-server `/internal/mobile-url-push`
+ * endpoint) and re-fans each event out as a `o8:mobile-url-push` window
+ * CustomEvent so the DevHostFrame (#781) and MobileSplitShell (#779) can
+ * react without coupling to the WS plumbing.
+ *
+ * Issue: https://github.com/hurttlocker/cortex-ide/issues/782
+ *
+ * Why a self-contained WS connection?
+ *   The mobile split-shell shares its primary WebSocket via the existing
+ *   `useWebSocket` hook in src/components/mobile/hooks/useWebSocket.ts.
+ *   That hook is owned by a parallel agent and we cannot modify it from
+ *   this slot, so this listener opens its own minimal connection just for
+ *   the dev-host channel. The connection is cheap (one socket per device),
+ *   auto-reconnects with exponential backoff, and never holds onto state.
+ *
+ * Contract for #781 (DevHostFrame) — listen for the window event:
+ *
+ *   window.addEventListener('o8:mobile-url-push', (event) => {
+ *     const { url, sentAt, sourceRepoId } = (event as CustomEvent<{
+ *       url: string;
+ *       sentAt: string;
+ *       sourceRepoId: string | null;
+ *     }>).detail;
+ *     // Re-point the dev-host iframe.
+ *   });
+ *
+ * Contract for #779 (MobileSplitShell) — mount this listener inside a
+ * useEffect on the landscape PWA route:
+ *
+ *   useEffect(() => attachMobileUrlPushListener({
+ *     onUrlReady: (detail) => { setLatestUrl(detail.url); },
+ *   }), []);
+ */
+
+import { useEffect } from 'react';
+import { getBrowserWsPort } from '@/lib/panel/ws-port-client';
+import { triggerHaptic } from '@/lib/mobile/haptic';
+
+export const MOBILE_URL_PUSH_EVENT = 'o8:mobile-url-push' as const;
+
+export interface MobileUrlPushDetail {
+  url: string;
+  sentAt: string;
+  sourceRepoId: string | null;
+}
+
+interface AttachOptions {
+  /**
+   * Optional handler for in-component reactions (banners, haptics, state
+   * sync). Called AFTER the global window event has been dispatched, so
+   * any listener bound via addEventListener already received the payload.
+   */
+  onUrlReady?: (detail: MobileUrlPushDetail) => void;
+  /**
+   * When true (default), trigger a `success` haptic on receipt. Disable
+   * for surfaces that already buzz from a different signal.
+   */
+  haptic?: boolean;
+}
+
+const INITIAL_BACKOFF_MS = 1_000;
+const MAX_BACKOFF_MS = 30_000;
+
+function readWsToken(): string {
+  if (typeof document === 'undefined') return '';
+  const meta = document.querySelector('meta[name="ws-token"]');
+  return meta?.getAttribute('content') ?? '';
+}
+
+function buildWsUrl(): string | null {
+  if (typeof window === 'undefined') return null;
+  const { hostname, protocol } = window.location;
+  const wsProto = protocol === 'https:' ? 'wss' : 'ws';
+  const token = readWsToken();
+  if (!token) return null;
+  return `${wsProto}://${hostname}:${getBrowserWsPort()}/ws?token=${encodeURIComponent(token)}`;
+}
+
+function isMobileUrlPushDetail(value: unknown): value is MobileUrlPushDetail {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.url === 'string' && typeof candidate.sentAt === 'string';
+}
+
+/**
+ * Attach the listener imperatively. Returns a cleanup function. Safe to
+ * call from any component that mounts on the landscape route.
+ */
+export function attachMobileUrlPushListener(options: AttachOptions = {}): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  let socket: WebSocket | null = null;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let backoffMs = INITIAL_BACKOFF_MS;
+  let disposed = false;
+
+  const dispatch = (detail: MobileUrlPushDetail) => {
+    window.dispatchEvent(new CustomEvent<MobileUrlPushDetail>(MOBILE_URL_PUSH_EVENT, { detail }));
+    if (options.haptic !== false) {
+      try {
+        triggerHaptic('success');
+      } catch {
+        // Haptic API can throw in unusual webviews — non-fatal.
+      }
+    }
+    try {
+      options.onUrlReady?.(detail);
+    } catch (error) {
+      console.warn('[mobile-url-push] onUrlReady handler threw', error);
+    }
+  };
+
+  const handleMessage = (event: MessageEvent) => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(typeof event.data === 'string' ? event.data : '');
+    } catch {
+      return;
+    }
+    if (!parsed || typeof parsed !== 'object') return;
+    const message = parsed as { channel?: unknown; event?: unknown; data?: unknown };
+    if (message.channel !== 'mobile-dev-host' || message.event !== 'url-push') return;
+    const data = message.data;
+    if (!isMobileUrlPushDetail(data)) return;
+    dispatch({
+      url: data.url,
+      sentAt: data.sentAt,
+      sourceRepoId: data.sourceRepoId ?? null,
+    });
+  };
+
+  const scheduleReconnect = () => {
+    if (disposed) return;
+    if (reconnectTimer) return;
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      connect();
+    }, backoffMs);
+    backoffMs = Math.min(MAX_BACKOFF_MS, backoffMs * 2);
+  };
+
+  const connect = () => {
+    if (disposed) return;
+    const url = buildWsUrl();
+    if (!url) {
+      scheduleReconnect();
+      return;
+    }
+    try {
+      socket = new WebSocket(url);
+    } catch (error) {
+      console.warn('[mobile-url-push] WebSocket open failed', error);
+      scheduleReconnect();
+      return;
+    }
+    socket.addEventListener('open', () => {
+      backoffMs = INITIAL_BACKOFF_MS;
+    });
+    socket.addEventListener('message', handleMessage);
+    socket.addEventListener('close', () => {
+      socket = null;
+      scheduleReconnect();
+    });
+    socket.addEventListener('error', () => {
+      // The close handler will fire next and trigger reconnection.
+    });
+  };
+
+  connect();
+
+  return () => {
+    disposed = true;
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    if (socket) {
+      try {
+        socket.close();
+      } catch {
+        // Ignored — close failures are harmless once the page unmounts.
+      }
+      socket = null;
+    }
+  };
+}
+
+/**
+ * React hook wrapper around `attachMobileUrlPushListener`. Mount once at
+ * the landscape root inside MobileSplitShell so the dev-host iframe can
+ * stay decoupled from WS plumbing.
+ */
+export function useMobileUrlPushListener(options: AttachOptions = {}): void {
+  const { onUrlReady, haptic } = options;
+  useEffect(() => {
+    return attachMobileUrlPushListener({ onUrlReady, haptic });
+  }, [onUrlReady, haptic]);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -129,6 +129,9 @@ const GATED_PREFIXES = [
   // Push subscription writes mutate stored push endpoints + can fan out test
   // notifications. /api/mobile/push/public-key is read-only allow-listed above.
   '/api/mobile/push/',
+  // Send-to-mobile URL push (#782). Loopback writes from the desktop chip
+  // pass; cross-origin must present the bearer token.
+  '/api/mobile/push-url',
 ];
 
 function isLoopbackHost(hostname?: string | null): boolean {

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -3085,6 +3085,62 @@ const httpServer = createServer((req, res) => {
     return;
   }
 
+  // ── Mobile dev-host URL push ──
+  // Invoked by /api/mobile/push-url after a desktop user long-presses a port
+  // chip and clicks "Send to mobile". Fans out a one-shot `mobile-dev-host`
+  // event to every WS client; the mobile-split-shell listener then dispatches
+  // the matching `o8:mobile-url-push` window CustomEvent for DevHostFrame.
+  if (req.url === '/internal/mobile-url-push' && req.method === 'POST') {
+    if (!isAuthorizedInternalRequest(req)) {
+      res.writeHead(401);
+      res.end('unauthorized');
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+    req.on('end', () => {
+      try {
+        const body = JSON.parse(Buffer.concat(chunks).toString('utf-8')) as {
+          url?: string;
+          sourceRepoId?: string | null;
+          sentAt?: string;
+        };
+        const url = typeof body.url === 'string' ? body.url.trim() : '';
+        if (!url) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: false, error: 'url required' }));
+          return;
+        }
+        const sentAt = typeof body.sentAt === 'string' && body.sentAt.trim()
+          ? body.sentAt
+          : currentIsoTime();
+        const sourceRepoId = typeof body.sourceRepoId === 'string' && body.sourceRepoId.trim()
+          ? body.sourceRepoId.trim()
+          : null;
+
+        // Count active clients before broadcasting so the desktop toast can
+        // tell the user "no phone connected" without depending on PWA pings.
+        const recipients = clients.size;
+        broadcast({
+          channel: 'mobile-dev-host',
+          event: 'url-push',
+          data: { url, sentAt, sourceRepoId },
+        });
+
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, recipients, sentAt }));
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          ok: false,
+          error: err instanceof Error ? err.message : 'invalid json',
+        }));
+      }
+    });
+    return;
+  }
+
   // Health check endpoint
   if (req.url === '/health') {
     res.writeHead(200, { 'Content-Type': 'application/json' });


### PR DESCRIPTION
## Summary
- Long-press (>=500ms) or right-click a port row in the desktop status-bar ports popover to swap to an action panel with "Send to mobile" + "Copy URL". Click still preserves the existing preview-pane behavior.
- New gated route `POST /api/mobile/push-url` validates LAN-only URLs (loopback, RFC1918 private ranges, `*.local`, `*.localhost`, `[::1]`) and rejects everything else with a 400 + actionable error.
- ws-server gains an internal `/internal/mobile-url-push` endpoint that broadcasts on a new `mobile-dev-host` / `url-push` channel; payload is `{ url, sentAt, sourceRepoId }` and the response reports the active recipient count so the desktop toast can say "No phone connected" without depending on PWA pings.
- New `src/components/mobile-split-shell/url-push-listener.ts` opens a self-contained WS subscription on the landscape route and re-fans each event out as a `o8:mobile-url-push` `window` CustomEvent + a soft success haptic. #779/#781 mount it via `useMobileUrlPushListener()` or `attachMobileUrlPushListener()` without touching this listener directly.

## Coordination notes
- Did NOT modify `MobileSplitShell.tsx` (#779) or `DevHostFrame.tsx` (#781). The contract is the `o8:mobile-url-push` window event documented in `url-push-listener.ts`.
- Reused the existing `broadcast()` helper inside ws-server — no new realtime envelope channel was added.

## Test plan
- [ ] Run `npm run dev`, open the desktop dashboard with at least one dev port detected.
- [ ] Hover the port chip → popover lists ports. Right-click a row → action panel appears with "Send to mobile" + "Copy URL". Long-press (touch) reaches the same panel after ~500ms.
- [ ] Click "Send to mobile" with no phone connected → toast reads "No phone connected".
- [ ] Open the mobile shell on a LAN device, mount `useMobileUrlPushListener({ onUrlReady: console.log })`, click "Send to mobile" again → window event fires and the listener logs `{ url, sentAt, sourceRepoId }`. Haptic buzz on the phone.
- [ ] `POST /api/mobile/push-url` with `{ url: "https://example.com" }` from `curl --no-keepalive http://localhost:3001/...` (loopback, no token) → 400 "Only LAN dev hosts can be pushed".
- [ ] Cross-origin LAN POST without bearer → 401 (middleware-gated).
- [ ] `npx tsc --noEmit` and `npx eslint <touched files>` both clean (verified locally).

Closes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)