### PR TITLE
fix: Recall Card re-fetches on directive change (#840)

### DIFF
--- a/src/components/desktop/thoughts/ContextRecallCard.tsx
+++ b/src/components/desktop/thoughts/ContextRecallCard.tsx
@@ -80,6 +80,12 @@ export function ContextRecallCard({ packet, repoName }: ContextRecallCardProps) 
     unavailable: false,
   });
 
+  // #840 — Bumped when a Cortex memory write (e.g. directive trailer append
+  // after a merge) fires the `o8:cortex-changes` window event. The directive
+  // fetch effect uses this as a dependency so the card re-fetches in place
+  // without a manual collapse/reopen.
+  const [directiveRefreshTick, setDirectiveRefreshTick] = useState(0);
+
   const repoPath = packet.workspaceTargetPath;
 
   const symbolText = useMemo(() => {
@@ -91,6 +97,9 @@ export function ContextRecallCard({ packet, repoName }: ContextRecallCardProps) 
   }, [packet.title, packet.summary, packet.issue]);
 
   // ── Directives — load once, share across packets ────────────────────
+  // Re-runs whenever `directiveRefreshTick` is bumped by the
+  // `o8:cortex-changes` listener below, so a merge that appends a `[merged]`
+  // trailer is reflected in the open card within ~ws-roundtrip latency.
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -107,6 +116,26 @@ export function ContextRecallCard({ packet, repoName }: ContextRecallCardProps) 
     return () => {
       cancelled = true;
     };
+  }, [directiveRefreshTick]);
+
+  // #840 — Listen for cortex-changes pushed from the server after a merge
+  // appends a directive trailer. Bridge already converts the WS message
+  // into an `o8:cortex-changes` window event in DesktopWebSocketContext.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent).detail as {
+        data?: { scope?: string };
+      } | undefined;
+      const scope = detail?.data?.scope;
+      // Only directive scope triggers a directive re-fetch — outcomes and
+      // codebase-memory will hook in here later if/when they need it.
+      if (scope === 'directive' || !scope) {
+        setDirectiveRefreshTick((tick) => tick + 1);
+      }
+    };
+    window.addEventListener('o8:cortex-changes', handler);
+    return () => window.removeEventListener('o8:cortex-changes', handler);
   }, []);
 
   // ── Recent outcomes — keyed on repoPath ─────────────────────────────

--- a/src/components/desktop/thoughts/mission-panel/PacketReviewCard.tsx
+++ b/src/components/desktop/thoughts/mission-panel/PacketReviewCard.tsx
@@ -41,11 +41,15 @@ export function PacketReviewCard({ packet, reviewState, onActionComplete }: Pack
   const [diff, setDiff] = useState<DiffPayload | null>(null);
   const [diffLoading, setDiffLoading] = useState(false);
   const [diffError, setDiffError] = useState<string | null>(null);
+  // #840 — Bumped on `o8:cortex-changes` so the directive list refetches
+  // after a merge appends a trailer.
+  const [directiveRefreshTick, setDirectiveRefreshTick] = useState(0);
 
   const worktreePath = reviewState?.worktreePath ?? packet.lane?.worktreePath ?? null;
   const baseBranchHint = packet.branchTarget && packet.branchTarget.trim() ? packet.branchTarget : null;
 
-  // Load directives once on mount.
+  // Load directives once on mount, and again whenever the cortex-changes
+  // bus signals a directive write.
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -63,6 +67,22 @@ export function PacketReviewCard({ packet, reviewState, onActionComplete }: Pack
       }
     })();
     return () => { cancelled = true; };
+  }, [directiveRefreshTick]);
+
+  // #840 — Re-fetch directives when the server broadcasts a directive write.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent).detail as {
+        data?: { scope?: string };
+      } | undefined;
+      const scope = detail?.data?.scope;
+      if (scope === 'directive' || !scope) {
+        setDirectiveRefreshTick((tick) => tick + 1);
+      }
+    };
+    window.addEventListener('o8:cortex-changes', handler);
+    return () => window.removeEventListener('o8:cortex-changes', handler);
   }, []);
 
   // Load diff when worktreePath becomes known.

--- a/src/lib/cortex/directive-merges.ts
+++ b/src/lib/cortex/directive-merges.ts
@@ -32,6 +32,7 @@ import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
 import { getDataDir } from '@/lib/data-dir-migration';
+import { publishCortexChange } from '@/lib/realtime/publisher';
 
 const MAX_TRAILER_ENTRIES = 10;
 const SECTION_HEADER = '## Recent Merges';
@@ -208,6 +209,19 @@ export function appendDirectiveTrailer({
         error instanceof Error ? error.message : error,
       );
     }
+  }
+
+  // #840 — Notify open Recall Cards / Packet Review Cards so the
+  // freshly-appended trailer is visible without a manual collapse/reopen.
+  // Fire-and-forget — never block the merge path on a websocket round-trip.
+  // Co-located with the writer so any caller (merge handler, external-merge
+  // handler #841, REPL smoke test) gets the broadcast automatically.
+  if (updated.length > 0) {
+    void publishCortexChange({
+      scope: 'directive',
+      repoPath,
+      reason: `trailer:${entry.status}`,
+    });
   }
 
   return updated;

--- a/src/lib/orchestrator/operator-mission-service/merge.ts
+++ b/src/lib/orchestrator/operator-mission-service/merge.ts
@@ -222,6 +222,10 @@ async function dispatchPacketMerge(
           console.log(
             `[living-specs] Appended ${violated ? '[violated]' : '[merged]'} trailer to ${updated.length} directive${updated.length === 1 ? '' : 's'} for packet ${packet.id} (${updated.join(', ')})`,
           );
+          // #840 — `appendDirectiveTrailer` itself fires
+          // `publishCortexChange({ scope: 'directive' })` so any caller
+          // (this path + REPL smoke tests + future external-merge handler)
+          // refreshes the Recall Card without extra wiring here.
         }
       }
     } catch (error) {

--- a/src/lib/realtime/publisher.ts
+++ b/src/lib/realtime/publisher.ts
@@ -38,3 +38,35 @@ export async function publishRealtimeMutation(request: Omit<RealtimeMutationPubl
     ...request,
   });
 }
+
+/**
+ * #840 — Lightweight broadcast for Cortex memory mutations the UI cares
+ * about (directives, outcomes, codebase-memory). The ws-server fans this
+ * out as a `cortex-changes` channel event, which the desktop WS context
+ * bridges to an `o8:cortex-changes` window event. The Recall Card and
+ * Packet Review Card listen for this and re-fetch their data without a
+ * full page reload.
+ *
+ * Best-effort — never throws, never blocks the merge path.
+ */
+export async function publishCortexChange(payload: {
+  scope: 'directive' | 'outcome' | 'codebase-memory';
+  /** Repo path the change applies to, when known. */
+  repoPath?: string;
+  /** Free-form reason for logs (e.g. `merge:packet-123`). */
+  reason?: string;
+}) {
+  try {
+    await fetch(`${REALTIME_INTERNAL_ORIGIN}/internal/cortex-changes`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${getOrCreateWsToken()}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(REALTIME_INTERNAL_TIMEOUT_MS),
+    });
+  } catch {
+    // Best-effort — UI still has poll fallback.
+  }
+}

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -12,6 +12,7 @@
  *   history — transcript updates (pushed on change)
  *   lane-lifecycle — lane status transitions (pushed on change)
  *   review  — review file updates (pushed on change)
+ *   cortex-changes — directive / outcome / codebase-memory writes (#840)
  *   pong    — keepalive response
  *
  * The client sends:
@@ -3081,6 +3082,53 @@ const httpServer = createServer((req, res) => {
 
       res.writeHead(400);
       res.end('unsupported kind');
+    });
+    return;
+  }
+
+  // ── #840 — Cortex memory change broadcast ──
+  // Invoked by `publishCortexChange()` after a directive trailer is appended
+  // (or any other Cortex memory write). Fans out a `cortex-changes` channel
+  // event; the desktop WS bridge converts it to an `o8:cortex-changes`
+  // window event so the Recall Card / Packet Review Card re-fetch without
+  // a full page reload.
+  if (req.url === '/internal/cortex-changes' && req.method === 'POST') {
+    if (!isAuthorizedInternalRequest(req)) {
+      res.writeHead(401);
+      res.end('unauthorized');
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+    req.on('end', () => {
+      try {
+        const body = JSON.parse(Buffer.concat(chunks).toString('utf-8')) as {
+          scope?: string;
+          repoPath?: string;
+          reason?: string;
+        };
+        const scope = typeof body.scope === 'string' ? body.scope : 'unknown';
+        broadcast({
+          channel: 'cortex-changes',
+          event: 'update',
+          data: {
+            scope,
+            repoPath: body.repoPath ?? null,
+            reason: body.reason ?? null,
+            ts: currentIsoTime(),
+          },
+        });
+        console.log(`[cortex-changes] Broadcast scope=${scope}${body.reason ? ` reason=${body.reason}` : ''}`);
+        res.writeHead(202);
+        res.end('accepted');
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          ok: false,
+          error: err instanceof Error ? err.message : 'invalid json',
+        }));
+      }
     });
     return;
   }


### PR DESCRIPTION
## Summary

After a merge writes a `[merged]` trailer via `appendDirectiveTrailer`, the Recall Card UI didn't re-fetch — directive content shown in the card was stale until the packet was collapsed/reopened.

This wires a tiny WS broadcast through the existing realtime bridge so any Cortex memory write fans out to open cards in ~ws-roundtrip latency.

- **Server**: new `/internal/cortex-changes` POST endpoint on `ws-server.ts` broadcasts a `cortex-changes` channel event. The existing `DesktopWebSocketContext` bridge automatically converts WS messages on non-system channels into `o8:<channel>` window events, so no client bridge changes were needed.
- **Writer**: `appendDirectiveTrailer` itself fires `publishCortexChange({ scope: 'directive' })` after a successful append. Co-locating the broadcast with the writer means any caller — current merge handler, REPL smoke tests, the external-merge handler in #841 — gets it for free.
- **Clients**: `ContextRecallCard` and `PacketReviewCard` add an `o8:cortex-changes` listener that bumps a refresh tick; their directives effect now depends on that tick, so it re-runs on event.

## Test plan

- [ ] Open the Recall Card on an awaiting_review packet
- [ ] Run `appendDirectiveTrailer({ repoPath, entry })` from a node REPL
- [ ] DIRECTIVE row content refreshes within ~2s with the new trailer line, no manual collapse needed
- [ ] Initial card load still works on first expand (200ms debounce respected)
- [ ] `npx tsc --noEmit` passes (verified locally)

Fixes #840

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>