### PR TITLE
fix: countOutcomes alignment + periodic valid_from backfill (#745 phase 2 follow-ups)

### DIFF
--- a/src/app/api/cortex/diagnostics/route.ts
+++ b/src/app/api/cortex/diagnostics/route.ts
@@ -64,11 +64,18 @@ function countOutcomes(): number {
     // longer participates in recall. Mirrors `liveOutcomeFilter()` in
     // `src/lib/cortex/decay.ts` (raw SQL form because this route uses
     // raw sqlite, not Drizzle, for the headline counter).
+    //
+    // #745 phase 2 — also require `valid_from IS NOT NULL` so this raw
+    // SQL matches `liveOutcomeFilter()` exactly. A row inserted with
+    // NULL `valid_from` between boots (e.g. another agent's raw INSERT
+    // after the o8 process started) would otherwise count as "live"
+    // here but be excluded from recall, silently inflating the
+    // substrate-eval gate.
     const sqlite = getSqlite();
     if (!sqlite || typeof sqlite.prepare !== 'function') return 0;
     const row = sqlite
       .prepare(
-        "SELECT COUNT(*) AS n FROM session_outcomes WHERE valid_to IS NULL OR valid_to > datetime('now')",
+        "SELECT COUNT(*) AS n FROM session_outcomes WHERE valid_from IS NOT NULL AND (valid_to IS NULL OR valid_to > datetime('now'))",
       )
       .get() as { n?: number } | undefined;
     return typeof row?.n === 'number' ? row.n : 0;

--- a/src/lib/cortex/decay.ts
+++ b/src/lib/cortex/decay.ts
@@ -28,7 +28,7 @@ import 'server-only';
 
 import { and, eq, isNotNull, isNull, or, sql } from 'drizzle-orm';
 
-import { getDb, sessionOutcomes } from '@/lib/db';
+import { getDb, runSessionOutcomeValidFromBackfill, sessionOutcomes } from '@/lib/db';
 
 const DEFAULT_TTL_DAYS = 30;
 const DECAY_TICK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6h
@@ -85,6 +85,14 @@ export async function decayOutcomes(
   if (!db) {
     return { decayed: 0, scanned: 0, skipped: true };
   }
+
+  // #745 phase 2 — step 0: backfill any rows whose `valid_from` got inserted
+  // as NULL by raw SQL between boots (legacy seeds, parallel-agent inserts).
+  // The boot-time backfill in `ensureIdempotentColumnAdds()` only fires on
+  // the first `getDb()` call per process, so a long-running Next server
+  // would otherwise carry stray NULLs until the next restart. Doing this
+  // before the age-out sweep guarantees the sweep sees a complete window.
+  runSessionOutcomeValidFromBackfill();
 
   try {
     // Count live rows for telemetry. Cheap because of `idx_so_valid_to`.

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -693,6 +693,37 @@ function backfillSessionOutcomeValidFrom(sqlite: Database.Database): void {
   }
 }
 
+/**
+ * #745 phase 2 — public entry point for the periodic backfill tick.
+ *
+ * The boot-time backfill in `ensureIdempotentColumnAdds()` only fires when
+ * `getDb()` is first called per process. Long-running processes that get a
+ * raw NULL-`valid_from` row inserted by another agent between boots leak the
+ * row as "live but unbackfilled" until the next process restart. The decay
+ * sweep does compensate via COALESCE in its WHERE clause, but recall paths
+ * that gate on `valid_from IS NOT NULL` (see `liveOutcomeFilter()`) still
+ * exclude these rows from results — and now `countOutcomes()` matches that
+ * exclusion too.
+ *
+ * The decay tick (every 6h) calls this as step 0 so any stray NULL gets
+ * stamped before the same tick runs the age-out sweep.
+ */
+export function runSessionOutcomeValidFromBackfill(): void {
+  if (!_sqlite) {
+    // No DB connection yet — nothing to backfill. The first `getDb()` call
+    // will run the boot-time backfill anyway.
+    return;
+  }
+  try {
+    backfillSessionOutcomeValidFrom(_sqlite);
+  } catch (error) {
+    console.warn(
+      '[db] periodic valid_from backfill failed:',
+      error instanceof Error ? error.message : error,
+    );
+  }
+}
+
 function backfillWatchedAgentColumns(sqlite: Database.Database): void {
   const result = sqlite.prepare(`
     UPDATE watched_agents


### PR DESCRIPTION
## Summary

Two Phase-2-discovered polish bugs in the temporal validity windows feature ([#745](https://github.com/hurttlocker/cortex-ide/issues/745)), flagged in the [Context Engine v2 Phase 2 audit](/tmp/context-engine-dogfood-phase2.md) honorable-mentions list.

### Bug 1 — `countOutcomes()` / `liveOutcomeFilter()` divergence

`countOutcomes()` in `src/app/api/cortex/diagnostics/route.ts` excluded by `valid_to` only:

```sql
WHERE valid_to IS NULL OR valid_to > datetime('now')
```

while `liveOutcomeFilter()` in `src/lib/cortex/decay.ts` *also* requires `valid_from IS NOT NULL` ([#835](https://github.com/hurttlocker/cortex-ide/issues/835)). A row inserted with NULL `valid_from` between boots (parallel-agent raw INSERT after the o8 process started) counted as "live" in the substrate-eval gate but was excluded from recall — silently inflating the threshold check.

Aligned the raw SQL with the full `liveOutcomeFilter()` semantics:

```sql
WHERE valid_from IS NOT NULL AND (valid_to IS NULL OR valid_to > datetime('now'))
```

### Bug 2 — `backfillSessionOutcomeValidFrom()` only fires on first `getDb()` per process

NULL-`valid_from` rows inserted by raw SQL during a long-running process (Phase 2 observed 6 `phase2-wip-*` rows from a parallel agent) survived until the next process restart. The decay sweep does compensate via `COALESCE`, but they showed up as "live but unbackfilled" in the interim — and after Bug 1's fix, would also be invisible to `countOutcomes()` until restart.

Wired the existing 6h decay tick to call `runSessionOutcomeValidFromBackfill()` as step 0 before computing new decays, so any stray NULL gets stamped before the age-out sweep runs.

## Verification

- `npx tsc --noEmit` passes.
- Smoke test against a legacy-shape `session_outcomes` table (nullable `valid_from`):
  - **pre-backfill**: `rawCount === drizzleCount` (0 vs 0, both exclude NULL row)
  - **post-backfill**: `rawCount === drizzleCount` (1 vs 1, both include the now-stamped row)
  - **contrast**: old broken count would have inflated to 1 even pre-backfill (no `valid_from` check).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Smoke test confirms `countOutcomes()` and `liveOutcomeFilter()` agree before and after backfill — never disagree
- [x] Smoke test confirms periodic backfill stamps NULL `valid_from` rows on the next 6h tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)