### PR TITLE
chore(cortex): substrate eval gate — measure outcome scale + query perf (closes #749)

### DIFF
--- a/docs/substrate-eval-gate.md
+++ b/docs/substrate-eval-gate.md
@@ -1,0 +1,120 @@
+# Substrate Eval Gate
+
+**Status:** active. Read-only instrumentation only — this doc defines *when* we
+start an evaluation, not what we replace SQLite with.
+
+## Purpose
+
+Cortex memory currently runs on SQLite + a directory of markdown directives.
+That stack is fast, simple, local-first, and ships inside the Tauri bundle
+with zero ops. We want to keep it for as long as it's *measurably* fine.
+
+This document defines the threshold values that trigger a substrate
+**evaluation** — not a migration. Crossing a threshold means we open a
+spike, gather data, and write a follow-up doc that proposes (or rejects) a
+specific replacement. It does not mean we cut over.
+
+We refuse to pre-optimise. The eval gate exists so we always have a written
+answer to "is SQLite still the right substrate, or are we papering over
+real pain?".
+
+## Thresholds
+
+The runtime check at `/api/cortex/diagnostics` (Settings → Diagnostics →
+Recall Health) compares the live numbers against these constants. The
+numbers in the UI are read straight from this doc's source of truth in
+`src/app/api/cortex/diagnostics/route.ts` (`SUBSTRATE_EVAL_THRESHOLDS`).
+
+Trigger an evaluation when **either** condition is true:
+
+| Trigger | Threshold | Why |
+|---|---|---|
+| `outcomes_count` | `>= 5,000` rows in `session_outcomes` | At ~5K rows, even a hot SQLite table starts to lose row-cache friendliness for `LIKE` and `JOIN` queries on the recall path. The decay job (#745) keeps live rows bounded, but if we cross 5K live rows we have a real workload, not a demo workload. |
+| Recall p95 latency | `>= 200ms`, sustained over a 7-day window | Operator-perceptible lag on the recall card and dispatch context starts at ~200ms p95. One-off spikes happen during compaction or boot — we only care about sustained signal. |
+
+Both numbers are conservative on purpose. They're easy to relax later once
+we know what the actual replacement looks like.
+
+## Sustainment definition
+
+The 7-day sustained signal needs at least **5 days out of 7** with
+p95 ≥ 200ms. This filters out:
+
+- single-day spikes from compaction or a heavy import
+- the first day after a fresh install (cold cache, low sample count)
+- regressions that self-heal within a couple of days
+
+The Diagnostics endpoint surfaces both the 24h and 7d p95. The 7d window
+is the trigger; the 24h is a leading indicator.
+
+## What "trigger eval" means
+
+Crossing a threshold does **not** mean migrate. It means:
+
+1. Open a spike issue (`spike: substrate evaluation`) and link this doc.
+2. Gather a week of representative recall traces (`<dataDir>/recall-metrics.json`).
+3. Identify the *specific* hot path — is it directives, outcomes, symbol
+   graph, or runtime recommendation? The Diagnostics tab's per-call-site
+   table tells us which.
+4. Pick at most three candidate substrates. Score on:
+   - Local-first (no cloud dependency, ships in Tauri)
+   - Operational simplicity (still single-binary, zero-ops)
+   - Drop-in shape (Drizzle-shaped repository so we don't rewrite call sites)
+   - License compatibility
+5. Prototype the top one in a branch behind a feature flag. Re-measure.
+6. Decide and write a follow-up doc.
+
+The eval explicitly does **not** assume any particular replacement. We list
+options here only to bound the scope of the spike — not to recommend one.
+Whichever wins on measurement, wins.
+
+Plausible substrates the spike should at least consider:
+
+- A graph-flavoured embedded store
+- A vector store with metadata filters
+- A different SQLite layout (covering indexes, virtual tables, FTS5)
+- A hybrid of the current setup with one new tier (e.g., Redis for hot
+  keys) only on the call site whose p95 is dominating
+
+We rank these on the spike's measurements, not on this doc's guesses.
+
+## What we instrument
+
+`src/lib/cortex/diagnostics.ts` owns the timing buffer. Every recall query
+on the dispatch / recall path is wrapped with `withTiming(label, fn)` or
+`withTimingSync(label, fn)`. Current call sites:
+
+| Label | Surface |
+|---|---|
+| `recall.recent-outcomes` | `/api/cortex/recent-outcomes` (Recall card outcomes row) |
+| `recall.directives` | `/api/cortex/directives` (Recall card directives + dispatch trailers) |
+| `recall.symbol-graph` | `build-context.ts` (dispatch context injection symbol trace) |
+| `recall.runtime-recommendation` | `/api/cortex/runtime-recommendation` (routing chip) |
+| `recall.proposer-outcomes` | `proposer.ts` (auto-directive proposer SQLite read) |
+
+The buffer at `<dataDir>/recall-metrics.json` keeps the most recent **1000
+samples** with FIFO eviction. That's about 4 weeks of normal usage on a
+single-operator install. The buffer hydrates on boot and lazily flushes
+every 10 appends, so the disk write rate is bounded.
+
+Adding a new recall site to the eval gate is a one-line wrap:
+
+```ts
+import { withTiming } from '@/lib/cortex/diagnostics';
+
+const rows = await withTiming('recall.<my-site>', () => existingQuery);
+```
+
+## What we do NOT do
+
+- We do not log timings to a remote service. Everything is local-only.
+- We do not block recall on the timing wrapper — the wrapper swallows nothing
+  but the logging itself, and re-throws every error from the wrapped fn.
+- We do not migrate any data. This issue (#749) is instrumentation only.
+- We do not recommend a specific replacement substrate in this doc — that
+  decision happens after the spike, with measurements in hand.
+
+## Owner
+
+The Cortex memory subsystem. Touch the thresholds here and the constants
+in `src/app/api/cortex/diagnostics/route.ts` together.

--- a/src/app/api/cortex/diagnostics/route.ts
+++ b/src/app/api/cortex/diagnostics/route.ts
@@ -1,0 +1,145 @@
+/**
+ * GET /api/cortex/diagnostics
+ *
+ * #749 — Substrate eval gate. Read-only summary of the substrate so we can
+ * answer "is SQLite still fine, or is it time to evaluate a swap?" without
+ * guessing. The Diagnostics tab in Settings calls this endpoint.
+ *
+ * Response shape:
+ *   {
+ *     ok: true,
+ *     outcomesCount: number,
+ *     directivesCount: number,
+ *     timing: RecallTimingSummary,         // last 24h
+ *     timing7d: RecallTimingSummary,       // last 7d, used for the threshold
+ *     thresholds: { outcomesEval, p95Ms, sustainedDays }
+ *   }
+ *
+ * Local-only by design — `/api/cortex/*` is gated by the global middleware
+ * on loopback origin + ws-token. No additional auth needed here.
+ */
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { getSqlite } from '@/lib/db';
+import { getDataDir } from '@/lib/data-dir-migration';
+import {
+  flushTimingBuffer,
+  summarizeTimings,
+  type RecallTimingSummary,
+} from '@/lib/cortex/diagnostics';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Threshold values referenced by `docs/substrate-eval-gate.md`. Surfaced
+ * inline so the UI can display the same numbers and the doc can't drift
+ * silently from the runtime check.
+ */
+export const SUBSTRATE_EVAL_THRESHOLDS = {
+  /** Eval trigger at this many `session_outcomes` rows. */
+  outcomesEval: 5_000,
+  /** Eval trigger at recall p95 above this many milliseconds. */
+  p95Ms: 200,
+  /** Sustained-over window in days for the p95 trigger. */
+  sustainedDays: 7,
+} as const;
+
+interface DiagnosticsResponse {
+  ok: true;
+  outcomesCount: number;
+  directivesCount: number;
+  timing: RecallTimingSummary;
+  timing7d: RecallTimingSummary;
+  thresholds: typeof SUBSTRATE_EVAL_THRESHOLDS;
+  /**
+   * Substrate "health" verdict — green/amber/red — derived from the same
+   * thresholds the doc records. The UI uses this to colour the row.
+   */
+  health: 'green' | 'amber' | 'red';
+  notes: string[];
+}
+
+function countOutcomes(): number {
+  try {
+    // Drizzle's COUNT helper has historically been finicky against the
+    // boolean column on older sqlite builds (#747). Drop down to raw SQL
+    // for the headline counter — it's the cheapest possible query.
+    const sqlite = getSqlite();
+    if (!sqlite || typeof sqlite.prepare !== 'function') return 0;
+    const row = sqlite.prepare('SELECT COUNT(*) AS n FROM session_outcomes').get() as { n?: number } | undefined;
+    return typeof row?.n === 'number' ? row.n : 0;
+  } catch (error) {
+    console.warn('[cortex-diagnostics] outcomes count failed:', error instanceof Error ? error.message : error);
+    return 0;
+  }
+}
+
+function countDirectives(): number {
+  try {
+    const dir = join(getDataDir(), 'directives');
+    if (!existsSync(dir)) return 0;
+    return readdirSync(dir).filter((name) => name.endsWith('.md')).length;
+  } catch (error) {
+    console.warn('[cortex-diagnostics] directives count failed:', error instanceof Error ? error.message : error);
+    return 0;
+  }
+}
+
+function classifyHealth(outcomes: number, p95Ms: number): { health: 'green' | 'amber' | 'red'; notes: string[] } {
+  const notes: string[] = [];
+  let health: 'green' | 'amber' | 'red' = 'green';
+
+  if (outcomes >= SUBSTRATE_EVAL_THRESHOLDS.outcomesEval) {
+    health = 'red';
+    notes.push(`Outcomes count ${outcomes.toLocaleString()} ≥ eval threshold ${SUBSTRATE_EVAL_THRESHOLDS.outcomesEval.toLocaleString()}.`);
+  } else if (outcomes >= SUBSTRATE_EVAL_THRESHOLDS.outcomesEval * 0.5) {
+    health = 'amber';
+    notes.push(`Outcomes count ${outcomes.toLocaleString()} crossed 50% of the eval threshold.`);
+  }
+
+  if (p95Ms >= SUBSTRATE_EVAL_THRESHOLDS.p95Ms) {
+    health = 'red';
+    notes.push(`Recall p95 ${p95Ms.toFixed(0)}ms ≥ eval threshold ${SUBSTRATE_EVAL_THRESHOLDS.p95Ms}ms (sustained check is in the doc).`);
+  } else if (p95Ms >= SUBSTRATE_EVAL_THRESHOLDS.p95Ms * 0.75) {
+    if (health === 'green') health = 'amber';
+    notes.push(`Recall p95 ${p95Ms.toFixed(0)}ms approaching the ${SUBSTRATE_EVAL_THRESHOLDS.p95Ms}ms eval threshold.`);
+  }
+
+  if (notes.length === 0) {
+    notes.push('Within thresholds. SQLite is fine; revisit when this card flips to amber.');
+  }
+  return { health, notes };
+}
+
+export async function GET() {
+  // Best-effort flush so concurrent recall queries land on disk before we
+  // serialize the buffer. The endpoint never errors on flush failure.
+  try { flushTimingBuffer(); } catch { /* swallow */ }
+
+  const outcomesCount = countOutcomes();
+  const directivesCount = countDirectives();
+  const timing = summarizeTimings(DAY_MS);
+  const timing7d = summarizeTimings(7 * DAY_MS);
+  const { health, notes } = classifyHealth(outcomesCount, timing7d.p95Ms);
+
+  const payload: DiagnosticsResponse = {
+    ok: true,
+    outcomesCount,
+    directivesCount,
+    timing,
+    timing7d,
+    thresholds: SUBSTRATE_EVAL_THRESHOLDS,
+    health,
+    notes,
+  };
+
+  return NextResponse.json(payload, {
+    headers: { 'Cache-Control': 'no-store, max-age=0' },
+  });
+}

--- a/src/app/api/cortex/directives/route.ts
+++ b/src/app/api/cortex/directives/route.ts
@@ -17,6 +17,7 @@ import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { getDataDir } from '@/lib/data-dir-migration';
 import { readAllDirectiveTrailers } from '@/lib/cortex/directive-merges';
+import { withTimingSync } from '@/lib/cortex/diagnostics';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -85,18 +86,21 @@ export async function GET() {
       });
     }
 
-    const entries = readdirSync(directivesDir).filter((name) => name.endsWith('.md'));
-    const directives: DirectiveSummary[] = [];
-    for (const name of entries) {
-      try {
-        const raw = readFileSync(join(directivesDir, name), 'utf-8');
-        const fallbackId = name.replace(/\.md$/, '');
-        const parsed = parseDirectiveFile(raw, fallbackId);
-        if (parsed) directives.push(parsed);
-      } catch (error) {
-        console.warn(`[cortex-directives] Failed to read ${name}:`, error);
+    const directives: DirectiveSummary[] = withTimingSync('recall.directives', () => {
+      const entries = readdirSync(directivesDir).filter((name) => name.endsWith('.md'));
+      const out: DirectiveSummary[] = [];
+      for (const name of entries) {
+        try {
+          const raw = readFileSync(join(directivesDir, name), 'utf-8');
+          const fallbackId = name.replace(/\.md$/, '');
+          const parsed = parseDirectiveFile(raw, fallbackId);
+          if (parsed) out.push(parsed);
+        } catch (error) {
+          console.warn(`[cortex-directives] Failed to read ${name}:`, error);
+        }
       }
-    }
+      return out;
+    });
 
     // #769 — Hydrate recent-merge trailers from the same markdown files.
     // The helper re-reads the dir, but the cost is trivial (≤dozens of small

--- a/src/app/api/cortex/recent-outcomes/route.ts
+++ b/src/app/api/cortex/recent-outcomes/route.ts
@@ -29,6 +29,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { and, desc, eq } from 'drizzle-orm';
 import { getDb, sessionOutcomes } from '@/lib/db';
 import { liveOutcomeFilter } from '@/lib/cortex/decay';
+import { withTiming } from '@/lib/cortex/diagnostics';
 
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
@@ -48,7 +49,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const rows = await db
+    const rows = await withTiming('recall.recent-outcomes', () => db
       .select({
         id: sessionOutcomes.id,
         outcome: sessionOutcomes.outcome,
@@ -62,7 +63,7 @@ export async function GET(request: NextRequest) {
       .from(sessionOutcomes)
       .where(and(eq(sessionOutcomes.repoPath, repoPath), liveOutcomeFilter()))
       .orderBy(desc(sessionOutcomes.completedAt))
-      .limit(limit);
+      .limit(limit));
 
     return NextResponse.json(
       { ok: true, outcomes: rows },

--- a/src/app/api/cortex/runtime-recommendation/route.ts
+++ b/src/app/api/cortex/runtime-recommendation/route.ts
@@ -30,6 +30,7 @@ export const dynamic = 'force-dynamic';
 
 import { NextRequest, NextResponse } from 'next/server';
 import { recommendRuntime } from '@/lib/dispatch/routing';
+import { withTiming } from '@/lib/cortex/diagnostics';
 
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
@@ -42,7 +43,10 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const recommendation = await recommendRuntime(repoPath);
+    const recommendation = await withTiming(
+      'recall.runtime-recommendation',
+      () => recommendRuntime(repoPath),
+    );
     return NextResponse.json(
       { ok: true, recommendation },
       { headers: { 'Cache-Control': 'no-store, max-age=0' } },

--- a/src/components/desktop/settings/DiagnosticsTab.tsx
+++ b/src/components/desktop/settings/DiagnosticsTab.tsx
@@ -15,6 +15,7 @@ import {
   TabBreadcrumb,
   TabHeading,
 } from './shared';
+import { RecallHealthSection } from './RecallHealthSection';
 
 // ── Types ──
 
@@ -250,9 +251,12 @@ export function DiagnosticsTab() {
         </div>
       </section>
 
-      {/* 02 — MAINTENANCE */}
-      <section>
-        <SectionLabel number="02">MAINTENANCE</SectionLabel>
+      {/* 02 — RECALL HEALTH (#749 substrate eval gate) */}
+      <RecallHealthSection />
+
+      {/* 03 — MAINTENANCE */}
+      <section style={{ marginTop: 32 }}>
+        <SectionLabel number="03">MAINTENANCE</SectionLabel>
 
         <div style={{
           display: 'flex',
@@ -377,9 +381,9 @@ export function DiagnosticsTab() {
         </div>
       </section>
 
-      {/* 03 — DANGER */}
+      {/* 04 — DANGER */}
       <section style={{ marginTop: 32 }}>
-        <SectionLabel number="03">DANGER</SectionLabel>
+        <SectionLabel number="04">DANGER</SectionLabel>
 
         <div style={{
           display: 'flex',

--- a/src/components/desktop/settings/RecallHealthSection.tsx
+++ b/src/components/desktop/settings/RecallHealthSection.tsx
@@ -1,0 +1,327 @@
+'use client';
+
+/**
+ * #749 — Substrate eval gate. Read-only Diagnostics surface that surfaces
+ * the substrate (SQLite + directives dir) row counts and recall query
+ * latency, so we can answer "is SQLite still fine, or is it time to
+ * evaluate a swap?" without guessing.
+ *
+ * The thresholds rendered here are the same ones written in
+ * `docs/substrate-eval-gate.md`. The endpoint at
+ * `/api/cortex/diagnostics` returns both for parity.
+ *
+ * Issues-style rows: uppercase mono label on the left, value + helper on
+ * the right, dot for status. No native form controls.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  MONO_FONT_STACK,
+  RAMS_HAIRLINE_SOFT,
+  RAMS_INK_QUIET,
+  SectionLabel,
+} from './shared';
+
+// ── Types ──
+
+interface RecallTimingSummary {
+  totalSamples: number;
+  windowedSamples: number;
+  windowMs: number;
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+  maxMs: number;
+  errorCount: number;
+  byLabel: Array<{
+    label: string;
+    samples: number;
+    p50Ms: number;
+    p95Ms: number;
+    p99Ms: number;
+  }>;
+}
+
+interface DiagnosticsResponse {
+  ok: true;
+  outcomesCount: number;
+  directivesCount: number;
+  timing: RecallTimingSummary;
+  timing7d: RecallTimingSummary;
+  thresholds: { outcomesEval: number; p95Ms: number; sustainedDays: number };
+  health: 'green' | 'amber' | 'red';
+  notes: string[];
+}
+
+// ── Helpers ──
+
+function formatMs(value: number) {
+  if (!Number.isFinite(value) || value <= 0) return '0ms';
+  if (value < 10) return `${value.toFixed(1)}ms`;
+  return `${Math.round(value)}ms`;
+}
+
+function formatCount(value: number) {
+  if (!Number.isFinite(value) || value < 0) return '0';
+  return value.toLocaleString();
+}
+
+function dotColorForHealth(health: 'green' | 'amber' | 'red') {
+  if (health === 'red') return '#ef4444';
+  if (health === 'amber') return '#f59e0b';
+  return RAMS_INK_QUIET;
+}
+
+// ── Component ──
+
+export function RecallHealthSection() {
+  const [data, setData] = useState<DiagnosticsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/cortex/diagnostics');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const payload = await res.json() as DiagnosticsResponse;
+      setData(payload);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to read diagnostics');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  return (
+    <section style={{ marginTop: 32 }}>
+      <SectionLabel number="02">RECALL HEALTH</SectionLabel>
+
+      <div style={{ borderTop: `1px solid ${RAMS_HAIRLINE_SOFT}` }}>
+        <Row
+          label="Outcomes count"
+          value={data ? formatCount(data.outcomesCount) : (loading ? '…' : '—')}
+          hint={data ? `Eval at ${formatCount(data.thresholds.outcomesEval)}` : undefined}
+          dot={data && data.outcomesCount >= data.thresholds.outcomesEval
+            ? '#ef4444'
+            : data && data.outcomesCount >= data.thresholds.outcomesEval * 0.5
+              ? '#f59e0b'
+              : RAMS_INK_QUIET}
+        />
+        <Row
+          label="Directives count"
+          value={data ? formatCount(data.directivesCount) : (loading ? '…' : '—')}
+          hint="Markdown files in the directives/ dir"
+          dot={RAMS_INK_QUIET}
+        />
+        <Row
+          label="Recall p50 (24h)"
+          value={data ? formatMs(data.timing.p50Ms) : (loading ? '…' : '—')}
+          hint={data ? `${formatCount(data.timing.windowedSamples)} samples` : undefined}
+          dot={RAMS_INK_QUIET}
+        />
+        <Row
+          label="Recall p95 (24h)"
+          value={data ? formatMs(data.timing.p95Ms) : (loading ? '…' : '—')}
+          hint={data ? `Eval at ${data.thresholds.p95Ms}ms` : undefined}
+          dot={data && data.timing.p95Ms >= data.thresholds.p95Ms
+            ? '#ef4444'
+            : data && data.timing.p95Ms >= data.thresholds.p95Ms * 0.75
+              ? '#f59e0b'
+              : RAMS_INK_QUIET}
+        />
+        <Row
+          label="Recall p99 (24h)"
+          value={data ? formatMs(data.timing.p99Ms) : (loading ? '…' : '—')}
+          hint={data ? `max ${formatMs(data.timing.maxMs)}` : undefined}
+          dot={RAMS_INK_QUIET}
+        />
+        <Row
+          label="Recall p95 (7d)"
+          value={data ? formatMs(data.timing7d.p95Ms) : (loading ? '…' : '—')}
+          hint={data
+            ? `Eval at ${data.thresholds.p95Ms}ms sustained ${data.thresholds.sustainedDays}d`
+            : undefined}
+          dot={data && data.timing7d.p95Ms >= data.thresholds.p95Ms
+            ? '#ef4444'
+            : data && data.timing7d.p95Ms >= data.thresholds.p95Ms * 0.75
+              ? '#f59e0b'
+              : RAMS_INK_QUIET}
+        />
+        <Row
+          label="Substrate health"
+          value={data ? data.health.toUpperCase() : (loading ? '…' : '—')}
+          hint={data ? data.notes[0] : undefined}
+          dot={data ? dotColorForHealth(data.health) : RAMS_INK_QUIET}
+        />
+      </div>
+
+      {data && data.timing.byLabel.length > 0 ? (
+        <div style={{ marginTop: 18 }}>
+          <ByLabelTable rows={data.timing.byLabel} />
+        </div>
+      ) : null}
+
+      {error ? (
+        <div style={{
+          marginTop: 14,
+          fontSize: 13,
+          color: 'var(--t-text)',
+          lineHeight: 1.55,
+        }}>
+          <span style={{
+            fontFamily: MONO_FONT_STACK,
+            fontSize: 11,
+            fontWeight: 500,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            color: '#ef4444',
+            marginRight: 8,
+          }}>
+            [error]
+          </span>
+          {error}
+        </div>
+      ) : null}
+
+      <div style={{
+        marginTop: 16,
+        fontSize: 12,
+        color: 'var(--t-text-secondary)',
+        lineHeight: 1.55,
+      }}>
+        Read-only instrumentation. See{' '}
+        <span style={{ fontFamily: MONO_FONT_STACK, fontSize: 11 }}>
+          docs/substrate-eval-gate.md
+        </span>{' '}
+        for the threshold definitions and decision procedure.
+      </div>
+    </section>
+  );
+}
+
+// ── Row primitive — Issues-style ──
+
+function Row({
+  label,
+  value,
+  hint,
+  dot,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  dot: string;
+}) {
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 14,
+      paddingTop: 12,
+      paddingBottom: 12,
+      borderBottom: `1px solid ${RAMS_HAIRLINE_SOFT}`,
+    }}>
+      <span style={{
+        width: 6,
+        height: 6,
+        borderRadius: 3,
+        background: dot,
+        flexShrink: 0,
+      }} />
+      <span style={{
+        fontFamily: MONO_FONT_STACK,
+        fontSize: 11,
+        fontWeight: 400,
+        color: RAMS_INK_QUIET,
+        textTransform: 'uppercase',
+        letterSpacing: '0.14em',
+        minWidth: 180,
+      }}>
+        {label}
+      </span>
+      <span style={{
+        fontSize: 13,
+        fontWeight: 400,
+        color: 'var(--t-text)',
+        flex: 1,
+        minWidth: 0,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        fontFamily: MONO_FONT_STACK,
+        letterSpacing: '0.02em',
+      }}>
+        {value}
+      </span>
+      {hint ? (
+        <span style={{
+          fontFamily: MONO_FONT_STACK,
+          fontSize: 11,
+          fontWeight: 400,
+          letterSpacing: '0.04em',
+          color: 'var(--t-text-secondary)',
+          textAlign: 'right',
+        }}>
+          {hint}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function ByLabelTable({
+  rows,
+}: {
+  rows: Array<{ label: string; samples: number; p50Ms: number; p95Ms: number; p99Ms: number }>;
+}) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: '2fr 1fr 1fr 1fr 1fr',
+        gap: 12,
+        paddingTop: 6,
+        paddingBottom: 6,
+        borderBottom: `1px solid ${RAMS_HAIRLINE_SOFT}`,
+        fontFamily: MONO_FONT_STACK,
+        fontSize: 10,
+        fontWeight: 400,
+        letterSpacing: '0.14em',
+        textTransform: 'uppercase',
+        color: RAMS_INK_QUIET,
+      }}>
+        <span>Call site</span>
+        <span style={{ textAlign: 'right' }}>Samples</span>
+        <span style={{ textAlign: 'right' }}>p50</span>
+        <span style={{ textAlign: 'right' }}>p95</span>
+        <span style={{ textAlign: 'right' }}>p99</span>
+      </div>
+      {rows.map((row) => (
+        <div key={row.label} style={{
+          display: 'grid',
+          gridTemplateColumns: '2fr 1fr 1fr 1fr 1fr',
+          gap: 12,
+          paddingTop: 8,
+          paddingBottom: 8,
+          borderBottom: `1px solid ${RAMS_HAIRLINE_SOFT}`,
+          fontFamily: MONO_FONT_STACK,
+          fontSize: 11.5,
+          letterSpacing: '0.02em',
+          color: 'var(--t-text)',
+        }}>
+          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {row.label}
+          </span>
+          <span style={{ textAlign: 'right' }}>{row.samples.toLocaleString()}</span>
+          <span style={{ textAlign: 'right' }}>{formatMs(row.p50Ms)}</span>
+          <span style={{ textAlign: 'right' }}>{formatMs(row.p95Ms)}</span>
+          <span style={{ textAlign: 'right' }}>{formatMs(row.p99Ms)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/codebase-memory/build-context.ts
+++ b/src/lib/codebase-memory/build-context.ts
@@ -43,6 +43,7 @@ import { and, desc, eq } from 'drizzle-orm';
 import { getDb, sessionOutcomes } from '@/lib/db';
 import { getDataDir } from '@/lib/data-dir-migration';
 import { liveOutcomeFilter } from '@/lib/cortex/decay';
+import { withTiming } from '@/lib/cortex/diagnostics';
 
 import { extractSymbols, traceSymbols, type SymbolEdge } from './client';
 
@@ -305,7 +306,10 @@ export async function buildContextBlock({
   try {
     const symbols = extractSymbols(packetBody, MAX_SYMBOLS);
     if (symbols.length > 0) {
-      const traced = await traceSymbols({ repoPath, symbols });
+      const traced = await withTiming(
+        'recall.symbol-graph',
+        () => traceSymbols({ repoPath, symbols }),
+      );
       if (!traced.unavailable) edges = traced.edges;
     }
   } catch {

--- a/src/lib/cortex/diagnostics.ts
+++ b/src/lib/cortex/diagnostics.ts
@@ -1,0 +1,326 @@
+/**
+ * #749 — Substrate eval gate (read-only instrumentation).
+ *
+ * Wraps recall-path queries with `performance.now()` timing and pushes each
+ * sample into an in-memory ring buffer. The buffer is hydrated from disk on
+ * first import and lazily flushed back on every Nth append, plus on demand
+ * via `flushTimingBuffer()`.
+ *
+ * No code changes to the substrate itself — this module is pure read-only
+ * observability so we can answer "is SQLite still fine, or is it time to
+ * evaluate a swap?" without guessing.
+ *
+ * Storage: `<dataDir>/recall-metrics.json` — buffer is FIFO-evicted at
+ * `MAX_SAMPLES` so the file stays small (< 200 KB) regardless of uptime.
+ *
+ * No-throw policy: timing must never affect recall behaviour. Every helper
+ * swallows IO errors and logs with the `[recall-metrics]` prefix.
+ */
+
+import 'server-only';
+
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { getDataDir } from '@/lib/data-dir-migration';
+
+/** Max number of samples kept in the ring buffer. FIFO eviction beyond this. */
+export const MAX_SAMPLES = 1000;
+
+/**
+ * Persist to disk after every N appends. Trades a tiny bit of crash-safety
+ * (the last <10 samples may be lost on a hard kill) for not slamming the FS
+ * on every recall query.
+ */
+const FLUSH_EVERY_N_SAMPLES = 10;
+
+const METRICS_FILE = 'recall-metrics.json';
+
+/** A single timing sample. Shape kept narrow on purpose — easy to extend later. */
+export interface RecallTimingSample {
+  /** Logical label, e.g. `recall.recent-outcomes`. */
+  label: string;
+  /** Wall-clock duration in milliseconds, post `performance.now()`. */
+  durationMs: number;
+  /** Unix epoch ms when the sample was recorded. */
+  timestamp: number;
+  /** True when the wrapped fn threw — durationMs still represents wall time. */
+  errored?: boolean;
+}
+
+interface PersistedFile {
+  version: 1;
+  samples: RecallTimingSample[];
+}
+
+// ── module-local state ────────────────────────────────────────────────────
+
+let _buffer: RecallTimingSample[] | null = null;
+let _appendsSinceFlush = 0;
+let _lastFileFailure = 0;
+
+function metricsFilePath(): string {
+  return join(getDataDir(), METRICS_FILE);
+}
+
+function loadFromDisk(): RecallTimingSample[] {
+  const path = metricsFilePath();
+  if (!existsSync(path)) return [];
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<PersistedFile>;
+    if (!parsed || parsed.version !== 1 || !Array.isArray(parsed.samples)) {
+      return [];
+    }
+    // Defensive — strip malformed entries but keep the rest.
+    const out: RecallTimingSample[] = [];
+    for (const entry of parsed.samples) {
+      if (!entry || typeof entry !== 'object') continue;
+      const e = entry as Partial<RecallTimingSample>;
+      if (
+        typeof e.label !== 'string' ||
+        typeof e.durationMs !== 'number' ||
+        typeof e.timestamp !== 'number'
+      ) continue;
+      if (!Number.isFinite(e.durationMs) || !Number.isFinite(e.timestamp)) continue;
+      out.push({
+        label: e.label,
+        durationMs: e.durationMs,
+        timestamp: e.timestamp,
+        errored: e.errored === true ? true : undefined,
+      });
+    }
+    // Hard cap on hydrate too — disk file may be older than the current ceiling.
+    return out.slice(-MAX_SAMPLES);
+  } catch (err) {
+    console.warn('[recall-metrics] Failed to hydrate buffer:', err instanceof Error ? err.message : err);
+    return [];
+  }
+}
+
+function ensureBuffer(): RecallTimingSample[] {
+  if (_buffer === null) {
+    _buffer = loadFromDisk();
+  }
+  return _buffer;
+}
+
+function flushToDisk(buffer: RecallTimingSample[]): void {
+  // Backoff after a failure — once /min, not on every append.
+  const now = Date.now();
+  if (_lastFileFailure > 0 && now - _lastFileFailure < 60_000) return;
+
+  const path = metricsFilePath();
+  const tmp = `${path}.tmp-${process.pid}`;
+  const payload: PersistedFile = { version: 1, samples: buffer };
+  try {
+    writeFileSync(tmp, JSON.stringify(payload), 'utf-8');
+    renameSync(tmp, path);
+    _lastFileFailure = 0;
+  } catch (err) {
+    _lastFileFailure = now;
+    console.warn('[recall-metrics] flush failed:', err instanceof Error ? err.message : err);
+  }
+}
+
+/**
+ * Append a sample. Drops oldest entries past MAX_SAMPLES (FIFO).
+ *
+ * The same logical operation can append multiple samples — each call records
+ * a single observation. Lazy disk flush every N appends.
+ */
+export function recordTiming(sample: RecallTimingSample): void {
+  const buf = ensureBuffer();
+  buf.push(sample);
+  if (buf.length > MAX_SAMPLES) {
+    // FIFO eviction — drop the oldest entries.
+    buf.splice(0, buf.length - MAX_SAMPLES);
+  }
+  _appendsSinceFlush += 1;
+  if (_appendsSinceFlush >= FLUSH_EVERY_N_SAMPLES) {
+    _appendsSinceFlush = 0;
+    flushToDisk(buf);
+  }
+}
+
+/**
+ * Force a flush to disk. Useful for the API endpoint so the buffer caller
+ * sees fresh-on-disk data, and during tests.
+ */
+export function flushTimingBuffer(): void {
+  const buf = ensureBuffer();
+  _appendsSinceFlush = 0;
+  flushToDisk(buf);
+}
+
+/**
+ * Read-only view of the current buffer. Returns a defensive copy so callers
+ * can sort / filter without mutating module state.
+ */
+export function readTimingBuffer(): RecallTimingSample[] {
+  return [...ensureBuffer()];
+}
+
+/** Reset the in-memory buffer + clear the on-disk file. Test-only. */
+export function __resetTimingBuffer(): void {
+  _buffer = [];
+  _appendsSinceFlush = 0;
+  _lastFileFailure = 0;
+  try {
+    flushToDisk([]);
+  } catch {
+    // ignore — best-effort cleanup
+  }
+}
+
+// ── timing wrappers ───────────────────────────────────────────────────────
+
+/**
+ * Wrap an async function with `performance.now()` timing. Records exactly
+ * one sample per call (success or throw). Re-throws the original error so
+ * call sites preserve their existing behaviour — instrumentation must not
+ * change the recall contract.
+ */
+export async function withTiming<T>(label: string, fn: () => PromiseLike<T>): Promise<T> {
+  const started = performance.now();
+  let errored = false;
+  try {
+    return await fn();
+  } catch (err) {
+    errored = true;
+    throw err;
+  } finally {
+    const durationMs = Math.max(0, performance.now() - started);
+    recordTiming({
+      label,
+      durationMs,
+      timestamp: Date.now(),
+      errored: errored ? true : undefined,
+    });
+    if (durationMs > 200) {
+      console.log(`[recall-metrics] ${label} ${durationMs.toFixed(1)}ms${errored ? ' (errored)' : ''}`);
+    }
+  }
+}
+
+/**
+ * Sync variant for call sites that aren't promise-shaped (the proposer's
+ * SQLite read happens inside a synchronous prepare/.all loop). Same recording
+ * semantics as `withTiming`.
+ */
+export function withTimingSync<T>(label: string, fn: () => T): T {
+  const started = performance.now();
+  let errored = false;
+  try {
+    return fn();
+  } catch (err) {
+    errored = true;
+    throw err;
+  } finally {
+    const durationMs = Math.max(0, performance.now() - started);
+    recordTiming({
+      label,
+      durationMs,
+      timestamp: Date.now(),
+      errored: errored ? true : undefined,
+    });
+    if (durationMs > 200) {
+      console.log(`[recall-metrics] ${label} ${durationMs.toFixed(1)}ms${errored ? ' (errored)' : ''}`);
+    }
+  }
+}
+
+// ── percentile helpers ────────────────────────────────────────────────────
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0]!;
+  // Nearest-rank — small dataset, no need for linear interpolation.
+  const rank = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, rank)]!;
+}
+
+export interface RecallTimingSummary {
+  totalSamples: number;
+  /** Samples with timestamp newer than `windowMs` ago. */
+  windowedSamples: number;
+  windowMs: number;
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+  maxMs: number;
+  errorCount: number;
+  /** Per-label breakdown across the windowed samples. */
+  byLabel: Array<{
+    label: string;
+    samples: number;
+    p50Ms: number;
+    p95Ms: number;
+    p99Ms: number;
+  }>;
+}
+
+const DEFAULT_WINDOW_MS = 24 * 60 * 60 * 1000; // 24h
+
+/**
+ * Compute aggregate stats over the buffer. `windowMs` filters to recent
+ * samples only — defaults to the last 24h, which is what the Diagnostics
+ * tab surfaces. Threshold doc references the 7-day signal — callers can
+ * pass a wider window for that lookup.
+ */
+export function summarizeTimings(windowMs = DEFAULT_WINDOW_MS): RecallTimingSummary {
+  const all = ensureBuffer();
+  const cutoff = Date.now() - Math.max(0, windowMs);
+  const windowed = windowMs > 0
+    ? all.filter((s) => s.timestamp >= cutoff)
+    : all;
+
+  if (windowed.length === 0) {
+    return {
+      totalSamples: all.length,
+      windowedSamples: 0,
+      windowMs,
+      p50Ms: 0,
+      p95Ms: 0,
+      p99Ms: 0,
+      maxMs: 0,
+      errorCount: 0,
+      byLabel: [],
+    };
+  }
+
+  const allDurations = windowed.map((s) => s.durationMs).sort((a, b) => a - b);
+  const errorCount = windowed.reduce((n, s) => n + (s.errored ? 1 : 0), 0);
+
+  const labelGroups = new Map<string, number[]>();
+  for (const sample of windowed) {
+    const arr = labelGroups.get(sample.label);
+    if (arr) arr.push(sample.durationMs);
+    else labelGroups.set(sample.label, [sample.durationMs]);
+  }
+
+  const byLabel = Array.from(labelGroups.entries())
+    .map(([label, raw]) => {
+      const sorted = [...raw].sort((a, b) => a - b);
+      return {
+        label,
+        samples: sorted.length,
+        p50Ms: percentile(sorted, 50),
+        p95Ms: percentile(sorted, 95),
+        p99Ms: percentile(sorted, 99),
+      };
+    })
+    .sort((a, b) => b.samples - a.samples);
+
+  return {
+    totalSamples: all.length,
+    windowedSamples: windowed.length,
+    windowMs,
+    p50Ms: percentile(allDurations, 50),
+    p95Ms: percentile(allDurations, 95),
+    p99Ms: percentile(allDurations, 99),
+    maxMs: allDurations[allDurations.length - 1] ?? 0,
+    errorCount,
+    byLabel,
+  };
+}

--- a/src/lib/cortex/proposer.ts
+++ b/src/lib/cortex/proposer.ts
@@ -31,6 +31,7 @@ import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 
 import { getDataDir } from '@/lib/data-dir-migration';
+import { withTimingSync } from '@/lib/cortex/diagnostics';
 
 const DEFAULT_WINDOW_DAYS = 14;
 const DEFAULT_THRESHOLD = 3;
@@ -300,12 +301,14 @@ function readRecentOutcomes(windowDays: number): OutcomeRow[] {
   `;
 
   try {
-    const rows = sqlite.prepare(sql).all(sinceIso) as Array<{
-      id: string;
-      summary: string;
-      completedAt: string;
-      changedFilesJson: string;
-    }>;
+    const rows = withTimingSync('recall.proposer-outcomes', () =>
+      sqlite.prepare(sql).all(sinceIso) as Array<{
+        id: string;
+        summary: string;
+        completedAt: string;
+        changedFilesJson: string;
+      }>,
+    );
     return rows.filter((r) => r && typeof r.id === 'string');
   } catch (err) {
     console.warn('[proposer] outcome read failed:', err instanceof Error ? err.message : err);


### PR DESCRIPTION
## Summary

Final Tier 1 of the post-YC context-engine track. Read-only instrumentation that measures SQLite scale + recall p95, surfaces both in Settings → Diagnostics, and writes a threshold doc that defines *when* we start a substrate evaluation. Closes #749 (parent epic #738).

- **`src/lib/cortex/diagnostics.ts`** — `withTiming<T>` / `withTimingSync<T>` wrappers + 1000-sample FIFO ring buffer persisted to `<dataDir>/recall-metrics.json`. Hydrates on boot, lazy flushes every 10 appends. Re-throws every wrapped error so recall behavior is unchanged.
- **5 recall sites wrapped**: `recall.recent-outcomes`, `recall.directives`, `recall.symbol-graph`, `recall.runtime-recommendation`, `recall.proposer-outcomes`. One-line wraps per site (the directives site got a small block-restructure to move the loop inside the timer). Substrate code untouched.
- **`/api/cortex/diagnostics`** — new GET endpoint returns outcomes count, directives count, 24h + 7d timing summaries, threshold constants, and a green/amber/red verdict. Gated by the existing `/api/cortex/*` middleware rule.
- **Settings → Diagnostics → "02 — RECALL HEALTH"** — new Issues-style row block: Outcomes count, Directives count, Recall p50/p95/p99 (24h), Recall p95 (7d), Substrate health. Plus a per-call-site breakdown table. Existing 02 MAINTENANCE / 03 DANGER renumbered to 03 / 04. Lives in a separate `RecallHealthSection.tsx` to keep `DiagnosticsTab.tsx` under the 800-line ceiling.
- **`docs/substrate-eval-gate.md`** — threshold definitions: eval at `outcomes >= 5,000` OR recall p95 ≥ 200ms sustained 5/7 days. Doc explicitly does NOT recommend a replacement; lists candidates only to bound the spike scope, decision happens after measurement.

## Test plan

- [ ] `npx tsc --noEmit` clean
- [ ] Settings → Diagnostics renders new "02 — RECALL HEALTH" section above Maintenance
- [ ] Outcomes count + directives count populate from local data dir
- [ ] After a few packet dispatches, p50/p95/p99 + per-call-site rows fill in
- [ ] `cat <dataDir>/recall-metrics.json` shows ≤ 1000 sample entries with FIFO eviction
- [ ] When `outcomes >= 5,000` OR `p95 >= 200ms`, the dot flips to amber/red and the notes line updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)