### PR TITLE
feat(diagnostics): in-app demo-sequence runner (closes #800)

### DIFF
--- a/src/app/api/panel/diagnostics/run-demo/route.ts
+++ b/src/app/api/panel/diagnostics/run-demo/route.ts
@@ -1,0 +1,55 @@
+/**
+ * #800 — POST /api/panel/diagnostics/run-demo
+ *
+ * Triggers the in-app demo sequence runner that drives the live o8 webview
+ * through the golden demo path (navigate → orchestrator → quick action),
+ * capturing screenshots and assertions at each step.
+ *
+ * Auth: gated globally by src/middleware.ts on loopback origin or the panel
+ * bearer token. No body required.
+ *
+ * Behaviour:
+ *   - 200 + { ok: true, result } when the run completes (pass or fail).
+ *   - 504 + { ok: false, error, result } when the 30s overall budget hits;
+ *     `result` still contains everything we captured before timing out.
+ *   - 500 + { ok: false, error } only for unrecoverable infra failures
+ *     (e.g. the data dir cannot be written to).
+ *
+ * Never throws — always returns a structured response.
+ */
+
+import { NextResponse } from 'next/server';
+import { runDemoSequence, type DemoRunResult } from '@/lib/diagnostics/demo-sequence';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store, max-age=0' };
+const OVERALL_TIMEOUT_MS = 30_000;
+
+function jsonResponse(payload: unknown, status = 200) {
+  return NextResponse.json(payload, { status, headers: NO_STORE_HEADERS });
+}
+
+export async function POST(): Promise<NextResponse> {
+  try {
+    const result: DemoRunResult = await runDemoSequence({ timeoutMs: OVERALL_TIMEOUT_MS });
+    if (result.truncated) {
+      return jsonResponse(
+        {
+          ok: false,
+          error: `Demo sequence exceeded ${OVERALL_TIMEOUT_MS}ms — partial results returned.`,
+          result,
+        },
+        504,
+      );
+    }
+    return jsonResponse({ ok: true, result });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return jsonResponse(
+      { ok: false, error: `Failed to run demo sequence: ${message}` },
+      500,
+    );
+  }
+}

--- a/src/components/desktop/settings/DemoRunSection.tsx
+++ b/src/components/desktop/settings/DemoRunSection.tsx
@@ -1,0 +1,495 @@
+'use client';
+
+/**
+ * #800 — In-app demo-sequence runner UI.
+ *
+ * Sits inside Settings → Diagnostics and lets the operator press a single
+ * button to drive the live o8 webview through the golden demo path. Each
+ * step renders as an Issues-style row with status pill, ms timing, and an
+ * expandable detail block (screenshot path + message).
+ *
+ * Result shape comes back from POST /api/panel/diagnostics/run-demo. We
+ * keep the most recent run cached in component state — refreshing the tab
+ * loses it, which is fine; the run is idempotent and safe to repeat.
+ *
+ * Design rules followed:
+ *   - Inline styles only / palette tokens only / Phosphor SVG only
+ *   - Plus Jakarta Sans for chrome / MONO for ms timing + paths
+ *   - Issues-style rows: dot + uppercase mono label + value + hint
+ *   - 800-line ceiling
+ */
+
+import { useCallback, useState } from 'react';
+import {
+  APP_FONT_STACK,
+  MONO_FONT_STACK,
+  RAMS_ACCENT,
+  RAMS_HAIRLINE_SOFT,
+  RAMS_INK_QUIET,
+  SectionLabel,
+} from './shared';
+
+// ── Types (mirror runDemoSequence's output) ──
+
+type DemoStepStatus = 'pass' | 'fail' | 'skipped';
+
+interface DemoStepResult {
+  name: string;
+  status: DemoStepStatus;
+  ms: number;
+  screenshotPath?: string;
+  message?: string;
+}
+
+interface DemoRunResult {
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  totalSteps: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  runDir: string;
+  steps: DemoStepResult[];
+  truncated?: boolean;
+}
+
+interface ApiPayload {
+  ok: boolean;
+  error?: string;
+  result?: DemoRunResult;
+}
+
+// ── Helpers ──
+
+function formatStepLabel(name: string): string {
+  // "01-navigate-dashboard" → "navigate dashboard"
+  const stripped = name.replace(/^\d+-/, '');
+  return stripped.replace(/-/g, ' ');
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function formatRelative(iso: string): string {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return iso;
+  const delta = Math.max(0, Date.now() - t);
+  const seconds = Math.floor(delta / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function statusTone(status: DemoStepStatus): { dot: string; label: string; pill: string } {
+  if (status === 'pass') {
+    return { dot: '#22c55e', label: 'PASS', pill: '#22c55e' };
+  }
+  if (status === 'fail') {
+    return { dot: '#ef4444', label: 'FAIL', pill: '#ef4444' };
+  }
+  return { dot: RAMS_INK_QUIET, label: 'SKIPPED', pill: RAMS_INK_QUIET };
+}
+
+// ── Component ──
+
+export function DemoRunSection({ sectionNumber }: { sectionNumber: string }) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<DemoRunResult | null>(null);
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const runDemo = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/panel/diagnostics/run-demo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const data = await res.json().catch(() => ({})) as ApiPayload;
+      if (data.result) {
+        setResult(data.result);
+      }
+      if (!res.ok || data.ok === false) {
+        setError(data.error || `HTTP ${res.status}`);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to run demo sequence');
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const toggle = useCallback((stepName: string) => {
+    setExpanded((prev) => ({ ...prev, [stepName]: !prev[stepName] }));
+  }, []);
+
+  return (
+    <section style={{ marginTop: 32 }}>
+      <SectionLabel number={sectionNumber}>DEMO SEQUENCE</SectionLabel>
+
+      <div style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'space-between',
+        gap: 20,
+        paddingTop: 4,
+        paddingBottom: 16,
+        borderBottom: `1px solid ${RAMS_HAIRLINE_SOFT}`,
+        flexWrap: 'wrap',
+      }}>
+        <div style={{ flex: 1, minWidth: 0, maxWidth: 520 }}>
+          <div style={{
+            fontSize: 14,
+            fontWeight: 500,
+            color: 'var(--t-text)',
+            marginBottom: 4,
+            letterSpacing: '-0.01em',
+            fontFamily: APP_FONT_STACK,
+          }}>
+            Run demo sequence
+          </div>
+          <div style={{
+            fontFamily: APP_FONT_STACK,
+            fontSize: 13,
+            color: 'var(--t-text-secondary)',
+            lineHeight: 1.55,
+          }}>
+            Drives the live webview through dashboard → Orchestrator tab →
+            quick action. Captures a screenshot per step and verifies route
+            + console-error state. Read-only — never sends, merges, or
+            deletes anything.
+          </div>
+          {result ? (
+            <div style={{
+              marginTop: 8,
+              fontFamily: MONO_FONT_STACK,
+              fontSize: 11,
+              fontWeight: 400,
+              letterSpacing: '0.04em',
+              color: RAMS_INK_QUIET,
+              textTransform: 'uppercase',
+            }}>
+              last run: {result.passed}/{result.totalSteps} passed · {formatRelative(result.finishedAt)} · {formatDuration(result.durationMs)}
+            </div>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={() => { void runDemo(); }}
+          disabled={busy}
+          style={runButtonStyle(busy)}
+        >
+          <PlayIcon />
+          <span>{busy ? 'running...' : 'run demo sequence'}</span>
+        </button>
+      </div>
+
+      {error ? (
+        <div style={{
+          marginTop: 14,
+          paddingTop: 2,
+          paddingBottom: 2,
+          fontSize: 13,
+          color: 'var(--t-text)',
+          lineHeight: 1.55,
+          fontFamily: APP_FONT_STACK,
+        }}>
+          <span style={{
+            fontFamily: MONO_FONT_STACK,
+            fontSize: 11,
+            fontWeight: 500,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            color: '#ef4444',
+            marginRight: 8,
+          }}>
+            [error]
+          </span>
+          {error}
+        </div>
+      ) : null}
+
+      {result ? (
+        <div style={{ marginTop: 14, borderTop: `1px solid ${RAMS_HAIRLINE_SOFT}` }}>
+          {result.steps.map((step) => (
+            <StepRow
+              key={step.name}
+              step={step}
+              open={!!expanded[step.name]}
+              onToggle={() => toggle(step.name)}
+            />
+          ))}
+          <RunDirRow runDir={result.runDir} />
+        </div>
+      ) : null}
+
+      <div style={{
+        marginTop: 16,
+        fontFamily: APP_FONT_STACK,
+        fontSize: 12,
+        color: 'var(--t-text-secondary)',
+        lineHeight: 1.55,
+      }}>
+        Screenshots saved locally under{' '}
+        <span style={{ fontFamily: MONO_FONT_STACK, fontSize: 11 }}>
+          ~/.o8/demo-runs/&lt;timestamp&gt;/
+        </span>
+        . Last 10 runs retained, older runs auto-pruned.
+      </div>
+    </section>
+  );
+}
+
+// ── Sub-views ──
+
+function StepRow({
+  step,
+  open,
+  onToggle,
+}: {
+  step: DemoStepResult;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  const tone = statusTone(step.status);
+  const interactive = !!step.message || !!step.screenshotPath;
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={interactive ? onToggle : undefined}
+        disabled={!interactive}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 14,
+          width: '100%',
+          paddingTop: 12,
+          paddingBottom: 12,
+          borderTop: 'none',
+          borderLeft: 'none',
+          borderRight: 'none',
+          borderBottom: `1px solid ${RAMS_HAIRLINE_SOFT}`,
+          background: 'transparent',
+          cursor: interactive ? 'pointer' : 'default',
+          textAlign: 'left',
+          minHeight: 44,
+        }}
+      >
+        <span style={{
+          width: 6,
+          height: 6,
+          borderRadius: 3,
+          background: tone.dot,
+          flexShrink: 0,
+        }} />
+        <span style={{
+          fontFamily: MONO_FONT_STACK,
+          fontSize: 11,
+          fontWeight: 400,
+          color: RAMS_INK_QUIET,
+          textTransform: 'uppercase',
+          letterSpacing: '0.14em',
+          minWidth: 200,
+        }}>
+          {formatStepLabel(step.name)}
+        </span>
+        <StatusPill tone={tone} />
+        <span style={{
+          fontFamily: MONO_FONT_STACK,
+          fontSize: 11,
+          fontWeight: 400,
+          letterSpacing: '0.04em',
+          color: 'var(--t-text-secondary)',
+          flex: 1,
+          minWidth: 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          textAlign: 'right',
+        }}>
+          {step.status === 'skipped' ? '—' : formatDuration(step.ms)}
+        </span>
+        {interactive ? <Caret rotated={open} /> : null}
+      </button>
+
+      {open && interactive ? (
+        <div style={{
+          paddingTop: 8,
+          paddingBottom: 12,
+          paddingLeft: 220,
+          borderBottom: `1px solid ${RAMS_HAIRLINE_SOFT}`,
+        }}>
+          {step.message ? (
+            <div style={{
+              fontFamily: APP_FONT_STACK,
+              fontSize: 12,
+              fontWeight: 400,
+              color: 'var(--t-text)',
+              lineHeight: 1.55,
+              letterSpacing: '-0.005em',
+              marginBottom: step.screenshotPath ? 6 : 0,
+              wordBreak: 'break-word',
+            }}>
+              {step.message}
+            </div>
+          ) : null}
+          {step.screenshotPath ? (
+            <div style={{
+              fontFamily: MONO_FONT_STACK,
+              fontSize: 11,
+              fontWeight: 400,
+              letterSpacing: '0.02em',
+              color: RAMS_INK_QUIET,
+              wordBreak: 'break-all',
+            }}>
+              {step.screenshotPath}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function RunDirRow({ runDir }: { runDir: string }) {
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 14,
+      paddingTop: 12,
+      paddingBottom: 12,
+      borderBottom: `1px solid ${RAMS_HAIRLINE_SOFT}`,
+    }}>
+      <span style={{
+        width: 6,
+        height: 6,
+        borderRadius: 3,
+        background: RAMS_INK_QUIET,
+        flexShrink: 0,
+      }} />
+      <span style={{
+        fontFamily: MONO_FONT_STACK,
+        fontSize: 11,
+        fontWeight: 400,
+        color: RAMS_INK_QUIET,
+        textTransform: 'uppercase',
+        letterSpacing: '0.14em',
+        minWidth: 200,
+      }}>
+        Run directory
+      </span>
+      <span style={{
+        fontFamily: MONO_FONT_STACK,
+        fontSize: 11,
+        fontWeight: 400,
+        letterSpacing: '0.02em',
+        color: 'var(--t-text)',
+        flex: 1,
+        minWidth: 0,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }}>
+        {runDir}
+      </span>
+    </div>
+  );
+}
+
+function StatusPill({ tone }: { tone: { label: string; pill: string } }) {
+  return (
+    <span style={{
+      fontFamily: MONO_FONT_STACK,
+      fontSize: 10,
+      fontWeight: 500,
+      letterSpacing: '0.14em',
+      color: tone.pill,
+      paddingTop: 2,
+      paddingBottom: 2,
+      paddingLeft: 6,
+      paddingRight: 6,
+      border: `1px solid ${tone.pill}`,
+      borderRadius: 3,
+      flexShrink: 0,
+    }}>
+      {tone.label}
+    </span>
+  );
+}
+
+function PlayIcon() {
+  // Phosphor "play" simplified — single triangle path, raw SVG so it works
+  // inside the Tauri webview where lucide / @phosphor-icons/react fail.
+  return (
+    <svg
+      width={12}
+      height={12}
+      viewBox="0 0 256 256"
+      fill="currentColor"
+      style={{ display: 'block', flexShrink: 0 }}
+    >
+      <path d="M232.4 114.5L88.32 26.51A15.94 15.94 0 0 0 64 39.91v176.18a15.94 15.94 0 0 0 24.32 13.4L232.4 141.5a15.95 15.95 0 0 0 0-27Z" />
+    </svg>
+  );
+}
+
+function Caret({ rotated }: { rotated?: boolean }) {
+  return (
+    <svg
+      width={12}
+      height={12}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      style={{
+        display: 'block',
+        flexShrink: 0,
+        color: RAMS_INK_QUIET,
+        transition: 'transform 200ms',
+        transform: rotated ? 'rotate(180deg)' : 'rotate(0)',
+      }}
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+// ── Styles ──
+
+function runButtonStyle(busy: boolean): React.CSSProperties {
+  return {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 8,
+    minHeight: 44,
+    paddingLeft: 14,
+    paddingRight: 14,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: busy ? RAMS_HAIRLINE_SOFT : 'rgba(255, 90, 31, 0.32)',
+    background: busy ? 'transparent' : 'rgba(255, 90, 31, 0.1)',
+    color: busy ? RAMS_INK_QUIET : RAMS_ACCENT,
+    fontFamily: MONO_FONT_STACK,
+    fontSize: 11.5,
+    fontWeight: 500,
+    letterSpacing: '0.04em',
+    textTransform: 'uppercase' as const,
+    cursor: busy ? 'default' : 'pointer',
+    transition: 'background 150ms cubic-bezier(0.22, 1, 0.36, 1), border-color 150ms cubic-bezier(0.22, 1, 0.36, 1)',
+    opacity: busy ? 0.6 : 1,
+  };
+}

--- a/src/components/desktop/settings/DiagnosticsTab.tsx
+++ b/src/components/desktop/settings/DiagnosticsTab.tsx
@@ -16,6 +16,7 @@ import {
 } from './shared';
 import { RecallHealthSection } from './RecallHealthSection';
 import { LoopStatusSection } from './LoopStatusSection';
+import { DemoRunSection } from './DemoRunSection';
 import {
   ResetConfirmModal,
   ResetDoneModal,
@@ -446,6 +447,9 @@ export function DiagnosticsTab() {
           <HairlineRule />
         </div>
       </section>
+
+      {/* 06 — DEMO SEQUENCE (#800 in-app golden-path runner) */}
+      <DemoRunSection sectionNumber="06" />
 
       {/* Two-step confirmation modal */}
       {resetStage === 'confirm' || resetStage === 'busy' || resetStage === 'error' ? (

--- a/src/lib/diagnostics/demo-sequence.ts
+++ b/src/lib/diagnostics/demo-sequence.ts
@@ -1,0 +1,404 @@
+/**
+ * #800 — In-app demo-sequence runner.
+ *
+ * Drives the live o8 webview through the golden demo path so users can
+ * sanity-check the app from Settings → Diagnostics without leaving o8.
+ *
+ * Steps (each step records pass/fail/skipped + ms + optional screenshot):
+ *   1. Navigate to /dashboard → wait → screenshot
+ *   2. Verify active route pathname === "/dashboard"
+ *   3. Click the Orchestrator tab via screen coordinates
+ *   4. Wait, screenshot, verify the chat surface shows a greeting
+ *   5. Click the first quick-action card on the empty state
+ *   6. Verify no NEW console errors fired between step 1 and step 6
+ *
+ * On any failure, subsequent steps are marked `skipped` (with a reason)
+ * and we still return everything captured so the UI can show partial
+ * progress. Total wall-clock budget is 30s — past that, the API route
+ * returns 504 with whatever it managed to capture.
+ *
+ * Screenshots land under `<dataDir>/demo-runs/<ISO timestamp>/<step>.png`
+ * (UTF-8 base64 → PNG buffer). We retain the most recent 10 runs and prune
+ * older directories synchronously after a successful start.
+ *
+ * No destructive UI actions — we only navigate, click into safe surfaces,
+ * and screenshot. The runner never sends, merges, deletes, or types text.
+ */
+
+import { mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { O8WebviewClient } from '@/lib/mcp/o8-webview-client';
+import { getDataDir } from '@/lib/data-dir-migration';
+
+// ── Public types ──
+
+export type DemoStepStatus = 'pass' | 'fail' | 'skipped';
+
+export interface DemoStepResult {
+  name: string;
+  status: DemoStepStatus;
+  ms: number;
+  screenshotPath?: string;
+  message?: string;
+}
+
+export interface DemoRunResult {
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  totalSteps: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  runDir: string;
+  steps: DemoStepResult[];
+  truncated?: boolean;
+}
+
+// ── Internals ──
+
+const ORCHESTRATOR_TAB_COORDS = { x: 199, y: 44 };
+const QUICK_ACTION_COORDS = { x: 410, y: 200 };
+const STEP_NAMES = [
+  '01-navigate-dashboard',
+  '02-verify-route',
+  '03-click-orchestrator',
+  '04-verify-greeting',
+  '05-click-quick-action',
+  '06-verify-no-errors',
+] as const;
+const RETAIN_RUNS = 10;
+
+interface ConsoleErrorsPayload {
+  errors: Array<{ message: string; source: string; lineno: number; timestamp: number }>;
+  count: number;
+  sinceLastFetch: number;
+}
+
+interface ActiveRoutePayload {
+  pathname: string;
+  search: string;
+  hash: string;
+  routerState: string | null;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function isoForDirName(): string {
+  // Filesystem-safe ISO: 2026-04-28T19-12-04-321Z
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+async function ensureRunDir(): Promise<{ runDir: string; rootDir: string }> {
+  const rootDir = join(getDataDir(), 'demo-runs');
+  await mkdir(rootDir, { recursive: true });
+  const runDir = join(rootDir, isoForDirName());
+  await mkdir(runDir, { recursive: true });
+  return { runDir, rootDir };
+}
+
+async function pruneOldRuns(rootDir: string): Promise<void> {
+  let entries: string[] = [];
+  try {
+    entries = await readdir(rootDir);
+  } catch {
+    return;
+  }
+  const dirs: { name: string; mtimeMs: number }[] = [];
+  for (const name of entries) {
+    try {
+      const info = await stat(join(rootDir, name));
+      if (info.isDirectory()) {
+        dirs.push({ name, mtimeMs: info.mtimeMs });
+      }
+    } catch {
+      // ignore unreadable entries
+    }
+  }
+  if (dirs.length <= RETAIN_RUNS) return;
+
+  dirs.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  const toDelete = dirs.slice(RETAIN_RUNS);
+  for (const entry of toDelete) {
+    try {
+      await rm(join(rootDir, entry.name), { recursive: true, force: true });
+    } catch {
+      // best effort — never block the run on prune failures
+    }
+  }
+}
+
+async function captureScreenshot(
+  client: O8WebviewClient,
+  runDir: string,
+  stepName: string,
+): Promise<string | undefined> {
+  try {
+    const shot = await client.screenshot();
+    const ext = shot.mimeType === 'image/jpeg' ? 'jpg' : 'png';
+    const filePath = join(runDir, `${stepName}.${ext}`);
+    await writeFile(filePath, Buffer.from(shot.imageBase64, 'base64'));
+    return filePath;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Runs the same Tauri-command shim the operator MCP server uses to read
+ * o8_view_console_errors / o8_view_active_route. The data lives outside
+ * the JS thread so it survives a busy webview and doesn't depend on any
+ * in-flight UI work.
+ */
+async function invokeTauriCommand<T>(
+  client: O8WebviewClient,
+  command: string,
+): Promise<T> {
+  const code = `(() => { try {
+    if (!window.__TAURI_INTERNALS__ || typeof window.__TAURI_INTERNALS__.invoke !== 'function') {
+      return JSON.stringify({ ok: false, err: 'tauri internals unavailable' });
+    }
+    return window.__TAURI_INTERNALS__.invoke(${JSON.stringify(command)})
+      .then((r) => JSON.stringify({ ok: true, data: r }))
+      .catch((e) => JSON.stringify({ ok: false, err: String(e && e.message || e) }));
+  } catch (e) { return JSON.stringify({ ok: false, err: String(e && e.message || e) }); } })()`;
+
+  const { result } = await client.evalJs(code);
+  let parsed: unknown = result;
+  try {
+    parsed = JSON.parse(result);
+  } catch {
+    throw new Error(`tauri invoke '${command}' returned non-JSON: ${String(result).slice(0, 200)}`);
+  }
+  if (typeof parsed === 'string') {
+    try { parsed = JSON.parse(parsed); } catch { /* leave as is */ }
+  }
+  const envelope = parsed as { ok?: boolean; data?: unknown; err?: string };
+  if (!envelope || envelope.ok !== true) {
+    throw new Error(envelope?.err || `tauri invoke '${command}' failed`);
+  }
+  return envelope.data as T;
+}
+
+interface StepContext {
+  client: O8WebviewClient;
+  runDir: string;
+  results: DemoStepResult[];
+  baselineErrorCount: number;
+}
+
+async function timeStep(
+  name: string,
+  fn: () => Promise<{ message?: string; screenshotPath?: string }>,
+): Promise<DemoStepResult> {
+  const started = Date.now();
+  try {
+    const out = await fn();
+    return {
+      name,
+      status: 'pass',
+      ms: Date.now() - started,
+      screenshotPath: out.screenshotPath,
+      message: out.message,
+    };
+  } catch (err) {
+    return {
+      name,
+      status: 'fail',
+      ms: Date.now() - started,
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function skippedStep(name: string, reason: string): DemoStepResult {
+  return { name, status: 'skipped', ms: 0, message: reason };
+}
+
+// ── Steps ──
+
+async function step1NavigateDashboard(ctx: StepContext): Promise<DemoStepResult> {
+  return timeStep(STEP_NAMES[0], async () => {
+    await ctx.client.navigate('/dashboard');
+    await sleep(2000);
+    const screenshotPath = await captureScreenshot(ctx.client, ctx.runDir, STEP_NAMES[0]);
+    return { screenshotPath };
+  });
+}
+
+async function step2VerifyRoute(ctx: StepContext): Promise<DemoStepResult> {
+  return timeStep(STEP_NAMES[1], async () => {
+    const route = await invokeTauriCommand<ActiveRoutePayload>(ctx.client, 'o8_view_active_route');
+    if (route.pathname !== '/dashboard') {
+      throw new Error(`expected pathname "/dashboard", got "${route.pathname}"`);
+    }
+    return { message: `pathname=${route.pathname}` };
+  });
+}
+
+async function step3ClickOrchestrator(ctx: StepContext): Promise<DemoStepResult> {
+  return timeStep(STEP_NAMES[2], async () => {
+    await ctx.client.click({ x: ORCHESTRATOR_TAB_COORDS.x, y: ORCHESTRATOR_TAB_COORDS.y });
+    return { message: `click (${ORCHESTRATOR_TAB_COORDS.x},${ORCHESTRATOR_TAB_COORDS.y})` };
+  });
+}
+
+async function step4VerifyGreeting(ctx: StepContext): Promise<DemoStepResult> {
+  return timeStep(STEP_NAMES[3], async () => {
+    await sleep(1000);
+    const screenshotPath = await captureScreenshot(ctx.client, ctx.runDir, STEP_NAMES[3]);
+    const { text } = await ctx.client.readPage();
+    const lower = text.toLowerCase();
+    const matched = lower.includes('good morning')
+      || lower.includes('good afternoon')
+      || lower.includes('good evening')
+      || lower.includes('orchestrator');
+    if (!matched) {
+      throw new Error('chat surface did not show a greeting/orchestrator marker');
+    }
+    return { screenshotPath, message: 'greeting/orchestrator marker present' };
+  });
+}
+
+async function step5ClickQuickAction(ctx: StepContext): Promise<DemoStepResult> {
+  return timeStep(STEP_NAMES[4], async () => {
+    await ctx.client.click({ x: QUICK_ACTION_COORDS.x, y: QUICK_ACTION_COORDS.y });
+    return { message: `click (${QUICK_ACTION_COORDS.x},${QUICK_ACTION_COORDS.y})` };
+  });
+}
+
+async function step6VerifyNoNewErrors(ctx: StepContext): Promise<DemoStepResult> {
+  return timeStep(STEP_NAMES[5], async () => {
+    await sleep(1500);
+    const screenshotPath = await captureScreenshot(ctx.client, ctx.runDir, STEP_NAMES[5]);
+    const errs = await invokeTauriCommand<ConsoleErrorsPayload>(ctx.client, 'o8_view_console_errors');
+    const newSinceBaseline = Math.max(0, errs.count - ctx.baselineErrorCount);
+    if (newSinceBaseline > 0) {
+      const recent = errs.errors.slice(-3).map((e) => e.message).join(' | ');
+      throw new Error(`${newSinceBaseline} new console error(s) since step 1: ${recent}`);
+    }
+    return {
+      screenshotPath,
+      message: `0 new errors since step 1 (total seen: ${errs.count})`,
+    };
+  });
+}
+
+// ── Orchestrator ──
+
+/**
+ * Resolve a promise to either its value or a sentinel timeout. We never
+ * race against a hung webview: even on timeout we capture whatever steps
+ * already finished and return them with `truncated: true`.
+ */
+async function withGlobalTimeout<T>(
+  fn: () => Promise<T>,
+  ms: number,
+  onTimeout: () => T,
+): Promise<{ value: T; timedOut: boolean }> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  let timedOut = false;
+  const timeoutPromise = new Promise<T>((resolve) => {
+    timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      resolve(onTimeout());
+    }, ms);
+  });
+  try {
+    const value = await Promise.race([fn(), timeoutPromise]);
+    return { value, timedOut };
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+  }
+}
+
+export async function runDemoSequence(opts?: { timeoutMs?: number }): Promise<DemoRunResult> {
+  const startedAt = nowIso();
+  const startedMs = Date.now();
+  const timeoutMs = Math.max(5_000, Math.min(opts?.timeoutMs ?? 30_000, 60_000));
+
+  const { runDir, rootDir } = await ensureRunDir();
+  // Prune older folders before the new run so the directory stays tidy
+  // even if the run errors out mid-flight.
+  await pruneOldRuns(rootDir);
+
+  const client = new O8WebviewClient();
+  const results: DemoStepResult[] = [];
+  let truncated = false;
+
+  // Establish the console-error baseline up front. If the webview is
+  // unreachable, every step after will fail quickly with the same root cause.
+  let baselineErrorCount = 0;
+  try {
+    const initial = await invokeTauriCommand<ConsoleErrorsPayload>(client, 'o8_view_console_errors');
+    baselineErrorCount = initial.count;
+  } catch {
+    baselineErrorCount = 0;
+  }
+
+  const ctx: StepContext = { client, runDir, results, baselineErrorCount };
+
+  const runAll = async (): Promise<void> => {
+    const steps: Array<(c: StepContext) => Promise<DemoStepResult>> = [
+      step1NavigateDashboard,
+      step2VerifyRoute,
+      step3ClickOrchestrator,
+      step4VerifyGreeting,
+      step5ClickQuickAction,
+      step6VerifyNoNewErrors,
+    ];
+    for (let i = 0; i < steps.length; i += 1) {
+      const result = await steps[i](ctx);
+      results.push(result);
+      if (result.status === 'fail') {
+        for (let j = i + 1; j < steps.length; j += 1) {
+          results.push(skippedStep(STEP_NAMES[j], `skipped after ${result.name} failed`));
+        }
+        return;
+      }
+    }
+  };
+
+  await withGlobalTimeout(
+    runAll,
+    timeoutMs,
+    () => {
+      truncated = true;
+      // Mark any unrecorded steps as skipped due to timeout.
+      const recorded = new Set(results.map((r) => r.name));
+      for (const name of STEP_NAMES) {
+        if (!recorded.has(name)) {
+          results.push(skippedStep(name, `skipped — overall ${timeoutMs}ms timeout reached`));
+        }
+      }
+      return undefined as unknown as void;
+    },
+  );
+
+  client.dispose();
+
+  const finishedAt = nowIso();
+  const durationMs = Date.now() - startedMs;
+  const passed = results.filter((r) => r.status === 'pass').length;
+  const failed = results.filter((r) => r.status === 'fail').length;
+  const skipped = results.filter((r) => r.status === 'skipped').length;
+
+  return {
+    startedAt,
+    finishedAt,
+    durationMs,
+    totalSteps: STEP_NAMES.length,
+    passed,
+    failed,
+    skipped,
+    runDir,
+    steps: results,
+    ...(truncated ? { truncated: true } : {}),
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a "Run demo sequence" button in Settings → Diagnostics that drives the live o8 webview through the golden demo path (dashboard → Orchestrator → quick action) with per-step screenshots, route assertion, and a console-error delta check.
- Reuses the existing \`O8WebviewClient\` for the \`/tmp/tauri-mcp-o8-<user>.sock\` protocol — no new Rust commands, no operator-MCP changes, and no new gated route prefix.
- Read-only: never sends, merges, deletes, or types into the UI. Path existence and observable state only.

## Files

- \`src/lib/diagnostics/demo-sequence.ts\` — runner: 6 steps, 30s overall budget, screenshots saved to \`~/.o8/demo-runs/<ISO timestamp>/<step>.png\`, last 10 runs retained, older folders auto-pruned.
- \`src/app/api/panel/diagnostics/run-demo/route.ts\` — gated POST. 200 + result on success, 504 + partial result on timeout, 500 on infra failure. Never throws.
- \`src/components/desktop/settings/DemoRunSection.tsx\` — Issues-style rows with PASS/FAIL/SKIPPED pills, ms timing, collapsible per-step detail showing message + screenshot path. "Last run" summary persists between clicks.
- \`src/components/desktop/settings/DiagnosticsTab.tsx\` — inserts section "06 — DEMO SEQUENCE" after the existing 05 — DANGER section.

## Sequence

1. \`navigate('/dashboard')\` → wait 2s → screenshot
2. \`o8_view_active_route\` (via Tauri command shim) → assert pathname === \`/dashboard\`
3. Click Orchestrator tab at coords (199, 44)
4. Wait 1s → screenshot → \`readPage()\` to verify greeting/orchestrator marker
5. Click first quick-action card at coords (410, 200)
6. Wait 1.5s → screenshot → \`o8_view_console_errors\` → assert 0 NEW errors since baseline

On any failure, subsequent steps are marked \`skipped\` with a reason. The 30s overall timeout is enforced at the runner level and surfaces as 504 from the API; everything captured before the timeout is still returned.

## Test plan

- [ ] Build with \`npm run ship\`, install, open Settings → Diagnostics → \"06 — DEMO SEQUENCE\".
- [ ] Click \"run demo sequence\" — expect 6 PASS rows, screenshots present in \`~/.o8/demo-runs/<ts>/\`, last-run summary updates.
- [ ] Force a fail by toggling away from \`/dashboard\` mid-run — confirm subsequent steps render as SKIPPED.
- [ ] Run demo 11 times — confirm only the most recent 10 directories survive under \`~/.o8/demo-runs/\`.
- [ ] Verify \`npx tsc --noEmit\` and \`npx eslint\` are both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)