### PR TITLE
feat(projects): AI semantics Stage 1 fingerprint extractor (epic #899 wave 1)

### DIFF
--- a/scripts/smoke-fingerprint.tsx
+++ b/scripts/smoke-fingerprint.tsx
@@ -1,0 +1,152 @@
+// #899 — Smoke test for the Stage 1 fingerprint extractor.
+//
+// Runs against the registered cortex-ide + o8-site repos plus a hypothetical
+// empty path. Verifies size cap, deterministic hash, cache invalidation,
+// and the privacy guarantees (no source code, no .env values).
+//
+// Run from the worktree root:
+//   O8_DATA_DIR=$(mktemp -d) npx tsx scripts/smoke-fingerprint.tsx
+
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readdirSync } from 'node:fs';
+
+import { computeFingerprint, __TEST } from '@/lib/projects/fingerprint';
+import {
+  getOrComputeFingerprint,
+  getOrComputeFingerprintForPath,
+  getFingerprintCacheDir,
+} from '@/lib/projects/fingerprint-cache';
+import { listRepos } from '@/lib/repos/registry';
+
+let pass = 0;
+let fail = 0;
+
+function check(name: string, cond: boolean, debug?: unknown) {
+  if (cond) {
+    pass++;
+    console.log(`  PASS  ${name}`);
+  } else {
+    fail++;
+    console.log(`  FAIL  ${name}${debug !== undefined ? ` :: ${JSON.stringify(debug)}` : ''}`);
+  }
+}
+
+function byteLen(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), 'utf-8');
+}
+
+async function main() {
+  console.log('--- 1. cortex-ide (large repo) ---');
+  const repos = await listRepos();
+  const cortex = repos.find((r) => r.name === 'cortex-ide');
+  if (!cortex) throw new Error('cortex-ide not in registry — run o8 once to populate ~/.o8/repos.json.');
+
+  const fp1 = await getOrComputeFingerprint(cortex.id);
+  console.log(JSON.stringify(fp1, null, 2));
+  console.log(`  size: ${byteLen(fp1)} bytes`);
+
+  check('cortex-ide ≤ 2KB', byteLen(fp1) <= __TEST.MAX_BYTES, byteLen(fp1));
+  check('cortex-ide manifest=package.json', fp1.manifest.type === 'package.json', fp1.manifest.type);
+  check('cortex-ide hash is sha256-shaped', /^[a-f0-9]{64}$/.test(fp1.hash), fp1.hash);
+  check('cortex-ide has nextConfig hint', fp1.deployHints.nextConfig !== undefined);
+  // envExampleKeys may be evicted by the size cap for big repos — that's the
+  // documented behaviour. We only assert that IF it's present, it's KEYS only.
+  const envCaptured = Array.isArray(fp1.deployHints.envExampleKeys);
+  console.log(`  (envExampleKeys ${envCaptured ? 'present' : 'evicted by size cap'})`);
+  const envOk = (fp1.deployHints.envExampleKeys ?? []).every((k) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(k));
+  check('envExampleKeys (if present) are KEYS only', envOk);
+
+  // Privacy: no version values inside dep arrays. Versions look like "1.2.3"
+  // or "^1.0.0" — bare names never contain digits-only or caret/tilde prefixes.
+  const depOk = (fp1.manifest.dependencies ?? []).every((n) => !/^[~^]?\d/.test(n));
+  check('dep entries are NAMES only (no versions)', depOk);
+
+  // Privacy: serialized fingerprint must not contain the literal contents of
+  // any .env value. Spot-check by ensuring no '=' immediately follows a
+  // candidate key (would indicate "KEY=val" leaked through).
+  const serialized = JSON.stringify(fp1);
+  check('no KEY=value patterns in fingerprint', !/[A-Z_]+=[^,"\s}]+/.test(serialized));
+
+  console.log('\n--- 2. o8-site (small repo) ---');
+  const o8 = repos.find((r) => r.name === 'o8-site');
+  if (o8) {
+    const fp2 = await getOrComputeFingerprint(o8.id);
+    console.log(JSON.stringify(fp2, null, 2));
+    console.log(`  size: ${byteLen(fp2)} bytes`);
+    check('o8-site ≤ 2KB', byteLen(fp2) <= __TEST.MAX_BYTES, byteLen(fp2));
+  } else {
+    console.log('  (skipped — o8-site not registered)');
+  }
+
+  console.log('\n--- 3. empty repo path ---');
+  const emptyDir = mkdtempSync(path.join(os.tmpdir(), 'fingerprint-empty-'));
+  try {
+    const fp3 = computeFingerprint('empty-repo-id', emptyDir);
+    console.log(JSON.stringify(fp3, null, 2));
+    check('empty repo skeleton has manifest=unknown', fp3.manifest.type === 'unknown');
+    check('empty repo skeleton has empty deployHints', Object.keys(fp3.deployHints).length === 0);
+    check('empty repo skeleton has empty topLevelFolders', fp3.topLevelFolders.length === 0);
+    check('empty repo skeleton ≤ 2KB', byteLen(fp3) <= __TEST.MAX_BYTES);
+    check('empty repo skeleton hash is sha256-shaped', /^[a-f0-9]{64}$/.test(fp3.hash));
+  } finally {
+    rmSync(emptyDir, { recursive: true, force: true });
+  }
+
+  console.log('\n--- 4. nonexistent repo path ---');
+  const fp4 = computeFingerprint('ghost-repo', '/this/path/does/not/exist/anywhere');
+  check('nonexistent repo returns valid skeleton', fp4.manifest.type === 'unknown' && fp4.topLevelFolders.length === 0);
+
+  console.log('\n--- 5. determinism + cache invalidation ---');
+  // Build a tiny throwaway repo, fingerprint twice — hash should match.
+  const fakeRepo = mkdtempSync(path.join(os.tmpdir(), 'fingerprint-fake-'));
+  try {
+    writeFileSync(
+      path.join(fakeRepo, 'package.json'),
+      JSON.stringify({
+        name: 'fake-pkg',
+        description: 'tiny',
+        dependencies: { lodash: '^4.0.0', react: '^18.0.0' },
+      }),
+    );
+    writeFileSync(path.join(fakeRepo, 'README.md'), '# Fake\n\nA test repo.\n');
+    writeFileSync(path.join(fakeRepo, '.env.example'), 'API_KEY=do_not_leak\nDATABASE_URL=postgres://lol\n');
+    mkdirSync(path.join(fakeRepo, 'src'));
+    mkdirSync(path.join(fakeRepo, 'docs'));
+
+    const a = computeFingerprint('fake-repo', fakeRepo);
+    const b = computeFingerprint('fake-repo', fakeRepo);
+    check('determinism: hash matches across two fresh runs', a.hash === b.hash, { a: a.hash, b: b.hash });
+    check('fake repo .env values not leaked', !JSON.stringify(a).includes('do_not_leak') && !JSON.stringify(a).includes('postgres://lol'));
+    const envKeys = a.deployHints.envExampleKeys ?? [];
+    check('fake repo .env keys ARE captured', envKeys.includes('API_KEY') && envKeys.includes('DATABASE_URL'));
+
+    // Now mutate the README → hash MUST change.
+    writeFileSync(path.join(fakeRepo, 'README.md'), '# Fake\n\nMUTATED.\n');
+    const c = computeFingerprint('fake-repo', fakeRepo);
+    check('cache invalidation: README change → new hash', a.hash !== c.hash, { a: a.hash, c: c.hash });
+
+    // Cache round-trip via getOrComputeFingerprintForPath.
+    const tmpData = mkdtempSync(path.join(os.tmpdir(), 'fingerprint-data-'));
+    process.env.O8_DATA_DIR = tmpData;
+    try {
+      const d1 = getOrComputeFingerprintForPath('fake-repo', fakeRepo);
+      const d2 = getOrComputeFingerprintForPath('fake-repo', fakeRepo);
+      check('cache: two reads return same hash', d1.hash === d2.hash);
+      check('cache: cache file written', readdirSync(getFingerprintCacheDir()).length > 0);
+    } finally {
+      rmSync(tmpData, { recursive: true, force: true });
+      delete process.env.O8_DATA_DIR;
+    }
+  } finally {
+    rmSync(fakeRepo, { recursive: true, force: true });
+  }
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  if (fail > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('smoke threw:', err);
+  process.exit(1);
+});

--- a/src/lib/projects/fingerprint-cache.ts
+++ b/src/lib/projects/fingerprint-cache.ts
@@ -1,0 +1,128 @@
+/**
+ * #899 — Fingerprint cache.
+ *
+ * Reads/writes one JSON file per repo at
+ * `~/.o8/repo-fingerprints/<repo-id>.json`. On read we recompute the
+ * current fingerprint and only short-circuit when the content hash matches
+ * the cached value — so README, manifest, or deploy-config edits invalidate
+ * automatically without a separate watcher.
+ *
+ * No throwing: every file/IO error degrades to "no cache, just recompute".
+ */
+
+import 'server-only';
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { getDataDir } from '@/lib/data-dir-migration';
+import { listRepos } from '@/lib/repos/registry';
+import {
+  computeFingerprint,
+  type GithubMeta,
+  type RepoFingerprint,
+} from './fingerprint';
+
+const CACHE_DIR_NAME = 'repo-fingerprints';
+
+function cacheDir(): string {
+  return join(getDataDir(), CACHE_DIR_NAME);
+}
+
+function cacheFilePath(repoId: string): string {
+  return join(cacheDir(), `${sanitizeId(repoId)}.json`);
+}
+
+/**
+ * Repo IDs come from `randomUUID()` so they're already filesystem-safe, but
+ * a defensive scrub means a malformed ID can never escape the cache dir.
+ */
+function sanitizeId(repoId: string): string {
+  return repoId.replace(/[^A-Za-z0-9_\-]/g, '_').slice(0, 64) || '_unknown';
+}
+
+function readCached(repoId: string): RepoFingerprint | null {
+  const path = cacheFilePath(repoId);
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<RepoFingerprint>;
+    if (!parsed || typeof parsed !== 'object' || typeof parsed.hash !== 'string') return null;
+    return parsed as RepoFingerprint;
+  } catch {
+    return null;
+  }
+}
+
+function writeCached(repoId: string, fp: RepoFingerprint): void {
+  try {
+    mkdirSync(cacheDir(), { recursive: true });
+    writeFileSync(cacheFilePath(repoId), JSON.stringify(fp, null, 2), 'utf-8');
+  } catch (err) {
+    console.warn(
+      '[fingerprint-cache] Failed to write cache:',
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
+/**
+ * Resolve a repo path for a given id via the registry. Returns null when
+ * the id isn't registered — callers should treat that as "no fingerprint".
+ */
+async function resolveRepoPath(repoId: string): Promise<string | null> {
+  try {
+    const repos = await listRepos();
+    const entry = repos.find((r) => r.id === repoId);
+    return entry?.localPath ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Public entry point. Recomputes the fingerprint from disk; if the new
+ * hash matches the cached one, returns the cached object (preserves the
+ * original `generatedAt`). Otherwise writes the new one and returns it.
+ *
+ * Optional `github` lets callers pipe in metadata they already fetched
+ * (description / topics / languages). When omitted those fields stay empty —
+ * Stage 2 (the LLM call) is responsible for making the most of whatever
+ * Stage 1 happens to have.
+ */
+export async function getOrComputeFingerprint(
+  repoId: string,
+  github?: GithubMeta,
+): Promise<RepoFingerprint> {
+  const repoPath = await resolveRepoPath(repoId);
+  const fresh = computeFingerprint(repoId, repoPath ?? '', github);
+  const cached = readCached(repoId);
+  if (cached && cached.hash === fresh.hash) {
+    return cached;
+  }
+  writeCached(repoId, fresh);
+  return fresh;
+}
+
+/**
+ * Direct path variant — useful for smoke tests that target an unregistered
+ * folder (and for the smoke script that covers the "empty repo skeleton"
+ * acceptance case). Bypasses the registry lookup.
+ */
+export function getOrComputeFingerprintForPath(
+  repoId: string,
+  repoPath: string,
+  github?: GithubMeta,
+): RepoFingerprint {
+  const fresh = computeFingerprint(repoId, repoPath, github);
+  const cached = readCached(repoId);
+  if (cached && cached.hash === fresh.hash) {
+    return cached;
+  }
+  writeCached(repoId, fresh);
+  return fresh;
+}
+
+export function getFingerprintCacheDir(): string {
+  return cacheDir();
+}

--- a/src/lib/projects/fingerprint.ts
+++ b/src/lib/projects/fingerprint.ts
@@ -1,0 +1,606 @@
+/**
+ * #899 — AI project semantics, Stage 1 fingerprint extractor (deterministic).
+ *
+ * Reads the public-ish surface of a repo (manifest dep KEYS, README first 100
+ * lines, top-level folders, deploy hints) and emits a ≤2KB JSON fingerprint
+ * that Stage 2 (the LLM call, future wave) will turn into project semantics.
+ *
+ * Privacy is load-bearing here:
+ *   - Never reads source code (.ts / .tsx / .py / .rs / .go bodies).
+ *   - Never reads `.env` — only `.env.example`, KEYS only (split on `=`,
+ *     discard the right side).
+ *   - Manifest values (versions) are stripped — only dep names survive.
+ *   - vercel.json / railway.json: top-level keys only, never values.
+ *   - next.config: only safe extracts (rewrites presence, image hostnames,
+ *     env keys) — pulled by regex, never via require/exec.
+ *   - README capped at 100 lines × 200 chars.
+ *
+ * Hard size cap is 2KB after JSON.stringify(). The truncate path drops
+ * `readme.firstLines` first, then deps, until we fit.
+ */
+
+import 'server-only';
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+
+// ── public types ──────────────────────────────────────────────────────────
+
+export type ManifestType =
+  | 'package.json'
+  | 'cargo.toml'
+  | 'pyproject.toml'
+  | 'requirements.txt'
+  | 'go.mod'
+  | 'unknown';
+
+export interface RepoFingerprint {
+  repoId: string;
+  /** sha256(canonicalize(rest)) — used for cache invalidation. */
+  hash: string;
+  generatedAt: number;
+  github: {
+    description?: string;
+    topics?: string[];
+    languages?: Record<string, number>;
+    primaryLanguage?: string;
+    homepage?: string;
+  };
+  manifest: {
+    type: ManifestType;
+    name?: string;
+    description?: string;
+    homepage?: string;
+    dependencies?: string[];
+    devDependencies?: string[];
+  };
+  readme?: {
+    firstLines: string[];
+    crossLinks?: string[];
+  };
+  topLevelFolders: string[];
+  deployHints: {
+    vercel?: string[];
+    railway?: string[];
+    docker?: boolean;
+    fly?: boolean;
+    wrangler?: boolean;
+    nextConfig?: {
+      hasRewrites?: boolean;
+      hasImagesDomains?: string[];
+      hasEnv?: string[];
+    };
+    envExampleKeys?: string[];
+  };
+}
+
+/** GitHub-side metadata, supplied by the caller (we never fetch). */
+export interface GithubMeta {
+  description?: string;
+  topics?: string[];
+  languages?: Record<string, number>;
+  primaryLanguage?: string;
+  homepage?: string;
+}
+
+const MAX_BYTES = 2048;
+const README_MAX_LINES = 100;
+const README_MAX_LINE_LEN = 200;
+const TOP_LEVEL_MAX = 30;
+const READ_FILE_BUDGET = 256 * 1024; // hard cap on any single read
+
+// ── safe IO ───────────────────────────────────────────────────────────────
+
+function safeReadJson(path: string): unknown {
+  try {
+    if (!existsSync(path)) return null;
+    const raw = readFileSync(path, { encoding: 'utf-8' }).slice(0, READ_FILE_BUDGET);
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function safeReadText(path: string): string | null {
+  try {
+    if (!existsSync(path)) return null;
+    return readFileSync(path, { encoding: 'utf-8' }).slice(0, READ_FILE_BUDGET);
+  } catch {
+    return null;
+  }
+}
+
+// ── manifest ──────────────────────────────────────────────────────────────
+
+function pickType(repoPath: string): ManifestType {
+  if (existsSync(join(repoPath, 'package.json'))) return 'package.json';
+  if (existsSync(join(repoPath, 'Cargo.toml'))) return 'cargo.toml';
+  if (existsSync(join(repoPath, 'pyproject.toml'))) return 'pyproject.toml';
+  if (existsSync(join(repoPath, 'requirements.txt'))) return 'requirements.txt';
+  if (existsSync(join(repoPath, 'go.mod'))) return 'go.mod';
+  return 'unknown';
+}
+
+function readPackageJson(repoPath: string) {
+  const parsed = safeReadJson(join(repoPath, 'package.json'));
+  if (!parsed || typeof parsed !== 'object') return null;
+  const obj = parsed as Record<string, unknown>;
+  const out: {
+    name?: string;
+    description?: string;
+    homepage?: string;
+    dependencies?: string[];
+    devDependencies?: string[];
+  } = {};
+  if (typeof obj.name === 'string') out.name = obj.name;
+  if (typeof obj.description === 'string') out.description = obj.description;
+  if (typeof obj.homepage === 'string') out.homepage = obj.homepage;
+  for (const key of ['dependencies', 'devDependencies'] as const) {
+    const block = obj[key];
+    if (block && typeof block === 'object' && !Array.isArray(block)) {
+      const names = Object.keys(block as Record<string, unknown>).filter(Boolean).sort();
+      if (names.length > 0) out[key] = names;
+    }
+  }
+  return out;
+}
+
+/**
+ * Read top-level KEY names from a TOML table. Versions/values discarded.
+ * Quoted keys ignored — Cargo/Pyproject deps are bare identifiers.
+ */
+function readTomlTableKeys(raw: string, tableName: string): string[] {
+  const headerRe = new RegExp(
+    `^\\[\\s*${tableName.replace(/\./g, '\\.')}\\s*\\]\\s*$`,
+    'm',
+  );
+  const headerMatch = raw.match(headerRe);
+  if (!headerMatch || headerMatch.index === undefined) return [];
+  const after = raw.slice(headerMatch.index + headerMatch[0].length);
+  const nextHeaderIdx = after.search(/^\[/m);
+  const block = nextHeaderIdx >= 0 ? after.slice(0, nextHeaderIdx) : after;
+  const keys: string[] = [];
+  for (const line of block.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx <= 0) continue;
+    const lhs = trimmed.slice(0, eqIdx).trim();
+    const baseKey = lhs.split('.')[0]?.trim();
+    if (!baseKey) continue;
+    if (baseKey.startsWith('"') || baseKey.startsWith("'")) continue;
+    if (!/^[A-Za-z0-9][A-Za-z0-9_\-]*$/.test(baseKey)) continue;
+    keys.push(baseKey);
+  }
+  return keys;
+}
+
+function readCargoToml(repoPath: string) {
+  const raw = safeReadText(join(repoPath, 'Cargo.toml'));
+  if (!raw) return null;
+  const out: { name?: string; description?: string; dependencies?: string[]; devDependencies?: string[] } = {};
+  // Pull `name` and `description` from `[package]`.
+  const pkgIdx = raw.search(/^\[\s*package\s*\]/m);
+  if (pkgIdx >= 0) {
+    const after = raw.slice(pkgIdx);
+    const nextHdr = after.search(/\n\[/);
+    const block = nextHdr >= 0 ? after.slice(0, nextHdr) : after;
+    const nameM = block.match(/^\s*name\s*=\s*"([^"]+)"/m);
+    if (nameM) out.name = nameM[1];
+    const descM = block.match(/^\s*description\s*=\s*"([^"]+)"/m);
+    if (descM) out.description = descM[1];
+  }
+  const deps = [...new Set(readTomlTableKeys(raw, 'dependencies'))].sort();
+  const devDeps = [...new Set(readTomlTableKeys(raw, 'dev-dependencies'))].sort();
+  if (deps.length > 0) out.dependencies = deps;
+  if (devDeps.length > 0) out.devDependencies = devDeps;
+  return out;
+}
+
+function readPyprojectToml(repoPath: string) {
+  const raw = safeReadText(join(repoPath, 'pyproject.toml'));
+  if (!raw) return null;
+  const out: { name?: string; description?: string; dependencies?: string[]; devDependencies?: string[] } = {};
+  const projectIdx = raw.search(/^\[\s*project\s*\]/m);
+  if (projectIdx >= 0) {
+    const after = raw.slice(projectIdx);
+    const nextHdr = after.search(/\n\[/);
+    const block = nextHdr >= 0 ? after.slice(0, nextHdr) : after;
+    const nameM = block.match(/^\s*name\s*=\s*"([^"]+)"/m);
+    if (nameM) out.name = nameM[1];
+    const descM = block.match(/^\s*description\s*=\s*"([^"]+)"/m);
+    if (descM) out.description = descM[1];
+    const arrM = block.match(/^\s*dependencies\s*=\s*\[([\s\S]*?)\]/m);
+    if (arrM) {
+      const names = new Set<string>();
+      for (const item of arrM[1].split(',')) {
+        const cleaned = item.replace(/[#].*$/g, '').trim().replace(/^['"]|['"]$/g, '');
+        const m = cleaned.match(/^([A-Za-z0-9][A-Za-z0-9_\-.]*)/);
+        if (m?.[1]) names.add(m[1]);
+      }
+      if (names.size > 0) out.dependencies = [...names].sort();
+    }
+  }
+  // Poetry layout
+  const poetryDeps = readTomlTableKeys(raw, 'tool.poetry.dependencies');
+  const poetryDevDeps = readTomlTableKeys(raw, 'tool.poetry.dev-dependencies');
+  if (poetryDeps.length > 0) {
+    out.dependencies = [...new Set([...(out.dependencies ?? []), ...poetryDeps])].sort();
+  }
+  if (poetryDevDeps.length > 0) {
+    out.devDependencies = [...new Set([...(out.devDependencies ?? []), ...poetryDevDeps])].sort();
+  }
+  return out;
+}
+
+function readRequirementsTxt(repoPath: string) {
+  const raw = safeReadText(join(repoPath, 'requirements.txt'));
+  if (!raw) return null;
+  const names = new Set<string>();
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('-')) continue;
+    // strip env markers + version specifiers
+    const m = trimmed.match(/^([A-Za-z0-9][A-Za-z0-9_\-.]*)/);
+    if (m?.[1]) names.add(m[1]);
+  }
+  if (names.size === 0) return null;
+  return { dependencies: [...names].sort() };
+}
+
+function readGoMod(repoPath: string) {
+  const raw = safeReadText(join(repoPath, 'go.mod'));
+  if (!raw) return null;
+  const out: { name?: string; dependencies?: string[] } = {};
+  const moduleM = raw.match(/^\s*module\s+(\S+)/m);
+  if (moduleM) out.name = moduleM[1];
+  // require ( ... ) block; also single-line `require x v1.2.3`.
+  const deps = new Set<string>();
+  const reqBlock = raw.match(/^\s*require\s*\(([\s\S]*?)\)/m);
+  if (reqBlock) {
+    for (const line of reqBlock[1].split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('//')) continue;
+      const m = trimmed.match(/^(\S+)/);
+      if (m?.[1]) deps.add(m[1]);
+    }
+  }
+  for (const m of raw.matchAll(/^\s*require\s+(\S+)\s+\S/gm)) {
+    if (m[1]) deps.add(m[1]);
+  }
+  if (deps.size > 0) out.dependencies = [...deps].sort();
+  return out;
+}
+
+function readManifest(type: ManifestType, repoPath: string): RepoFingerprint['manifest'] {
+  switch (type) {
+    case 'package.json': {
+      const m = readPackageJson(repoPath);
+      return { type, ...(m ?? {}) };
+    }
+    case 'cargo.toml': {
+      const m = readCargoToml(repoPath);
+      return { type, ...(m ?? {}) };
+    }
+    case 'pyproject.toml': {
+      const m = readPyprojectToml(repoPath);
+      return { type, ...(m ?? {}) };
+    }
+    case 'requirements.txt': {
+      const m = readRequirementsTxt(repoPath);
+      return { type, ...(m ?? {}) };
+    }
+    case 'go.mod': {
+      const m = readGoMod(repoPath);
+      return { type, ...(m ?? {}) };
+    }
+    default:
+      return { type: 'unknown' };
+  }
+}
+
+// ── readme ────────────────────────────────────────────────────────────────
+
+function readReadme(repoPath: string): RepoFingerprint['readme'] | undefined {
+  // First match wins, in priority order.
+  const candidates = ['README.md', 'README.MD', 'README', 'README.txt', 'readme.md'];
+  let raw: string | null = null;
+  for (const name of candidates) {
+    raw = safeReadText(join(repoPath, name));
+    if (raw) break;
+  }
+  if (!raw) return undefined;
+  const lines: string[] = [];
+  for (const line of raw.split('\n')) {
+    if (lines.length >= README_MAX_LINES) break;
+    const trimmed = line.replace(/\r$/, '');
+    lines.push(trimmed.length > README_MAX_LINE_LEN ? trimmed.slice(0, README_MAX_LINE_LEN) : trimmed);
+  }
+  // GitHub URL extraction (full README, not just truncated lines, so we don't
+  // miss a link in lines 101–200).
+  const linkSet = new Set<string>();
+  const linkRe = /\bhttps?:\/\/(?:www\.)?github\.com\/[A-Za-z0-9_.\-]+\/[A-Za-z0-9_.\-]+(?:\/[A-Za-z0-9_.\-/#?&=]*)?/g;
+  for (const m of raw.matchAll(linkRe)) {
+    // strip trailing punctuation that often clings to URLs in markdown.
+    const url = m[0].replace(/[).,;:!\]]+$/, '');
+    linkSet.add(url);
+    if (linkSet.size >= 16) break;
+  }
+  return {
+    firstLines: lines,
+    crossLinks: [...linkSet].sort(),
+  };
+}
+
+// ── top-level folders ─────────────────────────────────────────────────────
+
+function readTopLevelFolders(repoPath: string): string[] {
+  try {
+    const entries = readdirSync(repoPath, { withFileTypes: true });
+    const out: string[] = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const name = entry.name;
+      if (name === '.git' || name === 'node_modules') continue;
+      out.push(name);
+      if (out.length >= TOP_LEVEL_MAX * 2) break; // collect more then sort+slice
+    }
+    return out.sort().slice(0, TOP_LEVEL_MAX);
+  } catch {
+    return [];
+  }
+}
+
+// ── deploy hints ──────────────────────────────────────────────────────────
+
+function readJsonTopLevelKeys(repoPath: string, fileName: string): string[] | undefined {
+  const parsed = safeReadJson(join(repoPath, fileName));
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+  const keys = Object.keys(parsed as Record<string, unknown>).filter(Boolean).sort();
+  return keys.length > 0 ? keys : undefined;
+}
+
+/**
+ * Pull safe scraps from `next.config.{js,ts,mjs,cjs}` without executing it.
+ *
+ *   - hasRewrites: presence of an `async rewrites` definition.
+ *   - hasImagesDomains: hostnames inside `images.{domains,remotePatterns}`.
+ *     Hostname strings only — no protocols, no paths.
+ *   - hasEnv: keys in the top-level `env: { ... }` block. Keys only, never
+ *     values (some users inline secrets here, never our problem to leak).
+ */
+function readNextConfig(repoPath: string): RepoFingerprint['deployHints']['nextConfig'] | undefined {
+  const candidates = ['next.config.js', 'next.config.ts', 'next.config.mjs', 'next.config.cjs'];
+  let raw: string | null = null;
+  for (const name of candidates) {
+    raw = safeReadText(join(repoPath, name));
+    if (raw) break;
+  }
+  if (!raw) return undefined;
+  const out: NonNullable<RepoFingerprint['deployHints']['nextConfig']> = {};
+  if (/\brewrites\s*\(/.test(raw) || /\brewrites\s*:/.test(raw)) out.hasRewrites = true;
+  // images.domains: ['a.com', "b.com"]
+  const domains = new Set<string>();
+  const domainsBlock = raw.match(/\bdomains\s*:\s*\[([^\]]*)\]/);
+  if (domainsBlock) {
+    for (const m of domainsBlock[1].matchAll(/['"]([A-Za-z0-9.\-]+)['"]/g)) {
+      if (m[1]) domains.add(m[1]);
+    }
+  }
+  // remotePatterns: [{ hostname: 'x' }, ...]
+  for (const m of raw.matchAll(/hostname\s*:\s*['"]([A-Za-z0-9.\-]+)['"]/g)) {
+    if (m[1]) domains.add(m[1]);
+  }
+  if (domains.size > 0) out.hasImagesDomains = [...domains].sort();
+  // env: { KEY: ... } — keys only.
+  const envBlock = raw.match(/\benv\s*:\s*\{([\s\S]*?)\}/);
+  if (envBlock) {
+    const keys = new Set<string>();
+    for (const m of envBlock[1].matchAll(/['"]?([A-Z][A-Z0-9_]+)['"]?\s*:/g)) {
+      if (m[1]) keys.add(m[1]);
+    }
+    if (keys.size > 0) out.hasEnv = [...keys].sort();
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * `.env.example` → KEY names only. Splits each line on `=`, discards the
+ * right side. Comments and blanks ignored.
+ */
+function readEnvExampleKeys(repoPath: string): string[] | undefined {
+  const raw = safeReadText(join(repoPath, '.env.example'));
+  if (!raw) return undefined;
+  const keys = new Set<string>();
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx <= 0) continue;
+    const key = trimmed.slice(0, eqIdx).trim().replace(/^export\s+/, '');
+    if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) keys.add(key);
+  }
+  if (keys.size === 0) return undefined;
+  return [...keys].sort();
+}
+
+function readDeployHints(repoPath: string): RepoFingerprint['deployHints'] {
+  const out: RepoFingerprint['deployHints'] = {};
+  const vercel = readJsonTopLevelKeys(repoPath, 'vercel.json');
+  if (vercel) out.vercel = vercel;
+  const railway = readJsonTopLevelKeys(repoPath, 'railway.json');
+  if (railway) out.railway = railway;
+  if (existsSync(join(repoPath, 'Dockerfile'))) out.docker = true;
+  if (existsSync(join(repoPath, 'fly.toml'))) out.fly = true;
+  if (existsSync(join(repoPath, 'wrangler.toml'))) out.wrangler = true;
+  const nextCfg = readNextConfig(repoPath);
+  if (nextCfg) out.nextConfig = nextCfg;
+  const envKeys = readEnvExampleKeys(repoPath);
+  if (envKeys) out.envExampleKeys = envKeys;
+  return out;
+}
+
+// ── canonicalize + hash + size cap ───────────────────────────────────────
+
+/**
+ * Stable JSON: keys sorted recursively. Two fingerprints with identical
+ * content always produce the same string, so the hash is reproducible.
+ */
+export function canonicalize(value: unknown): string {
+  return JSON.stringify(value, sortReplacer);
+}
+
+function sortReplacer(_key: string, val: unknown): unknown {
+  if (val && typeof val === 'object' && !Array.isArray(val)) {
+    const obj = val as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    const out: Record<string, unknown> = {};
+    for (const k of keys) out[k] = obj[k];
+    return out;
+  }
+  return val;
+}
+
+function byteLength(value: unknown): number {
+  return Buffer.byteLength(canonicalize(value), 'utf-8');
+}
+
+/**
+ * Trim the fingerprint until JSON.stringify(fingerprint) ≤ 2KB. We attack
+ * the largest known offenders first (readme.firstLines, then deps lists),
+ * so the operationally most useful fields (deploy hints, manifest type,
+ * cross-links) survive.
+ */
+function enforceSizeCap(fp: RepoFingerprint): RepoFingerprint {
+  if (byteLength(fp) <= MAX_BYTES) return fp;
+  // 1) Halve readme firstLines, repeatedly, until empty.
+  if (fp.readme?.firstLines?.length) {
+    while (fp.readme.firstLines.length > 0 && byteLength(fp) > MAX_BYTES) {
+      const next = Math.floor(fp.readme.firstLines.length / 2);
+      fp.readme.firstLines = fp.readme.firstLines.slice(0, next);
+      if (next === 0) break;
+    }
+    if (fp.readme.firstLines.length === 0 && (!fp.readme.crossLinks || fp.readme.crossLinks.length === 0)) {
+      delete fp.readme;
+    }
+  }
+  if (byteLength(fp) <= MAX_BYTES) return fp;
+  // 2) Drop devDependencies.
+  if (fp.manifest.devDependencies?.length) {
+    delete fp.manifest.devDependencies;
+  }
+  if (byteLength(fp) <= MAX_BYTES) return fp;
+  // 3) Halve dependencies.
+  if (fp.manifest.dependencies?.length) {
+    while (fp.manifest.dependencies.length > 0 && byteLength(fp) > MAX_BYTES) {
+      const next = Math.floor(fp.manifest.dependencies.length / 2);
+      fp.manifest.dependencies = fp.manifest.dependencies.slice(0, next);
+      if (next === 0) break;
+    }
+    if (fp.manifest.dependencies?.length === 0) {
+      delete fp.manifest.dependencies;
+    }
+  }
+  if (byteLength(fp) <= MAX_BYTES) return fp;
+  // 4) Drop crossLinks.
+  if (fp.readme?.crossLinks) delete fp.readme.crossLinks;
+  if (byteLength(fp) <= MAX_BYTES) return fp;
+  // 5) Drop README entirely.
+  if (fp.readme) delete fp.readme;
+  if (byteLength(fp) <= MAX_BYTES) return fp;
+  // 6) Drop topLevelFolders.
+  if (fp.topLevelFolders.length > 0) fp.topLevelFolders = [];
+  if (byteLength(fp) <= MAX_BYTES) return fp;
+  // 7) Halve envExampleKeys (preserve deploy signal as long as possible).
+  while (
+    fp.deployHints.envExampleKeys &&
+    fp.deployHints.envExampleKeys.length > 0 &&
+    byteLength(fp) > MAX_BYTES
+  ) {
+    const next = Math.floor(fp.deployHints.envExampleKeys.length / 2);
+    fp.deployHints.envExampleKeys = fp.deployHints.envExampleKeys.slice(0, next);
+    if (next === 0) {
+      delete fp.deployHints.envExampleKeys;
+      break;
+    }
+  }
+  if (byteLength(fp) <= MAX_BYTES) return fp;
+  // 8) Last resort: drop manifest devDependencies + dependencies entirely.
+  if (fp.manifest.devDependencies) delete fp.manifest.devDependencies;
+  if (fp.manifest.dependencies) delete fp.manifest.dependencies;
+  return fp;
+}
+
+function hashRest(fp: RepoFingerprint): string {
+  // Hash everything *except* `hash` and `generatedAt` so the hash is content-
+  // addressed — the same repo state yields the same hash regardless of when
+  // the fingerprint was generated.
+  const { hash: _h, generatedAt: _g, ...rest } = fp;
+  return createHash('sha256').update(canonicalize(rest), 'utf-8').digest('hex');
+}
+
+// ── public surface ────────────────────────────────────────────────────────
+
+/**
+ * Compute a fingerprint for a single repo path. Synchronous + no-throw; a
+ * missing repo path yields a valid skeleton (empty manifest, no readme).
+ */
+export function computeFingerprint(
+  repoId: string,
+  repoPath: string,
+  github?: GithubMeta,
+): RepoFingerprint {
+  const safePath = repoPath?.trim() ?? '';
+  const exists = safePath ? safeIsDir(safePath) : false;
+  const manifestType = exists ? pickType(safePath) : 'unknown';
+  const manifest = exists ? readManifest(manifestType, safePath) : { type: 'unknown' as const };
+  const readme = exists ? readReadme(safePath) : undefined;
+  const topLevelFolders = exists ? readTopLevelFolders(safePath) : [];
+  const deployHints = exists ? readDeployHints(safePath) : {};
+
+  // Strip undefined keys from github so hashing is stable.
+  const githubFiltered: RepoFingerprint['github'] = {};
+  if (github?.description) githubFiltered.description = github.description;
+  if (github?.topics?.length) githubFiltered.topics = [...github.topics].sort();
+  if (github?.languages && Object.keys(github.languages).length > 0) {
+    githubFiltered.languages = github.languages;
+  }
+  if (github?.primaryLanguage) githubFiltered.primaryLanguage = github.primaryLanguage;
+  if (github?.homepage) githubFiltered.homepage = github.homepage;
+
+  const fp: RepoFingerprint = {
+    repoId,
+    // Placeholder of the same length the final sha256 hex will occupy, so
+    // `enforceSizeCap` budgets correctly. Rewritten to the real digest below.
+    hash: '0'.repeat(64),
+    generatedAt: Date.now(),
+    github: githubFiltered,
+    manifest,
+    ...(readme ? { readme } : {}),
+    topLevelFolders,
+    deployHints,
+  };
+
+  enforceSizeCap(fp);
+  fp.hash = hashRest(fp);
+  return fp;
+}
+
+function safeIsDir(p: string): boolean {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export const __TEST = {
+  MAX_BYTES,
+  README_MAX_LINES,
+  README_MAX_LINE_LEN,
+  TOP_LEVEL_MAX,
+  hashRest,
+  enforceSizeCap,
+  byteLength,
+};


### PR DESCRIPTION
## Summary

- Deterministic per-repo fingerprint (≤2KB JSON) for the Stage 2 LLM call (wave 2). Covers manifest dep KEYS, README first 100 lines, top-level folders, deploy hints (Vercel / Railway / Docker / Fly / Wrangler / Next config), and `.env.example` KEYS only.
- Cache at `~/.o8/repo-fingerprints/<repo-id>.json`. `getOrComputeFingerprint(repoId)` recomputes on every call, short-circuits when the content hash matches → README / manifest / deploy edits invalidate automatically without a watcher.
- Privacy is load-bearing: never reads source code, never reads `.env` (only `.env.example`, KEYS only), strips manifest version values, regex-only `next.config` parsing (no execution), README capped at 100 lines × 200 chars.

## What landed

| File | Purpose |
|------|---------|
| `src/lib/projects/fingerprint.ts` | Pure extractor: `computeFingerprint(repoId, repoPath, github?)` → `RepoFingerprint`. Sync, no-throw, hard 2KB cap with documented eviction order. |
| `src/lib/projects/fingerprint-cache.ts` | `getOrComputeFingerprint(repoId)` (registry-aware) + `getOrComputeFingerprintForPath(repoId, path)` for tests. JSON-per-repo cache. |
| `scripts/smoke-fingerprint.tsx` | 20-check smoke covering cortex-ide, o8-site, empty/nonexistent repos, determinism, cache invalidation, privacy spot checks. |

## Size cap eviction order

When a fingerprint exceeds 2KB after canonical JSON serialization:

1. Halve `readme.firstLines` repeatedly until empty
2. Drop `manifest.devDependencies`
3. Halve `manifest.dependencies` until empty
4. Drop `readme.crossLinks`
5. Drop `readme` entirely
6. Clear `topLevelFolders`
7. Halve `deployHints.envExampleKeys` until empty
8. Drop `manifest.dependencies` + `devDependencies`

Deploy signal (`vercel`, `railway`, `docker`, `fly`, `wrangler`, `nextConfig`) is preserved as long as possible because it is the most operationally useful for Stage 2.

The hash field is filled with a 64-char placeholder during cap enforcement so the final sha256 hex fits in the budget.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `O8_DATA_DIR=$HOME/.o8 npx tsx scripts/smoke-fingerprint.tsx` → 20 passed, 0 failed
- [x] cortex-ide fingerprint = 1896 B, o8-site = 1235 B, both ≤ 2KB
- [x] Empty repo path returns valid skeleton (`manifest.type='unknown'`, empty deployHints, empty topLevelFolders)
- [x] Nonexistent path returns valid skeleton
- [x] Synthetic 500-dep / 200-line / 100-key stress repo → 2000 B (under cap, eviction worked)
- [x] Determinism: two fresh runs of `computeFingerprint` produce identical hash
- [x] Cache invalidation: README mutation flips the hash
- [x] Privacy spot checks pass — no env values, no `KEY=value` patterns, no version strings in dep arrays

Refs #899. Wave 2 (the Stage 2 LLM call + Settings UI) is not in this PR.