### PR TITLE
fix(settings): 4 audit findings — inline remove confirm, emoji, unmount race, CSS shorthand

### DIFF
--- a/src/components/desktop/settings/APIKeysTab.tsx
+++ b/src/components/desktop/settings/APIKeysTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   APP_FONT_STACK,
   MONO_FONT_STACK,
@@ -42,16 +42,22 @@ export function APIKeysTab() {
   const [saving, setSaving] = useState(false);
   const [feedback, setFeedback] = useState<{ provider: string; type: 'success' | 'error'; message: string } | null>(null);
   const [adaptiveThinkingEnabled, setAdaptiveThinkingEnabled] = useState(() => readAdaptiveThinkingEnabled());
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
 
   const loadKeys = useCallback(async () => {
     try {
       const res = await fetch('/api/v2/keys');
       if (res.ok) {
         const data = await res.json();
-        setProviders(data.providers);
+        if (mountedRef.current) setProviders(data.providers);
       }
     } catch { /* ignore */ }
-    setLoading(false);
+    if (mountedRef.current) setLoading(false);
   }, []);
 
   useEffect(() => {

--- a/src/components/desktop/settings/DiagnosticsResetModals.tsx
+++ b/src/components/desktop/settings/DiagnosticsResetModals.tsx
@@ -77,7 +77,7 @@ export function ResetConfirmModal({
           color: '#d94f3a',
           marginBottom: 14,
         }}>
-          ⏵ DANGER · IRREVERSIBLE
+          DANGER · IRREVERSIBLE
         </div>
         <div style={{
           fontSize: 18,
@@ -234,7 +234,7 @@ export function ResetDoneModal({
           color: RAMS_ACCENT,
           marginBottom: 14,
         }}>
-          ⏵ RESET COMPLETE
+          RESET COMPLETE
         </div>
         <div style={{
           fontSize: 18,

--- a/src/components/desktop/settings/mcp/ExternalMcpServersSection.tsx
+++ b/src/components/desktop/settings/mcp/ExternalMcpServersSection.tsx
@@ -67,6 +67,8 @@ export function ExternalMcpServersSection() {
   const [pasteNote, setPasteNote] = useState<string | null>(null);
   const [pasteCandidates, setPasteCandidates] = useState<ParsedMcpServer[] | null>(null);
   const [expandedStderrId, setExpandedStderrId] = useState<string | null>(null);
+  // Inline remove confirmation — replaces window.confirm (disabled in Tauri).
+  const [pendingRemoval, setPendingRemoval] = useState<string | null>(null);
 
   const applyParsedServer = (server: ParsedMcpServer, fallbackName?: string) => {
     const values = parsedServerToFormValues(server);
@@ -499,8 +501,11 @@ export function ExternalMcpServersSection() {
               outcome={outcome}
               envCount={envCount}
               expandedStderr={expandedStderrId === server.id}
+              pendingRemoval={pendingRemoval === server.id}
               onTest={() => { void test(server); }}
-              onRemove={() => { void remove(server); }}
+              onRemoveRequest={() => { setPendingRemoval(server.id); }}
+              onRemoveConfirm={() => { setPendingRemoval(null); void remove(server); }}
+              onRemoveCancel={() => { setPendingRemoval(null); }}
               onToggleStderr={() => {
                 setExpandedStderrId((cur) => cur === server.id ? null : server.id);
               }}
@@ -520,8 +525,11 @@ function ServerRow({
   outcome,
   envCount,
   expandedStderr,
+  pendingRemoval,
   onTest,
-  onRemove,
+  onRemoveRequest,
+  onRemoveConfirm,
+  onRemoveCancel,
   onToggleStderr,
 }: {
   server: ExternalMcpServer;
@@ -531,8 +539,11 @@ function ServerRow({
   outcome: McpServerTestOutcome | undefined;
   envCount: number;
   expandedStderr: boolean;
+  pendingRemoval: boolean;
   onTest: () => void;
-  onRemove: () => void;
+  onRemoveRequest: () => void;
+  onRemoveConfirm: () => void;
+  onRemoveCancel: () => void;
   onToggleStderr: () => void;
 }) {
   const status = useMemo<{ label: string; tone: 'quiet' | 'accent'; color: string }>(() => {
@@ -639,19 +650,48 @@ function ServerRow({
           <button
             type="button"
             onClick={onTest}
-            disabled={testing || busy}
-            style={rowLinkStyle(testing || busy)}
+            disabled={testing || busy || pendingRemoval}
+            style={rowLinkStyle(testing || busy || pendingRemoval)}
           >
             {testing ? (testingNpxFamily ? 'fetching…' : 'testing…') : 'test'}
           </button>
-          <button
-            type="button"
-            onClick={onRemove}
-            disabled={busy}
-            style={rowLinkStyle(busy)}
-          >
-            remove
-          </button>
+          {pendingRemoval ? (
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+              <span style={{
+                fontFamily: MONO_FONT_STACK,
+                fontSize: 11,
+                fontWeight: 400,
+                letterSpacing: '0.12em',
+                textTransform: 'uppercase',
+                color: '#dc2626',
+              }}>
+                remove?
+              </span>
+              <button
+                type="button"
+                onClick={onRemoveConfirm}
+                style={rowLinkStyle(false)}
+              >
+                yes
+              </button>
+              <button
+                type="button"
+                onClick={onRemoveCancel}
+                style={rowLinkStyle(false)}
+              >
+                cancel
+              </button>
+            </span>
+          ) : (
+            <button
+              type="button"
+              onClick={onRemoveRequest}
+              disabled={busy}
+              style={rowLinkStyle(busy)}
+            >
+              remove
+            </button>
+          )}
         </div>
       </div>
 

--- a/src/components/desktop/settings/mcp/useExternalMcpServers.ts
+++ b/src/components/desktop/settings/mcp/useExternalMcpServers.ts
@@ -129,9 +129,6 @@ export function useExternalMcpServers(): UseExternalMcpServersResult {
   }, [load]);
 
   const remove = useCallback(async (server: ExternalMcpServer) => {
-    if (typeof window !== 'undefined' && !window.confirm(`Remove external MCP server "${server.name}"?`)) {
-      return;
-    }
     setActionId(server.id);
     setNote(null);
     try {

--- a/src/components/desktop/settings/shared.tsx
+++ b/src/components/desktop/settings/shared.tsx
@@ -519,7 +519,10 @@ export function ScopeBadge({ scope }: { scope: string }) {
   return (
     <span style={{
       display: 'inline-block',
-      padding: '2px 8px',
+      paddingTop: 2,
+      paddingRight: 8,
+      paddingBottom: 2,
+      paddingLeft: 8,
       borderRadius: 6,
       fontSize: 10,
       fontWeight: 600,
@@ -549,7 +552,10 @@ export function ScopeDiagnostic({
 
   return (
     <div style={{
-      padding: 12,
+      paddingTop: 12,
+      paddingRight: 12,
+      paddingBottom: 12,
+      paddingLeft: 12,
       borderRadius: 10,
       background: tone.bg,
       border: `1px solid ${tone.border}`,
@@ -557,7 +563,10 @@ export function ScopeDiagnostic({
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
         <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--t-text)' }}>{title}</span>
         <span style={{
-          padding: '2px 7px',
+          paddingTop: 2,
+          paddingRight: 7,
+          paddingBottom: 2,
+          paddingLeft: 7,
           borderRadius: 999,
           background: `${tone.pill}22`,
           color: tone.text,


### PR DESCRIPTION
Closes #826.

## Summary

- **#1 (prod-breaking)** `window.confirm` in `useExternalMcpServers.ts` removed. Confirmation now lives as an inline strip inside `ServerRow` in `ExternalMcpServersSection.tsx`: clicking Remove shows a `remove? yes / cancel` row inline — no dialog, works in Tauri.
- **#2 (rule violation)** Stripped `⏵` (U+23F5) emoji from `DiagnosticsResetModals.tsx` lines 80 and 237. Labels now read `DANGER · IRREVERSIBLE` and `RESET COMPLETE` without the prefix character.
- **#3 (unmount race)** Added `mountedRef = useRef(true)` + cleanup effect to `APIKeysTab`. All `setProviders`/`setLoading` calls inside `loadKeys` are guarded by `if (mountedRef.current)`.
- **#4 (CSS shorthand)** `padding: '2px 8px'` in `ScopeBadge` and `padding: 12` in `ScopeDiagnostic` (plus inner pill) split into explicit `paddingTop`/`paddingRight`/`paddingBottom`/`paddingLeft` longhand.

## Test plan

- [ ] Open Settings → MCP tab, click Remove on an external server — confirm strip appears inline, clicking Yes removes, Cancel dismisses
- [ ] Open Settings → General / Diagnostics tab, trigger factory reset modal — no emoji prefix on the danger/done headers
- [ ] Open Settings → API Keys, save/remove a key and navigate away mid-flight — no React unmounted-component warning
- [ ] `npx tsc --noEmit` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)