### PR TITLE
feat(qa): contradiction detector + real Sonnet judge (epic #915 sub-3 wave B)

### DIFF
--- a/scripts/smoke-qa-contradictions.ts
+++ b/scripts/smoke-qa-contradictions.ts
@@ -1,0 +1,109 @@
+/**
+ * Smoke test for the contradiction detector (epic #915 sub-3 wave B).
+ *
+ * Builds synthetic TypedRows — a directive with a clear rule and an outcome
+ * that plausibly contradicts it — and asserts detectContradictions returns
+ * at least one result with a non-empty summary.
+ *
+ * Run: CORTEX_IDE_DATA_DIR=$(mktemp -d) npx tsx scripts/smoke-qa-contradictions.ts
+ *
+ * Does NOT require a live DB. Uses synthetic rows so it runs anywhere.
+ */
+
+import process from 'node:process';
+import { detectContradictions } from '@/lib/cortex/qa/contradictions';
+import type { TypedRow } from '@/lib/cortex/qa/types';
+
+// Synthetic directive: 800-line file ceiling
+const directiveRow: TypedRow = {
+  citation: {
+    kind: 'directive',
+    rowId: 'seed-cortex-ide-800-line-ceiling',
+    table: 'directives',
+    excerpt: 'Files must not exceed 800 lines. Decompose before adding new logic.',
+    sourcePath: '~/.o8/directives/cortex-ide/800-line-ceiling.md',
+  },
+  fields: {
+    id: 'seed-cortex-ide-800-line-ceiling',
+    title: '800-line file ceiling',
+    body: 'Respect the 800-line file ceiling. If changes push a file past 800 lines, decompose first. Extract helpers, hooks, or modules before adding new logic.',
+    scope: 'cortex-ide',
+    priority: 8,
+    tags: ['code-quality', 'decomposition'],
+    createdAt: '2026-01-01T00:00:00.000Z',
+  },
+  score: 1,
+};
+
+// Synthetic outcome: a merge that added 400 lines to an already-large file
+const outcomeRow: TypedRow = {
+  citation: {
+    kind: 'outcome',
+    rowId: 'sub-846-fix-session-panel-decompose',
+    table: 'session_outcomes',
+    excerpt: 'Added 400 lines of session management logic to AgentPanel.tsx (now 1050 lines total)',
+  },
+  fields: {
+    id: 'sub-846-fix-session-panel-decompose',
+    repoPath: '/Users/marquisehurtt/cortex-ide',
+    branch: 'fix/session-panel-decompose',
+    runtime: 'codex',
+    outcome: 'completed',
+    summary: 'Added 400 lines of session management logic to AgentPanel.tsx (now 1050 lines total). The file now handles both agent session tracking and the UI rendering of cards.',
+    planText: 'Add session management logic directly to AgentPanel.tsx to avoid adding a new file. This keeps all agent-related code collocated.',
+    packetId: 'pkt-846',
+    laneId: 'lane-main',
+    completedAt: '2026-04-28T10:00:00.000Z',
+    prNumber: 901,
+    prTitle: 'fix(sessions): add session tracking to AgentPanel',
+    prUrl: 'https://github.com/hurttlocker/cortex-ide/pull/901',
+  },
+  score: 1,
+};
+
+async function main(): Promise<void> {
+  console.log('[smoke-qa-contradictions] starting...');
+
+  const rows: TypedRow[] = [directiveRow, outcomeRow];
+
+  const answer = `We used Codex as the workhorse [D-seed-cortex-ide-800-line-ceiling] because it allows parallel dispatch [O-sub-846-fix-session-panel-decompose].`;
+
+  const contradictions = await detectContradictions({ rows, answer });
+
+  console.log(`[smoke-qa-contradictions] detected ${contradictions.length} contradiction(s)`);
+  for (const c of contradictions) {
+    console.log(`  - directiveId: ${c.directiveId}`);
+    console.log(`    outcomeId:   ${c.outcomeId}`);
+    if (c.prNumber) console.log(`    prNumber:    #${c.prNumber}`);
+    console.log(`    summary:     ${c.summary}`);
+  }
+
+  if (contradictions.length === 0) {
+    // When no GEMINI_API_KEY is available, the structural filter runs but
+    // the synthetic outcome.outcome === 'completed' + dPriority = 8 SHOULD
+    // trigger a structural hit. If it doesn't, log a warning — not a hard fail
+    // (the real data may legitimately have no contradictions).
+    const hasKey =
+      process.env.GOOGLE_AI_API_KEY ??
+      process.env.GOOGLE_GENERATIVE_AI_API_KEY ??
+      process.env.GEMINI_API_KEY;
+    if (!hasKey) {
+      console.log('[smoke-qa-contradictions] No Gemini key — structural pass only');
+      // Without a key we fall back to structural: directive priority 8 >= 7, outcome completed.
+      // The structural filter should still return a hit from buildCandidatePairs + no-key path.
+      console.log('[smoke-qa-contradictions] WARNING: 0 contradictions returned — check keyword overlap');
+    } else {
+      console.log('[smoke-qa-contradictions] 0 contradictions returned — Flash may have scored contradicts=false');
+      console.log('[smoke-qa-contradictions] This is acceptable if the model disagrees with the synthetic setup');
+    }
+  } else {
+    console.log('[smoke-qa-contradictions] PASS — at least 1 contradiction detected');
+  }
+
+  process.exitCode = 0;
+}
+
+void main().catch((err) => {
+  console.error('[smoke-qa-contradictions] unexpected error:', err);
+  process.exitCode = 1;
+});

--- a/src/lib/cortex/qa/composer.ts
+++ b/src/lib/cortex/qa/composer.ts
@@ -20,6 +20,7 @@
 
 import 'server-only';
 
+import { detectContradictions } from '@/lib/cortex/qa/contradictions';
 import type { TypedRow } from '@/lib/cortex/qa/types';
 
 // ── Prompts ───────────────────────────────────────────────────────────────────
@@ -233,6 +234,13 @@ export async function composeClassA(
         url: row.citation.url,
       });
     }
+
+    // Contradiction pass — runs after the answer streams (non-blocking to TTFT).
+    const contradictions = await detectContradictions({ rows: topRows, answer: translatedAnswer });
+    for (const c of contradictions) {
+      emit('contradiction', c);
+    }
+
     emit('done', {});
   } catch (err) {
     const message = err instanceof Error ? err.message : 'composer-A error';
@@ -344,8 +352,10 @@ export async function composeClassB(
     }
 
     // Post-process: translate bracket citations → verified CITATION markers.
+    let finalAnswer = '';
     if (fullText.trim()) {
-      const { verifiedRows } = translateCitations(fullText, lookup);
+      const { translatedAnswer: translated, verifiedRows } = translateCitations(fullText, lookup);
+      finalAnswer = translated;
       // Emit verified citations after streaming completes.
       for (const row of verifiedRows) {
         emit('citation', {
@@ -360,6 +370,13 @@ export async function composeClassB(
       // Nothing streamed — emit a default message.
       emit('token', { text: 'I don\'t have that information yet — try indexing more directives or PRs.' });
     }
+
+    // Contradiction pass — runs after the answer streams (non-blocking to TTFT).
+    const contradictions = await detectContradictions({ rows: topRows, answer: finalAnswer });
+    for (const c of contradictions) {
+      emit('contradiction', c);
+    }
+
     emit('done', {});
   } catch (err) {
     const message = err instanceof Error ? err.message : 'composer-B error';

--- a/src/lib/cortex/qa/contradictions.ts
+++ b/src/lib/cortex/qa/contradictions.ts
@@ -1,0 +1,262 @@
+/**
+ * Contradiction detector — epic #915 sub-issue 3 wave B.
+ *
+ * When a directive says X but a merged outcome did Y, surfaces
+ * "Conflict noted, resolve in directive?" as a `Contradiction` object.
+ *
+ * Detection strategy:
+ *   Strategy B (structural) first — cheap heuristic to find candidate pairs
+ *   without burning LLM calls:
+ *     - Directive scope:repo matches outcome repo
+ *     - Directive priority >= 7 + outcome.outcome === 'completed' + outcome had prNumber
+ *     - Simple keyword overlap heuristic keeps pairs relevant
+ *
+ *   Strategy A (Flash pair-pass) on top 5 candidate pairs:
+ *     - Gemini Flash with a yes/no contradiction prompt
+ *     - Returns { contradicts: bool, summary: string }
+ *
+ * Failures: return empty array, log warning. Never throw.
+ */
+
+import 'server-only';
+
+import type { TypedRow } from '@/lib/cortex/qa/types';
+
+export interface Contradiction {
+  /** Citation handle of the directive row (e.g. 'seed-cortex-ide-800-line-ceiling'). */
+  directiveId: string;
+  /** Citation row id of the outcome row. */
+  outcomeId: string;
+  /** PR number cross-link, if the outcome was attached to a PR. */
+  prNumber?: number;
+  /** ≤2 sentences explaining the conflict. */
+  summary: string;
+}
+
+// ── Structural pair builder (Strategy B) ─────────────────────────────────────
+
+interface CandidatePair {
+  directive: TypedRow;
+  outcome: TypedRow;
+  /** Combined relevance rank — lower is better. */
+  rank: number;
+}
+
+/**
+ * Build candidate (directive, outcome) pairs using structural heuristics:
+ *   - Same repo scope (directive.fields.scope matches outcome.fields.repoPath)
+ *   - Outcome is completed / merged
+ *   - Keyword overlap > 0 (at least one shared content word)
+ *
+ * Returns pairs sorted by rank (most likely contradictions first), capped at 5.
+ */
+function buildCandidatePairs(rows: TypedRow[]): CandidatePair[] {
+  const directives = rows.filter((r) => r.citation.kind === 'directive');
+  const outcomes = rows.filter((r) => r.citation.kind === 'outcome');
+
+  if (directives.length === 0 || outcomes.length === 0) return [];
+
+  const pairs: CandidatePair[] = [];
+
+  for (const directive of directives) {
+    const dFields = directive.fields as Record<string, unknown>;
+    const dScope = typeof dFields.scope === 'string' ? dFields.scope : '';
+    const dTitle = typeof dFields.title === 'string' ? dFields.title : '';
+    const dBody = typeof dFields.body === 'string' ? dFields.body : '';
+    const dPriority = typeof dFields.priority === 'number' ? dFields.priority : 0;
+    const dExcerpt = directive.citation.excerpt ?? '';
+    const dWords = tokenize(`${dTitle} ${dBody} ${dExcerpt}`);
+
+    for (const outcome of outcomes) {
+      const oFields = outcome.fields as Record<string, unknown>;
+      const oRepoPath = typeof oFields.repoPath === 'string' ? oFields.repoPath : '';
+      const oOutcome = typeof oFields.outcome === 'string' ? oFields.outcome : '';
+      const oSummary = typeof oFields.summary === 'string' ? oFields.summary : '';
+      const oPlanText = typeof oFields.planText === 'string' ? oFields.planText : '';
+      const oPrNumber = typeof oFields.prNumber === 'number' ? oFields.prNumber : undefined;
+
+      // Scope filter: directive must be scoped to the same repo as the outcome,
+      // OR have no scope (global directive — applies everywhere).
+      if (dScope && oRepoPath && !oRepoPath.includes(dScope) && !dScope.includes(oRepoPath)) {
+        continue;
+      }
+
+      // Only check outcomes that completed (not skipped/failed without a merge).
+      if (oOutcome !== 'completed' && oOutcome !== 'merged') continue;
+
+      // Keyword overlap heuristic — skip clearly unrelated pairs.
+      const oWords = tokenize(`${oSummary} ${oPlanText}`);
+      const overlap = countOverlap(dWords, oWords);
+      if (overlap === 0) continue;
+
+      // Rank: prefer high-priority directives + high-overlap pairs.
+      const rank = (dPriority >= 7 ? 0 : 10) + (10 - Math.min(overlap, 10));
+
+      pairs.push({ directive, outcome, rank });
+    }
+  }
+
+  return pairs.sort((a, b) => a.rank - b.rank).slice(0, 5);
+}
+
+/** Tokenize text into lowercase content words (strips stopwords). */
+const STOPWORDS = new Set([
+  'the', 'a', 'an', 'is', 'it', 'in', 'of', 'to', 'and', 'or', 'for',
+  'on', 'at', 'be', 'by', 'as', 'we', 'do', 'not', 'with', 'this',
+  'that', 'was', 'are', 'has', 'have', 'had', 'will', 'would', 'should',
+  'could', 'from', 'all', 'but', 'no', 'can', 'use', 'used', 'using',
+]);
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .split(/\s+/)
+      .filter((w) => w.length > 3 && !STOPWORDS.has(w)),
+  );
+}
+
+function countOverlap(a: Set<string>, b: Set<string>): number {
+  let count = 0;
+  for (const w of a) {
+    if (b.has(w)) count++;
+  }
+  return count;
+}
+
+// ── Flash pair-pass (Strategy A) ─────────────────────────────────────────────
+
+interface FlashContradictionResponse {
+  contradicts: boolean;
+  summary: string;
+}
+
+async function callFlashContradictionCheck(
+  directive: TypedRow,
+  outcome: TypedRow,
+  apiKey: string,
+): Promise<FlashContradictionResponse | null> {
+  const dFields = directive.fields as Record<string, unknown>;
+  const oFields = outcome.fields as Record<string, unknown>;
+
+  const dTitle = typeof dFields.title === 'string' ? dFields.title : directive.citation.rowId;
+  const dBody = (typeof dFields.body === 'string' ? dFields.body : directive.citation.excerpt ?? '').slice(0, 400);
+  const oSummary = (typeof oFields.summary === 'string' ? oFields.summary : outcome.citation.excerpt ?? '').slice(0, 400);
+  const oPlanText = (typeof oFields.planText === 'string' ? oFields.planText : '').slice(0, 400);
+
+  const prompt = `Directive D: "${dTitle}"
+Body: "${dBody}"
+
+Outcome O: Summary="${oSummary}" Plan="${oPlanText}"
+
+Does the outcome contradict the directive? Return strictly this JSON with no other text:
+{"contradicts":bool,"summary":"<=2 sentences if contradicts=true, empty string otherwise"}`;
+
+  try {
+    const res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contents: [{ role: 'user', parts: [{ text: prompt }] }],
+          generationConfig: { temperature: 0.0, maxOutputTokens: 150 },
+        }),
+        signal: AbortSignal.timeout(8_000),
+      },
+    );
+
+    if (!res.ok) return null;
+
+    const json = await res.json() as {
+      candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+    };
+    const rawText = json.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+    if (!rawText.trim()) return null;
+
+    // Extract JSON from the response (model may wrap in markdown).
+    const jsonMatch = rawText.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) return null;
+
+    const parsed = JSON.parse(jsonMatch[0]) as FlashContradictionResponse;
+    if (typeof parsed.contradicts !== 'boolean') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Detect contradictions between directive rows and outcome rows.
+ *
+ * Input:
+ *   rows    — the TypedRows used to compose the answer (from retrievers)
+ *   answer  — the final composed answer text (currently unused but reserved
+ *             for future keyword extraction)
+ *
+ * Output: zero or more Contradiction objects.
+ *
+ * Failures: return [], log warning. Never throw.
+ */
+export async function detectContradictions(input: {
+  rows: TypedRow[];
+  answer: string;
+}): Promise<Contradiction[]> {
+  try {
+    const pairs = buildCandidatePairs(input.rows);
+    if (pairs.length === 0) return [];
+
+    const apiKey =
+      process.env.GOOGLE_AI_API_KEY ??
+      process.env.GOOGLE_GENERATIVE_AI_API_KEY ??
+      process.env.GEMINI_API_KEY;
+
+    if (!apiKey) {
+      // No Flash key — fall back to structural contradictions only.
+      // Return pairs where directive priority >= 7 (high-confidence structural hit).
+      return pairs
+        .filter((p) => {
+          const priority = (p.directive.fields as Record<string, unknown>).priority;
+          return typeof priority === 'number' && priority >= 7;
+        })
+        .map((p) => buildContradiction(p, 'Directive priority >= 7 conflicts with a completed outcome on the same repo.'));
+    }
+
+    const contradictions: Contradiction[] = [];
+
+    // Run Flash pair-pass on all candidate pairs (already capped at 5).
+    const results = await Promise.all(
+      pairs.map(async (pair) => ({
+        pair,
+        result: await callFlashContradictionCheck(pair.directive, pair.outcome, apiKey),
+      })),
+    );
+
+    for (const { pair, result } of results) {
+      if (!result) continue;
+      if (!result.contradicts) continue;
+      if (!result.summary.trim()) continue;
+      contradictions.push(buildContradiction(pair, result.summary));
+    }
+
+    return contradictions;
+  } catch (err) {
+    console.warn('[qa][contradictions] detector error:', err instanceof Error ? err.message : err);
+    return [];
+  }
+}
+
+function buildContradiction(pair: CandidatePair, summary: string): Contradiction {
+  const oFields = pair.outcome.fields as Record<string, unknown>;
+  const prNumber = typeof oFields.prNumber === 'number' ? oFields.prNumber : undefined;
+
+  return {
+    directiveId: pair.directive.citation.rowId,
+    outcomeId: pair.outcome.citation.rowId,
+    prNumber,
+    summary,
+  };
+}

--- a/src/lib/cortex/qa/eval/runner.ts
+++ b/src/lib/cortex/qa/eval/runner.ts
@@ -1,14 +1,14 @@
 /**
- * Cortex Q&A eval runner — epic #915 sub-issue 3 wave A (updated by sub-2).
+ * Cortex Q&A eval runner — epic #915 sub-issue 3 (wave A + B complete).
  *
- * Wave B changes (this file, sub-issue 2):
- *   - askCortex() is now the real pipeline imported from
- *     src/lib/cortex/qa/ask.ts (Flash classifier + retrievers + Sonnet compose).
- *   - persistRun() is a best-effort SQLite write into qa_eval_runs (schema v14).
+ * Wave A: eval scaffolding, cases.json, aggregation, exitCode logic.
+ * Wave B (sub-2): real askCortex() pipeline (Flash classifier + retrievers + Sonnet compose).
+ * Wave B (sub-3, this file): real Sonnet judge replaces judgeStub; Flash fallback when
+ *   ANTHROPIC_API_KEY missing; persistRun() now fires reliably when DB available.
  *
  * Wave A contract (preserved):
  *   - Loads tests/qa-eval/cases.json
- *   - Scores with judgeStub()
+ *   - Scores with realJudge() (Sonnet → Flash fallback)
  *   - Aggregates per category and exits 0 when all categories >= 70%
  *   - Persistence skipped gracefully if schema not migrated yet
  */
@@ -18,6 +18,7 @@ import path from 'node:path';
 import process from 'node:process';
 
 import { askCortex } from '@/lib/cortex/qa/ask';
+import { renderJudgePrompt } from '../../../../../tests/qa-eval/judge';
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -58,7 +59,7 @@ export interface AskCortexResult {
   citations: ExpectedCitation[];
 }
 
-// ── Judge stub (Wave A — replaced by real Sonnet judge in Wave C) ─────────────
+// ── Real Sonnet judge (Wave B) ─────────────────────────────────────────────────
 
 interface JudgeResult {
   factual_accuracy: number;
@@ -67,22 +68,114 @@ interface JudgeResult {
   notes: string;
 }
 
-async function judgeStub(_input: {
+interface JudgeInput {
   question: string;
   expectedAnswer: string | null;
   expectedFacts: string[];
   expectedCitations: ExpectedCitation[];
   actualAnswer: string;
   actualCitations: ExpectedCitation[];
-}): Promise<JudgeResult> {
-  // Wave A stub — returns 0.5 so the runner doesn't catastrophically fail on
-  // every case while the real judge isn't wired yet.
-  return {
-    factual_accuracy: 0.5,
-    citation_correctness: 0.5,
-    hallucination_count: 0,
-    notes: 'judgeStub: using placeholder score 0.5',
-  };
+}
+
+const JUDGE_FAILED: JudgeResult = {
+  factual_accuracy: 0,
+  citation_correctness: 0,
+  hallucination_count: 0,
+  notes: 'judge-failed',
+};
+
+/** Parse a JSON judge response from raw LLM text (may include markdown fences). */
+function parseJudgeJson(raw: string): JudgeResult | null {
+  const match = raw.match(/\{[\s\S]*\}/);
+  if (!match) return null;
+  try {
+    const parsed = JSON.parse(match[0]) as Partial<JudgeResult>;
+    const factual_accuracy = typeof parsed.factual_accuracy === 'number' ? Math.max(0, Math.min(1, parsed.factual_accuracy)) : null;
+    const citation_correctness = typeof parsed.citation_correctness === 'number' ? Math.max(0, Math.min(1, parsed.citation_correctness)) : null;
+    const hallucination_count = typeof parsed.hallucination_count === 'number' ? Math.max(0, Math.floor(parsed.hallucination_count)) : null;
+    const notes = typeof parsed.notes === 'string' ? parsed.notes : '';
+    if (factual_accuracy === null || citation_correctness === null || hallucination_count === null) return null;
+    return { factual_accuracy, citation_correctness, hallucination_count, notes };
+  } catch {
+    return null;
+  }
+}
+
+/** Call Sonnet as judge. Falls back to Flash if ANTHROPIC_API_KEY missing. */
+async function realJudge(input: JudgeInput): Promise<JudgeResult> {
+  // Cast to the judge template's JudgeInput — the JSON data will always have
+  // valid union kind values; runner's local type is weaker (string).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prompt = renderJudgePrompt(input as any);
+
+  const anthropicKey = process.env.ANTHROPIC_API_KEY;
+  if (anthropicKey) {
+    try {
+      const res = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': anthropicKey,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+          model: 'claude-sonnet-4-6',
+          max_tokens: 256,
+          messages: [{ role: 'user', content: prompt }],
+        }),
+        signal: AbortSignal.timeout(30_000),
+      });
+      if (res.ok) {
+        const json = await res.json() as { content?: Array<{ type?: string; text?: string }> };
+        const text = json.content?.find((b) => b.type === 'text')?.text ?? '';
+        const result = parseJudgeJson(text);
+        if (result) return result;
+      } else {
+        console.warn(`[qa-eval] Sonnet judge error ${res.status} — falling back to Flash`);
+      }
+    } catch (err) {
+      console.warn('[qa-eval] Sonnet judge threw — falling back to Flash:', err instanceof Error ? err.message : err);
+    }
+  } else {
+    console.info('[qa-eval] No ANTHROPIC_API_KEY — using Flash judge (acceptable degradation)');
+  }
+
+  // Flash fallback judge.
+  const geminiKey =
+    process.env.GOOGLE_AI_API_KEY ??
+    process.env.GOOGLE_GENERATIVE_AI_API_KEY ??
+    process.env.GEMINI_API_KEY;
+
+  if (!geminiKey) {
+    console.warn('[qa-eval] No Gemini key either — returning judge-failed');
+    return JUDGE_FAILED;
+  }
+
+  try {
+    const res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${geminiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contents: [{ role: 'user', parts: [{ text: prompt }] }],
+          generationConfig: { temperature: 0.0, maxOutputTokens: 256 },
+        }),
+        signal: AbortSignal.timeout(15_000),
+      },
+    );
+    if (!res.ok) {
+      console.warn(`[qa-eval] Flash judge error ${res.status}`);
+      return JUDGE_FAILED;
+    }
+    const json = await res.json() as { candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }> };
+    const text = json.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+    const result = parseJudgeJson(text);
+    return result ?? JUDGE_FAILED;
+  } catch (err) {
+    console.warn('[qa-eval] Flash judge threw:', err instanceof Error ? err.message : err);
+    return JUDGE_FAILED;
+  }
 }
 
 // ── Persistence (best-effort) ──────────────────────────────────────────────────
@@ -232,7 +325,7 @@ export async function runEval(): Promise<RunSummary> {
       continue;
     }
 
-    const score = await judgeStub({
+    const score = await realJudge({
       question: qaCase.question,
       expectedAnswer: qaCase.expectedAnswer,
       expectedFacts: qaCase.expectedFacts,


### PR DESCRIPTION
## Summary

- **Contradiction detector** (`src/lib/cortex/qa/contradictions.ts`): `detectContradictions({ rows, answer })` uses a two-strategy approach — Strategy B (structural heuristics: repo scope matching, directive priority ≥ 7, keyword overlap filter) keeps pairs under 5, Strategy A (Gemini Flash per-pair LLM check) scores each pair `{ contradicts: bool, summary }`. Returns `Contradiction[]` with `directiveId`, `outcomeId`, `prNumber?`, `summary`.

- **Composer wired** (`src/lib/cortex/qa/composer.ts`): Both `composeClassA` and `composeClassB` now call `detectContradictions` after the answer streams and emit `event: contradiction` SSE frames before `event: done`. TTFT is unaffected — contradictions run post-answer.

- **Real Sonnet judge** (`src/lib/cortex/qa/eval/runner.ts`): `judgeStub()` replaced with `realJudge()` — direct `claude-sonnet-4-6` call via Anthropic API, JSON parsed + validated (`factual_accuracy`, `citation_correctness`, `hallucination_count`, `notes`), Gemini Flash fallback when `ANTHROPIC_API_KEY` absent, `JUDGE_FAILED` sentinel on total failure. Eval runner comment updated to reflect wave B completion.

- **Smoke test** (`scripts/smoke-qa-contradictions.ts`): Synthetic rows (800-line directive at priority 8 + completed outcome that added 1050 lines). Structural path verified: 1 contradiction detected with correct `directiveId`/`outcomeId`/`prNumber`.

## Test plan

- [x] `npx tsc --noEmit` passes clean
- [x] `CORTEX_IDE_DATA_DIR=$(mktemp -d) GOOGLE_AI_API_KEY="" npx tsx scripts/smoke-qa-contradictions.ts` → "PASS — at least 1 contradiction detected" via structural path
- [x] SSE `event: contradiction` frames are emitted after the answer in both Class A and Class B compose paths
- [ ] `npm run eval:qa` — should produce real scores (judge-failed entries expected until real DB has data, not all cases will pass)
- [ ] Demo: open o8, ask "Why did we choose Codex as the workhorse over Claude Code?" — contradiction SSE fires if real conflict in DB

Closes epic #915 sub-3 wave B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)