### PR TITLE
fix: theme tokens for scope chip + sticky header (#842, #862)

### DIFF
--- a/src/components/desktop/thoughts/mission-panel/StatusGroupedLanes.tsx
+++ b/src/components/desktop/thoughts/mission-panel/StatusGroupedLanes.tsx
@@ -128,7 +128,7 @@ export function StatusGroupedLanes({ packets, renderPacket }: StatusGroupedLanes
                 paddingBottom: 0,
                 paddingLeft: 8,
                 border: 'none',
-                background: 'transparent',
+                background: 'var(--t-panel)',
                 cursor: 'pointer',
                 position: 'sticky',
                 top: 0,

--- a/src/components/desktop/thoughts/mission-panel/StatusGroupedLanes.tsx
+++ b/src/components/desktop/thoughts/mission-panel/StatusGroupedLanes.tsx
@@ -128,7 +128,12 @@ export function StatusGroupedLanes({ packets, renderPacket }: StatusGroupedLanes
                 paddingBottom: 0,
                 paddingLeft: 8,
                 border: 'none',
-                background: 'var(--t-panel)',
+                // #862 — keep glass tint, but blur scrolling content beneath the
+                // sticky header so packet text doesn't bleed through. Pattern
+                // mirrors SessionTimeline.tsx (chrome bar over vibrancy).
+                background: 'var(--t-bg-card)',
+                backdropFilter: 'blur(12px)',
+                WebkitBackdropFilter: 'blur(12px)',
                 cursor: 'pointer',
                 position: 'sticky',
                 top: 0,

--- a/src/components/desktop/thoughts/recall-card/DirectiveRow.tsx
+++ b/src/components/desktop/thoughts/recall-card/DirectiveRow.tsx
@@ -136,10 +136,10 @@ export function DirectiveRow({
               borderRadius: 6,
               background:
                 topDirective.scope === 'global'
-                  ? 'rgba(37, 99, 235, 0.10)'
-                  : 'rgba(148, 163, 184, 0.12)',
+                  ? 'var(--t-accent-soft)'
+                  : 'var(--t-divider-strong)',
               color:
-                topDirective.scope === 'global' ? '#2563eb' : 'var(--t-text-muted)',
+                topDirective.scope === 'global' ? 'var(--t-accent)' : 'var(--t-text-muted)',
             }}
           >
             {topDirective.scope}
@@ -183,7 +183,7 @@ export function DirectiveRow({
                       height: 4,
                       borderRadius: '50%',
                       background:
-                        d.scope === 'global' ? '#2563eb' : 'var(--t-text-faint)',
+                        d.scope === 'global' ? 'var(--t-accent)' : 'var(--t-text-faint)',
                       flexShrink: 0,
                     }}
                   />


### PR DESCRIPTION
## Summary
- **#842 DirectiveRow scope chip** (content surface): replace hardcoded `rgba(37,99,235,0.10)` / `rgba(148,163,184,0.12)` / `#2563eb` with `var(--t-accent-soft)` / `var(--t-divider-strong)` / `var(--t-accent)`. Same swap on the expanded directive list dot. Restores correct glass tint in midnight without the opaque-blob regression.
- **#862 sticky group header** (chrome surface): preserve the intentional glass transparency over macOS vibrancy. Instead of a solid bg, use the SessionTimeline pattern — low-alpha `var(--t-bg-card)` + `backdropFilter: blur(12px)` (with `WebkitBackdropFilter`). Scrolling packet content gets blurred beneath the IN REVIEW / BACKLOG / DONE labels rather than bled through.

## Transparency preservation
Per the glass-transparency rule (`feedback_glass_transparency.md`): chrome surfaces over macOS vibrancy must keep their low-opacity rgba tint, never get replaced with solid palette tokens. First pass on #862 used `var(--t-panel)` which would have collapsed the glass — reverted in second commit and switched to `backdropFilter` blur, matching the existing `SessionTimeline.tsx:389` pattern. The DirectiveRow chip is a content-surface chip (not chrome), so a token swap is correct there.

## Test plan
- [ ] Light theme: scope chip renders as soft blue/grey on white workspace, no opaque blob
- [ ] Midnight theme: scope chip renders as soft blue/grey on dark glass, no opaque blob
- [ ] Mission panel: scroll past 5+ packets across status groups; sticky `IN REVIEW · N` / `BACKLOG · N` headers stay glass-tinted with blurred (not bled) content beneath
- [ ] `npx tsc --noEmit` passes (verified locally — clean)

Fixes #842
Fixes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)