### PR TITLE
feat(cortex): per-runtime outcome telemetry → dispatch routing recommendation

### DIFF
--- a/src/app/api/cortex/runtime-recommendation/route.ts
+++ b/src/app/api/cortex/runtime-recommendation/route.ts
@@ -1,0 +1,56 @@
+/**
+ * GET /api/cortex/runtime-recommendation?repoPath=<absolute-path>
+ *
+ * Returns the dispatch routing recommendation for a single repo. Backed by
+ * `recommendRuntime()` (#747) which scores runtimes by `merged_clean` win
+ * rate over the live (non-decayed) outcomes for the repo.
+ *
+ * Response shape:
+ *   {
+ *     ok: true,
+ *     recommendation: {
+ *       runtime: 'codex' | 'claude-code' | 'gemini' | 'opencode' | null,
+ *       score: number,         // 0..1, only meaningful when runtime != null
+ *       evidence: {            // per-runtime breakdown for tooltip / audit
+ *         [runtime]: { runtime, score, total, mergedClean }
+ *       }
+ *     }
+ *   }
+ *
+ * `runtime: null` means insufficient sample to recommend — the caller should
+ * fall through to the user's default (codex). The `evidence` map is still
+ * populated so the UI can show coverage.
+ *
+ * Local-only by design: `/api/cortex/*` is gated by the global middleware on
+ * loopback origin + ws-token. No additional auth needed here.
+ */
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { recommendRuntime } from '@/lib/dispatch/routing';
+
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+  const repoPath = params.get('repoPath')?.trim() ?? '';
+  if (!repoPath) {
+    return NextResponse.json(
+      { ok: false, error: 'repoPath is required.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const recommendation = await recommendRuntime(repoPath);
+    return NextResponse.json(
+      { ok: true, recommendation },
+      { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+    );
+  } catch (error) {
+    const message = error instanceof Error
+      ? error.message
+      : 'Unable to compute runtime recommendation.';
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/src/components/desktop/thoughts/mission-panel/PacketMetaRows.tsx
+++ b/src/components/desktop/thoughts/mission-panel/PacketMetaRows.tsx
@@ -17,6 +17,57 @@ import type { EditingField } from './types';
 // endpoint revalidates on its own). Avoids prop-drilling the flag through
 // every mission-panel layer for a single opt-in toggle.
 let cachedExperimentalOpencode: boolean | null = null;
+
+// #747 — Routing recommendation cache. One entry per repoPath; refreshed
+// lazily so the chip stays consistent across packet cards on the same repo.
+interface RuntimeEvidenceRow {
+  runtime: OrchestratorRuntime;
+  score: number;
+  total: number;
+  mergedClean: number;
+}
+interface RuntimeRecommendationPayload {
+  runtime: OrchestratorRuntime | null;
+  score: number;
+  evidence: Partial<Record<OrchestratorRuntime, RuntimeEvidenceRow>>;
+}
+const recommendationCache = new Map<string, { value: RuntimeRecommendationPayload | null; expiresAt: number }>();
+const RECOMMENDATION_TTL_MS = 30_000;
+
+function useRuntimeRecommendation(repoPath: string | null | undefined): RuntimeRecommendationPayload | null {
+  const [payload, setPayload] = useState<RuntimeRecommendationPayload | null>(() => {
+    if (!repoPath) return null;
+    const cached = recommendationCache.get(repoPath);
+    return cached && cached.expiresAt > Date.now() ? cached.value : null;
+  });
+  useEffect(() => {
+    if (!repoPath) { setPayload(null); return; }
+    const cached = recommendationCache.get(repoPath);
+    if (cached && cached.expiresAt > Date.now()) {
+      setPayload(cached.value);
+      return;
+    }
+    let cancelled = false;
+    const controller = new AbortController();
+    const url = `/api/cortex/runtime-recommendation?repoPath=${encodeURIComponent(repoPath)}`;
+    fetch(url, { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) return null;
+        const data = await response.json().catch(() => null);
+        if (!data || data.ok !== true || !data.recommendation) return null;
+        return data.recommendation as RuntimeRecommendationPayload;
+      })
+      .then((value) => {
+        recommendationCache.set(repoPath, { value, expiresAt: Date.now() + RECOMMENDATION_TTL_MS });
+        if (!cancelled) setPayload(value);
+      })
+      .catch(() => {
+        // Network or middleware errors are non-fatal — chip just stays hidden.
+      });
+    return () => { cancelled = true; controller.abort(); };
+  }, [repoPath]);
+  return payload;
+}
 function useExperimentalOpencodeFlag(override?: boolean): boolean {
   const [flag, setFlag] = useState<boolean>(
     override !== undefined ? override : (cachedExperimentalOpencode ?? false),
@@ -60,6 +111,17 @@ export function PacketMetaRows({
   const isEditingRepo = editingField?.packetId === packet.id && editingField.field === 'repo';
   const isEditingBranch = editingField?.packetId === packet.id && editingField.field === 'branch';
   const canEditBranch = packet.queueState === 'draft';
+  // #747 — Routing recommendation chip. Only renders when the recommender has
+  // a confident pick (`runtime` non-null) and the operator hasn't already
+  // selected it. Per-runtime evidence rendered inside the popover.
+  const recommendation = useRuntimeRecommendation(packet.workspaceTargetPath);
+  const recommendedRuntime = recommendation?.runtime ?? null;
+  const recommendationScorePct = recommendation && recommendedRuntime
+    ? Math.round(recommendation.score * 100)
+    : null;
+  const showRecommendationChipOnRow = Boolean(
+    recommendedRuntime && recommendedRuntime !== packet.runtime,
+  );
 
   const workspaceLabel = packet.workspaceTargetPath
     ? (workspaceTargets.find((t) => t.localPath === packet.workspaceTargetPath)?.label ?? packet.workspaceTargetPath.split('/').pop() ?? 'target')
@@ -183,8 +245,32 @@ export function PacketMetaRows({
           onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
         >
           <span style={rowLabelStyle}>runtime</span>
-          <span style={{ ...rowValueStyle, color: orchestratorRuntimeTone(packet.runtime).color, fontWeight: 600 }}>
-            {runtimeDisplay}
+          <span style={{ ...rowValueStyle, color: orchestratorRuntimeTone(packet.runtime).color, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 6, whiteSpace: 'nowrap' as const }}>
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{runtimeDisplay}</span>
+            {showRecommendationChipOnRow && recommendedRuntime && recommendationScorePct !== null ? (
+              <span
+                title={`History on this repo prefers ${orchestratorRuntimeTone(recommendedRuntime).label} (${recommendationScorePct}% clean merge rate). Click to switch.`}
+                style={{
+                  fontSize: 9,
+                  fontWeight: 700,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.06em',
+                  color: orchestratorRuntimeTone(recommendedRuntime).color,
+                  background: 'var(--t-accent-soft)',
+                  borderWidth: 1,
+                  borderStyle: 'solid',
+                  borderColor: 'var(--t-accent-border)',
+                  borderRadius: 4,
+                  paddingTop: 1,
+                  paddingRight: 5,
+                  paddingBottom: 1,
+                  paddingLeft: 5,
+                  flexShrink: 0,
+                }}
+              >
+                {orchestratorRuntimeTone(recommendedRuntime).label} {recommendationScorePct}%
+              </span>
+            ) : null}
           </span>
           {chevron}
         </button>
@@ -205,38 +291,82 @@ export function PacketMetaRows({
               overflow: 'hidden',
             }}
           >
-            {listDispatchableRuntimes({ includeExperimental: opencodeEnabled || packet.runtime === 'opencode' }).map((runtime: OrchestratorRuntime) => (
-              <button
-                key={runtime}
-                type="button"
-                onClick={() => {
-                  onPatch((current) => ({ ...current, runtime }));
-                  onEditingFieldChange(null);
-                }}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 6,
-                  width: '100%',
-                  paddingTop: 7,
-                  paddingRight: 10,
-                  paddingBottom: 7,
-                  paddingLeft: 10,
-                  borderWidth: 0,
-                  background: packet.runtime === runtime ? 'var(--t-accent-soft)' : 'transparent',
-                  color: 'var(--t-text)',
-                  fontSize: 11.5,
-                  fontWeight: 500,
-                  cursor: 'pointer',
-                  textAlign: 'left',
-                }}
-                onMouseEnter={(e) => { if (packet.runtime !== runtime) e.currentTarget.style.background = 'var(--t-panel-hover)'; }}
-                onMouseLeave={(e) => { if (packet.runtime !== runtime) e.currentTarget.style.background = 'transparent'; }}
-              >
-                <span style={{ width: 6, height: 6, borderRadius: '50%', background: orchestratorRuntimeTone(runtime).color }} />
-                {orchestratorRuntimeTone(runtime).label}
-              </button>
-            ))}
+            {listDispatchableRuntimes({ includeExperimental: opencodeEnabled || packet.runtime === 'opencode' }).map((runtime: OrchestratorRuntime) => {
+              const evidence = recommendation?.evidence?.[runtime] ?? null;
+              const isRecommended = recommendedRuntime === runtime;
+              const evidencePct = evidence && evidence.total > 0
+                ? Math.round((evidence.mergedClean / evidence.total) * 100)
+                : null;
+              return (
+                <button
+                  key={runtime}
+                  type="button"
+                  onClick={() => {
+                    onPatch((current) => ({ ...current, runtime }));
+                    onEditingFieldChange(null);
+                  }}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    width: '100%',
+                    paddingTop: 7,
+                    paddingRight: 10,
+                    paddingBottom: 7,
+                    paddingLeft: 10,
+                    borderWidth: 0,
+                    background: packet.runtime === runtime ? 'var(--t-accent-soft)' : 'transparent',
+                    color: 'var(--t-text)',
+                    fontSize: 11.5,
+                    fontWeight: 500,
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                  }}
+                  onMouseEnter={(e) => { if (packet.runtime !== runtime) e.currentTarget.style.background = 'var(--t-panel-hover)'; }}
+                  onMouseLeave={(e) => { if (packet.runtime !== runtime) e.currentTarget.style.background = 'transparent'; }}
+                >
+                  <span style={{ width: 6, height: 6, borderRadius: '50%', background: orchestratorRuntimeTone(runtime).color, flexShrink: 0 }} />
+                  <span style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}>
+                    {orchestratorRuntimeTone(runtime).label}
+                  </span>
+                  {isRecommended && evidencePct !== null ? (
+                    <span
+                      style={{
+                        fontSize: 9,
+                        fontWeight: 700,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.06em',
+                        color: orchestratorRuntimeTone(runtime).color,
+                        background: 'var(--t-accent-soft)',
+                        borderWidth: 1,
+                        borderStyle: 'solid',
+                        borderColor: 'var(--t-accent-border)',
+                        borderRadius: 4,
+                        paddingTop: 1,
+                        paddingRight: 5,
+                        paddingBottom: 1,
+                        paddingLeft: 5,
+                        flexShrink: 0,
+                      }}
+                    >
+                      RECOMMENDED · {evidencePct}%
+                    </span>
+                  ) : evidence && evidence.total > 0 ? (
+                    <span
+                      style={{
+                        fontSize: 9.5,
+                        fontWeight: 600,
+                        color: 'var(--t-text-muted)',
+                        flexShrink: 0,
+                        fontVariantNumeric: 'tabular-nums',
+                      }}
+                    >
+                      {evidence.mergedClean}/{evidence.total}
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })}
           </div>
         ) : null}
       </div>

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -20,6 +20,7 @@ import * as schema from './schema';
 import { migrateLegacyApprovalStoreIfNeeded } from '@/lib/approvals/storage-migration';
 import { migrateLegacyLaneStoreIfNeeded } from '@/lib/lane/storage-migration';
 import { ensureUsageLogIndexes, ensureUsageLogSchema } from '@/lib/db/usage-log-migration';
+import { ensureSessionOutcomeRoutingColumns } from '@/lib/db/session-outcome-routing-migration';
 
 // ── Data directory ──
 
@@ -33,7 +34,7 @@ const DATA_DIR = process.env.O8_DATA_DIR
 // second migration step with no user-facing benefit.
 const DB_PATH = process.env.CORTEX_IDE_DB_PATH || path.join(DATA_DIR, 'cortex-ide.db');
 // Bump when ensureTables() adds new schema or backfill work.
-const DB_SCHEMA_VERSION = 11;
+const DB_SCHEMA_VERSION = 12;
 const DB_MIGRATION_MARKER_PATH = path.join(DATA_DIR, `.db-migrated-v${DB_SCHEMA_VERSION}`);
 
 // Ensure data directory exists
@@ -240,7 +241,8 @@ function ensureTables(sqlite: Database.Database): void {
       completed_at TEXT NOT NULL,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
       valid_from TEXT NOT NULL DEFAULT (datetime('now')),
-      valid_to TEXT
+      valid_to TEXT,
+      skipped_tests INTEGER, reworked INTEGER, merged_clean INTEGER
     );
 
     CREATE TABLE IF NOT EXISTS teams (
@@ -629,6 +631,7 @@ function ensureSessionOutcomeColumns(sqlite: Database.Database): void {
   }
   // Index on valid_to to keep "live entries only" recall queries cheap.
   sqlite.exec('CREATE INDEX IF NOT EXISTS idx_so_valid_to ON session_outcomes(valid_to)');
+  ensureSessionOutcomeRoutingColumns(sqlite); // #747
 }
 
 function backfillWatchedAgentColumns(sqlite: Database.Database): void {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -173,6 +173,20 @@ export const sessionOutcomes = sqliteTable('session_outcomes', {
    */
   validFrom: text('valid_from').notNull().default(sql`(datetime('now'))`),
   validTo: text('valid_to'),
+  /**
+   * #747 — Per-runtime outcome shape used by the dispatch routing recommender.
+   * Nullable because legacy rows (before v12) don't carry the signal. The
+   * `recommendRuntime()` helper coalesces to "no opinion" when these are NULL.
+   *
+   *  - `skippedTests`  — true when the agent skipped or stubbed required tests
+   *  - `reworked`      — true when the operator had to rerun-with-feedback
+   *                      before accepting (or rejected outright)
+   *  - `mergedClean`   — true when the diff merged without operator edits and
+   *                      `review_approved = true`. The headline routing signal.
+   */
+  skippedTests: integer('skipped_tests', { mode: 'boolean' }),
+  reworked: integer('reworked', { mode: 'boolean' }),
+  mergedClean: integer('merged_clean', { mode: 'boolean' }),
 }, (table) => ({
   repoRuntimeIdx: index('idx_so_repo_runtime').on(table.repoPath, table.runtime, table.completedAt),
   repoCompletedIdx: index('idx_so_repo_completed').on(table.repoPath, table.completedAt),

--- a/src/lib/db/session-outcome-routing-migration.ts
+++ b/src/lib/db/session-outcome-routing-migration.ts
@@ -1,0 +1,34 @@
+/**
+ * #747 — Per-runtime outcome telemetry columns on `session_outcomes`.
+ *
+ * Adds three nullable boolean columns (`skipped_tests`, `reworked`,
+ * `merged_clean`) and backfills `merged_clean` from the existing
+ * `review_approved` + `outcome` pair so the dispatch routing recommender
+ * has signal on day one. Idempotent — re-running on a v12 DB is a no-op.
+ *
+ * Lives outside `db/index.ts` to keep that file under the 800-line ceiling.
+ */
+import type Database from 'better-sqlite3';
+
+function columnExists(sqlite: Database.Database, table: string, column: string): boolean {
+  const rows = sqlite.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return rows.some((row) => row.name === column);
+}
+
+export function ensureSessionOutcomeRoutingColumns(sqlite: Database.Database): void {
+  if (!columnExists(sqlite, 'session_outcomes', 'skipped_tests')) {
+    sqlite.exec('ALTER TABLE session_outcomes ADD COLUMN skipped_tests INTEGER');
+  }
+  if (!columnExists(sqlite, 'session_outcomes', 'reworked')) {
+    sqlite.exec('ALTER TABLE session_outcomes ADD COLUMN reworked INTEGER');
+  }
+  if (!columnExists(sqlite, 'session_outcomes', 'merged_clean')) {
+    sqlite.exec('ALTER TABLE session_outcomes ADD COLUMN merged_clean INTEGER');
+    // Backfill: a prior outcome with `outcome='succeeded'` AND
+    // `review_approved=1` is a clean merge. Failed outcomes mark
+    // `merged_clean=0`. Everything else (NULL approved, partial, interrupted)
+    // stays NULL — we don't want to assume the unknown rows.
+    sqlite.exec("UPDATE session_outcomes SET merged_clean = 1 WHERE merged_clean IS NULL AND outcome = 'succeeded' AND review_approved = 1");
+    sqlite.exec("UPDATE session_outcomes SET merged_clean = 0 WHERE merged_clean IS NULL AND outcome = 'failed'");
+  }
+}

--- a/src/lib/dispatch/routing.ts
+++ b/src/lib/dispatch/routing.ts
@@ -1,0 +1,155 @@
+/**
+ * #747 — Per-runtime outcome telemetry → dispatch routing recommendation.
+ *
+ * Reads `session_outcomes` filtered by repo + temporal validity (#745) and
+ * scores each runtime by win-rate (`merged_clean / total_outcomes`). The
+ * recommender returns the top-scoring runtime when there's enough sample to
+ * trust, plus the full evidence map so the UI can show a chip + tooltip.
+ *
+ * No automatic switching mid-dispatch — the orchestrator only consults this
+ * helper at packet-create time and logs the recommendation alongside the
+ * actual choice. The operator's manual runtime popover always wins.
+ */
+import 'server-only';
+
+import { and, eq } from 'drizzle-orm';
+
+import { getDb, sessionOutcomes } from '@/lib/db';
+import { liveOutcomeFilter } from '@/lib/cortex/decay';
+import { ORCHESTRATOR_RUNTIMES } from '@/lib/orchestrator/runtime-capabilities';
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+
+/**
+ * Minimum number of live outcomes a (repo, runtime) pair needs before its
+ * win-rate is treated as a real signal. Below this we return `null` from
+ * `recommendRuntime()` so the dispatcher falls through to the user's default
+ * (codex). Three is chosen so the first few outcomes don't pin the chip on
+ * a fluky early result.
+ */
+export const MIN_SAMPLE_SIZE = 3;
+
+export interface RuntimeScore {
+  runtime: OrchestratorRuntime;
+  /** Win rate in [0, 1] — `merged_clean / total`. */
+  score: number;
+  /** Live outcomes used to compute the score. */
+  total: number;
+  /** Outcomes where `merged_clean = 1` — the numerator of `score`. */
+  mergedClean: number;
+}
+
+export interface RuntimeRecommendation {
+  /** Top-scoring runtime when sample size + delta justify a chip. */
+  runtime: OrchestratorRuntime | null;
+  /** Score of the recommended runtime, or 0 when none qualifies. */
+  score: number;
+  /**
+   * Per-runtime evidence keyed by runtime id. Always populated for every
+   * runtime that has at least one live outcome on the repo. Useful for
+   * tooltips and audit logs.
+   */
+  evidence: Partial<Record<OrchestratorRuntime, RuntimeScore>>;
+}
+
+const EMPTY: RuntimeRecommendation = { runtime: null, score: 0, evidence: {} };
+
+/**
+ * Score every runtime that has live outcomes on the repo. Returns one row per
+ * runtime — callers can pick the top, or render the full set in a tooltip.
+ */
+export async function scoreRuntimesForRepo(
+  repoPath: string,
+): Promise<RuntimeScore[]> {
+  const trimmed = repoPath?.trim();
+  if (!trimmed) return [];
+  const db = getDb();
+  if (!db) return [];
+
+  try {
+    // Drizzle's COUNT/SUM helpers can be flaky against the boolean column on
+    // older sqlite builds — pull live rows and aggregate in JS. The dataset
+    // is small (one repo's outcomes within the 30d validity window), so this
+    // stays cheap.
+    const rows = await db
+      .select({
+        runtime: sessionOutcomes.runtime,
+        mergedClean: sessionOutcomes.mergedClean,
+      })
+      .from(sessionOutcomes)
+      .where(and(eq(sessionOutcomes.repoPath, trimmed), liveOutcomeFilter()));
+
+    if (rows.length === 0) return [];
+
+    const tally = new Map<OrchestratorRuntime, { total: number; mergedClean: number }>();
+    for (const row of rows) {
+      const key = row.runtime as OrchestratorRuntime;
+      const prior = tally.get(key) ?? { total: 0, mergedClean: 0 };
+      prior.total += 1;
+      // Treat NULL as "unknown, not clean" — the recommender penalises
+      // outcomes that didn't make it to the merged-clean state. Legacy rows
+      // backfilled from `review_approved + outcome` already supply 1/0.
+      if (row.mergedClean === true) prior.mergedClean += 1;
+      tally.set(key, prior);
+    }
+
+    return Array.from(tally.entries()).map(([runtime, agg]) => ({
+      runtime,
+      total: agg.total,
+      mergedClean: agg.mergedClean,
+      score: agg.total > 0 ? agg.mergedClean / agg.total : 0,
+    }));
+  } catch (error) {
+    // Defensive: if the column is missing on a degraded DB the recommender
+    // should silently fall through to "no opinion" rather than crash the
+    // dispatch path.
+    console.warn(
+      '[dispatch-routing] scoreRuntimesForRepo failed:',
+      error instanceof Error ? error.message : error,
+    );
+    return [];
+  }
+}
+
+/**
+ * Pick the best-known runtime for `repoPath`. Returns `{ runtime: null }` when
+ * no runtime has at least `MIN_SAMPLE_SIZE` live outcomes — the caller should
+ * fall through to the user's default. The `evidence` map is always populated
+ * with whatever data we did find so the UI can still hint at coverage.
+ *
+ * Ties (equal score across two runtimes with sufficient sample) prefer the
+ * one with the larger sample — more outcomes, more trustworthy signal.
+ */
+export async function recommendRuntime(
+  repoPath: string,
+): Promise<RuntimeRecommendation> {
+  const scores = await scoreRuntimesForRepo(repoPath);
+  if (scores.length === 0) return EMPTY;
+
+  const evidence: Partial<Record<OrchestratorRuntime, RuntimeScore>> = {};
+  for (const row of scores) {
+    evidence[row.runtime] = row;
+  }
+
+  const eligible = scores
+    // Only recommend runtimes the operator can actually dispatch to. Discovery-
+    // only adapters (claude-code as of #650) still contribute evidence rows
+    // because we want history showing in the popover, but they should never
+    // be the surfaced "recommended" pick.
+    .filter((row) => {
+      const capability = ORCHESTRATOR_RUNTIMES[row.runtime];
+      return capability?.dispatchable === true && row.total >= MIN_SAMPLE_SIZE;
+    })
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      // Tie-break on sample size, then alphabetic for determinism.
+      if (b.total !== a.total) return b.total - a.total;
+      return a.runtime.localeCompare(b.runtime);
+    });
+
+  if (eligible.length === 0) {
+    return { runtime: null, score: 0, evidence };
+  }
+
+  const top = eligible[0]!;
+  return { runtime: top.runtime, score: top.score, evidence };
+}

--- a/src/lib/orchestrator/operator-mission-service/mission.ts
+++ b/src/lib/orchestrator/operator-mission-service/mission.ts
@@ -6,6 +6,7 @@ import { findLaneByPacket } from '@/lib/lane/registry';
 import { normalizeOrchestratorMissionState } from '@/lib/orchestrator/store';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 import { getTopRulesForPacket, readRepoScopedRules } from '@/lib/dispatch/rules-store';
+import { recommendRuntime } from '@/lib/dispatch/routing';
 import {
   buildMissionId,
   buildMissionPrompt,
@@ -145,6 +146,17 @@ export async function createMission(input: CreateMissionInput) {
 
   log(`Created mission ${missionId} with ${persisted.packets.length} packets.`);
 
+  // #747 — Per-packet routing recommendation snapshot. Logs the runtime the
+  // recommender would have picked next to the operator's actual choice. We
+  // never override the user's selection — this is observability so we can see
+  // whether the heuristic agrees with current operator behavior.
+  void logDispatchRoutingRecommendations(persisted.packets, missionId).catch((error) => {
+    console.warn(
+      '[dispatch-routing] recommendation logging failed:',
+      error instanceof Error ? error.message : error,
+    );
+  });
+
   return {
     missionId,
     packets: persisted.packets.map((packet) => ({
@@ -153,6 +165,34 @@ export async function createMission(input: CreateMissionInput) {
       wave: waves.get(packet.id) ?? 1,
     })),
   };
+}
+
+async function logDispatchRoutingRecommendations(
+  packets: OrchestratorPacket[],
+  missionId: string,
+): Promise<void> {
+  // Group by repo so we only score each repo once per mission.
+  const byRepo = new Map<string, OrchestratorPacket[]>();
+  for (const packet of packets) {
+    const repo = packet.workspaceTargetPath?.trim();
+    if (!repo) continue;
+    const prior = byRepo.get(repo) ?? [];
+    prior.push(packet);
+    byRepo.set(repo, prior);
+  }
+
+  for (const [repoPath, repoPackets] of byRepo) {
+    const recommendation = await recommendRuntime(repoPath);
+    for (const packet of repoPackets) {
+      const matched = recommendation.runtime !== null && packet.runtime === recommendation.runtime;
+      const evidenceSummary = Object.values(recommendation.evidence)
+        .map((row) => `${row.runtime}=${row.mergedClean}/${row.total}`)
+        .join(' ') || 'no-history';
+      console.log(
+        `[dispatch-routing] mission=${missionId} packet=${packet.referenceLabel} repo=${repoPath} chose=${packet.runtime} recommended=${recommendation.runtime ?? 'none'} score=${recommendation.score.toFixed(2)} matched=${matched} evidence=${evidenceSummary}`,
+      );
+    }
+  }
 }
 
 export async function dispatchMission(input: DispatchMissionInput) {


### PR DESCRIPTION
Closes #747. Part of #738 (Context Engine v2).

## Summary

- Adds three nullable boolean columns to `session_outcomes` (`skipped_tests`, `reworked`, `merged_clean`) — schema v12, idempotent column-add + backfill of `merged_clean` from `review_approved + outcome` so existing rows feed the recommender on day one.
- New `src/lib/dispatch/routing.ts` — `recommendRuntime(repoPath)` returns `{ runtime, score, evidence }` per (repo, runtime). Applies #745 temporal-validity filter and a `MIN_SAMPLE_SIZE=3` floor; ties tie-break on sample size then alphabetic.
- Discovery-only adapters (claude-code per #650) still contribute evidence rows so the popover shows their history, but are filtered out of the recommended pick.
- New `/api/cortex/runtime-recommendation` GET endpoint, gated through the existing `/api/cortex/*` middleware.
- Recommended chip wired into `PacketMetaRows.tsx` — appears next to the runtime value when the recommendation differs from the operator's pick, and inside the popover as `RECOMMENDED · X%` with `m/n` evidence rows for non-recommended runtimes. Manual override via the existing popover still works.
- `[dispatch-routing]` log emits at packet creation in `mission.ts createMission()` recording recommendation + actual choice + match flag + per-runtime evidence.

## What #748 (cross-repo learning) inherits

- The same `merged_clean` signal — the cross-repo aggregator can union scores across repos when a fleet-wide default is needed.
- The dispatchable filter pattern from `recommendRuntime()`.
- `MIN_SAMPLE_SIZE` as the tunable floor — #748 may want a lower floor across the broader sample pool.

## Test plan

- [x] Smoke: `recommendRuntime()` against seeded fresh DB returns the right pick (codex 4/5 wins over gemini at 1/2 below floor; claude-code excluded as non-dispatchable).
- [x] Empty-DB / blank-repoPath path returns `{ runtime: null, score: 0, evidence: {} }`.
- [x] Backfill: pre-v12 schema with `outcome + review_approved` populates `merged_clean` correctly (succeeded+approved=1 → 1, failed → 0, partial/interrupted/null-approved → NULL).
- [x] Idempotency: `ensureSessionOutcomeRoutingColumns()` triple-run on v12 DB is a no-op, row counts unchanged.
- [x] `npx tsc --noEmit` passes.
- [ ] Visual check: chip renders next to the runtime row when the recommended runtime differs from the operator's pick; popover shows `RECOMMENDED · X%` on the leader and `m/n` evidence on others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)