### PR TITLE
fix: composer draft, + New label, WS reconnect, tab race, eval object literal (Phase 3 friction)

### DIFF
--- a/scripts/smoke-eval-wrap.ts
+++ b/scripts/smoke-eval-wrap.ts
@@ -142,6 +142,63 @@ async function run() {
     },
   );
 
+  // Phase 4 follow-up: bare object literals were silently returning the
+  // last block-statement expression instead of the object. The wrapper now
+  // detects single object-literal expressions and parens-wraps them.
+  await check(
+    'bare object literal {a:1}',
+    '{a:1}',
+    (text) => {
+      try {
+        const env = JSON.parse(text);
+        return env.ok === true && env.value && env.value.a === 1;
+      } catch { return false; }
+    },
+  );
+
+  await check(
+    'multi-key bare object literal',
+    '{a:1, b:2, c:"hello"}',
+    (text) => {
+      try {
+        const env = JSON.parse(text);
+        return env.ok === true && env.value && env.value.a === 1 && env.value.b === 2 && env.value.c === 'hello';
+      } catch { return false; }
+    },
+  );
+
+  // Multi-statement code that does NOT start with `{` should still take
+  // the regular indirect-eval path and roundtrip cleanly.
+  await check(
+    'multi-statement var assignment still works',
+    'var y = {x:1}; JSON.stringify(y)',
+    (text) => {
+      try {
+        const env = JSON.parse(text);
+        return env.ok === true && env.value === '{"x":1}';
+      } catch { return false; }
+    },
+  );
+
+  // Arrow-function expression returns the function via the
+  // non-serializable fallback (functions can't JSON.stringify) — the
+  // wrapper should not crash, and value should be the function's
+  // toString.
+  await check(
+    'arrow function expression () => 42',
+    '() => 42',
+    (text) => {
+      try {
+        const env = JSON.parse(text);
+        return env.ok === true
+          && env.nonSerializable === true
+          && env.valueType === 'function'
+          && typeof env.value === 'string'
+          && env.value.includes('42');
+      } catch { return false; }
+    },
+  );
+
   console.log(`\n${pass} passed, ${fail} failed`);
   process.exit(fail === 0 ? 0 : 1);
 }

--- a/src/components/desktop/agent-panel/useAgentPanelState.ts
+++ b/src/components/desktop/agent-panel/useAgentPanelState.ts
@@ -318,6 +318,21 @@ export function useAgentPanelState({
     };
   }, [onAgentsUpdate, wsConnected]);
 
+  // Phase 4 friction fix #3: while the inventory snapshot is in stale mode
+  // (the "Showing cached session state while the gateway reconnects" banner)
+  // the 5-minute fallback poll is too slow to actually clear the banner —
+  // users see it sit indefinitely after a transient hiccup. Run a fast
+  // recovery poll (8s) WHILE we're in stale mode; the existing fetchAll
+  // logic flips fleetMeta back to 'live' as soon as the inventory snapshot
+  // rebuilds. The poll auto-stops once mode flips off 'stale'.
+  useEffect(() => {
+    if (fleetMeta?.mode !== 'stale') return undefined;
+    const id = setInterval(() => {
+      fetchNowRef.current?.();
+    }, 8000);
+    return () => clearInterval(id);
+  }, [fleetMeta?.mode]);
+
   const workspaceGroups = useMemo(() => buildWorkspaceGroups(agents), [agents]);
   const inferredRepo = useMemo(() => {
     const preferredGroup = workspaceGroups.find((group) => group.hasRunning && group.repo !== 'workspace')

--- a/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
+++ b/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
@@ -315,6 +315,57 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
     setTimeout(() => inputRef.current?.focus(), 50);
   }, [draftInjection?.id, draftInjection?.text, open]);
 
+  // Phase 4 friction fix #1: clear stale composer drafts on tab refocus.
+  // The composer state is preserved across tab switches (the parent uses
+  // display:none, not unmount), so a directive review draft sitting in
+  // the textarea before the user navigated away ends up appended to
+  // whatever they type next time they return. Snapshot the input on
+  // tab-blur (open: true→false) and clear + toast on next refocus
+  // (open: false→true) IF that snapshot was non-empty AND no fresh
+  // draft injection arrived in the interim. The newDraftArrived check
+  // prevents the clear from wiping a legitimate inject; the
+  // inject effect declared above runs first in declaration order, so
+  // we observe the post-inject input here.
+  const previousOpenRef = useRef(open);
+  const inputAtBlurRef = useRef<string>('');
+  const lastSeenDraftIdRef = useRef<string | null>(draftInjection?.id ?? null);
+  const [showDraftClearedToast, setShowDraftClearedToast] = useState(false);
+  const draftClearedToastTimerRef = useRef<number | null>(null);
+  useEffect(() => {
+    return () => {
+      if (draftClearedToastTimerRef.current !== null) {
+        window.clearTimeout(draftClearedToastTimerRef.current);
+      }
+    };
+  }, []);
+  useEffect(() => {
+    const wasOpen = previousOpenRef.current;
+    previousOpenRef.current = open;
+    if (wasOpen && !open) {
+      inputAtBlurRef.current = input;
+      lastSeenDraftIdRef.current = draftInjection?.id ?? null;
+      return;
+    }
+    if (open && !wasOpen) {
+      const staleDraft = inputAtBlurRef.current.trim();
+      const newDraftArrived = (draftInjection?.id ?? null) !== lastSeenDraftIdRef.current;
+      if (staleDraft && !newDraftArrived) {
+        setInput('');
+        setPreEnhanceInput(null);
+        setShowDraftClearedToast(true);
+        if (draftClearedToastTimerRef.current !== null) {
+          window.clearTimeout(draftClearedToastTimerRef.current);
+        }
+        draftClearedToastTimerRef.current = window.setTimeout(() => {
+          setShowDraftClearedToast(false);
+          draftClearedToastTimerRef.current = null;
+        }, 1800);
+      }
+      inputAtBlurRef.current = '';
+      lastSeenDraftIdRef.current = draftInjection?.id ?? null;
+    }
+  }, [open, input, draftInjection?.id]);
+
   useEffect(() => {
     requestAnimationFrame(() => {
       chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -983,6 +1034,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
         reloadNotice={reloadNotice}
         onDismissReloadNotice={dismissReloadNotice}
         showClearToast={showClearToast}
+        showDraftClearedToast={showDraftClearedToast}
         thoughtsBodyBackground={thoughtsBodyBackground}
       />
 

--- a/src/components/desktop/thoughts/chat-panel/ChatToastStack.tsx
+++ b/src/components/desktop/thoughts/chat-panel/ChatToastStack.tsx
@@ -16,6 +16,8 @@ export interface ChatToastStackProps {
   reloadNotice: OrchestratorReloadNotice | null;
   onDismissReloadNotice: () => void;
   showClearToast: boolean;
+  /** Phase 4 friction fix #1: tab-refocus draft auto-clear toast. */
+  showDraftClearedToast?: boolean;
   thoughtsBodyBackground: string;
 }
 
@@ -24,10 +26,11 @@ export function ChatToastStack(props: ChatToastStackProps) {
     reloadNotice,
     onDismissReloadNotice,
     showClearToast,
+    showDraftClearedToast = false,
     thoughtsBodyBackground,
   } = props;
 
-  if (!reloadNotice && !showClearToast) return null;
+  if (!reloadNotice && !showClearToast && !showDraftClearedToast) return null;
 
   return (
     <>
@@ -68,6 +71,39 @@ export function ChatToastStack(props: ChatToastStackProps) {
           }}
         >
           <ClearToast />
+        </div>
+      ) : null}
+
+      {showDraftClearedToast ? (
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            paddingTop: 0,
+            paddingRight: 12,
+            paddingBottom: 8,
+            paddingLeft: 12,
+            background: thoughtsBodyBackground,
+            flexShrink: 0,
+            pointerEvents: 'none',
+          }}
+        >
+          <div
+            style={{
+              paddingTop: 6,
+              paddingRight: 10,
+              paddingBottom: 6,
+              paddingLeft: 10,
+              borderRadius: 10,
+              border: '1px solid var(--t-divider-subtle)',
+              background: 'var(--t-panel-translucent)',
+              color: 'var(--t-text-muted)',
+              fontSize: 11,
+              fontFamily: '"SF Mono", ui-monospace, monospace',
+            }}
+          >
+            Draft cleared.
+          </div>
         </div>
       ) : null}
     </>

--- a/src/components/desktop/workspace-terminal/OrchestratorHeader.tsx
+++ b/src/components/desktop/workspace-terminal/OrchestratorHeader.tsx
@@ -274,8 +274,8 @@ export function OrchestratorHeader({
           <button
             type="button"
             onClick={onNewConversation}
-            aria-label="New orchestrator conversation"
-            title="New orchestrator conversation"
+            aria-label="Start a new orchestrator thread"
+            title="Start a new orchestrator thread"
             style={{
               height: 44,
               paddingTop: 0,
@@ -311,7 +311,7 @@ export function OrchestratorHeader({
             }}
           >
             <PlusIcon size={13} />
-            <span>New</span>
+            <span>New thread</span>
           </button>
         ) : null}
       </div>

--- a/src/components/desktop/workspace-terminal/OrchestratorTab.tsx
+++ b/src/components/desktop/workspace-terminal/OrchestratorTab.tsx
@@ -549,7 +549,7 @@ function OrchestratorTabInner({ tabId, active, repoPath, repoLabel }: Orchestrat
   const thoughtsChatPanel = (
     <ThoughtsChatPanel
       ref={chatPanelRef}
-      open
+      open={active}
       draftInjection={effectiveDraftInjection}
       agents={agents}
       missionState={data.missionState}
@@ -663,8 +663,8 @@ function OrchestratorTabInner({ tabId, active, repoPath, repoLabel }: Orchestrat
             <button
               type="button"
               onClick={handleNewConversation}
-              aria-label="New orchestrator conversation"
-              title="New orchestrator conversation"
+              aria-label="Start a new orchestrator thread"
+              title="Start a new orchestrator thread"
               style={{
                 background: 'transparent',
                 gap: 6,
@@ -674,7 +674,7 @@ function OrchestratorTabInner({ tabId, active, repoPath, repoLabel }: Orchestrat
               }}
             >
               <PlusIcon size={13} />
-              <span>New</span>
+              <span>New thread</span>
             </button>
           ) : null}
         </div>

--- a/src/components/desktop/workspace-terminal/useWorkspaceTerminalController.ts
+++ b/src/components/desktop/workspace-terminal/useWorkspaceTerminalController.ts
@@ -113,6 +113,29 @@ export function useWorkspaceTerminalController(
   const reportedChatSessionsSignatureRef = useRef('');
   const reportedActiveChatSessionKeyRef = useRef<string | null>(null);
 
+  // Phase 4 friction fix #4: tab-navigation race during HMR.
+  // The restore pipeline (loadInitialTabState → applyPersistedState) is
+  // async. While the await resolves, the user may have clicked a different
+  // tab — the late-landing setActiveTabId from restore would then yank
+  // them back, looking like a phantom navigation. Track a monotonic
+  // counter that bumps on every USER-driven setActiveTabId; restore
+  // captures the value at the start of its async work and bails if a
+  // newer user nav landed in the interim.
+  const userNavVersionRef = useRef(0);
+  const setActiveTabIdFromUser = useCallback((next: string) => {
+    userNavVersionRef.current += 1;
+    setActiveTabId(next);
+  }, []);
+  const setActiveTabIdFromRestore = useCallback((next: string, capturedVersion: number) => {
+    if (capturedVersion !== userNavVersionRef.current) {
+      // Newer user nav landed during the restore await — drop this stale
+      // restore action so the user's tab stays put.
+      return false;
+    }
+    setActiveTabId(next);
+    return true;
+  }, []);
+
   preferredRepoRef.current = preferredRepo;
 
   const stableRepoScope = !splitCreated && preferredRepo?.localPath
@@ -305,6 +328,10 @@ export function useWorkspaceTerminalController(
   }, [createDefaultOrchestratorTab, createDefaultChatTab]);
 
   const applyPersistedState = useCallback(async (saved: PersistedTabState, cancelled?: () => boolean) => {
+    // Capture the user-nav version at the start of restore. If the user
+    // clicks a different tab while computeRestoredTabs is awaiting, the
+    // captured version goes stale and we drop the activeTabId update.
+    const capturedNavVersion = userNavVersionRef.current;
     const result = await computeRestoredTabs(saved, {
       preferredRepo: preferredRepoRef.current,
       defaultTab,
@@ -314,7 +341,7 @@ export function useWorkspaceTerminalController(
 
     tabsRef.current = result.tabs;
     setTabs(result.tabs);
-    setActiveTabId(result.activeTabId);
+    setActiveTabIdFromRestore(result.activeTabId, capturedNavVersion);
     if (cancelled?.()) return false;
 
     if (termWsConnectedRef.current) {
@@ -423,6 +450,11 @@ export function useWorkspaceTerminalController(
   useEffect(() => {
     if (tabs.length > 0 || !termWsConnected || splitCreated || !primaryRestoreSettled) return;
     const timer = window.setTimeout(() => {
+      // Capture the user-nav version at the point where this fallback
+      // restore is scheduled. If the user clicks a tab between the timer
+      // firing and the async load resolving, we drop the late activeTabId
+      // assignment so the user's click stays sticky. Phase 4 friction #4.
+      const capturedNavVersion = userNavVersionRef.current;
       void (async () => {
         if (stableRepoScope && preferredRepo?.localPath) {
           const saved = await loadTabState(stableRepoScope, preferredRepo.localPath);
@@ -434,27 +466,27 @@ export function useWorkspaceTerminalController(
         if (!autoCreateDefaultTab) {
           tabsRef.current = [];
           setTabs([]);
-          setActiveTabId('');
+          setActiveTabIdFromRestore('', capturedNavVersion);
           return;
         }
         if (defaultTab === 'llm-chat') {
           const defaultTabs = createDefaultChatTabSet();
           tabsRef.current = defaultTabs;
           setTabs(defaultTabs);
-          setActiveTabId(defaultTabs[0].id);
+          setActiveTabIdFromRestore(defaultTabs[0].id, capturedNavVersion);
           return;
         }
         const fallbackShell = createDefaultShellTab();
         tabsRef.current = [fallbackShell];
         setTabs([fallbackShell]);
-        setActiveTabId(fallbackShell.id);
+        setActiveTabIdFromRestore(fallbackShell.id, capturedNavVersion);
         if (termWsConnected) {
           requestTerminalForTab(fallbackShell.id);
         }
       })();
     }, 250);
     return () => window.clearTimeout(timer);
-  }, [applyPersistedState, autoCreateDefaultTab, createDefaultChatTab, createDefaultChatTabSet, createDefaultShellTab, defaultTab, preferredRepo?.localPath, primaryRestoreSettled, requestTerminalForTab, splitCreated, stableRepoScope, tabs.length, termWsConnected]);
+  }, [applyPersistedState, autoCreateDefaultTab, createDefaultChatTab, createDefaultChatTabSet, createDefaultShellTab, defaultTab, preferredRepo?.localPath, primaryRestoreSettled, requestTerminalForTab, setActiveTabIdFromRestore, splitCreated, stableRepoScope, tabs.length, termWsConnected]);
 
   useEffect(() => {
     if (tabs.length > 0 || defaultTab !== 'llm-chat') return;
@@ -539,10 +571,10 @@ export function useWorkspaceTerminalController(
     const result = computeCliChatSession(options, tabsRef.current, activeTabId);
     tabsRef.current = result.tabs;
     setTabs(result.tabs);
-    setActiveTabId(result.activeTabId);
+    setActiveTabIdFromUser(result.activeTabId);
     if (result.needsPersist) persistTabsNow(result.tabs, result.activeTabId);
     return result.activeTabId;
-  }, [activeTabId, persistTabsNow]);
+  }, [activeTabId, persistTabsNow, setActiveTabIdFromUser]);
 
   const openWorkspaceLlmChatSession = useCallback((options: {
     repo?: RegisteredRepo;
@@ -562,9 +594,9 @@ export function useWorkspaceTerminalController(
     } else if (result.newTab) {
       setTabs((previous) => [result.newTab!, ...previous]);
     }
-    setActiveTabId(result.activeTabId);
+    setActiveTabIdFromUser(result.activeTabId);
     return result.activeTabId;
-  }, [activeTabId]);
+  }, [activeTabId, setActiveTabIdFromUser]);
 
   const openWorkspaceInspectorTab = useCallback((canvasTab: NonNullable<TerminalTab['canvasTab']>, options?: { repo?: RegisteredRepo; createNew?: boolean }) => {
     const result = computeInspectorTab(canvasTab, tabsRef.current, options);
@@ -578,10 +610,10 @@ export function useWorkspaceTerminalController(
       setTabs((previous) => [result.newTab!, ...previous]);
     }
     if (result.activeTabId !== null) {
-      setActiveTabId(result.activeTabId);
+      setActiveTabIdFromUser(result.activeTabId);
     }
     return result.updatedTabId ?? result.newTab?.id ?? '';
-  }, []);
+  }, [setActiveTabIdFromUser]);
 
   const handleOpenWorkspaceCommitTab = useCallback((hash: string, meta?: Record<string, string>, repo?: RegisteredRepo) => {
     const { canvasTab, repo: resolvedRepo } = buildCommitCanvasTab(hash, meta, repo);
@@ -602,7 +634,11 @@ export function useWorkspaceTerminalController(
     preferredRepo,
     setTabs,
     setPreviews,
-    setActiveTabId,
+    // External callers via the imperative handle are user-driven (e.g.
+    // the dashboard wiring an "open this tab" gesture) — bump the
+    // user-nav version so a concurrently-running restore doesn't yank
+    // the tab back. Phase 4 friction fix #4.
+    setActiveTabId: setActiveTabIdFromUser,
     onPreviewDetected,
     onOpenRepoDiff,
     handleSessionCreated,
@@ -612,7 +648,7 @@ export function useWorkspaceTerminalController(
     persistTabsNow,
     sendTerminalDetach,
     closeTabById: (tabId: string) => handleCloseTabRef.current(tabId),
-  }), [activeTabId, handleSessionCreated, onOpenRepoDiff, onPreviewDetected, openWorkspaceCliChatSession, openWorkspaceInspectorTab, openWorkspaceLlmChatSession, persistTabsNow, preferredRepo, sendTerminalDetach, stateScope]);
+  }), [activeTabId, handleSessionCreated, onOpenRepoDiff, onPreviewDetected, openWorkspaceCliChatSession, openWorkspaceInspectorTab, openWorkspaceLlmChatSession, persistTabsNow, preferredRepo, sendTerminalDetach, setActiveTabIdFromUser, stateScope]);
 
   const handleRegisterRepo = useCallback((localPath: string) => {
     fetch('/api/panel/repos', {
@@ -630,15 +666,15 @@ export function useWorkspaceTerminalController(
       pendingCliCommands.current.set(result.newTab.id, result.cliCommand);
     }
     setTabs((previous) => [result.newTab!, ...previous]);
-    setActiveTabId(result.activeTabId);
+    setActiveTabIdFromUser(result.activeTabId);
     requestTerminalForTab(result.newTab.id, result.cliCommand ?? undefined);
-  }, [requestTerminalForTab]);
+  }, [requestTerminalForTab, setActiveTabIdFromUser]);
 
   const handleNewChatTab = useCallback((runtime: Exclude<WorkspaceChatRuntime, 'chat'>, repo?: RegisteredRepo) => {
     const newTab = buildNewChatTab(runtime, repo);
     setTabs((previous) => [newTab, ...previous]);
-    setActiveTabId(newTab.id);
-  }, []);
+    setActiveTabIdFromUser(newTab.id);
+  }, [setActiveTabIdFromUser]);
 
   const handleNewLLMChatTab = useCallback((repo?: RegisteredRepo) => {
     const newTab = buildNewLlmChatTab(repo ?? preferredRepo ?? undefined);
@@ -647,8 +683,8 @@ export function useWorkspaceTerminalController(
       persistTabsNow(nextTabs, newTab.id);
       return nextTabs;
     });
-    setActiveTabId(newTab.id);
-  }, [persistTabsNow, preferredRepo]);
+    setActiveTabIdFromUser(newTab.id);
+  }, [persistTabsNow, preferredRepo, setActiveTabIdFromUser]);
 
   const handleUpdateChatMessages = useCallback((tabId: string, messages: MobileTranscriptEntry[]) => {
     setTabs((previous) => previous.map((tab) => (
@@ -696,8 +732,8 @@ export function useWorkspaceTerminalController(
     const result = computeCheckpointRestore(tabsRef.current, tabId);
     if (!result.newTab) return;
     setTabs((previous) => [...previous, result.newTab!]);
-    setActiveTabId(result.activeTabId);
-  }, []);
+    setActiveTabIdFromUser(result.activeTabId);
+  }, [setActiveTabIdFromUser]);
 
   const handleConsumeChatDraftInjection = useCallback((tabId: string, injectionId: string) => {
     setTabs((previous) => previous.map((tab) => (
@@ -721,13 +757,13 @@ export function useWorkspaceTerminalController(
       sendTerminalInput(target.tmuxSession!, command + '\n');
     } else if (target.kind === 'pending-shell') {
       pendingCliCommands.current.set(target.pendingTabId!, command);
-      setActiveTabId(target.pendingTabId!);
+      setActiveTabIdFromUser(target.pendingTabId!);
     } else {
       setTabs((previous) => [...previous, target.newTab!]);
-      setActiveTabId(target.newTab!.id);
+      setActiveTabIdFromUser(target.newTab!.id);
       requestTerminalForTab(target.newTab!.id, command);
     }
-  }, [requestTerminalForTab, sendTerminalInput, tabs]);
+  }, [requestTerminalForTab, sendTerminalInput, setActiveTabIdFromUser, tabs]);
 
   const handleCloseTab = useCallback((tabId: string) => {
     const result = computeCloseTab(tabsRef.current, tabId, activeTabId);
@@ -746,13 +782,13 @@ export function useWorkspaceTerminalController(
       if (pendingTabId === tabId) pendingRequestRef.current.delete(requestId);
     }
     setTabs(result.remaining);
-    if (result.nextActiveId !== null) setActiveTabId(result.nextActiveId);
+    if (result.nextActiveId !== null) setActiveTabIdFromUser(result.nextActiveId);
     setPreviews((prev) => {
       const toRemove = prev.filter((p) => p.tabId === tabId);
       toRemove.forEach((p) => detectedPortsRef.current.delete(p.port));
       return prev.filter((p) => p.tabId !== tabId);
     });
-  }, [activeTabId, sendTerminalDetach]);
+  }, [activeTabId, sendTerminalDetach, setActiveTabIdFromUser]);
 
   handleCloseTabRef.current = handleCloseTab;
 
@@ -818,11 +854,11 @@ export function useWorkspaceTerminalController(
   }, []);
 
   const handleSelectTab = useCallback((id: string) => {
-    setActiveTabId(id);
+    setActiveTabIdFromUser(id);
     setTabs((previous) => previous.map((tab) => (
       tab.id === id && tab.unseen ? { ...tab, unseen: false } : tab
     )));
-  }, []);
+  }, [setActiveTabIdFromUser]);
 
   const handleClosePreview = useCallback((id: string) => {
     setPreviews((previous) => {
@@ -843,13 +879,13 @@ export function useWorkspaceTerminalController(
     const newTab = buildHistoryChatTab(currentTab, historyTabId, title, historyRepo);
     setTabs((previous) => {
       if (previous.some((tab) => tab.id === historyTabId)) {
-        setActiveTabId(historyTabId);
+        setActiveTabIdFromUser(historyTabId);
         return previous;
       }
       return [...previous, newTab];
     });
-    setActiveTabId(historyTabId);
-  }, []);
+    setActiveTabIdFromUser(historyTabId);
+  }, [setActiveTabIdFromUser]);
 
   return {
     activeCheckpoint,

--- a/src/lib/mcp/o8-webview-tools.ts
+++ b/src/lib/mcp/o8-webview-tools.ts
@@ -126,6 +126,47 @@ function capEvalResult(raw: string): McpToolResult {
 // expressions like `JSON.stringify(arrayOfObjects)`,
 // `(() => { var x = ...; x.click(); return x.id; })()`, and
 // `var x = setItem(...); x`.
+
+// Phase 4 follow-up — bare object-literal expressions are a known JS parser
+// ambiguity. `{a: 1}` parses as a block statement (label `a:` + expression
+// `1`), so the indirect eval returns `1` rather than `{a:1}`. Detect single
+// object-literal expressions via a small balanced-brace + statement-keyword
+// heuristic and parens-wrap them so the parser sees an expression. Multi-
+// statement code (var/let/const/return + body) still goes through the
+// regular path.
+function looksLikeObjectLiteralExpression(trimmed: string): boolean {
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return false;
+  // Cheap statement-keyword reject — reduces false positives without a
+  // full tokenizer. These won't appear inside a normal object literal in
+  // a way that matters for the heuristic.
+  if (/\b(?:var|let|const|return|function|if|for|while|do|switch|try|throw|class)\b/.test(trimmed)) {
+    return false;
+  }
+  let depth = 0;
+  let inString: '"' | "'" | '`' | null = null;
+  let escaped = false;
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i];
+    if (escaped) { escaped = false; continue; }
+    if (inString) {
+      if (ch === '\\') { escaped = true; continue; }
+      if (ch === inString) { inString = null; }
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') { inString = ch; continue; }
+    if (ch === '{' || ch === '[' || ch === '(') { depth++; continue; }
+    if (ch === '}' || ch === ']' || ch === ')') {
+      depth--;
+      // If the outer `{` closes before the very end, this isn't a single
+      // object-literal expression (eg. `{a:1}{b:2}`).
+      if (depth === 0 && i !== trimmed.length - 1) return false;
+      continue;
+    }
+    if (ch === ';' && depth === 1) return false;
+  }
+  return depth === 0;
+}
+
 function wrapEvalCode(userCode: string): string {
   const trimmed = userCode.trim();
   // Run the user code via indirect eval — `(0, eval)(code)` evaluates in the
@@ -133,6 +174,9 @@ function wrapEvalCode(userCode: string): string {
   // which is what the user expects when they write `var x = 42; x`. Direct
   // `new Function(code)` would silently return undefined because function
   // bodies require an explicit `return`.
+  //
+  // Phase 4 follow-up: bare object literals (`{a:1}`) need a parens wrap
+  // so the parser sees them as expressions instead of block statements.
   //
   // After we have the value, probe JSON.stringify behaviour:
   //   - If JSON.stringify drops the value key (function, undefined,
@@ -142,7 +186,10 @@ function wrapEvalCode(userCode: string): string {
   //   - Otherwise return the envelope as-is.
   //
   // Errors during eval surface as { ok: false, error: { message, name, stack } }.
-  const codeJson = JSON.stringify(trimmed);
+  const evalSource = looksLikeObjectLiteralExpression(trimmed)
+    ? `(${trimmed})`
+    : trimmed;
+  const codeJson = JSON.stringify(evalSource);
   return `(() => {
   const __o8_user_code__ = ${codeJson};
   let __o8_value__;


### PR DESCRIPTION
## Summary

Phase 4 — bundles the 5 adjacent friction items the chips Phase 3 dogfood agent surfaced into one PR.

References: Phase 3 audit `/tmp/context-engine-dogfood-phase3.md` ("Other findings worth filing").

### 1. Composer pre-populated with stale directive draft
`ThoughtsChatPanel.tsx` now snapshots the composer input on tab blur (`open: true → false`) and clears + shows a "Draft cleared" toast on next refocus IF the snapshot was non-empty AND no fresh draft injection arrived in the interim. The new-draft check prevents wiping a legitimate `draftInjection` — the inject effect declared above runs first, so we observe post-inject input. `OrchestratorTab.tsx` now passes `active` as the `open` prop so the panel can detect tab focus changes.

### 2. "+ New" button rename
The orchestrator chrome `+ New` button (in `OrchestratorTab.tsx` and the unused `OrchestratorHeader.tsx`) renamed to `+ New thread` with matching aria-label/title — accurately describes what `handleNewConversation` does (mints a fresh threadId via `chatPanelRef.reset()`).

### 3. Persistent WS gateway disconnect banner
`useAgentPanelState.ts` adds a fast recovery poll: while `fleetMeta?.mode === 'stale'` the existing inventory fetch fires every 8s. The 5min fallback was too slow to actually clear the "Showing cached session state while the gateway reconnects" banner after a transient hiccup. The poll auto-stops once `mode` flips off `'stale'`. The existing `DesktopWebSocketContext` already has exponential-backoff reconnect (1→2→4→8→16→30s cap), so this fix is purely about the banner clearing once the runtime inventory rebuilds.

### 4. Tab navigation race during HMR
`useWorkspaceTerminalController.ts` introduces a monotonic `userNavVersionRef` counter. Every user-driven `setActiveTabId` (handleSelectTab, handleNewTab, handleNewChatTab, handleNewLLMChatTab, handleRestoreLatestCheckpoint, handleRunCommandInTerminal, handleCloseTab nextActiveId, handleOpenHistoryChat, openWorkspace*Session, plus the imperative-handle setActiveTabId) bumps the version. The async restore paths (`applyPersistedState` and the fallback path) capture the version at the start of their async work, then bail before applying `activeTabId` if a newer user nav landed in the interim — so HMR-triggered restores no longer yank the user back to a stale tab.

### 5. `o8_view_eval` drops bare object literals
`o8-webview-tools.ts` adds `looksLikeObjectLiteralExpression()` that detects single object-literal expressions via balanced-brace + statement-keyword heuristic, then parens-wraps the input before indirect eval. `{a:1}` parses as a block statement (label `a:` + expr `1`); paren-wrap forces expression context. Multi-statement code (`var y = {x:1}; y`) still takes the regular path — the heuristic rejects on top-level semicolons and statement keywords. Smoke test grew from 8 to 12 cases.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx tsx scripts/smoke-eval-wrap.ts` — 12/12 PASS (was 8/8 pre-PR)
- [ ] Composer draft: navigate to non-orchestrator tab + back, draft cleared, toast appears
- [ ] "+ New" label: orchestrator chrome reads "+ New thread"
- [ ] WS banner: simulate inventory stale state, verify 8s poll fires and banner clears once snapshot rebuilds
- [ ] Tab race: smoke-test the version counter — open multiple tabs, click a tab, trigger HMR, observe the user's tab stays selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)