### PR TITLE
fix: resurrect codebase-memory indexer (#852, #854, #850)

### DIFF
--- a/src/lib/codebase-memory/client.ts
+++ b/src/lib/codebase-memory/client.ts
@@ -16,6 +16,26 @@ import { callCodebaseMemoryTool } from './mcp-client';
 const TRACE_TOOL_NAME = 'trace_path';
 
 /**
+ * Derive the codebase-memory project name from a repo's absolute path.
+ *
+ * #854 — `trace_path` requires a `project` parameter; the binary does NOT
+ * auto-detect from `cwd`. The binary names projects as the absolute path
+ * with the leading slash stripped and remaining slashes replaced with
+ * hyphens, e.g. `/Users/marquisehurtt/UGC` → `Users-marquisehurtt-UGC`.
+ * Confirmed against `cli list_projects` on a freshly indexed repo.
+ *
+ * Windows paths (drive letter + backslashes) are normalized to slashes
+ * first so the same convention applies cross-platform.
+ */
+function repoPathToProjectName(repoPath: string): string {
+  return repoPath
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '')
+    .replace(/\//g, '-');
+}
+
+/**
  * Symbol patterns we mine from packet titles / summaries / issue bodies.
  *
  *   1. Multi-cap identifiers (PascalCase with ≥2 caps): `PacketCard`,
@@ -166,13 +186,17 @@ export async function traceSymbols({
   if (!binPath) return { unavailable: true, edges: [] };
 
   const edges: SymbolEdge[] = [];
+  // #854: trace_path requires `project` — the binary doesn't infer it from
+  // cwd, so without this every call returned "project not found or not
+  // indexed" and the SYMBOL GRAPH row was permanently unavailable.
+  const project = repoPathToProjectName(repoPath);
 
   for (const symbol of symbols) {
     const callResult = await callCodebaseMemoryTool({
       binPath,
       cwd: repoPath,
       toolName: TRACE_TOOL_NAME,
-      args: { function_name: symbol },
+      args: { function_name: symbol, project },
       timeoutMs,
     });
 

--- a/src/lib/codebase-memory/indexer.ts
+++ b/src/lib/codebase-memory/indexer.ts
@@ -46,8 +46,12 @@ const BINARY_WAIT_TIMEOUT_MS = 5 * 60_000;
 /** Tool exposed by codebase-memory-mcp (#738/#739). */
 const INDEX_TOOL_NAME = 'index_repository';
 
-/** Cap for the manual size walk so a giant node_modules doesn't stall boot. */
-const SIZE_WALK_ENTRY_CAP = 1500;
+/** Cap for the manual size walk so a giant node_modules doesn't stall boot.
+ *  Raised from 1,500 → 100,000 (#850) — cortex-ide alone has 61,887 entries
+ *  after excluding node_modules/.git/target/.next/dist, so the previous cap
+ *  deferred our primary dogfood repo on every boot. The walk is fast (sub-
+ *  100ms even at 60k entries on SSD) so the cap is only a paranoia bound. */
+const SIZE_WALK_ENTRY_CAP = 100_000;
 
 // Live in-process state. Reset on server restart — that's fine since the
 // next boot pass repopulates it.
@@ -211,7 +215,10 @@ async function runIndexJob({ binPath, repo, maxSizeBytes }: RunIndexJobOpts): Pr
     binPath,
     cwd: repo.localPath,
     toolName: INDEX_TOOL_NAME,
-    args: { path: repo.localPath },
+    // #852: binary v0.6.0+ requires `repo_path`, not `path`. Passing the wrong
+    // key returned `{ isError: true }` which the old mcp-client also dropped,
+    // so the indexer marked every repo as cached without ever indexing.
+    args: { repo_path: repo.localPath },
   });
 
   if (!result.ok) {

--- a/src/lib/codebase-memory/mcp-client.ts
+++ b/src/lib/codebase-memory/mcp-client.ts
@@ -266,6 +266,28 @@ export async function callCodebaseMemoryTool(
               });
               return;
             }
+            // #852: MCP tools/call can return a JSON-RPC success whose result
+            // payload has `isError: true`. Without this check we treated tool-
+            // level failures (e.g. "repo_path is required") as success and
+            // marked repos indexed when nothing was written.
+            const toolResult = callResp.result as
+              | { isError?: boolean; content?: Array<{ type?: string; text?: string }> }
+              | undefined;
+            if (toolResult && toolResult.isError === true) {
+              const text = toolResult.content
+                ?.map((c) => c?.text ?? '')
+                .filter(Boolean)
+                .join(' ')
+                .trim();
+              clearTimeout(timeout);
+              finish({
+                ok: false,
+                error: `${input.toolName} reported isError${text ? ` — ${text}` : ''}`,
+                stderr: stderrBuf || undefined,
+                durationMs: Date.now() - started,
+              });
+              return;
+            }
             clearTimeout(timeout);
             finish({
               ok: true,


### PR DESCRIPTION
## Summary

The codebase-memory pipeline was a silent no-op on cortex-ide. Three stacked P0 bugs each independently killed the symbol leg of the Context Engine — Recall Card SYMBOL row, dispatch context block's symbol leg, and cross-repo Jaccard were all operating against empty data.

- **#852 — indexer wrong param + missing isError check**: `indexer.ts` called `index_repository` with `{ path }`; binary v0.6.0+ requires `{ repo_path }`. Worse, `mcp-client.ts` only inspected the JSON-RPC `error` field — it never checked `result.isError`, so every tool-level failure was treated as success and HEAD was recorded, marking the repo "indexed" forever.
- **#854 — `traceSymbols` missing `project`**: `trace_path` requires `project` (the binary does NOT auto-detect from cwd). Without it every call returned `"project not found or not indexed"`. Added `repoPathToProjectName()` matching the binary's convention (leading slash stripped, slashes → hyphens).
- **#850 — `SIZE_WALK_ENTRY_CAP=1500` too low**: cortex-ide has 61,887 entries after excluding node_modules/.git/target/.next/dist, so it was deferred on every boot. Raised to 100,000 (walk is sub-100ms even at that bound; cap is just a paranoia limit).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Wrong-param call now surfaces `ok: false, error: "index_repository reported isError — repo_path is required"` instead of fake-success
- [x] `index_repository` on cortex-ide succeeds end-to-end through our `callCodebaseMemoryTool` wrapper: 14,323 nodes / 27,891 edges
- [x] `traceSymbols({ repoPath: '/Users/.../cortex-ide', symbols: ['PacketCard'] })` returns 1 edge with 5 neighbours including `ContextRecallCard`, `PacketReviewPanel`, `deriveGithubIssueUrl` — no longer `unavailable: true`
- [x] `list_projects` confirms `Users-<operator>-cortex-ide` registered with 14,323 nodes — so `repoPathToProjectName()` derivation matches the binary

Fixes #852
Fixes #854
Fixes #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)
