### PR TITLE
fix: webview navigate uses SPA pushState (#863)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import type { Metadata, Viewport } from 'next';
 import { resolvePortInfo } from '@/lib/panel/api-port';
+import NavigationBridge from '@/components/NavigationBridge';
 
 export const metadata: Metadata = {
   title: 'o8',
@@ -52,6 +53,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
             `,
           }}
         />
+        <NavigationBridge />
         {children}
         <script
           dangerouslySetInnerHTML={{

--- a/src/components/NavigationBridge.tsx
+++ b/src/components/NavigationBridge.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+/**
+ * Renderer-side navigation bridge for the o8 webview MCP tools.
+ *
+ * Exposes `window.__o8Navigate__(path)` so the operator MCP server's
+ * `o8_view_navigate` tool can drive Next.js App Router transitions via
+ * `router.push()` instead of `webview.navigate()` (full reload) or
+ * raw `pushState + popstate` (which doesn't always trigger soft
+ * navigation across page route segments — eg. /context-graph ↔
+ * /dashboard — and leaves Next.js mid-route, freezing the JS thread
+ * for 10–30s of hydration).
+ *
+ * Mounted once in the root layout. See issue #863.
+ */
+export default function NavigationBridge() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const navigate = (path: string) => {
+      // router.push handles same-origin paths; absolute URLs fall back
+      // to a full navigation as a safety net.
+      try {
+        router.push(path);
+      } catch (_err) {
+        window.location.assign(path);
+      }
+    };
+
+    (window as unknown as { __o8Navigate__?: (path: string) => void }).__o8Navigate__ = navigate;
+
+    const onCustomEvent = (event: Event) => {
+      const detail = (event as CustomEvent<{ path?: string }>).detail;
+      if (detail && typeof detail.path === 'string') {
+        navigate(detail.path);
+      }
+    };
+    window.addEventListener('o8:navigate', onCustomEvent as EventListener);
+
+    return () => {
+      window.removeEventListener('o8:navigate', onCustomEvent as EventListener);
+      const w = window as unknown as { __o8Navigate__?: (path: string) => void };
+      if (w.__o8Navigate__ === navigate) {
+        delete w.__o8Navigate__;
+      }
+    };
+  }, [router]);
+
+  return null;
+}

--- a/src/lib/mcp/o8-webview-client.ts
+++ b/src/lib/mcp/o8-webview-client.ts
@@ -513,9 +513,24 @@ export class O8WebviewClient {
   }
 
   async navigate(path: string): Promise<{ ok: boolean }> {
+    // Drive the renderer's Next.js App Router via the NavigationBridge
+    // (mounted in the root layout). This is the only path that performs
+    // a true SPA transition — `webview.navigate(url)` triggers a full
+    // HTTP reload and `pushState + popstate` doesn't always cross
+    // page-route segments (eg. /context-graph ↔ /dashboard), which
+    // leaves Next.js mid-route and freezes the JS thread for 10–30s.
+    // See issue #863.
+    //
+    // The pushState + popstate path is kept as a fallback for the few
+    // moments before NavigationBridge mounts after a cold launch.
     await this.evalJs(`(() => {
       const next = new URL(${JSON.stringify(path)}, window.location.origin);
       const route = \`\${next.pathname}\${next.search}\${next.hash}\`;
+      const bridge = (window).__o8Navigate__;
+      if (typeof bridge === 'function') {
+        bridge(route);
+        return route;
+      }
       window.history.pushState(window.history.state, '', route);
       const event = typeof PopStateEvent === 'function'
         ? new PopStateEvent('popstate', { state: window.history.state })

--- a/src/lib/mcp/o8-webview-tools.ts
+++ b/src/lib/mcp/o8-webview-tools.ts
@@ -159,7 +159,7 @@ export const O8_WEBVIEW_TOOLS: McpTool[] = [
   },
   {
     name: 'o8_view_navigate',
-    description: 'Navigate the o8 app to a new route by dispatching history.pushState. Use for deep-linking into specific tabs.',
+    description: 'Navigate the o8 app to a new route via Next.js App Router (router.push). Performs a true SPA transition — does NOT trigger a full Tauri webview reload, so subsequent o8_view_eval / o8_view_click calls remain responsive immediately. Use for deep-linking into specific tabs.',
     inputSchema: {
       type: 'object',
       properties: {


### PR DESCRIPTION
## Summary
Fixes #863. Mitigates #848, #858, #868, #869.

The o8 webview navigate tool now performs SPA navigation via the renderer rather than reloading the Tauri webview. This unblocks every dogfood agent that hit the /context-graph trap during the phase-1 Context Engine audit.

### What changed
- `src/components/NavigationBridge.tsx` (new) — client component mounted in the root layout, calls `useRouter()` from `next/navigation` and exposes `window.__o8Navigate__(path)` for the MCP tool to drive. Also accepts a `o8:navigate` custom event as a backup.
- `src/app/layout.tsx` — mount `NavigationBridge` once inside `<body>`.
- `src/lib/mcp/o8-webview-client.ts` — `navigate()` now calls `window.__o8Navigate__` first (router.push), falling back to `pushState + popstate` only for the cold-launch window before the bridge mounts.
- `src/lib/mcp/o8-webview-tools.ts` — tool description updated to reflect SPA semantics so callers understand subsequent eval/click calls remain responsive immediately.

The previous JS path (`pushState + popstate`) didn't reliably trigger a Next.js App Router soft navigation when crossing page-route segments (eg. `/context-graph` → `/dashboard`). That left Next.js mid-route, the JS main thread saturated by hydration, and `o8_view_eval` / `o8_view_click` timing out for 10–30s. Routing through `router.push()` is the right primitive — it's exactly what Next.js' Link/router APIs use internally.

### Why renderer-side, not Rust-side
The bug body suggested making the Rust `navigate_webview` action emit a Tauri event into the renderer. The same outcome is achievable with strictly less surface area: the renderer already receives `execute_js` calls via the existing socket; we only need a globally-mounted React listener that has access to `useRouter()`. No Rust changes, no `tauri-plugin-mcp` rebuild, no new Tauri event plumbing. The fix is purely in TS and is gated by the bridge's `window` global so any future Rust-side path can also call it.

## Test plan
- [ ] o8_view_navigate('/dashboard') from /context-graph returns without hang
- [ ] o8_view_eval works within 1s of navigate
- [ ] o8_view_click works within 1s of navigate
- [ ] No regression on initial app boot (cold launch falls back to pushState + popstate cleanly)
- [ ] /context-graph → /dashboard → /context-graph round-trip stays SPA (no full reload)

CI may show red — currently broken for billing reasons. Local `npx tsc --noEmit` passes.