### PR TITLE
fix(inline-diff): 5 audit findings — stale state, double stats, scroll jump, theme, line cap

### DIFF
--- a/src/app/api/worktrees/diff/route.ts
+++ b/src/app/api/worktrees/diff/route.ts
@@ -73,9 +73,9 @@ async function collectDiff(cwd: string, baseBranch: string | null) {
     // ignore
   }
 
-  let additions = 0;
-  let deletions = 0;
-  const files = new Set<string>();
+  // Track per-file totals across both numstat runs to avoid double-counting
+  // files that appear in both the base-branch diff and the dirty-tree diff.
+  const fileStats = new Map<string, { additions: number; deletions: number }>();
 
   async function consumeNumstat(args: string[]) {
     try {
@@ -85,9 +85,16 @@ async function collectDiff(cwd: string, baseBranch: string | null) {
         const [addStr = '0', delStr = '0', ...rest] = line.split('\t');
         const filePath = rest.join('\t');
         if (!filePath) continue;
-        files.add(filePath);
-        if (addStr !== '-') additions += Number.parseInt(addStr, 10) || 0;
-        if (delStr !== '-') deletions += Number.parseInt(delStr, 10) || 0;
+        const add = addStr !== '-' ? (Number.parseInt(addStr, 10) || 0) : 0;
+        const del = delStr !== '-' ? (Number.parseInt(delStr, 10) || 0) : 0;
+        const existing = fileStats.get(filePath);
+        if (existing) {
+          // Already seen this file — keep the higher stat (prefer broader diff).
+          existing.additions = Math.max(existing.additions, add);
+          existing.deletions = Math.max(existing.deletions, del);
+        } else {
+          fileStats.set(filePath, { additions: add, deletions: del });
+        }
       }
     } catch {
       // ignore
@@ -97,11 +104,18 @@ async function collectDiff(cwd: string, baseBranch: string | null) {
   if (baseBranch) await consumeNumstat(['diff', '--numstat', `${baseBranch}...HEAD`]);
   await consumeNumstat(['diff', '--numstat', 'HEAD']);
 
+  let additions = 0;
+  let deletions = 0;
+  for (const stat of fileStats.values()) {
+    additions += stat.additions;
+    deletions += stat.deletions;
+  }
+
   return {
     diff: sections.join('\n'),
     additions,
     deletions,
-    fileCount: files.size,
+    fileCount: fileStats.size,
   };
 }
 

--- a/src/components/desktop/InlineDiffViewer.tsx
+++ b/src/components/desktop/InlineDiffViewer.tsx
@@ -264,7 +264,11 @@ export const InlineDiffViewer = memo(function InlineDiffViewer({
     if (!root) return;
     const target = root.querySelector(`#${fileAnchorId(filePath)}`);
     if (target instanceof HTMLElement) {
-      root.scrollTo({ top: Math.max(0, target.offsetTop - 8), behavior: 'smooth' });
+      // Use getBoundingClientRect so the offset is relative to the scroll
+      // container, not the nearest positioned offsetParent (which may differ).
+      const top =
+        target.getBoundingClientRect().top - root.getBoundingClientRect().top + root.scrollTop;
+      root.scrollTo({ top: Math.max(0, top - 8), behavior: 'smooth' });
     }
   }, []);
 

--- a/src/components/desktop/inline-diff/HunkBlock.tsx
+++ b/src/components/desktop/inline-diff/HunkBlock.tsx
@@ -71,7 +71,14 @@ export const HunkBlock = memo(function HunkBlock({
   onToggleAccepted,
 }: HunkBlockProps) {
   const [collapsed, setCollapsed] = useState(false);
-  const [showAll, setShowAll] = useState(hunk.lines.length <= MAX_INITIAL_HUNK_LINES);
+  // Derive from current hunk content so a same-index refresh resets truncation.
+  const hunkHash = `${hunk.lines.length}:${hunk.startOldLine}:${hunk.startNewLine}`;
+  const [showAll, setShowAll] = useState(() => hunk.lines.length <= MAX_INITIAL_HUNK_LINES);
+  const [trackedHash, setTrackedHash] = useState(hunkHash);
+  if (hunkHash !== trackedHash) {
+    setTrackedHash(hunkHash);
+    setShowAll(hunk.lines.length <= MAX_INITIAL_HUNK_LINES);
+  }
 
   const decoratedLines = useMemo(() => decorateLines(hunk), [hunk]);
   const visibleLines = showAll ? decoratedLines : decoratedLines.slice(0, MAX_INITIAL_HUNK_LINES);

--- a/src/components/desktop/thoughts/mission-panel/review-card/DiffPane.tsx
+++ b/src/components/desktop/thoughts/mission-panel/review-card/DiffPane.tsx
@@ -13,6 +13,76 @@ import {
   paneStyle,
 } from './shared';
 
+const MAX_INITIAL_LINES = 200;
+
+/**
+ * Renders a patch body capped at MAX_INITIAL_LINES lines with an expand button.
+ * Mirrors the HunkBlock "Expand N more lines" pattern from InlineDiffViewer.
+ */
+function ExpandablePatch({ patch }: { patch: string }) {
+  const [showAll, setShowAll] = useState(false);
+  const allLines = patch.split('\n');
+  const visibleLines = showAll ? allLines : allLines.slice(0, MAX_INITIAL_LINES);
+  const hiddenCount = Math.max(0, allLines.length - visibleLines.length);
+  return (
+    <div style={{
+      borderTopWidth: 1,
+      borderTopStyle: 'solid',
+      borderTopColor: 'var(--t-divider-subtle)',
+      background: 'var(--t-bg)',
+    }}>
+      <pre style={{
+        margin: 0,
+        paddingTop: 6,
+        paddingRight: 10,
+        paddingBottom: 6,
+        paddingLeft: 10,
+        fontSize: 10,
+        fontFamily: MONO_FAMILY,
+        color: 'var(--t-text)',
+        overflowX: 'auto',
+        whiteSpace: 'pre',
+        lineHeight: 1.5,
+      }}>
+        {visibleLines.map((line, idx) => {
+          let color = 'var(--t-text-secondary)';
+          if (line.startsWith('+') && !line.startsWith('+++')) color = '#16a34a';
+          else if (line.startsWith('-') && !line.startsWith('---')) color = '#dc2626';
+          else if (line.startsWith('@@')) color = '#7c3aed';
+          return (
+            <div key={idx} style={{ color, whiteSpace: 'pre' }}>
+              {line || ' '}
+            </div>
+          );
+        })}
+      </pre>
+      {hiddenCount > 0 ? (
+        <button
+          type="button"
+          onClick={() => setShowAll(true)}
+          style={{
+            width: '100%',
+            minHeight: 28,
+            borderWidth: 0,
+            borderTopWidth: 1,
+            borderTopStyle: 'solid',
+            borderTopColor: 'var(--t-divider-subtle)',
+            background: 'var(--t-panel-translucent)',
+            color: 'var(--t-text-secondary)',
+            fontSize: 10,
+            fontWeight: 600,
+            cursor: 'pointer',
+            fontFamily: FONT_FAMILY,
+            letterSpacing: '-0.01em',
+          }}
+        >
+          Expand full diff ({hiddenCount} more line{hiddenCount === 1 ? '' : 's'})
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
 /**
  * #729 — DIFF pane: file tree with +/- totals + per-file unified diff with
  * hunk-level expansion.
@@ -103,8 +173,8 @@ export function DiffPane({ packet, reviewState, diff, diffLoading, diffError }: 
                   borderRadius: 8,
                   borderWidth: 1,
                   borderStyle: 'solid',
-                  borderColor: 'rgba(148, 163, 184, 0.16)',
-                  background: 'rgba(148, 163, 184, 0.06)',
+                  borderColor: 'var(--t-divider)',
+                  background: 'var(--t-bg-subtle)',
                   overflow: 'hidden',
                 }}
               >
@@ -158,35 +228,7 @@ export function DiffPane({ packet, reviewState, diff, diffLoading, diffError }: 
                   </span>
                 </button>
                 {isExpanded && file.patch ? (
-                  <pre style={{
-                    margin: 0,
-                    paddingTop: 6,
-                    paddingRight: 10,
-                    paddingBottom: 6,
-                    paddingLeft: 10,
-                    fontSize: 10,
-                    fontFamily: MONO_FAMILY,
-                    color: 'var(--t-text)',
-                    background: 'var(--t-bg)',
-                    borderTopWidth: 1,
-                    borderTopStyle: 'solid',
-                    borderTopColor: 'rgba(148, 163, 184, 0.12)',
-                    overflowX: 'auto',
-                    whiteSpace: 'pre',
-                    lineHeight: 1.5,
-                  }}>
-                    {file.patch.split('\n').map((line, idx) => {
-                      let color = 'var(--t-text-secondary)';
-                      if (line.startsWith('+') && !line.startsWith('+++')) color = '#16a34a';
-                      else if (line.startsWith('-') && !line.startsWith('---')) color = '#dc2626';
-                      else if (line.startsWith('@@')) color = '#7c3aed';
-                      return (
-                        <div key={idx} style={{ color, whiteSpace: 'pre' }}>
-                          {line || ' '}
-                        </div>
-                      );
-                    })}
-                  </pre>
+                  <ExpandablePatch patch={file.patch} />
                 ) : null}
               </div>
             );


### PR DESCRIPTION
## Summary

Closes #814. Live audit of `InlineDiffViewer` found 5 actionable bugs, all fixed in this PR.

- **#1 — Stale hunk state on refresh** (`HunkBlock.tsx`): `showAll` was initialized once at mount; if the same hunk index received new content on refresh, state stayed stale. Fixed by tracking a `hunkHash` (`lines.length:startOldLine:startNewLine`) and resetting `showAll` during render when the hash changes.
- **#2 — Double-counted diff stats** (`worktrees/diff/route.ts`): `consumeNumstat` ran twice when `baseBranch` set; files in both runs accumulated additions/deletions twice. Fixed by using `Map<path, {additions, deletions}>` with `Math.max` merge so each file contributes once.
- **#3 — jumpToFile wrong scroll offset** (`InlineDiffViewer.tsx`): `target.offsetTop` is relative to `offsetParent`, not the scroll container. Fixed with `getBoundingClientRect().top` arithmetic against the scroll root.
- **#4 — Hardcoded rgba theme violations** (`DiffPane.tsx`): Three `rgba(148,163,184,…)` surface colors render as light blobs in midnight. Replaced with `var(--t-divider)`, `var(--t-bg-subtle)`, `var(--t-divider-subtle)`.
- **#5 — No virtualization on large files** (`DiffPane.tsx`): Patch lines rendered synchronously without limit. Added `MAX_INITIAL_LINES = 200` cap with `ExpandablePatch` component and "Expand full diff" disclosure button matching HunkBlock's pattern.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified clean)
- [ ] Open a diff with a large file — confirm first 200 lines shown with expand button
- [ ] Refresh a diff — confirm hunk expand/collapse state resets correctly
- [ ] Check header badge counts with `baseBranch` set — should not double-count
- [ ] Click file pill in multi-file diff — confirm scroll lands at correct file header
- [ ] Check midnight theme — DiffPane file rows should use glass/subtle colors, not gray blobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)