### PR TITLE
feat(cortex): auto-directive proposer — surface suggestions after repeated outcomes (closes #746)

### DIFF
--- a/src/app/api/cortex/proposals/route.ts
+++ b/src/app/api/cortex/proposals/route.ts
@@ -1,0 +1,71 @@
+/**
+ * GET /api/cortex/proposals
+ *   → { ok: true, proposals: DirectiveProposalCandidate[], computedAt: number }
+ *
+ * POST /api/cortex/proposals
+ *   body: { action: 'dismiss', id: string, filePattern: string, fixPattern: string }
+ *   → { ok: true, snoozedUntil: string }
+ *
+ * Read-only window into the auto-directive proposer (#746). Dismissals
+ * append a 30-day snooze to ~/.o8/proposal-snooze.json — see
+ * `src/lib/cortex/proposer.ts` for the algorithm.
+ */
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { readCachedProposals, snoozeProposal } from '@/lib/cortex/proposer';
+
+export function GET() {
+  try {
+    const { candidates, computedAt } = readCachedProposals();
+    return NextResponse.json(
+      { ok: true, proposals: candidates, computedAt },
+      { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to load proposals.';
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+
+interface DismissBody {
+  action?: string;
+  id?: string;
+  filePattern?: string;
+  fixPattern?: string;
+}
+
+export async function POST(request: NextRequest) {
+  let body: DismissBody | null = null;
+  try {
+    body = (await request.json()) as DismissBody;
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  if (!body || body.action !== 'dismiss') {
+    return NextResponse.json({ ok: false, error: 'Unsupported action.' }, { status: 400 });
+  }
+  const id = typeof body.id === 'string' ? body.id.trim() : '';
+  const filePattern = typeof body.filePattern === 'string' ? body.filePattern.trim() : '';
+  const fixPattern = typeof body.fixPattern === 'string' ? body.fixPattern.trim() : '';
+  if (!id || !filePattern || !fixPattern) {
+    return NextResponse.json(
+      { ok: false, error: 'id, filePattern, and fixPattern are required for dismiss.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const entry = snoozeProposal({ id, filePattern, fixPattern });
+    return NextResponse.json(
+      { ok: true, snoozedUntil: entry.snoozedUntil },
+      { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to snooze proposal.';
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/panel/status/route.ts
+++ b/src/app/api/panel/status/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
 import { ensureCodebaseMemoryBootIndex } from '@/lib/codebase-memory/indexer';
+<<<<<<< HEAD
 import { ensureDecayBootHook } from '@/lib/cortex/decay';
+=======
+import { ensureProposerBootTick } from '@/lib/cortex/proposer';
+>>>>>>> 492cbca (feat(cortex): auto-directive proposer — surface suggestions after repeated outcomes (closes #746))
 
 export async function GET() {
   // Tauri shell hits /api/panel/status as a liveness probe right after the
@@ -8,9 +12,15 @@ export async function GET() {
   // codebase-memory boot index pass (closes #741). Idempotent — fires once
   // per server process. Runs in the background, never blocks the response.
   ensureCodebaseMemoryBootIndex();
+<<<<<<< HEAD
   // #745 — Temporal validity windows. Same idempotent pattern: first call
   // fires an immediate decay sweep on a microtask and schedules a 6h tick.
   ensureDecayBootHook();
+=======
+  // #746 — Auto-directive proposer tick. Same pattern: idempotent boot hook,
+  // self-schedules every 30 min, never blocks the liveness probe.
+  ensureProposerBootTick();
+>>>>>>> 492cbca (feat(cortex): auto-directive proposer — surface suggestions after repeated outcomes (closes #746))
 
   return NextResponse.json({
     connected: false,

--- a/src/app/api/panel/status/route.ts
+++ b/src/app/api/panel/status/route.ts
@@ -1,10 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureCodebaseMemoryBootIndex } from '@/lib/codebase-memory/indexer';
-<<<<<<< HEAD
 import { ensureDecayBootHook } from '@/lib/cortex/decay';
-=======
 import { ensureProposerBootTick } from '@/lib/cortex/proposer';
->>>>>>> 492cbca (feat(cortex): auto-directive proposer — surface suggestions after repeated outcomes (closes #746))
 
 export async function GET() {
   // Tauri shell hits /api/panel/status as a liveness probe right after the
@@ -12,15 +9,12 @@ export async function GET() {
   // codebase-memory boot index pass (closes #741). Idempotent — fires once
   // per server process. Runs in the background, never blocks the response.
   ensureCodebaseMemoryBootIndex();
-<<<<<<< HEAD
   // #745 — Temporal validity windows. Same idempotent pattern: first call
   // fires an immediate decay sweep on a microtask and schedules a 6h tick.
   ensureDecayBootHook();
-=======
   // #746 — Auto-directive proposer tick. Same pattern: idempotent boot hook,
   // self-schedules every 30 min, never blocks the liveness probe.
   ensureProposerBootTick();
->>>>>>> 492cbca (feat(cortex): auto-directive proposer — surface suggestions after repeated outcomes (closes #746))
 
   return NextResponse.json({
     connected: false,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1435,6 +1435,13 @@ function DashboardInner() {
     });
   }, [setThoughtsDraftInjection]);
 
+  // #746 — Auto-directive proposer Accept callback. Re-uses the same draft
+  // injection pipeline as design-mode capture so the orchestrator chat
+  // composer pre-fills with the proposed directive text.
+  const handleAcceptDirectiveProposal = useCallback((draft: { id: string; text: string }) => {
+    setThoughtsDraftInjection(draft);
+  }, [setThoughtsDraftInjection]);
+
   const injectPayloadIntoRepoChat = useCallback((payload: AgentPanelChatInjectionPayload, repoOverride?: WorkspaceSidePanelRepo | null) => {
     const nextInjection = {
       id: `${payload.reason}-${Date.now()}`,
@@ -2721,6 +2728,7 @@ function DashboardInner() {
             onSelectSession={handleSelectSession}
             latestDispatchedTabId={latestDispatchedTabId}
             latestDispatchedAt={latestDispatchedAt}
+            onAcceptDirectiveProposal={handleAcceptDirectiveProposal}
           >
             <TileContainer
               layout={tileLayout}

--- a/src/components/desktop/orchestrator-data-context.tsx
+++ b/src/components/desktop/orchestrator-data-context.tsx
@@ -32,6 +32,14 @@ export interface OrchestratorDataValue {
   latestDispatchedTabId?: string | null;
   /** Epoch ms timestamp of the most-recent dispatch — surfaced in tab tooltips. */
   latestDispatchedAt?: number | null;
+  /**
+   * #746 — Auto-directive proposer hook. The DirectiveProposalRow injects
+   * the candidate's draft text into the orchestrator chat composer when the
+   * operator clicks Accept. Drilling this through `draftInjection` directly
+   * would conflict with quick-action palette drafts; a dedicated hook keeps
+   * the two surfaces independent.
+   */
+  onAcceptDirectiveProposal?: (draft: { id: string; text: string }) => void;
 }
 
 const OrchestratorDataContext = createContext<OrchestratorDataValue | null>(null);

--- a/src/components/desktop/thoughts/DirectiveProposalRow.tsx
+++ b/src/components/desktop/thoughts/DirectiveProposalRow.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+/**
+ * #746 — DirectiveProposalRow.
+ *
+ * Yellow Issues-style row that surfaces above Open Issues in the Mission
+ * panel when the auto-directive proposer detects a recurring fix-pattern.
+ * Human-gated: Accept fills the chat composer with a draft directive;
+ * Dismiss snoozes the proposal for 30 days.
+ *
+ * The row mirrors the `IssueGroupList` row chrome (dense, 34px tall, no
+ * card outline) but tinted yellow so the operator notices it without it
+ * dominating the panel. Multiple proposals stack as sibling rows under a
+ * single header.
+ */
+
+import { useCallback, useState } from 'react';
+import type { DirectiveProposalCandidate } from './directive-proposal-types';
+
+interface DirectiveProposalRowProps {
+  proposal: DirectiveProposalCandidate;
+  onAccept: (proposal: DirectiveProposalCandidate) => void;
+  onDismiss: (proposal: DirectiveProposalCandidate) => void;
+  /** Set true while the dismiss POST is in flight to disable the buttons. */
+  busy?: boolean;
+}
+
+const YELLOW_ACCENT = '#f59e0b';
+const YELLOW_BG_SOFT = 'rgba(245, 158, 11, 0.08)';
+const YELLOW_BG_HOVER = 'rgba(245, 158, 11, 0.14)';
+const YELLOW_BORDER = 'rgba(245, 158, 11, 0.28)';
+const YELLOW_TEXT_DARK = '#b45309';
+const FONT_FAMILY = '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif';
+const MONO_FAMILY = 'var(--font-mono, "SF Mono", Menlo, monospace)';
+
+export function DirectiveProposalRow({ proposal, onAccept, onDismiss, busy }: DirectiveProposalRowProps) {
+  const [hovered, setHovered] = useState(false);
+
+  const handleAccept = useCallback(() => {
+    if (busy) return;
+    onAccept(proposal);
+  }, [busy, onAccept, proposal]);
+
+  const handleDismiss = useCallback(() => {
+    if (busy) return;
+    onDismiss(proposal);
+  }, [busy, onDismiss, proposal]);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        height: 34,
+        paddingTop: 0,
+        paddingRight: 8,
+        paddingBottom: 0,
+        paddingLeft: 10,
+        background: hovered ? YELLOW_BG_HOVER : YELLOW_BG_SOFT,
+        borderRadius: 8,
+        borderWidth: 1,
+        borderStyle: 'solid',
+        borderColor: YELLOW_BORDER,
+        transition: 'background 120ms cubic-bezier(0.22, 1, 0.36, 1)',
+        fontFamily: FONT_FAMILY,
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {/* Hits badge — mirrors the issue-number column width in IssueGroupList. */}
+      <span
+        title={`Observed ${proposal.hits}× in the last 14 days`}
+        style={{
+          width: 42,
+          flexShrink: 0,
+          fontSize: 10,
+          fontWeight: 700,
+          color: YELLOW_TEXT_DARK,
+          fontFamily: MONO_FAMILY,
+          letterSpacing: '-0.01em',
+        }}
+      >
+        {proposal.hits}× seen
+      </span>
+
+      {/* Pattern preview — file-glob + bigram in monospace so it reads as code. */}
+      <span
+        style={{
+          flex: 1,
+          minWidth: 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          fontSize: 12,
+          color: 'var(--t-text)',
+          letterSpacing: '-0.01em',
+        }}
+      >
+        <span style={{ color: 'var(--t-text-muted)', fontSize: 11 }}>add directive: </span>
+        <span style={{ fontFamily: MONO_FAMILY, fontSize: 11, color: 'var(--t-text)' }}>
+          {proposal.filePattern}
+        </span>
+        <span style={{ color: 'var(--t-text-muted)', fontSize: 11 }}> → </span>
+        <span style={{ fontFamily: MONO_FAMILY, fontSize: 11, color: 'var(--t-text)' }}>
+          {proposal.fixPattern}
+        </span>
+        <span style={{ color: 'var(--t-text-muted)', fontSize: 11 }}>?</span>
+      </span>
+
+      {/* Actions. Mirror the IssueGroupList "+" pattern (transparent buttons,
+          tight padding) but with text labels so Accept/Dismiss are explicit. */}
+      <button
+        type="button"
+        onClick={handleAccept}
+        disabled={busy}
+        title="Open the directive editor pre-filled with this draft"
+        style={{
+          flexShrink: 0,
+          paddingTop: 3,
+          paddingRight: 8,
+          paddingBottom: 3,
+          paddingLeft: 8,
+          borderRadius: 6,
+          borderWidth: 1,
+          borderStyle: 'solid',
+          borderColor: YELLOW_BORDER,
+          background: busy ? 'transparent' : YELLOW_ACCENT,
+          color: busy ? YELLOW_TEXT_DARK : '#fff',
+          fontSize: 10,
+          fontWeight: 700,
+          cursor: busy ? 'wait' : 'pointer',
+          fontFamily: FONT_FAMILY,
+          letterSpacing: '-0.01em',
+        }}
+      >
+        Accept
+      </button>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        disabled={busy}
+        title="Snooze for 30 days"
+        style={{
+          flexShrink: 0,
+          paddingTop: 3,
+          paddingRight: 8,
+          paddingBottom: 3,
+          paddingLeft: 8,
+          borderRadius: 6,
+          borderWidth: 1,
+          borderStyle: 'solid',
+          borderColor: YELLOW_BORDER,
+          background: 'transparent',
+          color: YELLOW_TEXT_DARK,
+          fontSize: 10,
+          fontWeight: 700,
+          cursor: busy ? 'wait' : 'pointer',
+          fontFamily: FONT_FAMILY,
+          letterSpacing: '-0.01em',
+        }}
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}

--- a/src/components/desktop/thoughts/ThoughtsMissionPanel.tsx
+++ b/src/components/desktop/thoughts/ThoughtsMissionPanel.tsx
@@ -27,6 +27,10 @@ import {
 import { IssueGroupList } from './mission-panel/IssueGroupList';
 import { PacketCard } from './mission-panel/PacketCard';
 import { StatusGroupedLanes } from './mission-panel/StatusGroupedLanes';
+import type { DirectiveProposalCandidate } from './directive-proposal-types';
+import { useDirectiveProposals } from './mission-panel/useDirectiveProposals';
+import { DirectiveProposalSection } from './mission-panel/DirectiveProposalSection';
+import { useOrchestratorData } from '../orchestrator-data-context';
 
 // #517 — Rough per-run cost estimate used only for the fan-out gate warning.
 // Not meant to be accurate — it just reminds the operator that running 3+
@@ -81,6 +85,7 @@ export function ThoughtsMissionPanel({
   const [reviewStateByPacketId, setReviewStateByPacketId] = useState<Record<string, ReviewPanelState>>({});
   const branchAutofillAttemptRef = useRef<Record<string, string>>({});
   const branchRequestByRepoPathRef = useRef<Record<string, Promise<Awaited<ReturnType<typeof fetchPacketBranches>>>>>({});
+  const orchestratorData = useOrchestratorData();
 
   // Close editing field on Escape or click outside any row in the
   // expanded packet card.
@@ -372,6 +377,37 @@ export function ThoughtsMissionPanel({
       body: JSON.stringify({ verb: 'resume', laneId: packet.lane?.laneId, message: 'Continue the previous task.', actor: 'user' }),
     }).catch(() => {});
   }, []);
+
+  // #746 — Auto-directive proposer rows. State + fetch + dismiss live in
+  // the dedicated hook; the panel just maps Accept onto the orchestrator
+  // data context's `onAcceptDirectiveProposal` callback.
+  const handleAcceptProposalDraft = useCallback((proposal: DirectiveProposalCandidate) => {
+    // Pre-fill the orchestrator chat composer via the shared draft injection
+    // hook. The operator edits + sends; orchestrator-side memory tools then
+    // write the directive markdown. We never write the file ourselves —
+    // human-gated by design.
+    const draftText = [
+      'Please save the following directive after I review it:',
+      '',
+      proposal.draftDirective,
+    ].join('\n');
+    orchestratorData?.onAcceptDirectiveProposal?.({
+      id: `proposal-accept-${proposal.id}-${Date.now()}`,
+      text: draftText,
+    });
+  }, [orchestratorData]);
+
+  const {
+    proposals,
+    pendingProposalId,
+    handleAccept: handleAcceptProposal,
+    handleDismiss: handleDismissProposal,
+  } = useDirectiveProposals({
+    open,
+    visible,
+    retryNonce: issuesRetryNonce,
+    onAccept: handleAcceptProposalDraft,
+  });
 
   // #517 — Best-of-n: bucket packets by comparisonGroupId so each group
   // renders ONCE via ComparisonCard instead of N separate PacketCards.
@@ -671,6 +707,16 @@ export function ThoughtsMissionPanel({
           </button>
         </div>
       ) : null}
+
+      {/* #746 — Auto-directive proposer rows. Anchored above Open Issues
+          because they're "advice the system gives the operator" — should
+          read like a recommendation, not a queued task. */}
+      <DirectiveProposalSection
+        proposals={proposals}
+        pendingProposalId={pendingProposalId}
+        onAccept={handleAcceptProposal}
+        onDismiss={handleDismissProposal}
+      />
 
       <IssueGroupList
         issueGroups={issueGroups}

--- a/src/components/desktop/thoughts/directive-proposal-types.ts
+++ b/src/components/desktop/thoughts/directive-proposal-types.ts
@@ -1,0 +1,17 @@
+/**
+ * #746 — Client-side type for the auto-directive proposer.
+ *
+ * Mirrors `DirectiveProposalCandidate` in `src/lib/cortex/proposer.ts`.
+ * Duplicated here because that module is `'server-only'` and the
+ * Mission panel runs in the browser. Keep the shapes in sync.
+ */
+
+export interface DirectiveProposalCandidate {
+  id: string;
+  filePattern: string;
+  fixPattern: string;
+  hits: number;
+  lastSeenAt: string;
+  outcomeIds: string[];
+  draftDirective: string;
+}

--- a/src/components/desktop/thoughts/mission-panel/DirectiveProposalSection.tsx
+++ b/src/components/desktop/thoughts/mission-panel/DirectiveProposalSection.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+/**
+ * #746 — Section wrapper for the auto-directive proposer rows. Renders the
+ * "Proposed directives" header + count badge + a stacked list of
+ * `DirectiveProposalRow` components. Anchored above Open Issues in the
+ * Mission panel because these rows are advice (system → operator), not
+ * queued tasks.
+ */
+
+import type { DirectiveProposalCandidate } from '../directive-proposal-types';
+import { DirectiveProposalRow } from '../DirectiveProposalRow';
+
+interface DirectiveProposalSectionProps {
+  proposals: DirectiveProposalCandidate[];
+  pendingProposalId: string | null;
+  onAccept: (proposal: DirectiveProposalCandidate) => void;
+  onDismiss: (proposal: DirectiveProposalCandidate) => void;
+}
+
+export function DirectiveProposalSection({
+  proposals,
+  pendingProposalId,
+  onAccept,
+  onDismiss,
+}: DirectiveProposalSectionProps) {
+  if (proposals.length === 0) return null;
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 4 }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          height: 28,
+          paddingTop: 0,
+          paddingRight: 8,
+          paddingBottom: 0,
+          paddingLeft: 8,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            textTransform: 'uppercase' as const,
+            letterSpacing: '0.05em',
+            color: 'var(--t-text-muted)',
+          }}
+        >
+          Proposed directives
+        </span>
+        <span
+          title="Surfaced when the same fix-pattern appears 3+ times in the last 14 days"
+          style={{
+            paddingTop: 1,
+            paddingRight: 6,
+            paddingBottom: 1,
+            paddingLeft: 6,
+            borderRadius: 999,
+            background: 'rgba(245, 158, 11, 0.12)',
+            color: '#b45309',
+            fontSize: 10,
+            fontWeight: 700,
+            fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+          }}
+        >
+          {proposals.length}
+        </span>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        {proposals.map((proposal) => (
+          <DirectiveProposalRow
+            key={proposal.id}
+            proposal={proposal}
+            onAccept={onAccept}
+            onDismiss={onDismiss}
+            busy={pendingProposalId === proposal.id}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/desktop/thoughts/mission-panel/useDirectiveProposals.ts
+++ b/src/components/desktop/thoughts/mission-panel/useDirectiveProposals.ts
@@ -1,0 +1,112 @@
+'use client';
+
+/**
+ * #746 — Hook that owns the auto-directive proposer state for
+ * `ThoughtsMissionPanel`. Pulled out of the panel so the panel stays under
+ * the 800-line ceiling.
+ *
+ * Responsibilities:
+ *   - Fetch the cached proposal set from `/api/cortex/proposals` on
+ *     panel-open + lifecycle events + 5-min fallback poll.
+ *   - Hide a row optimistically while the dismiss POST is in flight.
+ *   - Dispatch Accept by calling `onAccept` with the candidate; the
+ *     consumer (Mission panel) wires it to the orchestrator chat composer
+ *     via `OrchestratorDataContext.onAcceptDirectiveProposal`.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import type { DirectiveProposalCandidate } from '../directive-proposal-types';
+
+interface UseDirectiveProposalsArgs {
+  open: boolean;
+  visible: boolean;
+  /** Bumped by the parent's existing retry button — re-trigger the fetch alongside issues. */
+  retryNonce: number;
+  /**
+   * Called when the operator clicks Accept. The Mission panel wires this
+   * to the orchestrator chat composer via the OrchestratorData context.
+   */
+  onAccept: (proposal: DirectiveProposalCandidate) => void;
+}
+
+interface UseDirectiveProposalsReturn {
+  proposals: DirectiveProposalCandidate[];
+  pendingProposalId: string | null;
+  handleAccept: (proposal: DirectiveProposalCandidate) => void;
+  handleDismiss: (proposal: DirectiveProposalCandidate) => Promise<void>;
+}
+
+export function useDirectiveProposals({
+  open,
+  visible,
+  retryNonce,
+  onAccept,
+}: UseDirectiveProposalsArgs): UseDirectiveProposalsReturn {
+  const [proposals, setProposals] = useState<DirectiveProposalCandidate[]>([]);
+  const [pendingProposalId, setPendingProposalId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !visible) return;
+    let cancelled = false;
+    const loadProposals = async () => {
+      try {
+        const res = await fetch('/api/cortex/proposals', { cache: 'no-store' });
+        if (!res.ok || cancelled) return;
+        const data = (await res.json()) as { ok?: boolean; proposals?: DirectiveProposalCandidate[] };
+        if (cancelled) return;
+        if (data?.ok && Array.isArray(data.proposals)) {
+          setProposals(data.proposals);
+        }
+      } catch (err) {
+        console.warn('[proposer] proposal fetch failed:', err instanceof Error ? err.message : err);
+      }
+    };
+    void loadProposals();
+    // Re-poll on the same lifecycle events the issue panel listens for —
+    // dispatch + lane lifecycle is when new outcomes land.
+    const handler = () => { void loadProposals(); };
+    const events = ['o8:lane-lifecycle', 'o8:agent-lifecycle'];
+    for (const e of events) window.addEventListener(e, handler);
+    const fallbackId = setInterval(handler, 5 * 60 * 1000); // 5 min UI poll
+    return () => {
+      cancelled = true;
+      clearInterval(fallbackId);
+      for (const e of events) window.removeEventListener(e, handler);
+    };
+  }, [open, visible, retryNonce]);
+
+  const handleAccept = useCallback((proposal: DirectiveProposalCandidate) => {
+    onAccept(proposal);
+    // Hide the row locally — once a directive is created, the next tick
+    // will (eventually) shift the file/fix patterns enough that the
+    // proposer stops re-emitting it. If not, the operator can re-dismiss.
+    setProposals((current) => current.filter((p) => p.id !== proposal.id));
+  }, [onAccept]);
+
+  const handleDismiss = useCallback(async (proposal: DirectiveProposalCandidate) => {
+    setPendingProposalId(proposal.id);
+    try {
+      const res = await fetch('/api/cortex/proposals', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'dismiss',
+          id: proposal.id,
+          filePattern: proposal.filePattern,
+          fixPattern: proposal.fixPattern,
+        }),
+      });
+      const data = (await res.json().catch(() => null)) as { ok?: boolean } | null;
+      if (!res.ok || !data?.ok) {
+        console.warn('[proposer] dismiss failed', data);
+      }
+      setProposals((current) => current.filter((p) => p.id !== proposal.id));
+    } catch (err) {
+      console.warn('[proposer] dismiss request threw:', err instanceof Error ? err.message : err);
+    } finally {
+      setPendingProposalId(null);
+    }
+  }, []);
+
+  return { proposals, pendingProposalId, handleAccept, handleDismiss };
+}

--- a/src/lib/cortex/proposer.ts
+++ b/src/lib/cortex/proposer.ts
@@ -1,0 +1,438 @@
+/**
+ * #746 — Auto-directive proposer.
+ *
+ * When the same fix-pattern appears in `session_outcomes` ≥ 3 times within
+ * the last 14 days, this module surfaces a candidate directive to the
+ * Orchestrator's Mission panel. The orchestrator never writes a directive
+ * autonomously — the row is human-gated with Accept / Dismiss.
+ *
+ * Storage:
+ *   ~/.o8/proposal-snooze.json — append-only ledger of dismissed proposals,
+ *   each entry valid for 30 days. Stable proposal id is derived from the
+ *   matched (filePattern, fixPattern) pair so re-running the proposer keeps
+ *   suppressing the same row until the snooze expires.
+ *
+ * Algorithm (intentionally simple — tune during dogfooding):
+ *   1. Pull recent outcomes (14 d window, success+partial only — interrupted
+ *      and failed are noisy).
+ *   2. Extract `(filePattern, fixPattern)` pairs from each outcome:
+ *        - filePattern   — most-common file extension across `changedFilesJson`
+ *        - fixPattern    — top-frequency 2-gram from `summary` (after stop-word
+ *                           strip, lowercase, alpha+digit only)
+ *   3. Bucket pairs across outcomes; emit candidates with hits ≥ 3.
+ *   4. Filter against snooze ledger.
+ *   5. Rank by hit count descending, then most-recent occurrence.
+ */
+
+import 'server-only';
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+
+import { getDataDir } from '@/lib/data-dir-migration';
+
+const DEFAULT_WINDOW_DAYS = 14;
+const DEFAULT_THRESHOLD = 3;
+const SNOOZE_DAYS = 30;
+const MAX_CANDIDATES = 5;
+const SNOOZE_FILE = 'proposal-snooze.json';
+
+// English-ish stop words — minimal list, just enough to drop the most common
+// connector-noise from summary text. Bigger lists get the proposer too
+// aggressive on borderline phrases.
+const STOP_WORDS = new Set([
+  'a', 'an', 'and', 'are', 'as', 'at', 'be', 'by', 'for', 'from', 'has', 'have',
+  'in', 'into', 'is', 'it', 'its', 'of', 'on', 'or', 'that', 'the', 'this', 'to',
+  'was', 'were', 'will', 'with', 'when', 'while', 'over', 'under', 'now', 'then',
+  'so', 'do', 'did', 'does', 'add', 'added', 'fix', 'fixed', 'update', 'updated',
+  'change', 'changed', 'remove', 'removed', 'use', 'used', 'make', 'made',
+]);
+
+export interface DirectiveProposalCandidate {
+  /** Stable hash id derived from `(filePattern, fixPattern)` — used as the snooze key. */
+  id: string;
+  filePattern: string;
+  fixPattern: string;
+  hits: number;
+  /** Most recent matching outcome timestamp (ISO-8601). */
+  lastSeenAt: string;
+  /** Outcome ids that contributed — caller can render a list when needed. */
+  outcomeIds: string[];
+  /** Single-line draft text for the directive editor. */
+  draftDirective: string;
+}
+
+interface SnoozeEntry {
+  id: string;
+  snoozedUntil: string; // ISO-8601
+  filePattern: string;
+  fixPattern: string;
+}
+
+interface SnoozeLedger {
+  version: 1;
+  entries: SnoozeEntry[];
+}
+
+interface OutcomeRow {
+  id: string;
+  summary: string;
+  completedAt: string;
+  changedFilesJson: string;
+}
+
+// ── snooze helpers ────────────────────────────────────────────────────────
+
+function snoozeFilePath(): string {
+  return join(getDataDir(), SNOOZE_FILE);
+}
+
+function readSnoozeLedger(): SnoozeLedger {
+  const path = snoozeFilePath();
+  if (!existsSync(path)) {
+    return { version: 1, entries: [] };
+  }
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<SnoozeLedger>;
+    if (!parsed || parsed.version !== 1 || !Array.isArray(parsed.entries)) {
+      return { version: 1, entries: [] };
+    }
+    // Defensive — strip malformed entries but keep the rest.
+    const entries = parsed.entries.filter(
+      (e): e is SnoozeEntry =>
+        !!e &&
+        typeof e === 'object' &&
+        typeof e.id === 'string' &&
+        typeof e.snoozedUntil === 'string' &&
+        typeof e.filePattern === 'string' &&
+        typeof e.fixPattern === 'string',
+    );
+    return { version: 1, entries };
+  } catch (err) {
+    console.warn('[proposer] Failed to parse snooze ledger:', err instanceof Error ? err.message : err);
+    return { version: 1, entries: [] };
+  }
+}
+
+function writeSnoozeLedger(ledger: SnoozeLedger): void {
+  try {
+    writeFileSync(snoozeFilePath(), JSON.stringify(ledger, null, 2), 'utf-8');
+  } catch (err) {
+    console.warn('[proposer] Failed to write snooze ledger:', err instanceof Error ? err.message : err);
+  }
+}
+
+function activeSnoozedIds(now: Date): Set<string> {
+  const ledger = readSnoozeLedger();
+  const out = new Set<string>();
+  for (const entry of ledger.entries) {
+    const until = Date.parse(entry.snoozedUntil);
+    if (Number.isFinite(until) && until > now.getTime()) {
+      out.add(entry.id);
+    }
+  }
+  return out;
+}
+
+/**
+ * Append a snooze entry for the given candidate. Append-only — never rewrites
+ * existing entries. Stale entries (past their snoozedUntil) accumulate but
+ * are filtered at read time. Compaction is left to a future maintenance pass.
+ */
+export function snoozeProposal(candidate: { id: string; filePattern: string; fixPattern: string }): SnoozeEntry {
+  const snoozedUntil = new Date(Date.now() + SNOOZE_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  const entry: SnoozeEntry = {
+    id: candidate.id,
+    filePattern: candidate.filePattern,
+    fixPattern: candidate.fixPattern,
+    snoozedUntil,
+  };
+  const ledger = readSnoozeLedger();
+  ledger.entries.push(entry);
+  writeSnoozeLedger(ledger);
+  return entry;
+}
+
+// ── pattern extraction ────────────────────────────────────────────────────
+
+function makeProposalId(filePattern: string, fixPattern: string): string {
+  return createHash('sha1')
+    .update(`${filePattern}::${fixPattern}`, 'utf-8')
+    .digest('hex')
+    .slice(0, 16);
+}
+
+function safeParseChangedFiles(json: string): string[] {
+  try {
+    const parsed = JSON.parse(json);
+    if (Array.isArray(parsed)) {
+      return parsed
+        .map((entry) => {
+          if (typeof entry === 'string') return entry;
+          if (entry && typeof entry === 'object' && typeof entry.path === 'string') return entry.path;
+          return null;
+        })
+        .filter((s): s is string => !!s && s.length > 0);
+    }
+  } catch {
+    // ignore — empty list is the right answer for malformed rows
+  }
+  return [];
+}
+
+function extractFilePattern(changedFiles: string[]): string | null {
+  if (changedFiles.length === 0) return null;
+  const counts = new Map<string, number>();
+  for (const path of changedFiles) {
+    const match = path.match(/\.([a-zA-Z0-9]+)$/);
+    const ext = match ? `*.${match[1].toLowerCase()}` : null;
+    if (!ext) continue;
+    counts.set(ext, (counts.get(ext) ?? 0) + 1);
+  }
+  let best: string | null = null;
+  let bestCount = 0;
+  for (const [ext, count] of counts) {
+    if (count > bestCount) {
+      best = ext;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+function tokenize(summary: string): string[] {
+  return summary
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]+/g, ' ')
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 3 && !STOP_WORDS.has(token));
+}
+
+/**
+ * Return every distinct bigram in the summary. We aggregate across outcomes
+ * later — picking only the most-frequent per outcome made the matcher far
+ * too brittle when summaries vary in length or word order.
+ */
+function extractBigrams(summary: string): string[] {
+  const tokens = tokenize(summary);
+  if (tokens.length < 2) return [];
+  const seen = new Set<string>();
+  for (let i = 0; i < tokens.length - 1; i++) {
+    seen.add(`${tokens[i]} ${tokens[i + 1]}`);
+  }
+  return Array.from(seen);
+}
+
+interface CandidateAccumulator {
+  filePattern: string;
+  fixPattern: string;
+  outcomeIds: Set<string>;
+  lastSeenAt: string;
+}
+
+function pairKey(filePattern: string, fixPattern: string): string {
+  return `${filePattern} ${fixPattern}`;
+}
+
+function buildDraftDirective(filePattern: string, fixPattern: string, hits: number): string {
+  const pretty = fixPattern
+    .split(/\s+/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+  return [
+    `# ${pretty}`,
+    '',
+    `Observed ${hits}× in the last ${DEFAULT_WINDOW_DAYS} days on \`${filePattern}\` files.`,
+    '',
+    'Proposed rule (edit before saving):',
+    '',
+    `- When working on \`${filePattern}\`, ${fixPattern}.`,
+  ].join('\n');
+}
+
+// ── outcome read with defensive `valid_to` coalescing ─────────────────────
+
+/**
+ * Pull recent successful + partial outcomes inside the window. Defensively
+ * coalesces around `valid_to` (#745 may not have merged when this code runs)
+ * by reading `pragma table_info` first and only adding the clause if the
+ * column is present.
+ */
+function readRecentOutcomes(windowDays: number): OutcomeRow[] {
+  // Lazy require so this module stays tree-shake-friendly for client builds.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const dbModule = require('@/lib/db') as typeof import('@/lib/db');
+  const db = dbModule.getDb();
+  if (!db) return [];
+  const sqlite = dbModule.getSqlite();
+  if (!sqlite || typeof sqlite.prepare !== 'function') return [];
+
+  let hasValidTo = false;
+  try {
+    const cols = sqlite.pragma('table_info(session_outcomes)') as Array<{ name: string }>;
+    hasValidTo = Array.isArray(cols) && cols.some((col) => col?.name === 'valid_to');
+  } catch {
+    hasValidTo = false;
+  }
+
+  const sinceIso = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000).toISOString();
+
+  // outcome filter: 'succeeded' and 'partial' only — failed/interrupted runs
+  // amplify noise patterns that probably shouldn't become directives.
+  const validToClause = hasValidTo ? "AND (valid_to IS NULL OR valid_to > datetime('now'))" : '';
+  const sql = `
+    SELECT id, summary, completed_at AS completedAt, changed_files_json AS changedFilesJson
+    FROM session_outcomes
+    WHERE outcome IN ('succeeded', 'partial')
+      AND completed_at >= ?
+      ${validToClause}
+    ORDER BY completed_at DESC
+    LIMIT 500
+  `;
+
+  try {
+    const rows = sqlite.prepare(sql).all(sinceIso) as Array<{
+      id: string;
+      summary: string;
+      completedAt: string;
+      changedFilesJson: string;
+    }>;
+    return rows.filter((r) => r && typeof r.id === 'string');
+  } catch (err) {
+    console.warn('[proposer] outcome read failed:', err instanceof Error ? err.message : err);
+    return [];
+  }
+}
+
+// ── public surface ────────────────────────────────────────────────────────
+
+export interface ProposeOptions {
+  /** Window in days. Default 14. */
+  windowDays?: number;
+  /** Trigger threshold. Default 3. */
+  threshold?: number;
+  /** Cap on returned candidates. Default 5. */
+  limit?: number;
+  /** Inject a fixed `now` for tests — defaults to `new Date()`. */
+  now?: Date;
+}
+
+/**
+ * Run the proposer pass. Synchronous (we only touch SQLite + a small JSON
+ * file) and side-effect-free aside from reading the snooze ledger.
+ */
+export function proposeDirectives(options: ProposeOptions = {}): DirectiveProposalCandidate[] {
+  const windowDays = options.windowDays ?? DEFAULT_WINDOW_DAYS;
+  const threshold = options.threshold ?? DEFAULT_THRESHOLD;
+  const limit = options.limit ?? MAX_CANDIDATES;
+  const now = options.now ?? new Date();
+
+  const outcomes = readRecentOutcomes(windowDays);
+  if (outcomes.length === 0) return [];
+
+  // Aggregate every (filePattern × bigram) pair across all outcomes. Each
+  // outcome contributes its full bigram set; the threshold filter at the
+  // end requires the SAME pair to appear in ≥ 3 distinct outcomes.
+  const accumulators = new Map<string, CandidateAccumulator>();
+  for (const row of outcomes) {
+    const filePattern = extractFilePattern(safeParseChangedFiles(row.changedFilesJson));
+    if (!filePattern) continue;
+    const bigrams = extractBigrams(row.summary ?? '');
+    if (bigrams.length === 0) continue;
+    for (const bigram of bigrams) {
+      const key = pairKey(filePattern, bigram);
+      const existing = accumulators.get(key);
+      if (existing) {
+        existing.outcomeIds.add(row.id);
+        if (row.completedAt > existing.lastSeenAt) existing.lastSeenAt = row.completedAt;
+      } else {
+        accumulators.set(key, {
+          filePattern,
+          fixPattern: bigram,
+          outcomeIds: new Set([row.id]),
+          lastSeenAt: row.completedAt,
+        });
+      }
+    }
+  }
+
+  const snoozed = activeSnoozedIds(now);
+  const candidates: DirectiveProposalCandidate[] = [];
+  for (const acc of accumulators.values()) {
+    const hits = acc.outcomeIds.size;
+    if (hits < threshold) continue;
+    const id = makeProposalId(acc.filePattern, acc.fixPattern);
+    if (snoozed.has(id)) continue;
+    candidates.push({
+      id,
+      filePattern: acc.filePattern,
+      fixPattern: acc.fixPattern,
+      hits,
+      lastSeenAt: acc.lastSeenAt,
+      outcomeIds: Array.from(acc.outcomeIds),
+      draftDirective: buildDraftDirective(acc.filePattern, acc.fixPattern, hits),
+    });
+  }
+
+  candidates.sort((a, b) => {
+    if (b.hits !== a.hits) return b.hits - a.hits;
+    return b.lastSeenAt.localeCompare(a.lastSeenAt);
+  });
+
+  return candidates.slice(0, limit);
+}
+
+// ── boot tick wiring ──────────────────────────────────────────────────────
+
+let bootTickFired = false;
+let lastTickAt = 0;
+const TICK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
+
+/**
+ * Cache for the current tick — read by the API route. Keeps the proposer
+ * cheap when the Mission panel polls in.
+ */
+let cachedCandidates: DirectiveProposalCandidate[] = [];
+let cachedAt = 0;
+
+function runTick(): void {
+  try {
+    cachedCandidates = proposeDirectives();
+    cachedAt = Date.now();
+    lastTickAt = cachedAt;
+  } catch (err) {
+    console.warn('[proposer] tick threw:', err instanceof Error ? err.message : err);
+  }
+}
+
+/**
+ * Boot-time entrypoint. Mirrors the `ensureCodebaseMemoryBootIndex` pattern:
+ * fires once per server process via `setImmediate`, then schedules itself
+ * every 30 min. Idempotent.
+ */
+export function ensureProposerBootTick(): void {
+  if (bootTickFired) return;
+  bootTickFired = true;
+  setImmediate(() => runTick());
+  // Use unref so the interval doesn't keep the process alive in tests/CI.
+  const interval = setInterval(() => {
+    if (Date.now() - lastTickAt < TICK_INTERVAL_MS - 5_000) return;
+    runTick();
+  }, TICK_INTERVAL_MS);
+  if (typeof interval.unref === 'function') interval.unref();
+}
+
+/**
+ * Read the most recent cached candidate set. If the cache is empty (server
+ * just booted), runs the proposer inline. Cheap — bounded by the LIMIT 500
+ * query above and the threshold filter.
+ */
+export function readCachedProposals(): { candidates: DirectiveProposalCandidate[]; computedAt: number } {
+  if (cachedAt === 0) {
+    runTick();
+  }
+  return { candidates: cachedCandidates, computedAt: cachedAt };
+}


### PR DESCRIPTION
## Summary
- Adds `src/lib/cortex/proposer.ts` — server-only module that scans `session_outcomes` for recurring `(filePattern × bigram)` pairs (≥3 hits in 14 days), excluding stop-word noise. Emits ranked candidates with stable hash ids derived from the matched pair.
- Defensive coalescing for #745 — runs `pragma table_info` at query time and only adds the `valid_to IS NULL OR valid_to > datetime('now')` clause when the column is present, so the proposer continues to work whether #745 has merged or not.
- New API route `GET/POST /api/cortex/proposals` — read cache + dismiss action. Boot tick wired into `/api/panel/status` next to `ensureCodebaseMemoryBootIndex` (idempotent + 30 min self-scheduling, mirrors that pattern).
- New yellow Issues-style row component `DirectiveProposalRow` rendered above Open Issues via a tiny `DirectiveProposalSection` wrapper. Accept pre-fills the orchestrator chat composer through the existing `setThoughtsDraftInjection` pipeline (new `onAcceptDirectiveProposal` slot on `OrchestratorDataContext`); Dismiss POSTs an append-only entry to `~/.o8/proposal-snooze.json` with a 30-day TTL.
- Mission panel kept under the 800-line ceiling by extracting `useDirectiveProposals` (state + fetch + dismiss) and `DirectiveProposalSection` (render) into `mission-panel/`.

## Test plan
- [x] `npx tsc --noEmit` clean.
- [x] Smoke test with synthetic `session_outcomes`: 3× `(*.tsx, "handler memoization")` → 1 candidate emitted; `snoozeProposal()` suppresses next run; 31 days later it re-emerges. Snooze JSON written to `~/.o8/proposal-snooze.json`.
- [x] Boot tick is idempotent — calling `ensureProposerBootTick()` twice still runs the proposer once.
- [ ] Visual: row renders yellow above Open Issues in the Mission panel; Accept fills composer; Dismiss removes the row and writes snooze.

## What #747 inherits
Per-runtime telemetry can re-use:
1. The `pragma table_info` defensive-coalescing pattern around `valid_to`.
2. The `ensureProposerBootTick` boot/30-min self-scheduling shape — slot directly into `/api/panel/status`.
3. The cached-proposal pattern (`readCachedProposals` returning `{ candidates, computedAt }`) for cheap polling from the UI.
4. The `OrchestratorDataContext.onAcceptDirectiveProposal` Accept-into-composer pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)