### PR TITLE
fix(projects): consolidate directive parser + accept both POST shapes (#899 dogfood follow-ups)

### DIFF
--- a/scripts/smoke-projects-followups.ts
+++ b/scripts/smoke-projects-followups.ts
@@ -1,0 +1,136 @@
+/**
+ * Smoke tests for the #899 dogfood-followup fixes:
+ *   1. Shared directive parser includes `projects` in both call sites.
+ *   2. Filter membership logic works at the per-directive level.
+ *
+ * NOT a permanent test harness — there's no test runner configured. This is
+ * a one-shot script intended to be run before merging.
+ *
+ * Usage:
+ *   CORTEX_IDE_DATA_DIR=$(mktemp -d) npx tsx scripts/smoke-projects-followups.ts
+ */
+
+import { parseDirectiveFile } from '../src/lib/cortex/directives/parse';
+import { directiveAppliesToRepo } from '../src/lib/cortex/directives/filter';
+
+let failed = 0;
+function assert(cond: unknown, msg: string) {
+  if (cond) {
+    console.log(`  ok  ${msg}`);
+  } else {
+    failed++;
+    console.error(`  FAIL ${msg}`);
+  }
+}
+
+// ── Bug 1 — parser parses `projects:` field ───────────────────────────────
+
+console.log('Test: parseDirectiveFile picks up `projects` field');
+{
+  const raw = `---
+id: foo
+title: Foo
+scope: project
+projects: [o8, atlas]
+priority: 10
+---
+This is the body.
+
+## Recent Merges
+- 2026-04-29 [merged] feat(thing): bar (#1)
+`;
+  const parsed = parseDirectiveFile(raw, 'foo');
+  assert(parsed !== null, 'parser returns non-null');
+  assert(parsed?.id === 'foo', 'id matches');
+  assert(parsed?.scope === 'project', 'scope matches');
+  assert(JSON.stringify(parsed?.projects) === JSON.stringify(['o8', 'atlas']), `projects=${JSON.stringify(parsed?.projects)}`);
+  assert(parsed?.body === 'This is the body.', `body has Recent Merges trailer stripped (got ${JSON.stringify(parsed?.body)})`);
+  assert(parsed?.priority === 10, 'priority parsed');
+}
+
+console.log('Test: parseDirectiveFile handles bare comma-list shape');
+{
+  const raw = `---
+id: bar
+title: Bar
+scope: project
+projects: o8, atlas, beacon
+---
+body
+`;
+  const parsed = parseDirectiveFile(raw, 'bar');
+  assert(JSON.stringify(parsed?.projects) === JSON.stringify(['o8', 'atlas', 'beacon']), `projects=${JSON.stringify(parsed?.projects)}`);
+}
+
+console.log('Test: parseDirectiveFile defaults to empty projects when missing');
+{
+  const raw = `---
+id: baz
+title: Baz
+scope: global
+---
+body
+`;
+  const parsed = parseDirectiveFile(raw, 'baz');
+  assert(parsed?.projects.length === 0, 'projects array is empty');
+}
+
+// ── Bug 1 — filter logic is symmetric ─────────────────────────────────────
+
+console.log('Test: directiveAppliesToRepo — global tier always applies');
+{
+  const directive = parseDirectiveFile(`---
+id: g
+title: G
+scope: global
+---
+body
+`, 'g');
+  assert(directiveAppliesToRepo(directive!, '/tmp/repo-foo', new Set()), 'global passes for empty project set');
+}
+
+console.log('Test: directiveAppliesToRepo — project tier requires membership');
+{
+  const directive = parseDirectiveFile(`---
+id: p
+title: P
+scope: project
+projects: [o8]
+---
+body
+`, 'p');
+  assert(!directiveAppliesToRepo(directive!, '/tmp/repo-foo', new Set()), 'project rejects when repo not in any project');
+  assert(!directiveAppliesToRepo(directive!, '/tmp/repo-foo', new Set(['atlas'])), 'project rejects when repo in different project');
+  assert(directiveAppliesToRepo(directive!, '/tmp/repo-foo', new Set(['o8'])), 'project accepts when repo in matching project');
+}
+
+console.log('Test: directiveAppliesToRepo — repo tier matches by basename or repoName');
+{
+  const byScope = parseDirectiveFile(`---
+id: r1
+title: R1
+scope: my-repo
+---
+body
+`, 'r1');
+  assert(directiveAppliesToRepo(byScope!, '/tmp/my-repo', new Set()), 'scope literal matches basename');
+  assert(!directiveAppliesToRepo(byScope!, '/tmp/other-repo', new Set()), 'scope literal does not match different basename');
+
+  const byRepoName = parseDirectiveFile(`---
+id: r2
+title: R2
+scope: repo
+repoName: my-repo
+---
+body
+`, 'r2');
+  assert(directiveAppliesToRepo(byRepoName!, '/tmp/my-repo', new Set()), 'repoName field matches basename');
+  assert(!directiveAppliesToRepo(byRepoName!, '/tmp/other', new Set()), 'repoName field does not match different basename');
+}
+
+console.log('');
+if (failed > 0) {
+  console.error(`${failed} assertion(s) failed`);
+  process.exit(1);
+}
+console.log('All smoke tests passed');

--- a/scripts/smoke-projects-post.ts
+++ b/scripts/smoke-projects-post.ts
@@ -1,0 +1,130 @@
+/**
+ * Smoke test for Bug 2: POST /api/projects accepts both body shapes.
+ *
+ * Invokes the route's POST function directly with NextRequest mocks.
+ *
+ * Usage:
+ *   CORTEX_IDE_DATA_DIR=$(mktemp -d) npx tsx scripts/smoke-projects-post.ts
+ */
+
+import { NextRequest } from 'next/server';
+import { POST } from '../src/app/api/projects/route';
+
+let failed = 0;
+function assert(cond: unknown, msg: string) {
+  if (cond) {
+    console.log(`  ok  ${msg}`);
+  } else {
+    failed++;
+    console.error(`  FAIL ${msg}`);
+  }
+}
+
+function mkReq(body: unknown) {
+  return new NextRequest('http://localhost:3001/api/projects', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'host': 'localhost:3001' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function callPost(body: unknown): Promise<{ status: number; payload: any }> {
+  const res = await POST(mkReq(body));
+  const payload = await res.json();
+  return { status: res.status, payload };
+}
+
+(async () => {
+  console.log('Test: POST accepts legacy `repoIds` + `roles` shape');
+  {
+    const { status, payload } = await callPost({
+      name: 'Legacy Project ' + Date.now(),
+      repoIds: ['repo-a', 'repo-b'],
+      roles: ['frontend', 'backend'],
+    });
+    assert(status === 201, `status 201 (got ${status}, payload=${JSON.stringify(payload)})`);
+    assert(payload.project?.repos?.length === 2, `2 repos created (got ${payload.project?.repos?.length})`);
+    assert(payload.project?.repos?.[0]?.role === 'frontend', `role[0]=frontend (got ${payload.project?.repos?.[0]?.role})`);
+    assert(payload.project?.repos?.[1]?.role === 'backend', `role[1]=backend (got ${payload.project?.repos?.[1]?.role})`);
+  }
+
+  console.log('Test: POST accepts new `repos: [{repoId, role}]` shape');
+  {
+    const { status, payload } = await callPost({
+      name: 'Inverse Project ' + Date.now(),
+      repos: [
+        { repoId: 'repo-c', role: 'frontend' },
+        { repoId: 'repo-d', role: 'backend' },
+      ],
+    });
+    assert(status === 201, `status 201 (got ${status}, payload=${JSON.stringify(payload)})`);
+    assert(payload.project?.repos?.length === 2, `2 repos created (got ${payload.project?.repos?.length})`);
+    assert(payload.project?.repos?.[0]?.repoId === 'repo-c', `repoId[0]=repo-c (got ${payload.project?.repos?.[0]?.repoId})`);
+    assert(payload.project?.repos?.[0]?.role === 'frontend', `role[0]=frontend (got ${payload.project?.repos?.[0]?.role})`);
+    assert(payload.project?.repos?.[1]?.role === 'backend', `role[1]=backend (got ${payload.project?.repos?.[1]?.role})`);
+  }
+
+  console.log('Test: POST accepts `repos` without role (role optional)');
+  {
+    const { status, payload } = await callPost({
+      name: 'Roleless Project ' + Date.now(),
+      repos: [{ repoId: 'repo-e' }],
+    });
+    assert(status === 201, `status 201 (got ${status})`);
+    assert(payload.project?.repos?.length === 1, '1 repo');
+    assert(payload.project?.repos?.[0]?.role === null, `role is null (got ${payload.project?.repos?.[0]?.role})`);
+  }
+
+  console.log('Test: POST rejects malformed `repos` (array of strings)');
+  {
+    const { status, payload } = await callPost({
+      name: 'Bad Project ' + Date.now(),
+      repos: ['repo-x', 'repo-y'],
+    });
+    assert(status === 400, `status 400 (got ${status})`);
+    assert(typeof payload.error === 'string' && payload.error.includes('repoId'), `error mentions repoId (got ${payload.error})`);
+  }
+
+  console.log('Test: POST rejects `repos` with missing repoId');
+  {
+    const { status, payload } = await callPost({
+      name: 'Bad Project 2 ' + Date.now(),
+      repos: [{ role: 'frontend' }],
+    });
+    assert(status === 400, `status 400 (got ${status})`);
+    assert(typeof payload.error === 'string', `error returned (got ${payload.error})`);
+  }
+
+  console.log('Test: POST rejects sending both shapes at once');
+  {
+    const { status, payload } = await callPost({
+      name: 'Double Project ' + Date.now(),
+      repoIds: ['repo-a'],
+      repos: [{ repoId: 'repo-b' }],
+    });
+    assert(status === 400, `status 400 (got ${status})`);
+    assert(typeof payload.error === 'string' && payload.error.toLowerCase().includes('both'), `error mentions both (got ${payload.error})`);
+  }
+
+  console.log('Test: POST still requires `name`');
+  {
+    const { status } = await callPost({ repoIds: ['repo-a'] });
+    assert(status === 400, `missing name → 400 (got ${status})`);
+  }
+
+  console.log('Test: POST without repoIds or repos creates empty project (legacy behavior)');
+  {
+    const { status, payload } = await callPost({
+      name: 'Empty Project ' + Date.now(),
+    });
+    assert(status === 201, `status 201 (got ${status})`);
+    assert(Array.isArray(payload.project?.repos) && payload.project.repos.length === 0, 'no repos');
+  }
+
+  console.log('');
+  if (failed > 0) {
+    console.error(`${failed} assertion(s) failed`);
+    process.exit(1);
+  }
+  console.log('All POST smoke tests passed');
+})();

--- a/src/app/api/cortex/directives/route.ts
+++ b/src/app/api/cortex/directives/route.ts
@@ -3,21 +3,38 @@
  *
  * Lists directive markdown files from the data dir's `directives/` folder.
  * Each file has YAML-like front matter: id, title, scope, repoName, priority,
- * created, updated. The body below the second `---` is the directive text.
+ * created, updated, projects. The body below the second `---` is the
+ * directive text.
+ *
+ * Query params:
+ *   ?repoPath=<absolute-repo-path>  — optional. When supplied, the response is
+ *     filtered to directives that apply to that repo using the same tier rules
+ *     as the dispatch context builder (`lib/cortex/directives/filter.ts`):
+ *       - global  → always included
+ *       - project → included when the directive's `projects:` slug list
+ *                   intersects the repo's Project memberships
+ *       - repo    → included when `repoName` / `scope: <repoName>` matches
+ *
+ * Without the param the route returns every directive — preserves the original
+ * read-only behavior for callers that want the full list.
  *
  * Response:
- *   { directives: Array<{ id, title, scope, repoName?, priority?, body }> }
+ *   { directives: Array<{ id, title, scope, repoName?, priority?, body, recentMerges, projects? }> }
  *
- * Surface — Packet Review Card (#729) lists directive titles in its SPEC
- * pane. Read-only.
+ * Surface — Recall Card (#742) and Packet Review Card (#729) consume this.
  */
 
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { getDataDir } from '@/lib/data-dir-migration';
 import { readAllDirectiveTrailers } from '@/lib/cortex/directive-merges';
 import { withTimingSync } from '@/lib/cortex/diagnostics';
+import { parseDirectiveFile, type ParsedDirective } from '@/lib/cortex/directives/parse';
+import {
+  directiveAppliesToRepo,
+  resolveRepoProjectSlugs,
+} from '@/lib/cortex/directives/filter';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -29,53 +46,26 @@ interface DirectiveSummary {
   repoName: string | null;
   priority: number | null;
   body: string;
+  /** #899 — project slug membership; empty when not project-scoped. */
+  projects: string[];
   /** #769 — last 3 trailer lines newest-first; empty until a merge appends one. */
   recentMerges: string[];
 }
 
-const FRONT_MATTER_BOUNDARY = /^---\s*$/m;
-
-function parseDirectiveFile(raw: string, fallbackId: string): DirectiveSummary | null {
-  const text = raw.replace(/\r\n/g, '\n').trim();
-  if (!text.startsWith('---')) return null;
-
-  // Strip leading ---, find next ---
-  const afterFirst = text.slice(3).trimStart();
-  const closingIndex = afterFirst.search(FRONT_MATTER_BOUNDARY);
-  if (closingIndex < 0) return null;
-
-  const front = afterFirst.slice(0, closingIndex);
-  const rawBody = afterFirst.slice(closingIndex).replace(FRONT_MATTER_BOUNDARY, '').trim();
-  // #769 — Strip the `## Recent Merges` trailer so the body shown in the UI
-  // stays the operator-authored content. Trailer lines are surfaced via the
-  // separate `recentMerges` field so the recall card can render them with
-  // dedicated chrome.
-  const body = rawBody.replace(/\n*##\s+Recent Merges\b[\s\S]*$/, '').trim();
-
-  const meta: Record<string, string> = {};
-  for (const line of front.split('\n')) {
-    const idx = line.indexOf(':');
-    if (idx <= 0) continue;
-    const key = line.slice(0, idx).trim();
-    const value = line.slice(idx + 1).trim();
-    if (key) meta[key] = value;
-  }
-
-  const priorityRaw = meta.priority;
-  const priorityNum = priorityRaw ? Number.parseInt(priorityRaw, 10) : NaN;
-
+function toSummary(parsed: ParsedDirective): DirectiveSummary {
   return {
-    id: meta.id?.trim() || fallbackId,
-    title: meta.title?.trim() || fallbackId,
-    scope: meta.scope?.trim() || 'global',
-    repoName: meta.repoName?.trim() || null,
-    priority: Number.isFinite(priorityNum) ? priorityNum : null,
-    body,
+    id: parsed.id,
+    title: parsed.title,
+    scope: parsed.scope,
+    repoName: parsed.repoName,
+    priority: parsed.priority,
+    body: parsed.body,
+    projects: parsed.projects,
     recentMerges: [],
   };
 }
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   try {
     const dataDir = getDataDir();
     const directivesDir = join(dataDir, 'directives');
@@ -86,9 +76,11 @@ export async function GET() {
       });
     }
 
-    const directives: DirectiveSummary[] = withTimingSync('recall.directives', () => {
+    const repoPath = req.nextUrl.searchParams.get('repoPath')?.trim() || null;
+
+    const parsedAll: ParsedDirective[] = withTimingSync('recall.directives', () => {
       const entries = readdirSync(directivesDir).filter((name) => name.endsWith('.md'));
-      const out: DirectiveSummary[] = [];
+      const out: ParsedDirective[] = [];
       for (const name of entries) {
         try {
           const raw = readFileSync(join(directivesDir, name), 'utf-8');
@@ -101,6 +93,16 @@ export async function GET() {
       }
       return out;
     });
+
+    // #899 — when a repoPath is supplied, apply the same scope-tier filter
+    // that dispatch context uses. Resolves project memberships once.
+    let parsed: ParsedDirective[] = parsedAll;
+    if (repoPath) {
+      const projectSlugsForRepo = await resolveRepoProjectSlugs(repoPath);
+      parsed = parsedAll.filter((d) => directiveAppliesToRepo(d, repoPath, projectSlugsForRepo));
+    }
+
+    const directives = parsed.map(toSummary);
 
     // #769 — Hydrate recent-merge trailers from the same markdown files.
     // The helper re-reads the dir, but the cost is trivial (≤dozens of small

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -29,9 +29,17 @@ interface CreateProjectBody {
   name?: unknown;
   slug?: unknown;
   description?: unknown;
+  /** Parallel-array shape: list of repo IDs. Aligned with `roles`. */
   repoIds?: unknown;
-  // Optional parallel array of roles aligned to repoIds, or a map { repoId: role }.
+  /** Parallel array of roles aligned to repoIds, OR a map { repoId: role }. */
   roles?: unknown;
+  /**
+   * #899 dogfood follow-up — natural inverse of GET response.
+   * Object-array shape: `[{ repoId, role? }, ...]`. Auto-detected and
+   * normalized to `repoIds` + parallel `roles`. Both shapes can't be supplied
+   * at once — pick one or you'll get a 400.
+   */
+  repos?: unknown;
   suggestionOrigin?: unknown;
 }
 
@@ -65,6 +73,47 @@ function resolveRoleForRepo(
   return null;
 }
 
+/**
+ * #899 dogfood follow-up — accept the natural inverse of the GET response
+ * shape: `repos: [{ repoId, role? }, ...]`. Returns parallel arrays so the
+ * existing repoIds + roles path can consume them, OR a structured error
+ * describing why the shape was rejected (so callers don't silently get an
+ * empty project).
+ *
+ * Returns `null` when the body has no `repos` field — the caller falls back
+ * to the legacy `repoIds` + `roles` shape.
+ */
+function normalizeReposField(
+  reposField: unknown,
+): { ok: true; repoIds: string[]; roles: (ProjectRole | null)[] }
+  | { ok: false; error: string }
+  | null {
+  if (reposField === undefined) return null;
+  if (!Array.isArray(reposField)) {
+    return { ok: false, error: '`repos` must be an array.' };
+  }
+  const repoIds: string[] = [];
+  const roles: (ProjectRole | null)[] = [];
+  for (let i = 0; i < reposField.length; i++) {
+    const entry = reposField[i];
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      return {
+        ok: false,
+        error: `\`repos[${i}]\` must be an object with a \`repoId\` string. Did you mean to send \`repoIds\`?`,
+      };
+    }
+    const obj = entry as { repoId?: unknown; role?: unknown };
+    const repoId = asString(obj.repoId)?.trim();
+    if (!repoId) {
+      return { ok: false, error: `\`repos[${i}].repoId\` is required and must be a non-empty string.` };
+    }
+    repoIds.push(repoId);
+    const roleStr = asString(obj.role)?.trim();
+    roles.push(roleStr ? (roleStr as ProjectRole) : null);
+  }
+  return { ok: true, repoIds, roles };
+}
+
 export async function POST(req: NextRequest) {
   const denied = requirePanelAuth(req);
   if (denied) return denied;
@@ -81,6 +130,41 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Project name is required.' }, { status: 400 });
   }
 
+  // #899 dogfood follow-up — auto-detect either shape:
+  //   { repoIds: [...], roles: [...] | { repoId: role } }   ← parallel-array (legacy)
+  //   { repos: [{ repoId, role? }, ...] }                   ← object-array (natural inverse)
+  // Sending both at once is ambiguous and rejected. Sending a malformed
+  // `repos` (e.g. array of strings) returns a structured 400 instead of
+  // silently creating a project with zero repos.
+  let resolvedRepoIds: string[] = [];
+  let rolesSource: unknown = body.roles;
+  if (body.repos !== undefined && body.repoIds !== undefined) {
+    return NextResponse.json(
+      {
+        error:
+          'Pass either `repos: [{repoId, role?}]` (object array) OR `repoIds` + `roles` (parallel arrays), not both.',
+      },
+      { status: 400 },
+    );
+  }
+  const reposNormalized = normalizeReposField(body.repos);
+  if (reposNormalized) {
+    if (!reposNormalized.ok) {
+      return NextResponse.json({ error: reposNormalized.error }, { status: 400 });
+    }
+    resolvedRepoIds = reposNormalized.repoIds;
+    rolesSource = reposNormalized.roles;
+  } else if (body.repoIds !== undefined) {
+    const parsed = asStringArray(body.repoIds);
+    if (!parsed) {
+      return NextResponse.json(
+        { error: '`repoIds` must be an array of strings.' },
+        { status: 400 },
+      );
+    }
+    resolvedRepoIds = parsed;
+  }
+
   try {
     const project = createProject({
       name,
@@ -88,12 +172,11 @@ export async function POST(req: NextRequest) {
       description: asString(body.description) ?? null,
     });
 
-    const repoIds = asStringArray(body.repoIds) ?? [];
     const suggestionOrigin =
       (asString(body.suggestionOrigin) as SuggestionOrigin | undefined) ?? 'manual';
 
-    const repos = repoIds.map((repoId, index) => {
-      const role = resolveRoleForRepo(repoId, index, body.roles);
+    const repos = resolvedRepoIds.map((repoId, index) => {
+      const role = resolveRoleForRepo(repoId, index, rolesSource);
       return addRepoToProject(project.id, repoId, role, suggestionOrigin);
     });
 

--- a/src/components/desktop/thoughts/ContextRecallCard.tsx
+++ b/src/components/desktop/thoughts/ContextRecallCard.tsx
@@ -126,7 +126,14 @@ export function ContextRecallCard({ packet, repoName }: ContextRecallCardProps) 
     let cancelled = false;
     (async () => {
       try {
-        const response = await fetch('/api/cortex/directives', { cache: 'no-store' });
+        // #899 dogfood follow-up — pass repoPath so the server applies the
+        // same project / repo / global scope filter that dispatch uses.
+        // Without this, project-scoped directives leaked to repos that aren't
+        // in the project.
+        const url = repoPath
+          ? `/api/cortex/directives?repoPath=${encodeURIComponent(repoPath)}`
+          : '/api/cortex/directives';
+        const response = await fetch(url, { cache: 'no-store' });
         if (cancelled) return;
         if (!response.ok) {
           setDirectives((prev) => prev ?? []);
@@ -142,7 +149,7 @@ export function ContextRecallCard({ packet, repoName }: ContextRecallCardProps) 
     return () => {
       cancelled = true;
     };
-  }, [directiveRefreshTick]);
+  }, [directiveRefreshTick, repoPath]);
 
   // #840 — Listen for cortex-changes pushed from the server after a merge
   // appends a directive trailer. Bridge already converts the WS message

--- a/src/components/desktop/thoughts/mission-panel/PacketReviewCard.tsx
+++ b/src/components/desktop/thoughts/mission-panel/PacketReviewCard.tsx
@@ -47,14 +47,22 @@ export function PacketReviewCard({ packet, reviewState, onActionComplete }: Pack
 
   const worktreePath = reviewState?.worktreePath ?? packet.lane?.worktreePath ?? null;
   const baseBranchHint = packet.branchTarget && packet.branchTarget.trim() ? packet.branchTarget : null;
+  const repoPath = packet.workspaceTargetPath ?? null;
 
   // Load directives once on mount, and again whenever the cortex-changes
   // bus signals a directive write.
+  //
+  // #899 dogfood follow-up — pass repoPath so the server applies the same
+  // project / repo / global scope filter that dispatch uses. Without this,
+  // project-scoped directives leaked to repos outside the project.
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const response = await fetch('/api/cortex/directives', { cache: 'no-store' });
+        const url = repoPath
+          ? `/api/cortex/directives?repoPath=${encodeURIComponent(repoPath)}`
+          : '/api/cortex/directives';
+        const response = await fetch(url, { cache: 'no-store' });
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }
@@ -67,7 +75,7 @@ export function PacketReviewCard({ packet, reviewState, onActionComplete }: Pack
       }
     })();
     return () => { cancelled = true; };
-  }, [directiveRefreshTick]);
+  }, [directiveRefreshTick, repoPath]);
 
   // #840 — Re-fetch directives when the server broadcasts a directive write.
   useEffect(() => {

--- a/src/lib/codebase-memory/build-context.ts
+++ b/src/lib/codebase-memory/build-context.ts
@@ -37,16 +37,19 @@
 import 'server-only';
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { basename, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { and, desc, eq } from 'drizzle-orm';
 
 import { getDb, sessionOutcomes } from '@/lib/db';
 import { getDataDir } from '@/lib/data-dir-migration';
 import { liveOutcomeFilter } from '@/lib/cortex/decay';
 import { withTiming } from '@/lib/cortex/diagnostics';
-import { listRepos } from '@/lib/repos/registry';
 import { readRepoPathRegistry } from '@/lib/repos/repo-path-registry';
-import { listProjectsByRepoId } from '@/lib/projects/store';
+import { parseDirectiveFile, type ParsedDirective } from '@/lib/cortex/directives/parse';
+import {
+  directiveAppliesToRepo,
+  resolveRepoProjectSlugs,
+} from '@/lib/cortex/directives/filter';
 
 import { extractGraphResolvedSymbols, type SymbolEdge } from './client';
 
@@ -58,22 +61,7 @@ const DIRECTIVE_BODY_CHARS = 240;
 const OUTCOME_SUMMARY_CHARS = 160;
 const NEIGHBOUR_LIMIT = 4;
 
-const FRONT_MATTER_BOUNDARY = /^---\s*$/m;
-
-interface DirectiveEntry {
-  id: string;
-  title: string;
-  scope: string;
-  repoName: string | null;
-  /**
-   * #899 — `scope: project` directives carry a list of project slugs in the
-   * front matter (`projects: [atlas, beacon]`). Empty list when the directive
-   * isn't project-scoped or front matter omitted the field.
-   */
-  projects: string[];
-  priority: number | null;
-  body: string;
-}
+type DirectiveEntry = ParsedDirective;
 
 interface OutcomeRow {
   outcome: 'succeeded' | 'failed' | 'partial' | 'interrupted';
@@ -89,64 +77,6 @@ interface BuildContextBlockInput {
   repoPath: string;
   /** The packet body / summary we'll mine for symbols. */
   packetBody: string;
-}
-
-function parseDirectiveFile(raw: string, fallbackId: string): DirectiveEntry | null {
-  const text = raw.replace(/\r\n/g, '\n').trim();
-  if (!text.startsWith('---')) return null;
-
-  const afterFirst = text.slice(3).trimStart();
-  const closingIndex = afterFirst.search(FRONT_MATTER_BOUNDARY);
-  if (closingIndex < 0) return null;
-
-  const front = afterFirst.slice(0, closingIndex);
-  const body = afterFirst.slice(closingIndex).replace(FRONT_MATTER_BOUNDARY, '').trim();
-
-  const meta: Record<string, string> = {};
-  for (const line of front.split('\n')) {
-    const idx = line.indexOf(':');
-    if (idx <= 0) continue;
-    const key = line.slice(0, idx).trim();
-    const value = line.slice(idx + 1).trim();
-    if (key) meta[key] = value;
-  }
-
-  const priorityRaw = meta.priority;
-  const priorityNum = priorityRaw ? Number.parseInt(priorityRaw, 10) : NaN;
-
-  return {
-    id: meta.id?.trim() || fallbackId,
-    title: meta.title?.trim() || fallbackId,
-    scope: meta.scope?.trim() || 'global',
-    repoName: meta.repoName?.trim() || null,
-    projects: parseProjectsList(meta.projects),
-    priority: Number.isFinite(priorityNum) ? priorityNum : null,
-    body,
-  };
-}
-
-/**
- * #899 — parse the `projects:` front matter field into a normalized slug list.
- * Accepts the two YAML-ish shapes the directive parser already supports:
- *   projects: [atlas, beacon]
- *   projects: atlas, beacon
- * Returns an empty array when the field is missing/empty/malformed. Slugs are
- * lowercased and de-duplicated to keep membership checks predictable.
- */
-function parseProjectsList(raw: string | undefined): string[] {
-  if (!raw) return [];
-  const stripped = raw.trim().replace(/^\[|\]$/g, '').trim();
-  if (!stripped) return [];
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const part of stripped.split(',')) {
-    const slug = part.trim().replace(/^["']|["']$/g, '').toLowerCase();
-    if (!slug) continue;
-    if (seen.has(slug)) continue;
-    seen.add(slug);
-    out.push(slug);
-  }
-  return out;
 }
 
 function readDirectives(): DirectiveEntry[] {
@@ -203,58 +133,22 @@ async function isKnownRepoPath(repoPath: string): Promise<boolean> {
 }
 
 /**
- * Filter directives for a target repo across the three scope tiers.
- *
- * #899 — Tier order, broad → narrow:
- *   1. `scope: global` — always applies (#849 already gates these on a known
- *      repo path before this helper is called).
- *   2. `scope: project` — applies when the directive's `projects:` slug list
- *      intersects with the project memberships of the target repo. Resolved
- *      via the SQLite-backed `listProjectsByRepoId(repoId)` lookup, with the
- *      repoId resolved by matching the registered repo's `localPath` to the
- *      target `repoPath`. Repos that aren't in any Project naturally see no
- *      project-scoped directives.
- *   3. `scope: repo` (or `scope: <repoName>`) — applies when the explicit
- *      `repoName` field or the scope literal matches the target repo's basename.
- *
- * Lookups never throw — listProjectsByRepoId() / listRepos() are wrapped, and
- * any I/O or DB failure falls back to "skip the project tier" so a misbehaving
- * Projects table never starves repo + global directives.
+ * Filter directives for a target repo, sort by priority desc / title, and cap
+ * at MAX_DIRECTIVES — the dispatch context block keeps the operator-curated
+ * top N to stay within the token budget. Membership rules live in
+ * `lib/cortex/directives/filter.ts` so the Recall Card UI applies the same
+ * tiers (global / project / repo).
  */
 async function filterDirectivesForRepo(
   directives: DirectiveEntry[],
   repoPath: string,
 ): Promise<DirectiveEntry[]> {
-  const repoName = basename(repoPath).toLowerCase();
-
-  // Resolve project memberships once per call. Empty Set when:
-  //   - the repo isn't registered (no id to look up)
-  //   - the repo is registered but in zero projects
-  //   - the projects DB layer is unavailable
-  // In all three cases, project-scoped directives skip silently.
+  // Resolve project memberships once per call. Empty Set when the repo isn't
+  // registered, isn't in any Project, or the projects DB is unavailable.
   const projectSlugsForRepo = await resolveRepoProjectSlugs(repoPath);
 
   return directives
-    .filter((d) => {
-      const scope = d.scope.toLowerCase();
-      if (scope === 'global' || scope === '') return true;
-
-      // #899 — Project tier. Match if any directive project slug is in the
-      // repo's project membership set.
-      if (scope === 'project') {
-        if (d.projects.length === 0) return false;
-        for (const slug of d.projects) {
-          if (projectSlugsForRepo.has(slug)) return true;
-        }
-        return false;
-      }
-
-      // Repo tier — match either explicit repoName field or `scope: <repoName>`.
-      const declaredRepo = (d.repoName ?? '').toLowerCase();
-      if (declaredRepo && declaredRepo === repoName) return true;
-      if (scope === repoName) return true;
-      return false;
-    })
+    .filter((d) => directiveAppliesToRepo(d, repoPath, projectSlugsForRepo))
     .sort((a, b) => {
       const ap = a.priority ?? 0;
       const bp = b.priority ?? 0;
@@ -262,54 +156,6 @@ async function filterDirectivesForRepo(
       return a.title.localeCompare(b.title);
     })
     .slice(0, MAX_DIRECTIVES);
-}
-
-/**
- * #899 — resolve the set of project slugs that include the given repo path.
- *
- * Three-step lookup, each step swallows failures into an empty result:
- *   1. Read the repo registry (SQLite-free file at `~/.o8/repos.json`).
- *   2. Find the registry entry whose `localPath` resolves to `repoPath`.
- *   3. Ask the projects store for membership rows by the registry id.
- *
- * Returns an empty Set when the registry, the repo, or the projects DB is
- * unavailable. Project-scoped directives are an additive tier — losing them
- * never breaks repo + global directives.
- */
-async function resolveRepoProjectSlugs(repoPath: string): Promise<Set<string>> {
-  const out = new Set<string>();
-  const normalized = (() => {
-    try { return resolve(repoPath); } catch { return ''; }
-  })();
-  if (!normalized) return out;
-
-  let repoId: string | null = null;
-  try {
-    const repos = await listRepos();
-    const match = repos.find((r) => {
-      try {
-        return resolve(r.localPath) === normalized;
-      } catch {
-        return false;
-      }
-    });
-    repoId = match?.id ?? null;
-  } catch {
-    return out;
-  }
-  if (!repoId) return out;
-
-  try {
-    const projects = listProjectsByRepoId(repoId);
-    for (const project of projects) {
-      const slug = project.slug?.toLowerCase().trim();
-      if (slug) out.add(slug);
-    }
-  } catch {
-    // Project DB unavailable (migration not applied yet, etc.) — drop tier
-    // silently. Other tiers still resolve.
-  }
-  return out;
 }
 
 async function readRecentOutcomes(repoPath: string): Promise<OutcomeRow[]> {

--- a/src/lib/cortex/directives/filter.ts
+++ b/src/lib/cortex/directives/filter.ts
@@ -1,0 +1,115 @@
+/**
+ * Shared directive scope filter — keeps dispatch context (#743) and the
+ * Recall Card UI (`/api/cortex/directives`) on the same membership rules.
+ *
+ * Tier order, broad → narrow:
+ *   1. `scope: global` — always applies
+ *   2. `scope: project` — applies when the directive's `projects:` slug list
+ *      intersects with the project memberships of the target repo
+ *   3. `scope: repo` (or `scope: <repoName>`) — applies when the explicit
+ *      `repoName` field or the scope literal matches the target repo's basename
+ *
+ * Lookups never throw. Project DB / repo registry failures fall back to "skip
+ * the project tier" so a misbehaving Projects table never starves repo +
+ * global directives.
+ */
+
+import 'server-only';
+
+import { basename, resolve } from 'node:path';
+
+import { listRepos } from '@/lib/repos/registry';
+import { listProjectsByRepoId } from '@/lib/projects/store';
+
+import type { ParsedDirective } from './parse';
+
+/**
+ * Resolve the set of project slugs that include the given repo path.
+ *
+ * Three-step lookup, each step swallows failures into an empty result:
+ *   1. Read the repo registry.
+ *   2. Find the entry whose `localPath` resolves to `repoPath`.
+ *   3. Ask the projects store for membership rows by the registry id.
+ *
+ * Returns an empty Set when the registry, the repo, or the projects DB is
+ * unavailable. Project-scoped directives are an additive tier — losing them
+ * never breaks repo + global directives.
+ */
+export async function resolveRepoProjectSlugs(repoPath: string): Promise<Set<string>> {
+  const out = new Set<string>();
+  const normalized = (() => {
+    try { return resolve(repoPath); } catch { return ''; }
+  })();
+  if (!normalized) return out;
+
+  let repoId: string | null = null;
+  try {
+    const repos = await listRepos();
+    const match = repos.find((r) => {
+      try {
+        return resolve(r.localPath) === normalized;
+      } catch {
+        return false;
+      }
+    });
+    repoId = match?.id ?? null;
+  } catch {
+    return out;
+  }
+  if (!repoId) return out;
+
+  try {
+    const projects = listProjectsByRepoId(repoId);
+    for (const project of projects) {
+      const slug = project.slug?.toLowerCase().trim();
+      if (slug) out.add(slug);
+    }
+  } catch {
+    // Project DB unavailable (migration not applied yet, etc.) — drop tier
+    // silently. Other tiers still resolve.
+  }
+  return out;
+}
+
+/**
+ * Pure predicate — does the directive apply to this target repo, given the
+ * pre-resolved project slug set? Caller resolves slugs once with
+ * `resolveRepoProjectSlugs(repoPath)` and reuses it across the directive list.
+ */
+export function directiveAppliesToRepo(
+  directive: ParsedDirective,
+  repoPath: string,
+  projectSlugsForRepo: Set<string>,
+): boolean {
+  const repoName = basename(repoPath).toLowerCase();
+  const scope = directive.scope.toLowerCase();
+  if (scope === 'global' || scope === '') return true;
+
+  if (scope === 'project') {
+    if (directive.projects.length === 0) return false;
+    for (const slug of directive.projects) {
+      if (projectSlugsForRepo.has(slug)) return true;
+    }
+    return false;
+  }
+
+  // Repo tier — match either explicit repoName field or `scope: <repoName>`.
+  const declaredRepo = (directive.repoName ?? '').toLowerCase();
+  if (declaredRepo && declaredRepo === repoName) return true;
+  if (scope === repoName) return true;
+  return false;
+}
+
+/**
+ * Convenience: filter a directive list for a target repo. Performs the
+ * project-slug lookup once and returns directives in input order.
+ *
+ * Callers that want a sort/cap apply it on the returned array.
+ */
+export async function filterDirectivesByRepo(
+  directives: ParsedDirective[],
+  repoPath: string,
+): Promise<ParsedDirective[]> {
+  const projectSlugsForRepo = await resolveRepoProjectSlugs(repoPath);
+  return directives.filter((d) => directiveAppliesToRepo(d, repoPath, projectSlugsForRepo));
+}

--- a/src/lib/cortex/directives/parse.ts
+++ b/src/lib/cortex/directives/parse.ts
@@ -1,0 +1,112 @@
+/**
+ * Shared directive front-matter parser.
+ *
+ * Two call sites read directive markdown files and need the same shape:
+ *   - `src/lib/codebase-memory/build-context.ts` (dispatch context — filters
+ *     project-scoped directives by repo membership)
+ *   - `src/app/api/cortex/directives/route.ts` (Recall Card UI)
+ *
+ * Before this helper was extracted, the parsers diverged: the dispatch path
+ * read the `projects:` front-matter field; the UI route did not. The result
+ * was project-scoped directives leaking into the Recall Card for repos that
+ * weren't members of the project. Surfaced by the #899 dogfood agent.
+ *
+ * Format:
+ *   ---
+ *   id: example
+ *   title: Example
+ *   scope: project        # or `global` / `repo` / `<repoName>`
+ *   repoName: cortex-ide  # optional
+ *   priority: 10          # optional
+ *   projects: [o8, atlas] # optional — only meaningful when scope: project
+ *   ---
+ *   <body>
+ *
+ *   ## Recent Merges        # appended by #769; stripped from `body`
+ *   - 2026-04-29 [merged] feat(...)
+ */
+
+const FRONT_MATTER_BOUNDARY = /^---\s*$/m;
+
+export interface ParsedDirective {
+  id: string;
+  title: string;
+  scope: string;
+  repoName: string | null;
+  /**
+   * #899 — `scope: project` directives carry a list of project slugs in the
+   * front matter (`projects: [atlas, beacon]`). Empty list when the directive
+   * isn't project-scoped or front matter omitted the field. Slugs are
+   * lowercased and de-duplicated to keep membership checks predictable.
+   */
+  projects: string[];
+  priority: number | null;
+  /** Body with the `## Recent Merges` trailer (#769) stripped. */
+  body: string;
+}
+
+/**
+ * Parse a single directive markdown file. Returns null when the input is
+ * missing front matter or the closing `---` boundary — callers treat null
+ * as "skip this file" rather than throwing.
+ */
+export function parseDirectiveFile(raw: string, fallbackId: string): ParsedDirective | null {
+  const text = raw.replace(/\r\n/g, '\n').trim();
+  if (!text.startsWith('---')) return null;
+
+  const afterFirst = text.slice(3).trimStart();
+  const closingIndex = afterFirst.search(FRONT_MATTER_BOUNDARY);
+  if (closingIndex < 0) return null;
+
+  const front = afterFirst.slice(0, closingIndex);
+  const rawBody = afterFirst.slice(closingIndex).replace(FRONT_MATTER_BOUNDARY, '').trim();
+  // #769 — strip the `## Recent Merges` trailer so the operator-authored
+  // content is what callers render / mine. Trailer lines surface separately
+  // via `readAllDirectiveTrailers()` in the API route.
+  const body = rawBody.replace(/\n*##\s+Recent Merges\b[\s\S]*$/, '').trim();
+
+  const meta: Record<string, string> = {};
+  for (const line of front.split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx <= 0) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    if (key) meta[key] = value;
+  }
+
+  const priorityRaw = meta.priority;
+  const priorityNum = priorityRaw ? Number.parseInt(priorityRaw, 10) : NaN;
+
+  return {
+    id: meta.id?.trim() || fallbackId,
+    title: meta.title?.trim() || fallbackId,
+    scope: meta.scope?.trim() || 'global',
+    repoName: meta.repoName?.trim() || null,
+    projects: parseProjectsList(meta.projects),
+    priority: Number.isFinite(priorityNum) ? priorityNum : null,
+    body,
+  };
+}
+
+/**
+ * Parse the `projects:` front-matter field into a normalized slug list.
+ * Accepts both YAML-ish shapes the directive parser already supports:
+ *   projects: [atlas, beacon]
+ *   projects: atlas, beacon
+ * Returns an empty array when the field is missing/empty/malformed.
+ */
+export function parseProjectsList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  const stripped = raw.trim().replace(/^\[|\]$/g, '').trim();
+  if (!stripped) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const part of stripped.split(',')) {
+    const slug = part.trim().replace(/^["']|["']$/g, '').toLowerCase();
+    if (!slug) continue;
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    out.push(slug);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Fixes the two bugs the Projects-flow dogfood agent surfaced in the post-merge audit of epic #899.

### Bug 1 — Two divergent directive parsers
`src/app/api/cortex/directives/route.ts` did not parse the `projects:` front-matter field that `src/lib/codebase-memory/build-context.ts` DID parse. Result: the Recall Card UI showed project-scoped directives to ALL repos, not just project members. Consolidated to a shared parser.

### Bug 2 — POST /api/projects accepted wrong-shaped bodies silently
Sending `{repos: [{repoId, role}]}` (the natural inverse of GET) created a project with `repos: []` — silent empty-project. Now auto-detects both shapes and validates.

## Test plan

- [ ] Project-scoped directive (`projects: [o8]`) appears in Recall Card ONLY when viewed from a repo in project "o8"
- [ ] POST /api/projects with `{repos: [{repoId, role}]}` body works correctly
- [ ] npx tsc --noEmit passes

🤖 Agent committed before hitting Anthropic cap; commit pushed manually.