### PR TITLE
fix: reset/rerun packets land in Backlog not In Progress (#865)

### DIFF
--- a/src/components/desktop/thoughts/mission-panel/groupPackets.ts
+++ b/src/components/desktop/thoughts/mission-panel/groupPackets.ts
@@ -49,12 +49,16 @@ export const PACKET_GROUP_ORDER: readonly PacketGroupDef[] = [
  *   already labels this state "Completed", which we surface as Done.
  * - In Review — `status === 'awaiting_review'`. The packet has a worktree
  *   diff waiting on the human merge gate.
- * - Backlog — `queueState === 'draft'` AND no lane binding yet. These are
- *   packets the operator has scoped but not dispatched.
- * - In Progress — everything live: queued/launching/running/idle (lane
- *   spawned) + recovering/failed/blocked. Failed/blocked stay visible at
- *   the top because the operator needs to act on them, not because the
- *   work is "in progress" in the strict sense.
+ * - Backlog — `status === 'draft' | 'queued'` AND no real lane binding
+ *   (`lane.laneId` empty). Covers the freshly-scoped case AND the
+ *   reset / rerun-with-feedback case (#865), where resetPacket leaves
+ *   status='draft' + queueState='queued' + lane=null and the reconciler
+ *   may then promote status to 'queued'. The operator's mental model:
+ *   "I reset it; it's waiting to run" = backlog.
+ * - In Progress — every live runtime status: launching/idle/running/
+ *   recovering/failed/blocked. Failed/blocked stay visible at the top
+ *   because the operator needs to act on them, not because the work is
+ *   "in progress" in the strict sense.
  *
  * Cancelled is currently never assigned — packets don't carry a
  * `cancelled` status today, and the issue (#772) said "No new data model".
@@ -72,7 +76,10 @@ export function classifyPacketGroup(packet: OrchestratorPacket): PacketGroupId {
   if (packet.status === 'awaiting_review') {
     return 'in_review';
   }
-  if (packet.queueState === 'draft' && !packet.lane?.laneId) {
+  // #865 — reset/rerun-with-feedback packets carry status='draft' (or
+  // 'queued' once the reconciler runs) with lane=null. Treat both as
+  // backlog so the operator sees "waiting to run" not "in progress".
+  if ((packet.status === 'draft' || packet.status === 'queued') && !packet.lane?.laneId) {
     return 'backlog';
   }
   return 'in_progress';


### PR DESCRIPTION
## Summary

After `resetPacket` / `rerunWithFeedback`, a packet carries `status='draft'` (or `'queued'` once the reconciler runs at `src/lib/orchestrator/store.ts:835`) with `queueState='queued'` and `lane=null`. The Mission panel grouping classifier in `groupPackets.ts` was keyed off `queueState === 'draft'`, so reset/rerun packets fell through to **In Progress** even though they had no live lane and were waiting on the next dispatch tick.

Switch classification to `status === 'draft' | 'queued'` AND no real `lane.laneId`. Matches the operator's mental model: "I reset it; it's waiting to run" = backlog. Existing fresh-scoped drafts still land in backlog because the reconciler keeps `status='draft'` when `queueState='draft'`.

Single-file change to the pure classifier in `src/components/desktop/thoughts/mission-panel/groupPackets.ts`. No data-layer changes.

Fixes #865

## Test plan
- [x] Smoke-test the classifier across reset, rerun-with-feedback, fresh-scoped, released, archived, awaiting_review, running, launching, recovering, failed, blocked, idle-with-bound-lane, and queued-with-bound-lane cases — all PASS.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: in Mission panel, reset a running packet via packet card menu → reload → verify packet appears in BACKLOG, not IN PROGRESS.
- [ ] Manual: rerun-with-feedback after rejecting a diff → verify packet appears in BACKLOG until the dispatch tick relaunches it (then promotes to IN PROGRESS via lane.laneId).

🤖 Generated with [Claude Code](https://claude.com/claude-code)