### PR TITLE
feat(cortex): temporal validity windows on session_outcomes (closes #745)

### DIFF
--- a/src/app/api/cortex/recent-outcomes/route.ts
+++ b/src/app/api/cortex/recent-outcomes/route.ts
@@ -26,8 +26,9 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 import { NextRequest, NextResponse } from 'next/server';
-import { desc, eq } from 'drizzle-orm';
+import { and, desc, eq } from 'drizzle-orm';
 import { getDb, sessionOutcomes } from '@/lib/db';
+import { liveOutcomeFilter } from '@/lib/cortex/decay';
 
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
@@ -59,7 +60,7 @@ export async function GET(request: NextRequest) {
         durationMs: sessionOutcomes.durationMs,
       })
       .from(sessionOutcomes)
-      .where(eq(sessionOutcomes.repoPath, repoPath))
+      .where(and(eq(sessionOutcomes.repoPath, repoPath), liveOutcomeFilter()))
       .orderBy(desc(sessionOutcomes.completedAt))
       .limit(limit);
 

--- a/src/app/api/panel/status/route.ts
+++ b/src/app/api/panel/status/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { ensureCodebaseMemoryBootIndex } from '@/lib/codebase-memory/indexer';
+import { ensureDecayBootHook } from '@/lib/cortex/decay';
 
 export async function GET() {
   // Tauri shell hits /api/panel/status as a liveness probe right after the
@@ -7,6 +8,9 @@ export async function GET() {
   // codebase-memory boot index pass (closes #741). Idempotent — fires once
   // per server process. Runs in the background, never blocks the response.
   ensureCodebaseMemoryBootIndex();
+  // #745 — Temporal validity windows. Same idempotent pattern: first call
+  // fires an immediate decay sweep on a microtask and schedules a 6h tick.
+  ensureDecayBootHook();
 
   return NextResponse.json({
     connected: false,

--- a/src/lib/codebase-memory/build-context.ts
+++ b/src/lib/codebase-memory/build-context.ts
@@ -38,10 +38,11 @@ import 'server-only';
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
-import { desc, eq } from 'drizzle-orm';
+import { and, desc, eq } from 'drizzle-orm';
 
 import { getDb, sessionOutcomes } from '@/lib/db';
 import { getDataDir } from '@/lib/data-dir-migration';
+import { liveOutcomeFilter } from '@/lib/cortex/decay';
 
 import { extractSymbols, traceSymbols, type SymbolEdge } from './client';
 
@@ -171,7 +172,7 @@ async function readRecentOutcomes(repoPath: string): Promise<OutcomeRow[]> {
         reviewApproved: sessionOutcomes.reviewApproved,
       })
       .from(sessionOutcomes)
-      .where(eq(sessionOutcomes.repoPath, repoPath))
+      .where(and(eq(sessionOutcomes.repoPath, repoPath), liveOutcomeFilter()))
       .orderBy(desc(sessionOutcomes.completedAt))
       .limit(MAX_OUTCOMES);
     return rows;

--- a/src/lib/cortex/decay.ts
+++ b/src/lib/cortex/decay.ts
@@ -1,0 +1,240 @@
+/**
+ * #745 — Temporal validity windows on `session_outcomes`.
+ *
+ * Outcomes age out after 30 days unless re-confirmed by a fresher outcome on
+ * the same `(repo_path, file_path, symbol)` tuple. Recall callers filter to
+ * live rows only via `liveOutcomeFilter()` so stale entries never leak into
+ * the `<context>` block, the recall card, or the dispatch trailer lookups.
+ *
+ * Two helpers ship here:
+ *   - `decayOutcomes()` — sweep + age check. Stamps `valid_to = NOW` on every
+ *     outcome older than 30d that has no recent confirmation. Idempotent —
+ *     rows already stamped are skipped. Safe to run on every boot.
+ *   - `confirmOutcome()` — when a writer lands a new outcome, extend any
+ *     prior live outcome on the same tuple so the older row's `valid_to`
+ *     pushes out to NOW + 30d. Append-only — never deletes.
+ *
+ * Cadence:
+ *   - Boot pass: wired into `/api/panel/status` next to
+ *     `ensureCodebaseMemoryBootIndex()`.
+ *   - Tick pass: same trigger fires every 6h via `setInterval` on the first
+ *     boot of a Next process.
+ *
+ * No-throw policy: every helper swallows DB errors and logs with the
+ * `[cortex-decay]` prefix. Recall paths must never block on this module.
+ */
+
+import 'server-only';
+
+import { and, eq, isNull, lte, or, sql } from 'drizzle-orm';
+
+import { getDb, sessionOutcomes } from '@/lib/db';
+
+const DEFAULT_TTL_DAYS = 30;
+const DECAY_TICK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6h
+
+function logInfo(msg: string, ...rest: unknown[]) {
+  console.log(`[cortex-decay] ${msg}`, ...rest);
+}
+function logWarn(msg: string, ...rest: unknown[]) {
+  console.warn(`[cortex-decay] ${msg}`, ...rest);
+}
+
+/**
+ * SQL fragment that selects only outcomes that are still live — either never
+ * decayed (`valid_to IS NULL`) or whose decay timestamp is in the future
+ * (e.g. just confirmed by `confirmOutcome()`). Pull this into Drizzle
+ * `.where()` clauses to keep the recall surface consistent.
+ */
+export function liveOutcomeFilter() {
+  return or(
+    isNull(sessionOutcomes.validTo),
+    sql`${sessionOutcomes.validTo} > datetime('now')`,
+  );
+}
+
+export interface DecayOutcomesResult {
+  decayed: number;
+  scanned: number;
+  skipped: boolean;
+}
+
+/**
+ * Mark outcomes older than `ttlDays` (default 30) as decayed by stamping
+ * `valid_to = datetime('now')`. Skips rows that already carry a `valid_to`
+ * stamp so re-runs are no-ops.
+ *
+ * Returns the count of rows that were just decayed plus the total live rows
+ * scanned so callers can log whether the sweep had any effect.
+ */
+export async function decayOutcomes(
+  opts: { ttlDays?: number } = {},
+): Promise<DecayOutcomesResult> {
+  const ttlDays = opts.ttlDays ?? DEFAULT_TTL_DAYS;
+  const db = getDb();
+  if (!db) {
+    return { decayed: 0, scanned: 0, skipped: true };
+  }
+
+  try {
+    // Count live rows for telemetry. Cheap because of `idx_so_valid_to`.
+    const liveRows = await db
+      .select({ id: sessionOutcomes.id })
+      .from(sessionOutcomes)
+      .where(isNull(sessionOutcomes.validTo));
+    const scanned = liveRows.length;
+
+    // SQLite stores timestamps as ISO strings, so `datetime(...)` math works
+    // directly. We compare against `valid_from` since the validity window
+    // starts there — `completed_at` is the work timestamp, but the outcome
+    // becomes "valid" the moment it's recorded.
+    const result = await db
+      .update(sessionOutcomes)
+      .set({ validTo: sql`datetime('now')` })
+      .where(
+        and(
+          isNull(sessionOutcomes.validTo),
+          lte(
+            sessionOutcomes.validFrom,
+            sql`datetime('now', ${`-${ttlDays} days`})`,
+          ),
+        ),
+      )
+      .run();
+
+    const decayed = (result as unknown as { changes?: number }).changes ?? 0;
+    if (decayed > 0) {
+      logInfo(
+        `decayed ${decayed} outcome${decayed === 1 ? '' : 's'} older than ${ttlDays}d (${scanned} live before sweep)`,
+      );
+    }
+    return { decayed, scanned, skipped: false };
+  } catch (error) {
+    logWarn(
+      'decay sweep failed:',
+      error instanceof Error ? error.message : error,
+    );
+    return { decayed: 0, scanned: 0, skipped: true };
+  }
+}
+
+export interface ConfirmOutcomeInput {
+  repoPath: string;
+  /** Optional file path — narrows the confirmation tuple. */
+  filePath?: string | null;
+  /** Optional symbol name — narrows the confirmation tuple further. */
+  symbol?: string | null;
+  /**
+   * Optional override for how far ahead to push `valid_to`. Defaults to
+   * `ttlDays` from now (i.e. the row stays live for another window).
+   */
+  ttlDays?: number;
+}
+
+export interface ConfirmOutcomeResult {
+  /** Number of prior outcome rows whose validity was extended. */
+  extended: number;
+  /** True when the DB was unavailable — the caller should still write the new row. */
+  skipped: boolean;
+}
+
+/**
+ * Extend the `valid_to` of every live outcome that matches the supplied
+ * `(repo_path, file_path, symbol)` tuple so the older entries don't decay
+ * the moment a fresher outcome confirms the same code-graph node.
+ *
+ * - When `filePath` and `symbol` are both omitted, every live outcome on the
+ *   repo gets extended (broadest match — used when the writer doesn't know
+ *   the precise tuple).
+ * - When provided, we look for matches inside `changed_files_json` /
+ *   `patterns_json` blobs. Lightweight LIKE queries — the tuple is a hint,
+ *   not a hard schema, until #738 wires a structured node store.
+ *
+ * Append-only — never deletes. The intent is to keep history trustworthy
+ * while letting fresher signals override stale ones.
+ */
+export async function confirmOutcome(
+  input: ConfirmOutcomeInput,
+): Promise<ConfirmOutcomeResult> {
+  const repoPath = input.repoPath?.trim();
+  if (!repoPath) {
+    return { extended: 0, skipped: true };
+  }
+  const ttlDays = input.ttlDays ?? DEFAULT_TTL_DAYS;
+  const db = getDb();
+  if (!db) {
+    return { extended: 0, skipped: true };
+  }
+
+  try {
+    const filePath = input.filePath?.trim() || null;
+    const symbol = input.symbol?.trim() || null;
+
+    // The extension target — push valid_to to NOW + ttlDays so the row stays
+    // live for another window. We always overwrite an existing future
+    // `valid_to` because a fresh confirmation is the most recent signal.
+    const nextValidTo = sql`datetime('now', ${`+${ttlDays} days`})`;
+
+    // When neither filePath nor symbol narrows the tuple, extend the whole
+    // repo. When provided, AND the LIKE clauses on top.
+    const conditions = [eq(sessionOutcomes.repoPath, repoPath)];
+    if (filePath) {
+      conditions.push(sql`${sessionOutcomes.changedFilesJson} LIKE ${`%${filePath}%`}`);
+    }
+    if (symbol) {
+      conditions.push(sql`${sessionOutcomes.patternsJson} LIKE ${`%${symbol}%`}`);
+    }
+
+    const result = await db
+      .update(sessionOutcomes)
+      .set({ validTo: nextValidTo })
+      .where(and(...conditions))
+      .run();
+
+    const extended = (result as unknown as { changes?: number }).changes ?? 0;
+    if (extended > 0) {
+      logInfo(
+        `extended ${extended} outcome${extended === 1 ? '' : 's'} for ${repoPath}${
+          filePath ? ` file=${filePath}` : ''
+        }${symbol ? ` symbol=${symbol}` : ''}`,
+      );
+    }
+    return { extended, skipped: false };
+  } catch (error) {
+    logWarn(
+      'confirm extension failed:',
+      error instanceof Error ? error.message : error,
+    );
+    return { extended: 0, skipped: true };
+  }
+}
+
+let bootHookFired = false;
+let tickHandle: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Idempotent boot trigger. First call schedules a recurring 6h tick and
+ * fires an immediate sweep on the next microtask so the route handler that
+ * called us doesn't pay for the DB walk inline. Subsequent calls are
+ * no-ops.
+ */
+export function ensureDecayBootHook(): void {
+  if (bootHookFired) return;
+  bootHookFired = true;
+
+  setImmediate(() => {
+    void decayOutcomes().catch((err: unknown) => {
+      logWarn('boot sweep threw:', err);
+    });
+  });
+
+  // Recurring tick — guard against double-scheduling if Next reloads modules.
+  if (tickHandle) return;
+  tickHandle = setInterval(() => {
+    void decayOutcomes().catch((err: unknown) => {
+      logWarn('tick sweep threw:', err);
+    });
+  }, DECAY_TICK_INTERVAL_MS);
+  // Don't keep the event loop alive purely for the decay tick.
+  if (typeof tickHandle.unref === 'function') tickHandle.unref();
+}

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -33,7 +33,7 @@ const DATA_DIR = process.env.O8_DATA_DIR
 // second migration step with no user-facing benefit.
 const DB_PATH = process.env.CORTEX_IDE_DB_PATH || path.join(DATA_DIR, 'cortex-ide.db');
 // Bump when ensureTables() adds new schema or backfill work.
-const DB_SCHEMA_VERSION = 10;
+const DB_SCHEMA_VERSION = 11;
 const DB_MIGRATION_MARKER_PATH = path.join(DATA_DIR, `.db-migrated-v${DB_SCHEMA_VERSION}`);
 
 // Ensure data directory exists
@@ -238,7 +238,9 @@ function ensureTables(sqlite: Database.Database): void {
       transcript_path TEXT,
       started_at TEXT NOT NULL,
       completed_at TEXT NOT NULL,
-      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      valid_from TEXT NOT NULL DEFAULT (datetime('now')),
+      valid_to TEXT
     );
 
     CREATE TABLE IF NOT EXISTS teams (
@@ -479,6 +481,7 @@ function ensureTables(sqlite: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_so_repo_completed ON session_outcomes(repo_path, completed_at DESC);
     CREATE INDEX IF NOT EXISTS idx_so_lane_id ON session_outcomes(lane_id);
     CREATE INDEX IF NOT EXISTS idx_so_packet_id ON session_outcomes(packet_id);
+    CREATE INDEX IF NOT EXISTS idx_so_valid_to ON session_outcomes(valid_to);
     CREATE INDEX IF NOT EXISTS idx_team_members_team ON team_members(team_id);
     CREATE INDEX IF NOT EXISTS idx_team_members_user ON team_members(user_id);
     CREATE INDEX IF NOT EXISTS idx_github_repositories_installation ON github_repositories(installation_id);
@@ -609,6 +612,23 @@ function ensureSessionOutcomeColumns(sqlite: Database.Database): void {
   if (!tableColumnExists(sqlite, 'session_outcomes', 'plan_text')) {
     sqlite.exec('ALTER TABLE session_outcomes ADD COLUMN plan_text TEXT');
   }
+  // #745 — Temporal validity windows. SQLite ALTER TABLE ADD COLUMN rejects
+  // any non-literal DEFAULT (even CURRENT_TIMESTAMP) on the bundled
+  // better-sqlite3 build, so add the column as nullable, backfill historical
+  // rows from `completed_at`, and let Drizzle's schema-level default supply
+  // `datetime('now')` for fresh inserts. Fresh DBs get the NOT NULL DEFAULT
+  // (datetime('now')) shape via the CREATE TABLE in ensureTables() above.
+  if (!tableColumnExists(sqlite, 'session_outcomes', 'valid_from')) {
+    sqlite.exec('ALTER TABLE session_outcomes ADD COLUMN valid_from TEXT');
+    sqlite.exec(
+      "UPDATE session_outcomes SET valid_from = COALESCE(completed_at, created_at, datetime('now')) WHERE valid_from IS NULL OR valid_from = ''",
+    );
+  }
+  if (!tableColumnExists(sqlite, 'session_outcomes', 'valid_to')) {
+    sqlite.exec('ALTER TABLE session_outcomes ADD COLUMN valid_to TEXT');
+  }
+  // Index on valid_to to keep "live entries only" recall queries cheap.
+  sqlite.exec('CREATE INDEX IF NOT EXISTS idx_so_valid_to ON session_outcomes(valid_to)');
 }
 
 function backfillWatchedAgentColumns(sqlite: Database.Database): void {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -165,11 +165,20 @@ export const sessionOutcomes = sqliteTable('session_outcomes', {
   startedAt: text('started_at').notNull(),
   completedAt: text('completed_at').notNull(),
   createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+  /**
+   * #745 — Temporal validity windows. `valid_from` defaults to NOW; `valid_to`
+   * is NULL for live entries and gets stamped to NOW once the row decays
+   * (no confirmations within 30d) or is superseded by a fresher outcome on
+   * the same `(repo_path, file_path, symbol)` tuple.
+   */
+  validFrom: text('valid_from').notNull().default(sql`(datetime('now'))`),
+  validTo: text('valid_to'),
 }, (table) => ({
   repoRuntimeIdx: index('idx_so_repo_runtime').on(table.repoPath, table.runtime, table.completedAt),
   repoCompletedIdx: index('idx_so_repo_completed').on(table.repoPath, table.completedAt),
   laneIdIdx: index('idx_so_lane_id').on(table.laneId),
   packetIdIdx: index('idx_so_packet_id').on(table.packetId),
+  validToIdx: index('idx_so_valid_to').on(table.validTo),
 }));
 
 // ══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- Adds `valid_from` + `valid_to` columns to `session_outcomes` so outcomes auto-decay after 30 days unless re-confirmed by a fresher outcome on the same `(repo_path, file_path, symbol)` tuple.
- Schema bumped to v11 with the idempotent column-add pattern from #9 (#db_migration_v9_idempotent). SQLite ALTER TABLE rejects non-literal DEFAULTs even on `CURRENT_TIMESTAMP`, so existing-DB columns are added nullable + backfilled from `completed_at`; fresh DBs get `NOT NULL DEFAULT (datetime('now'))` via the CREATE TABLE shape.
- New `src/lib/cortex/decay.ts` exports `decayOutcomes()` (sweep + age check), `confirmOutcome()` (extend prior on overlap), and `liveOutcomeFilter()` (shared `WHERE` fragment for recall callers).
- Boot hook fires from `/api/panel/status` next to `ensureCodebaseMemoryBootIndex()`. Schedules a 6h `setInterval` tick whose handle is `unref()`'d so it never keeps the event loop alive on its own.
- Recall callers updated to apply the live filter: `/api/cortex/recent-outcomes` (#742) and the `<context>` block builder in `build-context.ts` (#743).
- No current `session_outcomes` writers exist — `confirmOutcome()` is exported and ready for #770 / future writers to call before they insert.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Smoke against fresh DB: row inserted 31d old gets stamped on `decayOutcomes()`, young rows stay live, idempotent on second run
- [x] `confirmOutcome()` resurrects a previously-decayed row by pushing `valid_to` 30d into the future
- [x] Hand-built v10-shaped DB upgrades cleanly via the idempotent path; pre-existing rows have `valid_from` backfilled to `completed_at`, no data loss
- [x] 2nd `getDb()` boot is a true no-op — column count unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)