### PR TITLE
feat(projects): Recall Card Project pulse section (epic #899 wave 2)

### DIFF
--- a/src/app/api/cortex/project-pulse/route.ts
+++ b/src/app/api/cortex/project-pulse/route.ts
@@ -1,0 +1,93 @@
+/**
+ * GET /api/cortex/project-pulse?repoPath=<absolute-path>[&force=1]
+ *
+ * Aggregates peer-repo activity (commits, open PRs, open issues) across every
+ * Project the given repo belongs to. Read-only — the underlying data is the
+ * existing GitHub cache (#899 wave 2).
+ *
+ * 5-minute in-memory TTL keyed by repoPath; pass `?force=1` to bypass.
+ *
+ * Response shape:
+ *   {
+ *     ok: true,
+ *     pulses: ProjectPulse[],
+ *   }
+ *
+ * Failure policy: any error returns `{ ok: false, error }` with status 500.
+ * Empty / non-project / cache-miss states return `{ ok: true, pulses: [] }` so
+ * the Recall Card can simply hide the row.
+ */
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { resolve } from 'node:path';
+import { NextRequest, NextResponse } from 'next/server';
+import { listRepos } from '@/lib/repos/registry';
+import { getProjectPulse, type ProjectPulse } from '@/lib/projects/pulse';
+
+interface CacheEntry {
+  pulses: ProjectPulse[];
+  ts: number;
+}
+
+const TTL_MS = 5 * 60 * 1000;
+const cache = new Map<string, CacheEntry>();
+
+async function resolveRepoIdFromPath(repoPath: string): Promise<string | null> {
+  const normalized = (() => {
+    try { return resolve(repoPath); } catch { return ''; }
+  })();
+  if (!normalized) return null;
+  const repos = await listRepos().catch(() => []);
+  const match = repos.find((r) => {
+    try {
+      return resolve(r.localPath) === normalized;
+    } catch {
+      return false;
+    }
+  });
+  return match?.id ?? null;
+}
+
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+  const repoPath = params.get('repoPath')?.trim() ?? '';
+  if (!repoPath) {
+    return NextResponse.json(
+      { ok: false, error: 'repoPath is required.' },
+      { status: 400 },
+    );
+  }
+  const force = params.get('force') === '1';
+
+  // Cache hit — but only when not forced.
+  const cached = cache.get(repoPath);
+  if (!force && cached && Date.now() - cached.ts < TTL_MS) {
+    return NextResponse.json(
+      { ok: true, pulses: cached.pulses },
+      { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+    );
+  }
+
+  try {
+    const repoId = await resolveRepoIdFromPath(repoPath);
+    if (!repoId) {
+      // Repo isn't registered — treat as "no projects" rather than an error.
+      cache.set(repoPath, { pulses: [], ts: Date.now() });
+      return NextResponse.json(
+        { ok: true, pulses: [] },
+        { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+      );
+    }
+    const pulses = await getProjectPulse(repoId);
+    cache.set(repoPath, { pulses, ts: Date.now() });
+    return NextResponse.json(
+      { ok: true, pulses },
+      { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to load project pulse.';
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/src/components/desktop/thoughts/ContextRecallCard.tsx
+++ b/src/components/desktop/thoughts/ContextRecallCard.tsx
@@ -32,6 +32,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import type { ProjectPulse } from '@/lib/projects/pulse';
 import {
   indexEntryForRepo,
   pickTopDirective,
@@ -42,9 +43,10 @@ import {
 } from './recall-card/shared';
 import { DirectiveRow } from './recall-card/DirectiveRow';
 import { OutcomesRow } from './recall-card/OutcomesRow';
+import { ProjectPulseRow } from './recall-card/ProjectPulseRow';
 import { SymbolGraphFallbackRow, SymbolGraphRow } from './recall-card/SymbolGraphRow';
 
-type OpenRow = 'directive' | 'outcomes' | 'symbols' | null;
+type OpenRow = 'directive' | 'outcomes' | 'symbols' | 'pulse' | null;
 
 interface OutcomesCacheEntry {
   repoPath: string;
@@ -56,6 +58,11 @@ interface EdgesCacheEntry {
   key: string;
   rows: SymbolEdgeView[] | null;
   unavailable: boolean;
+}
+
+interface PulseCacheEntry {
+  repoPath: string;
+  pulses: ProjectPulse[] | null;
 }
 
 interface ContextRecallCardProps {
@@ -79,12 +86,21 @@ export function ContextRecallCard({ packet, repoName }: ContextRecallCardProps) 
     rows: null,
     unavailable: false,
   });
+  // #899 wave 2 — peer-repo activity, keyed on repoPath so a mid-flight
+  // packet switch shows "loading" rather than stale data.
+  const [pulseByRepo, setPulseByRepo] = useState<PulseCacheEntry>({
+    repoPath: '',
+    pulses: null,
+  });
 
   // #840 — Bumped when a Cortex memory write (e.g. directive trailer append
   // after a merge) fires the `o8:cortex-changes` window event. The directive
   // fetch effect uses this as a dependency so the card re-fetches in place
   // without a manual collapse/reopen.
   const [directiveRefreshTick, setDirectiveRefreshTick] = useState(0);
+  // #899 — Same WS bridge also bumps this so the project-pulse row refreshes
+  // on directive changes (a new directive may shift which projects matter).
+  const [pulseRefreshTick, setPulseRefreshTick] = useState(0);
 
   const repoPath = packet.workspaceTargetPath;
 
@@ -155,6 +171,9 @@ export function ContextRecallCard({ packet, repoName }: ContextRecallCardProps) 
         if (pending) {
           pending = false;
           setDirectiveRefreshTick((tick) => tick + 1);
+          // #899 wave 2 — directive change may shift project membership /
+          // priorities, so refresh the pulse on the same debounced edge.
+          setPulseRefreshTick((tick) => tick + 1);
         }
       }, 250);
     };
@@ -193,6 +212,33 @@ export function ContextRecallCard({ packet, repoName }: ContextRecallCardProps) 
       cancelled = true;
     };
   }, [repoPath]);
+
+  // ── Project pulse — keyed on repoPath, refreshes on cortex-changes ──
+  // #899 wave 2. Failure modes — non-OK, throw, or repo not in any project —
+  // all settle to an empty list so the row can hide gracefully.
+  useEffect(() => {
+    if (!repoPath) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const url = `/api/cortex/project-pulse?repoPath=${encodeURIComponent(repoPath)}`;
+        const response = await fetch(url, { cache: 'no-store' });
+        if (cancelled) return;
+        if (!response.ok) {
+          setPulseByRepo({ repoPath, pulses: [] });
+          return;
+        }
+        const payload = (await response.json()) as { ok?: boolean; pulses?: ProjectPulse[] };
+        if (cancelled) return;
+        setPulseByRepo({ repoPath, pulses: payload.pulses ?? [] });
+      } catch {
+        if (!cancelled) setPulseByRepo({ repoPath, pulses: [] });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [repoPath, pulseRefreshTick]);
 
   // ── Index state — gates the SYMBOL GRAPH row ────────────────────────
   // #897 — On a non-OK response (or thrown error) we used to silently
@@ -293,6 +339,12 @@ export function ContextRecallCard({ packet, repoName }: ContextRecallCardProps) 
   const liveEdgesUnavailable =
     edgesByKey.key === symbolKey && symbolKey && edgesByKey.unavailable;
 
+  // #899 wave 2 — same repoPath fence as outcomes; mid-flight repo switches
+  // show loading instead of stale peer activity.
+  const livePulses =
+    repoPath && pulseByRepo.repoPath === repoPath ? pulseByRepo.pulses : null;
+  const showPulseRow = (livePulses?.length ?? 0) > 0;
+
   const repoEntry = indexEntryForRepo(indexState, repoPath);
   const showSymbolRow = repoEntryReady && !liveEdgesUnavailable;
   const symbolStatusHint = (() => {
@@ -347,6 +399,14 @@ export function ContextRecallCard({ packet, repoName }: ContextRecallCardProps) 
           onIndexStateChange={setIndexState}
         />
       )}
+      {showPulseRow ? (
+        <ProjectPulseRow
+          open={openRow === 'pulse'}
+          onToggle={() => setOpenRow(openRow === 'pulse' ? null : 'pulse')}
+          loading={livePulses === null}
+          pulses={livePulses ?? []}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/desktop/thoughts/recall-card/ProjectPulseRow.tsx
+++ b/src/components/desktop/thoughts/recall-card/ProjectPulseRow.tsx
@@ -1,0 +1,439 @@
+'use client';
+
+/**
+ * #899 wave 2 — PROJECT PULSE row of the Context Recall Card.
+ *
+ * Aggregates activity from peer repos in every Project the packet's repo
+ * belongs to. Surfaces:
+ *   - recent commits (last 24h, max 5 per repo)
+ *   - open PRs (max 5 per repo)
+ *   - open issues (max 5 per repo)
+ *
+ * Hidden entirely when the repo isn't in any project (the parent guards on
+ * `pulses.length > 0` before mounting this row).
+ */
+
+import { useMemo } from 'react';
+import {
+  Chevron,
+  expandedSurfaceStyle,
+  FONT_FAMILY,
+  formatRelative,
+  rowChromeStyle,
+  rowLabelStyle,
+  rowValueStyle,
+} from './shared';
+import type {
+  ProjectPulse,
+  ProjectPulseRepo,
+  PulseCommit,
+  PulseIssue,
+  PulsePullRequest,
+} from '@/lib/projects/pulse';
+
+interface ProjectPulseRowProps {
+  open: boolean;
+  onToggle: () => void;
+  loading: boolean;
+  pulses: ProjectPulse[];
+}
+
+function openExternal(url: string | null | undefined) {
+  if (!url) return;
+  if (typeof window === 'undefined') return;
+  window.open(url, '_blank', 'noopener,noreferrer');
+}
+
+function summarizeRepo(repo: ProjectPulseRepo): string | null {
+  const parts: string[] = [];
+  if (repo.recentCommits.length > 0) {
+    const author = repo.recentCommits[0].author;
+    const verb = author ? `${author} pushed` : 'pushed';
+    parts.push(`${verb} ${repo.recentCommits.length} in ${repo.repoName}`);
+  }
+  if (repo.openPrs.length > 0) {
+    parts.push(`${repo.openPrs.length} open PR${repo.openPrs.length === 1 ? '' : 's'} in ${repo.repoName}`);
+  }
+  if (repo.openIssues.length > 0 && repo.recentCommits.length === 0 && repo.openPrs.length === 0) {
+    parts.push(`${repo.openIssues.length} open issue${repo.openIssues.length === 1 ? '' : 's'} in ${repo.repoName}`);
+  }
+  return parts.length > 0 ? parts.join(', ') : null;
+}
+
+function summarizePulses(pulses: ProjectPulse[]): string {
+  const fragments: string[] = [];
+  for (const pulse of pulses) {
+    for (const repo of pulse.byRepo) {
+      const piece = summarizeRepo(repo);
+      if (piece) fragments.push(piece);
+    }
+  }
+  if (fragments.length === 0) return 'No peer-repo activity in cache yet';
+  // Cap at 3 fragments so the collapsed row stays single-line.
+  const head = fragments.slice(0, 3).join('; ');
+  const remainder = fragments.length - 3;
+  return remainder > 0 ? `${head} (+${remainder} more)` : head;
+}
+
+export function ProjectPulseRow({ open, onToggle, loading, pulses }: ProjectPulseRowProps) {
+  const summary = useMemo(() => {
+    if (loading) return 'Gathering project pulse…';
+    return summarizePulses(pulses);
+  }, [loading, pulses]);
+
+  const totalRepos = useMemo(
+    () => pulses.reduce((acc, p) => acc + p.byRepo.length, 0),
+    [pulses],
+  );
+
+  return (
+    <div
+      data-packet-row
+      style={{
+        borderBottomWidth: 1,
+        borderBottomStyle: 'solid',
+        borderBottomColor: 'var(--t-divider-subtle)',
+      }}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        style={{
+          ...rowChromeStyle,
+          background: open ? 'var(--t-divider-subtle)' : 'transparent',
+        }}
+        onMouseEnter={(e) => {
+          if (!open) e.currentTarget.style.background = 'var(--t-divider-subtle)';
+        }}
+        onMouseLeave={(e) => {
+          if (!open) e.currentTarget.style.background = 'transparent';
+        }}
+      >
+        <span style={rowLabelStyle}>pulse</span>
+        <span
+          style={{
+            ...rowValueStyle,
+            color: totalRepos > 0 ? 'var(--t-text)' : 'var(--t-text-muted)',
+          }}
+        >
+          {summary}
+        </span>
+        {totalRepos > 0 ? (
+          <span
+            style={{
+              fontSize: 9.5,
+              color: 'var(--t-text-faint)',
+              letterSpacing: '0.02em',
+              flexShrink: 0,
+              paddingRight: 4,
+            }}
+          >
+            {totalRepos} repo{totalRepos === 1 ? '' : 's'}
+          </span>
+        ) : null}
+        <Chevron open={open} />
+      </button>
+      {open ? (
+        <div style={{ ...expandedSurfaceStyle, gap: 10 }}>
+          {pulses.map((pulse) => (
+            <ProjectBlock key={pulse.projectId} pulse={pulse} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ProjectBlock({ pulse }: { pulse: ProjectPulse }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      <div
+        style={{
+          fontFamily: FONT_FAMILY,
+          fontSize: 9,
+          fontWeight: 700,
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+          color: 'var(--t-text-muted)',
+        }}
+      >
+        {pulse.projectName}
+      </div>
+      {pulse.byRepo.map((repo) => (
+        <RepoBlock key={repo.repoId} repo={repo} />
+      ))}
+    </div>
+  );
+}
+
+function RepoBlock({ repo }: { repo: ProjectPulseRepo }) {
+  const isEmpty =
+    repo.recentCommits.length === 0 &&
+    repo.openPrs.length === 0 &&
+    repo.openIssues.length === 0;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+        paddingTop: 4,
+        paddingBottom: 4,
+        borderTopWidth: 1,
+        borderTopStyle: 'solid',
+        borderTopColor: 'var(--t-divider-subtle)',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 6,
+          fontFamily: FONT_FAMILY,
+          fontSize: 10.5,
+          color: 'var(--t-text)',
+        }}
+      >
+        <span style={{ fontWeight: 600 }}>{repo.repoName}</span>
+        {repo.role ? (
+          <span
+            style={{
+              fontSize: 9,
+              color: 'var(--t-text-faint)',
+              letterSpacing: '0.02em',
+              textTransform: 'uppercase',
+            }}
+          >
+            {repo.role}
+          </span>
+        ) : null}
+      </div>
+      {isEmpty ? (
+        <div
+          style={{
+            fontFamily: FONT_FAMILY,
+            fontSize: 10,
+            color: 'var(--t-text-faint)',
+            letterSpacing: '0.01em',
+          }}
+        >
+          No cached activity
+        </div>
+      ) : null}
+      {repo.recentCommits.length > 0 ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {repo.recentCommits.map((commit) => (
+            <CommitLine key={commit.hash} commit={commit} />
+          ))}
+        </div>
+      ) : null}
+      {repo.openPrs.length > 0 ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {repo.openPrs.map((pr) => (
+            <PrLine key={pr.number} pr={pr} />
+          ))}
+        </div>
+      ) : null}
+      {repo.openIssues.length > 0 ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {repo.openIssues.map((issue) => (
+            <IssueLine key={issue.number} issue={issue} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function CommitLine({ commit }: { commit: PulseCommit }) {
+  const handleClick = () => openExternal(commit.url);
+  const clickable = Boolean(commit.url);
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={!clickable}
+      style={{
+        display: 'flex',
+        alignItems: 'baseline',
+        gap: 6,
+        textAlign: 'left',
+        background: 'transparent',
+        borderWidth: 0,
+        paddingTop: 0,
+        paddingRight: 0,
+        paddingBottom: 0,
+        paddingLeft: 0,
+        cursor: clickable ? 'pointer' : 'default',
+        fontFamily: FONT_FAMILY,
+        fontSize: 10,
+        color: 'var(--t-text)',
+        lineHeight: 1.4,
+      }}
+    >
+      <span
+        style={{
+          fontSize: 9,
+          color: 'var(--t-text-faint)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.04em',
+          flexShrink: 0,
+          width: 38,
+        }}
+      >
+        commit
+      </span>
+      <span
+        style={{
+          flex: 1,
+          minWidth: 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {commit.message || commit.hash}
+      </span>
+      <span
+        style={{
+          fontSize: 9.5,
+          color: 'var(--t-text-faint)',
+          letterSpacing: '0.02em',
+          flexShrink: 0,
+        }}
+      >
+        {commit.author ? `${commit.author} · ` : ''}
+        {formatRelative(commit.date)}
+      </span>
+    </button>
+  );
+}
+
+function PrLine({ pr }: { pr: PulsePullRequest }) {
+  const handleClick = () => openExternal(pr.url);
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      style={{
+        display: 'flex',
+        alignItems: 'baseline',
+        gap: 6,
+        textAlign: 'left',
+        background: 'transparent',
+        borderWidth: 0,
+        paddingTop: 0,
+        paddingRight: 0,
+        paddingBottom: 0,
+        paddingLeft: 0,
+        cursor: 'pointer',
+        fontFamily: FONT_FAMILY,
+        fontSize: 10,
+        color: 'var(--t-text)',
+        lineHeight: 1.4,
+      }}
+    >
+      <span
+        style={{
+          fontSize: 9,
+          color: 'var(--t-text-faint)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.04em',
+          flexShrink: 0,
+          width: 38,
+        }}
+      >
+        pr #{pr.number}
+      </span>
+      <span
+        style={{
+          flex: 1,
+          minWidth: 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {pr.title}
+      </span>
+      <span
+        style={{
+          fontSize: 9.5,
+          color: 'var(--t-text-faint)',
+          letterSpacing: '0.02em',
+          flexShrink: 0,
+        }}
+      >
+        {pr.author ? `${pr.author} · ` : ''}
+        {formatRelative(pr.updatedAt)}
+      </span>
+    </button>
+  );
+}
+
+function IssueLine({ issue }: { issue: PulseIssue }) {
+  const handleClick = () => openExternal(issue.url);
+  const labelText = issue.labels.length > 0
+    ? issue.labels.slice(0, 2).map((l) => l.name).join(', ')
+    : null;
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      style={{
+        display: 'flex',
+        alignItems: 'baseline',
+        gap: 6,
+        textAlign: 'left',
+        background: 'transparent',
+        borderWidth: 0,
+        paddingTop: 0,
+        paddingRight: 0,
+        paddingBottom: 0,
+        paddingLeft: 0,
+        cursor: 'pointer',
+        fontFamily: FONT_FAMILY,
+        fontSize: 10,
+        color: 'var(--t-text)',
+        lineHeight: 1.4,
+      }}
+    >
+      <span
+        style={{
+          fontSize: 9,
+          color: 'var(--t-text-faint)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.04em',
+          flexShrink: 0,
+          width: 38,
+        }}
+      >
+        iss #{issue.number}
+      </span>
+      <span
+        style={{
+          flex: 1,
+          minWidth: 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {issue.title}
+      </span>
+      {labelText ? (
+        <span
+          style={{
+            fontSize: 9.5,
+            color: 'var(--t-text-faint)',
+            letterSpacing: '0.02em',
+            flexShrink: 0,
+          }}
+        >
+          {labelText}
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/src/lib/projects/pulse.ts
+++ b/src/lib/projects/pulse.ts
@@ -1,0 +1,253 @@
+/**
+ * Project Pulse — aggregated peer-repo activity for the Recall Card (epic #899
+ * wave 2). Given a repo, walk every Project the repo belongs to and collect
+ * recent commits / open PRs / open issues from each peer repo so the operator
+ * can see what teammates just shipped without leaving the packet.
+ *
+ * Wedge constraints (v0.2):
+ *   - NO new GitHub API calls. Only the cache that already exists (SQLite
+ *     `github_issues` / `github_pull_requests` and the in-memory commit cache).
+ *   - Stale or missing cache entries return empty arrays — never throw.
+ *   - The current repo is excluded; only PEER repos surface.
+ *
+ * Drift detection (commits-touching-directive-files) is deferred to v0.2.5.
+ * Don't add it here.
+ */
+
+import 'server-only';
+
+import { listProjectsByRepoId } from './store';
+import type { ProjectRole } from './types';
+import { listRepos } from '@/lib/repos/registry';
+import { normalizeRepoSlug } from '@/lib/github-broker/repo';
+import {
+  listGitHubIssues,
+  listGitHubPullRequests,
+  type GitHubIssueSnapshot,
+  type GitHubPullRequestSnapshot,
+} from '@/lib/github-broker/store';
+import { getCached } from '@/lib/github/cache';
+
+const RECENT_WINDOW_MS = 24 * 60 * 60 * 1000; // 24h
+const MAX_PER_LIST = 5;
+
+/** Lightweight commit shape from the in-memory cache. */
+interface CachedCommit {
+  hash: string;
+  message: string;
+  date: string;
+  author?: string | null;
+}
+
+export interface PulseCommit {
+  hash: string;
+  message: string;
+  date: string;
+  author: string | null;
+  url: string | null;
+}
+
+export interface PulsePullRequest {
+  number: number;
+  title: string;
+  state: string;
+  author: string | null;
+  url: string;
+  updatedAt: string;
+}
+
+export interface PulseIssue {
+  number: number;
+  title: string;
+  state: string;
+  url: string;
+  labels: Array<{ name: string; color: string }>;
+  updatedAt: string;
+}
+
+export interface ProjectPulseRepo {
+  repoId: string;
+  repoName: string;
+  repoFullName: string | null;
+  role: ProjectRole | null;
+  recentCommits: PulseCommit[];
+  openPrs: PulsePullRequest[];
+  openIssues: PulseIssue[];
+}
+
+export interface ProjectPulse {
+  projectId: string;
+  projectName: string;
+  projectSlug: string;
+  byRepo: ProjectPulseRepo[];
+  generatedAt: number;
+}
+
+function isWithin(iso: string | null | undefined, windowMs: number): boolean {
+  if (!iso) return false;
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return false;
+  return Date.now() - t <= windowMs;
+}
+
+function commitUrl(repoFullName: string | null, hash: string): string | null {
+  if (!repoFullName || !hash) return null;
+  return `https://github.com/${repoFullName}/commit/${hash}`;
+}
+
+function readCachedCommits(repoFullName: string): CachedCommit[] {
+  // The /api/panel/commits route caches under `commits:${repo}:${limit}`; we
+  // try a small set of common limits since the cache is shared across all
+  // dashboard reads. Whatever's there, we use.
+  const candidates = [15, 20, 30, 10, 5];
+  for (const limit of candidates) {
+    const hit = getCached<CachedCommit[]>(`commits:${repoFullName}:${limit}`);
+    if (hit && hit.length > 0) return hit;
+  }
+  return [];
+}
+
+function mapCommit(commit: CachedCommit, repoFullName: string | null): PulseCommit {
+  return {
+    hash: commit.hash,
+    message: commit.message,
+    date: commit.date,
+    author: commit.author ?? null,
+    url: commitUrl(repoFullName, commit.hash),
+  };
+}
+
+function mapPullRequest(pr: GitHubPullRequestSnapshot): PulsePullRequest {
+  return {
+    number: pr.number,
+    title: pr.title,
+    state: pr.state,
+    author: pr.author?.login ?? null,
+    url: pr.url,
+    updatedAt: pr.updatedAt,
+  };
+}
+
+function mapIssue(issue: GitHubIssueSnapshot): PulseIssue {
+  return {
+    number: issue.number,
+    title: issue.title,
+    state: issue.state,
+    url: issue.url,
+    labels: issue.labels,
+    updatedAt: issue.updatedAt,
+  };
+}
+
+/**
+ * Resolve a repoId to its `owner/name` GitHub slug. Returns null when the
+ * repo isn't registered, has no remote, or the remote isn't a GitHub URL.
+ */
+function repoFullNameFromRegistry(
+  repoId: string,
+  registry: Awaited<ReturnType<typeof listRepos>>,
+): { repoFullName: string | null; repoName: string } {
+  const entry = registry.find((r) => r.id === repoId);
+  if (!entry) return { repoFullName: null, repoName: repoId };
+  return {
+    repoFullName: normalizeRepoSlug(entry.remoteUrl),
+    repoName: entry.name,
+  };
+}
+
+/**
+ * For every Project the source repo belongs to, return per-peer-repo activity
+ * pulled from existing caches. Self-rows are excluded so the card focuses on
+ * what teammates shipped.
+ */
+export async function getProjectPulse(repoId: string): Promise<ProjectPulse[]> {
+  if (!repoId) return [];
+
+  // Project memberships — empty list when the repo isn't in any project.
+  let projects: ReturnType<typeof listProjectsByRepoId>;
+  try {
+    projects = listProjectsByRepoId(repoId);
+  } catch {
+    return [];
+  }
+  if (projects.length === 0) return [];
+
+  // Resolve registry once for the whole fan-out.
+  const registry = await listRepos().catch(() => []);
+  const generatedAt = Date.now();
+
+  const pulses: ProjectPulse[] = [];
+
+  for (const project of projects) {
+    const peerRows: ProjectPulseRepo[] = [];
+
+    for (const repoLink of project.repos) {
+      // Skip the current repo — peers only.
+      if (repoLink.repoId === repoId) continue;
+
+      const { repoFullName, repoName } = repoFullNameFromRegistry(repoLink.repoId, registry);
+
+      // Without a GitHub slug we can't reach the cache. Surface the row with
+      // empty arrays so the operator at least sees the peer exists.
+      if (!repoFullName) {
+        peerRows.push({
+          repoId: repoLink.repoId,
+          repoName,
+          repoFullName: null,
+          role: repoLink.role,
+          recentCommits: [],
+          openPrs: [],
+          openIssues: [],
+        });
+        continue;
+      }
+
+      // Issues + PRs come from the durable SQLite cache. Wrapped because a
+      // missing table or migration glitch shouldn't poison the whole pulse.
+      let issues: GitHubIssueSnapshot[] = [];
+      let prs: GitHubPullRequestSnapshot[] = [];
+      try {
+        issues = listGitHubIssues(repoFullName);
+      } catch {
+        issues = [];
+      }
+      try {
+        prs = listGitHubPullRequests(repoFullName);
+      } catch {
+        prs = [];
+      }
+
+      // Commits — best-effort from the in-memory cache. The /api/panel/commits
+      // route only populates this when the dashboard has fetched the repo;
+      // empty is the default state.
+      const cachedCommits = readCachedCommits(repoFullName)
+        .filter((c) => isWithin(c.date, RECENT_WINDOW_MS))
+        .slice(0, MAX_PER_LIST)
+        .map((c) => mapCommit(c, repoFullName));
+
+      peerRows.push({
+        repoId: repoLink.repoId,
+        repoName,
+        repoFullName,
+        role: repoLink.role,
+        recentCommits: cachedCommits,
+        openPrs: prs.slice(0, MAX_PER_LIST).map(mapPullRequest),
+        openIssues: issues.slice(0, MAX_PER_LIST).map(mapIssue),
+      });
+    }
+
+    // If a project has no peers (just the source repo), drop it entirely so
+    // the card doesn't render an empty "Project pulse" header.
+    if (peerRows.length === 0) continue;
+
+    pulses.push({
+      projectId: project.id,
+      projectName: project.name,
+      projectSlug: project.slug,
+      byRepo: peerRows,
+      generatedAt,
+    });
+  }
+
+  return pulses;
+}


### PR DESCRIPTION
## Summary
- New `[PROJECT PULSE]` row in the Context Recall Card aggregating peer-repo activity for every Project the packet's repo belongs to.
- Surfaces last-24h commits (max 5/repo), open PRs (max 5/repo), and open issues (max 5/repo) drawn from the existing GitHub cache — no new API calls.
- Hidden when the repo isn't in any project; rebuilds on the existing 250ms-debounced `o8:cortex-changes` WS bridge so directive edits propagate without a manual reopen.

## Files
- `src/lib/projects/pulse.ts` — `getProjectPulse(repoId)` walks every project, collects peer-repo activity from `listGitHubIssues` / `listGitHubPullRequests` (SQLite) plus the in-memory commit cache (`getCached('commits:<slug>:N')`). Self-rows excluded. All cache failures and missing-registry paths degrade to empty arrays gracefully.
- `src/app/api/cortex/project-pulse/route.ts` — gated under `/api/cortex/*`. Resolves `repoPath` to a registry repoId, calls `getProjectPulse`, caches results for 5 min in-memory keyed by repoPath. `?force=1` bypass.
- `src/components/desktop/thoughts/recall-card/ProjectPulseRow.tsx` — Issues-style row with collapsed one-line summary, expanded per-project / per-repo blocks. Each commit / PR / issue is a clickable line opening the GitHub URL via `window.open(_, '_blank', 'noopener,noreferrer')`.
- `src/components/desktop/thoughts/ContextRecallCard.tsx` — wires the row in after SYMBOLS. Reuses the existing 250ms cortex-changes debounce; bumps a separate refresh tick for the pulse row alongside the directive tick.

## Drift detection
Commits-touching-directive-files is deferred to v0.2.5 — explicitly NOT in this PR.

## Test plan
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on touched files — clean.
- [x] Fresh-DB smoke (`/tmp/pulse-smoke.ts`): created a project, added two repo IDs, confirmed `getProjectPulse(source)` excludes self and surfaces the peer; confirmed unmapped peer (no registry entry) degrades to empty arrays; confirmed source-repo-not-in-any-project returns `[]`.
- [ ] In-app: register `cortex-ide` + `o8-site` as a project, expand a `cortex-ide` packet's Recall Card, verify pulse row appears with peer activity.
- [ ] Empty case: repo with no project membership renders no pulse row at all.
- [ ] Click a commit / PR / issue line → external GitHub URL opens.
- [ ] Edit a directive → row refreshes within ~ws roundtrip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)