### PR TITLE
fix: Spec-Update parsing, live outcomesCount, packet_transcript binding race (#843, #837, #846)

### DIFF
--- a/src/app/api/cortex/diagnostics/route.ts
+++ b/src/app/api/cortex/diagnostics/route.ts
@@ -57,9 +57,20 @@ function countOutcomes(): number {
     // Drizzle's COUNT helper has historically been finicky against the
     // boolean column on older sqlite builds (#747). Drop down to raw SQL
     // for the headline counter — it's the cheapest possible query.
+    //
+    // #837 — only count LIVE outcomes. Decayed rows (`valid_to` past now)
+    // were inflating the count above the 5,000-row eval threshold
+    // prematurely and tripping the substrate-eval gate on data that no
+    // longer participates in recall. Mirrors `liveOutcomeFilter()` in
+    // `src/lib/cortex/decay.ts` (raw SQL form because this route uses
+    // raw sqlite, not Drizzle, for the headline counter).
     const sqlite = getSqlite();
     if (!sqlite || typeof sqlite.prepare !== 'function') return 0;
-    const row = sqlite.prepare('SELECT COUNT(*) AS n FROM session_outcomes').get() as { n?: number } | undefined;
+    const row = sqlite
+      .prepare(
+        "SELECT COUNT(*) AS n FROM session_outcomes WHERE valid_to IS NULL OR valid_to > datetime('now')",
+      )
+      .get() as { n?: number } | undefined;
     return typeof row?.n === 'number' ? row.n : 0;
   } catch (error) {
     console.warn('[cortex-diagnostics] outcomes count failed:', error instanceof Error ? error.message : error);

--- a/src/app/api/orchestrator/packet-transcript/route.ts
+++ b/src/app/api/orchestrator/packet-transcript/route.ts
@@ -3,6 +3,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { requirePanelAuth } from '@/lib/panel/auth';
 import { getCodexRolloutPath } from '@/lib/codex/sessions';
 import { getOwnedCodexTelemetrySources } from '@/lib/codex/owned';
+import { listLanes } from '@/lib/lane/registry';
 import { readOrchestratorControlPlaneState } from '@/lib/orchestrator/control-plane';
 import { normalizeCodexEvents, type TranscriptEvent } from '@/lib/orchestrator/transcript-normalizer';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
@@ -38,6 +39,24 @@ function findPacket(packetId: string): OrchestratorPacket | null {
   try {
     const mission = readOrchestratorControlPlaneState();
     return mission.packets.find((packet) => packet.id === packetId) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * #846 — Lane-registry fallback for the binding race.
+ *
+ * When a packet completes fast (small dispatches finish before mission
+ * state catches up), `packet.lane` may be null in the control-plane state
+ * by the time MCP reads it back, even though the lane registry already has
+ * the sessionKey recorded. Look it up by packetId across ALL lanes
+ * (including completed/archived) so the transcript stays reachable.
+ */
+function resolveSessionKeyFromLaneRegistry(packetId: string): string | null {
+  try {
+    const lane = listLanes().find((candidate) => candidate.packetId === packetId);
+    return lane?.sessionKey?.trim() || null;
   } catch {
     return null;
   }
@@ -120,9 +139,14 @@ export async function GET(request: NextRequest) {
 
   try {
     const packet = findPacket(packetId);
-    const sessionKey = packet?.lane?.sessionKey?.trim() ?? '';
+    // #846 — Fall back to the lane registry when the mission-state binding
+    // got stripped (fast-completing packets race the control-plane writer).
+    // The lane registry retains `packetId → sessionKey` even after the lane
+    // archives, so the transcript remains reachable.
+    const packetSessionKey = packet?.lane?.sessionKey?.trim() ?? '';
+    const sessionKey = packetSessionKey || resolveSessionKeyFromLaneRegistry(packetId);
 
-    if (!packet) {
+    if (!packet && !sessionKey) {
       return NextResponse.json(
         { events: [], nextCursor: null, note: 'packet_not_found' },
         { headers: { 'Cache-Control': 'no-store, max-age=0' } },

--- a/src/lib/cortex/directive-merges.ts
+++ b/src/lib/cortex/directive-merges.ts
@@ -51,6 +51,8 @@ export interface DirectiveTrailerEntry {
 
 interface DirectiveMeta {
   id: string;
+  /** Optional `title:` from front matter — used for `Spec-Update:` matching by title (#843). */
+  title: string | null;
   scope: string;
   repoName: string | null;
   history: boolean;
@@ -68,6 +70,7 @@ interface ParsedDirective {
 function parseFrontMatter(text: string, fallbackId: string): DirectiveMeta {
   const result: DirectiveMeta = {
     id: fallbackId,
+    title: null,
     scope: 'global',
     repoName: null,
     history: true,
@@ -87,6 +90,7 @@ function parseFrontMatter(text: string, fallbackId: string): DirectiveMeta {
     const value = line.slice(idx + 1).trim();
     if (!key) continue;
     if (key === 'id') result.id = value || fallbackId;
+    else if (key === 'title') result.title = value || null;
     else if (key === 'scope') result.scope = value || 'global';
     else if (key === 'repoName') result.repoName = value || null;
     else if (key === 'history') {
@@ -99,6 +103,58 @@ function parseFrontMatter(text: string, fallbackId: string): DirectiveMeta {
   }
 
   return result;
+}
+
+/**
+ * #843 — Parse `Spec-Update: <directive-name>` lines out of a commit message
+ * so callers can target a single directive instead of blanket-appending.
+ *
+ * Convention (documented for future contributors):
+ *   - One trailer per line, anywhere in the commit message body.
+ *   - Format: `Spec-Update: <name>` where `<name>` matches a directive's
+ *     `title` from its front matter, OR its filename (with or without `.md`),
+ *     OR its `id`. Matching is case-insensitive and trims whitespace.
+ *   - Multiple `Spec-Update:` lines append to each named directive in turn.
+ *   - When no `Spec-Update:` line is present, the trailer falls back to the
+ *     existing blanket-append behavior — every directive whose scope matches
+ *     the merging repo gets the line.
+ *
+ * Returns the lower-cased target names. An empty array means "blanket
+ * append" — no targeting requested.
+ */
+export function parseSpecUpdateTargets(commitMessage: string | null | undefined): string[] {
+  if (!commitMessage) return [];
+  const targets: string[] = [];
+  for (const rawLine of commitMessage.split(/\r?\n/)) {
+    const match = /^\s*Spec-Update:\s*(.+?)\s*$/i.exec(rawLine);
+    if (!match) continue;
+    const name = match[1].trim();
+    if (!name) continue;
+    targets.push(name.toLowerCase());
+  }
+  return targets;
+}
+
+/**
+ * #843 — Does this directive match any of the requested `Spec-Update:`
+ * targets? Returns true when targets is empty (no targeting → blanket).
+ * Match keys: title, filename (with/without `.md`), and id — all
+ * case-insensitive.
+ */
+function matchesSpecUpdateTargets(
+  meta: DirectiveMeta,
+  fileName: string,
+  targets: string[],
+): boolean {
+  if (targets.length === 0) return true;
+  const candidates = new Set<string>();
+  if (meta.id) candidates.add(meta.id.toLowerCase());
+  if (meta.title) candidates.add(meta.title.toLowerCase());
+  if (fileName) {
+    candidates.add(fileName.toLowerCase());
+    candidates.add(fileName.replace(/\.md$/i, '').toLowerCase());
+  }
+  return targets.some((target) => candidates.has(target));
 }
 
 function splitOnRecentMerges(text: string): { before: string; section: string | null } {
@@ -169,13 +225,19 @@ function listDirectiveFiles(): { name: string; path: string }[] {
  * Append a trailer entry to every directive matching the repo. Returns the
  * list of directive ids that were updated so callers can log + surface
  * the touch in telemetry. Never throws — per-file errors are logged.
+ *
+ * #843 — Optional `commitMessage` lets callers narrow the trailer to a
+ * specific directive via `Spec-Update: <name>` lines in the commit body.
+ * See `parseSpecUpdateTargets()` for the convention.
  */
 export function appendDirectiveTrailer({
   repoPath,
   entry,
+  commitMessage,
 }: {
   repoPath: string;
   entry: DirectiveTrailerEntry;
+  commitMessage?: string | null;
 }): string[] {
   if (!repoPath?.trim()) return [];
   const updated: string[] = [];
@@ -184,6 +246,7 @@ export function appendDirectiveTrailer({
   if (files.length === 0) return [];
 
   const newLine = formatTrailerLine(entry);
+  const specUpdateTargets = parseSpecUpdateTargets(commitMessage);
 
   for (const file of files) {
     try {
@@ -192,6 +255,7 @@ export function appendDirectiveTrailer({
       const parsed = parseDirective(raw, fallbackId);
       if (!parsed.meta.history) continue;
       if (!matchesRepoScope(parsed.meta, repoPath)) continue;
+      if (!matchesSpecUpdateTargets(parsed.meta, file.name, specUpdateTargets)) continue;
 
       // #841 — idempotency. If the exact same trailer line is already
       // present, skip the write so internal merges + the external-merge

--- a/src/lib/cortex/external-merge-watcher.ts
+++ b/src/lib/cortex/external-merge-watcher.ts
@@ -65,6 +65,8 @@ interface ParsedMerge {
   date: string;
   title: string;
   issueNumber: number | null;
+  /** #843 — Full commit message (subject + body) so `Spec-Update:` lines reach `appendDirectiveTrailer`. */
+  commitMessage: string;
 }
 
 function logInfo(msg: string, ...rest: unknown[]) {
@@ -140,7 +142,9 @@ async function readRecentMerges(
         ref,
         `--max-count=${limit}`,
         // Use the byte 0x1e (record separator) between commits and 0x00 between fields.
-        '--format=%H%x00%cI%x00%s%x1e',
+        // `%B` is the full commit message (subject + body) — needed so `Spec-Update:`
+        // lines (#843) can be parsed by `appendDirectiveTrailer`.
+        '--format=%H%x00%cI%x00%s%x00%B%x1e',
       ],
       {
         maxBuffer: 1024 * 1024,
@@ -153,9 +157,9 @@ async function readRecentMerges(
     for (const record of records) {
       const parts = record.split('\x00');
       if (parts.length < 3) continue;
-      const [sha, isoDate, subject] = parts;
+      const [sha, isoDate, subject, body] = parts;
       if (!sha || !isoDate || !subject) continue;
-      merges.push(parseMerge(sha, isoDate, subject));
+      merges.push(parseMerge(sha, isoDate, subject, body ?? ''));
     }
     return merges;
   } catch (error) {
@@ -172,7 +176,7 @@ async function readRecentMerges(
  * `appendDirectiveTrailer` renders the trailer with the format
  * `<title> (#N)` once instead of duplicating the issue number.
  */
-function parseMerge(sha: string, isoDate: string, subject: string): ParsedMerge {
+function parseMerge(sha: string, isoDate: string, subject: string, body: string): ParsedMerge {
   const trailing = SUBJECT_TRAILING_REF_RE.exec(subject);
   if (trailing) {
     const number = Number.parseInt(trailing[1], 10);
@@ -181,6 +185,7 @@ function parseMerge(sha: string, isoDate: string, subject: string): ParsedMerge 
       date: isoDate.slice(0, 10),
       title: subject.replace(SUBJECT_TRAILING_REF_RE, '').trim(),
       issueNumber: Number.isFinite(number) ? number : null,
+      commitMessage: body,
     };
   }
 
@@ -192,6 +197,7 @@ function parseMerge(sha: string, isoDate: string, subject: string): ParsedMerge 
       date: isoDate.slice(0, 10),
       title: subject.replace(LEADING_MERGE_REF_RE, '').trim(),
       issueNumber: Number.isFinite(number) ? number : null,
+      commitMessage: body,
     };
   }
 
@@ -200,6 +206,7 @@ function parseMerge(sha: string, isoDate: string, subject: string): ParsedMerge 
     date: isoDate.slice(0, 10),
     title: subject.trim(),
     issueNumber: null,
+    commitMessage: body,
   };
 }
 
@@ -277,6 +284,9 @@ export async function ingestExternalMerges(): Promise<{
               title: merge.title,
               issueNumber: merge.issueNumber,
             },
+            // #843 — Forward the full commit message so any
+            // `Spec-Update: <name>` lines target a single directive.
+            commitMessage: merge.commitMessage,
           });
           updatedHere += updated.length;
         } catch (error) {

--- a/src/lib/orchestrator/operator-mission-service/merge.ts
+++ b/src/lib/orchestrator/operator-mission-service/merge.ts
@@ -217,6 +217,10 @@ async function dispatchPacketMerge(
             title: packet.title,
             issueNumber: packet.issue?.number ?? null,
           },
+          // #843 — Pass the merge commit message through so any
+          // `Spec-Update: <directive-name>` lines in the body narrow the
+          // trailer to a specific directive instead of blanket-appending.
+          commitMessage: input.commitMessage ?? null,
         });
         if (updated.length > 0) {
           console.log(


### PR DESCRIPTION
## Summary

Three follow-up bugs from the Context Engine v2 dogfood audit, bundled because they touch different files in the same area.

- **#843** — Parse `Spec-Update: <directive-name>` lines out of merge commit messages so trailers can target a specific directive instead of blanket-appending. Wired through both the internal merge path (`operator-mission-service/merge.ts`) and the external-merge watcher (#841). Match is case-insensitive against the directive's `title`, filename (with or without `.md`), or `id`. Multiple `Spec-Update:` lines append to each named directive. The convention is documented on `parseSpecUpdateTargets()` so future contributors can find it.
- **#837** — Diagnostics `outcomesCount` was counting decayed rows, which inflated the count above the 5,000-row substrate-eval threshold prematurely. The route uses raw sqlite (not Drizzle) for the headline counter, so the live filter is inlined as `WHERE valid_to IS NULL OR valid_to > datetime('now')` — same shape as `liveOutcomeFilter()` in `lib/cortex/decay.ts`.
- **#846** — `o8_packet_transcript` returned `no_session_binding` on fast-completing packets because mission state stripped `packet.lane` before MCP read it back, while the lane registry still had the `packetId → sessionKey` mapping. Added a fallback in the route handler that does `listLanes().find(l => l.packetId === packetId)` when the mission-state binding is missing. Lane registry retains the binding across `completed` and `archived` statuses, so transcripts stay reachable.

Fixes #843
Fixes #837
Fixes #846

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] `Spec-Update: <name>` in a merge commit narrows the trailer to that single directive (manual: merge a PR with `Spec-Update: 800-line ceiling` in the body, confirm only that directive's `## Recent Merges` section grows)
- [ ] Diagnostics tab: verify `outcomesCount` shrinks after a decay sweep instead of staying inflated
- [ ] `o8_packet_transcript` succeeds for a packet that has just finished and lost its mission-state lane binding

🤖 Generated with [Claude Code](https://claude.com/claude-code)