### PR TITLE
fix(split-pane): 3 audit fixes — render loop, stale cursor, deserialize migration

### DIFF
--- a/src/components/desktop/workspace-terminal/OrchestratorTab.tsx
+++ b/src/components/desktop/workspace-terminal/OrchestratorTab.tsx
@@ -330,7 +330,12 @@ function OrchestratorTabInner({ tabId, active, repoPath, repoLabel }: Orchestrat
     autoTiledComparisonGroupIdRef.current = nextAutoTileGroup.groupId;
     sessionTiles.autoTileSessions(sessionKeys);
     console.log(`[best-of-n] Auto-tiled comparison group ${nextAutoTileGroup.groupId}`);
-  }, [comparisonGroups, sessionTiles]);
+  // Narrow to the stable callback — listing the whole `sessionTiles` object
+  // would re-fire on every render because useSessionTiles returns a fresh
+  // literal each time. autoTileSessions is wrapped in useCallback inside the
+  // hook, so it's stable as long as its own deps don't change.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [comparisonGroups, sessionTiles.autoTileSessions]);
 
   const handleTogglePermission = useCallback(() => {
     setPermissionMode((current) => {

--- a/src/components/desktop/workspace-terminal/SessionTileSurface.tsx
+++ b/src/components/desktop/workspace-terminal/SessionTileSurface.tsx
@@ -10,7 +10,7 @@
  * absolutely-positioned sibling of the container so React preserves
  * component state across split/resize/close changes.
  */
-import { useCallback, useMemo, useRef, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
 import { SessionTranscriptPane } from '@/components/desktop/SessionTranscriptPane';
 import {
   collectAllLeaves,
@@ -41,6 +41,26 @@ export function SessionTileSurface({
   onFocusSession,
 }: SessionTileSurfaceProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  // Track listeners so we can remove them on unmount-during-drag (issue #818).
+  const dragListenersRef = useRef<{
+    handleMove: (event: MouseEvent) => void;
+    handleUp: () => void;
+  } | null>(null);
+
+  // Cleanup: if component unmounts while a drag is in progress, reset the
+  // body cursor and remove any dangling document listeners so they don't
+  // persist after the surface is gone.
+  useEffect(() => {
+    return () => {
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      if (dragListenersRef.current) {
+        document.removeEventListener('mousemove', dragListenersRef.current.handleMove);
+        document.removeEventListener('mouseup', dragListenersRef.current.handleUp);
+        dragListenersRef.current = null;
+      }
+    };
+  }, []);
 
   const { leaves, leafRects, splitFrames } = useMemo(() => {
     const { leafRects, splitFrames } = computeSessionTileLayout(layout.root);
@@ -70,11 +90,13 @@ export function SessionTileSurface({
         const handleUp = () => {
           document.removeEventListener('mousemove', handleMove);
           document.removeEventListener('mouseup', handleUp);
+          dragListenersRef.current = null;
           document.body.style.cursor = '';
           document.body.style.userSelect = '';
         };
         document.body.style.cursor = direction === 'vertical' ? 'col-resize' : 'row-resize';
         document.body.style.userSelect = 'none';
+        dragListenersRef.current = { handleMove, handleUp };
         document.addEventListener('mousemove', handleMove);
         document.addEventListener('mouseup', handleUp);
       },

--- a/src/lib/orchestrator/session-tiles.ts
+++ b/src/lib/orchestrator/session-tiles.ts
@@ -316,15 +316,47 @@ export function serializeSessionTileLayout(layout: SessionTileLayout): string {
   });
 }
 
+/**
+ * Migrate a parsed layout from a prior version to the current one.
+ *
+ * Add a `case` for every old version that can be salvaged. Return `null`
+ * when the version is too old or unknown to migrate safely — the caller
+ * will fall back to the default layout instead of silently resetting state.
+ *
+ * Currently a no-op because SESSION_TILE_LAYOUT_VERSION === 1 has no
+ * prior versions. The scaffold ensures future bumps don't silently destroy
+ * user data (issue #818 audit finding #3).
+ */
+function migrateSessionTileLayout(
+  parsed: { version?: unknown; root?: unknown },
+): SessionTileLayout | null {
+  switch (parsed.version) {
+    // v1 is current — caller should never reach here for current version,
+    // but handle it safely as a no-op fallback.
+    case 1: {
+      if (!isPlainSessionNode(parsed.root)) return null;
+      return { version: SESSION_TILE_LAYOUT_VERSION, root: parsed.root };
+    }
+    // Add future cases here:
+    // case 2: { /* migrate v2 → v3 */ }
+    default:
+      return null;
+  }
+}
+
 export function deserializeSessionTileLayout(
   raw: string | null | undefined,
 ): SessionTileLayout | null {
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as { version?: unknown; root?: unknown };
-    if (parsed.version !== SESSION_TILE_LAYOUT_VERSION) return null;
-    if (!isPlainSessionNode(parsed.root)) return null;
-    return { version: SESSION_TILE_LAYOUT_VERSION, root: parsed.root };
+    if (parsed.version === SESSION_TILE_LAYOUT_VERSION) {
+      // Fast path: current version, validate shape directly.
+      if (!isPlainSessionNode(parsed.root)) return null;
+      return { version: SESSION_TILE_LAYOUT_VERSION, root: parsed.root };
+    }
+    // Older version — attempt migration rather than silently returning null.
+    return migrateSessionTileLayout(parsed);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

- **Render loop fix** (`OrchestratorTab.tsx`): narrowed the `useEffect` dep from the entire `sessionTiles` hook return object (new reference every render) to `[comparisonGroups, sessionTiles.autoTileSessions]`. The whole-object dep caused the auto-tile effect to re-fire on every unrelated state change (pill menu open, focus changes).
- **Stale cursor fix** (`SessionTileSurface.tsx`): added a `useEffect` unmount cleanup that resets `document.body.style.cursor/userSelect` and removes dangling `mousemove`/`mouseup` listeners tracked via `dragListenersRef`. Previously, closing a tile mid-drag left the body locked in `col-resize` permanently.
- **Deserialize migration scaffold** (`session-tiles.ts`): added `migrateSessionTileLayout()` switch before the hard `return null` path in `deserializeSessionTileLayout`. Current v1 is a no-op case, but the scaffold ensures future `SESSION_TILE_LAYOUT_VERSION` bumps attempt a migration instead of silently resetting every user's persisted split layout.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally, no errors)
- [ ] Open orchestrator tab with active comparison group — confirm auto-tile fires once, not in a loop
- [ ] Start a resize drag on a split handle, then close the tile mid-drag — confirm cursor resets to default
- [ ] Confirm localStorage with `version: 1` still deserializes correctly (no regression)

Closes #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)