### PR TITLE
fix(rerun-with-feedback): withLockedState double-write clobber + style tag mount leak (#820)

### DIFF
--- a/src/components/desktop/thoughts/mission-panel/RejectedFeedbackPanel.tsx
+++ b/src/components/desktop/thoughts/mission-panel/RejectedFeedbackPanel.tsx
@@ -277,9 +277,6 @@ export function RejectedFeedbackPanel({ packet }: RejectedFeedbackPanelProps) {
         </div>
       ) : null}
 
-      <style>
-        {`@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }`}
-      </style>
     </div>
   );
 }

--- a/src/lib/orchestrator/control-plane.ts
+++ b/src/lib/orchestrator/control-plane.ts
@@ -105,6 +105,11 @@ export async function syncOrchestratorControlPlaneState(state?: OrchestratorMiss
 /**
  * #460 — Locked read-modify-write: read state, apply a mutation, reconcile, and persist.
  * Use this for any operation that needs exclusive access to orchestrator-state.json.
+ *
+ * If the callback returns an OrchestratorMissionState, that value is used as the
+ * basis for reconcile + write instead of the pre-callback snapshot. This allows
+ * callers that run a sub-operation (e.g. runDispatchTick) producing a new state
+ * to persist that result without a second write that would clobber it.
  */
 export async function withLockedState<T>(
   fn: (state: OrchestratorMissionState) => T | Promise<T>,
@@ -113,7 +118,16 @@ export async function withLockedState<T>(
   try {
     const current = readOrchestratorControlPlaneState();
     const result = await fn(current);
-    const reconciled = reconcileOrchestratorControlPlaneState(current);
+    // If the callback returned a mission state, reconcile from that (post-operation
+    // snapshot). Otherwise fall back to the mutated `current` object as before.
+    const basisForReconcile: OrchestratorMissionState =
+      result !== null
+      && typeof result === 'object'
+      && 'packets' in (result as object)
+      && 'lanes' in (result as object)
+        ? (result as unknown as OrchestratorMissionState)
+        : current;
+    const reconciled = reconcileOrchestratorControlPlaneState(basisForReconcile);
     const state = writeOrchestratorControlPlaneState(reconciled);
     return { result, state };
   } finally {

--- a/src/lib/orchestrator/operator-mission-service/rerun-with-feedback.ts
+++ b/src/lib/orchestrator/operator-mission-service/rerun-with-feedback.ts
@@ -1,4 +1,4 @@
-import { withLockedState, writeOrchestratorControlPlaneState } from '@/lib/orchestrator/control-plane';
+import { withLockedState } from '@/lib/orchestrator/control-plane';
 import { runDispatchTick } from '@/lib/orchestrator/dispatch';
 import { archiveLane, listLanes, updateLane } from '@/lib/lane/registry';
 import { getWorktreeManager } from '@/lib/worktree/launch';
@@ -148,9 +148,10 @@ export async function rerunWithFeedback(input: RerunWithFeedbackInput) {
     packet.prompt = appendFeedback(originalPrompt, feedback);
 
     // Step 4 — run a dispatch tick so the packet relaunches with the
-    // updated prompt.
-    const afterDispatch = await runDispatchTick(current);
-    writeOrchestratorControlPlaneState(afterDispatch);
+    // updated prompt. Return afterDispatch so withLockedState uses it as
+    // the basis for reconcile + write (prevents the pre-dispatch snapshot
+    // from clobbering the dispatch result — #820 CRITICAL fix).
+    return await runDispatchTick(current);
   });
 
   const dispatchedPacket = finalState.packets.find((candidate) => candidate.id === packetId) ?? null;


### PR DESCRIPTION
## Summary

- **CRITICAL (#820)**: `withLockedState` was reconciling from the pre-dispatch snapshot after the callback returned, overwriting the post-dispatch state written by the manual `writeOrchestratorControlPlaneState` call inside the callback. Fixed by returning `afterDispatch` from the callback — `withLockedState` now detects when a callback returns an `OrchestratorMissionState` (duck-typed via `packets` + `lanes` keys) and uses it as the reconcile basis instead of the stale pre-dispatch `current`. The manual write is removed entirely.
- **MEDIUM (#820)**: bare `<style>` tag in `RejectedFeedbackPanel` injected a duplicate `@keyframes spin` rule on every component mount. Removed the tag — `@keyframes spin` already lives in `globals.css`, so the animation works without any local injection.

## Test plan

- [ ] Reject a packet, type feedback, hit "Try again with feedback" — the packet should immediately show a lane assignment (dispatched=true) rather than "queued, awaiting next tick"
- [ ] Confirm `@keyframes spin` spinner still animates during submit (sourced from globals.css)
- [ ] `npx tsc --noEmit` passes (verified locally before commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)