### PR TITLE
fix(diagnostics): raise demo runner outer timeout from 30s to 60s (closes #811)

### DIFF
--- a/src/app/api/panel/diagnostics/run-demo/route.ts
+++ b/src/app/api/panel/diagnostics/run-demo/route.ts
@@ -10,7 +10,7 @@
  *
  * Behaviour:
  *   - 200 + { ok: true, result } when the run completes (pass or fail).
- *   - 504 + { ok: false, error, result } when the 30s overall budget hits;
+ *   - 504 + { ok: false, error, result } when the 60s overall budget hits;
  *     `result` still contains everything we captured before timing out.
  *   - 500 + { ok: false, error } only for unrecoverable infra failures
  *     (e.g. the data dir cannot be written to).
@@ -25,7 +25,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 const NO_STORE_HEADERS = { 'Cache-Control': 'no-store, max-age=0' };
-const OVERALL_TIMEOUT_MS = 30_000;
+const OVERALL_TIMEOUT_MS = 60_000;
 
 function jsonResponse(payload: unknown, status = 200) {
   return NextResponse.json(payload, { status, headers: NO_STORE_HEADERS });


### PR DESCRIPTION
## Summary

- The API route `run-demo/route.ts` had `OVERALL_TIMEOUT_MS = 30_000`, which it passed explicitly to `runDemoSequence()` — overriding the library's 45s default and causing steps 6–11 to cascade-skip after steps 1+4 burned ~27s on Next.js dev compile.
- Bumped `OVERALL_TIMEOUT_MS` to `60_000` in the route so all 11 steps run within budget; the skip message already interpolates the value dynamically (`overall ${timeoutMs}ms timeout reached` — no string change needed).

## Test plan

- [ ] Run Settings → Diagnostics → Run Demo with a fresh Next.js dev compile active and confirm steps 6–11 no longer skip with "overall 30000ms timeout reached"
- [ ] Confirm 504 response still fires correctly if a run genuinely exceeds 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)