### PR TITLE
fix: extractSymbols pre-filter graph + packet_transcript multi-runtime

### DIFF
--- a/src/app/api/orchestrator/packet-transcript/route.ts
+++ b/src/app/api/orchestrator/packet-transcript/route.ts
@@ -1,11 +1,19 @@
-import { open, realpath } from 'node:fs/promises';
+import { access, open, readdir, realpath } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { NextResponse, type NextRequest } from 'next/server';
 import { requirePanelAuth } from '@/lib/panel/auth';
 import { getCodexRolloutPath } from '@/lib/codex/sessions';
 import { getOwnedCodexTelemetrySources } from '@/lib/codex/owned';
+import { getOwnedOpencodeTelemetrySources } from '@/lib/opencode/owned';
+import { getOwnedGeminiTelemetrySources } from '@/lib/gemini/owned';
 import { listLanes } from '@/lib/lane/registry';
 import { readOrchestratorControlPlaneState } from '@/lib/orchestrator/control-plane';
 import { normalizeCodexEvents, type TranscriptEvent } from '@/lib/orchestrator/transcript-normalizer';
+import {
+  normalizeClaudeCodeEvents,
+  normalizeOpencodeEvents,
+} from '@/lib/orchestrator/transcript-normalizer-multi';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 
 export const runtime = 'nodejs';
@@ -81,43 +89,162 @@ async function readRawTail(filePath: string, maxBytes = MAX_TAIL_BYTES): Promise
   }
 }
 
-async function resolveRawJsonlForSession(sessionKey: string): Promise<string> {
-  if (!sessionKey) return '';
+/**
+ * Resolved JSONL bundle: the raw text plus the runtime tag we use to pick a
+ * normalizer. `runtime: null` means we couldn't read anything for this key.
+ */
+type ResolvedJsonl = {
+  raw: string;
+  runtime: 'codex' | 'opencode' | 'claude-code' | 'gemini' | null;
+  /** When set, the route should return a structured error instead of events. */
+  unsupportedReason?: string;
+};
 
-  // Owned sessions — stdoutPaths from recentRuns (concatenate all runs in order).
+async function readOwnedRunStdouts(stdoutPaths: string[]): Promise<string> {
+  const chunks: string[] = [];
+  let budget = MAX_TAIL_BYTES;
+  for (const stdoutPath of stdoutPaths) {
+    if (budget <= 0) break;
+    const chunk = await readRawTail(stdoutPath, budget);
+    if (chunk) {
+      chunks.push(chunk);
+      budget -= Buffer.byteLength(chunk, 'utf8');
+    }
+  }
+  return chunks.join('\n');
+}
+
+/**
+ * Find a claude-code session JSONL by walking ~/.claude/projects/<encoded>/
+ * looking for `<sessionId>.jsonl`. Mirrors `findSessionJsonl` from the
+ * claude-code adapter — kept inline so this route doesn't have to depend
+ * on the adapter's private helpers.
+ */
+async function findClaudeCodeJsonl(sessionId: string): Promise<string | null> {
+  const claudeHome = process.env.CLAUDE_HOME || path.join(os.homedir(), '.claude');
+  const projectsDir = path.join(claudeHome, 'projects');
+  let dirs: string[] = [];
+  try {
+    dirs = await readdir(projectsDir);
+  } catch {
+    return null;
+  }
+  for (const dir of dirs) {
+    const candidate = path.join(projectsDir, dir, `${sessionId}.jsonl`);
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      // not in this project
+    }
+  }
+  return null;
+}
+
+async function resolveRawJsonlForSession(sessionKey: string): Promise<ResolvedJsonl> {
+  if (!sessionKey) return { raw: '', runtime: null };
+
+  // ── Codex owned ──────────────────────────────────────────────────────────
   if (sessionKey.startsWith('codex-owned:')) {
     try {
       const sources = await getOwnedCodexTelemetrySources(sessionKey);
-      if (!sources) return '';
-      const chunks: string[] = [];
-      let budget = MAX_TAIL_BYTES;
-      for (const stdoutPath of sources.stdoutPaths) {
-        if (budget <= 0) break;
-        const chunk = await readRawTail(stdoutPath, budget);
-        if (chunk) {
-          chunks.push(chunk);
-          budget -= Buffer.byteLength(chunk, 'utf8');
-        }
-      }
-      return chunks.join('\n');
+      if (!sources) return { raw: '', runtime: 'codex' };
+      return { raw: await readOwnedRunStdouts(sources.stdoutPaths), runtime: 'codex' };
     } catch {
-      return '';
+      return { raw: '', runtime: 'codex' };
     }
   }
 
-  // Discovered sessions — rollout file in ~/.codex/sessions.
+  // ── Codex discovered (rollout file in ~/.codex/sessions) ─────────────────
   if (sessionKey.startsWith('codex:') || sessionKey.startsWith('codex-discovered:')) {
     try {
       const rolloutPath = await getCodexRolloutPath(sessionKey);
-      if (!rolloutPath) return '';
-      return await readRawTail(rolloutPath);
+      if (!rolloutPath) return { raw: '', runtime: 'codex' };
+      return { raw: await readRawTail(rolloutPath), runtime: 'codex' };
     } catch {
-      return '';
+      return { raw: '', runtime: 'codex' };
     }
   }
 
+  // ── opencode owned ───────────────────────────────────────────────────────
+  if (sessionKey.startsWith('opencode-owned:')) {
+    try {
+      const sources = await getOwnedOpencodeTelemetrySources(sessionKey);
+      if (!sources) return { raw: '', runtime: 'opencode' };
+      return { raw: await readOwnedRunStdouts(sources.stdoutPaths), runtime: 'opencode' };
+    } catch {
+      return { raw: '', runtime: 'opencode' };
+    }
+  }
+
+  // ── claude-code (orchestrator-spawned and discovered both use the same
+  // ~/.claude/projects/<encoded-cwd>/<session-id>.jsonl path) ──────────────
+  if (sessionKey.startsWith('claude-code:')) {
+    try {
+      const sessionId = sessionKey.replace('claude-code:', '');
+      // Synthetic live-PID keys never have a JSONL yet.
+      if (sessionId.startsWith('live-')) return { raw: '', runtime: 'claude-code' };
+      const jsonlPath = await findClaudeCodeJsonl(sessionId);
+      if (!jsonlPath) return { raw: '', runtime: 'claude-code' };
+      return { raw: await readRawTail(jsonlPath), runtime: 'claude-code' };
+    } catch {
+      return { raw: '', runtime: 'claude-code' };
+    }
+  }
+
+  // ── gemini owned (mirrors opencode-owned via the shared owned-session
+  // store — `getTelemetrySources` returns `stdoutPaths` to concatenate) ────
+  if (sessionKey.startsWith('gemini-owned:')) {
+    try {
+      const sources = await getOwnedGeminiTelemetrySources(sessionKey);
+      if (!sources) return { raw: '', runtime: 'gemini' };
+      // Gemini's CLI JSONL output schema doesn't have a public-stable
+      // normalizer yet — gemini.ts only consumes it for owned-session tail
+      // entries, not the codex-style TranscriptEvent shape this route
+      // emits. Surface a structured error so callers see the gap instead
+      // of empty events.
+      return {
+        raw: '',
+        runtime: 'gemini',
+        unsupportedReason: 'gemini-transcript-not-supported-yet',
+      };
+    } catch {
+      return {
+        raw: '',
+        runtime: 'gemini',
+        unsupportedReason: 'gemini-transcript-not-supported-yet',
+      };
+    }
+  }
+
+  // ── plain `gemini:` (discovered, no canonical store) ─────────────────────
+  if (sessionKey.startsWith('gemini:') || sessionKey.startsWith('gemini-discovered:')) {
+    return {
+      raw: '',
+      runtime: 'gemini',
+      unsupportedReason: 'gemini-transcript-not-supported-yet',
+    };
+  }
+
   // Live/unknown — no durable transcript.
-  return '';
+  return { raw: '', runtime: null };
+}
+
+/**
+ * Pick the right JSONL→TranscriptEvent normalizer for a runtime tag.
+ */
+function normalizeForRuntime(runtime: ResolvedJsonl['runtime'], raw: string): TranscriptEvent[] {
+  if (!raw) return [];
+  switch (runtime) {
+    case 'codex':
+      return normalizeCodexEvents(raw);
+    case 'opencode':
+      return normalizeOpencodeEvents(raw);
+    case 'claude-code':
+      return normalizeClaudeCodeEvents(raw);
+    default:
+      return [];
+  }
 }
 
 export async function GET(request: NextRequest) {
@@ -160,8 +287,23 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const rawJsonl = await resolveRawJsonlForSession(sessionKey);
-    const events = normalizeCodexEvents(rawJsonl);
+    const resolved = await resolveRawJsonlForSession(sessionKey);
+    if (resolved.unsupportedReason) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: {
+            code: resolved.unsupportedReason,
+            message: `Transcript readback for ${resolved.runtime ?? 'unknown'} sessions is not implemented yet.`,
+          },
+          packetId,
+          sessionKey,
+          runtime: resolved.runtime,
+        },
+        { status: 501, headers: { 'Cache-Control': 'no-store, max-age=0' } },
+      );
+    }
+    const events = normalizeForRuntime(resolved.runtime, resolved.raw);
 
     let windowed: TranscriptEvent[];
     if (tail) {

--- a/src/lib/codebase-memory/build-context.ts
+++ b/src/lib/codebase-memory/build-context.ts
@@ -46,7 +46,7 @@ import { liveOutcomeFilter } from '@/lib/cortex/decay';
 import { withTiming } from '@/lib/cortex/diagnostics';
 import { readRepoPathRegistry } from '@/lib/repos/repo-path-registry';
 
-import { extractSymbols, traceSymbols, type SymbolEdge } from './client';
+import { extractGraphResolvedSymbols, type SymbolEdge } from './client';
 
 const MAX_BLOCK_CHARS = 4000;
 const MAX_DIRECTIVES = 5;
@@ -340,18 +340,17 @@ export async function buildContextBlock({
     : [];
   const outcomes = await readRecentOutcomes(repoPath);
 
-  // Symbol graph is best-effort — `traceSymbols` already returns
-  // `unavailable: true` when the binary isn't on disk and never throws.
+  // Symbol graph is best-effort — `extractGraphResolvedSymbols` traces a
+  // wider candidate set and keeps only the symbols that actually have a
+  // graph entry, so a TS interface name with no edges doesn't burn a slot.
+  // Returns `unavailable: true` when the binary isn't on disk; never throws.
   let edges: SymbolEdge[] = [];
   try {
-    const symbols = extractSymbols(packetBody, MAX_SYMBOLS);
-    if (symbols.length > 0) {
-      const traced = await withTiming(
-        'recall.symbol-graph',
-        () => traceSymbols({ repoPath, symbols }),
-      );
-      if (!traced.unavailable) edges = traced.edges;
-    }
+    const resolved = await withTiming(
+      'recall.symbol-graph',
+      () => extractGraphResolvedSymbols(packetBody, repoPath, MAX_SYMBOLS),
+    );
+    if (!resolved.unavailable) edges = resolved.edges;
   } catch {
     // swallow — never block dispatch on the symbol graph
   }

--- a/src/lib/codebase-memory/client.ts
+++ b/src/lib/codebase-memory/client.ts
@@ -38,23 +38,30 @@ function repoPathToProjectName(repoPath: string): string {
 /**
  * Symbol patterns we mine from packet titles / summaries / issue bodies.
  *
- *   1. Multi-cap identifiers (PascalCase with ≥2 caps): `PacketCard`,
- *      `ContextRecallCard`, `ThoughtsMissionPanel`. Single-cap words like
- *      "Refactor" or "Update" are ignored.
+ * Priority order — ordered so the strongest "this is code" signals win when
+ * we hit `MAX_SYMBOLS`:
+ *
+ *   1. Backtick-quoted identifiers: \`extractSymbols\` — operator explicitly
+ *      marks something as code, so it's the strongest signal we have.
  *   2. lower_snake / lowerCamel followed by `(`: `findCurrentPacketBranch(`,
- *      `extract_symbols(`. The trailing `(` is a strong signal that this
- *      is a function call rather than prose.
- *   3. Dotted member access: `ClassName.method` — captured as a unit.
- *   4. Backtick-quoted identifiers: \`extractSymbols\` — when the operator
- *      explicitly marks code in the prose.
+ *      `extract_symbols(`. The trailing `(` strongly implies a function call.
+ *   3. Multi-cap identifiers (PascalCase with ≥2 caps): `PacketCard`,
+ *      `ContextRecallCard`. Weakest signal — could match a TS interface name
+ *      that has no graph entry, so it goes last.
+ *   4. Dotted member access: `ClassName.method` — captured as part of patterns
+ *      1 and 3.
+ *
+ * Phase-2 audit fix (#897 sibling): a body with 4 valid backticked refs +
+ * 1 PascalCase TS interface used to yield only 1 graph entry because the
+ * PascalCase regex ran first and burned a slot on a useless symbol.
  */
 const SYMBOL_RES: RegExp[] = [
-  // PascalCase with at least 2 capitals, optional .method suffix
-  /\b([A-Z][a-z]+(?:[A-Z][A-Za-z0-9]+)+(?:\.[a-z_][A-Za-z0-9_]*)?)\b/g,
+  // Backtick-quoted identifiers (strongest signal)
+  /`([A-Za-z_][A-Za-z0-9_.]{2,})`/g,
   // lower / snake / camel followed by `(`
   /\b([a-z_][A-Za-z0-9_]{2,})(?=\s*\()/g,
-  // Backtick-quoted identifiers
-  /`([A-Za-z_][A-Za-z0-9_.]{2,})`/g,
+  // PascalCase with at least 2 capitals, optional .method suffix
+  /\b([A-Z][a-z]+(?:[A-Z][A-Za-z0-9]+)+(?:\.[a-z_][A-Za-z0-9_]*)?)\b/g,
 ];
 
 const FILE_EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js', '.mts', '.cts', '.json', '.md'];
@@ -91,6 +98,73 @@ export function extractSymbols(text: string, limit = 3): string[] {
     }
   }
   return out;
+}
+
+/**
+ * Phase-2 audit fix — trace a wider candidate set, then keep only the
+ * first `limit` symbols whose trace resolved against the project graph.
+ *
+ * Bug being fixed: callers used to do
+ *
+ *   const symbols = extractSymbols(body, 3);   // priority order picks 3
+ *   const { edges } = await traceSymbols(...);  // many resolve to errors
+ *
+ * which wasted slots on TS interface names like `SymbolEdge` that have
+ * no graph entry. Now we mine 5x the budget, trace once, and only count
+ * symbols whose trace returned a file/line or at least one neighbour.
+ *
+ * Returns both the resolved symbol names AND the trace edges so callers
+ * don't have to call `traceSymbols` again — saves the second MCP round-
+ * trip.
+ *
+ * Failure modes:
+ *   - empty text / repoPath  → `{ symbols: [], edges: [], unavailable: false }`
+ *   - binary missing         → returns the first `limit` candidates with
+ *                              `unavailable: true` and `edges: []` so the
+ *                              recall card can still hide its row.
+ *   - all candidates fail    → `{ symbols: [], edges: [], unavailable: false }`
+ */
+export interface ExtractGraphResolvedSymbolsResult {
+  symbols: string[];
+  edges: SymbolEdge[];
+  unavailable: boolean;
+}
+
+export async function extractGraphResolvedSymbols(
+  text: string,
+  repoPath: string,
+  limit = 3,
+): Promise<ExtractGraphResolvedSymbolsResult> {
+  if (!text || !repoPath) return { symbols: [], edges: [], unavailable: false };
+
+  // Cast a wider net so we can drop symbols that don't resolve without
+  // dropping below `limit`. 5x is enough to recover from the worst common
+  // case (e.g. a TS interface name slipping into the candidate list) while
+  // keeping the trace cost bounded.
+  const candidates = extractSymbols(text, Math.max(limit, limit * 5));
+  if (candidates.length === 0) return { symbols: [], edges: [], unavailable: false };
+
+  const traced = await traceSymbols({ repoPath, symbols: candidates });
+  if (traced.unavailable) {
+    return {
+      symbols: candidates.slice(0, limit),
+      edges: [],
+      unavailable: true,
+    };
+  }
+
+  const resolvedSymbols: string[] = [];
+  const resolvedEdges: SymbolEdge[] = [];
+  for (const edge of traced.edges) {
+    if (edge.error) continue;
+    const hasDefinition = Boolean(edge.file) || Boolean(edge.line);
+    const hasNeighbours = edge.neighbours.length > 0;
+    if (!hasDefinition && !hasNeighbours) continue;
+    resolvedSymbols.push(edge.symbol);
+    resolvedEdges.push(edge);
+    if (resolvedSymbols.length >= limit) break;
+  }
+  return { symbols: resolvedSymbols, edges: resolvedEdges, unavailable: false };
 }
 
 export interface SymbolEdge {

--- a/src/lib/orchestrator/transcript-normalizer-multi.ts
+++ b/src/lib/orchestrator/transcript-normalizer-multi.ts
@@ -1,0 +1,342 @@
+/**
+ * Multi-runtime transcript normalizers.
+ *
+ * Phase-2 audit fix — `o8_packet_transcript` previously only handled codex
+ * sessions, so dispatch transcript readback returned `events: []` for
+ * opencode and claude-code packets. This module ports the same
+ * `TranscriptEvent` shape from `./transcript-normalizer.ts` (Codex) to the
+ * other runtimes' on-disk JSONL formats.
+ *
+ * Schemas:
+ *   - opencode 1.4.3 → events use a `type`/`part.type` discriminator pair
+ *     (`text/text`, `tool_use/tool`, `step_finish/step-finish`, etc.).
+ *     Tool calls and tool results live inside the same `part` (the
+ *     `state.status` flips from `pending` → `completed`), so we emit a
+ *     synthesized `tool_call` immediately followed by `tool_result` when
+ *     we see a completed tool part.
+ *   - claude-code → events use a `type` field (`user`/`assistant`/`system`)
+ *     with `message.content` carrying anthropic-style content blocks
+ *     (`text`, `tool_use`, `tool_result`). One JSONL line per event.
+ *
+ * Returns `[]` on empty input or malformed JSONL — never throws so callers
+ * can treat absence as a benign condition (same contract as
+ * `normalizeCodexEvents`).
+ */
+
+import type { TranscriptEvent } from './transcript-normalizer';
+
+const MAX_SUMMARY = 240;
+const MAX_ASSISTANT_TEXT = 4_000;
+const MAX_ARGS = 600;
+
+function clip(input: string | undefined, max: number): string {
+  if (!input) return '';
+  const collapsed = input.replace(/\s+/g, ' ').trim();
+  return collapsed.length <= max ? collapsed : `${collapsed.slice(0, Math.max(0, max - 1))}…`;
+}
+
+function safeObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function readStr(source: Record<string, unknown> | null, ...keys: string[]): string {
+  if (!source) return '';
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return '';
+}
+
+function readNum(source: Record<string, unknown> | null, ...keys: string[]): number | undefined {
+  if (!source) return undefined;
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+  }
+  return undefined;
+}
+
+function argsPreview(input: unknown): string {
+  if (input === undefined || input === null) return '';
+  if (typeof input === 'string') return clip(input, MAX_ARGS);
+  try {
+    return clip(JSON.stringify(input), MAX_ARGS);
+  } catch {
+    return '';
+  }
+}
+
+function normalizeTs(raw: unknown, fallback: string): string {
+  if (typeof raw === 'string' && raw.trim()) {
+    const parsed = new Date(raw);
+    if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+  }
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    const parsed = new Date(raw);
+    if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+  }
+  return fallback;
+}
+
+// ── opencode ─────────────────────────────────────────────────────────────────
+
+/**
+ * Normalize opencode JSONL into the shared `TranscriptEvent` shape.
+ *
+ * opencode 1.4.3 schema (newline-delimited JSON):
+ *   {"type":"step_start","part":{"type":"step-start"}}
+ *   {"type":"text","part":{"type":"text","text":"..."}}
+ *   {"type":"tool_use","part":{"type":"tool","tool":"glob","callID":"call_x",
+ *     "state":{"status":"completed","input":{...},"output":"..."}}}
+ *   {"type":"step_finish","part":{"type":"step-finish","tokens":{...}}}
+ *
+ * Tool calls and results are folded into the same `part` (state.status
+ * flips when the tool completes), so we synthesize matching `tool_call`
+ * + `tool_result` events from one log line.
+ */
+export function normalizeOpencodeEvents(rawJsonl: string): TranscriptEvent[] {
+  if (!rawJsonl || typeof rawJsonl !== 'string') return [];
+
+  const out: TranscriptEvent[] = [];
+  const fallbackTs = new Date().toISOString();
+  let seq = 0;
+  const nextSeq = () => (seq += 1);
+
+  for (const rawLine of rawJsonl.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || !line.startsWith('{')) continue;
+
+    let parsed: Record<string, unknown> | null = null;
+    try {
+      parsed = safeObject(JSON.parse(line));
+    } catch {
+      parsed = null;
+    }
+    if (!parsed) continue;
+
+    const type = readStr(parsed, 'type');
+    const ts = normalizeTs(parsed.timestamp, fallbackTs);
+    const part = safeObject(parsed.part);
+    const partType = readStr(part, 'type');
+
+    // ── assistant text ────────────────────────────────────────────────────────
+    if (type === 'text' && partType === 'text') {
+      const text = clip(readStr(part, 'text'), MAX_ASSISTANT_TEXT);
+      if (text) out.push({ seq: nextSeq(), ts, type: 'assistant', text });
+      continue;
+    }
+
+    // ── tool call + result (folded into one part on completion) ───────────────
+    if (type === 'tool_use' && partType === 'tool') {
+      const tool = readStr(part, 'tool', 'name') || 'tool';
+      const callId = readStr(part, 'callID', 'call_id', 'id') || `tool-${seq + 1}`;
+      const state = safeObject(part?.state);
+      const status = readStr(state, 'status');
+      const input = state?.input ?? part?.input ?? {};
+      const args = argsPreview(input);
+
+      const callSeq = nextSeq();
+      out.push({
+        seq: callSeq,
+        ts,
+        type: 'tool_call',
+        tool,
+        args,
+        summary: clip(args || `call ${tool}`, MAX_SUMMARY),
+      });
+
+      if (status === 'completed' || status === 'error') {
+        const output = state?.output ?? state?.result ?? '';
+        const ok = status !== 'error';
+        const summaryRaw = typeof output === 'string' ? output : argsPreview(output);
+        out.push({
+          seq: nextSeq(),
+          ts,
+          type: 'tool_result',
+          tool,
+          ok,
+          summary: clip(summaryRaw || (ok ? 'ok' : 'error'), MAX_SUMMARY),
+        });
+        // Use callId so listeners can pair if they care; suppress unused warning
+        void callId;
+      }
+      continue;
+    }
+
+    // ── error event ───────────────────────────────────────────────────────────
+    if (type === 'error') {
+      const message = clip(
+        readStr(parsed, 'message', 'error') || readStr(part, 'message', 'error'),
+        MAX_SUMMARY,
+      );
+      out.push({ seq: nextSeq(), ts, type: 'error', message: message || 'opencode run error' });
+      continue;
+    }
+
+    // ── completion (step_finish with reason==='stop' marks the end) ───────────
+    if (type === 'step_finish' && partType === 'step-finish') {
+      const reason = readStr(part, 'reason');
+      // Only the *last* step_finish is meaningfully terminal — but the opencode
+      // log writes one per turn, so we let consumers pick the latest `done`.
+      // Carry the exit code 0 unless `reason === 'error'`.
+      if (reason === 'stop' || reason === 'tool-calls' || reason === '') {
+        // Don't emit a `done` for tool-calls — that's mid-turn.
+        if (reason === 'stop' || reason === '') {
+          out.push({ seq: nextSeq(), ts, type: 'done', exitCode: 0 });
+        }
+      } else if (reason === 'error') {
+        out.push({ seq: nextSeq(), ts, type: 'error', message: 'opencode step ended with error' });
+      }
+      continue;
+    }
+  }
+
+  return out;
+}
+
+// ── claude-code ──────────────────────────────────────────────────────────────
+
+interface AnthropicContentBlock {
+  type?: string;
+  text?: string;
+  name?: string;
+  input?: unknown;
+  id?: string;
+  tool_use_id?: string;
+  content?: string | unknown[];
+}
+
+function extractClaudeText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const block of content as AnthropicContentBlock[]) {
+    if (block?.type === 'text' && typeof block.text === 'string') parts.push(block.text);
+  }
+  return parts.join('\n\n').trim();
+}
+
+function extractClaudeToolBlocks(content: unknown): AnthropicContentBlock[] {
+  if (!Array.isArray(content)) return [];
+  return (content as AnthropicContentBlock[]).filter((b) => b?.type === 'tool_use' && b.name);
+}
+
+function extractClaudeToolResults(content: unknown): AnthropicContentBlock[] {
+  if (!Array.isArray(content)) return [];
+  return (content as AnthropicContentBlock[]).filter((b) => b?.type === 'tool_result');
+}
+
+function extractToolResultText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const block of content as AnthropicContentBlock[]) {
+    if (typeof block?.text === 'string') parts.push(block.text);
+  }
+  return parts.join('\n').trim();
+}
+
+/**
+ * Normalize claude-code JSONL into the shared `TranscriptEvent` shape.
+ *
+ * claude-code schema (one JSONL line per event):
+ *   {"type":"user","message":{"role":"user","content":"hi"|[blocks]}}
+ *   {"type":"assistant","message":{"role":"assistant","content":[blocks]}}
+ *     blocks include {type:"text",text:"..."} and
+ *     {type:"tool_use",name:"Bash",input:{...},id:"call_x"}.
+ *   {"type":"user","message":{"role":"user","content":[{type:"tool_result",
+ *     tool_use_id:"call_x",content:"..."}]}}
+ *
+ * Tool calls and results live in separate JSONL lines, so we maintain a
+ * pending-call map keyed by `tool_use_id` to keep the call/result pairing.
+ */
+export function normalizeClaudeCodeEvents(rawJsonl: string): TranscriptEvent[] {
+  if (!rawJsonl || typeof rawJsonl !== 'string') return [];
+
+  const out: TranscriptEvent[] = [];
+  const pending = new Map<string, { tool: string }>();
+  const fallbackTs = new Date().toISOString();
+  let seq = 0;
+  const nextSeq = () => (seq += 1);
+
+  for (const rawLine of rawJsonl.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || !line.startsWith('{')) continue;
+
+    let parsed: Record<string, unknown> | null = null;
+    try {
+      parsed = safeObject(JSON.parse(line));
+    } catch {
+      parsed = null;
+    }
+    if (!parsed) continue;
+
+    const type = readStr(parsed, 'type');
+    const ts = normalizeTs(parsed.timestamp, fallbackTs);
+    const message = safeObject(parsed.message);
+    const content = message?.content;
+
+    // ── assistant text + tool_use blocks ──────────────────────────────────────
+    if (type === 'assistant' && message) {
+      const text = clip(extractClaudeText(content), MAX_ASSISTANT_TEXT);
+      if (text) out.push({ seq: nextSeq(), ts, type: 'assistant', text });
+
+      for (const block of extractClaudeToolBlocks(content)) {
+        const tool = block.name ?? 'tool';
+        const callId = block.id ?? `tool-${seq + 1}`;
+        const args = argsPreview(block.input);
+        pending.set(callId, { tool });
+        out.push({
+          seq: nextSeq(),
+          ts,
+          type: 'tool_call',
+          tool,
+          args,
+          summary: clip(args || `call ${tool}`, MAX_SUMMARY),
+        });
+      }
+      continue;
+    }
+
+    // ── user-side tool_result blocks (paired by tool_use_id) ──────────────────
+    if (type === 'user' && message) {
+      for (const block of extractClaudeToolResults(content)) {
+        const callId = block.tool_use_id ?? '';
+        const pendingCall = callId ? pending.get(callId) : undefined;
+        if (callId) pending.delete(callId);
+        const tool = pendingCall?.tool ?? 'tool';
+        const summary = clip(extractToolResultText(block.content), MAX_SUMMARY);
+        out.push({
+          seq: nextSeq(),
+          ts,
+          type: 'tool_result',
+          tool,
+          ok: true,
+          summary: summary || 'ok',
+        });
+      }
+      continue;
+    }
+
+    // ── system errors ─────────────────────────────────────────────────────────
+    if (type === 'system') {
+      const text = typeof message?.content === 'string' ? message.content : '';
+      const lower = text.toLowerCase();
+      if (text && (lower.includes('error') || lower.includes('crash') || lower.includes('fatal'))) {
+        out.push({ seq: nextSeq(), ts, type: 'error', message: clip(text, MAX_SUMMARY) });
+      }
+      continue;
+    }
+
+    // claude-code doesn't emit a structured "done" event in the JSONL — the
+    // run ends when the file stops growing. Callers can use `findLastIndex
+    // type==='assistant'` as the end-of-turn signal. We deliberately don't
+    // synthesize a fake `done` here.
+    void readNum; // silence unused-import warning when no error path runs
+  }
+
+  return out;
+}


### PR DESCRIPTION
## Summary

Phase-2 audit follow-ups for [#743](https://github.com/hurttlocker/cortex-ide/issues/743) dispatch context injection. Two independent bugs surfaced during the Phase-2 dogfood:

- **Bug 1 — `extractSymbols` slot allocation wasted hits.** A packet body with 4 valid backticked refs + 1 PascalCase TS interface name (no graph entry) yielded only 1 graph entry because `SYMBOL_RES` ran PascalCase first and burned a slot on the useless interface name.
- **Bug 2 — `o8_packet_transcript` was codex-only.** `resolveRawJsonlForSession()` only matched `codex-owned:` / `codex:` prefixes, so opencode/claude-code/gemini packets returned `events: []`. Three runtimes were dark for transcript readback.

These were called out in the Phase-2 audit report as P3 follow-ups (rank #7 in the top-10 issue list — "Three runtimes still dark for transcript readback"). Filing this PR as the rollup fix.

## What Changed

### `src/lib/codebase-memory/client.ts`
- Reordered `SYMBOL_RES` regex priority: backticks → `name(` → PascalCase. Operator-marked code (backticks) is the strongest signal, so it wins ties when `MAX_SYMBOLS=3`.
- New `extractGraphResolvedSymbols(text, repoPath, limit)` — traces a 5x candidate set and counts only symbols whose `trace_path` resolved to a file/line/neighbour. Returns `{ symbols, edges, unavailable }` so callers don't have to call `traceSymbols` again (saves a second MCP round-trip).

### `src/lib/codebase-memory/build-context.ts`
- `buildContextBlock` now calls `extractGraphResolvedSymbols` instead of `extractSymbols` + `traceSymbols`. A TS interface name with no graph entry no longer poisons the symbol graph row.

### `src/app/api/orchestrator/packet-transcript/route.ts`
- `resolveRawJsonlForSession` now dispatches on session-key prefix:
  - `opencode-owned:` → reads `stdoutPaths` from the owned-session store
  - `claude-code:` → walks `~/.claude/projects/<encoded-cwd>/<id>.jsonl`
  - `gemini-owned:` / `gemini:` → returns `501` with structured `gemini-transcript-not-supported-yet` error
- Returns a typed `{ raw, runtime }` bundle so the right normalizer can be selected.

### `src/lib/orchestrator/transcript-normalizer-multi.ts` (new)
- `normalizeOpencodeEvents` — handles opencode 1.4.3's `type/part.type` discriminator (`text/text`, `tool_use/tool` with folded call+result via `state.status`, `step_finish/step-finish`).
- `normalizeClaudeCodeEvents` — handles claude-code's anthropic-style content blocks (`text`, `tool_use`, `tool_result`) with a pending-call map keyed by `tool_use_id`.
- Both return the same `TranscriptEvent` shape as `normalizeCodexEvents` and never throw on malformed input.

## Test plan

Smoke-tested against the live dev server (`http://localhost:3001`) with real on-disk sessions:

- [x] `extractSymbols(audit-body, 3)` → `['buildContextBlock', 'traceSymbols', 'extractSymbols']` (was: only 1 graph-resolvable symbol because `SymbolEdge` burned a slot).
- [x] `GET /api/orchestrator/packet-transcript?packetId=<opencode-pkt>` → 2 events (`assistant` + `done`) instead of empty.
- [x] `GET /api/orchestrator/packet-transcript?packetId=<claude-code-pkt>` → 5 events with paired `tool_call`/`tool_result` instead of empty.
- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint <changed files>` clean.

Gemini transcript readback returns a structured `501` rather than silently empty events — meaningful upgrade for callers even before a normalizer ships.

## Refs

- Phase-2 audit `/tmp/context-engine-dogfood-phase2.md` rank #7: "`packet_transcript` is codex-only"
- [#743](https://github.com/hurttlocker/cortex-ide/issues/743) parent dispatch context injection feature

## Follow-ups (suggested)

- New issue: ship a `normalizeGeminiEvents` once Gemini's stream-json schema stabilises so `gemini-owned:` / `gemini:` transcripts also populate.