### PR TITLE
feat(settings): in-app Loop Status widget (closes #796)

### DIFF
--- a/src/app/api/panel/git/log/route.ts
+++ b/src/app/api/panel/git/log/route.ts
@@ -1,0 +1,126 @@
+/**
+ * #796 — Compact git log endpoint for the in-app Loop Status widget.
+ *
+ * Returns the last N commits as `{ commits: [{ hash, title, ageMs }], total }`.
+ * Loop Status renders the "recent merges" disclosure from this; we keep the
+ * shape minimal on purpose so the section stays readable in Issues-style
+ * rows. The richer `/api/panel/git-log` endpoint stays as the canonical
+ * source for the Changes panel and history viewers.
+ *
+ * Repo discovery:
+ *   1. `?repoPath=<absolute|~ relative>` — explicit override
+ *   2. `~/.o8/repos.json` — first registered repo
+ *   3. `process.cwd()` — last resort for dev
+ *
+ * The middleware in `src/middleware.ts` gates this prefix on loopback +
+ * ws-token, so we don't re-implement auth here.
+ */
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { execFile } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { listRepos } from '@/lib/repos/registry';
+
+const execFileAsync = promisify(execFile);
+
+interface CompactCommit {
+  hash: string;
+  title: string;
+  ageMs: number;
+}
+
+interface CompactGitLogResponse {
+  commits: CompactCommit[];
+  total: number;
+  repoPath: string | null;
+  error?: string;
+}
+
+function expandHome(input: string) {
+  if (!input) return input;
+  if (input.startsWith('~')) {
+    return path.resolve(input.replace(/^~/, os.homedir()));
+  }
+  return path.resolve(input);
+}
+
+async function resolveRepoPath(explicit: string | null): Promise<string | null> {
+  if (explicit && explicit.trim()) {
+    return expandHome(explicit.trim());
+  }
+  try {
+    const repos = await listRepos();
+    if (repos.length > 0 && repos[0]?.localPath) {
+      return expandHome(repos[0].localPath);
+    }
+  } catch {
+    /* registry unreadable — fall through */
+  }
+  return process.cwd() || null;
+}
+
+export async function GET(request: Request): Promise<NextResponse<CompactGitLogResponse>> {
+  const url = new URL(request.url);
+  const explicit = url.searchParams.get('repoPath');
+  const limitParam = url.searchParams.get('limit');
+  const limit = Math.min(Math.max(parseInt(limitParam ?? '5', 10) || 5, 1), 50);
+
+  const repoPath = await resolveRepoPath(explicit);
+  if (!repoPath) {
+    return NextResponse.json({
+      commits: [],
+      total: 0,
+      repoPath: null,
+      error: 'No repo path could be resolved.',
+    });
+  }
+
+  const sep = '\x1f';
+  const recordSep = '\x1e';
+  const format = `%H${sep}%s${sep}%ct${recordSep}`;
+
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['-C', repoPath, 'log', `--format=${format}`, '-n', String(limit)],
+      { maxBuffer: 1024 * 1024, timeout: 8000 },
+    );
+
+    const now = Date.now();
+    const commits: CompactCommit[] = stdout
+      .split(recordSep)
+      .map((chunk) => chunk.replace(/^\n/, '').trim())
+      .filter(Boolean)
+      .map((chunk) => {
+        const [hash, title, ctSec] = chunk.split(sep);
+        if (!hash || !title || !ctSec) return null;
+        const seconds = parseInt(ctSec, 10);
+        if (!Number.isFinite(seconds)) return null;
+        return {
+          hash,
+          title,
+          ageMs: Math.max(0, now - seconds * 1000),
+        };
+      })
+      .filter((entry): entry is CompactCommit => entry !== null);
+
+    return NextResponse.json({
+      commits,
+      total: commits.length,
+      repoPath,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'git log failed';
+    return NextResponse.json({
+      commits: [],
+      total: 0,
+      repoPath,
+      error: message,
+    });
+  }
+}

--- a/src/app/api/panel/loop-status/route.ts
+++ b/src/app/api/panel/loop-status/route.ts
@@ -1,0 +1,105 @@
+/**
+ * #796 — Read-only reader for the autonomous-loop cron state file.
+ *
+ * Schema of `~/.o8/loop-cron-state.json` (all fields optional except jobId):
+ *   {
+ *     "jobId":          "string",   // unique per scheduled job
+ *     "cronExpression": "string",   // e.g. "0,20,40 * * * *"
+ *     "lastFiredAt":    "ISO 8601",
+ *     "nextFireAt":     "ISO 8601",
+ *     "prompt":         "string"
+ *   }
+ *
+ * If the file is missing or unparseable we respond with `{ ok: true,
+ * active: false }` so the Loop Status widget can render "No active loop"
+ * gracefully. We never create or mutate this file — the cron tooling owns
+ * its lifecycle.
+ *
+ * Middleware in `src/middleware.ts` already gates `/api/panel/*` on
+ * loopback + ws-token, so no extra auth here.
+ */
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+interface CronStatePayload {
+  ok: boolean;
+  active: boolean;
+  jobId: string | null;
+  cronExpression: string | null;
+  lastFiredAt: string | null;
+  nextFireAt: string | null;
+  prompt: string | null;
+  note?: string;
+}
+
+function emptyResponse(note?: string): CronStatePayload {
+  return {
+    ok: true,
+    active: false,
+    jobId: null,
+    cronExpression: null,
+    lastFiredAt: null,
+    nextFireAt: null,
+    prompt: null,
+    ...(note ? { note } : {}),
+  };
+}
+
+function pickString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+export async function GET(): Promise<NextResponse<CronStatePayload>> {
+  const filePath = path.join(os.homedir(), '.o8', 'loop-cron-state.json');
+
+  let raw: string;
+  try {
+    raw = await readFile(filePath, 'utf8');
+  } catch (err) {
+    const code = typeof err === 'object' && err !== null && 'code' in err
+      ? String((err as { code?: unknown }).code)
+      : '';
+    if (code === 'ENOENT') {
+      return NextResponse.json(emptyResponse('Cron state file not present.'));
+    }
+    return NextResponse.json(emptyResponse('Cron state file unreadable.'));
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    return NextResponse.json(emptyResponse('Cron state file is not valid JSON.'));
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    return NextResponse.json(emptyResponse('Cron state payload not an object.'));
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const jobId = pickString(record.jobId);
+  const cronExpression = pickString(record.cronExpression);
+  const lastFiredAt = pickString(record.lastFiredAt);
+  const nextFireAt = pickString(record.nextFireAt);
+  const prompt = pickString(record.prompt);
+
+  // We treat "active" as: file exists AND has at least a jobId or a cron
+  // expression. That keeps a half-written file from masquerading as live.
+  const active = !!(jobId || cronExpression);
+
+  return NextResponse.json({
+    ok: true,
+    active,
+    jobId,
+    cronExpression,
+    lastFiredAt,
+    nextFireAt,
+    prompt,
+  });
+}

--- a/src/components/desktop/settings/DiagnosticsResetModals.tsx
+++ b/src/components/desktop/settings/DiagnosticsResetModals.tsx
@@ -1,0 +1,272 @@
+'use client';
+
+/**
+ * Factory-reset confirmation + done modals extracted from `DiagnosticsTab.tsx`
+ * to keep the parent file under the 800-line ceiling after #796 added the
+ * Loop Status section. No behavior change — both components are pure
+ * presentation, fed by props from the parent.
+ */
+
+import {
+  APP_FONT_STACK,
+  MONO_FONT_STACK,
+  RAMS_ACCENT,
+  RAMS_HAIRLINE,
+  RAMS_INK_QUIET,
+  RamsButton,
+} from './shared';
+
+export type FactoryResetStage = 'idle' | 'confirm' | 'busy' | 'done' | 'error';
+
+export interface FactoryResetResult {
+  dataDir: string;
+  removed: string[];
+  failed: { entry: string; error: string }[];
+  durationMs: number;
+}
+
+export function ResetConfirmModal({
+  stage,
+  confirmText,
+  onConfirmTextChange,
+  error,
+  onCancel,
+  onSubmit,
+}: {
+  stage: FactoryResetStage;
+  confirmText: string;
+  onConfirmTextChange: (v: string) => void;
+  error: string | null;
+  onCancel: () => void;
+  onSubmit: () => void;
+}) {
+  const ready = confirmText === 'RESET' && stage !== 'busy';
+
+  return (
+    <div style={{
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      background: 'rgba(0, 0, 0, 0.42)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: 1000,
+      fontFamily: APP_FONT_STACK,
+    }}>
+      <div style={{
+        width: 480,
+        maxWidth: '90vw',
+        background: 'var(--t-bg-card, #ffffff)',
+        border: `1px solid ${RAMS_HAIRLINE}`,
+        borderRadius: 4,
+        paddingTop: 24,
+        paddingRight: 28,
+        paddingBottom: 24,
+        paddingLeft: 28,
+        boxShadow: '0 12px 48px rgba(0, 0, 0, 0.18)',
+      }}>
+        <div style={{
+          fontFamily: MONO_FONT_STACK,
+          fontSize: 10,
+          fontWeight: 500,
+          letterSpacing: '0.22em',
+          textTransform: 'uppercase',
+          color: '#d94f3a',
+          marginBottom: 14,
+        }}>
+          ⏵ DANGER · IRREVERSIBLE
+        </div>
+        <div style={{
+          fontSize: 18,
+          fontWeight: 500,
+          color: 'var(--t-text)',
+          letterSpacing: '-0.02em',
+          marginBottom: 14,
+        }}>
+          Factory reset o8
+        </div>
+        <div style={{ fontSize: 13, color: 'var(--t-text-secondary)', lineHeight: 1.55, marginBottom: 18 }}>
+          This will permanently delete everything inside{' '}
+          <span style={{ fontFamily: MONO_FONT_STACK, fontSize: 12 }}>~/.o8</span>:
+        </div>
+        <ul style={{
+          fontSize: 13,
+          color: 'var(--t-text-secondary)',
+          lineHeight: 1.7,
+          paddingLeft: 18,
+          marginTop: 0,
+          marginBottom: 18,
+        }}>
+          <li>SQLite database (sessions, approvals, lanes, watched agents)</li>
+          <li>Encrypted API keys (Anthropic, OpenAI, Gemini, etc.)</li>
+          <li>Mission state and orchestrator history</li>
+          <li>Watched repo registry, directives, WS token</li>
+          <li>Per-server logs</li>
+        </ul>
+        <div style={{ fontSize: 13, color: 'var(--t-text-secondary)', lineHeight: 1.55, marginBottom: 18 }}>
+          The macOS Keychain master key and{' '}
+          <span style={{ fontFamily: MONO_FONT_STACK, fontSize: 12 }}>~/.cortex-ide</span>{' '}
+          (legacy rollback dir) are left untouched.
+        </div>
+        <div style={{ marginBottom: 14 }}>
+          <div style={{
+            fontFamily: MONO_FONT_STACK,
+            fontSize: 10,
+            fontWeight: 400,
+            letterSpacing: '0.14em',
+            textTransform: 'uppercase',
+            color: RAMS_INK_QUIET,
+            marginBottom: 6,
+          }}>
+            Type RESET to confirm
+          </div>
+          <input
+            type="text"
+            value={confirmText}
+            onChange={(event) => onConfirmTextChange(event.target.value)}
+            disabled={stage === 'busy'}
+            autoFocus
+            spellCheck={false}
+            autoCapitalize="off"
+            autoCorrect="off"
+            style={{
+              width: '100%',
+              boxSizing: 'border-box',
+              fontFamily: MONO_FONT_STACK,
+              fontSize: 13,
+              fontWeight: 400,
+              letterSpacing: '0.04em',
+              color: 'var(--t-text)',
+              background: 'var(--t-input-bg, transparent)',
+              border: `1px solid ${RAMS_HAIRLINE}`,
+              borderRadius: 4,
+              paddingTop: 9,
+              paddingRight: 12,
+              paddingBottom: 9,
+              paddingLeft: 12,
+              outline: 'none',
+            }}
+          />
+        </div>
+        {error ? (
+          <div style={{
+            marginBottom: 14,
+            paddingTop: 2,
+            paddingBottom: 2,
+            fontSize: 12,
+            color: 'var(--t-text)',
+            lineHeight: 1.5,
+          }}>
+            <span style={{
+              fontFamily: MONO_FONT_STACK,
+              fontSize: 11,
+              fontWeight: 500,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: '#ef4444',
+              marginRight: 8,
+            }}>
+              [error]
+            </span>
+            {error}
+          </div>
+        ) : null}
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 6 }}>
+          <RamsButton variant="ghost" onClick={onCancel} disabled={stage === 'busy'}>
+            cancel
+          </RamsButton>
+          <RamsButton
+            variant="danger"
+            onClick={onSubmit}
+            disabled={!ready}
+            busy={stage === 'busy'}
+          >
+            {stage === 'busy' ? 'wiping...' : 'reset everything'}
+          </RamsButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ResetDoneModal({
+  result,
+  onDismiss,
+}: {
+  result: FactoryResetResult;
+  onDismiss: () => void;
+}) {
+  return (
+    <div style={{
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      background: 'rgba(0, 0, 0, 0.42)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: 1000,
+      fontFamily: APP_FONT_STACK,
+    }}>
+      <div style={{
+        width: 460,
+        maxWidth: '90vw',
+        background: 'var(--t-bg-card, #ffffff)',
+        border: `1px solid ${RAMS_HAIRLINE}`,
+        borderRadius: 4,
+        paddingTop: 24,
+        paddingRight: 28,
+        paddingBottom: 24,
+        paddingLeft: 28,
+        boxShadow: '0 12px 48px rgba(0, 0, 0, 0.18)',
+      }}>
+        <div style={{
+          fontFamily: MONO_FONT_STACK,
+          fontSize: 10,
+          fontWeight: 500,
+          letterSpacing: '0.22em',
+          textTransform: 'uppercase',
+          color: RAMS_ACCENT,
+          marginBottom: 14,
+        }}>
+          ⏵ RESET COMPLETE
+        </div>
+        <div style={{
+          fontSize: 18,
+          fontWeight: 500,
+          color: 'var(--t-text)',
+          letterSpacing: '-0.02em',
+          marginBottom: 12,
+        }}>
+          Quit and reopen o8 to reinitialize
+        </div>
+        <div style={{ fontSize: 13, color: 'var(--t-text-secondary)', lineHeight: 1.55, marginBottom: 16 }}>
+          {result.removed.length} entries removed in {result.durationMs}ms.{' '}
+          {result.failed.length > 0
+            ? `${result.failed.length} entries could not be deleted (likely held open by the running app — they will be cleared on next launch).`
+            : 'The current session is still running against the deleted database — close o8 fully and relaunch before continuing.'}
+        </div>
+        <div style={{
+          fontFamily: MONO_FONT_STACK,
+          fontSize: 11,
+          letterSpacing: '0.02em',
+          color: RAMS_INK_QUIET,
+          marginBottom: 18,
+          wordBreak: 'break-all',
+        }}>
+          {result.dataDir}
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <RamsButton variant="ghost" onClick={onDismiss}>
+            close
+          </RamsButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/desktop/settings/DiagnosticsTab.tsx
+++ b/src/components/desktop/settings/DiagnosticsTab.tsx
@@ -5,7 +5,6 @@ import {
   APP_FONT_STACK,
   MONO_FONT_STACK,
   RAMS_ACCENT,
-  RAMS_HAIRLINE,
   RAMS_HAIRLINE_SOFT,
   RAMS_INK_QUIET,
   BracketLabel,
@@ -16,6 +15,13 @@ import {
   TabHeading,
 } from './shared';
 import { RecallHealthSection } from './RecallHealthSection';
+import { LoopStatusSection } from './LoopStatusSection';
+import {
+  ResetConfirmModal,
+  ResetDoneModal,
+  type FactoryResetResult,
+  type FactoryResetStage,
+} from './DiagnosticsResetModals';
 
 // ── Types ──
 
@@ -40,15 +46,6 @@ interface CodexSessionsPruneResult {
   sessionsRoot: string;
   skipped: number;
 }
-
-interface FactoryResetResult {
-  dataDir: string;
-  removed: string[];
-  failed: { entry: string; error: string }[];
-  durationMs: number;
-}
-
-type FactoryResetStage = 'idle' | 'confirm' | 'busy' | 'done' | 'error';
 
 const HIDDEN_DIAGNOSTIC_TOOL_IDS = new Set(['ollama']);
 
@@ -254,9 +251,12 @@ export function DiagnosticsTab() {
       {/* 02 — RECALL HEALTH (#749 substrate eval gate) */}
       <RecallHealthSection />
 
-      {/* 03 — MAINTENANCE */}
+      {/* 03 — LOOP STATUS (#796 in-app dogfood-loop visibility) */}
+      <LoopStatusSection sectionNumber="03" />
+
+      {/* 04 — MAINTENANCE */}
       <section style={{ marginTop: 32 }}>
-        <SectionLabel number="03">MAINTENANCE</SectionLabel>
+        <SectionLabel number="04">MAINTENANCE</SectionLabel>
 
         <div style={{
           display: 'flex',
@@ -381,9 +381,9 @@ export function DiagnosticsTab() {
         </div>
       </section>
 
-      {/* 04 — DANGER */}
+      {/* 05 — DANGER */}
       <section style={{ marginTop: 32 }}>
-        <SectionLabel number="04">DANGER</SectionLabel>
+        <SectionLabel number="05">DANGER</SectionLabel>
 
         <div style={{
           display: 'flex',
@@ -465,254 +465,6 @@ export function DiagnosticsTab() {
           onDismiss={dismissResetDone}
         />
       ) : null}
-    </div>
-  );
-}
-
-// ── Reset modals ──
-
-function ResetConfirmModal({
-  stage,
-  confirmText,
-  onConfirmTextChange,
-  error,
-  onCancel,
-  onSubmit,
-}: {
-  stage: FactoryResetStage;
-  confirmText: string;
-  onConfirmTextChange: (v: string) => void;
-  error: string | null;
-  onCancel: () => void;
-  onSubmit: () => void;
-}) {
-  const ready = confirmText === 'RESET' && stage !== 'busy';
-
-  return (
-    <div style={{
-      position: 'fixed',
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      background: 'rgba(0, 0, 0, 0.42)',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      zIndex: 1000,
-      fontFamily: APP_FONT_STACK,
-    }}>
-      <div style={{
-        width: 480,
-        maxWidth: '90vw',
-        background: 'var(--t-bg-card, #ffffff)',
-        border: `1px solid ${RAMS_HAIRLINE}`,
-        borderRadius: 4,
-        paddingTop: 24,
-        paddingRight: 28,
-        paddingBottom: 24,
-        paddingLeft: 28,
-        boxShadow: '0 12px 48px rgba(0, 0, 0, 0.18)',
-      }}>
-        <div style={{
-          fontFamily: MONO_FONT_STACK,
-          fontSize: 10,
-          fontWeight: 500,
-          letterSpacing: '0.22em',
-          textTransform: 'uppercase',
-          color: '#d94f3a',
-          marginBottom: 14,
-        }}>
-          ⏵ DANGER · IRREVERSIBLE
-        </div>
-        <div style={{
-          fontSize: 18,
-          fontWeight: 500,
-          color: 'var(--t-text)',
-          letterSpacing: '-0.02em',
-          marginBottom: 14,
-        }}>
-          Factory reset o8
-        </div>
-        <div style={{ fontSize: 13, color: 'var(--t-text-secondary)', lineHeight: 1.55, marginBottom: 18 }}>
-          This will permanently delete everything inside{' '}
-          <span style={{ fontFamily: MONO_FONT_STACK, fontSize: 12 }}>~/.o8</span>:
-        </div>
-        <ul style={{
-          fontSize: 13,
-          color: 'var(--t-text-secondary)',
-          lineHeight: 1.7,
-          paddingLeft: 18,
-          marginTop: 0,
-          marginBottom: 18,
-        }}>
-          <li>SQLite database (sessions, approvals, lanes, watched agents)</li>
-          <li>Encrypted API keys (Anthropic, OpenAI, Gemini, etc.)</li>
-          <li>Mission state and orchestrator history</li>
-          <li>Watched repo registry, directives, WS token</li>
-          <li>Per-server logs</li>
-        </ul>
-        <div style={{ fontSize: 13, color: 'var(--t-text-secondary)', lineHeight: 1.55, marginBottom: 18 }}>
-          The macOS Keychain master key and{' '}
-          <span style={{ fontFamily: MONO_FONT_STACK, fontSize: 12 }}>~/.cortex-ide</span>{' '}
-          (legacy rollback dir) are left untouched.
-        </div>
-        <div style={{ marginBottom: 14 }}>
-          <div style={{
-            fontFamily: MONO_FONT_STACK,
-            fontSize: 10,
-            fontWeight: 400,
-            letterSpacing: '0.14em',
-            textTransform: 'uppercase',
-            color: RAMS_INK_QUIET,
-            marginBottom: 6,
-          }}>
-            Type RESET to confirm
-          </div>
-          <input
-            type="text"
-            value={confirmText}
-            onChange={(event) => onConfirmTextChange(event.target.value)}
-            disabled={stage === 'busy'}
-            autoFocus
-            spellCheck={false}
-            autoCapitalize="off"
-            autoCorrect="off"
-            style={{
-              width: '100%',
-              boxSizing: 'border-box',
-              fontFamily: MONO_FONT_STACK,
-              fontSize: 13,
-              fontWeight: 400,
-              letterSpacing: '0.04em',
-              color: 'var(--t-text)',
-              background: 'var(--t-input-bg, transparent)',
-              border: `1px solid ${RAMS_HAIRLINE}`,
-              borderRadius: 4,
-              paddingTop: 9,
-              paddingRight: 12,
-              paddingBottom: 9,
-              paddingLeft: 12,
-              outline: 'none',
-            }}
-          />
-        </div>
-        {error ? (
-          <div style={{
-            marginBottom: 14,
-            paddingTop: 2,
-            paddingBottom: 2,
-            fontSize: 12,
-            color: 'var(--t-text)',
-            lineHeight: 1.5,
-          }}>
-            <span style={{
-              fontFamily: MONO_FONT_STACK,
-              fontSize: 11,
-              fontWeight: 500,
-              letterSpacing: '0.12em',
-              textTransform: 'uppercase',
-              color: '#ef4444',
-              marginRight: 8,
-            }}>
-              [error]
-            </span>
-            {error}
-          </div>
-        ) : null}
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 6 }}>
-          <RamsButton variant="ghost" onClick={onCancel} disabled={stage === 'busy'}>
-            cancel
-          </RamsButton>
-          <RamsButton
-            variant="danger"
-            onClick={onSubmit}
-            disabled={!ready}
-            busy={stage === 'busy'}
-          >
-            {stage === 'busy' ? 'wiping...' : 'reset everything'}
-          </RamsButton>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ResetDoneModal({
-  result,
-  onDismiss,
-}: {
-  result: FactoryResetResult;
-  onDismiss: () => void;
-}) {
-  return (
-    <div style={{
-      position: 'fixed',
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      background: 'rgba(0, 0, 0, 0.42)',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      zIndex: 1000,
-      fontFamily: APP_FONT_STACK,
-    }}>
-      <div style={{
-        width: 460,
-        maxWidth: '90vw',
-        background: 'var(--t-bg-card, #ffffff)',
-        border: `1px solid ${RAMS_HAIRLINE}`,
-        borderRadius: 4,
-        paddingTop: 24,
-        paddingRight: 28,
-        paddingBottom: 24,
-        paddingLeft: 28,
-        boxShadow: '0 12px 48px rgba(0, 0, 0, 0.18)',
-      }}>
-        <div style={{
-          fontFamily: MONO_FONT_STACK,
-          fontSize: 10,
-          fontWeight: 500,
-          letterSpacing: '0.22em',
-          textTransform: 'uppercase',
-          color: RAMS_ACCENT,
-          marginBottom: 14,
-        }}>
-          ⏵ RESET COMPLETE
-        </div>
-        <div style={{
-          fontSize: 18,
-          fontWeight: 500,
-          color: 'var(--t-text)',
-          letterSpacing: '-0.02em',
-          marginBottom: 12,
-        }}>
-          Quit and reopen o8 to reinitialize
-        </div>
-        <div style={{ fontSize: 13, color: 'var(--t-text-secondary)', lineHeight: 1.55, marginBottom: 16 }}>
-          {result.removed.length} entries removed in {result.durationMs}ms.{' '}
-          {result.failed.length > 0
-            ? `${result.failed.length} entries could not be deleted (likely held open by the running app — they will be cleared on next launch).`
-            : 'The current session is still running against the deleted database — close o8 fully and relaunch before continuing.'}
-        </div>
-        <div style={{
-          fontFamily: MONO_FONT_STACK,
-          fontSize: 11,
-          letterSpacing: '0.02em',
-          color: RAMS_INK_QUIET,
-          marginBottom: 18,
-          wordBreak: 'break-all',
-        }}>
-          {result.dataDir}
-        </div>
-        <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-          <RamsButton variant="ghost" onClick={onDismiss}>
-            close
-          </RamsButton>
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/components/desktop/settings/LoopStatusSection.tsx
+++ b/src/components/desktop/settings/LoopStatusSection.tsx
@@ -1,0 +1,595 @@
+'use client';
+
+/**
+ * #796 — In-app visibility into the autonomous dogfood loop.
+ *
+ * The founder runs cron-style sub-agent dispatches in the background. Until
+ * this section shipped, there was zero in-app visibility into what the loop
+ * was doing — they had to ask Claude. Now Settings → Diagnostics shows:
+ *
+ *   - Cron last-fire age + next-fire age (read-only)
+ *   - Open PR count
+ *   - Active lane count + first 3 titles
+ *   - Last 5 merges (collapsed by default)
+ *
+ * This is a READER. We never create or mutate `~/.o8/loop-cron-state.json`.
+ *
+ * Data sources (graceful when any is missing):
+ *   - `/api/panel/loop-status` → cron state
+ *   - `/api/lanes?active=true` → active lanes
+ *   - `/api/panel/prs` → open PR count
+ *   - `/api/panel/git/log?limit=5` → recent merges
+ *
+ * Cron state file schema (`~/.o8/loop-cron-state.json`, optional):
+ *   {
+ *     "jobId": "string",            // unique per scheduled job
+ *     "cronExpression": "string",   // e.g. "0,20,40 * * * *"
+ *     "lastFiredAt": "ISO 8601",    // most recent tick start
+ *     "nextFireAt":  "ISO 8601",    // wall-clock of upcoming tick
+ *     "prompt":      "string"       // first ~120 chars shown verbatim
+ *   }
+ *
+ * If the file is absent the section renders "No active loop" gracefully —
+ * no errors, no busy indicators, nothing scary in the empty state.
+ *
+ * Design rules followed:
+ *   - Inline styles only / palette tokens only / Phosphor SVG only
+ *   - Plus Jakarta Sans for chrome, MONO for hashes + counts
+ *   - Issues-style rows: dot + uppercase mono label + value + hint
+ *   - 800-line ceiling (this file lives well under it)
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  APP_FONT_STACK,
+  MONO_FONT_STACK,
+  RAMS_ACCENT,
+  RAMS_HAIRLINE_SOFT,
+  RAMS_INK_QUIET,
+  SectionLabel,
+} from './shared';
+
+// ── Types ──
+
+interface CronStateResponse {
+  ok: boolean;
+  active: boolean;
+  jobId?: string | null;
+  cronExpression?: string | null;
+  lastFiredAt?: string | null;
+  nextFireAt?: string | null;
+  prompt?: string | null;
+  note?: string;
+}
+
+interface LaneSummary {
+  id: string;
+  label: string;
+  status: string;
+}
+
+interface RecentCommit {
+  hash: string;
+  title: string;
+  ageMs: number;
+}
+
+interface LoopStatusData {
+  cron: CronStateResponse | null;
+  lanes: LaneSummary[];
+  openPrCount: number;
+  recentCommits: RecentCommit[];
+}
+
+// ── Helpers ──
+
+function formatAge(ms: number | null | undefined, opts?: { future?: boolean }): string {
+  if (ms === null || ms === undefined || !Number.isFinite(ms)) return '—';
+  const abs = Math.max(0, Math.abs(ms));
+  const seconds = Math.floor(abs / 1000);
+  if (seconds < 60) return opts?.future ? `in ${seconds}s` : `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return opts?.future ? `in ${minutes}m` : `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return opts?.future ? `in ${hours}h` : `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return opts?.future ? `in ${days}d` : `${days}d ago`;
+}
+
+function timestampDelta(iso: string | null | undefined, mode: 'past' | 'future'): number | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return null;
+  const now = Date.now();
+  return mode === 'past' ? now - t : t - now;
+}
+
+function shortHash(hash: string) {
+  return hash.length >= 7 ? hash.slice(0, 7) : hash;
+}
+
+// ── Component ──
+
+export function LoopStatusSection({ sectionNumber }: { sectionNumber: string }) {
+  const [data, setData] = useState<LoopStatusData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [showMerges, setShowMerges] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [cron, lanes, prs, gitLog] = await Promise.all([
+          fetch('/api/panel/loop-status', { cache: 'no-store' })
+            .then(async (res) => res.ok ? (await res.json()) as CronStateResponse : null)
+            .catch(() => null),
+          fetch('/api/lanes?active=true', { cache: 'no-store' })
+            .then(async (res) => res.ok ? (await res.json()) as { lanes?: LaneSummary[] } : null)
+            .catch(() => null),
+          fetch('/api/panel/prs', { cache: 'no-store' })
+            .then(async (res) => res.ok ? (await res.json()) as { prs?: Array<{ state?: string }> } : null)
+            .catch(() => null),
+          fetch('/api/panel/git/log?limit=5', { cache: 'no-store' })
+            .then(async (res) => res.ok ? (await res.json()) as { commits?: RecentCommit[] } : null)
+            .catch(() => null),
+        ]);
+
+        if (cancelled) return;
+
+        const openPrs = (prs?.prs ?? []).filter(
+          (pr) => !pr.state || String(pr.state).toUpperCase() === 'OPEN',
+        );
+
+        setData({
+          cron: cron ?? null,
+          lanes: (lanes?.lanes ?? []).map((lane) => ({
+            id: lane.id,
+            label: lane.label,
+            status: lane.status,
+          })),
+          openPrCount: openPrs.length,
+          recentCommits: gitLog?.commits ?? [],
+        });
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const cron = data?.cron ?? null;
+  const isActive = !!cron?.active;
+  const lastFiredMs = timestampDelta(cron?.lastFiredAt ?? null, 'past');
+  const nextFireMs = timestampDelta(cron?.nextFireAt ?? null, 'future');
+  const lanes = data?.lanes ?? [];
+  const openPrCount = data?.openPrCount ?? 0;
+  const commits = data?.recentCommits ?? [];
+
+  return (
+    <section style={{ marginTop: 32 }}>
+      <SectionLabel number={sectionNumber}>LOOP STATUS</SectionLabel>
+
+      {loading && !data ? (
+        <div style={{
+          paddingTop: 14,
+          paddingBottom: 14,
+          fontFamily: APP_FONT_STACK,
+          fontSize: 13,
+          color: RAMS_INK_QUIET,
+          lineHeight: 1.55,
+        }}>
+          Loading…
+        </div>
+      ) : null}
+
+      {!loading && !isActive ? (
+        <NoActiveLoop
+          openPrCount={openPrCount}
+          laneCount={lanes.length}
+          commits={commits}
+          showMerges={showMerges}
+          onToggleMerges={() => setShowMerges((v) => !v)}
+        />
+      ) : null}
+
+      {!loading && isActive ? (
+        <ActiveLoopRows
+          cron={cron}
+          lastFiredMs={lastFiredMs}
+          nextFireMs={nextFireMs}
+          lanes={lanes}
+          openPrCount={openPrCount}
+          commits={commits}
+          showMerges={showMerges}
+          onToggleMerges={() => setShowMerges((v) => !v)}
+        />
+      ) : null}
+
+      <div style={{
+        marginTop: 16,
+        fontFamily: APP_FONT_STACK,
+        fontSize: 12,
+        color: 'var(--t-text-secondary)',
+        lineHeight: 1.55,
+      }}>
+        Read-only. Loop is armed and disarmed via the cron tooling — this
+        section never writes{' '}
+        <span style={{ fontFamily: MONO_FONT_STACK, fontSize: 11 }}>
+          ~/.o8/loop-cron-state.json
+        </span>.
+      </div>
+    </section>
+  );
+}
+
+// ── Sub-views ──
+
+function NoActiveLoop({
+  openPrCount,
+  laneCount,
+  commits,
+  showMerges,
+  onToggleMerges,
+}: {
+  openPrCount: number;
+  laneCount: number;
+  commits: RecentCommit[];
+  showMerges: boolean;
+  onToggleMerges: () => void;
+}) {
+  return (
+    <div style={{ borderTop: `1px solid ${RAMS_HAIRLINE_SOFT}` }}>
+      <Row
+        dot={RAMS_INK_QUIET}
+        label="Cron"
+        value="No active loop"
+        hint="No state file found"
+      />
+      <Row
+        dot={RAMS_INK_QUIET}
+        label="Open PRs"
+        value={String(openPrCount)}
+      />
+      <Row
+        dot={RAMS_INK_QUIET}
+        label="Active lanes"
+        value={String(laneCount)}
+      />
+      <DiscloseRow
+        label="Recent merges"
+        value={`Last ${commits.length}`}
+        hint={commits.length === 0 ? 'No commits' : undefined}
+        open={showMerges}
+        onToggle={onToggleMerges}
+        commits={commits}
+      />
+    </div>
+  );
+}
+
+function ActiveLoopRows({
+  cron,
+  lastFiredMs,
+  nextFireMs,
+  lanes,
+  openPrCount,
+  commits,
+  showMerges,
+  onToggleMerges,
+}: {
+  cron: CronStateResponse | null;
+  lastFiredMs: number | null;
+  nextFireMs: number | null;
+  lanes: LaneSummary[];
+  openPrCount: number;
+  commits: RecentCommit[];
+  showMerges: boolean;
+  onToggleMerges: () => void;
+}) {
+  const cronExpr = cron?.cronExpression ?? null;
+  const cronValueParts: string[] = [];
+  if (cronExpr) cronValueParts.push(cronExpr);
+  cronValueParts.push(
+    lastFiredMs !== null ? `last fired ${formatAge(lastFiredMs)}` : 'never fired',
+  );
+  if (nextFireMs !== null) {
+    cronValueParts.push(`next ${formatAge(nextFireMs, { future: true })}`);
+  }
+
+  const firstThreeLanes = lanes.slice(0, 3);
+  const laneTitles = firstThreeLanes.map((lane) => lane.label).filter(Boolean).join(' · ');
+
+  return (
+    <div style={{ borderTop: `1px solid ${RAMS_HAIRLINE_SOFT}` }}>
+      <Row
+        dot={RAMS_ACCENT}
+        label="Cron"
+        value={cronValueParts.join(' · ')}
+        hint={cron?.jobId ?? undefined}
+      />
+      {cron?.prompt ? (
+        <Row
+          dot={RAMS_INK_QUIET}
+          label="Prompt"
+          value={truncatePrompt(cron.prompt)}
+          mono={false}
+        />
+      ) : null}
+      <Row
+        dot={RAMS_INK_QUIET}
+        label="Open PRs"
+        value={String(openPrCount)}
+      />
+      <Row
+        dot={lanes.length > 0 ? RAMS_ACCENT : RAMS_INK_QUIET}
+        label="Active lanes"
+        value={String(lanes.length)}
+        hint={laneTitles || undefined}
+      />
+      <DiscloseRow
+        label="Recent merges"
+        value={`Last ${commits.length}`}
+        hint={commits.length === 0 ? 'No commits' : undefined}
+        open={showMerges}
+        onToggle={onToggleMerges}
+        commits={commits}
+      />
+    </div>
+  );
+}
+
+function truncatePrompt(prompt: string) {
+  const trimmed = prompt.trim();
+  if (trimmed.length <= 120) return trimmed;
+  return `${trimmed.slice(0, 117)}…`;
+}
+
+// ── Row primitives — Issues-style ──
+
+function Row({
+  dot,
+  label,
+  value,
+  hint,
+  mono = true,
+}: {
+  dot: string;
+  label: string;
+  value: string;
+  hint?: string;
+  mono?: boolean;
+}) {
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 14,
+      paddingTop: 12,
+      paddingBottom: 12,
+      borderBottom: `1px solid ${RAMS_HAIRLINE_SOFT}`,
+    }}>
+      <span style={{
+        width: 6,
+        height: 6,
+        borderRadius: 3,
+        background: dot,
+        flexShrink: 0,
+      }} />
+      <span style={{
+        fontFamily: MONO_FONT_STACK,
+        fontSize: 11,
+        fontWeight: 400,
+        color: RAMS_INK_QUIET,
+        textTransform: 'uppercase',
+        letterSpacing: '0.14em',
+        minWidth: 180,
+      }}>
+        {label}
+      </span>
+      <span style={{
+        fontSize: 13,
+        fontWeight: 400,
+        color: 'var(--t-text)',
+        flex: 1,
+        minWidth: 0,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        fontFamily: mono ? MONO_FONT_STACK : APP_FONT_STACK,
+        letterSpacing: mono ? '0.02em' : '-0.005em',
+      }}>
+        {value}
+      </span>
+      {hint ? (
+        <span style={{
+          fontFamily: MONO_FONT_STACK,
+          fontSize: 11,
+          fontWeight: 400,
+          letterSpacing: '0.04em',
+          color: 'var(--t-text-secondary)',
+          textAlign: 'right',
+          maxWidth: 320,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}>
+          {hint}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function DiscloseRow({
+  label,
+  value,
+  hint,
+  open,
+  onToggle,
+  commits,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  open: boolean;
+  onToggle: () => void;
+  commits: RecentCommit[];
+}) {
+  const interactive = commits.length > 0;
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={interactive ? onToggle : undefined}
+        disabled={!interactive}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 14,
+          width: '100%',
+          paddingTop: 12,
+          paddingBottom: 12,
+          borderTop: 'none',
+          borderLeft: 'none',
+          borderRight: 'none',
+          borderBottom: `1px solid ${RAMS_HAIRLINE_SOFT}`,
+          background: 'transparent',
+          cursor: interactive ? 'pointer' : 'default',
+          textAlign: 'left',
+          minHeight: 44,
+        }}
+      >
+        <span style={{
+          width: 6,
+          height: 6,
+          borderRadius: 3,
+          background: RAMS_INK_QUIET,
+          flexShrink: 0,
+        }} />
+        <span style={{
+          fontFamily: MONO_FONT_STACK,
+          fontSize: 11,
+          fontWeight: 400,
+          color: RAMS_INK_QUIET,
+          textTransform: 'uppercase',
+          letterSpacing: '0.14em',
+          minWidth: 180,
+        }}>
+          {label}
+        </span>
+        <span style={{
+          fontSize: 13,
+          fontWeight: 400,
+          color: 'var(--t-text)',
+          flex: 1,
+          minWidth: 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          fontFamily: MONO_FONT_STACK,
+          letterSpacing: '0.02em',
+        }}>
+          {value}
+        </span>
+        {hint ? (
+          <span style={{
+            fontFamily: MONO_FONT_STACK,
+            fontSize: 11,
+            fontWeight: 400,
+            letterSpacing: '0.04em',
+            color: 'var(--t-text-secondary)',
+            marginRight: 6,
+          }}>
+            {hint}
+          </span>
+        ) : null}
+        {interactive ? (
+          <Caret rotated={open} />
+        ) : null}
+      </button>
+
+      {open && commits.length > 0 ? (
+        <div style={{
+          paddingTop: 6,
+          paddingBottom: 12,
+          borderBottom: `1px solid ${RAMS_HAIRLINE_SOFT}`,
+        }}>
+          {commits.map((commit) => (
+            <CommitRow key={commit.hash} commit={commit} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function CommitRow({ commit }: { commit: RecentCommit }) {
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'baseline',
+      gap: 14,
+      paddingTop: 6,
+      paddingBottom: 6,
+      paddingLeft: 200,
+    }}>
+      <span style={{
+        fontFamily: MONO_FONT_STACK,
+        fontSize: 11,
+        fontWeight: 400,
+        letterSpacing: '0.04em',
+        color: RAMS_INK_QUIET,
+        minWidth: 64,
+      }}>
+        {shortHash(commit.hash)}
+      </span>
+      <span style={{
+        fontFamily: APP_FONT_STACK,
+        fontSize: 13,
+        fontWeight: 400,
+        color: 'var(--t-text)',
+        flex: 1,
+        minWidth: 0,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        letterSpacing: '-0.005em',
+      }}>
+        {commit.title}
+      </span>
+      <span style={{
+        fontFamily: MONO_FONT_STACK,
+        fontSize: 11,
+        fontWeight: 400,
+        letterSpacing: '0.04em',
+        color: 'var(--t-text-secondary)',
+        flexShrink: 0,
+      }}>
+        {formatAge(commit.ageMs)}
+      </span>
+    </div>
+  );
+}
+
+function Caret({ rotated }: { rotated?: boolean }) {
+  return (
+    <svg
+      width={12}
+      height={12}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      style={{
+        display: 'block',
+        flexShrink: 0,
+        color: RAMS_INK_QUIET,
+        transition: 'transform 200ms',
+        transform: rotated ? 'rotate(180deg)' : 'rotate(0)',
+      }}
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `Settings → Diagnostics → 03 — LOOP STATUS` so the founder can glance at what the autonomous dogfood loop is doing — cron last/next-fire age, active lanes (count + first 3 titles), open PR count, last 5 merges (collapsible disclosure).
- Pure reader. Never creates or mutates `~/.o8/loop-cron-state.json`; renders "No active loop" gracefully when the file is absent.
- Section order: 01 RUNTIMES, 02 RECALL HEALTH, 03 LOOP STATUS, 04 MAINTENANCE, 05 DANGER. The factory-reset modals were extracted to `DiagnosticsResetModals.tsx` so `DiagnosticsTab.tsx` stays under the 800-line ceiling — no behavior change.

## Data sources (all degrade independently)

- `/api/panel/loop-status` — new, gated GET, reads `~/.o8/loop-cron-state.json`
- `/api/lanes?active=true` — existing
- `/api/panel/prs` — existing
- `/api/panel/git/log?limit=5` — new, gated GET, returns `{ commits: [{ hash, title, ageMs }], total }`

## Files

- `src/components/desktop/settings/LoopStatusSection.tsx` (new)
- `src/components/desktop/settings/DiagnosticsResetModals.tsx` (new — extracted from DiagnosticsTab)
- `src/components/desktop/settings/DiagnosticsTab.tsx` (insert section + renumber)
- `src/app/api/panel/git/log/route.ts` (new)
- `src/app/api/panel/loop-status/route.ts` (new)

## Test plan

- [ ] Open Settings → Diagnostics with no `~/.o8/loop-cron-state.json` — section renders "No active loop" and zero counts; merges row says "No commits" if git log is empty.
- [ ] Drop a fake state file with `jobId`, `cronExpression`, `lastFiredAt`, `nextFireAt`, `prompt` and reload — Cron row shows expression + last-fired/next-fire ages, optional Prompt row appears (truncated to 120 chars).
- [ ] Open the "Recent merges" disclosure — short hash + commit title + relative age render in five rows.
- [ ] Verify section numbering: 01 RUNTIMES → 02 RECALL HEALTH → 03 LOOP STATUS → 04 MAINTENANCE → 05 DANGER.
- [ ] `npx tsc --noEmit` clean (verified locally).
- [ ] `npx eslint` clean on all touched files (verified locally).

Closes #796.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)