### PR TITLE
feat(panel): loop-state writer endpoint + shell helper (closes #798)

### DIFF
--- a/scripts/loop-state-write.mjs
+++ b/scripts/loop-state-write.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * #798 — CLI helper that POSTs to /api/panel/loop-state.
+ *
+ * Wraps the gated panel endpoint so loop tooling (e.g. CronCreate output)
+ * can pipe directly into a state write without re-implementing token /
+ * port resolution.
+ *
+ * Usage:
+ *   node scripts/loop-state-write.mjs arm \
+ *     --jobId=c9ffe2f4 \
+ *     --cron='*\/20 * * * *' \
+ *     --prompt='check the deploy queue'
+ *
+ *   node scripts/loop-state-write.mjs tick --nextFireAt=2026-04-28T12:20:00Z
+ *
+ *   node scripts/loop-state-write.mjs disarm
+ *
+ * Resolution order:
+ *   - ws-token: $O8_WS_TOKEN env, otherwise ~/.o8/ws-token (with a
+ *     ~/.cortex-ide/ws-token legacy fallback).
+ *   - port: $O8_API_PORT, $PORT, ~/.o8/api-port, then 3001.
+ *
+ * Exits 0 on success, 1 on validation/network error. Prints the response
+ * payload to stdout on success and the error reason to stderr on failure.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+function parseArgs(argv) {
+  const [, , action, ...rest] = argv;
+  const flags = {};
+  for (const arg of rest) {
+    if (!arg.startsWith('--')) continue;
+    const eq = arg.indexOf('=');
+    if (eq === -1) {
+      flags[arg.slice(2)] = true;
+    } else {
+      flags[arg.slice(2, eq)] = arg.slice(eq + 1);
+    }
+  }
+  return { action, flags };
+}
+
+function dataDirCandidates() {
+  const home = homedir();
+  // Prefer the new ~/.o8 location, fall back to ~/.cortex-ide for installs
+  // that haven't run the migration yet.
+  return [
+    process.env.O8_DATA_DIR,
+    process.env.CORTEX_IDE_DATA_DIR,
+    join(home, '.o8'),
+    join(home, '.cortex-ide'),
+  ].filter(Boolean);
+}
+
+function readFirstExisting(filename) {
+  for (const dir of dataDirCandidates()) {
+    const candidate = join(dir, filename);
+    if (existsSync(candidate)) {
+      try {
+        const raw = readFileSync(candidate, 'utf8').trim();
+        if (raw) return raw;
+      } catch {
+        // try next candidate
+      }
+    }
+  }
+  return null;
+}
+
+function resolveWsToken() {
+  if (process.env.O8_WS_TOKEN) return process.env.O8_WS_TOKEN.trim();
+  return readFirstExisting('ws-token');
+}
+
+function resolveApiPort() {
+  const fromEnv = process.env.O8_API_PORT
+    || process.env.PORT
+    || process.env.CORTEX_IDE_PORT;
+  if (fromEnv) {
+    const n = parseInt(fromEnv, 10);
+    if (Number.isInteger(n) && n > 0 && n < 65536) return n;
+  }
+  const fromFile = readFirstExisting('api-port');
+  if (fromFile) {
+    const n = parseInt(fromFile, 10);
+    if (Number.isInteger(n) && n > 0 && n < 65536) return n;
+  }
+  return 3001;
+}
+
+function buildPayload(action, flags) {
+  if (action === 'arm') {
+    const jobId = flags.jobId || flags['job-id'];
+    const cronExpression = flags.cron || flags.cronExpression || flags['cron-expression'];
+    const prompt = flags.prompt;
+    if (!jobId) throw new Error('--jobId is required for arm');
+    if (!cronExpression) throw new Error('--cron is required for arm');
+    if (!prompt) throw new Error('--prompt is required for arm');
+    const body = { action: 'arm', jobId, cronExpression, prompt };
+    const nextFireAt = flags.nextFireAt || flags['next-fire-at'];
+    if (nextFireAt) body.nextFireAt = nextFireAt;
+    return body;
+  }
+  if (action === 'tick') {
+    const body = { action: 'tick' };
+    const nextFireAt = flags.nextFireAt || flags['next-fire-at'];
+    if (nextFireAt) body.nextFireAt = nextFireAt;
+    return body;
+  }
+  if (action === 'disarm') {
+    return { action: 'disarm' };
+  }
+  throw new Error(`Unknown action: ${action || '<none>'}. Expected arm, tick, or disarm.`);
+}
+
+async function main() {
+  const { action, flags } = parseArgs(process.argv);
+  if (!action) {
+    process.stderr.write('Usage: loop-state-write.mjs <arm|tick|disarm> [--flag=value ...]\n');
+    process.exit(1);
+  }
+
+  let payload;
+  try {
+    payload = buildPayload(action, flags);
+  } catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(1);
+  }
+
+  const port = resolveApiPort();
+  const token = resolveWsToken();
+  const url = `http://127.0.0.1:${port}/api/panel/loop-state`;
+
+  const headers = { 'content-type': 'application/json' };
+  if (token) headers.authorization = `Bearer ${token}`;
+
+  let res;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    process.stderr.write(`Request to ${url} failed: ${err.message}\n`);
+    process.exit(1);
+  }
+
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(`HTTP ${res.status}: ${text}\n`);
+    process.exit(1);
+  }
+
+  process.stdout.write(text.endsWith('\n') ? text : `${text}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`Unexpected error: ${err?.message || err}\n`);
+  process.exit(1);
+});

--- a/src/app/api/panel/loop-state/route.ts
+++ b/src/app/api/panel/loop-state/route.ts
@@ -1,0 +1,270 @@
+/**
+ * #798 — Writer for the autonomous-loop cron state file.
+ *
+ * Companion to the read-only `/api/panel/loop-status` endpoint shipped in
+ * #797. Today nothing writes `~/.o8/loop-cron-state.json`, so the Loop
+ * Status widget always shows "No active loop." This route is the missing
+ * writer.
+ *
+ * Schema of `~/.o8/loop-cron-state.json` (matches the reader exactly):
+ *   {
+ *     "jobId":          "string",   // unique per scheduled job
+ *     "cronExpression": "string",
+ *     "prompt":         "string",
+ *     "armedAt":        "ISO 8601",
+ *     "lastFiredAt":    "ISO 8601 | null",
+ *     "nextFireAt":     "ISO 8601 | null",
+ *     "status":         "armed" | "disarmed",
+ *     "disarmedAt":     "ISO 8601" (only when status === 'disarmed')
+ *   }
+ *
+ * Write actions:
+ *   POST { action: 'arm', jobId, cronExpression, prompt, nextFireAt? }
+ *     → fresh state, status: 'armed', lastFiredAt: null
+ *   POST { action: 'tick', nextFireAt? }
+ *     → reads existing, updates lastFiredAt = now and (optionally) nextFireAt
+ *   POST { action: 'disarm' }
+ *     → unlinks the file (cleanest signal — reader treats absence as inactive)
+ *
+ * Read action:
+ *   GET → same payload shape as `/api/panel/loop-status` for symmetry.
+ *
+ * Atomic temp-file rename mirrors the recall-metrics.json pattern from #749
+ * so a crash mid-write never leaves a half-written JSON file on disk.
+ *
+ * Middleware in `src/middleware.ts` already gates `/api/panel/*` on
+ * loopback + ws-token, so no extra auth here.
+ */
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextResponse, type NextRequest } from 'next/server';
+import { readFile, writeFile, rename, unlink } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+interface LoopStatePayload {
+  ok: boolean;
+  active: boolean;
+  jobId: string | null;
+  cronExpression: string | null;
+  lastFiredAt: string | null;
+  nextFireAt: string | null;
+  prompt: string | null;
+  status?: string | null;
+  armedAt?: string | null;
+  disarmedAt?: string | null;
+  note?: string;
+}
+
+interface PersistedState {
+  jobId?: string;
+  cronExpression?: string;
+  prompt?: string;
+  armedAt?: string;
+  lastFiredAt?: string | null;
+  nextFireAt?: string | null;
+  status?: 'armed' | 'disarmed';
+  disarmedAt?: string;
+}
+
+function stateFilePath(): string {
+  // Mirrors the reader at /api/panel/loop-status — must stay in sync. We
+  // resolve via os.homedir() rather than getDataDir() because the reader
+  // hardcodes ~/.o8 and dual sources would drift. If the data-dir override
+  // becomes important later, both endpoints flip together.
+  return path.join(os.homedir(), '.o8', 'loop-cron-state.json');
+}
+
+function pickString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function emptyResponse(note?: string): LoopStatePayload {
+  return {
+    ok: true,
+    active: false,
+    jobId: null,
+    cronExpression: null,
+    lastFiredAt: null,
+    nextFireAt: null,
+    prompt: null,
+    ...(note ? { note } : {}),
+  };
+}
+
+async function readState(): Promise<PersistedState | null> {
+  const filePath = stateFilePath();
+  let raw: string;
+  try {
+    raw = await readFile(filePath, 'utf8');
+  } catch (err) {
+    const code = typeof err === 'object' && err !== null && 'code' in err
+      ? String((err as { code?: unknown }).code)
+      : '';
+    if (code === 'ENOENT') return null;
+    throw err;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return null;
+    return parsed as PersistedState;
+  } catch {
+    return null;
+  }
+}
+
+async function writeStateAtomic(state: PersistedState): Promise<void> {
+  const filePath = stateFilePath();
+  const tmp = `${filePath}.tmp-${process.pid}`;
+  await writeFile(tmp, JSON.stringify(state, null, 2), 'utf8');
+  await rename(tmp, filePath);
+}
+
+async function unlinkState(): Promise<void> {
+  const filePath = stateFilePath();
+  if (!existsSync(filePath)) return;
+  try {
+    await unlink(filePath);
+  } catch (err) {
+    const code = typeof err === 'object' && err !== null && 'code' in err
+      ? String((err as { code?: unknown }).code)
+      : '';
+    if (code === 'ENOENT') return;
+    throw err;
+  }
+}
+
+function shapeResponse(state: PersistedState | null): LoopStatePayload {
+  if (!state) return emptyResponse('Cron state file not present.');
+  const jobId = pickString(state.jobId);
+  const cronExpression = pickString(state.cronExpression);
+  const lastFiredAt = pickString(state.lastFiredAt ?? null);
+  const nextFireAt = pickString(state.nextFireAt ?? null);
+  const prompt = pickString(state.prompt);
+  const status = pickString(state.status ?? null);
+  const armedAt = pickString(state.armedAt ?? null);
+  const disarmedAt = pickString(state.disarmedAt ?? null);
+
+  // Mirror loop-status' definition: active iff a job identifier or cron
+  // expression survives validation AND the status isn't explicitly disarmed.
+  const isDisarmed = status === 'disarmed';
+  const active = !isDisarmed && !!(jobId || cronExpression);
+
+  return {
+    ok: true,
+    active,
+    jobId,
+    cronExpression,
+    lastFiredAt,
+    nextFireAt,
+    prompt,
+    status,
+    armedAt,
+    disarmedAt,
+  };
+}
+
+export async function GET(): Promise<NextResponse<LoopStatePayload>> {
+  try {
+    const state = await readState();
+    return NextResponse.json(shapeResponse(state));
+  } catch (err) {
+    console.warn('[loop-state] GET failed:', err instanceof Error ? err.message : err);
+    return NextResponse.json(emptyResponse('Cron state file unreadable.'));
+  }
+}
+
+interface PostBody {
+  action?: unknown;
+  jobId?: unknown;
+  cronExpression?: unknown;
+  prompt?: unknown;
+  nextFireAt?: unknown;
+}
+
+interface ErrorBody {
+  ok: false;
+  error: string;
+}
+
+type PostResponse = LoopStatePayload | ErrorBody;
+
+function badRequest(message: string): NextResponse<ErrorBody> {
+  return NextResponse.json({ ok: false, error: message }, { status: 400 });
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse<PostResponse>> {
+  let body: PostBody;
+  try {
+    body = (await req.json()) as PostBody;
+  } catch {
+    return badRequest('Body must be valid JSON.');
+  }
+
+  const action = pickString(body.action);
+  if (!action) return badRequest('Missing required field: action.');
+
+  const now = new Date().toISOString();
+
+  try {
+    if (action === 'arm') {
+      const jobId = pickString(body.jobId);
+      const cronExpression = pickString(body.cronExpression);
+      const prompt = pickString(body.prompt);
+      if (!jobId) return badRequest('arm requires jobId.');
+      if (!cronExpression) return badRequest('arm requires cronExpression.');
+      if (!prompt) return badRequest('arm requires prompt.');
+
+      const nextFireAt = pickString(body.nextFireAt);
+      const next: PersistedState = {
+        jobId,
+        cronExpression,
+        prompt,
+        armedAt: now,
+        lastFiredAt: null,
+        nextFireAt,
+        status: 'armed',
+      };
+      await writeStateAtomic(next);
+      return NextResponse.json(shapeResponse(next));
+    }
+
+    if (action === 'tick') {
+      const existing = await readState();
+      if (!existing || !pickString(existing.jobId)) {
+        return badRequest('tick requires an armed loop — no state file present.');
+      }
+      const nextFireAt = pickString(body.nextFireAt) ?? pickString(existing.nextFireAt ?? null);
+      const next: PersistedState = {
+        ...existing,
+        lastFiredAt: now,
+        nextFireAt,
+        status: existing.status === 'disarmed' ? 'armed' : (existing.status ?? 'armed'),
+      };
+      // If the caller wanted to re-arm a disarmed entry by ticking it, the
+      // disarmedAt field becomes stale — drop it so the reader doesn't
+      // surface a misleading timestamp.
+      if (next.status === 'armed') delete next.disarmedAt;
+      await writeStateAtomic(next);
+      return NextResponse.json(shapeResponse(next));
+    }
+
+    if (action === 'disarm') {
+      // Cleanest signal: unlink the file. The reader treats ENOENT as
+      // "no active loop," which is exactly what disarm means.
+      await unlinkState();
+      return NextResponse.json(emptyResponse('Loop disarmed.'));
+    }
+
+    return badRequest(`Unknown action: ${action}. Expected arm, tick, or disarm.`);
+  } catch (err) {
+    console.warn('[loop-state] POST failed:', err instanceof Error ? err.message : err);
+    return NextResponse.json(
+      { ok: false as const, error: err instanceof Error ? err.message : 'write failed' },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `POST /api/panel/loop-state` (gated under `/api/panel/*` middleware) with `arm` / `tick` / `disarm` actions writing `~/.o8/loop-cron-state.json` via atomic temp-file rename (same pattern as `recall-metrics.json` from #749).
- `GET /api/panel/loop-state` returns the same shape as `/api/panel/loop-status` so callers have a single endpoint surface for both read and write.
- Adds `scripts/loop-state-write.mjs` — a small node helper that resolves the ws-token + api-port from `~/.o8` and POSTs to the endpoint, so loop tooling (e.g. `CronCreate` output) can pipe straight into a state write.

Closes #798.

## What this unblocks

#797 shipped a Loop Status section in Settings -> Diagnostics that READS `~/.o8/loop-cron-state.json` but nothing writes it, so the widget always shows "No active loop." With this endpoint in place, the loop driver writes `arm` once (jobId, cron, prompt, optional nextFireAt), `tick` on each fire to update `lastFiredAt` + `nextFireAt`, and `disarm` (file unlink) when the loop ends.

## Validation

- `npx tsc --noEmit` passes
- `node --check scripts/loop-state-write.mjs` passes
- Script error paths exercised: missing action prints usage; `arm` without `--jobId` rejects with a clear message
- Endpoint refuses writes that don't supply required fields (returns 400 with reason)
- File ceilings: route 270 lines, script 166 lines

## Test plan

- [ ] `node scripts/loop-state-write.mjs arm --jobId=test-1 --cron='*/20 * * * *' --prompt='hello'` against a running app, then check the Diagnostics widget renders the active loop
- [ ] `node scripts/loop-state-write.mjs tick --nextFireAt=...` updates `lastFiredAt`
- [ ] `node scripts/loop-state-write.mjs disarm` removes the file and the widget falls back to "No active loop"
- [ ] `GET /api/panel/loop-state` returns the same shape as `/api/panel/loop-status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)