### PR TITLE
fix(qa): CLI --verbose flag + stdin piping + composer empty-answer guard

### DIFF
--- a/src/lib/cortex/qa/ask.ts
+++ b/src/lib/cortex/qa/ask.ts
@@ -108,6 +108,21 @@ export async function askCortex(
   const topRows = unionMerge(results);
   const retrievalMs = Date.now() - retrievalStart;
 
+  // [qa-debug] Log retrieval diagnostics so we can trace empty-answer false-positives.
+  const isDebug = process.env.QA_DEBUG === '1';
+  if (isDebug) {
+    console.log('[qa-debug] question:', question);
+    console.log('[qa-debug] bm25Variants:', classification.bm25Variants);
+    for (const r of results) {
+      console.log(`[qa-debug] retriever=${r.retriever} rows=${r.rows.length} durationMs=${r.durationMs}`);
+    }
+    console.log('[qa-debug] topRows after unionMerge:', topRows.length);
+    console.log('[qa-debug] composer class:', classification.class);
+    if (topRows.length === 0) {
+      console.warn('[qa-debug] topRows is EMPTY — composer will respond "no data"');
+    }
+  }
+
   // 3. Compose (collect via emit accumulator)
   let answer = '';
   const citations: Citation[] = [];

--- a/src/lib/cortex/qa/eval/runner.ts
+++ b/src/lib/cortex/qa/eval/runner.ts
@@ -140,21 +140,26 @@ async function persistRun(row: RunRow): Promise<void> {
     // Dynamic import so fresh-clone CI doesn't crash on missing DB.
     const { getSqlite } = await import('@/lib/db');
     const db = getSqlite();
+    // Schema: id(TEXT PK), question_id, category, expected_answer, actual_answer,
+    //         citations_json, factual_accuracy, citation_correctness,
+    //         hallucination_count, run_at(INTEGER).
+    // `id` uses questionId + runAt so each eval run per question overwrites cleanly.
+    const id = `${row.questionId}::${row.runAt}`;
     db.prepare(
       `INSERT OR REPLACE INTO qa_eval_runs
-         (question_id, category, expected, actual, factual_accuracy,
-          citation_correctness, hallucination_count, notes, run_at)
+         (id, question_id, category, expected_answer, actual_answer,
+          factual_accuracy, citation_correctness, hallucination_count, run_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
+      id,
       row.questionId,
       row.category,
-      row.expected,
+      row.expected ?? '',
       row.actual,
       row.factualAccuracy,
       row.citationCorrectness,
       row.hallucinationCount,
-      row.notes,
-      row.runAt,
+      new Date(row.runAt).getTime(),
     );
   } catch {
     // Table may not exist yet (schema v14 not migrated). Skip silently.

--- a/src/lib/cortex/qa/llm/sonnet-adapter.ts
+++ b/src/lib/cortex/qa/llm/sonnet-adapter.ts
@@ -115,14 +115,22 @@ export function resetSonnetProviderCache(): void {
 // ── CLI streaming parser ──────────────────────────────────────────────────────
 
 /**
- * Parse a stream-json output line from the Claude CLI.
- * Returns delta text when available; null otherwise.
+ * Parse a stream-json output line from the Claude CLI (streaming mode).
+ * Returns text from assistant events; null for all other event types.
+ *
+ * With --verbose the relevant event shapes are:
+ *   - content_block_delta { delta: { type: 'text_delta', text } }   — API streaming
+ *   - assistant { message: { content: [{ type: 'text', text }] } }  — verbose fallback
+ *
+ * We skip `result` events here to avoid duplicating text that already came
+ * through the assistant event.
  */
-function extractCliDeltaText(line: string): string | null {
+function extractCliStreamingText(line: string): string | null {
   if (!line.trim()) return null;
   try {
     const evt = JSON.parse(line) as Record<string, unknown>;
-    // stream-json format: { type: 'content_block_delta', delta: { type: 'text_delta', text: '...' } }
+
+    // API streaming delta — { type: 'content_block_delta', delta: { type: 'text_delta', text } }
     if (
       evt['type'] === 'content_block_delta' &&
       typeof evt['delta'] === 'object' &&
@@ -133,7 +141,41 @@ function extractCliDeltaText(line: string): string | null {
         return delta['text'];
       }
     }
-    // result message: { type: 'result', result: '...' } — used for non-streaming
+
+    // Verbose assistant event — { type: 'assistant', message: { content: [{ type: 'text', text }] } }
+    if (evt['type'] === 'assistant' && typeof evt['message'] === 'object' && evt['message'] !== null) {
+      const msg = evt['message'] as Record<string, unknown>;
+      const content = msg['content'];
+      if (Array.isArray(content)) {
+        const parts: string[] = [];
+        for (const block of content) {
+          if (
+            typeof block === 'object' &&
+            block !== null &&
+            (block as Record<string, unknown>)['type'] === 'text' &&
+            typeof (block as Record<string, unknown>)['text'] === 'string'
+          ) {
+            parts.push((block as Record<string, unknown>)['text'] as string);
+          }
+        }
+        if (parts.length > 0) return parts.join('');
+      }
+    }
+  } catch {
+    // not JSON — skip
+  }
+  return null;
+}
+
+/**
+ * Parse a stream-json output line for the non-streaming (batch) path.
+ * Extracts text only from the terminal `result` event, which contains the
+ * complete response text. Skips assistant events to avoid double-counting.
+ */
+function extractCliResultText(line: string): string | null {
+  if (!line.trim()) return null;
+  try {
+    const evt = JSON.parse(line) as Record<string, unknown>;
     if (evt['type'] === 'result' && typeof evt['result'] === 'string') {
       return evt['result'];
     }
@@ -145,16 +187,15 @@ function extractCliDeltaText(line: string): string | null {
 
 /**
  * Full text extractor for non-streaming CLI output.
- * Scans all lines for delta text or a result line and concatenates.
+ * Scans all lines for the terminal `result` event and returns its text.
  */
 function extractCliFullText(output: string): string {
   const lines = output.split('\n').filter(Boolean);
-  const parts: string[] = [];
   for (const line of lines) {
-    const text = extractCliDeltaText(line);
-    if (text) parts.push(text);
+    const text = extractCliResultText(line);
+    if (text !== null) return text;
   }
-  return parts.join('');
+  return '';
 }
 
 // ── callSonnet public API ─────────────────────────────────────────────────────
@@ -213,12 +254,15 @@ async function callSonnetCli(
   // Always use tmpdir so no project .claude/ config is inherited.
   const cwd = os.tmpdir();
 
+  // --verbose is required when combining --print and --output-format stream-json.
+  // Prompt is fed via stdin so multi-line content never gets mangled by shell arg
+  // parsing (positional args with newlines confuse the CLI's argv parser).
   const cliArgs = [
     '--print',
+    '--verbose',
     '--dangerously-skip-permissions',
     '--output-format', 'stream-json',
     '--model', 'claude-sonnet-4-6',
-    prompt,
   ];
 
   const env = {
@@ -234,8 +278,12 @@ async function callSonnetCli(
       const child = spawn(claudeBin, cliArgs, {
         cwd,
         env,
-        stdio: ['ignore', 'pipe', 'pipe'],
+        stdio: ['pipe', 'pipe', 'pipe'],
       });
+
+      // Write prompt to stdin, then close so the CLI knows input is done.
+      child.stdin!.write(prompt, 'utf-8');
+      child.stdin!.end();
 
       let lineBuffer = '';
       const decoder = new TextDecoder();
@@ -246,14 +294,14 @@ async function callSonnetCli(
         const lines = lineBuffer.split('\n');
         lineBuffer = lines.pop() ?? '';
         for (const line of lines) {
-          const text = extractCliDeltaText(line);
+          const text = extractCliStreamingText(line);
           if (text) yield text;
         }
       }
 
       // Flush remaining buffer.
       if (lineBuffer.trim()) {
-        const text = extractCliDeltaText(lineBuffer);
+        const text = extractCliStreamingText(lineBuffer);
         if (text) yield text;
       }
 
@@ -264,16 +312,42 @@ async function callSonnetCli(
     return { tokens, tier: 'cli' };
   }
 
-  // Non-streaming: run to completion and return full text.
+  // Non-streaming: spawn, write prompt to stdin, collect stdout to completion.
+  // Using spawn (not execFileAsync) so we can write to stdin — execFile's type
+  // definition doesn't expose the `input` option even though the runtime accepts it.
   try {
-    const { stdout } = await execFileAsync(claudeBin, cliArgs, {
-      cwd,
-      env,
-      timeout: 60_000,
-      maxBuffer: 4 * 1024 * 1024, // 4MB
+    const text = await new Promise<string>((resolve, reject) => {
+      const { spawn: spawnSync } = require('node:child_process') as typeof import('node:child_process');
+      const child = spawnSync(claudeBin, cliArgs, {
+        cwd,
+        env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      child.stdin!.write(prompt, 'utf-8');
+      child.stdin!.end();
+
+      let stdout = '';
+      let stderr = '';
+      child.stdout!.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+      child.stderr!.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+
+      const timer = setTimeout(() => {
+        child.kill();
+        reject(new Error('[qa] Claude CLI timed out after 60s'));
+      }, 60_000);
+
+      child.on('close', (code) => {
+        clearTimeout(timer);
+        if (code !== 0 && stdout.trim() === '') {
+          reject(new Error(`[qa] Claude CLI exited with code ${code}: ${stderr.slice(0, 400)}`));
+        } else {
+          resolve(stdout);
+        }
+      });
     });
-    const text = extractCliFullText(stdout);
-    return { text, tier: 'cli' };
+
+    return { text: extractCliFullText(text), tier: 'cli' };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new Error(`[qa] Claude CLI invocation failed: ${message}`);


### PR DESCRIPTION
## Summary

- **Bug 1 fixed**: Claude CLI was called with `--print --output-format stream-json` but missing `--verbose`, causing every judge invocation to fail with "requires --verbose". Fixed by adding `--verbose` and switching prompt delivery from positional argv to stdin (`write+close`), which also prevents multi-line prompts from being mangled by shell argument parsing.

- **Bug 2 fixed**: `extractCliDeltaText` only matched `content_block_delta` events (API streaming). In `--verbose` mode the CLI emits `assistant` events instead of per-token deltas. Split into `extractCliStreamingText` (matches `assistant`/`content_block_delta` — no duplication) and `extractCliResultText` (matches only terminal `result` event). This means `composeClassB` streaming now yields tokens correctly instead of falling through to the "I don't have that information yet" guard.

- **Bonus fix**: `qa_eval_runs` INSERT in `runner.ts` had wrong column names (`expected`→`expected_answer`, `actual`→`actual_answer`), missing `id` PK, and `run_at` as ISO string instead of epoch ms. Fixed to match the actual schema from `v14-fts5-migration.ts`.

- **Adds `QA_DEBUG=1` logging** in `ask.ts` to trace retrieval row counts, bm25Variants, and whether the "no data" composer path fires.

## Eval gate results after fix

**Before**: all 6 categories at 0.0% (infrastructure failure — judge threw on every case).

**After** (`npm run eval:qa`):
```
  FAIL  ownership    1.0%   (scored=5/5, gaps=1, hallucinations=2)
  FAIL  decisions    53.0%  (scored=5/5, gaps=0, hallucinations=1)
  FAIL  processes    18.0%  (scored=5/5, gaps=0, hallucinations=0)
  FAIL  incidents    21.4%  (scored=5/5, gaps=1, hallucinations=2)
  FAIL  specs        0.0%   (scored=5/5, gaps=0, hallucinations=0)
  FAIL  cross-repo   22.0%  (scored=5/5, gaps=1, hallucinations=2)

overall: cases=30 known-gaps=3 avg_factual=19.2% avg_citation=16.5% hallucinations=7
```

The gate is now functioning — real scores instead of all zeros. The quality gaps (ownership directives have dynamic IDs, specs retrieval misses) are content/ingestion issues, not infrastructure bugs, and are out of scope for this PR.

## Test plan

- [x] `npx tsc --noEmit` passes clean
- [x] `echo "ping" | claude --print --verbose --output-format stream-json --model claude-sonnet-4-6` returns parsable JSON (confirmed)
- [x] Non-streaming `callSonnet` returns correct text (manual test: extracts `result` event)
- [x] Streaming `callSonnet` yields tokens without duplication (manual test: "streaming test works" once)
- [x] Full `npm run eval:qa` produces real per-category scores (not all zeros)

🤖 Generated with [Claude Code](https://claude.com/claude-code)