### PR TITLE
fix: Mission panel — separator, accurate label, dispatch confirm (#864, #866, #867)

### DIFF
--- a/src/components/desktop/thoughts/InputButtons.tsx
+++ b/src/components/desktop/thoughts/InputButtons.tsx
@@ -283,7 +283,7 @@ export function InputButtons({
       <button
         type="button"
         onClick={onToggleMission}
-        title={missionOpen ? 'Hide issues' : 'Show issues'}
+        title={missionOpen ? 'Hide panel' : 'Show panel'}
         style={{
           display: 'inline-flex',
           alignItems: 'center',

--- a/src/components/desktop/thoughts/ThoughtsMissionPanel.tsx
+++ b/src/components/desktop/thoughts/ThoughtsMissionPanel.tsx
@@ -727,6 +727,48 @@ export function ThoughtsMissionPanel({
         onCreatePacketFromIssue={handleCreatePacketFromIssue}
       />
 
+      {/* #864 — Separator between Issues and Packets. Only renders when
+          BOTH sections have content; otherwise the divider would appear at
+          the top or bottom of an otherwise-empty panel and read as noise.
+          Uses the bracketed-label motif from DESIGN.md (uppercase mono
+          micro-label + hairline rule) so it scans as a section break, not
+          a header. */}
+      {issueGroups.length > 0 && missionState.packets.length > 0 ? (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            paddingTop: 12,
+            paddingRight: 8,
+            paddingBottom: 4,
+            paddingLeft: 8,
+          }}
+          aria-hidden="true"
+        >
+          <span
+            style={{
+              fontSize: 10,
+              fontWeight: 600,
+              letterSpacing: '0.16em',
+              textTransform: 'uppercase' as const,
+              color: 'var(--t-text-muted)',
+              fontFamily: 'var(--font-mono, "SF Mono", Menlo, monospace)',
+              flexShrink: 0,
+            }}
+          >
+            (PACKETS)
+          </span>
+          <span
+            style={{
+              flex: 1,
+              height: 1,
+              background: 'var(--t-border)',
+            }}
+          />
+        </div>
+      ) : null}
+
       {pendingFanOutCost ? (
         <div
           style={{

--- a/src/components/desktop/thoughts/mission-panel/IssueGroupList.tsx
+++ b/src/components/desktop/thoughts/mission-panel/IssueGroupList.tsx
@@ -1,7 +1,13 @@
 'use client';
 
+import { useEffect, useRef, useState } from 'react';
 import type { OrchestratorMissionState } from '@/lib/orchestrator/types';
 import type { RepoIssue, RepoIssuesGroup } from './types';
+
+// #867 — Two-step confirm window. First click on "+" arms the row; second
+// click within this window actually dispatches. Auto-cancels after the
+// timeout so an idle armed row doesn't sit hot indefinitely.
+const CONFIRM_TIMEOUT_MS = 5000;
 
 interface IssueGroupListProps {
   issueGroups: RepoIssuesGroup[];
@@ -20,6 +26,35 @@ export function IssueGroupList({
   missionState,
   onCreatePacketFromIssue,
 }: IssueGroupListProps) {
+  // #867 — Track which issue row is currently armed for dispatch. Only one
+  // row can be armed at a time; clicking another row's "+" cancels the
+  // previous arm. Key shape: `${repoId}::${issueNumber}`.
+  const [confirmingKey, setConfirmingKey] = useState<string | null>(null);
+  const confirmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear any pending arm-timer on unmount so we don't fire setState on a
+  // gone component.
+  useEffect(() => {
+    return () => {
+      if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
+    };
+  }, []);
+
+  const armConfirm = (key: string) => {
+    if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
+    setConfirmingKey(key);
+    confirmTimerRef.current = setTimeout(() => {
+      setConfirmingKey((current) => (current === key ? null : current));
+      confirmTimerRef.current = null;
+    }, CONFIRM_TIMEOUT_MS);
+  };
+
+  const cancelConfirm = () => {
+    if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
+    confirmTimerRef.current = null;
+    setConfirmingKey(null);
+  };
+
   return (
     <>
       {issueGroups.map((group) => {
@@ -78,6 +113,8 @@ export function IssueGroupList({
                   const alreadyPacketed = missionState.packets.some(
                     (packet) => packet.summary.includes(`#${issue.number}`) || packet.title === issue.title,
                   );
+                  const issueKey = `${group.repoId}::${issue.number}`;
+                  const isConfirming = confirmingKey === issueKey;
                   return (
                     <div
                       key={`${group.repoId}-${issue.number}`}
@@ -102,10 +139,93 @@ export function IssueGroupList({
                         {issue.title}
                       </span>
                       {!alreadyPacketed ? (
-                        <button type="button" onClick={() => onCreatePacketFromIssue(issue)} title="Create work packet"
-                          style={{ border: 'none', background: 'transparent', cursor: 'pointer', padding: '2px 4px', flexShrink: 0, display: 'flex', alignItems: 'center' }}>
-                          <span style={{ fontSize: 14, color: 'var(--t-text-muted)', opacity: 0.5, lineHeight: 1 }}>+</span>
-                        </button>
+                        isConfirming ? (
+                          // #867 — Inline confirm strip. Two buttons: confirm
+                          // (orange accent, dispatches) and cancel (neutral,
+                          // disarms). Auto-disarms after CONFIRM_TIMEOUT_MS.
+                          <div
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 4,
+                              flexShrink: 0,
+                            }}
+                          >
+                            <button
+                              type="button"
+                              onClick={() => {
+                                cancelConfirm();
+                                onCreatePacketFromIssue(issue);
+                              }}
+                              title="Confirm dispatch"
+                              style={{
+                                borderWidth: 1,
+                                borderStyle: 'solid',
+                                borderColor: 'rgba(255, 90, 31, 0.45)',
+                                background: 'rgba(255, 90, 31, 0.12)',
+                                color: '#c2410c',
+                                cursor: 'pointer',
+                                paddingTop: 2,
+                                paddingRight: 8,
+                                paddingBottom: 2,
+                                paddingLeft: 8,
+                                borderRadius: 6,
+                                fontSize: 10,
+                                fontWeight: 700,
+                                letterSpacing: '0.04em',
+                                textTransform: 'uppercase' as const,
+                                fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+                              }}
+                            >
+                              Dispatch
+                            </button>
+                            <button
+                              type="button"
+                              onClick={cancelConfirm}
+                              title="Cancel"
+                              style={{
+                                borderWidth: 1,
+                                borderStyle: 'solid',
+                                borderColor: 'var(--t-border)',
+                                background: 'transparent',
+                                color: 'var(--t-text-secondary)',
+                                cursor: 'pointer',
+                                paddingTop: 2,
+                                paddingRight: 8,
+                                paddingBottom: 2,
+                                paddingLeft: 8,
+                                borderRadius: 6,
+                                fontSize: 10,
+                                fontWeight: 600,
+                                letterSpacing: '0.04em',
+                                textTransform: 'uppercase' as const,
+                                fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+                              }}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => armConfirm(issueKey)}
+                            title="Create work packet"
+                            style={{
+                              borderWidth: 0,
+                              background: 'transparent',
+                              cursor: 'pointer',
+                              paddingTop: 2,
+                              paddingRight: 4,
+                              paddingBottom: 2,
+                              paddingLeft: 4,
+                              flexShrink: 0,
+                              display: 'flex',
+                              alignItems: 'center',
+                            }}
+                          >
+                            <span style={{ fontSize: 14, color: 'var(--t-text-muted)', opacity: 0.5, lineHeight: 1 }}>+</span>
+                          </button>
+                        )
                       ) : null}
                     </div>
                   );


### PR DESCRIPTION
## Summary

Three Mission panel UX fixes flagged in the Context Engine v2 dogfood audit, all touching `ThoughtsMissionPanel.tsx` (and one toolbar button + the issue list child).

- **#864 — Separator between Issues and Packets.** Added a bracketed-label section break `(PACKETS)` plus a hairline rule between `IssueGroupList` and `StatusGroupedLanes`. Only renders when both sections have content so empty states stay clean. Uses the uppercase mono micro-label motif from `DESIGN.md`.
- **#866 — Accurate toolbar label.** The composer toolbar button labeled "Hide issues" actually collapses the entire Mission panel (issues + packets). Renamed to **"Hide panel"** / **"Show panel"** in `InputButtons.tsx`.
- **#867 — Two-step dispatch confirm on the "+" icon.** Clicking the small "+" next to a GitHub issue used to dispatch immediately. Now first click arms the row with inline `Dispatch` / `Cancel` buttons; auto-disarms after 5 seconds. Only one row can be armed at a time.

Fixes #864
Fixes #866
Fixes #867

## Test plan

- [ ] Open Orchestrator tab with both GitHub issues AND packets visible — verify the `(PACKETS)` divider appears between the two sections.
- [ ] With packets but no issues (or vice versa), verify the divider is suppressed.
- [ ] Hover the issues toggle in the composer toolbar — verify tooltip reads "Hide panel" / "Show panel".
- [ ] Click the "+" next to a GitHub issue — verify it does NOT dispatch immediately and instead shows `Dispatch` / `Cancel` buttons.
- [ ] Click `Cancel` — verify the row reverts to the "+" icon.
- [ ] Click `Dispatch` — verify the packet is created.
- [ ] Click "+" on one row, then click "+" on a different row — verify only the second row stays armed.
- [ ] Wait 5 seconds after arming a row without clicking — verify it auto-disarms back to "+".
- [ ] `npx tsc --noEmit` passes (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)