### PR TITLE
fix(steer-composer): resolve 5 SteerComposer audit findings (#816)

### DIFF
--- a/src/components/desktop/workspace-terminal/AgentTilePane.tsx
+++ b/src/components/desktop/workspace-terminal/AgentTilePane.tsx
@@ -86,6 +86,8 @@ function AgentTilePaneBase({ sessionKey, agent, focused, onClose, onFocus }: Age
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
+  // Fix #4: synchronous guard so held-Enter can't double-fire before setState flushes
+  const sendingRef = useRef(false);
   const [sendError, setSendError] = useState<string | null>(null);
   const name = useMemo(() => displayName(agent, sessionKey), [agent, sessionKey]);
   const runtime = useMemo(() => inferRuntime(sessionKey, agent?.runtime), [agent?.runtime, sessionKey]);
@@ -96,9 +98,19 @@ function AgentTilePaneBase({ sessionKey, agent, focused, onClose, onFocus }: Age
   const canSend = canSteer && !sending && trimmedDraft.length > 0;
   const lastEntryKey = entries.length > 0 ? `${entries[entries.length - 1]?.id}:${entryContent(entries[entries.length - 1]!)}` : '';
 
+  // Fix #1: keep a ref in sync with latest agent so submitSteer re-derives
+  // canSteer at call time, not at callback-creation time.
+  const agentRef = useRef(agent);
+  useEffect(() => { agentRef.current = agent; }, [agent]);
+
   const submitSteer = useCallback(async () => {
     const message = trimmedDraft;
-    if (!message || !canSteer || sending) return;
+    // Fix #1: re-derive canSteer from the latest agent ref to avoid stale closure
+    const currentStatus = classifyStatus(agentRef.current?.status);
+    const canSteerNow = currentStatus === 'running' || currentStatus === 'waiting';
+    // Fix #4: check sendingRef synchronously before any setState to prevent held-Enter race
+    if (!message || !canSteerNow || sendingRef.current) return;
+    sendingRef.current = true;
     setSending(true);
     setSendError(null);
     try {
@@ -114,20 +126,27 @@ function AgentTilePaneBase({ sessionKey, agent, focused, onClose, onFocus }: Age
       const payload = await response
         .json()
         .catch(() => null) as { ok?: boolean; note?: string; error?: string } | null;
+      // Fix #2: always clear draft after a send-attempt to prevent double-send on retry after error
+      setDraft('');
       if (!response.ok || payload?.ok === false) {
         const note = payload?.error ?? payload?.note ?? response.statusText ?? 'Unable to send steer.';
         setSendError(note);
         return;
       }
-      setDraft('');
+      // Fix #5: set transcript to loading but fall back to idle after 10s if WS push never arrives
       transcriptStore.setStatus(sessionKey, 'loading');
+      setTimeout(() => {
+        transcriptStore.setStatus(sessionKey, 'idle');
+      }, 10_000);
     } catch (err) {
+      // Draft already cleared above; just surface the error
       setSendError(err instanceof Error ? err.message : 'Unable to send steer.');
     } finally {
+      sendingRef.current = false;
       setSending(false);
       requestAnimationFrame(() => textareaRef.current?.focus());
     }
-  }, [canSteer, sending, sessionKey, trimmedDraft]);
+  }, [sessionKey, trimmedDraft]);
 
   const handleTextareaKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {

--- a/src/lib/runtime/actions.ts
+++ b/src/lib/runtime/actions.ts
@@ -359,8 +359,17 @@ function unavailable(agent: AgentSummary, action: RuntimeActionKind, note: strin
 
 export async function performRuntimeAction(payload: RuntimeActionRequest): Promise<RuntimeActionResult> {
   const surfaceId = payload.surfaceId?.trim();
+  // Fix #3: return structured error instead of throwing across the API boundary (CLAUDE.md rule)
   if (!surfaceId) {
-    throw new Error('surfaceId is required');
+    return {
+      ok: false,
+      action: payload.action,
+      surfaceId: '',
+      runtime: '',
+      clientMutationId: payload.clientMutationId,
+      status: 'unavailable',
+      note: 'surfaceId is required',
+    };
   }
 
   // Try cached snapshot first to avoid expensive full re-discovery on every action.
@@ -372,7 +381,16 @@ export async function performRuntimeAction(payload: RuntimeActionRequest): Promi
     agent = findRuntimeAgent(fresh, surfaceId);
   }
   if (!agent) {
-    throw new Error('Runtime surface not found.');
+    // Fix #3: return structured error instead of throwing across the API boundary
+    return {
+      ok: false,
+      action: payload.action,
+      surfaceId,
+      runtime: '',
+      clientMutationId: payload.clientMutationId,
+      status: 'unavailable',
+      note: 'Runtime surface not found.',
+    };
   }
 
   const runtimeSurface = agent.runtimeSurface;


### PR DESCRIPTION
## Summary

Resolves all 5 audit findings from issue #816.

- **Fix #1 (stale canSteer closure):** Added `agentRef = useRef(agent)` synced via effect. `submitSteer` re-derives `canSteerNow` from `agentRef.current` at call time, not at `useCallback` creation time — prevents steering a session that transitioned `running → awaiting_review` in the same tick.
- **Fix #2 (double-send on error):** Moved `setDraft('')` to run unconditionally after the fetch (before the ok-check), so an error response no longer leaves the draft populated for an immediate retry.
- **Fix #3 (throws across API boundary):** Converted the two `throw new Error(...)` calls in `performRuntimeAction` (`surfaceId is required`, `Runtime surface not found`) to `return { ok: false, status: 'unavailable', ... }` — no more unhandled exceptions bubbling to the route's catch block and producing a 500.
- **Fix #4 (sending race on held Enter):** Added `sendingRef = useRef(false)` set synchronously at the top of `submitSteer` before any async operation, so held-Enter can't fire twice before `setSending(true)` flushes.
- **Fix #5 (transcript loading deadlock):** After setting `transcriptStore.setStatus(sessionKey, 'loading')`, a `setTimeout(..., 10_000)` fallback resets status to `'idle'` if the WS push never arrives (e.g. disconnect), preventing the "Loading transcript…" state from hanging indefinitely.

## Test plan

- [ ] Steer a running agent — transcript updates correctly
- [ ] Steer fails (network error) — draft is cleared, error shown; hitting Enter again does NOT resend
- [ ] Rapidly held Enter during steer flight — only one request fires
- [ ] Disconnect WS mid-steer — transcript pane recovers to idle after ~10s
- [ ] Call `POST /api/runtime/action` with missing surfaceId — returns structured JSON error, not 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)