### PR TITLE
feat(projects): scope:project directives + cross-repo proposer rewrite (epic #899 wave 1)

### DIFF
--- a/src/lib/codebase-memory/build-context.ts
+++ b/src/lib/codebase-memory/build-context.ts
@@ -44,7 +44,9 @@ import { getDb, sessionOutcomes } from '@/lib/db';
 import { getDataDir } from '@/lib/data-dir-migration';
 import { liveOutcomeFilter } from '@/lib/cortex/decay';
 import { withTiming } from '@/lib/cortex/diagnostics';
+import { listRepos } from '@/lib/repos/registry';
 import { readRepoPathRegistry } from '@/lib/repos/repo-path-registry';
+import { listProjectsByRepoId } from '@/lib/projects/store';
 
 import { extractGraphResolvedSymbols, type SymbolEdge } from './client';
 
@@ -63,6 +65,12 @@ interface DirectiveEntry {
   title: string;
   scope: string;
   repoName: string | null;
+  /**
+   * #899 — `scope: project` directives carry a list of project slugs in the
+   * front matter (`projects: [atlas, beacon]`). Empty list when the directive
+   * isn't project-scoped or front matter omitted the field.
+   */
+  projects: string[];
   priority: number | null;
   body: string;
 }
@@ -111,9 +119,34 @@ function parseDirectiveFile(raw: string, fallbackId: string): DirectiveEntry | n
     title: meta.title?.trim() || fallbackId,
     scope: meta.scope?.trim() || 'global',
     repoName: meta.repoName?.trim() || null,
+    projects: parseProjectsList(meta.projects),
     priority: Number.isFinite(priorityNum) ? priorityNum : null,
     body,
   };
+}
+
+/**
+ * #899 — parse the `projects:` front matter field into a normalized slug list.
+ * Accepts the two YAML-ish shapes the directive parser already supports:
+ *   projects: [atlas, beacon]
+ *   projects: atlas, beacon
+ * Returns an empty array when the field is missing/empty/malformed. Slugs are
+ * lowercased and de-duplicated to keep membership checks predictable.
+ */
+function parseProjectsList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  const stripped = raw.trim().replace(/^\[|\]$/g, '').trim();
+  if (!stripped) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const part of stripped.split(',')) {
+    const slug = part.trim().replace(/^["']|["']$/g, '').toLowerCase();
+    if (!slug) continue;
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    out.push(slug);
+  }
+  return out;
 }
 
 function readDirectives(): DirectiveEntry[] {
@@ -169,14 +202,54 @@ async function isKnownRepoPath(repoPath: string): Promise<boolean> {
   return registry.repos.some((entry) => entry.path === normalized);
 }
 
-/** Filter directives by repo (global + matching repo name). */
-function filterDirectivesForRepo(directives: DirectiveEntry[], repoPath: string): DirectiveEntry[] {
+/**
+ * Filter directives for a target repo across the three scope tiers.
+ *
+ * #899 — Tier order, broad → narrow:
+ *   1. `scope: global` — always applies (#849 already gates these on a known
+ *      repo path before this helper is called).
+ *   2. `scope: project` — applies when the directive's `projects:` slug list
+ *      intersects with the project memberships of the target repo. Resolved
+ *      via the SQLite-backed `listProjectsByRepoId(repoId)` lookup, with the
+ *      repoId resolved by matching the registered repo's `localPath` to the
+ *      target `repoPath`. Repos that aren't in any Project naturally see no
+ *      project-scoped directives.
+ *   3. `scope: repo` (or `scope: <repoName>`) — applies when the explicit
+ *      `repoName` field or the scope literal matches the target repo's basename.
+ *
+ * Lookups never throw — listProjectsByRepoId() / listRepos() are wrapped, and
+ * any I/O or DB failure falls back to "skip the project tier" so a misbehaving
+ * Projects table never starves repo + global directives.
+ */
+async function filterDirectivesForRepo(
+  directives: DirectiveEntry[],
+  repoPath: string,
+): Promise<DirectiveEntry[]> {
   const repoName = basename(repoPath).toLowerCase();
+
+  // Resolve project memberships once per call. Empty Set when:
+  //   - the repo isn't registered (no id to look up)
+  //   - the repo is registered but in zero projects
+  //   - the projects DB layer is unavailable
+  // In all three cases, project-scoped directives skip silently.
+  const projectSlugsForRepo = await resolveRepoProjectSlugs(repoPath);
+
   return directives
     .filter((d) => {
       const scope = d.scope.toLowerCase();
       if (scope === 'global' || scope === '') return true;
-      // Repo-scoped: match either explicit repoName field or scope===repoName
+
+      // #899 — Project tier. Match if any directive project slug is in the
+      // repo's project membership set.
+      if (scope === 'project') {
+        if (d.projects.length === 0) return false;
+        for (const slug of d.projects) {
+          if (projectSlugsForRepo.has(slug)) return true;
+        }
+        return false;
+      }
+
+      // Repo tier — match either explicit repoName field or `scope: <repoName>`.
       const declaredRepo = (d.repoName ?? '').toLowerCase();
       if (declaredRepo && declaredRepo === repoName) return true;
       if (scope === repoName) return true;
@@ -189,6 +262,54 @@ function filterDirectivesForRepo(directives: DirectiveEntry[], repoPath: string)
       return a.title.localeCompare(b.title);
     })
     .slice(0, MAX_DIRECTIVES);
+}
+
+/**
+ * #899 — resolve the set of project slugs that include the given repo path.
+ *
+ * Three-step lookup, each step swallows failures into an empty result:
+ *   1. Read the repo registry (SQLite-free file at `~/.o8/repos.json`).
+ *   2. Find the registry entry whose `localPath` resolves to `repoPath`.
+ *   3. Ask the projects store for membership rows by the registry id.
+ *
+ * Returns an empty Set when the registry, the repo, or the projects DB is
+ * unavailable. Project-scoped directives are an additive tier — losing them
+ * never breaks repo + global directives.
+ */
+async function resolveRepoProjectSlugs(repoPath: string): Promise<Set<string>> {
+  const out = new Set<string>();
+  const normalized = (() => {
+    try { return resolve(repoPath); } catch { return ''; }
+  })();
+  if (!normalized) return out;
+
+  let repoId: string | null = null;
+  try {
+    const repos = await listRepos();
+    const match = repos.find((r) => {
+      try {
+        return resolve(r.localPath) === normalized;
+      } catch {
+        return false;
+      }
+    });
+    repoId = match?.id ?? null;
+  } catch {
+    return out;
+  }
+  if (!repoId) return out;
+
+  try {
+    const projects = listProjectsByRepoId(repoId);
+    for (const project of projects) {
+      const slug = project.slug?.toLowerCase().trim();
+      if (slug) out.add(slug);
+    }
+  } catch {
+    // Project DB unavailable (migration not applied yet, etc.) — drop tier
+    // silently. Other tiers still resolve.
+  }
+  return out;
 }
 
 async function readRecentOutcomes(repoPath: string): Promise<OutcomeRow[]> {
@@ -348,7 +469,7 @@ export async function buildContextBlock({
   // empty for unknown paths since they key off repoPath in the DB.
   const repoIsKnown = await isKnownRepoPath(repoPath);
   const directives = repoIsKnown
-    ? filterDirectivesForRepo(readDirectives(), repoPath)
+    ? await filterDirectivesForRepo(readDirectives(), repoPath)
     : [];
   const outcomes = await readRecentOutcomes(repoPath);
 

--- a/src/lib/cortex/cross-repo-proposer.ts
+++ b/src/lib/cortex/cross-repo-proposer.ts
@@ -1,21 +1,28 @@
 /**
- * #748 — Cross-repo learning.
+ * #748 / #899 — Cross-repo learning.
  *
- * When a directive lands in repo A and ≥ 2 other registered repos share a
- * stack signature with A (Jaccard overlap ≥ SIMILARITY_THRESHOLD; see
- * `SIMILARITY_THRESHOLD` constant for the empirical floor and #853 for
- * rationale), surface a yellow proposal row in those target repos'
- * orchestrator views. The operator
- * accepts (duplicates the directive scoped to the target) or dismisses
- * (snoozes the (target, directive) pair for 30 days). Always human-gated.
+ * Default path (#899): when a `scope: repo` directive lands in repo A,
+ * resolve A's project memberships, then propose the directive to every other
+ * repo in those projects. Project membership is the explicit, operator-curated
+ * grouping that replaced the production-inert Jaccard candidate-selection
+ * step.
  *
- * The proposer never writes a directive itself. Accept text drives the
- * orchestrator chat composer; the orchestrator's existing memory tools
- * handle the actual markdown write — this matches #746's flow.
+ * Legacy path (#748, gated): set `O8_LEGACY_JACCARD_PROPOSER=1` to fall back
+ * to the original behavior — Jaccard overlap of stack signatures with a
+ * `repos.length < 3` floor and `SIMILARITY_THRESHOLD ≥ 0.4`. This existed for
+ * one version after the project rewrite so any regression in the new path can
+ * be reverted by env flag.
+ *
+ * Either way, the operator accepts (duplicates the directive scoped to the
+ * target) or dismisses (snoozes the (target, directive) pair for 30 days).
+ * Always human-gated. The proposer never writes a directive itself — Accept
+ * text drives the orchestrator chat composer; the orchestrator's existing
+ * memory tools handle the actual markdown write — this matches #746's flow.
  *
  * Storage:
- *   ~/.o8/stack-signatures.json — cached signatures (owned by stack-signature.ts)
  *   ~/.o8/cross-repo-snooze.json — append-only ledger of dismissed (target, directive) pairs
+ *   ~/.o8/directive-origins.json — circular-propagation guard (#855)
+ *   ~/.o8/stack-signatures.json — only read on the legacy Jaccard path
  *
  * Proposal id: sha1(`${targetRepoId}::${directiveId}`).slice(0,16) — stable
  * across ticks so dismiss survives recomputes.
@@ -31,22 +38,38 @@ import { getDataDir } from '@/lib/data-dir-migration';
 import { listRepos } from '@/lib/repos/registry';
 import type { RepoRegistryEntry } from '@/lib/repos/types';
 import { readOrComputeSignatures } from '@/lib/cortex/stack-signature';
+import { listProjectsByRepoId } from '@/lib/projects/store';
 
-// #853 — empirical floor for real-world repos. The original 0.8 spec was
-// chosen without validating against actual registered repos; in practice
-// `cortex-ide` (Next + Tauri + 52 deps) vs `eyes-web` (Next + Vercel + 55
-// deps) scores Jaccard ≈ 0.126, far below 0.8. Two repos sharing a Next.js
-// + TypeScript stack typically clear 0.4 even when their feature surfaces
-// are unrelated, so 0.4 is the practical floor for any pair to clear at
-// all. TODO: replace raw Jaccard with a tech-stack-weighted similarity
-// (Next/TS/Tauri tags overweighted vs. file-list overlap) once we have
-// > 3 repos worth of empirical pairs to calibrate against.
+// #853 / #899 — Jaccard constants live behind the legacy gate. The empirical
+// 0.4 floor and ≥ 3-repos minimum mathematically excluded asymmetric stacks
+// (cortex-ide 52 deps vs o8-site 7 deps caps at Jaccard ≈ 0.135), which is
+// why #748 was production-inert. The default path (project membership) needs
+// neither constant.
 const SIMILARITY_THRESHOLD = 0.4;
 const MIN_SIMILAR_REPOS = 2;
 const SNOOZE_DAYS = 30;
 const MAX_CANDIDATES = 12;
 const SNOOZE_FILE = 'cross-repo-snooze.json';
 const ORIGIN_FILE = 'directive-origins.json';
+
+/**
+ * #899 — fixed similarity score for project-membership matches. Project
+ * grouping is binary ("in this project" or not), so we render the badge as
+ * 100% to signal "explicit operator-curated link" rather than a fuzzy stack
+ * overlap. The UI tooltip distinguishes the two via the `source` discriminator.
+ */
+const PROJECT_MEMBERSHIP_SCORE = 1.0;
+
+/**
+ * #899 — emergency fallback. Set `O8_LEGACY_JACCARD_PROPOSER=1` to revert to
+ * the pre-Project Jaccard candidate selection for one version. Default OFF.
+ */
+function isLegacyJaccardEnabled(): boolean {
+  const raw = process.env.O8_LEGACY_JACCARD_PROPOSER;
+  if (!raw) return false;
+  const v = raw.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes';
+}
 
 // ── directive read (same parser shape as cortex/directives/route.ts) ──────
 
@@ -354,6 +377,11 @@ function findSourceRepo(
   directive: DirectiveSummary,
   repos: RepoRegistryEntry[],
 ): RepoRegistryEntry | null {
+  // #899 — `scope: project` directives already span every member repo of the
+  // listed Projects. They're the explicit cross-repo solution, so the proposer
+  // never fans them out further. Skip before scope/repoName resolution.
+  if (directive.scope?.toLowerCase() === 'project') return null;
+
   // Repo-scoped directive: front matter `repoName: <name>` or `scope: <name>`.
   const declared = (directive.repoName || directive.scope || '').toLowerCase();
   if (declared && declared !== 'global' && declared !== 'repo') {
@@ -386,7 +414,13 @@ export interface CrossRepoProposalCandidate {
   directiveTitle: string;
   directiveBody: string;
   directivePriority: number | null;
-  /** Jaccard similarity between source and target (0..1). */
+  /**
+   * Match score in [0..1].
+   *   - Default path (#899): always 1.0 — the link is an explicit Project
+   *     membership, not a fuzzy stack overlap.
+   *   - Legacy path (Jaccard, gated by O8_LEGACY_JACCARD_PROPOSER): Jaccard
+   *     similarity over stack signatures, ≥ SIMILARITY_THRESHOLD.
+   */
   similarity: number;
   /** Pre-rendered draft text the chat composer fills with on Accept. */
   draftDirective: string;
@@ -427,19 +461,48 @@ function buildDraft(directive: DirectiveSummary, target: RepoRegistryEntry): str
 }
 
 /**
- * Compute proposals for every registered repo. Synchronous read of cached
- * signatures + the directives dir + snooze ledger.
+ * #899 — collect every peer repo id for a source repo via its project
+ * memberships. "Peer" = "in any of the same Projects as the source", excluding
+ * the source itself. Empty Set when the source has no project links or the
+ * Projects DB is unavailable.
+ */
+function collectProjectPeers(sourceRepoId: string): Set<string> {
+  const peers = new Set<string>();
+  let projects: Array<{ id: string; repos: Array<{ repoId: string }> }> = [];
+  try {
+    projects = listProjectsByRepoId(sourceRepoId);
+  } catch {
+    return peers;
+  }
+  for (const project of projects) {
+    for (const link of project.repos) {
+      if (link.repoId !== sourceRepoId) peers.add(link.repoId);
+    }
+  }
+  return peers;
+}
+
+/**
+ * Compute proposals for every registered repo.
+ *
+ * #899 default path: for each `scope: repo` directive, find its source repo,
+ * then propose to every peer repo that shares at least one Project with the
+ * source. The Jaccard candidate-selection step that gated #748 production-inert
+ * has been replaced by this explicit-membership lookup.
  *
  * Returns an empty result when:
- *   - signatures haven't been computed yet (caller should kick boot tick)
- *   - fewer than 3 repos are registered (the issue specifies ≥ 3 sharing a stack)
+ *   - the registry is unreadable
  *   - no repo-scoped directives exist
+ *   - no Projects link the source repo to any other repo (and legacy gate off)
+ *
+ * Set `O8_LEGACY_JACCARD_PROPOSER=1` to fall back to the pre-#899 behavior.
  */
 export async function proposeAcrossRepos(
   options: ProposeOptions = {},
 ): Promise<ProposeAcrossReposOutput> {
   const limit = options.limit ?? MAX_CANDIDATES;
   const now = options.now ?? new Date();
+  const useLegacy = isLegacyJaccardEnabled();
 
   let repos: RepoRegistryEntry[] = [];
   try {
@@ -447,12 +510,22 @@ export async function proposeAcrossRepos(
   } catch {
     return { byDirective: {}, candidates: [] };
   }
-  if (repos.length < 3) return { byDirective: {}, candidates: [] };
 
-  const signatureStore = await readOrComputeSignatures();
-  const sigByRepoId = new Map<string, string[]>();
-  for (const sig of signatureStore.signatures) {
-    sigByRepoId.set(sig.repoId, sig.deps);
+  // #899 — the legacy floor of `repos.length < 3` was a Jaccard-era guard
+  // ("≥ 3 sharing a stack"). With explicit Projects, two repos in one Project
+  // is a perfectly valid fan-out target, so we drop that gate on the default
+  // path and keep it only when the legacy flag is on.
+  if (useLegacy && repos.length < 3) return { byDirective: {}, candidates: [] };
+
+  // Legacy path also needs stack signatures. The default path doesn't load
+  // them — saves the I/O when the operator has opted into Projects.
+  let sigByRepoId: Map<string, string[]> | null = null;
+  if (useLegacy) {
+    const signatureStore = await readOrComputeSignatures();
+    sigByRepoId = new Map<string, string[]>();
+    for (const sig of signatureStore.signatures) {
+      sigByRepoId.set(sig.repoId, sig.deps);
+    }
   }
 
   const directives = readAllDirectives();
@@ -466,32 +539,54 @@ export async function proposeAcrossRepos(
     const sourceRepo = findSourceRepo(directive, repos);
     if (!sourceRepo) continue;
 
-    const sourceDeps = sigByRepoId.get(sourceRepo.id);
-    // No signature recorded yet — skip (boot tick will fix it on next pass).
-    if (!sourceDeps || sourceDeps.length === 0) continue;
-
     // #855 — circular propagation guard. If this directive was previously
     // accepted from another repo, its origin is recorded in the sidecar
-    // ledger. Never propose it back to that origin.
+    // ledger. Never propose it back to that origin. Applied uniformly on
+    // both paths so the guard survives env-flag toggles.
     const directiveOrigin = originRepoIdFor(directive.id);
 
-    // Find every other repo with similarity ≥ threshold.
     const similarRepos: { repo: RepoRegistryEntry; similarity: number }[] = [];
-    for (const target of repos) {
-      if (target.id === sourceRepo.id) continue;
-      // #855 — skip if target IS the origin repo of this directive.
-      if (directiveOrigin && target.id === directiveOrigin) continue;
-      const targetDeps = sigByRepoId.get(target.id);
-      if (!targetDeps || targetDeps.length === 0) continue;
-      const sim = jaccard(sourceDeps, targetDeps);
-      if (sim >= SIMILARITY_THRESHOLD) {
-        similarRepos.push({ repo: target, similarity: sim });
-      }
-    }
 
-    // Issue spec: only fire when ≥ 2 similar repos exist (3 total counting
-    // source). One similar peer isn't a "stack" worth fanning out to.
-    if (similarRepos.length < MIN_SIMILAR_REPOS) continue;
+    if (useLegacy && sigByRepoId) {
+      // ── Legacy Jaccard path (gated; preserves pre-#899 behavior) ─────────
+      const sourceDeps = sigByRepoId.get(sourceRepo.id);
+      // No signature recorded yet — skip (boot tick will fix it on next pass).
+      if (!sourceDeps || sourceDeps.length === 0) continue;
+
+      for (const target of repos) {
+        if (target.id === sourceRepo.id) continue;
+        if (directiveOrigin && target.id === directiveOrigin) continue;
+        const targetDeps = sigByRepoId.get(target.id);
+        if (!targetDeps || targetDeps.length === 0) continue;
+        const sim = jaccard(sourceDeps, targetDeps);
+        if (sim >= SIMILARITY_THRESHOLD) {
+          similarRepos.push({ repo: target, similarity: sim });
+        }
+      }
+
+      // Legacy spec: only fire when ≥ 2 similar repos exist (3 total counting
+      // source). One similar peer isn't a "stack" worth fanning out to.
+      if (similarRepos.length < MIN_SIMILAR_REPOS) continue;
+    } else {
+      // ── #899 Project-membership path (default) ───────────────────────────
+      // Look up the source repo's project peers. Empty set when the source
+      // isn't in any Project (operator hasn't grouped it yet) or the Projects
+      // DB is unavailable; either way, no proposals fire — which is the
+      // correct behavior. Operators opt into cross-repo by grouping repos.
+      const peerIds = collectProjectPeers(sourceRepo.id);
+      if (peerIds.size === 0) continue;
+
+      for (const target of repos) {
+        if (target.id === sourceRepo.id) continue;
+        // Origin guard — same rule as the Jaccard path.
+        if (directiveOrigin && target.id === directiveOrigin) continue;
+        if (!peerIds.has(target.id)) continue;
+        similarRepos.push({ repo: target, similarity: PROJECT_MEMBERSHIP_SCORE });
+      }
+
+      // No floor on peer count — a 2-repo Project is a valid fan-out target.
+      if (similarRepos.length === 0) continue;
+    }
 
     byDirective[directive.id] = similarRepos.map((s) => s.repo.id);
     for (const { repo: target, similarity } of similarRepos) {
@@ -515,7 +610,9 @@ export async function proposeAcrossRepos(
   }
 
   // Sort by similarity (highest match first), then alphabetically by target
-  // name so output stays stable across recomputes.
+  // name so output stays stable across recomputes. Project-membership matches
+  // all share PROJECT_MEMBERSHIP_SCORE, so the alphabetic tiebreak does the
+  // real ordering work on the default path.
   candidates.sort((a, b) => {
     if (b.similarity !== a.similarity) return b.similarity - a.similarity;
     if (a.targetRepoName !== b.targetRepoName) return a.targetRepoName.localeCompare(b.targetRepoName);


### PR DESCRIPTION
## Summary

Wave 1 of epic #899 (replace Jaccard-based cross-repo with explicit Projects). Two changes land here:

- **`scope: project` directive tier** — `build-context.ts` now parses `projects: [slug, ...]` from front matter and adds a third filter tier between `global` and `repo`. Project membership is resolved via `listProjectsByRepoId(repoId)` from the foundation PR (#910). Repos not in any Project silently see no project-scoped directives.
- **Cross-repo proposer rewrite** — default path replaces the production-inert Jaccard candidate-selection (#748 / #853 — 0.4 floor was unreachable, repos.length<3 floor) with explicit project-membership lookup. `scope: repo` directive in repo A → fan-out to project-peer repos via `listProjectsByRepoId`. Snooze ledger (#838), origin guard (#855), and `?force=1` cache bypass preserved verbatim. Legacy Jaccard path is gated behind `O8_LEGACY_JACCARD_PROPOSER=1` for one-version emergency fallback.

`scope: project` directives skip cross-repo fan-out — they're already the cross-repo solution.

Builds on top of #910 (now merged on main).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Lint clean for changed files
- [x] Smoke: 2 repos in a Project (Atlas: repoA + repoB), 1 outside (repoC). Directive in repoA → proposal to repoB only, similarity=1.0. repoC ignored.
- [x] Smoke: `recordDirectiveOrigin({ directiveId, originRepoId: 'b' })` → next pass skips repoB (circular guard).
- [x] Smoke: `O8_LEGACY_JACCARD_PROPOSER=1` flips back to Jaccard path; with no signatures/<3 repos, returns empty as expected.
- [x] Smoke: build-context filter tiers — global directive applies everywhere, project directive applies only to repos in matching Projects, repo directive applies only to its named repo.
- [ ] Manual: in installed app, create a Project linking 2 repos, add a `scope: repo` directive to one, verify the proposer surfaces it for the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)