### PR TITLE
fix: /context-graph adds close affordance + stops auto-firing (#848, #869)

### DIFF
--- a/src/app/api/panel/diagnostics/run-demo/route.ts
+++ b/src/app/api/panel/diagnostics/run-demo/route.ts
@@ -6,10 +6,15 @@
  * capturing screenshots and assertions at each step.
  *
  * Auth: gated globally by src/middleware.ts on loopback origin or the panel
- * bearer token. No body required.
+ * bearer token. Body MUST include `{ confirmed: true }` — see #848. The
+ * Settings → Diagnostics "Run demo sequence" button is the only intentional
+ * caller; without the explicit confirmation flag we refuse so a stray fetch
+ * (browser back/forward refire, MCP tool, scripted poll) can never hijack
+ * the live webview by walking it through /context-graph.
  *
  * Behaviour:
  *   - 200 + { ok: true, result } when the run completes (pass or fail).
+ *   - 403 + { ok: false, error } when `confirmed !== true`.
  *   - 504 + { ok: false, error, result } when the 60s overall budget hits;
  *     `result` still contains everything we captured before timing out.
  *   - 500 + { ok: false, error } only for unrecoverable infra failures
@@ -18,6 +23,7 @@
  * Never throws — always returns a structured response.
  */
 
+import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { runDemoSequence, type DemoRunResult } from '@/lib/diagnostics/demo-sequence';
 
@@ -31,7 +37,27 @@ function jsonResponse(payload: unknown, status = 200) {
   return NextResponse.json(payload, { status, headers: NO_STORE_HEADERS });
 }
 
-export async function POST(): Promise<NextResponse> {
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  // #848 — refuse unless the caller explicitly confirms. The Settings UI is
+  // the only intentional invoker; this guard stops accidental refires
+  // (stale fetch retries, MCP scripts, etc.) from stranding the user.
+  let confirmed = false;
+  try {
+    const body = (await req.json().catch(() => ({}))) as { confirmed?: unknown };
+    confirmed = body && body.confirmed === true;
+  } catch {
+    confirmed = false;
+  }
+  if (!confirmed) {
+    return jsonResponse(
+      {
+        ok: false,
+        error: 'Demo sequence requires explicit confirmation. Open Settings → Diagnostics and click "Run demo sequence".',
+      },
+      403,
+    );
+  }
+
   try {
     const result: DemoRunResult = await runDemoSequence({ timeoutMs: OVERALL_TIMEOUT_MS });
     if (result.truncated) {

--- a/src/app/context-graph/page.tsx
+++ b/src/app/context-graph/page.tsx
@@ -24,6 +24,7 @@
  */
 
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import GraphCanvas from './GraphCanvas';
 import LeftColumn from './LeftColumn';
 import RightColumn from './RightColumn';
@@ -125,6 +126,7 @@ function ProgressBar({
 
 export default function ContextGraphPage() {
   const [counts, setCounts] = useState<SourceCounts>(FALLBACK_COUNTS);
+  const router = useRouter();
 
   useEffect(() => {
     let cancelled = false;
@@ -135,6 +137,22 @@ export default function ContextGraphPage() {
       cancelled = true;
     };
   }, []);
+
+  // #869 — back-nav affordance. Esc key returns the user to the dashboard
+  // so they're never stranded on this marketing surface, especially when
+  // navigated here by an automated demo or MCP tool.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        router.push('/dashboard');
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [router]);
 
   const totalFmt = counts.total.toLocaleString('en-US');
   const relevantFmt = counts.relevant.toLocaleString('en-US');
@@ -155,6 +173,49 @@ export default function ContextGraphPage() {
         boxSizing: 'border-box',
       }}
     >
+      {/* ─── Close affordance (#869) ─────────────────────────────── */}
+      {/* Fixed top-right; on-brand bracketed editorial link. Always visible
+          so a user (or dogfood agent) navigated here by the demo runner or
+          an MCP tool can exit back to /dashboard. Esc does the same. */}
+      <button
+        type="button"
+        onClick={() => router.push('/dashboard')}
+        aria-label="Close and return to dashboard (Esc)"
+        title="Close (Esc)"
+        style={{
+          position: 'fixed',
+          top: '24px',
+          right: '32px',
+          zIndex: 10,
+          background: 'transparent',
+          border: 'none',
+          paddingTop: '8px',
+          paddingBottom: '8px',
+          paddingLeft: '10px',
+          paddingRight: '10px',
+          margin: 0,
+          cursor: 'pointer',
+          fontFamily: FONT_MONO,
+          fontSize: '11px',
+          fontWeight: 500,
+          letterSpacing: '0.16em',
+          textTransform: 'uppercase',
+          color: 'var(--t-text-muted)',
+          lineHeight: 1,
+          minHeight: '44px',
+          display: 'inline-flex',
+          alignItems: 'center',
+        }}
+        onMouseEnter={(event) => {
+          (event.currentTarget as HTMLButtonElement).style.color = 'var(--t-text-strong)';
+        }}
+        onMouseLeave={(event) => {
+          (event.currentTarget as HTMLButtonElement).style.color = 'var(--t-text-muted)';
+        }}
+      >
+        [CLOSE]
+      </button>
+
       <main
         style={{
           maxWidth: '1240px',

--- a/src/components/desktop/settings/DemoRunSection.tsx
+++ b/src/components/desktop/settings/DemoRunSection.tsx
@@ -129,10 +129,21 @@ export function DemoRunSection({ sectionNumber }: { sectionNumber: string }) {
   const runDemo = useCallback(async () => {
     setBusy(true);
     setError(null);
+    // #848 — record an intentional opt-in just before firing. The flag is
+    // only ever set here (the explicit Settings button); any future surface
+    // that wants to launch the demo must do the same so we never auto-fire
+    // and never strand a user on /context-graph by accident.
+    try {
+      window.localStorage.setItem('o8:demo-sequence:enabled', '1');
+    } catch {
+      // localStorage unavailable (private mode, SSR) — fine, the API still
+      // requires `confirmed: true` in the body so we're covered.
+    }
     try {
       const res = await fetch('/api/panel/diagnostics/run-demo', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ confirmed: true }),
       });
       const data = await res.json().catch(() => ({})) as ApiPayload;
       if (data.result) {

--- a/src/lib/diagnostics/demo-sequence.ts
+++ b/src/lib/diagnostics/demo-sequence.ts
@@ -544,7 +544,17 @@ async function step11NavigateContextGraph(ctx: StepContext): Promise<DemoStepRes
         'context-graph route did not show "Fig. 1.1", "sources", "context", or "graph"',
       );
     }
-    return { screenshotPath, message: 'context-graph surface rendered' };
+    // #848 — never strand the user on /context-graph after the demo. Always
+    // navigate back to /dashboard so the run leaves the webview where it
+    // started. Best-effort — a navigate failure here is non-fatal because
+    // the assertion above has already passed.
+    try {
+      await ctx.client.navigate('/dashboard');
+      await sleep(300);
+    } catch {
+      // ignore — the user can hit Esc / [CLOSE] on /context-graph
+    }
+    return { screenshotPath, message: 'context-graph surface rendered; returned to /dashboard' };
   });
 }
 


### PR DESCRIPTION
## Summary

Two fixes for the `/context-graph` webview trap that ate dogfood time across five separate agents.

- **#869** — `/context-graph` now has a fixed top-right `[CLOSE]` link (Swiss-editorial brackets, Plus Jakarta mono per DESIGN.md) and an Esc keydown handler. Both call `router.push('/dashboard')` so a user navigated here by the demo runner or any MCP tool is never stranded.
- **#848** — `POST /api/panel/diagnostics/run-demo` now requires `{ confirmed: true }` in the body. The Settings → Diagnostics "Run demo sequence" button is the only intentional caller; it sends the flag and also writes `o8:demo-sequence:enabled` to localStorage as a paper trail. Stray fetches, MCP scripts, and back/forward refires get a 403 instead of hijacking the webview. Step 11 of the runner now navigates back to `/dashboard` after the assertion so even a successful run leaves the user where they started.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] `curl localhost:3001/context-graph` returns 200 (verified locally)
- [ ] Open the installed app to dashboard → verify `/context-graph` does not auto-fire
- [ ] Manually navigate to `/context-graph` → `[CLOSE]` is visible top-right; click returns to `/dashboard`
- [ ] On `/context-graph`, press Esc → returns to `/dashboard`
- [ ] Settings → Diagnostics → "Run demo sequence" still works end-to-end and ends back on `/dashboard`
- [ ] `curl -X POST localhost:3001/api/panel/diagnostics/run-demo` (no body) returns 403

Fixes #848
Fixes #869