### PR TITLE
fix: chip placement + fetch-storm guard (#845, #847)

### DIFF
--- a/src/components/desktop/thoughts/chat-panel/ChatMessageList.tsx
+++ b/src/components/desktop/thoughts/chat-panel/ChatMessageList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { forwardRef } from 'react';
+import { Fragment, forwardRef } from 'react';
 import { DesktopAgentMessage } from '../../DesktopAgentMessage';
 import { SuggestedReplies } from '../SuggestedReplies';
 import type { MobileTranscriptEntry } from '@/lib/mobile/types';
@@ -58,6 +58,16 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
     && onSelectSuggestion
     && onDismissSuggestions,
   );
+  // #845 — chips must render directly under the assistant message they belong
+  // to (not at the list tail). Find the index of the LAST assistant entry; the
+  // map below renders the chip row right after that bubble.
+  let lastAssistantIndex = -1;
+  for (let i = displayMessages.length - 1; i >= 0; i -= 1) {
+    if (displayMessages[i]?.role === 'assistant') {
+      lastAssistantIndex = i;
+      break;
+    }
+  }
   const showEmptyWithOverride = displayMessages.length === 0 && !displayWaiting && emptyStateOverride;
   const showEmptyWithFallback = displayMessages.length === 0 && !displayWaiting && !emptyStateOverride;
   const isCompacting = displayWaiting && displayMessages.length > 0 &&
@@ -87,23 +97,32 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
 
       {topContent}
 
-      {displayMessages.map((msg, index) => (
-        <DesktopAgentMessage
-          key={msg.id}
-          entry={msg}
-          isLast={index === displayMessages.length - 1 && !displayWaiting}
-          repoPath={repoPath}
-        />
-      ))}
-
-      {hasSuggestedReplies && suggestedReplies && onSelectSuggestion && onDismissSuggestions ? (
-        <SuggestedReplies
-          chips={suggestedReplies}
-          disabled={displayWaiting}
-          onSelect={onSelectSuggestion}
-          onDismiss={onDismissSuggestions}
-        />
-      ) : null}
+      {displayMessages.map((msg, index) => {
+        const isLatestAssistant = index === lastAssistantIndex;
+        const showChipsHere = isLatestAssistant
+          && hasSuggestedReplies
+          && msg.id === suggestedReplyMessageId
+          && suggestedReplies
+          && onSelectSuggestion
+          && onDismissSuggestions;
+        return (
+          <Fragment key={msg.id}>
+            <DesktopAgentMessage
+              entry={msg}
+              isLast={index === displayMessages.length - 1 && !displayWaiting}
+              repoPath={repoPath}
+            />
+            {showChipsHere ? (
+              <SuggestedReplies
+                chips={suggestedReplies}
+                disabled={displayWaiting}
+                onSelect={onSelectSuggestion}
+                onDismiss={onDismissSuggestions}
+              />
+            ) : null}
+          </Fragment>
+        );
+      })}
 
       {isCompacting ? (
         <div style={{

--- a/src/components/desktop/thoughts/chat-panel/useSuggestedReplies.ts
+++ b/src/components/desktop/thoughts/chat-panel/useSuggestedReplies.ts
@@ -27,6 +27,11 @@ interface SuggestionsResponse {
 
 const MAX_CONTEXT_TURNS = 4;
 const MIN_ASSISTANT_LEN = 12;
+// #847 — when the suggestions endpoint fails (network error or non-OK status),
+// back off for this window before retrying. Without this, every dependency
+// change (scroll, resize, upstream state update) re-fires the fetch and
+// produces a network storm against a known-broken endpoint.
+const ERROR_COOLDOWN_MS = 10_000;
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((s) => typeof s === 'string');
@@ -37,6 +42,13 @@ export function useSuggestedReplies({ enabled, messages, isStreaming }: UseSugge
   const [dismissedMessages, setDismissedMessages] = useState<Set<string>>(new Set());
   const inflightRef = useRef<Set<string>>(new Set());
   const abortRef = useRef<AbortController | null>(null);
+  // #847 — per-message cooldown timestamps (millis). When set, the effect
+  // skips that message id until Date.now() exceeds the timestamp. Stored as
+  // a ref + a tick state so a setTimeout can wake the effect when the window
+  // elapses without binding the effect to wall-clock changes.
+  const errorCooldownRef = useRef<Map<string, number>>(new Map());
+  const cooldownTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [cooldownTick, setCooldownTick] = useState(0);
 
   // Identify the last assistant message; that's the only one we ever attach
   // chips to. Chips on older assistant messages aren't useful and would be
@@ -58,6 +70,22 @@ export function useSuggestedReplies({ enabled, messages, isStreaming }: UseSugge
     if (chipsByMessage.has(lastAssistantId)) return;
     if (dismissedMessages.has(lastAssistantId)) return;
     if (inflightRef.current.has(lastAssistantId)) return;
+    // #847 — respect error cooldown. If a previous fetch failed within
+    // ERROR_COOLDOWN_MS, schedule a wake-up tick at the cooldown's end and
+    // bail. Subsequent dependency changes will re-evaluate; without the
+    // wake-up the effect would never retry on its own once deps stop
+    // changing.
+    const cooldownUntil = errorCooldownRef.current.get(lastAssistantId);
+    if (cooldownUntil && Date.now() < cooldownUntil) {
+      if (cooldownTimerRef.current === null) {
+        const remaining = Math.max(0, cooldownUntil - Date.now());
+        cooldownTimerRef.current = setTimeout(() => {
+          cooldownTimerRef.current = null;
+          setCooldownTick((tick) => tick + 1);
+        }, remaining + 25);
+      }
+      return;
+    }
 
     const target = messages.find((m) => m.id === lastAssistantId);
     if (!target) return;
@@ -93,18 +121,29 @@ export function useSuggestedReplies({ enabled, messages, isStreaming }: UseSugge
           }),
           signal: controller.signal,
         });
-        if (!res.ok) return;
+        if (!res.ok) {
+          // #847 — non-OK status (e.g. 500 from #844 thinking-budget starvation)
+          // arms the cooldown so we don't fetch-storm against a broken endpoint.
+          errorCooldownRef.current.set(lastAssistantId, Date.now() + ERROR_COOLDOWN_MS);
+          return;
+        }
         const data = await res.json() as SuggestionsResponse;
         const suggestions = isStringArray(data.suggestions) ? data.suggestions : [];
+        // Successful fetch — clear any prior cooldown for this message id.
+        errorCooldownRef.current.delete(lastAssistantId);
         setChipsByMessage((prev) => {
           const next = new Map(prev);
           next.set(lastAssistantId, suggestions);
           return next;
         });
-      } catch {
-        // Network/abort — leave the cache empty so we may retry on next render
-        // if the message is still the last one. inflight cleanup below ensures
-        // we don't permanently block.
+      } catch (err) {
+        // #847 — distinguish abort from real failures. Aborts happen when the
+        // last-assistant id changes mid-flight; those should stay retryable.
+        // Real network errors arm the cooldown.
+        const isAbort = err instanceof DOMException && err.name === 'AbortError';
+        if (!isAbort) {
+          errorCooldownRef.current.set(lastAssistantId, Date.now() + ERROR_COOLDOWN_MS);
+        }
       } finally {
         inflightRef.current.delete(lastAssistantId);
       }
@@ -113,7 +152,7 @@ export function useSuggestedReplies({ enabled, messages, isStreaming }: UseSugge
     return () => {
       controller.abort();
     };
-  }, [chipsByMessage, dismissedMessages, enabled, isStreaming, lastAssistantId, messages]);
+  }, [chipsByMessage, dismissedMessages, enabled, isStreaming, lastAssistantId, messages, cooldownTick]);
 
   // When messages collapse to nothing (e.g. reset/clear), drop caches so a new
   // thread starts clean.
@@ -122,8 +161,23 @@ export function useSuggestedReplies({ enabled, messages, isStreaming }: UseSugge
       setChipsByMessage((prev) => (prev.size === 0 ? prev : new Map()));
       setDismissedMessages((prev) => (prev.size === 0 ? prev : new Set()));
       inflightRef.current.clear();
+      errorCooldownRef.current.clear();
+      if (cooldownTimerRef.current !== null) {
+        clearTimeout(cooldownTimerRef.current);
+        cooldownTimerRef.current = null;
+      }
     }
   }, [messages.length]);
+
+  // Cleanup any pending cooldown timer when the hook unmounts.
+  useEffect(() => {
+    return () => {
+      if (cooldownTimerRef.current !== null) {
+        clearTimeout(cooldownTimerRef.current);
+        cooldownTimerRef.current = null;
+      }
+    };
+  }, []);
 
   const chipsForLastAssistant = useMemo(() => {
     if (!enabled || !lastAssistantId) return [];


### PR DESCRIPTION
## Summary

Two suggested-reply chips polish fixes unblocked by the #844 thinking-budget merge.

- **#845** — chips were rendering once at the END of the entire message list, breaking spatial association on long threads. Now rendered inline inside the map loop, immediately after the LATEST assistant message bubble. `Fragment` wraps each (msg, optional chip row) pair.
- **#847** — `useSuggestedReplies` would re-fire fetches on every dependency change (scroll, resize, upstream state) when the endpoint returned errors. Now arms a 10s per-message error cooldown on non-OK status or real network failure (aborts stay retryable so a new last-assistant id can still trigger immediately). A `setTimeout`-driven `cooldownTick` wakes the effect when the window elapses so retries still happen, just bounded.

Fixes #845
Fixes #847

## Test plan

- [ ] Long thread (10+ turns) — chips appear under the LAST assistant bubble even when scrolled away from the tail.
- [ ] Force `/api/v2/chat/suggestions` to return 500 — DevTools network tab shows ONE request, then a 10s gap, then ONE retry. No tight loop.
- [ ] Successful response after a prior error clears the cooldown for that message id.
- [ ] Aborts (last-assistant id changes mid-flight) do NOT arm the cooldown.
- [ ] `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)