### PR TITLE
fix: invalidate proposer caches on state changes (#836, #851)

### DIFF
--- a/src/app/api/cortex/cross-repo-proposals/route.ts
+++ b/src/app/api/cortex/cross-repo-proposals/route.ts
@@ -22,9 +22,14 @@ import {
   snoozeCrossRepoProposal,
 } from '@/lib/cortex/cross-repo-proposer';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    const { candidates, computedAt } = await readCachedCrossRepoProposals();
+    // #851 — `?force=1` (or `force=true`) bypasses the in-memory cache so
+    // operators see fresh cross-repo proposals immediately after a registry
+    // change, directive write, or outcome row, without waiting on the tick.
+    const forceParam = request.nextUrl.searchParams.get('force');
+    const force = forceParam === '1' || forceParam === 'true';
+    const { candidates, computedAt } = await readCachedCrossRepoProposals({ force });
     return NextResponse.json(
       { ok: true, proposals: candidates, computedAt },
       { headers: { 'Cache-Control': 'no-store, max-age=0' } },

--- a/src/app/api/cortex/proposals/route.ts
+++ b/src/app/api/cortex/proposals/route.ts
@@ -17,9 +17,14 @@ export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 import { readCachedProposals, snoozeProposal } from '@/lib/cortex/proposer';
 
-export function GET() {
+export function GET(request: NextRequest) {
   try {
-    const { candidates, computedAt } = readCachedProposals();
+    // #836 — `?force=1` (or `force=true`) bypasses the in-memory cache so
+    // operators can always see fresh proposals after a directive change or
+    // new outcome row, without restarting the server or waiting on the tick.
+    const forceParam = request.nextUrl.searchParams.get('force');
+    const force = forceParam === '1' || forceParam === 'true';
+    const { candidates, computedAt } = readCachedProposals({ force });
     return NextResponse.json(
       { ok: true, proposals: candidates, computedAt },
       { headers: { 'Cache-Control': 'no-store, max-age=0' } },

--- a/src/lib/cortex/cross-repo-proposer.ts
+++ b/src/lib/cortex/cross-repo-proposer.ts
@@ -396,7 +396,11 @@ export async function proposeAcrossRepos(
 
 let bootTickFired = false;
 let lastTickAt = 0;
-const TICK_INTERVAL_MS = 30 * 60 * 1000;
+// #851 — shortened from 30 min to 5 min so a directive add/edit, repo
+// add/remove, or new outcome row surfaces in the proposer within a single
+// poll cycle. The `?force=1` query param on the route covers the
+// "right now" case explicitly.
+const TICK_INTERVAL_MS = 5 * 60 * 1000;
 
 let cachedCandidates: CrossRepoProposalCandidate[] = [];
 let cachedAt = 0;
@@ -426,12 +430,30 @@ export function ensureCrossRepoProposerBootTick(): void {
   if (typeof interval.unref === 'function') interval.unref();
 }
 
-export async function readCachedCrossRepoProposals(): Promise<{
+/**
+ * #851 — `force` bypasses the cache and recomputes inline so a fresh repo
+ * add, directive edit, or outcome row surfaces immediately instead of
+ * waiting for the next tick.
+ */
+export async function readCachedCrossRepoProposals(
+  options: { force?: boolean } = {},
+): Promise<{
   candidates: CrossRepoProposalCandidate[];
   computedAt: number;
 }> {
-  if (cachedAt === 0) {
+  if (options.force || cachedAt === 0) {
     await runTick();
   }
   return { candidates: cachedCandidates, computedAt: cachedAt };
+}
+
+/**
+ * #851 — Drop the cached payload so the next read recomputes from scratch.
+ * Call sites: any registry mutation (repo add/remove), any directive write,
+ * any new outcome row that shifts the candidate set. Cheap — no I/O, just
+ * zeroes the in-memory state so the next read falls through to `runTick()`.
+ */
+export function invalidateCrossRepoProposerCache(): void {
+  cachedCandidates = [];
+  cachedAt = 0;
 }

--- a/src/lib/cortex/proposer.ts
+++ b/src/lib/cortex/proposer.ts
@@ -399,7 +399,11 @@ export function proposeDirectives(options: ProposeOptions = {}): DirectivePropos
 
 let bootTickFired = false;
 let lastTickAt = 0;
-const TICK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
+// #836 — shortened from 30 min to 5 min so the Mission panel's poll cadence
+// (also 5 min) and the cache TTL line up. Combined with the `?force=1`
+// query param on the route, fresh data lands immediately when the operator
+// asks for it.
+const TICK_INTERVAL_MS = 5 * 60 * 1000;
 
 /**
  * Cache for the current tick — read by the API route. Keeps the proposer
@@ -421,7 +425,7 @@ function runTick(): void {
 /**
  * Boot-time entrypoint. Mirrors the `ensureCodebaseMemoryBootIndex` pattern:
  * fires once per server process via `setImmediate`, then schedules itself
- * every 30 min. Idempotent.
+ * every 5 min (#836). Idempotent.
  */
 export function ensureProposerBootTick(): void {
   if (bootTickFired) return;
@@ -439,10 +443,28 @@ export function ensureProposerBootTick(): void {
  * Read the most recent cached candidate set. If the cache is empty (server
  * just booted), runs the proposer inline. Cheap — bounded by the LIMIT 500
  * query above and the threshold filter.
+ *
+ * #836 — `force` bypasses the cache and recomputes inline so the Mission
+ * panel can show fresh data immediately after a directive change or new
+ * outcome row, without waiting on the next tick.
  */
-export function readCachedProposals(): { candidates: DirectiveProposalCandidate[]; computedAt: number } {
-  if (cachedAt === 0) {
+export function readCachedProposals(
+  options: { force?: boolean } = {},
+): { candidates: DirectiveProposalCandidate[]; computedAt: number } {
+  if (options.force || cachedAt === 0) {
     runTick();
   }
   return { candidates: cachedCandidates, computedAt: cachedAt };
+}
+
+/**
+ * #836 — Drop the cached payload so the next read recomputes from scratch.
+ * Call sites: anything that mutates `session_outcomes` or the directives dir
+ * such that the proposer's input set has shifted. Cheap — no I/O, just zeroes
+ * the in-memory state so the next `readCachedProposals()` call falls through
+ * to `runTick()`.
+ */
+export function invalidateProposerCache(): void {
+  cachedCandidates = [];
+  cachedAt = 0;
 }

--- a/src/lib/repos/registry.ts
+++ b/src/lib/repos/registry.ts
@@ -308,6 +308,20 @@ function fireSignatureRecompute(): void {
       error instanceof Error ? error.message : error,
     );
   }
+  // #851 — Stack signatures change → cross-repo proposer's similarity
+  // matrix changes → cache must drop so the next read sees the new repo
+  // set. Lazy-required for the same reasons as the signature import.
+  try {
+    const mod = require('@/lib/cortex/cross-repo-proposer') as
+      | typeof import('@/lib/cortex/cross-repo-proposer')
+      | undefined;
+    mod?.invalidateCrossRepoProposerCache?.();
+  } catch (error) {
+    console.warn(
+      '[repo-registry] cross-repo cache invalidation failed:',
+      error instanceof Error ? error.message : error,
+    );
+  }
 }
 
 export async function listRepos() {


### PR DESCRIPTION
## Summary

Both the auto-directive proposer (#746) and cross-repo learning proposer (#748) cached candidate lists for 30 minutes with no invalidation path. New outcome rows, directive edits, or registry changes were invisible until restart or the next tick — making both features functionally undemoable per the [context-engine dogfood report](https://github.com/hurttlocker/cortex-ide/issues/836).

## What changed

- **Shortened TTL** from 30 min → 5 min on both proposers so worst-case staleness lines up with the UI's 5-min poll cadence.
- **`?force=1` query param** on both GET routes (`/api/cortex/proposals`, `/api/cortex/cross-repo-proposals`) that bypasses the in-memory cache and recomputes inline.
- **Registry hook**: `fireSignatureRecompute()` in `src/lib/repos/registry.ts` now also calls `invalidateCrossRepoProposerCache()` so the moment a new repo lands in `~/.o8/repos.json` the next read sees it (covers #851 (a)).
- **Exports**: `invalidateProposerCache()` and `invalidateCrossRepoProposerCache()` for future call sites that mutate `session_outcomes` or the directives dir to drop the cache without going through the route.

## Files

- `src/lib/cortex/proposer.ts` — TTL shortened, `force` opt added to `readCachedProposals`, `invalidateProposerCache()` exported.
- `src/lib/cortex/cross-repo-proposer.ts` — same shape for the cross-repo proposer.
- `src/app/api/cortex/proposals/route.ts` — wires `?force=1` from the request URL.
- `src/app/api/cortex/cross-repo-proposals/route.ts` — same.
- `src/lib/repos/registry.ts` — `fireSignatureRecompute()` also invalidates the cross-repo proposer cache.

## Test plan

End-to-end smoke at `/tmp/smoke-cache-invalidation.ts`:

- [x] Seed 3 succeeded outcomes → cache populated → add 3 more with a distinct fix bigram → confirm `?force=1` recomputes (computedAt advanced) and surfaces 5 new candidate ids that weren't in the original set.
- [x] Seed 2 repos + matching directive → cross-repo cache empty (< 3 repos) → add a third repo to `repos.json` + signatures → confirm `?force=1` surfaces 2 cross-repo proposals (alpha→{beta,gamma}).
- [x] Direct route handler invocation: `GET /api/cortex/proposals?force=1` returns `{ ok: true }` with fresh data; same for cross-repo.
- [x] `npx tsc --noEmit` passes.
- [x] Without `?force=1`, the route still returns the cached payload (computedAt unchanged) — verifies we didn't regress the hot read path.

Fixes #836
Fixes #851

🤖 Generated with [Claude Code](https://claude.com/claude-code)