### PR TITLE
feat(mobile): Browser tab gates the chat+iframe split (closes #786)

### DIFF
--- a/src/components/mobile-remote-shell.tsx
+++ b/src/components/mobile-remote-shell.tsx
@@ -8,6 +8,7 @@ import {
   useState,
   lazy,
   type CSSProperties,
+  type ReactNode,
 } from 'react';
 import type { RuntimeReviewPacket } from '@/lib/fleet/types';
 import type { MobileInboxSnapshot, MobileReviewFileResponse, MobileTranscriptEntry } from '@/lib/mobile/types';
@@ -26,7 +27,7 @@ import { ShimmerCard } from './mobile/ShimmerCard';
 import { AlertProvider, useAlerts } from '@/lib/alerts/context';
 import { AlertTray } from '@/components/shared/AlertTray';
 import { type MobileScreen } from './mobile/SpeedDial';
-import { MobileSplitShell } from './mobile-split-shell/MobileSplitShell';
+import { MobileBrowserTabRoot } from './mobile-split-shell/MobileBrowserTabRoot';
 
 // Lazy-loaded panels — only loaded when opened (#45)
 const shimmerFallback = { loading: () => <ShimmerCard /> };
@@ -47,7 +48,7 @@ const SettingsView = lazy(async () => ({ default: (await import('./mobile/Settin
 const IssuesPage = lazy(() => import('./mobile/IssuesPage'));
 const OrchestratorView = dynamic(() => import('./mobile/OrchestratorView').then((m) => ({ default: m.OrchestratorView })), { ssr: false, ...shimmerFallback });
 
-const BETA_ENABLED_VIEWS = new Set(['fleet', 'activity', 'settings', 'orchestrator']);
+const BETA_ENABLED_VIEWS = new Set(['fleet', 'activity', 'settings', 'orchestrator', 'browser']);
 const MOBILE_SESSION_LIST_WINDOW_MS = 24 * 60 * 60 * 1000;
 const MOBILE_SESSION_LIST_LIMIT = 20;
 const MOBILE_INITIAL_INBOX_LIMIT = 15;
@@ -65,17 +66,13 @@ import {
 } from './mobile/neomorph';
 
 export function MobileRemoteShell(props: MobileRemoteShellProps) {
-  // MobileSplitShell is a transparent passthrough in portrait — it only
-  // adds chrome (right pane + drag handle) when the device rotates to
-  // landscape and matches the (orientation: landscape) and (min-width:
-  // 720px) media query. Wrapping at this layer keeps MobileRemoteShellInner
-  // mounted at the same React tree depth across rotations, so transcript,
-  // draft, and scroll state survive (closes #779).
+  // The chat-left + iframe-right split is now opt-in via the Browser tab
+  // (closes #786). MobileBrowserTabRoot is mounted only when activeView
+  // === 'browser' inside MobileRemoteShellInner — every other tab renders
+  // the regular portrait shell unchanged.
   return (
     <AlertProvider>
-      <MobileSplitShell>
-        <MobileRemoteShellInner {...props} />
-      </MobileSplitShell>
+      <MobileRemoteShellInner {...props} />
     </AlertProvider>
   );
 }
@@ -180,6 +177,27 @@ function buildVisibleMobileSessionList(sessions: MobileInboxSnapshot['sessions']
   }
 
   return [...activeSessions, ...recentSessions].slice(0, MOBILE_SESSION_LIST_LIMIT);
+}
+
+// Conditional wrapper for the Browser tab: when active, mounts
+// MobileBrowserTabRoot (which owns the chat-left + iframe-right split via
+// MobileSplitShell + the orientation-lock attempt + the portrait hint
+// banner). On every other tab this is a transparent passthrough so the
+// regular shell renders unchanged. Defined as a component (not an inline
+// ternary) so the chat surface JSX isn't duplicated (closes #786).
+function BrowserTabConditionalWrap({
+  isBrowserTab,
+  onBack,
+  children,
+}: {
+  isBrowserTab: boolean;
+  onBack: () => void;
+  children: ReactNode;
+}) {
+  if (!isBrowserTab) {
+    return <>{children}</>;
+  }
+  return <MobileBrowserTabRoot onBack={onBack}>{children}</MobileBrowserTabRoot>;
 }
 
 function MobileRemoteShellInner({
@@ -403,7 +421,11 @@ function MobileRemoteShellInner({
   const hasTerminalSession = Boolean(selectedSession?.tmuxSession);
   const showBetaPlaceholder = !BETA_ENABLED_VIEWS.has(activeView);
   const isIndexView = activeView === 'squad';
-  const isThreadView = activeView === 'chat';
+  // Treat the Browser tab the same as the Chat tab for showing thread
+  // surfaces — Browser is a chat+iframe split, so the left pane needs the
+  // full chat affordances (transcript, composer, etc.). The right pane is
+  // injected by MobileBrowserTabRoot via MobileSplitShell.
+  const isThreadView = activeView === 'chat' || activeView === 'browser';
   const showRecentPicker = !showBetaPlaceholder && (isIndexView || (isThreadView && !selectedSession));
   const isSessionListSurface = showBetaPlaceholder || showRecentPicker || activeView === 'fleet';
   const showThreadSurface = !showBetaPlaceholder && isThreadView && Boolean(selectedSession);
@@ -626,7 +648,7 @@ function MobileRemoteShellInner({
           activeView={activeView}
           compactLine={compactLine}
           enabledViews={BETA_ENABLED_VIEWS}
-          activeScreen={activeView === 'costs' ? 'costs' : activeView === 'fleet' ? 'fleet' : activeView === 'activity' ? 'approvals' : activeView === 'settings' ? 'settings' : activeView === 'issues' ? 'issues' : activeView === 'orchestrator' ? 'orchestrator' : 'chat'}
+          activeScreen={activeView === 'costs' ? 'costs' : activeView === 'fleet' ? 'fleet' : activeView === 'activity' ? 'approvals' : activeView === 'settings' ? 'settings' : activeView === 'issues' ? 'issues' : activeView === 'orchestrator' ? 'orchestrator' : activeView === 'browser' ? 'browser' : 'chat'}
           onNavigate={(screen: MobileScreen) => {
             switch (screen) {
               case 'chat':
@@ -650,6 +672,9 @@ function MobileRemoteShellInner({
               case 'orchestrator':
                 setActiveView('orchestrator');
                 break;
+              case 'browser':
+                setActiveView('browser');
+                break;
             }
           }}
           onNewChat={showBetaPlaceholder ? undefined : handleCreateNewChat}
@@ -658,7 +683,10 @@ function MobileRemoteShellInner({
         {activeView === 'orchestrator' ? (
           <OrchestratorView onBack={returnToHome} />
         ) : (
-        <>
+        <BrowserTabConditionalWrap
+          isBrowserTab={activeView === 'browser'}
+          onBack={returnToHome}
+        >
         <PullToRefresh onRefresh={async () => { await refreshInbox(true); await new Promise(r => setTimeout(r, 600)); }}>
         <PageTransition activeKey={activeView}>
         <div style={scrollViewStyle}>
@@ -908,7 +936,7 @@ function MobileRemoteShellInner({
             </div>
           ) : null}
         </div>
-        </>
+        </BrowserTabConditionalWrap>
         )}
       </div>
       <ControlsSheet

--- a/src/components/mobile-split-shell/MobileBrowserTabRoot.tsx
+++ b/src/components/mobile-split-shell/MobileBrowserTabRoot.tsx
@@ -1,0 +1,326 @@
+'use client';
+
+/**
+ * MobileBrowserTabRoot — wraps the existing MobileSplitShell behind an
+ * explicit Browser tab in the mobile bottom nav (closes #786).
+ *
+ * Behavior contract:
+ *   - On mount, attempt `screen.orientation.lock('landscape')` (best-effort,
+ *     wrapped in try/catch — never throws, never blocks render).
+ *   - On unmount, attempt `screen.orientation.unlock()` (same try/catch).
+ *   - In landscape, mount MobileSplitShell as-is — children become the left
+ *     pane, DevHostFrame ships on the right (the existing #779 layout).
+ *   - In portrait, render a dismissible banner ("Rotate to landscape") +
+ *     a vertical stack of children (chat) on top and the iframe below.
+ *     Banner dismissal persists to localStorage.
+ *
+ * What we don't do:
+ *   - Modify MobileSplitShell.tsx, DevHostFrame.tsx, landscape-controller.ts,
+ *     or url-push-listener.ts. They stay exactly as #779/#781/#782 shipped.
+ *
+ * Hard rules honored:
+ *   - inline styles only / palette tokens for surfaces
+ *   - Plus Jakarta Sans for chrome; Phosphor SVG drawn inline
+ *   - 100dvh + safe-area-inset-* iOS-safe layout
+ *   - File ceiling 800 lines (this file is well under)
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from 'react';
+import { MobileSplitShell } from './MobileSplitShell';
+import { useLandscapeSplit } from './landscape-controller';
+import { DevHostFrame } from './DevHostFrame';
+import { useMobileUrlPushListener } from './url-push-listener';
+
+const FONT_STACK = '"Plus Jakarta Sans", system-ui, -apple-system, "Segoe UI", sans-serif';
+const HINT_DISMISSED_KEY = 'o8:mobile-browser:landscape-hint-dismissed';
+
+// Shape of `screen.orientation` that we touch. The DOM lib types ship a
+// readonly OrientationLockType union; declaring a narrowed shape here lets
+// us call `.lock()` / `.unlock()` without ts-ignoring the call sites and
+// keeps the try/catch tight.
+interface OrientationLockTarget {
+  lock?: (orientation: 'landscape') => Promise<void>;
+  unlock?: () => void;
+}
+
+function getOrientationTarget(): OrientationLockTarget | null {
+  if (typeof window === 'undefined') return null;
+  // `screen.orientation` is missing on iOS Safari < 16.4 and inside locked
+  // PWA chrome — we treat both as no-op surfaces.
+  const candidate = (window.screen as unknown as { orientation?: OrientationLockTarget }).orientation;
+  return candidate ?? null;
+}
+
+function attemptLandscapeLock(): void {
+  const target = getOrientationTarget();
+  if (!target?.lock) return;
+  try {
+    const promise = target.lock('landscape');
+    if (promise && typeof promise.catch === 'function') {
+      // Lock can reject in non-fullscreen PWAs / Safari — swallow silently.
+      promise.catch(() => undefined);
+    }
+  } catch {
+    // Some browsers throw synchronously. Best-effort means best-effort.
+  }
+}
+
+function attemptOrientationUnlock(): void {
+  const target = getOrientationTarget();
+  if (!target?.unlock) return;
+  try {
+    target.unlock();
+  } catch {
+    // Same swallow rule — never block tab teardown.
+  }
+}
+
+function readHintDismissed(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(HINT_DISMISSED_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function writeHintDismissed(value: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (value) {
+      window.localStorage.setItem(HINT_DISMISSED_KEY, '1');
+    } else {
+      window.localStorage.removeItem(HINT_DISMISSED_KEY);
+    }
+  } catch {
+    // Storage may be disabled — swallow.
+  }
+}
+
+interface MobileBrowserTabRootProps {
+  children: ReactNode;
+  onBack?: () => void;
+}
+
+export function MobileBrowserTabRoot({ children, onBack }: MobileBrowserTabRootProps) {
+  const { isSplit } = useLandscapeSplit();
+  const [hintDismissed, setHintDismissed] = useState<boolean>(() => readHintDismissed());
+
+  // Fire-and-forget orientation lock. The actual lock might be denied by
+  // Safari / iOS PWA — if it succeeds the user feels snappy, if it fails
+  // the hint banner picks up the slack.
+  useEffect(() => {
+    attemptLandscapeLock();
+    return () => {
+      attemptOrientationUnlock();
+    };
+  }, []);
+
+  const dismissHint = useCallback(() => {
+    setHintDismissed(true);
+    writeHintDismissed(true);
+  }, []);
+
+  if (isSplit) {
+    // Landscape — defer entirely to MobileSplitShell. It already paints the
+    // chat-left + DevHostFrame-right layout, handles drag-resize, and owns
+    // the URL-push WS listener inside its inner SplitLayout component (so
+    // we don't open a second WebSocket in this branch).
+    return <MobileSplitShell>{children}</MobileSplitShell>;
+  }
+
+  // Portrait fallback — vertical stack: chat on top, iframe below, with an
+  // optional hint banner offering rotation. Dismissal is sticky so the
+  // user only ever sees it once. We mount the URL-push listener inside the
+  // fallback (and not at the root of MobileBrowserTabRoot) so we don't open
+  // a duplicate WS to the one MobileSplitShell already opens in landscape.
+  return (
+    <PortraitFallback
+      hintDismissed={hintDismissed}
+      onDismissHint={dismissHint}
+      onBack={onBack}
+    >
+      {children}
+    </PortraitFallback>
+  );
+}
+
+interface PortraitFallbackProps {
+  children: ReactNode;
+  hintDismissed: boolean;
+  onDismissHint: () => void;
+  onBack?: () => void;
+}
+
+function PortraitFallback({ children, hintDismissed, onDismissHint, onBack }: PortraitFallbackProps) {
+  // Subscribe to send-to-mobile URL pushes (#782) so the iframe re-points
+  // when desktop fires a long-press push. We mount it here (instead of at
+  // the MobileBrowserTabRoot level) because in landscape MobileSplitShell
+  // already opens its own listener, and we don't want two WebSockets per
+  // device.
+  useMobileUrlPushListener();
+
+  // We use a fixed full-viewport container so the chat surface and iframe
+  // live in their own scroll/positioning contexts. iOS dynamic viewport is
+  // covered by 100dvh with a 100vh fallback for older Safaris. The top
+  // padding leaves room for the floating TopBar (44px button + 8px offset
+  // above safe-area), so the hint banner and chat pane don't slide under
+  // it.
+  const containerStyle: CSSProperties = {
+    position: 'fixed',
+    inset: 0,
+    height: '100dvh',
+    minHeight: '100vh',
+    width: '100vw',
+    display: 'grid',
+    gridTemplateRows: hintDismissed ? '1fr 1fr' : 'auto 1fr 1fr',
+    background: 'var(--t-bg, #111111)',
+    paddingTop: 'calc(env(safe-area-inset-top, 0px) + 64px)',
+    paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+    paddingLeft: 'env(safe-area-inset-left, 0px)',
+    paddingRight: 'env(safe-area-inset-right, 0px)',
+    isolation: 'isolate',
+    overflow: 'hidden',
+  };
+
+  const chatPaneStyle: CSSProperties = {
+    position: 'relative',
+    minHeight: 0,
+    overflow: 'hidden',
+    transform: 'translateZ(0)',
+    isolation: 'isolate',
+  };
+
+  const iframePaneStyle: CSSProperties = {
+    position: 'relative',
+    minHeight: 0,
+    overflow: 'hidden',
+    background: 'var(--t-panel, rgba(30,28,26,0.82))',
+    color: 'var(--t-text, #FAF5F0)',
+    borderTop: '1px solid var(--t-border, rgba(255,248,240,0.08))',
+    transform: 'translateZ(0)',
+  };
+
+  return (
+    <div style={containerStyle}>
+      {hintDismissed ? null : (
+        <RotateHintBanner onDismiss={onDismissHint} onBack={onBack} />
+      )}
+      <div style={chatPaneStyle}>{children}</div>
+      <div style={iframePaneStyle}>
+        <DevHostFrame />
+      </div>
+    </div>
+  );
+}
+
+interface RotateHintBannerProps {
+  onDismiss: () => void;
+  onBack?: () => void;
+}
+
+function RotateHintBanner({ onDismiss, onBack }: RotateHintBannerProps) {
+  const wrapStyle: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+    padding: '10px 12px',
+    margin: '8px 12px 0',
+    borderRadius: 12,
+    background: 'var(--t-bg-card, rgba(46,42,38,0.62))',
+    border: '1px solid var(--t-border, rgba(255,248,240,0.10))',
+    color: 'var(--t-text, #FAF5F0)',
+    fontFamily: FONT_STACK,
+  };
+
+  const iconWrapStyle: CSSProperties = {
+    width: 28,
+    height: 28,
+    flexShrink: 0,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 8,
+    color: 'var(--t-text-muted, rgba(255,248,240,0.62))',
+  };
+
+  const textStyle: CSSProperties = {
+    flex: 1,
+    minWidth: 0,
+    fontSize: 13,
+    lineHeight: 1.35,
+    letterSpacing: '-0.01em',
+  };
+
+  const buttonRowStyle: CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 6,
+  };
+
+  const baseChipStyle: CSSProperties = {
+    minHeight: 32,
+    padding: '6px 10px',
+    borderRadius: 8,
+    border: '1px solid var(--t-border, rgba(255,248,240,0.10))',
+    background: 'transparent',
+    color: 'var(--t-text, #FAF5F0)',
+    fontFamily: FONT_STACK,
+    fontSize: 12,
+    fontWeight: 600,
+    letterSpacing: '-0.01em',
+    cursor: 'pointer',
+    WebkitTapHighlightColor: 'transparent',
+  };
+
+  return (
+    <div style={wrapStyle} role="status" aria-live="polite">
+      <span style={iconWrapStyle} aria-hidden="true">
+        {/* Phosphor "DeviceMobile" tilt — drawn inline. */}
+        <svg
+          viewBox="0 0 256 256"
+          width="18"
+          height="18"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="14"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <rect
+            x="56"
+            y="32"
+            width="144"
+            height="192"
+            rx="16"
+            transform="rotate(15 128 128)"
+          />
+          <line x1="100" y1="208" x2="156" y2="208" transform="rotate(15 128 128)" />
+        </svg>
+      </span>
+      <span style={textStyle}>Rotate to landscape for the split view</span>
+      <span style={buttonRowStyle}>
+        {onBack ? (
+          <button type="button" onClick={onBack} style={baseChipStyle} aria-label="Back to chat">
+            Back
+          </button>
+        ) : null}
+        <button
+          type="button"
+          onClick={onDismiss}
+          style={baseChipStyle}
+          aria-label="Dismiss rotation hint"
+        >
+          Got it
+        </button>
+      </span>
+    </div>
+  );
+}

--- a/src/components/mobile/SpeedDial.tsx
+++ b/src/components/mobile/SpeedDial.tsx
@@ -3,7 +3,7 @@
 import { useState, memo, type CSSProperties } from 'react';
 import { useTheme } from './ThemeContext';
 
-export type MobileScreen = 'chat' | 'fleet' | 'approvals' | 'costs' | 'settings' | 'issues' | 'orchestrator';
+export type MobileScreen = 'chat' | 'fleet' | 'approvals' | 'costs' | 'settings' | 'issues' | 'orchestrator' | 'browser';
 
 interface SpeedDialProps {
   activeScreen: MobileScreen;
@@ -28,6 +28,12 @@ const MENU_ITEMS: { screen: MobileScreen; label: string; iconPath: string }[] = 
     screen: 'fleet',
     label: 'Agents',
     iconPath: 'M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2 M9 7a4 4 0 1 0 0-8 4 4 0 0 0 0 8 M23 21v-2a4 4 0 0 0-3-3.87 M16 3.13a4 4 0 0 1 0 7.75',
+  },
+  {
+    screen: 'browser',
+    label: 'Browser',
+    // Phosphor "Globe" — drawn inline per repo policy (no React icon shim).
+    iconPath: 'M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2z M2 12h20 M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z',
   },
   {
     screen: 'issues',
@@ -58,6 +64,7 @@ const SCREEN_TO_VIEW: Record<MobileScreen, string> = {
   settings: 'settings',
   issues: 'issues',
   orchestrator: 'orchestrator',
+  browser: 'browser',
 };
 
 const menuFontFamily = "-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', sans-serif";

--- a/src/components/mobile/TopBar.tsx
+++ b/src/components/mobile/TopBar.tsx
@@ -64,6 +64,8 @@ function screenTitle(activeView: TopBarProps['activeView']) {
       return 'Costs';
     case 'orchestrator':
       return 'Orchestrator';
+    case 'browser':
+      return 'Browser';
     default:
       return 'Code';
   }
@@ -84,10 +86,13 @@ export const TopBar = memo(function TopBar({
   const { colors } = useTheme();
   void compactLine;
 
-  if (activeView !== 'squad' && activeView !== 'chat') {
+  if (activeView !== 'squad' && activeView !== 'chat' && activeView !== 'browser') {
     return null;
   }
 
+  // Browser tab gets the SpeedDial nav (same as squad/index) so the user
+  // can swap tabs from the same affordance — only the actual chat thread
+  // view should reveal the back-arrow + thread-controls layout.
   const isThreadView = activeView === 'chat';
   const primaryText = colors.text;
   const chromeBackground = colors.surface;

--- a/src/components/mobile/hooks/useMobileState.ts
+++ b/src/components/mobile/hooks/useMobileState.ts
@@ -38,7 +38,7 @@ export function useMobileState(init: MobileStateInit) {
     sessionKey: initialSession?.sessionKey ?? '',
     fallback: initialSession ?? null,
   }));
-  const [activeView, setActiveView] = useState<'squad' | 'chat' | 'costs' | 'fleet' | 'activity' | 'settings' | 'issues' | 'orchestrator'>('squad');
+  const [activeView, setActiveView] = useState<'squad' | 'chat' | 'costs' | 'fleet' | 'activity' | 'settings' | 'issues' | 'orchestrator' | 'browser'>('squad');
   const [refreshError, setRefreshError] = useState<string | null>(null);
   const [surfaceNote, setSurfaceNote] = useState<string | null>(null);
 

--- a/src/components/mobile/types.ts
+++ b/src/components/mobile/types.ts
@@ -198,7 +198,7 @@ export interface TopBarProps {
   selectedSession?: SessionSummary;
   headerVisible: boolean;
   pendingApprovalsCount: number;
-  activeView: 'squad' | 'chat' | 'costs' | 'fleet' | 'activity' | 'settings' | 'issues' | 'orchestrator';
+  activeView: 'squad' | 'chat' | 'costs' | 'fleet' | 'activity' | 'settings' | 'issues' | 'orchestrator' | 'browser';
   compactLine: CompactLine;
   activeScreen: import('./SpeedDial').MobileScreen;
   enabledViews: ReadonlySet<string>;


### PR DESCRIPTION
## Summary

- Adds an explicit **Browser** tab to the mobile bottom nav (Phosphor Globe SVG) so the chat+iframe split is opt-in instead of auto-triggering on rotation
- Removes the root-level `<MobileSplitShell>` wrapper from `mobile-remote-shell.tsx` — every non-Browser tab renders the regular portrait shell unchanged
- New `MobileBrowserTabRoot` wraps the existing `MobileSplitShell` from #779 with a best-effort `screen.orientation.lock('landscape')` (try/catch, never throws) and a dismissible rotate hint banner for portrait

## What changed

- **`MobileBrowserTabRoot.tsx` (new)** — owns orientation lock + portrait fallback (chat top / iframe below) + persistent hint banner (`o8:mobile-browser:landscape-hint-dismissed`)
- **`mobile-remote-shell.tsx`** — drops the always-on `<MobileSplitShell>` wrap; adds a `BrowserTabConditionalWrap` that mounts `MobileBrowserTabRoot` only when `activeView === 'browser'`; treats Browser as a thread surface so the chat content (transcript + composer) renders in the left pane
- **`SpeedDial.tsx`** — adds Browser screen between Agents and Issues with a Phosphor Globe icon; updates the screen↔view map
- **`TopBar.tsx`** — renders the SpeedDial chrome on the Browser tab so users can swap tabs without relying on the swipe gesture; back-arrow stays scoped to the actual chat thread
- **`types.ts` + `useMobileState.ts`** — extend `activeView` and `MobileScreen` unions to include `'browser'`

## Behavior

- **Tap Browser** → orientation lock attempted; in landscape `MobileSplitShell` paints chat-left + DevHostFrame-right (existing #779 layout, unchanged); in portrait the wrapper renders the rotate hint + chat top / iframe below
- **Tap Chat** → returns to chat, orientation released, no iframe — same as before #786
- **Long-press port chip on desktop → push URL** → iframe navigates if Browser tab is active. The url-push listener mounts inside `PortraitFallback` only; landscape delegates to `MobileSplitShell`'s built-in listener so we don't open a duplicate WebSocket

## Files preserved unchanged

- `MobileSplitShell.tsx` (the actual split — DO NOT REWRITE rule)
- `DevHostFrame.tsx`, `url-push-listener.ts`, `landscape-controller.ts`
- `/api/panel/lan-host`, `/api/mobile/push-url`

## Test plan

- [ ] Mobile bottom-nav SpeedDial menu shows the Browser entry with Globe icon
- [ ] Tap Browser in landscape → split paints chat-left + iframe-right (regression check vs #779)
- [ ] Tap Browser in portrait → rotate hint shows + chat top / iframe below
- [ ] Dismiss hint → it stays dismissed across sessions (localStorage)
- [ ] Tap Chat → orientation unlocks, single-pane chat returns
- [ ] Long-press port chip on desktop while phone is on Browser tab → iframe navigates
- [ ] Other tabs (Agents / Issues / Activity / Costs / Settings) render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)