### PR TITLE
fix(cmdk): close 3 audit findings — stale closure, dead return, inline arrows

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1238,6 +1238,33 @@ function DashboardInner() {
     });
   }, [openCanvasTab]);
 
+  // Stable callbacks passed to CommandPalette — extracted to avoid defeating
+  // memo boundaries with fresh inline arrows on every render (#809).
+  const handlePaletteClose = useCallback(() => {
+    setCommandPaletteOpen(false);
+  }, []);
+
+  const handlePaletteSelectIssue = useCallback((issueNumber: number, repo?: string) => {
+    handleSelectIssue(issueNumber, repo);
+  }, [handleSelectIssue]);
+
+  const handlePaletteSelectFile = useCallback((filePath: string, line?: number) => {
+    openCanvasTab({
+      id: `file:${filePath}${activeWorkspace ? `:${activeWorkspace}` : ''}`,
+      kind: 'file',
+      label: filePath.split('/').pop() ?? filePath,
+      resourceId: filePath,
+      meta: {
+        ...(activeWorkspace ? { workspace: activeWorkspace } : {}),
+        ...(line ? { line: String(line) } : {}),
+      },
+    });
+  }, [activeWorkspace, openCanvasTab]);
+
+  const handlePaletteSelectAgent = useCallback((sessionKey: string) => {
+    handleSelectSession(sessionKey);
+  }, [handleSelectSession]);
+
   const handleSelectPR = useCallback((prNumber: number, repo?: string) => {
     openCanvasTab({
       id: `pr:${prNumber}${repo ? `:${repo}` : ''}`,
@@ -2403,27 +2430,12 @@ function DashboardInner() {
         <Suspense fallback={null}>
           <LazyCommandPalette
             open={commandPaletteOpen}
-            onClose={() => setCommandPaletteOpen(false)}
+            onClose={handlePaletteClose}
             workspace={activeWorkspace ?? null}
             repo={globalRepo ?? null}
-            onSelectIssue={(issueNumber, repo) => {
-              handleSelectIssue(issueNumber, repo);
-            }}
-            onSelectFile={(filePath, line) => {
-              openCanvasTab({
-                id: `file:${filePath}${activeWorkspace ? `:${activeWorkspace}` : ''}`,
-                kind: 'file',
-                label: filePath.split('/').pop() ?? filePath,
-                resourceId: filePath,
-                meta: {
-                  ...(activeWorkspace ? { workspace: activeWorkspace } : {}),
-                  ...(line ? { line: String(line) } : {}),
-                },
-              });
-            }}
-            onSelectAgent={(sessionKey) => {
-              handleSelectSession(sessionKey);
-            }}
+            onSelectIssue={handlePaletteSelectIssue}
+            onSelectFile={handlePaletteSelectFile}
+            onSelectAgent={handlePaletteSelectAgent}
           />
         </Suspense>
       ) : null}

--- a/src/components/desktop/CommandPalette.tsx
+++ b/src/components/desktop/CommandPalette.tsx
@@ -213,6 +213,7 @@ export const CommandPalette = memo(function CommandPalette({
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const selectedIndexRef = useRef(selectedIndex);
 
   // Reset state on open and refresh recents from localStorage.
   useEffect(() => {
@@ -339,6 +340,12 @@ export const CommandPalette = memo(function CommandPalette({
     }
   }, [items.length, selectedIndex]);
 
+  // Sync selectedIndexRef so the Enter handler always reads the latest index
+  // without closing over a stale value.
+  useEffect(() => {
+    selectedIndexRef.current = selectedIndex;
+  }, [selectedIndex]);
+
   // Scroll the active item into view.
   useEffect(() => {
     const list = listRef.current;
@@ -397,12 +404,10 @@ export const CommandPalette = memo(function CommandPalette({
     }
     if (event.key === 'Enter') {
       event.preventDefault();
-      const target = items[selectedIndex];
+      const target = items[selectedIndexRef.current];
       if (target) handleActivate(target);
     }
-  }, [handleActivate, items, onClose, selectedIndex]);
-
-  if (!open) return null;
+  }, [handleActivate, items, onClose]);
 
   const showEmpty = !loading && !error && items.length === 0;
   const trimmed = query.trim();


### PR DESCRIPTION
Closes #809

## Summary

- **Stale `selectedIndex` closure** (`CommandPalette.tsx` line 400): added `selectedIndexRef` synced via `useEffect`, Enter handler now reads `selectedIndexRef.current` instead of the captured state value — eliminates the race where fast ArrowDown+Enter selects the wrong item.
- **Dead `return null` before-hooks guard** (`CommandPalette.tsx` line 405): removed the `if (!open) return null` guard that violated CLAUDE.md's no-early-return-before-hooks rule. The component is already wrapped in `{commandPaletteOpen ? ... : null}` at the call site, so the guard was unreachable dead code.
- **Inline arrows defeating memo boundary** (`dashboard/page.tsx` lines 2406–2426): extracted four stable `useCallback`-wrapped named callbacks (`handlePaletteClose`, `handlePaletteSelectIssue`, `handlePaletteSelectFile`, `handlePaletteSelectAgent`) so `LazyCommandPalette`'s memo boundary is preserved on every render.

## Test plan
- [ ] `npx tsc --noEmit` passes (verified clean before commit)
- [ ] Open palette with Cmd+K, arrow down 3+ items rapidly then press Enter — confirm correct item activates
- [ ] Palette still opens/closes normally; Esc still closes
- [ ] No visible regressions in issue/file/agent selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)