### PR TITLE
feat(cortex): cross-repo learning — propagate stack-specific directives (#748)

### DIFF
--- a/src/app/api/cortex/cross-repo-proposals/route.ts
+++ b/src/app/api/cortex/cross-repo-proposals/route.ts
@@ -1,0 +1,74 @@
+/**
+ * GET /api/cortex/cross-repo-proposals
+ *   → { ok: true, proposals: CrossRepoProposalCandidate[], computedAt: number }
+ *
+ * POST /api/cortex/cross-repo-proposals
+ *   body: { action: 'dismiss', targetRepoId: string, directiveId: string }
+ *   → { ok: true, snoozedUntil: string }
+ *
+ * Cross-repo learning surface for #748. Read-only window into the
+ * proposer cache; dismissals snooze a (targetRepoId, directiveId) pair for
+ * 30 days. Always human-gated — Accept never auto-writes a directive.
+ *
+ * Gated by middleware (loopback + ws-token) under the `/api/cortex/` prefix.
+ */
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  readCachedCrossRepoProposals,
+  snoozeCrossRepoProposal,
+} from '@/lib/cortex/cross-repo-proposer';
+
+export async function GET() {
+  try {
+    const { candidates, computedAt } = await readCachedCrossRepoProposals();
+    return NextResponse.json(
+      { ok: true, proposals: candidates, computedAt },
+      { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to load cross-repo proposals.';
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+
+interface DismissBody {
+  action?: string;
+  targetRepoId?: string;
+  directiveId?: string;
+}
+
+export async function POST(request: NextRequest) {
+  let body: DismissBody | null = null;
+  try {
+    body = (await request.json()) as DismissBody;
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  if (!body || body.action !== 'dismiss') {
+    return NextResponse.json({ ok: false, error: 'Unsupported action.' }, { status: 400 });
+  }
+  const targetRepoId = typeof body.targetRepoId === 'string' ? body.targetRepoId.trim() : '';
+  const directiveId = typeof body.directiveId === 'string' ? body.directiveId.trim() : '';
+  if (!targetRepoId || !directiveId) {
+    return NextResponse.json(
+      { ok: false, error: 'targetRepoId and directiveId are required for dismiss.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const entry = snoozeCrossRepoProposal({ targetRepoId, directiveId });
+    return NextResponse.json(
+      { ok: true, snoozedUntil: entry.snoozedUntil },
+      { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to snooze proposal.';
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/panel/status/route.ts
+++ b/src/app/api/panel/status/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import { ensureCodebaseMemoryBootIndex } from '@/lib/codebase-memory/indexer';
 import { ensureDecayBootHook } from '@/lib/cortex/decay';
 import { ensureProposerBootTick } from '@/lib/cortex/proposer';
+import { ensureStackSignatureBoot } from '@/lib/cortex/stack-signature';
+import { ensureCrossRepoProposerBootTick } from '@/lib/cortex/cross-repo-proposer';
 
 export async function GET() {
   // Tauri shell hits /api/panel/status as a liveness probe right after the
@@ -15,6 +17,11 @@ export async function GET() {
   // #746 — Auto-directive proposer tick. Same pattern: idempotent boot hook,
   // self-schedules every 30 min, never blocks the liveness probe.
   ensureProposerBootTick();
+  // #748 — Cross-repo learning. First call seeds the stack-signature cache,
+  // then the proposer tick fans out matching directives across registered
+  // repos every 30 min. Both boot hooks are idempotent + microtask-driven.
+  ensureStackSignatureBoot();
+  ensureCrossRepoProposerBootTick();
 
   return NextResponse.json({
     connected: false,

--- a/src/components/desktop/thoughts/DirectiveProposalRow.tsx
+++ b/src/components/desktop/thoughts/DirectiveProposalRow.tsx
@@ -1,17 +1,19 @@
 'use client';
 
 /**
- * #746 — DirectiveProposalRow.
+ * #746 / #748 — DirectiveProposalRow.
  *
  * Yellow Issues-style row that surfaces above Open Issues in the Mission
- * panel when the auto-directive proposer detects a recurring fix-pattern.
- * Human-gated: Accept fills the chat composer with a draft directive;
- * Dismiss snoozes the proposal for 30 days.
+ * panel. Two proposal sources share this chrome:
  *
- * The row mirrors the `IssueGroupList` row chrome (dense, 34px tall, no
- * card outline) but tinted yellow so the operator notices it without it
- * dominating the panel. Multiple proposals stack as sibling rows under a
- * single header.
+ *   - `auto` (#746) — recurring (filePattern, fixPattern) pairs from the
+ *     local outcome ledger. Renders `<hits>× seen   add directive: pattern → bigram?`
+ *   - `cross-repo` (#748) — a stack-similar repo already has this directive.
+ *     Renders `<sourceRepo> → <targetRepo>   <directive title>` with a
+ *     similarity chip in place of the hits badge.
+ *
+ * Human-gated: Accept fills the chat composer with a draft directive;
+ * Dismiss snoozes the proposal.
  */
 
 import { useCallback, useState } from 'react';
@@ -68,45 +70,11 @@ export function DirectiveProposalRow({ proposal, onAccept, onDismiss, busy }: Di
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
-      {/* Hits badge — mirrors the issue-number column width in IssueGroupList. */}
-      <span
-        title={`Observed ${proposal.hits}× in the last 14 days`}
-        style={{
-          width: 42,
-          flexShrink: 0,
-          fontSize: 10,
-          fontWeight: 700,
-          color: YELLOW_TEXT_DARK,
-          fontFamily: MONO_FAMILY,
-          letterSpacing: '-0.01em',
-        }}
-      >
-        {proposal.hits}× seen
-      </span>
-
-      {/* Pattern preview — file-glob + bigram in monospace so it reads as code. */}
-      <span
-        style={{
-          flex: 1,
-          minWidth: 0,
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-          fontSize: 12,
-          color: 'var(--t-text)',
-          letterSpacing: '-0.01em',
-        }}
-      >
-        <span style={{ color: 'var(--t-text-muted)', fontSize: 11 }}>add directive: </span>
-        <span style={{ fontFamily: MONO_FAMILY, fontSize: 11, color: 'var(--t-text)' }}>
-          {proposal.filePattern}
-        </span>
-        <span style={{ color: 'var(--t-text-muted)', fontSize: 11 }}> → </span>
-        <span style={{ fontFamily: MONO_FAMILY, fontSize: 11, color: 'var(--t-text)' }}>
-          {proposal.fixPattern}
-        </span>
-        <span style={{ color: 'var(--t-text-muted)', fontSize: 11 }}>?</span>
-      </span>
+      {proposal.source === 'cross-repo' ? (
+        <CrossRepoBody proposal={proposal} />
+      ) : (
+        <AutoBody proposal={proposal} />
+      )}
 
       {/* Actions. Mirror the IssueGroupList "+" pattern (transparent buttons,
           tight padding) but with text labels so Accept/Dismiss are explicit. */}
@@ -114,7 +82,11 @@ export function DirectiveProposalRow({ proposal, onAccept, onDismiss, busy }: Di
         type="button"
         onClick={handleAccept}
         disabled={busy}
-        title="Open the directive editor pre-filled with this draft"
+        title={
+          proposal.source === 'cross-repo'
+            ? `Import this directive into ${proposal.targetRepoName}`
+            : 'Open the directive editor pre-filled with this draft'
+        }
         style={{
           flexShrink: 0,
           paddingTop: 3,
@@ -163,5 +135,108 @@ export function DirectiveProposalRow({ proposal, onAccept, onDismiss, busy }: Di
         Dismiss
       </button>
     </div>
+  );
+}
+
+// ── auto-proposer body (#746) ──────────────────────────────────────────────
+
+function AutoBody({ proposal }: { proposal: Extract<DirectiveProposalCandidate, { source: 'auto' }> }) {
+  return (
+    <>
+      {/* Hits badge — mirrors the issue-number column width in IssueGroupList. */}
+      <span
+        title={`Observed ${proposal.hits}× in the last 14 days`}
+        style={{
+          width: 42,
+          flexShrink: 0,
+          fontSize: 10,
+          fontWeight: 700,
+          color: YELLOW_TEXT_DARK,
+          fontFamily: MONO_FAMILY,
+          letterSpacing: '-0.01em',
+        }}
+      >
+        {proposal.hits}× seen
+      </span>
+
+      {/* Pattern preview — file-glob + bigram in monospace so it reads as code. */}
+      <span
+        style={{
+          flex: 1,
+          minWidth: 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          fontSize: 12,
+          color: 'var(--t-text)',
+          letterSpacing: '-0.01em',
+        }}
+      >
+        <span style={{ color: 'var(--t-text-muted)', fontSize: 11 }}>add directive: </span>
+        <span style={{ fontFamily: MONO_FAMILY, fontSize: 11, color: 'var(--t-text)' }}>
+          {proposal.filePattern}
+        </span>
+        <span style={{ color: 'var(--t-text-muted)', fontSize: 11 }}> → </span>
+        <span style={{ fontFamily: MONO_FAMILY, fontSize: 11, color: 'var(--t-text)' }}>
+          {proposal.fixPattern}
+        </span>
+        <span style={{ color: 'var(--t-text-muted)', fontSize: 11 }}>?</span>
+      </span>
+    </>
+  );
+}
+
+// ── cross-repo body (#748) ─────────────────────────────────────────────────
+
+function CrossRepoBody({
+  proposal,
+}: {
+  proposal: Extract<DirectiveProposalCandidate, { source: 'cross-repo' }>;
+}) {
+  // Render similarity as `87%` so the badge stays narrow. Matches the
+  // hits-badge column width on auto rows so the layout doesn't shift when
+  // the two row kinds are stacked.
+  const similarityLabel = `${Math.round(proposal.similarity * 100)}%`;
+  return (
+    <>
+      <span
+        title={`Stack overlap: ${similarityLabel} between ${proposal.sourceRepoName} and ${proposal.targetRepoName}`}
+        style={{
+          width: 42,
+          flexShrink: 0,
+          fontSize: 10,
+          fontWeight: 700,
+          color: YELLOW_TEXT_DARK,
+          fontFamily: MONO_FAMILY,
+          letterSpacing: '-0.01em',
+        }}
+      >
+        {similarityLabel}
+      </span>
+      <span
+        style={{
+          flex: 1,
+          minWidth: 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          fontSize: 12,
+          color: 'var(--t-text)',
+          letterSpacing: '-0.01em',
+        }}
+      >
+        <span style={{ color: 'var(--t-text-muted)', fontSize: 11 }}>import from </span>
+        <span style={{ fontFamily: MONO_FAMILY, fontSize: 11, color: 'var(--t-text)' }}>
+          {proposal.sourceRepoName}
+        </span>
+        <span style={{ color: 'var(--t-text-muted)', fontSize: 11 }}> → </span>
+        <span style={{ fontFamily: MONO_FAMILY, fontSize: 11, color: 'var(--t-text)' }}>
+          {proposal.targetRepoName}
+        </span>
+        <span style={{ color: 'var(--t-text-muted)', fontSize: 11 }}>: </span>
+        <span style={{ fontSize: 11, color: 'var(--t-text)' }}>{proposal.directiveTitle}</span>
+        <span style={{ color: 'var(--t-text-muted)', fontSize: 11 }}>?</span>
+      </span>
+    </>
   );
 }

--- a/src/components/desktop/thoughts/directive-proposal-types.ts
+++ b/src/components/desktop/thoughts/directive-proposal-types.ts
@@ -1,12 +1,22 @@
 /**
- * #746 — Client-side type for the auto-directive proposer.
+ * #746 / #748 — Client-side types for directive proposals.
  *
- * Mirrors `DirectiveProposalCandidate` in `src/lib/cortex/proposer.ts`.
- * Duplicated here because that module is `'server-only'` and the
- * Mission panel runs in the browser. Keep the shapes in sync.
+ * Two proposal sources share the same `DirectiveProposalRow` chrome:
+ *   - `auto` — surfaced by the in-repo auto-proposer (#746). Mirrors
+ *     `DirectiveProposalCandidate` in `src/lib/cortex/proposer.ts`.
+ *   - `cross-repo` — surfaced by the cross-repo learner (#748). When a
+ *     directive lands in repo A and ≥ 2 stack-similar repos exist, those
+ *     repos see a yellow row offering to import the rule. Mirrors
+ *     `CrossRepoProposalCandidate` in `src/lib/cortex/cross-repo-proposer.ts`.
+ *
+ * Both lib modules are `'server-only'`, so duplicate the shapes here for
+ * the browser. Keep them in sync.
  */
 
-export interface DirectiveProposalCandidate {
+export type DirectiveProposalSource = 'auto' | 'cross-repo';
+
+export interface AutoDirectiveProposal {
+  source: 'auto';
   id: string;
   filePattern: string;
   fixPattern: string;
@@ -15,3 +25,27 @@ export interface DirectiveProposalCandidate {
   outcomeIds: string[];
   draftDirective: string;
 }
+
+export interface CrossRepoDirectiveProposal {
+  source: 'cross-repo';
+  id: string;
+  /** Repo the operator will see this proposal in. */
+  targetRepoId: string;
+  targetRepoName: string;
+  /** Repo the directive originated from. */
+  sourceRepoId: string;
+  sourceRepoName: string;
+  /** Directive payload. */
+  directiveId: string;
+  directiveTitle: string;
+  directiveBody: string;
+  directivePriority: number | null;
+  /** Jaccard similarity between source and target (0..1). */
+  similarity: number;
+  /** Pre-rendered draft text the chat composer fills with on Accept. */
+  draftDirective: string;
+}
+
+export type DirectiveProposalCandidate =
+  | AutoDirectiveProposal
+  | CrossRepoDirectiveProposal;

--- a/src/components/desktop/thoughts/mission-panel/useDirectiveProposals.ts
+++ b/src/components/desktop/thoughts/mission-panel/useDirectiveProposals.ts
@@ -1,21 +1,28 @@
 'use client';
 
 /**
- * #746 — Hook that owns the auto-directive proposer state for
- * `ThoughtsMissionPanel`. Pulled out of the panel so the panel stays under
- * the 800-line ceiling.
+ * #746 / #748 — Hook that owns directive-proposal state for
+ * `ThoughtsMissionPanel`. Fetches BOTH proposal sources (auto + cross-repo)
+ * in parallel and merges them into a single yellow-row list. Pulled out of
+ * the panel so the panel stays under the 800-line ceiling.
  *
  * Responsibilities:
- *   - Fetch the cached proposal set from `/api/cortex/proposals` on
- *     panel-open + lifecycle events + 5-min fallback poll.
+ *   - Fetch the cached proposal sets from `/api/cortex/proposals` (#746)
+ *     and `/api/cortex/cross-repo-proposals` (#748) on panel-open,
+ *     lifecycle events, and a 5-min fallback poll.
  *   - Hide a row optimistically while the dismiss POST is in flight.
+ *   - Route dismiss to the correct endpoint based on `proposal.source`.
  *   - Dispatch Accept by calling `onAccept` with the candidate; the
  *     consumer (Mission panel) wires it to the orchestrator chat composer
  *     via `OrchestratorDataContext.onAcceptDirectiveProposal`.
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import type { DirectiveProposalCandidate } from '../directive-proposal-types';
+import type {
+  AutoDirectiveProposal,
+  CrossRepoDirectiveProposal,
+  DirectiveProposalCandidate,
+} from '../directive-proposal-types';
 
 interface UseDirectiveProposalsArgs {
   open: boolean;
@@ -36,6 +43,13 @@ interface UseDirectiveProposalsReturn {
   handleDismiss: (proposal: DirectiveProposalCandidate) => Promise<void>;
 }
 
+// Server returns these as plain JSON without a discriminator stamped on
+// every record (the `source` field was added in #748). We tag them at the
+// fetch boundary so the row component can branch on `proposal.source`
+// safely even if the cache predates the field.
+type RawAutoProposal = Omit<AutoDirectiveProposal, 'source'> & { source?: 'auto' };
+type RawCrossRepoProposal = Omit<CrossRepoDirectiveProposal, 'source'> & { source?: 'cross-repo' };
+
 export function useDirectiveProposals({
   open,
   visible,
@@ -50,13 +64,41 @@ export function useDirectiveProposals({
     let cancelled = false;
     const loadProposals = async () => {
       try {
-        const res = await fetch('/api/cortex/proposals', { cache: 'no-store' });
-        if (!res.ok || cancelled) return;
-        const data = (await res.json()) as { ok?: boolean; proposals?: DirectiveProposalCandidate[] };
+        const [autoRes, crossRes] = await Promise.allSettled([
+          fetch('/api/cortex/proposals', { cache: 'no-store' }),
+          fetch('/api/cortex/cross-repo-proposals', { cache: 'no-store' }),
+        ]);
         if (cancelled) return;
-        if (data?.ok && Array.isArray(data.proposals)) {
-          setProposals(data.proposals);
+
+        const merged: DirectiveProposalCandidate[] = [];
+
+        if (autoRes.status === 'fulfilled' && autoRes.value.ok) {
+          try {
+            const data = (await autoRes.value.json()) as { ok?: boolean; proposals?: RawAutoProposal[] };
+            if (!cancelled && data?.ok && Array.isArray(data.proposals)) {
+              for (const p of data.proposals) {
+                merged.push({ ...p, source: 'auto' } as AutoDirectiveProposal);
+              }
+            }
+          } catch (err) {
+            console.warn('[proposer] auto parse failed:', err instanceof Error ? err.message : err);
+          }
         }
+
+        if (crossRes.status === 'fulfilled' && crossRes.value.ok) {
+          try {
+            const data = (await crossRes.value.json()) as { ok?: boolean; proposals?: RawCrossRepoProposal[] };
+            if (!cancelled && data?.ok && Array.isArray(data.proposals)) {
+              for (const p of data.proposals) {
+                merged.push({ ...p, source: 'cross-repo' } as CrossRepoDirectiveProposal);
+              }
+            }
+          } catch (err) {
+            console.warn('[proposer] cross-repo parse failed:', err instanceof Error ? err.message : err);
+          }
+        }
+
+        if (!cancelled) setProposals(merged);
       } catch (err) {
         console.warn('[proposer] proposal fetch failed:', err instanceof Error ? err.message : err);
       }
@@ -86,16 +128,29 @@ export function useDirectiveProposals({
   const handleDismiss = useCallback(async (proposal: DirectiveProposalCandidate) => {
     setPendingProposalId(proposal.id);
     try {
-      const res = await fetch('/api/cortex/proposals', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          action: 'dismiss',
-          id: proposal.id,
-          filePattern: proposal.filePattern,
-          fixPattern: proposal.fixPattern,
-        }),
-      });
+      let res: Response;
+      if (proposal.source === 'cross-repo') {
+        res = await fetch('/api/cortex/cross-repo-proposals', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            action: 'dismiss',
+            targetRepoId: proposal.targetRepoId,
+            directiveId: proposal.directiveId,
+          }),
+        });
+      } else {
+        res = await fetch('/api/cortex/proposals', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            action: 'dismiss',
+            id: proposal.id,
+            filePattern: proposal.filePattern,
+            fixPattern: proposal.fixPattern,
+          }),
+        });
+      }
       const data = (await res.json().catch(() => null)) as { ok?: boolean } | null;
       if (!res.ok || !data?.ok) {
         console.warn('[proposer] dismiss failed', data);

--- a/src/lib/cortex/cross-repo-proposer.ts
+++ b/src/lib/cortex/cross-repo-proposer.ts
@@ -1,0 +1,437 @@
+/**
+ * #748 — Cross-repo learning.
+ *
+ * When a directive lands in repo A and ≥ 2 other registered repos share a
+ * stack signature with A (Jaccard overlap ≥ 0.8), surface a yellow
+ * proposal row in those target repos' orchestrator views. The operator
+ * accepts (duplicates the directive scoped to the target) or dismisses
+ * (snoozes the (target, directive) pair for 30 days). Always human-gated.
+ *
+ * The proposer never writes a directive itself. Accept text drives the
+ * orchestrator chat composer; the orchestrator's existing memory tools
+ * handle the actual markdown write — this matches #746's flow.
+ *
+ * Storage:
+ *   ~/.o8/stack-signatures.json — cached signatures (owned by stack-signature.ts)
+ *   ~/.o8/cross-repo-snooze.json — append-only ledger of dismissed (target, directive) pairs
+ *
+ * Proposal id: sha1(`${targetRepoId}::${directiveId}`).slice(0,16) — stable
+ * across ticks so dismiss survives recomputes.
+ */
+
+import 'server-only';
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+
+import { getDataDir } from '@/lib/data-dir-migration';
+import { listRepos } from '@/lib/repos/registry';
+import type { RepoRegistryEntry } from '@/lib/repos/types';
+import { readOrComputeSignatures } from '@/lib/cortex/stack-signature';
+
+const SIMILARITY_THRESHOLD = 0.8;
+const MIN_SIMILAR_REPOS = 2;
+const SNOOZE_DAYS = 30;
+const MAX_CANDIDATES = 12;
+const SNOOZE_FILE = 'cross-repo-snooze.json';
+
+// ── directive read (same parser shape as cortex/directives/route.ts) ──────
+
+const FRONT_MATTER_BOUNDARY = /^---\s*$/m;
+
+interface DirectiveSummary {
+  id: string;
+  title: string;
+  scope: string;
+  repoName: string | null;
+  priority: number | null;
+  body: string;
+}
+
+function parseDirectiveFile(raw: string, fallbackId: string): DirectiveSummary | null {
+  const text = raw.replace(/\r\n/g, '\n').trim();
+  if (!text.startsWith('---')) return null;
+
+  const afterFirst = text.slice(3).trimStart();
+  const closingIndex = afterFirst.search(FRONT_MATTER_BOUNDARY);
+  if (closingIndex < 0) return null;
+
+  const front = afterFirst.slice(0, closingIndex);
+  const rawBody = afterFirst.slice(closingIndex).replace(FRONT_MATTER_BOUNDARY, '').trim();
+  const body = rawBody.replace(/\n*##\s+Recent Merges\b[\s\S]*$/, '').trim();
+
+  const meta: Record<string, string> = {};
+  for (const line of front.split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx <= 0) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    if (key) meta[key] = value;
+  }
+
+  const priorityRaw = meta.priority;
+  const priorityNum = priorityRaw ? Number.parseInt(priorityRaw, 10) : NaN;
+
+  return {
+    id: meta.id?.trim() || fallbackId,
+    title: meta.title?.trim() || fallbackId,
+    scope: meta.scope?.trim() || 'global',
+    repoName: meta.repoName?.trim() || null,
+    priority: Number.isFinite(priorityNum) ? priorityNum : null,
+    body,
+  };
+}
+
+function listDirectiveFiles(): { name: string; path: string }[] {
+  try {
+    const dir = join(getDataDir(), 'directives');
+    if (!existsSync(dir)) return [];
+    return readdirSync(dir)
+      .filter((name) => name.endsWith('.md'))
+      .map((name) => ({ name, path: join(dir, name) }));
+  } catch {
+    return [];
+  }
+}
+
+function readAllDirectives(): DirectiveSummary[] {
+  const files = listDirectiveFiles();
+  const out: DirectiveSummary[] = [];
+  for (const file of files) {
+    try {
+      const raw = readFileSync(file.path, 'utf-8');
+      const fallbackId = file.name.replace(/\.md$/, '');
+      const parsed = parseDirectiveFile(raw, fallbackId);
+      if (parsed) out.push(parsed);
+    } catch {
+      // skip unreadable
+    }
+  }
+  return out;
+}
+
+// ── snooze ledger ─────────────────────────────────────────────────────────
+
+interface SnoozeEntry {
+  /** Composite proposal id — `sha1(targetRepoId::directiveId).slice(0,16)`. */
+  id: string;
+  targetRepoId: string;
+  directiveId: string;
+  snoozedUntil: string; // ISO-8601
+}
+
+interface SnoozeLedger {
+  version: 1;
+  entries: SnoozeEntry[];
+}
+
+function snoozeFilePath(): string {
+  return join(getDataDir(), SNOOZE_FILE);
+}
+
+function readSnoozeLedger(): SnoozeLedger {
+  const path = snoozeFilePath();
+  if (!existsSync(path)) return { version: 1, entries: [] };
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<SnoozeLedger>;
+    if (!parsed || parsed.version !== 1 || !Array.isArray(parsed.entries)) {
+      return { version: 1, entries: [] };
+    }
+    const entries = parsed.entries.filter(
+      (e): e is SnoozeEntry =>
+        !!e &&
+        typeof e === 'object' &&
+        typeof e.id === 'string' &&
+        typeof e.targetRepoId === 'string' &&
+        typeof e.directiveId === 'string' &&
+        typeof e.snoozedUntil === 'string',
+    );
+    return { version: 1, entries };
+  } catch (err) {
+    console.warn('[cross-repo-proposer] Failed to parse snooze ledger:', err instanceof Error ? err.message : err);
+    return { version: 1, entries: [] };
+  }
+}
+
+function writeSnoozeLedger(ledger: SnoozeLedger): void {
+  try {
+    writeFileSync(snoozeFilePath(), JSON.stringify(ledger, null, 2), 'utf-8');
+  } catch (err) {
+    console.warn('[cross-repo-proposer] Failed to write snooze ledger:', err instanceof Error ? err.message : err);
+  }
+}
+
+function activeSnoozedIds(now: Date): Set<string> {
+  const ledger = readSnoozeLedger();
+  const out = new Set<string>();
+  for (const entry of ledger.entries) {
+    const until = Date.parse(entry.snoozedUntil);
+    if (Number.isFinite(until) && until > now.getTime()) {
+      out.add(entry.id);
+    }
+  }
+  return out;
+}
+
+/**
+ * Append-only snooze. Stale entries pile up but are filtered at read time;
+ * matches #746's pattern.
+ */
+export function snoozeCrossRepoProposal(input: {
+  targetRepoId: string;
+  directiveId: string;
+}): SnoozeEntry {
+  const id = makeProposalId(input.targetRepoId, input.directiveId);
+  const snoozedUntil = new Date(Date.now() + SNOOZE_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  const entry: SnoozeEntry = {
+    id,
+    targetRepoId: input.targetRepoId,
+    directiveId: input.directiveId,
+    snoozedUntil,
+  };
+  const ledger = readSnoozeLedger();
+  ledger.entries.push(entry);
+  writeSnoozeLedger(ledger);
+  return entry;
+}
+
+// ── proposal id + similarity ──────────────────────────────────────────────
+
+function makeProposalId(targetRepoId: string, directiveId: string): string {
+  return createHash('sha1')
+    .update(`${targetRepoId}::${directiveId}`, 'utf-8')
+    .digest('hex')
+    .slice(0, 16);
+}
+
+function jaccard(aDeps: string[], bDeps: string[]): number {
+  if (aDeps.length === 0 && bDeps.length === 0) return 0;
+  const setA = new Set(aDeps);
+  const setB = new Set(bDeps);
+  let intersect = 0;
+  for (const dep of setA) {
+    if (setB.has(dep)) intersect += 1;
+  }
+  const union = setA.size + setB.size - intersect;
+  if (union === 0) return 0;
+  return intersect / union;
+}
+
+// ── source-repo resolution for a directive ───────────────────────────────
+
+function findSourceRepo(
+  directive: DirectiveSummary,
+  repos: RepoRegistryEntry[],
+): RepoRegistryEntry | null {
+  // Repo-scoped directive: front matter `repoName: <name>` or `scope: <name>`.
+  const declared = (directive.repoName || directive.scope || '').toLowerCase();
+  if (declared && declared !== 'global' && declared !== 'repo') {
+    const match = repos.find((r) => r.name.toLowerCase() === declared);
+    if (match) return match;
+  }
+  // Some directives use `scope: repo` + `repoName:` — handled by the branch above.
+  // `scope: global` directives never propose cross-repo (they already apply
+  // everywhere); return null so the caller skips them.
+  return null;
+}
+
+// ── public surface ────────────────────────────────────────────────────────
+
+export interface CrossRepoProposalCandidate {
+  /**
+   * Discriminator so `DirectiveProposalRow` can render both auto rows and
+   * cross-repo rows from a shared list. Always `'cross-repo'` here.
+   */
+  source: 'cross-repo';
+  id: string;
+  /** Repo the operator will see this proposal in. */
+  targetRepoId: string;
+  targetRepoName: string;
+  /** Repo the directive originated from. */
+  sourceRepoId: string;
+  sourceRepoName: string;
+  /** Directive payload. */
+  directiveId: string;
+  directiveTitle: string;
+  directiveBody: string;
+  directivePriority: number | null;
+  /** Jaccard similarity between source and target (0..1). */
+  similarity: number;
+  /** Pre-rendered draft text the chat composer fills with on Accept. */
+  draftDirective: string;
+}
+
+export interface ProposeAcrossReposOutput {
+  /**
+   * Map of directive id → list of target repo IDs that meet the similarity
+   * threshold (and aren't snoozed). Useful for callers that just need to
+   * know "who to fan this out to".
+   */
+  byDirective: Record<string, string[]>;
+  /** Flat list — what the API surface returns. */
+  candidates: CrossRepoProposalCandidate[];
+}
+
+interface ProposeOptions {
+  /** Override "now" for tests. */
+  now?: Date;
+  /** Cap on candidates returned. */
+  limit?: number;
+}
+
+function buildDraft(directive: DirectiveSummary, target: RepoRegistryEntry): string {
+  // Re-emit the directive body with target repo metadata patched in. The
+  // operator edits before saving — this is a starting point, not a final
+  // form. Keeping the existing body verbatim avoids "lossy translation"
+  // surprises.
+  return [
+    `# ${directive.title}`,
+    '',
+    `Imported from \`${directive.repoName ?? '(source repo)'}\` for \`${target.name}\`.`,
+    '',
+    'Original rule:',
+    '',
+    directive.body || '_(empty body — the source directive has no description)_',
+  ].join('\n');
+}
+
+/**
+ * Compute proposals for every registered repo. Synchronous read of cached
+ * signatures + the directives dir + snooze ledger.
+ *
+ * Returns an empty result when:
+ *   - signatures haven't been computed yet (caller should kick boot tick)
+ *   - fewer than 3 repos are registered (the issue specifies ≥ 3 sharing a stack)
+ *   - no repo-scoped directives exist
+ */
+export async function proposeAcrossRepos(
+  options: ProposeOptions = {},
+): Promise<ProposeAcrossReposOutput> {
+  const limit = options.limit ?? MAX_CANDIDATES;
+  const now = options.now ?? new Date();
+
+  let repos: RepoRegistryEntry[] = [];
+  try {
+    repos = await listRepos();
+  } catch {
+    return { byDirective: {}, candidates: [] };
+  }
+  if (repos.length < 3) return { byDirective: {}, candidates: [] };
+
+  const signatureStore = await readOrComputeSignatures();
+  const sigByRepoId = new Map<string, string[]>();
+  for (const sig of signatureStore.signatures) {
+    sigByRepoId.set(sig.repoId, sig.deps);
+  }
+
+  const directives = readAllDirectives();
+  if (directives.length === 0) return { byDirective: {}, candidates: [] };
+
+  const snoozed = activeSnoozedIds(now);
+  const candidates: CrossRepoProposalCandidate[] = [];
+  const byDirective: Record<string, string[]> = {};
+
+  for (const directive of directives) {
+    const sourceRepo = findSourceRepo(directive, repos);
+    if (!sourceRepo) continue;
+
+    const sourceDeps = sigByRepoId.get(sourceRepo.id);
+    // No signature recorded yet — skip (boot tick will fix it on next pass).
+    if (!sourceDeps || sourceDeps.length === 0) continue;
+
+    // Find every other repo with similarity ≥ threshold.
+    const similarRepos: { repo: RepoRegistryEntry; similarity: number }[] = [];
+    for (const target of repos) {
+      if (target.id === sourceRepo.id) continue;
+      const targetDeps = sigByRepoId.get(target.id);
+      if (!targetDeps || targetDeps.length === 0) continue;
+      const sim = jaccard(sourceDeps, targetDeps);
+      if (sim >= SIMILARITY_THRESHOLD) {
+        similarRepos.push({ repo: target, similarity: sim });
+      }
+    }
+
+    // Issue spec: only fire when ≥ 2 similar repos exist (3 total counting
+    // source). One similar peer isn't a "stack" worth fanning out to.
+    if (similarRepos.length < MIN_SIMILAR_REPOS) continue;
+
+    byDirective[directive.id] = similarRepos.map((s) => s.repo.id);
+    for (const { repo: target, similarity } of similarRepos) {
+      const id = makeProposalId(target.id, directive.id);
+      if (snoozed.has(id)) continue;
+      candidates.push({
+        source: 'cross-repo',
+        id,
+        targetRepoId: target.id,
+        targetRepoName: target.name,
+        sourceRepoId: sourceRepo.id,
+        sourceRepoName: sourceRepo.name,
+        directiveId: directive.id,
+        directiveTitle: directive.title,
+        directiveBody: directive.body,
+        directivePriority: directive.priority,
+        similarity,
+        draftDirective: buildDraft(directive, target),
+      });
+    }
+  }
+
+  // Sort by similarity (highest match first), then alphabetically by target
+  // name so output stays stable across recomputes.
+  candidates.sort((a, b) => {
+    if (b.similarity !== a.similarity) return b.similarity - a.similarity;
+    if (a.targetRepoName !== b.targetRepoName) return a.targetRepoName.localeCompare(b.targetRepoName);
+    return a.directiveTitle.localeCompare(b.directiveTitle);
+  });
+
+  return {
+    byDirective,
+    candidates: candidates.slice(0, limit),
+  };
+}
+
+// ── boot tick wiring ──────────────────────────────────────────────────────
+
+let bootTickFired = false;
+let lastTickAt = 0;
+const TICK_INTERVAL_MS = 30 * 60 * 1000;
+
+let cachedCandidates: CrossRepoProposalCandidate[] = [];
+let cachedAt = 0;
+
+async function runTick(): Promise<void> {
+  try {
+    const result = await proposeAcrossRepos();
+    cachedCandidates = result.candidates;
+    cachedAt = Date.now();
+    lastTickAt = cachedAt;
+  } catch (err) {
+    console.warn('[cross-repo-proposer] tick threw:', err instanceof Error ? err.message : err);
+  }
+}
+
+/** Idempotent boot hook — same shape as `ensureProposerBootTick`. */
+export function ensureCrossRepoProposerBootTick(): void {
+  if (bootTickFired) return;
+  bootTickFired = true;
+  setImmediate(() => {
+    void runTick();
+  });
+  const interval = setInterval(() => {
+    if (Date.now() - lastTickAt < TICK_INTERVAL_MS - 5_000) return;
+    void runTick();
+  }, TICK_INTERVAL_MS);
+  if (typeof interval.unref === 'function') interval.unref();
+}
+
+export async function readCachedCrossRepoProposals(): Promise<{
+  candidates: CrossRepoProposalCandidate[];
+  computedAt: number;
+}> {
+  if (cachedAt === 0) {
+    await runTick();
+  }
+  return { candidates: cachedCandidates, computedAt: cachedAt };
+}

--- a/src/lib/cortex/proposer.ts
+++ b/src/lib/cortex/proposer.ts
@@ -50,6 +50,12 @@ const STOP_WORDS = new Set([
 ]);
 
 export interface DirectiveProposalCandidate {
+  /**
+   * #748 — Discriminator so the same `DirectiveProposalRow` UI can render
+   * both auto-proposer rows (this module) and cross-repo rows
+   * (`cross-repo-proposer.ts`). Always `'auto'` for outputs of this module.
+   */
+  source: 'auto';
   /** Stable hash id derived from `(filePattern, fixPattern)` — used as the snooze key. */
   id: string;
   filePattern: string;
@@ -367,6 +373,7 @@ export function proposeDirectives(options: ProposeOptions = {}): DirectivePropos
     const id = makeProposalId(acc.filePattern, acc.fixPattern);
     if (snoozed.has(id)) continue;
     candidates.push({
+      source: 'auto',
       id,
       filePattern: acc.filePattern,
       fixPattern: acc.fixPattern,

--- a/src/lib/cortex/stack-signature.ts
+++ b/src/lib/cortex/stack-signature.ts
@@ -1,0 +1,340 @@
+/**
+ * #748 — Stack signature compute.
+ *
+ * Reads `package.json` (`dependencies` + `devDependencies`), `Cargo.toml`
+ * (`[dependencies]` + `[dev-dependencies]` table keys), and `pyproject.toml`
+ * (`[project.dependencies]` + `[tool.poetry.dependencies]` keys) for a
+ * single repo and produces a stable `{ deps, hash }` shape. The hash is
+ * a sha1 over the sorted dep list, used by callers as a quick equality
+ * check before falling back to a Jaccard similarity computation.
+ *
+ * Cache lives at `~/.o8/stack-signatures.json` — keyed by registered
+ * repo id so the cross-repo proposer can resolve signatures without
+ * re-reading every manifest on each tick. Recomputed fire-and-forget
+ * when the repo registry mutates (add/remove).
+ *
+ * Toml is parsed by hand. `Cargo.toml` and `pyproject.toml` only need
+ * top-level table keys, never values, so a 30-line scanner is enough —
+ * pulling in `@iarna/toml` would be cargo-cult and add a dependency.
+ *
+ * Read-only / synchronous / never throws. Manifest parse failures degrade
+ * to "no deps detected" so a single broken file never poisons the boot
+ * tick.
+ */
+
+import 'server-only';
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+
+import { getDataDir } from '@/lib/data-dir-migration';
+import { listRepos } from '@/lib/repos/registry';
+import type { RepoRegistryEntry } from '@/lib/repos/types';
+
+const SIGNATURE_FILE = 'stack-signatures.json';
+
+export interface StackSignature {
+  /** Sorted, deduped union of top-level deps from every manifest in the repo. */
+  deps: string[];
+  /** sha1(deps.join(',')) — used for fast equality + change-detection. */
+  hash: string;
+}
+
+interface StoredEntry extends StackSignature {
+  repoId: string;
+  repoPath: string;
+  computedAt: string;
+}
+
+interface SignatureStore {
+  version: 1;
+  signatures: StoredEntry[];
+}
+
+// ── manifest parsers ──────────────────────────────────────────────────────
+
+function readJsonSafe(path: string): unknown {
+  try {
+    if (!existsSync(path)) return null;
+    const raw = readFileSync(path, 'utf-8');
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function readPackageDeps(repoPath: string): string[] {
+  const parsed = readJsonSafe(join(repoPath, 'package.json'));
+  if (!parsed || typeof parsed !== 'object') return [];
+  const out: string[] = [];
+  const obj = parsed as Record<string, unknown>;
+  for (const key of ['dependencies', 'devDependencies']) {
+    const block = obj[key];
+    if (block && typeof block === 'object' && !Array.isArray(block)) {
+      for (const name of Object.keys(block as Record<string, unknown>)) {
+        if (name) out.push(name);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Read top-level keys from a TOML table. Implemented by a regex scan that
+ * jumps to the `[table-name]` header and reads bare keys until the next
+ * header. Handles whitespace around `=`, quoted-string keys are skipped
+ * (deps in Cargo.toml are always bare identifiers).
+ *
+ * Returns dep NAMES only — values (versions, paths, features) are
+ * intentionally discarded. Two repos with the same `serde` are siblings
+ * even if one pins `1.0.193` and the other `1.0.200`.
+ */
+function readTomlTableKeys(raw: string, tableName: string): string[] {
+  const headerRe = new RegExp(
+    `^\\[\\s*${tableName.replace(/\./g, '\\.')}\\s*\\]\\s*$`,
+    'm',
+  );
+  const headerMatch = raw.match(headerRe);
+  if (!headerMatch || headerMatch.index === undefined) return [];
+
+  const after = raw.slice(headerMatch.index + headerMatch[0].length);
+  const nextHeaderIdx = after.search(/^\[/m);
+  const block = nextHeaderIdx >= 0 ? after.slice(0, nextHeaderIdx) : after;
+
+  const keys: string[] = [];
+  for (const line of block.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    // `name = ...` or `name.feature = ...` — take everything before the
+    // first `=` or `.`.
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx <= 0) continue;
+    const lhs = trimmed.slice(0, eqIdx).trim();
+    if (!lhs) continue;
+    // Strip dotted-key suffixes: `serde.version = ...` should still record
+    // `serde` once. Same for `serde.features`.
+    const baseKey = lhs.split('.')[0]?.trim();
+    if (!baseKey) continue;
+    // Quoted keys would leak quotes; bail out — deps are always bare.
+    if (baseKey.startsWith('"') || baseKey.startsWith("'")) continue;
+    if (!/^[A-Za-z0-9][A-Za-z0-9_\-]*$/.test(baseKey)) continue;
+    keys.push(baseKey);
+  }
+  return keys;
+}
+
+function readCargoDeps(repoPath: string): string[] {
+  const path = join(repoPath, 'Cargo.toml');
+  if (!existsSync(path)) return [];
+  let raw = '';
+  try {
+    raw = readFileSync(path, 'utf-8');
+  } catch {
+    return [];
+  }
+  return [
+    ...readTomlTableKeys(raw, 'dependencies'),
+    ...readTomlTableKeys(raw, 'dev-dependencies'),
+  ];
+}
+
+function readPyprojectDeps(repoPath: string): string[] {
+  const path = join(repoPath, 'pyproject.toml');
+  if (!existsSync(path)) return [];
+  let raw = '';
+  try {
+    raw = readFileSync(path, 'utf-8');
+  } catch {
+    return [];
+  }
+  // Two layouts: PEP-621 `[project.dependencies]` is an inline array, not a
+  // table. We pull both Poetry-style table keys and PEP-621 array entries.
+  const out: string[] = [];
+
+  // Poetry layout: `[tool.poetry.dependencies]` table with key = value.
+  out.push(...readTomlTableKeys(raw, 'tool.poetry.dependencies'));
+  out.push(...readTomlTableKeys(raw, 'tool.poetry.dev-dependencies'));
+
+  // PEP-621: `[project] dependencies = ["pkg>=1", "other ; python_version<3.11"]`
+  // Match both `dependencies = [ ... ]` and `optional-dependencies.foo = [...]`.
+  const projectArrRe = /^\s*dependencies\s*=\s*\[([\s\S]*?)\]/m;
+  // Anchor to the `[project]` table to avoid pulling other tables' arrays.
+  const projectIdx = raw.search(/^\[\s*project\s*\]/m);
+  if (projectIdx >= 0) {
+    const projectScope = raw.slice(projectIdx);
+    const nextHdr = projectScope.search(/\n\[/);
+    const projectBlock = nextHdr >= 0 ? projectScope.slice(0, nextHdr) : projectScope;
+    const arrMatch = projectBlock.match(projectArrRe);
+    if (arrMatch) {
+      for (const item of arrMatch[1].split(',')) {
+        const cleaned = item
+          .replace(/[#].*$/g, '')
+          .trim()
+          .replace(/^['"]|['"]$/g, '');
+        if (!cleaned) continue;
+        // PEP-508 spec strings: take everything before the first non-name char.
+        const nameMatch = cleaned.match(/^([A-Za-z0-9][A-Za-z0-9_\-.]*)/);
+        if (nameMatch?.[1]) out.push(nameMatch[1]);
+      }
+    }
+  }
+
+  return out;
+}
+
+function normalizeDeps(raw: string[]): string[] {
+  const set = new Set<string>();
+  for (const name of raw) {
+    const trimmed = name.trim().toLowerCase();
+    if (!trimmed) continue;
+    set.add(trimmed);
+  }
+  return [...set].sort();
+}
+
+function hashDeps(deps: string[]): string {
+  return createHash('sha1').update(deps.join(','), 'utf-8').digest('hex').slice(0, 16);
+}
+
+// ── public surface ────────────────────────────────────────────────────────
+
+/**
+ * Compute the signature for a single repo. Synchronous + no-throw — a missing
+ * manifest yields an empty `deps` array, not a rejected promise.
+ *
+ * Returns `null` only when the path is empty (caller should skip recording).
+ */
+export function computeSignature(repoPath: string): StackSignature | null {
+  if (!repoPath?.trim()) return null;
+  const all = [
+    ...readPackageDeps(repoPath),
+    ...readCargoDeps(repoPath),
+    ...readPyprojectDeps(repoPath),
+  ];
+  const deps = normalizeDeps(all);
+  return { deps, hash: hashDeps(deps) };
+}
+
+// ── cache (~/.o8/stack-signatures.json) ───────────────────────────────────
+
+function signatureFilePath(): string {
+  return join(getDataDir(), SIGNATURE_FILE);
+}
+
+export function readSignatureStore(): SignatureStore {
+  const path = signatureFilePath();
+  if (!existsSync(path)) return { version: 1, signatures: [] };
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<SignatureStore>;
+    if (!parsed || parsed.version !== 1 || !Array.isArray(parsed.signatures)) {
+      return { version: 1, signatures: [] };
+    }
+    const signatures = parsed.signatures.filter(
+      (e): e is StoredEntry =>
+        !!e &&
+        typeof e === 'object' &&
+        typeof e.repoId === 'string' &&
+        typeof e.repoPath === 'string' &&
+        typeof e.hash === 'string' &&
+        Array.isArray(e.deps),
+    );
+    return { version: 1, signatures };
+  } catch (err) {
+    console.warn('[stack-signature] Failed to parse store:', err instanceof Error ? err.message : err);
+    return { version: 1, signatures: [] };
+  }
+}
+
+function writeSignatureStore(store: SignatureStore): void {
+  try {
+    writeFileSync(signatureFilePath(), JSON.stringify(store, null, 2), 'utf-8');
+  } catch (err) {
+    console.warn('[stack-signature] Failed to write store:', err instanceof Error ? err.message : err);
+  }
+}
+
+/**
+ * Recompute signatures for every registered repo and overwrite the cache.
+ * Called at boot + after any registry add/remove. Wraps in try/catch so a
+ * single bad repo doesn't kill the sweep.
+ */
+export async function computeAllSignatures(): Promise<SignatureStore> {
+  let entries: RepoRegistryEntry[] = [];
+  try {
+    entries = await listRepos();
+  } catch (err) {
+    console.warn('[stack-signature] listRepos failed:', err instanceof Error ? err.message : err);
+    return { version: 1, signatures: [] };
+  }
+
+  const now = new Date().toISOString();
+  const signatures: StoredEntry[] = [];
+  for (const entry of entries) {
+    try {
+      const sig = computeSignature(entry.localPath);
+      if (!sig) continue;
+      signatures.push({
+        repoId: entry.id,
+        repoPath: entry.localPath,
+        deps: sig.deps,
+        hash: sig.hash,
+        computedAt: now,
+      });
+    } catch (err) {
+      console.warn(
+        `[stack-signature] compute failed for ${entry.localPath}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  const store: SignatureStore = { version: 1, signatures };
+  writeSignatureStore(store);
+  return store;
+}
+
+/**
+ * Read the cached store. If the cache is empty or the file doesn't exist,
+ * trigger a recompute synchronously inline. Used by the cross-repo proposer
+ * so a fresh-boot read still has data to work with.
+ */
+export async function readOrComputeSignatures(): Promise<SignatureStore> {
+  const existing = readSignatureStore();
+  if (existing.signatures.length > 0) return existing;
+  return computeAllSignatures();
+}
+
+// ── boot tick wiring ──────────────────────────────────────────────────────
+
+let bootRan = false;
+
+/**
+ * Idempotent boot hook. Mirrors `ensureProposerBootTick` — schedules a
+ * one-shot compute + sets `bootRan` so subsequent calls are no-ops. The
+ * registry hook handles incremental updates on add/remove; the boot tick
+ * just ensures the cache exists for the very first session.
+ */
+export function ensureStackSignatureBoot(): void {
+  if (bootRan) return;
+  bootRan = true;
+  setImmediate(() => {
+    void computeAllSignatures().catch((err) => {
+      console.warn('[stack-signature] boot compute threw:', err instanceof Error ? err.message : err);
+    });
+  });
+}
+
+/**
+ * Trigger a recompute without waiting on the result. Called from the
+ * registry add/remove paths so signatures stay in sync as the user adds
+ * repos, without making the registry write block on the recompute.
+ */
+export function triggerSignatureRecompute(): void {
+  setImmediate(() => {
+    void computeAllSignatures().catch((err) => {
+      console.warn('[stack-signature] recompute threw:', err instanceof Error ? err.message : err);
+    });
+  });
+}

--- a/src/lib/repos/registry.ts
+++ b/src/lib/repos/registry.ts
@@ -284,6 +284,32 @@ async function writeStore(store: RepoRegistryStore) {
   });
 }
 
+/**
+ * #748 — Recompute stack signatures whenever the registry mutates so the
+ * cross-repo proposer always reads fresh data. Lazy-required so the cold
+ * `addRepo` path doesn't pay for the import unless needed (and so test
+ * harnesses that mock the registry don't drag in fs/cortex code).
+ *
+ * Fire-and-forget — the registry write returns immediately and the
+ * recompute lands shortly after on a microtask. Failures are logged inside
+ * `triggerSignatureRecompute` and never propagate.
+ */
+function fireSignatureRecompute(): void {
+  try {
+    const mod = require('@/lib/cortex/stack-signature') as
+      | typeof import('@/lib/cortex/stack-signature')
+      | undefined;
+    mod?.triggerSignatureRecompute?.();
+  } catch (error) {
+    // Treat any import-time failure as a no-op. The boot tick will refresh
+    // signatures on the next server restart even if this hook misfires.
+    console.warn(
+      '[repo-registry] signature recompute trigger failed:',
+      error instanceof Error ? error.message : error,
+    );
+  }
+}
+
 export async function listRepos() {
   const store = await readStore();
   return store.repos;
@@ -317,6 +343,7 @@ export async function addRepo(localPath: string) {
 
     const repos = store.repos.map((repo) => (repo.id === existing.id ? updated : repo));
     await writeStore({ version: 1, repos });
+    fireSignatureRecompute();
     return updated;
   }
 
@@ -336,6 +363,7 @@ export async function addRepo(localPath: string) {
     repos: [...store.repos, entry],
   });
 
+  fireSignatureRecompute();
   return entry;
 }
 
@@ -378,6 +406,8 @@ export async function removeRepo(id: string) {
     version: 1,
     repos: store.repos.filter((repo) => repo.id !== id),
   });
+
+  fireSignatureRecompute();
 }
 
 export function getRepoRegistryPath() {


### PR DESCRIPTION
## Summary

Closes #748. Part of epic #738 (Context Engine v2 / post-YC moat).

When a directive lands in repo A and ≥ 2 other registered repos share a stack signature with A (Jaccard overlap ≥ 0.8 on top-level deps), o8 surfaces a yellow Issues-style row in those target repos offering to import the directive. Always human-gated.

- **Stack signature** = sorted union of top-level deps from `package.json` (`dependencies` + `devDependencies`), `Cargo.toml` (`[dependencies]` + `[dev-dependencies]` table keys), and `pyproject.toml` (`[project] dependencies` array + `[tool.poetry.dependencies]` keys). Cached at `~/.o8/stack-signatures.json`.
- **Similarity** = Jaccard overlap on the deduped dep names. Threshold ≥ 0.8 + minimum 2 similar peers (3 total counting source) before any proposal fires.
- **Proposal row** reuses the #746 `DirectiveProposalRow` chrome with a new `source: 'auto' | 'cross-repo'` discriminator. Cross-repo rows render `<similarity%>  import from <source> → <target>: <directive title>?` instead of the auto-proposer's `<hits>× seen  add directive: pattern → bigram?`.
- **Snooze** is per-(target_repo, directive_id) at `~/.o8/cross-repo-snooze.json`, 30-day expiry. Append-only.
- **Boot wiring** piggybacks on `/api/panel/status` alongside the existing memory + decay + auto-proposer hooks. Repo registry add/remove triggers a fire-and-forget signature recompute.

## Files

- `src/lib/cortex/stack-signature.ts` — `computeSignature(repoPath)` + cache
- `src/lib/cortex/cross-repo-proposer.ts` — `proposeAcrossRepos()` + snooze
- `src/lib/repos/registry.ts` — recompute hook on add/remove
- `src/components/desktop/thoughts/DirectiveProposalRow.tsx` — split into `AutoBody` + `CrossRepoBody` branches
- `src/components/desktop/thoughts/directive-proposal-types.ts` — discriminated union
- `src/components/desktop/thoughts/mission-panel/useDirectiveProposals.ts` — parallel-fetch both endpoints, route dismiss to the right one
- `src/app/api/cortex/cross-repo-proposals/route.ts` — new gated GET/POST endpoint
- `src/app/api/panel/status/route.ts` — new boot hooks
- `src/lib/cortex/proposer.ts` — stamp `source: 'auto'` on emitted candidates

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Lint passes for touched files (unrelated repo-wide warnings remain)
- [x] Smoke test: signature compute on cortex-ide returns 50+ deps including `next` (package.json) and `tauri-*` (Cargo.toml)
- [x] Smoke test: 3 mock repos with shared 11-dep package.json + a repo-A directive → proposer emits 2 cross-repo candidates (one per peer) with similarity = 1.0 and `source: 'cross-repo'`
- [x] Smoke test: snooze for one (target, directive) pair → next compute drops only that one, peer remains
- [x] Smoke test: 3 mock repos with totally different stacks → 0 proposals (similarity below threshold)
- [x] Smoke test: signature cache file written to `~/.o8/stack-signatures.json` with version+repoId+deps shape
- [ ] Visual check in installed o8.app once shipped — verify cross-repo row stacks correctly with auto rows under the "Proposed directives" header

🤖 Generated with [Claude Code](https://claude.com/claude-code)