### PR TITLE
fix: disable Gemini thinking budget so chips render (#844)

### DIFF
--- a/src/app/api/v2/chat/suggestions/route.ts
+++ b/src/app/api/v2/chat/suggestions/route.ts
@@ -115,6 +115,7 @@ export async function POST(request: NextRequest) {
             temperature: 0.4,
             maxOutputTokens: 200,
             responseMimeType: 'application/json',
+            thinkingConfig: { thinkingBudget: 0 },
           },
         }),
         signal: controller.signal,


### PR DESCRIPTION
## Summary
Fixes #844.

gemini-2.5-flash was consuming the entire 200-token `maxOutputTokens` budget on internal thinking tokens, so `parseSuggestions()` always saw empty output and returned `[]`. Setting `thinkingConfig: { thinkingBudget: 0 }` reserves the full budget for actual JSON output.

## Test plan
- [ ] curl POST /api/v2/chat/suggestions returns non-empty suggestions array
- [ ] Chip row renders below assistant messages in orchestrator chat

Verified against live Gemini API with the route's exact SYSTEM_PROMPT + sample body:
- Before: `finishReason: "MAX_TOKENS"`, `thoughtsTokenCount: 188`, output truncated to `"Here is the JSON requested:\n"` -> parses to `[]`
- After: `finishReason: "STOP"`, no thinking tokens, populated `{ suggestions: [...] }` array of 3 chips