### PR TITLE
fix: chip fetch resilience under WS disconnect (#771 phase 4)

### DIFF
--- a/src/components/desktop/thoughts/SuggestedReplies.tsx
+++ b/src/components/desktop/thoughts/SuggestedReplies.tsx
@@ -15,6 +15,10 @@ interface SuggestedRepliesProps {
   disabled?: boolean;
   onSelect: (chip: string) => void;
   onDismiss: () => void;
+  // Phase 4 — when true and `chips` is empty, render a [•••] placeholder so
+  // the user knows a fetch was attempted (instead of silently rendering
+  // nothing). Suppressed once real chips arrive.
+  isPlaceholder?: boolean;
 }
 
 // Rams "one orange" — matches the orchestrator accent already used in ThoughtsChatPanel
@@ -49,15 +53,56 @@ function getReducedMotionServerSnapshot(): boolean {
   return false;
 }
 
-export function SuggestedReplies({ chips, disabled = false, onSelect, onDismiss }: SuggestedRepliesProps) {
+export function SuggestedReplies({ chips, disabled = false, onSelect, onDismiss, isPlaceholder = false }: SuggestedRepliesProps) {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const [dismissHover, setDismissHover] = useState(false);
   const reduceMotion = useSyncExternalStore(subscribeReducedMotion, getReducedMotion, getReducedMotionServerSnapshot);
 
-  if (chips.length === 0) return null;
-
   const filteredChips = chips.filter((chip) => chip.trim().length > 0);
-  if (filteredChips.length === 0) return null;
+  const hasChips = filteredChips.length > 0;
+
+  // Phase 4 — placeholder strip when a fetch failed (or is mid-retry) and we
+  // don't have chips yet. Renders a muted three-dot row so the user knows
+  // chips were attempted instead of silently rendering nothing.
+  if (!hasChips && isPlaceholder) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        aria-label="Loading suggested replies"
+        style={{
+          alignSelf: 'flex-start',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 4,
+          marginTop: 4,
+          marginLeft: 2,
+          paddingTop: 7,
+          paddingRight: 10,
+          paddingBottom: 7,
+          paddingLeft: 10,
+          color: 'var(--t-text-tertiary, var(--t-text-secondary, #9ca3af))',
+          opacity: 0.85,
+          transition: reduceMotion ? 'none' : 'opacity 160ms ease',
+        }}
+      >
+        {[0, 1, 2].map((i) => (
+          <span
+            key={i}
+            style={{
+              width: 4,
+              height: 4,
+              borderRadius: '50%',
+              background: 'currentColor',
+              animation: reduceMotion ? 'none' : `llmDot 1.2s ease-in-out ${i * 0.18}s infinite`,
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (!hasChips) return null;
 
   return (
     <div

--- a/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
+++ b/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
@@ -665,6 +665,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
   const {
     lastAssistantId: suggestedReplyMessageId,
     chipsForLastAssistant,
+    isPlaceholderVisibleForLastAssistant: suggestedRepliesPending,
     dismissChips: dismissSuggestedReplies,
   } = useSuggestedReplies({
     enabled: isOrchestratorMode,
@@ -975,6 +976,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
         isOrchestratorMode={isOrchestratorMode}
         suggestedReplyMessageId={suggestedReplyMessageId}
         suggestedReplies={chipsForLastAssistant}
+        suggestedRepliesPending={suggestedRepliesPending}
         onSelectSuggestion={(chip) => { sendNow(chip); }}
         onDismissSuggestions={dismissSuggestedReplies}
       />

--- a/src/components/desktop/thoughts/chat-panel/ChatMessageList.tsx
+++ b/src/components/desktop/thoughts/chat-panel/ChatMessageList.tsx
@@ -30,6 +30,10 @@ interface ChatMessageListProps {
   suggestedReplies?: string[];
   onSelectSuggestion?: (chip: string) => void;
   onDismissSuggestions?: () => void;
+  // Phase 4 — when true, render a [•••] placeholder under the last assistant
+  // message even if `suggestedReplies` is empty. Indicates a fetch is in
+  // flight or just failed, so the user knows chips were attempted.
+  suggestedRepliesPending?: boolean;
 }
 
 export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(function ChatMessageList({
@@ -50,11 +54,18 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
   suggestedReplies,
   onSelectSuggestion,
   onDismissSuggestions,
+  suggestedRepliesPending = false,
 }, chatEndRef) {
+  // Phase 4 — chips strip renders when EITHER chips arrived OR a fetch is in
+  // flight / just failed (placeholder). Both share the same anchor under the
+  // last assistant message. Without the placeholder branch the strip would
+  // silently render nothing during transient failures.
   const hasSuggestedReplies = Boolean(
     suggestedReplyMessageId
-    && suggestedReplies
-    && suggestedReplies.length > 0
+    && (
+      (suggestedReplies && suggestedReplies.length > 0)
+      || suggestedRepliesPending
+    )
     && onSelectSuggestion
     && onDismissSuggestions,
   );
@@ -102,7 +113,6 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
         const showChipsHere = isLatestAssistant
           && hasSuggestedReplies
           && msg.id === suggestedReplyMessageId
-          && suggestedReplies
           && onSelectSuggestion
           && onDismissSuggestions;
         return (
@@ -114,10 +124,11 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
             />
             {showChipsHere ? (
               <SuggestedReplies
-                chips={suggestedReplies}
+                chips={suggestedReplies ?? []}
                 disabled={displayWaiting}
                 onSelect={onSelectSuggestion}
                 onDismiss={onDismissSuggestions}
+                isPlaceholder={suggestedRepliesPending}
               />
             ) : null}
           </Fragment>

--- a/src/components/desktop/thoughts/chat-panel/useSuggestedReplies.ts
+++ b/src/components/desktop/thoughts/chat-panel/useSuggestedReplies.ts
@@ -6,7 +6,9 @@
  * One in-flight fetch at a time. Cached by message id so re-renders don't
  * re-fetch. Dismissals are sticky for the lifetime of the thread.
  *
- * Closes #771.
+ * Closes #771. Phase 4 follow-up adds fetch resilience: 5xx soft-retry,
+ * placeholder during in-flight, distinct treatment of 4xx (immediate cooldown)
+ * vs 5xx (one retry then cooldown).
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MobileTranscriptEntry } from '@/lib/mobile/types';
@@ -32,6 +34,14 @@ const MIN_ASSISTANT_LEN = 12;
 // change (scroll, resize, upstream state update) re-fires the fetch and
 // produces a network storm against a known-broken endpoint.
 const ERROR_COOLDOWN_MS = 10_000;
+// Phase 4 — when a fetch returns 5xx (transient gateway error), retry ONCE
+// after this delay before settling into the cooldown. 4xx errors skip retry
+// because they signal a deterministic problem (bad request shape, missing
+// key, etc.) that retrying won't fix.
+const SOFT_RETRY_DELAY_MS = 2_500;
+// Phase 4 — placeholder visible window after a failed fetch attempt. Lets the
+// user see the chip-row was attempted instead of silently rendering nothing.
+const PLACEHOLDER_VISIBLE_MS = 2_000;
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((s) => typeof s === 'string');
@@ -49,6 +59,13 @@ export function useSuggestedReplies({ enabled, messages, isStreaming }: UseSugge
   const errorCooldownRef = useRef<Map<string, number>>(new Map());
   const cooldownTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [cooldownTick, setCooldownTick] = useState(0);
+  // Phase 4 — per-message retry budget (each id may retry once on 5xx).
+  const retriesUsedRef = useRef<Map<string, number>>(new Map());
+  // Phase 4 — placeholder window: messageId → timestamp at which placeholder
+  // should disappear. Surfaced as `isPlaceholderVisible` so the UI can render
+  // a [•••] strip while we're either in-flight or just-failed.
+  const [pendingMessages, setPendingMessages] = useState<Set<string>>(new Set());
+  const placeholderTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Identify the last assistant message; that's the only one we ever attach
   // chips to. Chips on older assistant messages aren't useful and would be
@@ -109,6 +126,33 @@ export function useSuggestedReplies({ enabled, messages, isStreaming }: UseSugge
     const controller = new AbortController();
     abortRef.current = controller;
 
+    // Phase 4 — placeholder visibility helpers. The placeholder is ONLY shown
+    // once a fetch has failed (5xx during retry, or after retry exhausted /
+    // network error / 4xx). The happy path and initial in-flight render
+    // nothing — chips appear when the fetch resolves.
+    const showPlaceholder = () => {
+      setPendingMessages((prev) => {
+        if (prev.has(lastAssistantId)) return prev;
+        const next = new Set(prev);
+        next.add(lastAssistantId);
+        return next;
+      });
+    };
+    const schedulePlaceholderHide = () => {
+      if (placeholderTimerRef.current !== null) {
+        clearTimeout(placeholderTimerRef.current);
+      }
+      placeholderTimerRef.current = setTimeout(() => {
+        placeholderTimerRef.current = null;
+        setPendingMessages((prev) => {
+          if (!prev.has(lastAssistantId)) return prev;
+          const next = new Set(prev);
+          next.delete(lastAssistantId);
+          return next;
+        });
+      }, PLACEHOLDER_VISIBLE_MS);
+    };
+
     void (async () => {
       try {
         const res = await fetch('/api/v2/chat/suggestions', {
@@ -122,15 +166,45 @@ export function useSuggestedReplies({ enabled, messages, isStreaming }: UseSugge
           signal: controller.signal,
         });
         if (!res.ok) {
-          // #847 — non-OK status (e.g. 500 from #844 thinking-budget starvation)
-          // arms the cooldown so we don't fetch-storm against a broken endpoint.
+          // Phase 4 — distinguish 5xx (transient, retryable) from 4xx
+          // (deterministic, no retry). 5xx gets ONE soft retry after
+          // SOFT_RETRY_DELAY_MS before falling through to the cooldown. This
+          // covers the WS-disconnect window where the API briefly 503s while
+          // the gateway flaps but is otherwise healthy.
+          const retries = retriesUsedRef.current.get(lastAssistantId) ?? 0;
+          const isTransient = res.status >= 500 && res.status < 600;
+          if (isTransient && retries === 0) {
+            retriesUsedRef.current.set(lastAssistantId, retries + 1);
+            // Re-arm the effect after the retry delay; clear the inflight flag
+            // first so the next pass can proceed. Show the placeholder so the
+            // user sees a fetch is in flight across the retry window.
+            inflightRef.current.delete(lastAssistantId);
+            showPlaceholder();
+            setTimeout(() => {
+              if (controller.signal.aborted) return;
+              setCooldownTick((tick) => tick + 1);
+            }, SOFT_RETRY_DELAY_MS);
+            return;
+          }
+          // #847 — non-OK status (4xx, or 5xx after retry exhausted) arms the
+          // cooldown so we don't fetch-storm against a broken endpoint.
           errorCooldownRef.current.set(lastAssistantId, Date.now() + ERROR_COOLDOWN_MS);
+          showPlaceholder();
+          schedulePlaceholderHide();
           return;
         }
         const data = await res.json() as SuggestionsResponse;
         const suggestions = isStringArray(data.suggestions) ? data.suggestions : [];
-        // Successful fetch — clear any prior cooldown for this message id.
+        // Successful fetch — clear any prior cooldown + retry budget + pending
+        // flag for this message id.
         errorCooldownRef.current.delete(lastAssistantId);
+        retriesUsedRef.current.delete(lastAssistantId);
+        setPendingMessages((prev) => {
+          if (!prev.has(lastAssistantId)) return prev;
+          const next = new Set(prev);
+          next.delete(lastAssistantId);
+          return next;
+        });
         setChipsByMessage((prev) => {
           const next = new Map(prev);
           next.set(lastAssistantId, suggestions);
@@ -138,11 +212,29 @@ export function useSuggestedReplies({ enabled, messages, isStreaming }: UseSugge
         });
       } catch (err) {
         // #847 — distinguish abort from real failures. Aborts happen when the
-        // last-assistant id changes mid-flight; those should stay retryable.
-        // Real network errors arm the cooldown.
+        // last-assistant id changes mid-flight (e.g. soft-retry re-arm,
+        // unmount). We leave the pending flag alone on abort: if a retry is
+        // about to fire, the next pass will keep the placeholder up; if the
+        // user navigated away the cleanup effect drops the flag.
         const isAbort = err instanceof DOMException && err.name === 'AbortError';
         if (!isAbort) {
+          // Phase 4 — treat network errors (TypeError on fetch, gateway
+          // unreachable, etc.) the same as 5xx: ONE soft retry then cooldown.
+          // The WS-disconnect window often produces these alongside 5xx.
+          const retries = retriesUsedRef.current.get(lastAssistantId) ?? 0;
+          if (retries === 0) {
+            retriesUsedRef.current.set(lastAssistantId, retries + 1);
+            inflightRef.current.delete(lastAssistantId);
+            showPlaceholder();
+            setTimeout(() => {
+              if (controller.signal.aborted) return;
+              setCooldownTick((tick) => tick + 1);
+            }, SOFT_RETRY_DELAY_MS);
+            return;
+          }
           errorCooldownRef.current.set(lastAssistantId, Date.now() + ERROR_COOLDOWN_MS);
+          showPlaceholder();
+          schedulePlaceholderHide();
         }
       } finally {
         inflightRef.current.delete(lastAssistantId);
@@ -160,21 +252,31 @@ export function useSuggestedReplies({ enabled, messages, isStreaming }: UseSugge
     if (messages.length === 0) {
       setChipsByMessage((prev) => (prev.size === 0 ? prev : new Map()));
       setDismissedMessages((prev) => (prev.size === 0 ? prev : new Set()));
+      setPendingMessages((prev) => (prev.size === 0 ? prev : new Set()));
       inflightRef.current.clear();
       errorCooldownRef.current.clear();
+      retriesUsedRef.current.clear();
       if (cooldownTimerRef.current !== null) {
         clearTimeout(cooldownTimerRef.current);
         cooldownTimerRef.current = null;
       }
+      if (placeholderTimerRef.current !== null) {
+        clearTimeout(placeholderTimerRef.current);
+        placeholderTimerRef.current = null;
+      }
     }
   }, [messages.length]);
 
-  // Cleanup any pending cooldown timer when the hook unmounts.
+  // Cleanup any pending cooldown / placeholder timers when the hook unmounts.
   useEffect(() => {
     return () => {
       if (cooldownTimerRef.current !== null) {
         clearTimeout(cooldownTimerRef.current);
         cooldownTimerRef.current = null;
+      }
+      if (placeholderTimerRef.current !== null) {
+        clearTimeout(placeholderTimerRef.current);
+        placeholderTimerRef.current = null;
       }
     };
   }, []);
@@ -184,6 +286,18 @@ export function useSuggestedReplies({ enabled, messages, isStreaming }: UseSugge
     if (dismissedMessages.has(lastAssistantId)) return [];
     return chipsByMessage.get(lastAssistantId) ?? [];
   }, [chipsByMessage, dismissedMessages, enabled, lastAssistantId]);
+
+  // Phase 4 — placeholder visible when a fetch is currently in-flight or has
+  // just failed (within PLACEHOLDER_VISIBLE_MS). Used by the UI to render a
+  // [•••] strip so the user knows chips were attempted instead of silently
+  // rendering nothing. Suppressed once chips actually arrive or the user
+  // dismissed the row.
+  const isPlaceholderVisibleForLastAssistant = useMemo(() => {
+    if (!enabled || !lastAssistantId) return false;
+    if (dismissedMessages.has(lastAssistantId)) return false;
+    if ((chipsByMessage.get(lastAssistantId)?.length ?? 0) > 0) return false;
+    return pendingMessages.has(lastAssistantId);
+  }, [chipsByMessage, dismissedMessages, enabled, lastAssistantId, pendingMessages]);
 
   const dismissChips = useCallback(() => {
     if (!lastAssistantId) return;
@@ -198,6 +312,7 @@ export function useSuggestedReplies({ enabled, messages, isStreaming }: UseSugge
   return {
     lastAssistantId,
     chipsForLastAssistant,
+    isPlaceholderVisibleForLastAssistant,
     dismissChips,
   };
 }


### PR DESCRIPTION
## Summary

Phase 4 follow-up to #771 / #847. Phase 3 dogfood audit (`/tmp/context-engine-dogfood-phase3.md`, chips section) flagged that suggested-reply chips fail to render at all on a follow-up turn during dev recompile + WS gateway disconnect. The existing `ERROR_COOLDOWN_MS` from #883 silences fetch storms but provides zero retry — a single transient 5xx during the disconnect window settles into 10s of empty.

Three coordinated changes:

- **Soft retry on transient errors** (`useSuggestedReplies`). 5xx + non-abort network errors get one retry after 2.5s before the existing cooldown takes over. 4xx still short-circuits — deterministic failures don't benefit from retrying.
- **Placeholder during failure window** (`SuggestedReplies`). On any failed fetch (5xx or network error), a muted three-dot row renders under the last assistant message for ~2s after the final failure. Happy paths show nothing — placeholder is a failure affordance, not generic loading state.
- **Pending-flag plumbing**. `useSuggestedReplies` exposes `isPlaceholderVisibleForLastAssistant`; `ThoughtsChatPanel` threads it as `suggestedRepliesPending` to `ChatMessageList` which passes `isPlaceholder` to `SuggestedReplies`. The strip anchor widens from "has chips" to "has chips OR pending" so the placeholder can render under the same assistant message.

The chip fetcher is HTTP, not WS, so a WS-only gateway flap doesn't directly break it — but the same disconnect window often produces transient 5xx on the API path, and the retry path covers that.

Refs: `/tmp/context-engine-dogfood-phase3.md` (chips CAVEATS held; Phase 4 backlog item 3), #771.

## Test plan

- [ ] Force suggestions endpoint to return 503 → fetcher attempts, retries once at ~2.5s, then settles to 10s cooldown. Three-dot placeholder visible across attempt + retry + 2s tail (~5s total).
- [ ] WS reconnect during chip generation: chips render normally on success; if 5xx happens during the flap, retry fires and chips render after recovery.
- [ ] Successful fetches still populate chips normally with no placeholder flicker.
- [ ] 4xx response short-circuits straight to cooldown (no retry, brief placeholder, then nothing).
- [ ] `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)