### PR TITLE
fix: approvals audit fixes (#832)

### DIFF
--- a/src/app/api/panel/approvals/route.ts
+++ b/src/app/api/panel/approvals/route.ts
@@ -165,15 +165,25 @@ export async function POST(request: NextRequest) {
   }
 
   try {
+    // resolveApproval is atomic in SQLite and guards against double-resolve.
+    // Call it first so a concurrent request loses the race and short-circuits
+    // before any file mutation occurs (close TOCTOU window).
+    const approval = resolveApproval(id, action, 'desktop');
+    if (!approval) {
+      return NextResponse.json({ ok: false, error: 'Approval not found' }, { status: 404 });
+    }
+
+    // If resolveApproval returned a record that is already resolved (status !== pending
+    // before our call), skip the file edit — it was already applied by the winner.
     let appliedEdit: { filePath: string; message: string } | undefined;
-    if (action === 'approve' && current.toolName === 'edit_file') {
+    if (action === 'approve' && current.toolName === 'edit_file' && approval.status === 'approved' && approval.resolvedAt === approval.updatedAt) {
       const applyResult = await applyApprovedFileEdit(current);
       if (!applyResult.ok) {
         return NextResponse.json({
           ok: false,
           error: applyResult.error,
           code: applyResult.code,
-          approval: current,
+          approval,
         }, {
           status: applyResult.status,
           headers: { 'Cache-Control': 'no-store, max-age=0' },
@@ -184,11 +194,6 @@ export async function POST(request: NextRequest) {
         filePath: applyResult.filePath,
         message: applyResult.message,
       };
-    }
-
-    const approval = resolveApproval(id, action, 'desktop');
-    if (!approval) {
-      return NextResponse.json({ ok: false, error: 'Approval not found' }, { status: 404 });
     }
 
     // Route resolution based on continuation type

--- a/src/components/desktop/ApprovalQueuePanel.tsx
+++ b/src/components/desktop/ApprovalQueuePanel.tsx
@@ -114,7 +114,10 @@ function DiffPreview({ diff }: { diff: { before?: string; after?: string; path?:
           display: 'flex',
           alignItems: 'center',
           gap: 6,
-          padding: '4px 8px',
+          paddingTop: 4,
+          paddingRight: 8,
+          paddingBottom: 4,
+          paddingLeft: 8,
           borderRadius: 8,
           border: '1px solid var(--t-divider)',
           background: 'var(--t-code-bg, rgba(0,0,0,0.03))',
@@ -226,7 +229,10 @@ function ApprovalCard({
               letterSpacing: '0.04em',
               color: colors.text,
               background: colors.badge,
-              padding: '2px 6px',
+              paddingTop: 2,
+              paddingRight: 6,
+              paddingBottom: 2,
+              paddingLeft: 6,
               borderRadius: 6,
             }}>
               {approval.risk}
@@ -277,7 +283,10 @@ function ApprovalCard({
       {approval.command && (
         <div style={{
           marginTop: 8,
-          padding: '6px 10px',
+          paddingTop: 6,
+          paddingRight: 10,
+          paddingBottom: 6,
+          paddingLeft: 10,
           borderRadius: 8,
           background: 'var(--t-code-bg, rgba(0,0,0,0.03))',
           border: '1px solid var(--t-divider)',
@@ -307,7 +316,10 @@ function ApprovalCard({
               key={key}
               style={{
                 fontSize: 10,
-                padding: '2px 6px',
+                paddingTop: 2,
+                paddingRight: 6,
+                paddingBottom: 2,
+                paddingLeft: 6,
                 borderRadius: 6,
                 background: 'var(--t-code-bg, rgba(0,0,0,0.03))',
                 color: 'var(--t-text-secondary)',
@@ -417,7 +429,10 @@ function EmptyState() {
       flexDirection: 'column',
       alignItems: 'center',
       justifyContent: 'center',
-      padding: '60px 24px',
+      paddingTop: 60,
+      paddingRight: 24,
+      paddingBottom: 60,
+      paddingLeft: 24,
       gap: 12,
     }}>
       <div style={{
@@ -511,7 +526,7 @@ export function ApprovalQueuePanel({ onClose, embedded }: { onClose?: () => void
     // Hide entirely when empty and loaded (no need to show "All clear" inline)
     if (loaded && pending.length === 0) return null;
     return (
-      <div style={{ padding: '8px 12px' }}>
+      <div style={{ paddingTop: 8, paddingRight: 12, paddingBottom: 8, paddingLeft: 12 }}>
         {!loaded && pending.length === 0 ? (
           <div style={{
             height: 60,
@@ -547,7 +562,10 @@ export function ApprovalQueuePanel({ onClose, embedded }: { onClose?: () => void
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
-        padding: '16px 20px 12px',
+        paddingTop: 16,
+        paddingRight: 20,
+        paddingBottom: 12,
+        paddingLeft: 20,
         borderBottom: '1px solid var(--t-divider)',
         flexShrink: 0,
       }}>
@@ -567,7 +585,10 @@ export function ApprovalQueuePanel({ onClose, embedded }: { onClose?: () => void
               fontWeight: 700,
               color: '#fff',
               background: '#ef4444',
-              padding: '1px 7px',
+              paddingTop: 1,
+              paddingRight: 7,
+              paddingBottom: 1,
+              paddingLeft: 7,
               borderRadius: 10,
               lineHeight: '18px',
             }}>
@@ -606,7 +627,10 @@ export function ApprovalQueuePanel({ onClose, embedded }: { onClose?: () => void
       <div style={{
         flex: 1,
         overflowY: 'auto',
-        padding: '12px 16px',
+        paddingTop: 12,
+        paddingRight: 16,
+        paddingBottom: 12,
+        paddingLeft: 16,
       }}>
         {/* Loading skeleton */}
         {!loaded && pending.length === 0 && (
@@ -614,7 +638,10 @@ export function ApprovalQueuePanel({ onClose, embedded }: { onClose?: () => void
             display: 'flex',
             flexDirection: 'column',
             gap: 10,
-            padding: '20px 0',
+            paddingTop: 20,
+            paddingRight: 0,
+            paddingBottom: 20,
+            paddingLeft: 0,
           }}>
             {[1, 2].map((i) => (
               <div key={i} style={{
@@ -653,7 +680,10 @@ export function ApprovalQueuePanel({ onClose, embedded }: { onClose?: () => void
                 display: 'flex',
                 alignItems: 'center',
                 gap: 6,
-                padding: '8px 0',
+                paddingTop: 8,
+                paddingRight: 0,
+                paddingBottom: 8,
+                paddingLeft: 0,
                 border: 'none',
                 background: 'none',
                 color: 'var(--t-text-secondary)',

--- a/src/components/desktop/ApprovalReviewScreenshot.tsx
+++ b/src/components/desktop/ApprovalReviewScreenshot.tsx
@@ -68,6 +68,7 @@ export function ApprovalReviewScreenshot({ approval }: { approval: ApprovalRecor
 
         if (attempt < MAX_LOOKUP_ATTEMPTS - 1) {
           await new Promise((resolve) => window.setTimeout(resolve, LOOKUP_RETRY_MS));
+          if (cancelled) return;
         }
       }
     })();

--- a/src/components/desktop/agent-panel-chat/ApprovalCards.tsx
+++ b/src/components/desktop/agent-panel-chat/ApprovalCards.tsx
@@ -17,9 +17,9 @@ const GATE_CATEGORY_LABELS: Record<string, string> = {
 
 function GateReportSection({ approval }: { approval: SidebarApproval }) {
   const gate = approval.gateResult;
-  if (!gate || gate.violations.length === 0) return null;
-
   const [expanded, setExpanded] = useState(false);
+
+  if (!gate || gate.violations.length === 0) return null;
   const categories = ['security', 'budget', 'integrity'] as const;
 
   return (
@@ -65,7 +65,7 @@ function GateReportSection({ approval }: { approval: SidebarApproval }) {
           {categories.map((cat) => {
             const catViolations = gate.violations.filter((v) => v.category === cat);
             if (catViolations.length === 0) return (
-              <div key={cat} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '4px 8px', fontSize: 11 }}>
+              <div key={cat} style={{ display: 'flex', alignItems: 'center', gap: 6, paddingTop: 4, paddingRight: 8, paddingBottom: 4, paddingLeft: 8, fontSize: 11 }}>
                 <span style={{ color: '#16a34a', fontWeight: 800 }}>{'\u2713'}</span>
                 <span style={{ fontWeight: 700, color: 'var(--t-text-secondary)' }}>{GATE_CATEGORY_LABELS[cat]}</span>
                 <span style={{ color: 'var(--t-text-muted)', fontWeight: 600 }}>passed</span>
@@ -73,7 +73,7 @@ function GateReportSection({ approval }: { approval: SidebarApproval }) {
             );
 
             return (
-              <div key={cat} style={{ padding: '4px 8px' }}>
+              <div key={cat} style={{ paddingTop: 4, paddingRight: 8, paddingBottom: 4, paddingLeft: 8 }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, marginBottom: 2 }}>
                   <span style={{ color: '#dc2626', fontWeight: 800 }}>{'\u2717'}</span>
                   <span style={{ fontWeight: 700, color: 'var(--t-text-secondary)' }}>{GATE_CATEGORY_LABELS[cat]}</span>
@@ -117,14 +117,17 @@ function ConflictSection({
   resolvingId: string | null;
 }) {
   const conflict = approval.conflictReport;
-  if (!conflict || conflict.files.length === 0) return null;
-
   const [selectedStrategy, setSelectedStrategy] = useState<string>('theirs');
+
+  if (!conflict || conflict.files.length === 0) return null;
 
   return (
     <div style={{ marginBottom: 8 }}>
       <div style={{
-        padding: '8px 10px',
+        paddingTop: 8,
+        paddingRight: 10,
+        paddingBottom: 8,
+        paddingLeft: 10,
         borderRadius: 10,
         background: 'rgba(245, 158, 11, 0.06)',
         border: '1px solid rgba(245, 158, 11, 0.12)',
@@ -260,7 +263,10 @@ export const SidebarApprovalCard = memo(function SidebarApprovalCard({
       display: 'flex',
       flexDirection: 'column',
       gap: 10,
-      padding: '10px 14px 12px',
+      paddingTop: 10,
+      paddingRight: 14,
+      paddingBottom: 12,
+      paddingLeft: 14,
       marginTop: 8,
       marginRight: 14,
       marginBottom: 10,
@@ -314,7 +320,10 @@ export const SidebarApprovalCard = memo(function SidebarApprovalCard({
           justifyContent: 'center',
           minWidth: 22,
           height: 22,
-          padding: '0 7px',
+          paddingTop: 0,
+          paddingRight: 7,
+          paddingBottom: 0,
+          paddingLeft: 7,
           borderRadius: 999,
           background: 'rgba(239, 68, 68, 0.12)',
           color: '#dc2626',
@@ -343,7 +352,10 @@ export const SidebarApprovalCard = memo(function SidebarApprovalCard({
             <div
               key={approval.id}
               style={{
-                padding: '12px 12px 10px',
+                paddingTop: 12,
+                paddingRight: 12,
+                paddingBottom: 10,
+                paddingLeft: 12,
                 borderRadius: 14,
                 background: THEME_BG_CARD,
                 border: `1px solid ${riskTone.border}`,
@@ -376,7 +388,10 @@ export const SidebarApprovalCard = memo(function SidebarApprovalCard({
                 <span style={{
                   display: 'inline-flex',
                   alignItems: 'center',
-                  padding: '3px 8px',
+                  paddingTop: 3,
+                  paddingRight: 8,
+                  paddingBottom: 3,
+                  paddingLeft: 8,
                   borderRadius: 999,
                   background: riskTone.bg,
                   color: riskTone.fg,
@@ -408,7 +423,10 @@ export const SidebarApprovalCard = memo(function SidebarApprovalCard({
                 <>
                   {approval.command ? (
                     <div style={{
-                      padding: '8px 10px',
+                      paddingTop: 8,
+                      paddingRight: 10,
+                      paddingBottom: 8,
+                      paddingLeft: 10,
                       borderRadius: 10,
                       background: 'rgba(15, 23, 42, 0.96)',
                       color: '#e2e8f0',

--- a/src/components/desktop/thoughts/ThoughtsApprovals.tsx
+++ b/src/components/desktop/thoughts/ThoughtsApprovals.tsx
@@ -13,7 +13,10 @@ export function ThoughtsApprovals({
 
   return (
     <div style={{
-      padding: '8px 12px',
+      paddingTop: 8,
+      paddingRight: 12,
+      paddingBottom: 8,
+      paddingLeft: 12,
       display: 'flex',
       flexDirection: 'column',
       gap: 8,
@@ -24,7 +27,10 @@ export function ThoughtsApprovals({
     }}>
       {approvals.map((approval) => (
         <div key={approval.id} style={{
-          padding: '10px 12px',
+          paddingTop: 10,
+          paddingRight: 12,
+          paddingBottom: 10,
+          paddingLeft: 12,
           borderRadius: 14,
           background: approval.risk === 'high'
             ? 'rgba(239, 68, 68, 0.06)'
@@ -53,7 +59,7 @@ export function ThoughtsApprovals({
             </span>
             <span style={{
               fontSize: 9, fontWeight: 600, textTransform: 'uppercase',
-              padding: '2px 6px', borderRadius: 5,
+              paddingTop: 2, paddingRight: 6, paddingBottom: 2, paddingLeft: 6, borderRadius: 5,
               background: approval.risk === 'high'
                 ? 'rgba(239, 68, 68, 0.1)'
                 : approval.risk === 'medium'
@@ -77,7 +83,7 @@ export function ThoughtsApprovals({
           </div>
           {approval.command && (
             <div style={{
-              padding: '6px 8px', borderRadius: 8,
+              paddingTop: 6, paddingRight: 8, paddingBottom: 6, paddingLeft: 8, borderRadius: 8,
               background: 'var(--t-code-bg)',
               fontFamily: 'SF Mono, Menlo, monospace',
               fontSize: 10, color: 'var(--t-text)',
@@ -93,7 +99,7 @@ export function ThoughtsApprovals({
               onClick={() => onResolve(approval.id, 'approve')}
               disabled={resolvingId === approval.id}
               style={{
-                flex: 1, padding: '7px 0', borderRadius: 10, border: 'none',
+                flex: 1, paddingTop: 7, paddingRight: 0, paddingBottom: 7, paddingLeft: 0, borderRadius: 10, border: 'none',
                 background: '#22c55e', color: '#fff',
                 fontSize: 11, fontWeight: 700, cursor: 'pointer',
                 opacity: resolvingId === approval.id ? 0.5 : 1,
@@ -107,7 +113,7 @@ export function ThoughtsApprovals({
               onClick={() => onResolve(approval.id, 'reject')}
               disabled={resolvingId === approval.id}
               style={{
-                flex: 1, padding: '7px 0', borderRadius: 10,
+                flex: 1, paddingTop: 7, paddingRight: 0, paddingBottom: 7, paddingLeft: 0, borderRadius: 10,
                 border: '1px solid rgba(239, 68, 68, 0.2)',
                 background: 'rgba(239, 68, 68, 0.06)',
                 color: '#ef4444',

--- a/src/lib/approvals/llm.ts
+++ b/src/lib/approvals/llm.ts
@@ -116,7 +116,7 @@ export async function resumeLlmApproval(
     const body = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
     const note = typeof body?.error === 'string' ? body.error : `HTTP ${response.status}`;
     recordApprovalAudit(approval.id, 'resume_failed', options.actor, note);
-    throw new Error(note);
+    return { approval, note };
   }
 
   const reader = response.body.getReader();
@@ -176,11 +176,12 @@ export async function resumeLlmApproval(
       timestamp: Date.now(),
       model: continuation.model,
     });
-  recordApprovalAudit(approval.id, 'resumed', options.actor, 'Approval approved; follow-up approval is pending.');
+    recordApprovalAudit(approval.id, 'resumed', options.actor, 'Approval approved; follow-up approval is pending.');
+    // nextApproval omitted when SSE stream lacks an id — mobile re-polls /api/panel/approvals
     return {
       approval,
       assistantMessage,
-      nextApproval: nextApproval ?? undefined,
+      ...(nextApproval !== null ? { nextApproval } : {}),
       note: 'Approval recorded. Another approval is required to continue this chat turn.',
     };
   }

--- a/src/lib/approvals/store.ts
+++ b/src/lib/approvals/store.ts
@@ -256,20 +256,27 @@ export function approvalSeverity(risk: ApprovalRisk): EventSeverity {
 
 export function expireStaleApprovals() {
   const cutoff = Date.now() - STALE_APPROVAL_TTL_MS;
-  const result = getSqlite()
+  const staleIds = getSqlite()
     .prepare(`
-      UPDATE approvals
-      SET status = 'rejected'
+      SELECT id FROM approvals
       WHERE status = 'pending'
         AND created_at < ?
     `)
-    .run(cutoff);
+    .all(cutoff) as Array<{ id: string }>;
 
-  if (result.changes > 0) {
-    console.log(`[approvals] Expired ${result.changes} stale pending approvals`);
+  let changes = 0;
+  for (const { id } of staleIds) {
+    const resolved = resolveApproval(id, 'reject', 'system', 'Expired: stale pending approval TTL exceeded');
+    if (resolved) {
+      changes += 1;
+    }
   }
 
-  return result.changes;
+  if (changes > 0) {
+    console.log(`[approvals] Expired ${changes} stale pending approvals`);
+  }
+
+  return changes;
 }
 
 export function listApprovals(options: { status?: ApprovalRecord['status'] | 'all'; sessionKey?: string } = {}) {


### PR DESCRIPTION
Closes #832. 7 findings across the approvals subsystem.

## Summary

- **CRITICAL — ApprovalCards: hooks before null guards.** `GateReportSection` and `ConflictSection` both had `if (!x) return null` before their `useState` declarations. Hoisted all hook calls above the conditional returns to fix the hooks-ordering violation.
- **HIGH — llm: `resumeLlmApproval` returns structured error instead of throwing.** Line 119 `throw new Error(note)` replaced with `return { approval, note }` — a valid `ApprovalDecisionResult`. Callers in `panel/approvals/route.ts` and `mobile/action/route.ts` already wrap in try/catch or check `result.note`; no caller changes needed.
- **HIGH — approvals route: TOCTOU close.** `resolveApproval` is now called before `applyApprovedFileEdit`. Since `resolveApproval` is atomic in SQLite and guards against double-resolve, a concurrent request hitting the same approval ID after resolution will short-circuit before the file edit fires a second time.
- **MEDIUM — store: `expireStaleApprovals` now populates full resolution metadata.** Replaced raw `UPDATE` SQL with a `SELECT id` loop calling `resolveApproval(id, 'reject', 'system', '...')` per stale record, which writes `resolution`, `resolvedAt`, and the audit event atomically.
- **MEDIUM — llm: `nextApproval` key omitted when null.** When `nextApproval` is null the property is now spread-conditionally excluded from the return object, so mobile clients never receive a hint with no ID. Comment added per spec.
- **MEDIUM — CSS padding shorthand split across 3 components.** All multi-value `padding: '...'` strings in `ApprovalCards.tsx`, `ApprovalQueuePanel.tsx`, `ThoughtsApprovals.tsx` split into explicit `paddingTop/Right/Bottom/Left` longhand per CLAUDE.md rules.
- **LOW — ApprovalReviewScreenshot: cancellation re-check after sleep.** Added `if (cancelled) return;` immediately after `await new Promise(resolve => window.setTimeout(resolve, LOOKUP_RETRY_MS))` to stop unmounted components from firing the next fetch iteration.

## Test plan

- [ ] `npx tsc --noEmit` passes (confirmed clean in this PR)
- [ ] Approve an LLM chat approval on desktop — no double-apply of file edits under concurrent load
- [ ] Approve an LLM chat approval on mobile when SSE stream has no `parsed.id` — no undefined `nextApproval` in response
- [ ] Trigger stale approval expiry (TTL > 30 min) — verify `resolvedAt`, `resolution`, and audit event are populated
- [ ] Mount/unmount `ApprovalReviewScreenshot` rapidly — no post-unmount fetch errors in console
- [ ] Verify no React hooks warning ("Rendered fewer hooks than expected") on gate-report or conflict approval cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)