### PR TITLE
feat(projects): schema v13 + storage + API + MCP tools (epic #899 wave 1)

### DIFF
--- a/scripts/smoke-projects.ts
+++ b/scripts/smoke-projects.ts
@@ -1,0 +1,145 @@
+/**
+ * Smoke test for the Projects foundation (epic #899).
+ *
+ * Exercises the full storage layer in a fresh data directory:
+ *   create → add 2 repos with roles → list → set role → remove repo → delete
+ *
+ * Usage:
+ *   CORTEX_IDE_DATA_DIR=$(mktemp -d) npx tsx scripts/smoke-projects.ts
+ *
+ * Per CLAUDE.md "Dispatch smoke-test pattern": runs the script as a file
+ * (`npx tsx <script>`), never via `tsx -e "import(...)"`. Named exports come
+ * back as `undefined` through `tsx -e` because of the CJS namespace shim.
+ */
+
+import {
+  addRepoToProject,
+  createProject,
+  deleteProject,
+  getProject,
+  isDismissed,
+  listProjects,
+  listProjectsByRepoId,
+  recordDismissedSuggestion,
+  removeRepoFromProject,
+  setRepoRole,
+  updateProject,
+} from '../src/lib/projects/store';
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(`Assertion failed: ${message}`);
+  }
+}
+
+function step(label: string, fn: () => void): void {
+  process.stdout.write(`• ${label} … `);
+  try {
+    fn();
+    process.stdout.write('ok\n');
+  } catch (err) {
+    process.stdout.write('FAIL\n');
+    throw err;
+  }
+}
+
+const project = createProject({
+  name: 'O8 Suite',
+  description: 'cortex-ide + landing site + mobile, grouped as one product',
+});
+
+step('createProject returns shape', () => {
+  assert(project.id.startsWith('proj-'), 'id prefix proj-');
+  assert(project.slug === 'o8-suite', `slug should be o8-suite, got ${project.slug}`);
+  assert(project.name === 'O8 Suite', 'name preserved');
+  assert(project.description !== null, 'description set');
+  assert(typeof project.createdAt === 'number', 'createdAt is number');
+});
+
+step('getProject finds the row', () => {
+  const fetched = getProject(project.id);
+  assert(fetched, 'getProject returned null');
+  assert(fetched.slug === 'o8-suite', 'slug round-trips');
+});
+
+step('addRepoToProject adds 2 repos with roles', () => {
+  const link1 = addRepoToProject(project.id, 'repo-cortex-ide', 'fullstack', 'manual');
+  const link2 = addRepoToProject(project.id, 'repo-o8-site', 'site', 'manual');
+  assert(link1.repoId === 'repo-cortex-ide', 'repo1 id');
+  assert(link1.role === 'fullstack', `repo1 role got ${link1.role}`);
+  assert(link2.role === 'site', 'repo2 role');
+});
+
+step('listProjects returns the project + both repos', () => {
+  const projects = listProjects();
+  assert(projects.length === 1, `expected 1 project, got ${projects.length}`);
+  const found = projects[0];
+  assert(found.repos.length === 2, `expected 2 repos, got ${found.repos.length}`);
+});
+
+step('listProjectsByRepoId finds membership', () => {
+  const memberships = listProjectsByRepoId('repo-cortex-ide');
+  assert(memberships.length === 1, 'expected 1 membership');
+  assert(memberships[0].id === project.id, 'membership points to project');
+  assert(memberships[0].repos.length === 2, 'membership carries repos');
+});
+
+step('addRepoToProject is idempotent + refreshes role', () => {
+  const link = addRepoToProject(project.id, 'repo-cortex-ide', 'backend', 'manual');
+  assert(link.role === 'backend', 'role refreshed to backend');
+  const all = listProjects();
+  assert(all[0].repos.length === 2, 'still 2 repos after re-add');
+});
+
+step('setRepoRole updates role on existing link', () => {
+  const link = setRepoRole(project.id, 'repo-cortex-ide', 'fullstack');
+  assert(link, 'setRepoRole returned null');
+  assert(link.role === 'fullstack', 'role updated');
+});
+
+step('updateProject patches name + description', () => {
+  const updated = updateProject(project.id, {
+    name: 'O8 Product Suite',
+    description: null,
+  });
+  assert(updated, 'updateProject null');
+  assert(updated.name === 'O8 Product Suite', 'name updated');
+  assert(updated.description === null, 'description cleared');
+});
+
+step('removeRepoFromProject drops the link', () => {
+  const removed = removeRepoFromProject(project.id, 'repo-cortex-ide');
+  assert(removed, 'remove returned false');
+  const fresh = listProjects();
+  assert(fresh[0].repos.length === 1, 'expected 1 repo after remove');
+  assert(fresh[0].repos[0].repoId === 'repo-o8-site', 'remaining repo is the site');
+});
+
+step('removeRepoFromProject is idempotent (returns false on missing)', () => {
+  const removed = removeRepoFromProject(project.id, 'repo-cortex-ide');
+  assert(!removed, 'remove returned true on missing link');
+});
+
+step('recordDismissedSuggestion + isDismissed round-trip', () => {
+  recordDismissedSuggestion('fingerprint-abc', 'not-related');
+  assert(isDismissed('fingerprint-abc'), 'fingerprint should be dismissed');
+  assert(!isDismissed('fingerprint-xyz'), 'unknown fingerprint should not be dismissed');
+});
+
+step('deleteProject cascades into project_repos', () => {
+  const deleted = deleteProject(project.id);
+  assert(deleted, 'delete returned false');
+  assert(getProject(project.id) === null, 'project still exists after delete');
+  assert(listProjects().length === 0, 'projects list is empty after delete');
+});
+
+step('createProject auto-suffixes slug on collision', () => {
+  const first = createProject({ name: 'Alpha' });
+  const second = createProject({ name: 'Alpha' });
+  assert(first.slug === 'alpha', 'first slug is alpha');
+  assert(second.slug.startsWith('alpha-'), `second slug should suffix, got ${second.slug}`);
+  deleteProject(first.id);
+  deleteProject(second.id);
+});
+
+console.log('\n✓ All smoke tests passed.');

--- a/src/app/api/projects/[id]/repos/[repoId]/route.ts
+++ b/src/app/api/projects/[id]/repos/[repoId]/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requirePanelAuth } from '@/lib/panel/auth';
+import { removeRepoFromProject, setRepoRole } from '@/lib/projects/store';
+import type { ProjectRole } from '@/lib/projects/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const NO_STORE = { 'Cache-Control': 'no-store, max-age=0' } as const;
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; repoId: string }> },
+) {
+  const denied = requirePanelAuth(req);
+  if (denied) return denied;
+
+  const { id, repoId } = await params;
+  const removed = removeRepoFromProject(id, repoId);
+  if (!removed) {
+    return NextResponse.json({ error: 'Project repo link not found.' }, { status: 404 });
+  }
+  return NextResponse.json({ ok: true }, { headers: NO_STORE });
+}
+
+interface PatchRepoBody {
+  role?: unknown;
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; repoId: string }> },
+) {
+  const denied = requirePanelAuth(req);
+  if (denied) return denied;
+
+  const { id, repoId } = await params;
+  let body: PatchRepoBody;
+  try {
+    body = (await req.json()) as PatchRepoBody;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  if (body.role !== null && typeof body.role !== 'string') {
+    return NextResponse.json(
+      { error: 'role must be a string or null.' },
+      { status: 400 },
+    );
+  }
+
+  const role = body.role ? (body.role as ProjectRole) : null;
+  const link = setRepoRole(id, repoId, role);
+  if (!link) {
+    return NextResponse.json({ error: 'Project repo link not found.' }, { status: 404 });
+  }
+  return NextResponse.json({ link }, { headers: NO_STORE });
+}

--- a/src/app/api/projects/[id]/repos/route.ts
+++ b/src/app/api/projects/[id]/repos/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requirePanelAuth } from '@/lib/panel/auth';
+import { addRepoToProject } from '@/lib/projects/store';
+import type { ProjectRole, SuggestionOrigin } from '@/lib/projects/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const NO_STORE = { 'Cache-Control': 'no-store, max-age=0' } as const;
+
+interface AddRepoBody {
+  repoId?: unknown;
+  role?: unknown;
+  suggestionOrigin?: unknown;
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const denied = requirePanelAuth(req);
+  if (denied) return denied;
+
+  const { id } = await params;
+  let body: AddRepoBody;
+  try {
+    body = (await req.json()) as AddRepoBody;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  const repoId = typeof body.repoId === 'string' ? body.repoId.trim() : '';
+  if (!repoId) {
+    return NextResponse.json({ error: 'repoId is required.' }, { status: 400 });
+  }
+
+  const role = typeof body.role === 'string' && body.role
+    ? (body.role as ProjectRole)
+    : null;
+  const suggestionOrigin = typeof body.suggestionOrigin === 'string' && body.suggestionOrigin
+    ? (body.suggestionOrigin as SuggestionOrigin)
+    : 'manual';
+
+  try {
+    const link = addRepoToProject(id, repoId, role, suggestionOrigin);
+    return NextResponse.json({ link }, { status: 201, headers: NO_STORE });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to add repo.';
+    const status = /not found/i.test(message) ? 404 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requirePanelAuth } from '@/lib/panel/auth';
+import {
+  deleteProject,
+  getProjectWithRepos,
+  updateProject,
+} from '@/lib/projects/store';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const NO_STORE = { 'Cache-Control': 'no-store, max-age=0' } as const;
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const denied = requirePanelAuth(req);
+  if (denied) return denied;
+
+  const { id } = await params;
+  const project = getProjectWithRepos(id);
+  if (!project) {
+    return NextResponse.json({ error: 'Project not found.' }, { status: 404 });
+  }
+  return NextResponse.json({ project }, { headers: NO_STORE });
+}
+
+interface UpdateProjectBody {
+  name?: unknown;
+  description?: unknown;
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const denied = requirePanelAuth(req);
+  if (denied) return denied;
+
+  const { id } = await params;
+  let body: UpdateProjectBody;
+  try {
+    body = (await req.json()) as UpdateProjectBody;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  const updates: { name?: string; description?: string | null } = {};
+  if (body.name !== undefined) {
+    if (typeof body.name !== 'string') {
+      return NextResponse.json({ error: 'name must be a string.' }, { status: 400 });
+    }
+    updates.name = body.name;
+  }
+  if (body.description !== undefined) {
+    if (body.description !== null && typeof body.description !== 'string') {
+      return NextResponse.json({ error: 'description must be a string or null.' }, { status: 400 });
+    }
+    updates.description = body.description as string | null;
+  }
+
+  try {
+    const project = updateProject(id, updates);
+    if (!project) {
+      return NextResponse.json({ error: 'Project not found.' }, { status: 404 });
+    }
+    const withRepos = getProjectWithRepos(id);
+    return NextResponse.json({ project: withRepos ?? project }, { headers: NO_STORE });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to update project.';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const denied = requirePanelAuth(req);
+  if (denied) return denied;
+
+  const { id } = await params;
+  const deleted = deleteProject(id);
+  if (!deleted) {
+    return NextResponse.json({ error: 'Project not found.' }, { status: 404 });
+  }
+  return NextResponse.json({ ok: true }, { headers: NO_STORE });
+}

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requirePanelAuth } from '@/lib/panel/auth';
+import {
+  addRepoToProject,
+  createProject,
+  listProjects,
+} from '@/lib/projects/store';
+import type { ProjectRole, SuggestionOrigin } from '@/lib/projects/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const NO_STORE = { 'Cache-Control': 'no-store, max-age=0' } as const;
+
+export async function GET(req: NextRequest) {
+  const denied = requirePanelAuth(req);
+  if (denied) return denied;
+
+  try {
+    const projects = listProjects();
+    return NextResponse.json({ projects }, { headers: NO_STORE });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to list projects.';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+interface CreateProjectBody {
+  name?: unknown;
+  slug?: unknown;
+  description?: unknown;
+  repoIds?: unknown;
+  // Optional parallel array of roles aligned to repoIds, or a map { repoId: role }.
+  roles?: unknown;
+  suggestionOrigin?: unknown;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === 'string' && entry.trim()) out.push(entry);
+  }
+  return out;
+}
+
+function resolveRoleForRepo(
+  repoId: string,
+  index: number,
+  roles: unknown,
+): ProjectRole | null {
+  if (!roles) return null;
+  if (Array.isArray(roles)) {
+    const candidate = roles[index];
+    return typeof candidate === 'string' && candidate ? (candidate as ProjectRole) : null;
+  }
+  if (typeof roles === 'object') {
+    const entry = (roles as Record<string, unknown>)[repoId];
+    return typeof entry === 'string' && entry ? (entry as ProjectRole) : null;
+  }
+  return null;
+}
+
+export async function POST(req: NextRequest) {
+  const denied = requirePanelAuth(req);
+  if (denied) return denied;
+
+  let body: CreateProjectBody;
+  try {
+    body = (await req.json()) as CreateProjectBody;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  const name = asString(body.name)?.trim();
+  if (!name) {
+    return NextResponse.json({ error: 'Project name is required.' }, { status: 400 });
+  }
+
+  try {
+    const project = createProject({
+      name,
+      slug: asString(body.slug),
+      description: asString(body.description) ?? null,
+    });
+
+    const repoIds = asStringArray(body.repoIds) ?? [];
+    const suggestionOrigin =
+      (asString(body.suggestionOrigin) as SuggestionOrigin | undefined) ?? 'manual';
+
+    const repos = repoIds.map((repoId, index) => {
+      const role = resolveRoleForRepo(repoId, index, body.roles);
+      return addRepoToProject(project.id, repoId, role, suggestionOrigin);
+    });
+
+    return NextResponse.json(
+      { project: { ...project, repos } },
+      { status: 201, headers: NO_STORE },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to create project.';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -34,7 +34,7 @@ const DATA_DIR = process.env.O8_DATA_DIR
 // second migration step with no user-facing benefit.
 const DB_PATH = process.env.CORTEX_IDE_DB_PATH || path.join(DATA_DIR, 'cortex-ide.db');
 // Bump when ensureTables() adds new schema or backfill work.
-const DB_SCHEMA_VERSION = 12;
+const DB_SCHEMA_VERSION = 13;
 
 function migrationMarkerPath(version: number): string {
   return path.join(DATA_DIR, `.db-migrated-v${version}`);
@@ -105,6 +105,8 @@ function ensureIdempotentColumnAdds(sqlite: Database.Database): void {
   ensureApprovalEventsTable(sqlite);
   ensureExternalMcpServerColumns(sqlite);
   ensurePushSubscriptionsTable(sqlite);
+  ensureProjectsTables(sqlite);
+  ensureProjectScopeColumns(sqlite);
   // #835 — recover any session_outcomes rows whose `valid_from` was inserted
   // as NULL (legacy seeds, raw INSERTs that bypassed the Drizzle schema
   // default). The column-add backfill in `ensureSessionOutcomeColumns` only
@@ -567,6 +569,35 @@ function ensureTables(sqlite: Database.Database): void {
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
     CREATE INDEX IF NOT EXISTS idx_push_subscriptions_created_at ON push_subscriptions(created_at);
+
+    -- Schema v13 — Projects (epic #899). Operator-curated repo groupings that
+    -- replace the Jaccard-based cross-repo proposer (#748). project_repos.role
+    -- is free-form text in the DB; the curated set lives in src/lib/projects/types.ts.
+    CREATE TABLE IF NOT EXISTS projects (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      slug TEXT NOT NULL UNIQUE,
+      description TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS project_repos (
+      project_id TEXT NOT NULL,
+      repo_id TEXT NOT NULL,
+      role TEXT,
+      suggestion_origin TEXT NOT NULL DEFAULT 'manual',
+      added_at INTEGER NOT NULL,
+      PRIMARY KEY (project_id, repo_id),
+      FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_project_repos_repo_id ON project_repos(repo_id);
+
+    CREATE TABLE IF NOT EXISTS dismissed_suggestions (
+      fingerprint TEXT PRIMARY KEY,
+      dismissed_at INTEGER NOT NULL,
+      reason TEXT
+    );
   `);
 
   ensureApprovalContextColumns(sqlite);
@@ -870,6 +901,62 @@ function ensurePushSubscriptionsTable(sqlite: Database.Database): void {
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
     CREATE INDEX IF NOT EXISTS idx_push_subscriptions_created_at ON push_subscriptions(created_at);
+  `);
+}
+
+/**
+ * Schema v13 — Projects model (epic #899). Creates the three Projects tables
+ * for installs that landed before v13. Idempotent.
+ */
+function ensureProjectsTables(sqlite: Database.Database): void {
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS projects (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      slug TEXT NOT NULL UNIQUE,
+      description TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS project_repos (
+      project_id TEXT NOT NULL,
+      repo_id TEXT NOT NULL,
+      role TEXT,
+      suggestion_origin TEXT NOT NULL DEFAULT 'manual',
+      added_at INTEGER NOT NULL,
+      PRIMARY KEY (project_id, repo_id),
+      FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_project_repos_repo_id ON project_repos(repo_id);
+
+    CREATE TABLE IF NOT EXISTS dismissed_suggestions (
+      fingerprint TEXT PRIMARY KEY,
+      dismissed_at INTEGER NOT NULL,
+      reason TEXT
+    );
+  `);
+}
+
+/**
+ * Schema v13 — add nullable `project_id` to existing tables that should be
+ * scopable to a Project. Cross-repo signals (outcomes, approvals, lanes) can
+ * then propagate to every member repo via the new Projects model.
+ */
+function ensureProjectScopeColumns(sqlite: Database.Database): void {
+  if (!tableColumnExists(sqlite, 'session_outcomes', 'project_id')) {
+    sqlite.exec('ALTER TABLE session_outcomes ADD COLUMN project_id TEXT');
+  }
+  if (!tableColumnExists(sqlite, 'approvals', 'project_id')) {
+    sqlite.exec('ALTER TABLE approvals ADD COLUMN project_id TEXT');
+  }
+  if (!tableColumnExists(sqlite, 'lanes', 'project_id')) {
+    sqlite.exec('ALTER TABLE lanes ADD COLUMN project_id TEXT');
+  }
+  sqlite.exec(`
+    CREATE INDEX IF NOT EXISTS idx_session_outcomes_project_id ON session_outcomes(project_id);
+    CREATE INDEX IF NOT EXISTS idx_approvals_project_id ON approvals(project_id);
+    CREATE INDEX IF NOT EXISTS idx_lanes_project_id ON lanes(project_id);
   `);
 }
 

--- a/src/lib/mcp/cortex-mcp-server.ts
+++ b/src/lib/mcp/cortex-mcp-server.ts
@@ -18,6 +18,15 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { parseMcpConfigInput, type ParsedMcpServer } from './parse-config';
 import { getOrCreateWsToken } from '../ws-auth';
+import {
+  addRepoToProject,
+  createProject,
+  deleteProject,
+  listProjects,
+  removeRepoFromProject,
+  setRepoRole,
+} from '../projects/store';
+import type { ProjectRole } from '../projects/types';
 
 /**
  * Resolve the backend base URL from env, port file, or legacy default.
@@ -351,6 +360,94 @@ const TOOLS: McpTool[] = [
           description: 'For transport="http": the MCP endpoint URL.',
         },
       },
+    },
+  },
+  // ── Projects (epic #899) ──
+  {
+    name: 'cortex_create_project',
+    description:
+      'Create a new Project — an operator-curated grouping of repos that share product/team boundaries. ' +
+      'Optionally seed with repos and per-repo roles (frontend/backend/shared/etc.).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Display name for the project.' },
+        description: { type: 'string', description: 'Optional description.' },
+        repoIds: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Optional list of repo IDs (from the repo registry) to add at creation time.',
+        },
+        roles: {
+          description:
+            'Optional roles per repo. Either a parallel array (same length as repoIds) or a map { repoId: role }. ' +
+            'Curated roles: frontend, backend, fullstack, mobile, library, service, infra, docs, site, shared.',
+        },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'cortex_add_repo_to_project',
+    description: 'Link a repo into an existing project, optionally with a role tag.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectId: { type: 'string', description: 'Project ID returned by cortex_create_project.' },
+        repoId: { type: 'string', description: 'Repo ID from the repo registry (~/.o8/repos.json).' },
+        role: {
+          type: 'string',
+          description: 'Optional role tag. Curated values: frontend, backend, fullstack, mobile, library, service, infra, docs, site, shared.',
+        },
+      },
+      required: ['projectId', 'repoId'],
+    },
+  },
+  {
+    name: 'cortex_remove_repo_from_project',
+    description: 'Unlink a repo from a project. The repo itself is left intact in the registry.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectId: { type: 'string' },
+        repoId: { type: 'string' },
+      },
+      required: ['projectId', 'repoId'],
+    },
+  },
+  {
+    name: 'cortex_set_repo_role',
+    description: 'Update the role tag on an existing project ↔ repo link.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectId: { type: 'string' },
+        repoId: { type: 'string' },
+        role: {
+          type: 'string',
+          description: 'Curated role. Pass empty string to clear the role.',
+        },
+      },
+      required: ['projectId', 'repoId', 'role'],
+    },
+  },
+  {
+    name: 'cortex_list_projects',
+    description: 'List every project the operator has defined, with their member repos and roles.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'cortex_delete_project',
+    description: 'Delete a project. The repos themselves are not removed from the registry; only the grouping goes away.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectId: { type: 'string' },
+      },
+      required: ['projectId'],
     },
   },
 ];
@@ -917,6 +1014,116 @@ async function handleRegisterMcp(args: Record<string, unknown>): Promise<McpTool
   }
 }
 
+// ── Projects handlers (epic #899) ──
+//
+// These call the storage layer directly rather than going through HTTP. The
+// MCP server runs in its own node process but shares the SQLite file with the
+// Next backend; better-sqlite3 + WAL mode is multi-process safe. This keeps
+// project mutations atomic and avoids the panel-auth round-trip.
+
+function resolveRoleArg(value: unknown): ProjectRole | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? (trimmed as ProjectRole) : null;
+}
+
+async function handleCreateProject(args: Record<string, unknown>): Promise<McpToolResult> {
+  try {
+    const name = typeof args.name === 'string' ? args.name.trim() : '';
+    if (!name) return textResult('name is required.', true);
+    const description = typeof args.description === 'string' ? args.description : null;
+
+    const project = createProject({ name, description });
+
+    const repoIds = Array.isArray(args.repoIds)
+      ? args.repoIds.filter((value): value is string => typeof value === 'string' && Boolean(value))
+      : [];
+    const roles = args.roles;
+
+    for (let index = 0; index < repoIds.length; index += 1) {
+      const repoId = repoIds[index];
+      let role: ProjectRole | null = null;
+      if (Array.isArray(roles)) {
+        role = resolveRoleArg(roles[index]);
+      } else if (roles && typeof roles === 'object') {
+        role = resolveRoleArg((roles as Record<string, unknown>)[repoId]);
+      }
+      addRepoToProject(project.id, repoId, role, 'manual');
+    }
+
+    return jsonResult({ projectId: project.id, slug: project.slug });
+  } catch (err) {
+    return textResult(`Failed to create project: ${err instanceof Error ? err.message : String(err)}`, true);
+  }
+}
+
+async function handleAddRepoToProject(args: Record<string, unknown>): Promise<McpToolResult> {
+  try {
+    const projectId = typeof args.projectId === 'string' ? args.projectId : '';
+    const repoId = typeof args.repoId === 'string' ? args.repoId : '';
+    if (!projectId || !repoId) {
+      return textResult('projectId and repoId are required.', true);
+    }
+    const role = resolveRoleArg(args.role);
+    addRepoToProject(projectId, repoId, role, 'manual');
+    return jsonResult({ ok: true });
+  } catch (err) {
+    return textResult(`Failed to add repo: ${err instanceof Error ? err.message : String(err)}`, true);
+  }
+}
+
+async function handleRemoveRepoFromProject(args: Record<string, unknown>): Promise<McpToolResult> {
+  try {
+    const projectId = typeof args.projectId === 'string' ? args.projectId : '';
+    const repoId = typeof args.repoId === 'string' ? args.repoId : '';
+    if (!projectId || !repoId) {
+      return textResult('projectId and repoId are required.', true);
+    }
+    const removed = removeRepoFromProject(projectId, repoId);
+    return jsonResult({ ok: removed });
+  } catch (err) {
+    return textResult(`Failed to remove repo: ${err instanceof Error ? err.message : String(err)}`, true);
+  }
+}
+
+async function handleSetRepoRole(args: Record<string, unknown>): Promise<McpToolResult> {
+  try {
+    const projectId = typeof args.projectId === 'string' ? args.projectId : '';
+    const repoId = typeof args.repoId === 'string' ? args.repoId : '';
+    if (!projectId || !repoId) {
+      return textResult('projectId and repoId are required.', true);
+    }
+    const role = resolveRoleArg(args.role);
+    const link = setRepoRole(projectId, repoId, role);
+    if (!link) {
+      return textResult('Project repo link not found.', true);
+    }
+    return jsonResult({ ok: true });
+  } catch (err) {
+    return textResult(`Failed to set role: ${err instanceof Error ? err.message : String(err)}`, true);
+  }
+}
+
+async function handleListProjects(): Promise<McpToolResult> {
+  try {
+    const projects = listProjects();
+    return jsonResult({ projects });
+  } catch (err) {
+    return textResult(`Failed to list projects: ${err instanceof Error ? err.message : String(err)}`, true);
+  }
+}
+
+async function handleDeleteProject(args: Record<string, unknown>): Promise<McpToolResult> {
+  try {
+    const projectId = typeof args.projectId === 'string' ? args.projectId : '';
+    if (!projectId) return textResult('projectId is required.', true);
+    const deleted = deleteProject(projectId);
+    return jsonResult({ ok: deleted });
+  } catch (err) {
+    return textResult(`Failed to delete project: ${err instanceof Error ? err.message : String(err)}`, true);
+  }
+}
+
 const TOOL_HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<McpToolResult>> = {
   cortex_fleet_status: handleFleetStatus,
   cortex_list_issues: handleListIssues,
@@ -932,6 +1139,12 @@ const TOOL_HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<M
   cortex_read_transcript: handleReadTranscript,
   cortex_interrupt_agent: handleInterruptAgent,
   register_mcp: handleRegisterMcp,
+  cortex_create_project: handleCreateProject,
+  cortex_add_repo_to_project: handleAddRepoToProject,
+  cortex_remove_repo_from_project: handleRemoveRepoFromProject,
+  cortex_set_repo_role: handleSetRepoRole,
+  cortex_list_projects: handleListProjects,
+  cortex_delete_project: handleDeleteProject,
 };
 
 // ── JSON-RPC Server ──

--- a/src/lib/projects/store.ts
+++ b/src/lib/projects/store.ts
@@ -1,0 +1,363 @@
+/**
+ * Projects storage — better-sqlite3 directly (matches the rest of the SQLite
+ * surface; Drizzle is reserved for the schema-owning tables in `@/lib/db`).
+ *
+ * The schema lives in `@/lib/db` (v11 migration); this file is the read/write
+ * layer used by the API routes and the cortex MCP tools.
+ */
+
+import 'server-only';
+
+import { randomUUID } from 'node:crypto';
+import { getSqlite } from '@/lib/db';
+import type {
+  Project,
+  ProjectRepo,
+  ProjectRole,
+  ProjectWithRepos,
+  SuggestionOrigin,
+} from './types';
+
+// ── Helpers ──
+
+function db() {
+  return getSqlite();
+}
+
+function nowMs(): number {
+  return Date.now();
+}
+
+function generateProjectId(): string {
+  return `proj-${randomUUID().slice(0, 12)}`;
+}
+
+/**
+ * Slugify a name into a URL-safe identifier. Uniqueness is guarded by the
+ * UNIQUE index on `projects.slug`; collisions retry by appending a 4-char
+ * suffix until the row inserts.
+ */
+function slugifyName(name: string): string {
+  const base = name
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+  return base || 'project';
+}
+
+interface ProjectRow {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+interface ProjectRepoRow {
+  project_id: string;
+  repo_id: string;
+  role: string | null;
+  suggestion_origin: string;
+  added_at: number;
+}
+
+function mapProjectRow(row: ProjectRow): Project {
+  return {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    description: row.description,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapProjectRepoRow(row: ProjectRepoRow): ProjectRepo {
+  return {
+    projectId: row.project_id,
+    repoId: row.repo_id,
+    role: (row.role as ProjectRole | null) ?? null,
+    suggestionOrigin: row.suggestion_origin as SuggestionOrigin,
+    addedAt: row.added_at,
+  };
+}
+
+// ── Project CRUD ──
+
+export interface CreateProjectInput {
+  name: string;
+  slug?: string;
+  description?: string | null;
+}
+
+export function createProject(input: CreateProjectInput): Project {
+  const trimmedName = input.name.trim();
+  if (!trimmedName) {
+    throw new Error('Project name is required.');
+  }
+
+  const sqlite = db();
+  const now = nowMs();
+  const id = generateProjectId();
+  const description = input.description?.trim() || null;
+
+  // Pick a slug: explicit > slugified name. Retry on UNIQUE collisions by
+  // appending a short random suffix (no parsing of the SQLite error needed —
+  // we just check whether a row with that slug already exists).
+  const requested = (input.slug?.trim() || slugifyName(trimmedName)).toLowerCase();
+  const slugExists = sqlite.prepare(
+    'SELECT 1 FROM projects WHERE slug = ? LIMIT 1',
+  );
+  let slug = requested;
+  let attempts = 0;
+  while (slugExists.get(slug)) {
+    attempts += 1;
+    if (attempts > 6) {
+      throw new Error(`Could not find a unique slug starting with "${requested}".`);
+    }
+    slug = `${requested}-${randomUUID().slice(0, 4)}`;
+  }
+
+  sqlite.prepare(
+    `INSERT INTO projects (id, name, slug, description, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(id, trimmedName, slug, description, now, now);
+
+  return {
+    id,
+    name: trimmedName,
+    slug,
+    description,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function getProject(id: string): Project | null {
+  const row = db().prepare(
+    'SELECT id, name, slug, description, created_at, updated_at FROM projects WHERE id = ?',
+  ).get(id) as ProjectRow | undefined;
+  return row ? mapProjectRow(row) : null;
+}
+
+export function getProjectBySlug(slug: string): Project | null {
+  const row = db().prepare(
+    'SELECT id, name, slug, description, created_at, updated_at FROM projects WHERE slug = ?',
+  ).get(slug) as ProjectRow | undefined;
+  return row ? mapProjectRow(row) : null;
+}
+
+function listReposForProject(projectId: string): ProjectRepo[] {
+  const rows = db().prepare(
+    `SELECT project_id, repo_id, role, suggestion_origin, added_at
+     FROM project_repos
+     WHERE project_id = ?
+     ORDER BY added_at ASC`,
+  ).all(projectId) as ProjectRepoRow[];
+  return rows.map(mapProjectRepoRow);
+}
+
+export function getProjectWithRepos(id: string): ProjectWithRepos | null {
+  const project = getProject(id);
+  if (!project) return null;
+  return { ...project, repos: listReposForProject(id) };
+}
+
+export function listProjects(): ProjectWithRepos[] {
+  const sqlite = db();
+  const projects = sqlite.prepare(
+    `SELECT id, name, slug, description, created_at, updated_at
+     FROM projects
+     ORDER BY created_at DESC`,
+  ).all() as ProjectRow[];
+  if (projects.length === 0) return [];
+
+  // Single fetch of all repos, then bucket by project_id — avoids N queries.
+  const repoRows = sqlite.prepare(
+    `SELECT project_id, repo_id, role, suggestion_origin, added_at
+     FROM project_repos
+     ORDER BY added_at ASC`,
+  ).all() as ProjectRepoRow[];
+
+  const reposByProject = new Map<string, ProjectRepo[]>();
+  for (const row of repoRows) {
+    const list = reposByProject.get(row.project_id) ?? [];
+    list.push(mapProjectRepoRow(row));
+    reposByProject.set(row.project_id, list);
+  }
+
+  return projects.map((row) => ({
+    ...mapProjectRow(row),
+    repos: reposByProject.get(row.id) ?? [],
+  }));
+}
+
+export interface UpdateProjectInput {
+  name?: string;
+  description?: string | null;
+}
+
+export function updateProject(id: string, input: UpdateProjectInput): Project | null {
+  const existing = getProject(id);
+  if (!existing) return null;
+
+  const updates: string[] = [];
+  const values: Array<string | number | null> = [];
+
+  if (input.name !== undefined) {
+    const trimmed = input.name.trim();
+    if (!trimmed) {
+      throw new Error('Project name cannot be empty.');
+    }
+    updates.push('name = ?');
+    values.push(trimmed);
+  }
+  if (input.description !== undefined) {
+    const trimmed = input.description?.trim() ?? null;
+    updates.push('description = ?');
+    values.push(trimmed && trimmed.length > 0 ? trimmed : null);
+  }
+
+  if (updates.length === 0) {
+    return existing;
+  }
+
+  const now = nowMs();
+  updates.push('updated_at = ?');
+  values.push(now);
+  values.push(id);
+
+  db().prepare(
+    `UPDATE projects SET ${updates.join(', ')} WHERE id = ?`,
+  ).run(...values);
+
+  return getProject(id);
+}
+
+export function deleteProject(id: string): boolean {
+  const result = db().prepare('DELETE FROM projects WHERE id = ?').run(id);
+  // The FK on project_repos.project_id is ON DELETE CASCADE so no separate
+  // cleanup is required.
+  return (result.changes ?? 0) > 0;
+}
+
+// ── Project ↔ Repo links ──
+
+export function addRepoToProject(
+  projectId: string,
+  repoId: string,
+  role: ProjectRole | null = null,
+  suggestionOrigin: SuggestionOrigin = 'manual',
+): ProjectRepo {
+  const project = getProject(projectId);
+  if (!project) {
+    throw new Error(`Project not found: ${projectId}`);
+  }
+
+  const now = nowMs();
+  const sqlite = db();
+
+  // INSERT OR REPLACE so re-adding refreshes role/origin. We treat repeat
+  // calls as "ensure this link exists with these attributes" rather than an
+  // error — the orchestrator should be free to call this idempotently.
+  sqlite.prepare(
+    `INSERT INTO project_repos (project_id, repo_id, role, suggestion_origin, added_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(project_id, repo_id) DO UPDATE SET
+       role = excluded.role,
+       suggestion_origin = excluded.suggestion_origin`,
+  ).run(projectId, repoId, role, suggestionOrigin, now);
+
+  // Bump the project's updated_at so listProjects ordering stays sensible.
+  sqlite.prepare('UPDATE projects SET updated_at = ? WHERE id = ?').run(now, projectId);
+
+  const row = sqlite.prepare(
+    `SELECT project_id, repo_id, role, suggestion_origin, added_at
+     FROM project_repos
+     WHERE project_id = ? AND repo_id = ?`,
+  ).get(projectId, repoId) as ProjectRepoRow;
+  return mapProjectRepoRow(row);
+}
+
+export function removeRepoFromProject(projectId: string, repoId: string): boolean {
+  const sqlite = db();
+  const result = sqlite.prepare(
+    'DELETE FROM project_repos WHERE project_id = ? AND repo_id = ?',
+  ).run(projectId, repoId);
+  if ((result.changes ?? 0) > 0) {
+    sqlite.prepare('UPDATE projects SET updated_at = ? WHERE id = ?').run(nowMs(), projectId);
+    return true;
+  }
+  return false;
+}
+
+export function setRepoRole(
+  projectId: string,
+  repoId: string,
+  role: ProjectRole | null,
+): ProjectRepo | null {
+  const sqlite = db();
+  const result = sqlite.prepare(
+    'UPDATE project_repos SET role = ? WHERE project_id = ? AND repo_id = ?',
+  ).run(role, projectId, repoId);
+  if ((result.changes ?? 0) === 0) return null;
+
+  sqlite.prepare('UPDATE projects SET updated_at = ? WHERE id = ?').run(nowMs(), projectId);
+
+  const row = sqlite.prepare(
+    `SELECT project_id, repo_id, role, suggestion_origin, added_at
+     FROM project_repos
+     WHERE project_id = ? AND repo_id = ?`,
+  ).get(projectId, repoId) as ProjectRepoRow | undefined;
+  return row ? mapProjectRepoRow(row) : null;
+}
+
+/**
+ * Return every project that lists the given repo. Used by the directive scope
+ * resolver and the cross-repo activity feed — both ask "what projects does
+ * this repo participate in?" before fanning out signals.
+ */
+export function listProjectsByRepoId(repoId: string): ProjectWithRepos[] {
+  const sqlite = db();
+  const rows = sqlite.prepare(
+    `SELECT p.id, p.name, p.slug, p.description, p.created_at, p.updated_at
+     FROM projects p
+     INNER JOIN project_repos pr ON pr.project_id = p.id
+     WHERE pr.repo_id = ?
+     ORDER BY p.created_at DESC`,
+  ).all(repoId) as ProjectRow[];
+
+  if (rows.length === 0) return [];
+
+  return rows.map((row) => ({
+    ...mapProjectRow(row),
+    repos: listReposForProject(row.id),
+  }));
+}
+
+// ── Dismissed suggestions ──
+
+export function recordDismissedSuggestion(fingerprint: string, reason?: string | null): void {
+  if (!fingerprint) {
+    throw new Error('Fingerprint is required.');
+  }
+  db().prepare(
+    `INSERT INTO dismissed_suggestions (fingerprint, dismissed_at, reason)
+     VALUES (?, ?, ?)
+     ON CONFLICT(fingerprint) DO UPDATE SET
+       dismissed_at = excluded.dismissed_at,
+       reason = excluded.reason`,
+  ).run(fingerprint, nowMs(), reason ?? null);
+}
+
+export function isDismissed(fingerprint: string): boolean {
+  if (!fingerprint) return false;
+  const row = db().prepare(
+    'SELECT 1 FROM dismissed_suggestions WHERE fingerprint = ? LIMIT 1',
+  ).get(fingerprint);
+  return Boolean(row);
+}

--- a/src/lib/projects/types.ts
+++ b/src/lib/projects/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Projects model — operator-curated repo groupings (epic #899).
+ *
+ * Replaces the Jaccard-based cross-repo proposer (#748) with explicit
+ * Projects: a Project owns N repos, each tagged with a role
+ * (frontend / backend / shared / etc.). Directives, outcomes, approvals,
+ * and lanes can scope to a project_id so signals propagate across the
+ * whole product surface instead of getting trapped in a single repo.
+ */
+
+/** Role a repo plays inside a Project. Free-form string in DB; this enum is the curated set. */
+export type ProjectRole =
+  | 'frontend'
+  | 'backend'
+  | 'fullstack'
+  | 'mobile'
+  | 'library'
+  | 'service'
+  | 'infra'
+  | 'docs'
+  | 'site'
+  | 'shared';
+
+/**
+ * Where a project_repos row originated from. The dismissed_suggestions table
+ * keys off `ai-semantic` groupings so we don't keep re-suggesting them after
+ * the operator says no.
+ */
+export type SuggestionOrigin = 'manual' | 'github-org' | 'ai-semantic';
+
+export interface Project {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ProjectRepo {
+  projectId: string;
+  repoId: string;
+  role: ProjectRole | null;
+  suggestionOrigin: SuggestionOrigin;
+  addedAt: number;
+}
+
+export interface ProjectWithRepos extends Project {
+  repos: ProjectRepo[];
+}
+
+export interface DismissedSuggestion {
+  fingerprint: string;
+  dismissedAt: number;
+  reason: string | null;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -122,6 +122,9 @@ const GATED_PREFIXES = [
   // Cortex memory/directive surface — local-only by design. Even read-only
   // endpoints leak operator preferences and repo names; gate them too.
   '/api/cortex/',
+  // Projects model (epic #899) — leaks repo names and operator-curated
+  // groupings. Loopback-only with bearer-token fallback for LAN clients.
+  '/api/projects',
   // Setup routes are gated too — GET is allowlisted above, POST needs loopback
   // or a token (so an evil cross-origin page can't POST to /api/setup/claude-desktop
   // and silently write to the user's Claude config).


### PR DESCRIPTION
## Summary

Wave 1 of epic #899 — the four-layer foundation that everything else
in the Projects roadmap depends on.

This replaces the Jaccard-based cross-repo proposer (#748, structurally
inert per the Phase 2 audit) with explicit operator-curated **Projects**:
groupings of repos by product/team boundary, each with per-repo role
tags. Once shipped, directives can scope to a project, outcomes can
propagate across all peer repos, and the Recall Card grows a
"Project pulse" section.

Per the brainstormer-locked spec in #899 + the AI semantics addendum,
this PR is intentionally just the chassis: schema → types → storage →
API → MCP tools, in that dependency order. No UI changes; no
proposer rewrite; no directive integration. Those land in subsequent
waves.

### What's in here

- **Schema v13** (idempotent on every boot — installs upgraded from v12
  pick up the new tables + columns automatically via the
  `ensureIdempotentColumnAdds` path)
  - `projects` (id, name, slug UNIQUE, description, created_at, updated_at)
  - `project_repos` (project_id, repo_id, role, suggestion_origin) with
    ON DELETE CASCADE on `project_id` and an idx on `repo_id` for the
    "what projects does this repo belong to?" query
  - `dismissed_suggestions` (fingerprint, dismissed_at, reason) — keys
    AI-semantic groupings the operator already said no to
  - Nullable `project_id` columns added to `session_outcomes`,
    `approvals`, and `lanes` plus indexes
- **Types** in `src/lib/projects/types.ts` with the 10-role curated set
  (frontend / backend / fullstack / mobile / library / service / infra /
  docs / site / shared)
- **Storage** in `src/lib/projects/store.ts` using better-sqlite3
  directly (matches the repo registry's conventions; Drizzle is
  reserved for schema-owning tables). Provides:
  `createProject`, `getProject`, `getProjectBySlug`, `getProjectWithRepos`,
  `listProjects`, `updateProject`, `deleteProject`,
  `addRepoToProject` (idempotent ON CONFLICT upsert),
  `removeRepoFromProject`, `setRepoRole`, `listProjectsByRepoId`,
  `recordDismissedSuggestion`, `isDismissed`. Slug uniqueness handled
  with a 6-attempt suffix retry.
- **8 API routes** under `/api/projects/*`, all gated by the global
  middleware (`/api/projects` added to `GATED_PREFIXES`):
  `GET /api/projects`, `POST /api/projects`,
  `GET /api/projects/:id`, `PATCH /api/projects/:id`, `DELETE /api/projects/:id`,
  `POST /api/projects/:id/repos`, `DELETE /api/projects/:id/repos/:repoId`,
  `PATCH /api/projects/:id/repos/:repoId`
- **6 cortex MCP tools** in `cortex-mcp-server.ts` that call the
  storage layer directly (better-sqlite3 + WAL mode is multi-process
  safe, so the MCP child process and the Next backend can share the
  same DB file without round-tripping through HTTP):
  `cortex_create_project`, `cortex_add_repo_to_project`,
  `cortex_remove_repo_from_project`, `cortex_set_repo_role`,
  `cortex_list_projects`, `cortex_delete_project`

### Schema version note

Spec called for v11; live trunk had already shipped v12 in earlier
PRs, so this lands as v13. All migration markers `v1..v13` are written
on first boot; existing `v12` installs pick up the new tables /
columns via the always-on `ensureIdempotentColumnAdds` path.

### What's *not* in here (intentional)

- Settings → Projects UI — wave 2
- Auto-suggest from shared GitHub org — wave 2
- `scope: project` directive support — wave 3
- Cross-repo proposer rewrite + `O8_LEGACY_JACCARD_PROPOSER` flag — wave 4
- Recall Card Project pulse section — wave 5

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `CORTEX_IDE_DATA_DIR=$(mktemp -d) npx tsx scripts/smoke-projects.ts`
      passes 13/13 (create → add 2 repos with roles → list →
      listByRepoId → idempotent re-add → setRole → updateProject →
      removeRepo → idempotent re-remove → dismissed-suggestion
      round-trip → cascade delete → slug collision retry)
- [x] Re-run on the same data dir is idempotent (migration markers
      `.db-migrated-v1` … `.db-migrated-v13` all written, no errors)
- [x] eslint passes on all new files
- [ ] Visual sanity check on a fresh prod boot once this lands

Closes-progress: #899 (wave 1 of N)

🤖 Generated with [Claude Code](https://claude.com/claude-code)