### PR TITLE
epic(orchestrator): #888 — Augment Intent UX steal (children #889–#895)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -119,6 +119,8 @@ const LazyCommandPalette = lazy(() => import('@/components/desktop/CommandPalett
 const LazyDesignModeOverlay = lazy(() => import('@/components/desktop/DesignModeOverlay').then(m => ({ default: m.DesignModeOverlay })));
 const LazyWorkspaceSidePanel = lazy(() => import('@/components/desktop/WorkspaceSidePanel').then(m => ({ default: m.WorkspaceSidePanel })));
 const LazyO8Panel = lazy(() => import('@/components/desktop/O8Panel').then(m => ({ default: m.O8Panel })));
+// #888/#895 — packet-mode right panel (Spec / Agent Overview / Changes).
+const LazyPacketRightPanel = lazy(() => import('@/components/desktop/PacketRightPanel').then(m => ({ default: m.PacketRightPanel })));
 import { OrchestratorDataProvider } from '@/components/desktop/orchestrator-data-context';
 import { TileContainer } from '@/components/desktop/TileContainer';
 import type { AgentPanelChatInjectionPayload } from '@/lib/chat/injection';
@@ -259,6 +261,10 @@ function DashboardInner() {
   const [activeTileId, setActiveTileId] = useState<string | null>(getFirstLeaf(initialTileLayout.root).id);
   const [latestDispatchedTabId, setLatestDispatchedTabId] = useState<string | null>(null);
   const [latestDispatchedAt, setLatestDispatchedAt] = useState<number | null>(null);
+  // #888/#895 — packet selection lifted from ThoughtsMissionPanel so the
+  // right-side workspace panel can flip into packet mode (Spec / Agent
+  // Overview) when one is expanded. See `src/lib/panel/mode.ts`.
+  const [selectedPacketId, setSelectedPacketId] = useState<string | null>(null);
   const lastMarkedWorkspaceReadRef = useRef<string>('');
 
   // ── Cmd+K command palette (#661) — full-screen overlay search across
@@ -2740,6 +2746,8 @@ function DashboardInner() {
             latestDispatchedTabId={latestDispatchedTabId}
             latestDispatchedAt={latestDispatchedAt}
             onAcceptDirectiveProposal={handleAcceptDirectiveProposal}
+            selectedPacketId={selectedPacketId}
+            onSelectedPacketChange={setSelectedPacketId}
           >
             <TileContainer
               layout={tileLayout}
@@ -2846,6 +2854,30 @@ function DashboardInner() {
                             else openCanvasTab(tab);
                           })();
                         }}
+                      />
+                    </Suspense>
+                  </motion.div>
+                ) : selectedPacketId ? (
+                  <motion.div
+                    key={`packet:${selectedPacketId}`}
+                    initial={{ opacity: 0, x: 12 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    exit={{ opacity: 0, x: 12 }}
+                    transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
+                    style={{
+                      flex: 1,
+                      minHeight: 0,
+                      display: 'flex',
+                      flexDirection: 'column',
+                    }}
+                  >
+                    <Suspense fallback={null}>
+                      <LazyPacketRightPanel
+                        selectedPacketId={selectedPacketId}
+                        missionState={thoughtsMissionState}
+                        workspaceSidePanelRepo={workspaceSidePanelRepo}
+                        onClose={() => setSelectedPacketId(null)}
+                        onOpenFile={(filePath, repo) => handleSelectFile(filePath, repo?.localPath)}
                       />
                     </Suspense>
                   </motion.div>

--- a/src/components/desktop/OrchestratorEmptyState.tsx
+++ b/src/components/desktop/OrchestratorEmptyState.tsx
@@ -4,17 +4,20 @@
  * OrchestratorEmptyState — the curated landing view for the Orchestrator
  * tab when it has no messages yet.
  *
- * Jobs philosophy applied:
- *   - Big, quiet, confident greeting. No wall of text.
- *   - 4 quick actions, not 6. Focus means saying no.
- *   - Each action is a COMMAND, not a question. The orchestrator is a
- *     control plane — users give it orders, not conversations.
- *   - Clicking an action fills the composer AND sends, so the first
- *     moment of using the Orchestrator is "I clicked a thing and
- *     something happened" not "I have to type."
+ * Two-column "Let's get building" layout (#888/#889):
+ *   - LEFT  — greeting + 4 quick-action cards (existing pattern).
+ *   - RIGHT — repo-grouped recent-work cards from the lanes table, with
+ *             status dots + relative timestamps. GROUPED BY REPO and
+ *             SHOW ARCHIVED toggles in the header. Click a card to
+ *             expand its packet in the mission rail.
+ *
+ * Style: paper-and-ink Rams, Issues-style uppercase labels, one orange
+ * accent (status dot for `done` lanes). Inline styles only, theme
+ * tokens, no native form controls.
  */
 
-import { memo } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import type { Lane, LaneStatus } from '@/lib/lane/types';
 
 interface QuickAction {
   id: string;
@@ -50,91 +53,270 @@ const QUICK_ACTIONS: QuickAction[] = [
   },
 ];
 
+const GROUPED_KEY = 'cortex-ide:orchestrator:empty:grouped';
+const ARCHIVED_KEY = 'cortex-ide:orchestrator:empty:show-archived';
+
+type LaneSummary = Pick<Lane, 'id' | 'label' | 'repoPath' | 'branch' | 'runtime' | 'status' | 'updatedAt' | 'lastEventAt' | 'packetId'>;
+
 interface OrchestratorEmptyStateProps {
   greeting: string;
   runtimeLabel: string;
   onActionClick: (prompt: string) => void;
+  /** When provided, clicking a recent-work card expands that packet. */
+  onSelectPacket?: (packetId: string) => void;
+}
+
+function readBoolPref(key: string, fallback: boolean): boolean {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (raw === '1') return true;
+    if (raw === '0') return false;
+    return fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeBoolPref(key: string, value: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, value ? '1' : '0');
+  } catch {
+    // ignore
+  }
+}
+
+function repoBaseName(repoPath: string): string {
+  const cleaned = repoPath.replace(/\/+$/, '');
+  const parts = cleaned.split('/');
+  if (parts.length >= 2) return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`;
+  return parts[parts.length - 1] || repoPath;
+}
+
+function formatRelativeShort(input: string | null | undefined): string {
+  if (!input) return '';
+  const ts = Date.parse(input);
+  if (Number.isNaN(ts)) return '';
+  const delta = Date.now() - ts;
+  if (delta < 0) return 'now';
+  const minutes = Math.floor(delta / 60_000);
+  if (minutes < 1) return 'now';
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo`;
+  const years = Math.floor(months / 12);
+  return `${years}y`;
+}
+
+/**
+ * Status dot derivation per #889 acceptance criteria:
+ *   filled-orange — done (completed lanes)
+ *   half-filled   — in-progress (running, launching, awaiting_input, paused)
+ *   hollow        — not started or idle
+ */
+type StatusDotKind = 'done' | 'in-progress' | 'idle';
+
+function statusDotKind(status: LaneStatus): StatusDotKind {
+  if (status === 'completed' || status === 'archived') return 'done';
+  if (status === 'idle') return 'idle';
+  return 'in-progress';
+}
+
+function StatusDot({ kind }: { kind: StatusDotKind }) {
+  const orange = '#FF5A1F';
+  const muted = 'var(--t-text-faint, #94a3b8)';
+  if (kind === 'done') {
+    return <span aria-hidden style={{ display: 'inline-block', width: 7, height: 7, borderRadius: '50%', background: orange, flexShrink: 0 }} />;
+  }
+  if (kind === 'in-progress') {
+    return (
+      <span
+        aria-hidden
+        style={{
+          display: 'inline-block',
+          width: 7,
+          height: 7,
+          borderRadius: '50%',
+          background: `linear-gradient(90deg, ${orange} 0% 50%, transparent 50% 100%)`,
+          borderWidth: 1,
+          borderStyle: 'solid',
+          borderColor: orange,
+          flexShrink: 0,
+        }}
+      />
+    );
+  }
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: 'inline-block',
+        width: 7,
+        height: 7,
+        borderRadius: '50%',
+        background: 'transparent',
+        borderWidth: 1,
+        borderStyle: 'solid',
+        borderColor: muted,
+        flexShrink: 0,
+      }}
+    />
+  );
 }
 
 function OrchestratorEmptyStateBase({
   greeting,
   runtimeLabel,
   onActionClick,
+  onSelectPacket,
 }: OrchestratorEmptyStateProps) {
+  const [lanes, setLanes] = useState<LaneSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [groupedByRepo, setGroupedByRepo] = useState<boolean>(() => readBoolPref(GROUPED_KEY, true));
+  const [showArchived, setShowArchived] = useState<boolean>(() => readBoolPref(ARCHIVED_KEY, false));
+
+  const fetchLanes = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/lanes?active=false', { cache: 'no-store' });
+      if (!res.ok) return;
+      const data = await res.json() as { lanes?: LaneSummary[] };
+      const list = (data.lanes ?? []).slice().sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+      setLanes(list);
+    } catch {
+      // silent — best effort
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchLanes();
+  }, [fetchLanes]);
+
+  const filtered = useMemo(() => {
+    const list = lanes.filter((lane) => showArchived ? true : lane.status !== 'archived');
+    return list.slice(0, 24);
+  }, [lanes, showArchived]);
+
+  const grouped = useMemo(() => {
+    if (!groupedByRepo) {
+      return [{ repoLabel: 'All repos', lanes: filtered }];
+    }
+    const map = new Map<string, LaneSummary[]>();
+    for (const lane of filtered) {
+      const key = repoBaseName(lane.repoPath);
+      const bucket = map.get(key);
+      if (bucket) bucket.push(lane);
+      else map.set(key, [lane]);
+    }
+    return Array.from(map.entries()).map(([repoLabel, bucket]) => ({ repoLabel, lanes: bucket }));
+  }, [filtered, groupedByRepo]);
+
+  const handleToggleGrouped = useCallback(() => {
+    setGroupedByRepo((prev) => {
+      const next = !prev;
+      writeBoolPref(GROUPED_KEY, next);
+      return next;
+    });
+  }, []);
+
+  const handleToggleArchived = useCallback(() => {
+    setShowArchived((prev) => {
+      const next = !prev;
+      writeBoolPref(ARCHIVED_KEY, next);
+      return next;
+    });
+  }, []);
+
   return (
     <div
       style={{
         display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
+        flexDirection: 'row',
+        alignItems: 'stretch',
         flex: 1,
         minHeight: 0,
+        gap: 24,
         paddingTop: 24,
         paddingRight: 24,
         paddingBottom: 24,
         paddingLeft: 24,
-        gap: 32,
       }}
     >
-      {/* Greeting */}
+      {/* LEFT — greeting + quick actions */}
       <div
         style={{
+          flex: 1,
+          minWidth: 0,
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
-          gap: 6,
+          justifyContent: 'center',
+          gap: 28,
         }}
       >
         <div
           style={{
-            fontSize: 28,
-            fontWeight: 300,
-            color: 'var(--t-text-secondary)',
-            letterSpacing: '-0.03em',
-            lineHeight: 1.2,
-            fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 6,
           }}
         >
-          {greeting}
+          <div
+            style={{
+              fontSize: 34,
+              fontWeight: 300,
+              color: 'var(--t-text-secondary)',
+              letterSpacing: '-0.03em',
+              lineHeight: 1.15,
+              fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+              textAlign: 'center',
+            }}
+          >
+            Let&rsquo;s get building.
+          </div>
+          <div
+            style={{
+              fontSize: 13,
+              fontWeight: 500,
+              color: 'var(--t-text)',
+              letterSpacing: '-0.01em',
+              fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+            }}
+          >
+            {greeting}
+          </div>
+          <div
+            style={{
+              fontSize: 10,
+              fontWeight: 600,
+              color: 'var(--t-text-muted)',
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              marginTop: 4,
+            }}
+          >
+            {runtimeLabel}
+          </div>
         </div>
-        <div
-          style={{
-            fontSize: 13,
-            fontWeight: 500,
-            color: 'var(--t-text)',
-            letterSpacing: '-0.01em',
-            fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
-          }}
-        >
-          Command your fleet.
-        </div>
-        <div
-          style={{
-            fontSize: 10,
-            fontWeight: 600,
-            color: 'var(--t-text-muted)',
-            letterSpacing: '0.08em',
-            textTransform: 'uppercase',
-            marginTop: 4,
-          }}
-        >
-          {runtimeLabel}
-        </div>
-      </div>
 
-      {/* Quick actions — 2×2 grid, uniform baseline; hover lifts each card identically */}
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(2, minmax(220px, 1fr))',
-          gap: 10,
-          width: '100%',
-          maxWidth: 560,
-        }}
-      >
-        {QUICK_ACTIONS.map((action) => {
-          return (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(2, minmax(220px, 1fr))',
+            gap: 10,
+            width: '100%',
+            maxWidth: 480,
+          }}
+        >
+          {QUICK_ACTIONS.map((action) => (
             <button
               key={action.id}
               type="button"
@@ -193,10 +375,214 @@ function OrchestratorEmptyStateBase({
                 {action.detail}
               </div>
             </button>
-          );
-        })}
+          ))}
+        </div>
+      </div>
+
+      {/* RIGHT — repo-grouped recent work */}
+      <div
+        style={{
+          width: 320,
+          minWidth: 280,
+          maxWidth: 360,
+          flexShrink: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+          minHeight: 0,
+        }}
+      >
+        {/* Header — toggles */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            paddingTop: 4,
+            paddingBottom: 6,
+            gap: 8,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 9,
+              fontWeight: 700,
+              color: 'var(--t-text-muted)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.06em',
+              fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+            }}
+          >
+            Recent work
+          </span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+            <ToggleChip active={groupedByRepo} label="Grouped" onClick={handleToggleGrouped} title="Group by repo" />
+            <ToggleChip active={showArchived} label="Archived" onClick={handleToggleArchived} title="Show archived" />
+          </div>
+        </div>
+
+        <div
+          style={{
+            flex: 1,
+            minHeight: 0,
+            overflowY: 'auto',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 14,
+          }}
+        >
+          {loading && grouped.every((g) => g.lanes.length === 0) ? (
+            <div
+              style={{
+                fontSize: 11,
+                color: 'var(--t-text-muted)',
+                paddingTop: 12,
+                fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+              }}
+            >
+              Loading…
+            </div>
+          ) : grouped.every((g) => g.lanes.length === 0) ? (
+            <div
+              style={{
+                fontSize: 11,
+                color: 'var(--t-text-muted)',
+                paddingTop: 12,
+                lineHeight: 1.55,
+                fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+              }}
+            >
+              No recent work yet. Dispatched packets will appear here grouped by repo.
+            </div>
+          ) : (
+            grouped.map((group) => (
+              <div key={group.repoLabel} style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                <div
+                  style={{
+                    fontSize: 9,
+                    fontWeight: 700,
+                    color: 'var(--t-text-muted)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.06em',
+                    fontFamily: 'var(--font-mono, "SF Mono", Menlo, monospace)',
+                    paddingBottom: 2,
+                  }}
+                >
+                  {group.repoLabel}
+                </div>
+                {group.lanes.map((lane) => (
+                  <RecentLaneRow key={lane.id} lane={lane} onSelect={onSelectPacket} />
+                ))}
+              </div>
+            ))
+          )}
+        </div>
       </div>
     </div>
+  );
+}
+
+function ToggleChip({ active, label, onClick, title }: { active: boolean; label: string; onClick: () => void; title?: string }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-pressed={active}
+      style={{
+        height: 22,
+        paddingTop: 0,
+        paddingRight: 8,
+        paddingBottom: 0,
+        paddingLeft: 8,
+        borderRadius: 6,
+        borderWidth: 1,
+        borderStyle: 'solid',
+        borderColor: active ? 'var(--t-accent-border)' : 'var(--t-border)',
+        background: active ? 'var(--t-accent-soft)' : 'transparent',
+        color: active ? 'var(--t-accent)' : 'var(--t-text-muted)',
+        fontSize: 9,
+        fontWeight: 700,
+        textTransform: 'uppercase',
+        letterSpacing: '0.06em',
+        cursor: 'pointer',
+        fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+        transition: 'background 150ms cubic-bezier(0.22, 1, 0.36, 1), border-color 150ms cubic-bezier(0.22, 1, 0.36, 1), color 150ms cubic-bezier(0.22, 1, 0.36, 1)',
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+interface RecentLaneRowProps {
+  lane: LaneSummary;
+  onSelect?: (packetId: string) => void;
+}
+
+function RecentLaneRow({ lane, onSelect }: RecentLaneRowProps) {
+  const dotKind = statusDotKind(lane.status);
+  const stamp = formatRelativeShort(lane.lastEventAt ?? lane.updatedAt);
+  const handleClick = useCallback(() => {
+    if (lane.packetId && onSelect) onSelect(lane.packetId);
+  }, [lane.packetId, onSelect]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={!lane.packetId || !onSelect}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        paddingTop: 6,
+        paddingRight: 8,
+        paddingBottom: 6,
+        paddingLeft: 8,
+        borderRadius: 8,
+        borderWidth: 0,
+        background: 'transparent',
+        cursor: lane.packetId && onSelect ? 'pointer' : 'default',
+        textAlign: 'left',
+        transition: 'background 120ms cubic-bezier(0.22, 1, 0.36, 1)',
+        fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+      }}
+      onMouseEnter={(e) => {
+        if (!lane.packetId || !onSelect) return;
+        e.currentTarget.style.background = 'var(--t-panel-hover)';
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.background = 'transparent';
+      }}
+    >
+      <StatusDot kind={dotKind} />
+      <span
+        style={{
+          flex: 1,
+          minWidth: 0,
+          fontSize: 11.5,
+          fontWeight: 500,
+          color: 'var(--t-text)',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          letterSpacing: '-0.005em',
+        }}
+      >
+        {lane.label}
+      </span>
+      <span
+        style={{
+          flexShrink: 0,
+          fontSize: 10,
+          color: 'var(--t-text-muted)',
+          fontFamily: 'var(--font-mono, "SF Mono", Menlo, monospace)',
+        }}
+      >
+        {stamp}
+      </span>
+    </button>
   );
 }
 

--- a/src/components/desktop/PacketRightPanel.tsx
+++ b/src/components/desktop/PacketRightPanel.tsx
@@ -1,0 +1,381 @@
+'use client';
+
+/**
+ * PacketRightPanel — packet-mode view of the right-side workspace panel.
+ *
+ * Renders when a packet is expanded in the orchestrator's mission rail
+ * (see `derivePanelMode` in `src/lib/panel/mode.ts`). Three tabs:
+ *
+ *   - SPEC          — re-uses the editable spec.md surface (#773).
+ *   - AGENT OVERVIEW — lane / sub-agent summary for the selected packet.
+ *   - CHANGES        — proxy to the existing right-panel Changes tab so
+ *                      the packet-tab "Changes N" link from #893 has a
+ *                      single render path.
+ *
+ * Style follows the o8 Rams language: paper-and-ink, Plus Jakarta Sans,
+ * Issues-style uppercase tab labels, one orange accent for the active
+ * tab. No native form controls, no hardcoded rgba surfaces.
+ */
+
+import { useMemo, useState } from 'react';
+import type {
+  OrchestratorMissionState,
+  OrchestratorPacket,
+} from '@/lib/orchestrator/types';
+import type { WorkspaceSidePanelRepo } from '@/components/desktop/WorkspaceSidePanel';
+import { PacketSpecEditor } from '@/components/desktop/thoughts/mission-panel/PacketSpecEditor';
+import { ChangesTab } from '@/components/desktop/workspace-side-panel/ChangesTab';
+import { orchestratorRuntimeTone, orchestratorStatusTone } from '@/lib/orchestrator/display';
+
+type TabId = 'spec' | 'agent-overview' | 'changes';
+
+interface PacketRightPanelProps {
+  selectedPacketId: string;
+  missionState: OrchestratorMissionState;
+  workspaceSidePanelRepo: WorkspaceSidePanelRepo | null;
+  onClose: () => void;
+  onOpenFile: (path: string, repo: WorkspaceSidePanelRepo | null) => void;
+}
+
+export function PacketRightPanel({
+  selectedPacketId,
+  missionState,
+  workspaceSidePanelRepo,
+  onClose,
+  onOpenFile,
+}: PacketRightPanelProps) {
+  const packet = useMemo<OrchestratorPacket | null>(
+    () => missionState.packets.find((candidate) => candidate.id === selectedPacketId) ?? null,
+    [missionState.packets, selectedPacketId],
+  );
+  const [activeTab, setActiveTab] = useState<TabId>('spec');
+
+  if (!packet) {
+    return (
+      <div
+        data-chrome-surface="true"
+        style={{
+          flex: 1,
+          minHeight: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'var(--t-text-muted)',
+          fontSize: 12,
+          background: 'transparent',
+          fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+        }}
+      >
+        Packet unavailable.
+      </div>
+    );
+  }
+
+  const statusMeta = orchestratorStatusTone(packet.status);
+  const runtimeMeta = orchestratorRuntimeTone(packet.runtime);
+
+  return (
+    <div
+      data-chrome-surface="true"
+      style={{
+        flex: 1,
+        minHeight: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        background: 'transparent',
+        fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          paddingTop: 10,
+          paddingRight: 12,
+          paddingBottom: 10,
+          paddingLeft: 12,
+          borderBottomWidth: '0.5px',
+          borderBottomStyle: 'solid',
+          borderBottomColor: 'var(--t-divider-subtle)',
+          flexShrink: 0,
+        }}
+      >
+        <span
+          aria-hidden
+          style={{
+            width: 6,
+            height: 6,
+            borderRadius: '50%',
+            background: statusMeta.color,
+            flexShrink: 0,
+          }}
+        />
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div
+            style={{
+              fontSize: 12,
+              fontWeight: 700,
+              color: 'var(--t-text)',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              letterSpacing: '-0.01em',
+            }}
+            title={packet.title}
+          >
+            {packet.title}
+          </div>
+          <div
+            style={{
+              marginTop: 2,
+              fontSize: 11,
+              color: 'var(--t-text-muted)',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {runtimeMeta.label}
+            {packet.referenceLabel ? (
+              <>
+                {' · '}
+                <span style={{ fontFamily: 'var(--font-mono, "SF Mono", Menlo, monospace)' }}>
+                  {packet.referenceLabel}
+                </span>
+              </>
+            ) : null}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          title="Close packet panel"
+          aria-label="Close packet panel"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 26,
+            height: 26,
+            borderRadius: 8,
+            borderWidth: 0,
+            background: 'transparent',
+            color: 'var(--t-text-secondary)',
+            cursor: 'pointer',
+            flexShrink: 0,
+          }}
+        >
+          <svg width={12} height={12} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block' }}>
+            <path d="M18 6 6 18" />
+            <path d="m6 6 12 12" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Tab strip — Issues-style uppercase, one orange accent */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+          paddingTop: 6,
+          paddingRight: 8,
+          paddingBottom: 6,
+          paddingLeft: 8,
+          borderBottomWidth: 1,
+          borderBottomStyle: 'solid',
+          borderBottomColor: 'var(--t-divider-subtle)',
+          flexShrink: 0,
+        }}
+      >
+        <PanelModeTab
+          active={activeTab === 'spec'}
+          label="Spec"
+          onClick={() => setActiveTab('spec')}
+        />
+        <PanelModeTab
+          active={activeTab === 'agent-overview'}
+          label="Agent Overview"
+          onClick={() => setActiveTab('agent-overview')}
+        />
+        <PanelModeTab
+          active={activeTab === 'changes'}
+          label="Changes"
+          onClick={() => setActiveTab('changes')}
+        />
+      </div>
+
+      <div style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
+        {activeTab === 'spec' ? (
+          <div style={{ paddingTop: 6, paddingRight: 6, paddingBottom: 12, paddingLeft: 6 }}>
+            <PacketSpecEditor packetId={packet.id} />
+          </div>
+        ) : null}
+        {activeTab === 'agent-overview' ? (
+          <PacketAgentOverview packet={packet} />
+        ) : null}
+        {activeTab === 'changes' ? (
+          <ChangesTab repo={workspaceSidePanelRepo} onOpenFile={onOpenFile} />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+interface PanelModeTabProps {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}
+
+function PanelModeTab({ active, label, onClick }: PanelModeTabProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      style={{
+        height: 26,
+        paddingTop: 0,
+        paddingRight: 10,
+        paddingBottom: 0,
+        paddingLeft: 10,
+        borderRadius: 8,
+        borderWidth: 0,
+        background: active ? 'var(--t-accent-soft)' : 'transparent',
+        color: active ? 'var(--t-accent)' : 'var(--t-text-muted)',
+        fontSize: 10,
+        fontWeight: 700,
+        textTransform: 'uppercase',
+        letterSpacing: '0.06em',
+        cursor: 'pointer',
+        fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+        transition: 'background 150ms cubic-bezier(0.22, 1, 0.36, 1), color 150ms cubic-bezier(0.22, 1, 0.36, 1)',
+      }}
+      onMouseEnter={(event) => {
+        if (active) return;
+        event.currentTarget.style.color = 'var(--t-text)';
+      }}
+      onMouseLeave={(event) => {
+        if (active) return;
+        event.currentTarget.style.color = 'var(--t-text-muted)';
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+interface PacketAgentOverviewProps {
+  packet: OrchestratorPacket;
+}
+
+function PacketAgentOverview({ packet }: PacketAgentOverviewProps) {
+  const lane = packet.lane;
+  const runtimeMeta = orchestratorRuntimeTone(packet.runtime);
+  const statusMeta = orchestratorStatusTone(packet.status);
+
+  const rows: Array<{ label: string; value: string | null; mono?: boolean }> = [
+    { label: 'Status', value: statusMeta.label },
+    { label: 'Runtime', value: runtimeMeta.label },
+    { label: 'Branch', value: packet.branchTarget || null },
+    { label: 'Repo', value: packet.workspaceTargetPath, mono: true },
+    { label: 'Lane', value: lane?.laneId ? lane.laneId.slice(0, 16) : null, mono: true },
+    { label: 'Session', value: lane?.sessionKey ? lane.sessionKey.slice(0, 16) : null, mono: true },
+  ];
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        paddingTop: 4,
+      }}
+    >
+      {rows.map((row) => (
+        <div
+          key={row.label}
+          style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 12,
+            paddingTop: 8,
+            paddingRight: 14,
+            paddingBottom: 8,
+            paddingLeft: 14,
+            borderBottomWidth: 1,
+            borderBottomStyle: 'solid',
+            borderBottomColor: 'var(--t-divider-subtle)',
+          }}
+        >
+          <span
+            style={{
+              fontSize: 9,
+              fontWeight: 700,
+              color: 'var(--t-text-muted)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.06em',
+              width: 92,
+              flexShrink: 0,
+            }}
+          >
+            {row.label}
+          </span>
+          <span
+            style={{
+              flex: 1,
+              minWidth: 0,
+              fontSize: 11.5,
+              color: row.value ? 'var(--t-text)' : 'var(--t-text-faint)',
+              fontFamily: row.mono ? 'var(--font-mono, "SF Mono", Menlo, monospace)' : undefined,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              wordBreak: 'break-all',
+            }}
+          >
+            {row.value ?? '—'}
+          </span>
+        </div>
+      ))}
+
+      {packet.summary ? (
+        <div
+          style={{
+            paddingTop: 12,
+            paddingRight: 14,
+            paddingBottom: 12,
+            paddingLeft: 14,
+            borderBottomWidth: 1,
+            borderBottomStyle: 'solid',
+            borderBottomColor: 'var(--t-divider-subtle)',
+          }}
+        >
+          <div
+            style={{
+              fontSize: 9,
+              fontWeight: 700,
+              color: 'var(--t-text-muted)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.06em',
+              marginBottom: 6,
+            }}
+          >
+            Summary
+          </div>
+          <div
+            style={{
+              fontSize: 12,
+              color: 'var(--t-text)',
+              lineHeight: 1.55,
+              whiteSpace: 'pre-wrap',
+            }}
+          >
+            {packet.summary}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/desktop/orchestrator-data-context.tsx
+++ b/src/components/desktop/orchestrator-data-context.tsx
@@ -40,6 +40,15 @@ export interface OrchestratorDataValue {
    * the two surfaces independent.
    */
   onAcceptDirectiveProposal?: (draft: { id: string; text: string }) => void;
+  /**
+   * #888/#895 — When the operator expands a packet in the orchestrator's
+   * mission rail, the dashboard's right-side workspace panel pivots from
+   * `idle` (Changes/Files/Git Log) to `packet` (Spec/Agent Overview).
+   * The selection is owned by ThoughtsMissionPanel and surfaced here so
+   * the dashboard can react without prop-drilling through every layer.
+   */
+  selectedPacketId?: string | null;
+  onSelectedPacketChange?: (packetId: string | null) => void;
 }
 
 const OrchestratorDataContext = createContext<OrchestratorDataValue | null>(null);

--- a/src/components/desktop/orchestrator/IntentChips.tsx
+++ b/src/components/desktop/orchestrator/IntentChips.tsx
@@ -1,0 +1,268 @@
+'use client';
+
+/**
+ * IntentChips — repo + branch chips that appear below the composer
+ * once the operator types something into the orchestrator chat (#891).
+ *
+ * Reads:
+ *   - workspaceTargets passed by ThoughtsChatPanel (already loaded
+ *     from the registry).
+ *   - active branch via fetchPacketBranches (existing helper).
+ *
+ * Writes:
+ *   - selected repo localPath + branch into local state. The composer
+ *     is the source of truth for intent text; the chips advise the
+ *     orchestrator about scope, but no API mutation fires until send.
+ *
+ * Style: Issues-style row chips. No native form controls. Theme tokens.
+ * Disappears when input is empty (parent gates this via `visible`).
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { OrchestratorWorkspaceTarget } from '@/lib/orchestrator/types';
+import { BranchPickerPopover } from '@/components/desktop/thoughts/BranchPickerPopover';
+
+interface IntentChipsProps {
+  visible: boolean;
+  workspaceTargets: OrchestratorWorkspaceTarget[];
+  selectedRepoPath: string | null;
+  onSelectRepoPath: (next: string | null) => void;
+  selectedBranch: string;
+  onSelectBranch: (next: string) => void;
+}
+
+export function IntentChips({
+  visible,
+  workspaceTargets,
+  selectedRepoPath,
+  onSelectRepoPath,
+  selectedBranch,
+  onSelectBranch,
+}: IntentChipsProps) {
+  const [repoOpen, setRepoOpen] = useState(false);
+  const [branchOpen, setBranchOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // Close popovers on outside click.
+  useEffect(() => {
+    if (!repoOpen && !branchOpen) return;
+    const onPointer = (event: PointerEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      if (containerRef.current && !containerRef.current.contains(target)) {
+        setRepoOpen(false);
+        setBranchOpen(false);
+      }
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setRepoOpen(false);
+        setBranchOpen(false);
+      }
+    };
+    document.addEventListener('pointerdown', onPointer);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('pointerdown', onPointer);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [repoOpen, branchOpen]);
+
+  const repoLabel = useMemo(() => {
+    const target = workspaceTargets.find((t) => t.localPath === selectedRepoPath);
+    return target?.label ?? target?.repoName ?? (selectedRepoPath ? selectedRepoPath.split('/').pop() ?? selectedRepoPath : null);
+  }, [selectedRepoPath, workspaceTargets]);
+
+  const handleSelectRepo = useCallback((path: string) => {
+    onSelectRepoPath(path);
+    setRepoOpen(false);
+  }, [onSelectRepoPath]);
+
+  const handleSelectBranch = useCallback((branchName: string) => {
+    onSelectBranch(branchName);
+    setBranchOpen(false);
+  }, [onSelectBranch]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+        gap: 6,
+        paddingTop: 6,
+        paddingRight: 14,
+        paddingBottom: 6,
+        paddingLeft: 14,
+        fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+        position: 'relative',
+      }}
+    >
+      <span
+        style={{
+          fontSize: 10,
+          fontWeight: 500,
+          color: 'var(--t-text-muted)',
+          letterSpacing: '-0.005em',
+        }}
+      >
+        Work on
+      </span>
+      <ChipButton
+        active={repoOpen}
+        onClick={() => { setRepoOpen((v) => !v); setBranchOpen(false); }}
+        muted={!selectedRepoPath}
+      >
+        {repoLabel ?? 'choose repo'}
+      </ChipButton>
+      <span
+        style={{
+          fontSize: 10,
+          fontWeight: 500,
+          color: 'var(--t-text-muted)',
+          letterSpacing: '-0.005em',
+        }}
+      >
+        off
+      </span>
+      <ChipButton
+        active={branchOpen}
+        onClick={() => { setBranchOpen((v) => !v); setRepoOpen(false); }}
+        muted={!selectedBranch}
+      >
+        {selectedBranch || 'main'}
+      </ChipButton>
+
+      {/* Repo popover — Issues-style row list, NOT native select. */}
+      {repoOpen ? (
+        <div
+          style={{
+            position: 'absolute',
+            top: 32,
+            left: 56,
+            zIndex: 30,
+            minWidth: 220,
+            maxWidth: 320,
+            maxHeight: 240,
+            overflowY: 'auto',
+            borderRadius: 8,
+            borderWidth: 1,
+            borderStyle: 'solid',
+            borderColor: 'var(--t-divider-subtle)',
+            background: 'var(--t-panel-solid)',
+            boxShadow: '0 8px 24px rgba(0, 0, 0, 0.18)',
+          }}
+        >
+          {workspaceTargets.length === 0 ? (
+            <div style={{ paddingTop: 8, paddingRight: 10, paddingBottom: 8, paddingLeft: 10, fontSize: 11, color: 'var(--t-text-muted)' }}>
+              No repos in registry. Add one from the workspace settings.
+            </div>
+          ) : (
+            workspaceTargets.map((target) => {
+              const isSelected = target.localPath === selectedRepoPath;
+              return (
+                <button
+                  key={target.id}
+                  type="button"
+                  onClick={() => handleSelectRepo(target.localPath)}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    width: '100%',
+                    paddingTop: 7,
+                    paddingRight: 10,
+                    paddingBottom: 7,
+                    paddingLeft: 10,
+                    borderWidth: 0,
+                    background: isSelected ? 'var(--t-accent-soft)' : 'transparent',
+                    color: isSelected ? 'var(--t-accent)' : 'var(--t-text)',
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+                  }}
+                  onMouseEnter={(e) => { if (!isSelected) e.currentTarget.style.background = 'var(--t-divider-subtle)'; }}
+                  onMouseLeave={(e) => { if (!isSelected) e.currentTarget.style.background = 'transparent'; }}
+                >
+                  <span style={{ fontSize: 11.5, fontWeight: 600, letterSpacing: '-0.005em' }}>{target.label}</span>
+                  <span
+                    style={{
+                      fontSize: 10,
+                      color: 'var(--t-text-muted)',
+                      fontFamily: 'var(--font-mono, "SF Mono", Menlo, monospace)',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {target.localPath}
+                  </span>
+                </button>
+              );
+            })
+          )}
+        </div>
+      ) : null}
+
+      {branchOpen ? (
+        <BranchPickerPopover
+          open
+          workspaceTargetPath={selectedRepoPath}
+          selectedBranch={selectedBranch}
+          onSelect={handleSelectBranch}
+          onClose={() => setBranchOpen(false)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+interface ChipButtonProps {
+  active: boolean;
+  onClick: () => void;
+  muted?: boolean;
+  children: React.ReactNode;
+}
+
+function ChipButton({ active, onClick, muted, children }: ChipButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-expanded={active}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 4,
+        height: 22,
+        paddingTop: 0,
+        paddingRight: 8,
+        paddingBottom: 0,
+        paddingLeft: 8,
+        borderRadius: 6,
+        borderWidth: 1,
+        borderStyle: 'solid',
+        borderColor: active ? 'var(--t-accent-border)' : 'var(--t-border)',
+        background: active ? 'var(--t-accent-soft)' : 'var(--t-bg-card)',
+        color: muted ? 'var(--t-text-faint)' : (active ? 'var(--t-accent)' : 'var(--t-text)'),
+        cursor: 'pointer',
+        fontFamily: 'var(--font-mono, "SF Mono", Menlo, monospace)',
+        fontSize: 10.5,
+        fontWeight: 600,
+        letterSpacing: 0,
+        transition: 'background 150ms cubic-bezier(0.22, 1, 0.36, 1), border-color 150ms cubic-bezier(0.22, 1, 0.36, 1)',
+        maxWidth: 160,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {children}
+      <svg width={9} height={9} viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden style={{ flexShrink: 0, opacity: 0.7 }}>
+        <path d="M2.5 3.5L5 6L7.5 3.5" />
+      </svg>
+    </button>
+  );
+}

--- a/src/components/desktop/orchestrator/LivingAgentPanel.tsx
+++ b/src/components/desktop/orchestrator/LivingAgentPanel.tsx
@@ -74,12 +74,8 @@ function LivingAgentPanelBase({ packet, toolCalls = [] }: LivingAgentPanelProps)
   const [, setRenderTick] = useState(0);
   const lastRenderRef = useRef<number>(0);
   const [subAgents, setSubAgents] = useState<SubAgentRow[]>([]);
-  const reducedMotionRef = useRef(false);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    reducedMotionRef.current = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
-  }, []);
+  // The motion of this panel is delegated to its children (ToolCallChip).
+  // The chips handle prefers-reduced-motion themselves.
 
   // Throttle: never re-render this surface more than once per 100ms even
   // if events arrive in a burst. We schedule a trailing tick so the last

--- a/src/components/desktop/orchestrator/LivingAgentPanel.tsx
+++ b/src/components/desktop/orchestrator/LivingAgentPanel.tsx
@@ -1,0 +1,357 @@
+'use client';
+
+/**
+ * LivingAgentPanel — the calm, state-streaming "Coordinator" surface
+ * that lives on the left side of an active packet view (#888/#890).
+ *
+ * Renders three sections, top to bottom:
+ *
+ *   1. ACTIVITY      — Coordinator tool-call chips streaming in as
+ *                      they happen. Compact one-line chips, calm
+ *                      slide-in (100ms fade), no bounce.
+ *   2. SUB-AGENTS    — "N / M background agents running". Each
+ *                      sub-agent renders as one row. Spawn/complete
+ *                      events update the count without layout shift
+ *                      (we reserve a min-height for the section).
+ *   3. VERIFIER      — Yellow Issues-style row when verifier flagged
+ *                      anything for the active packet.
+ *
+ * Subscribes to the existing window-level events that the
+ * orchestrator stream socket already publishes:
+ *   - `cortex:agent-supervisor-update` (sub-agent lifecycle)
+ *
+ * Tool-call events come through the orchestrator chat panel's
+ * messages array — to avoid re-plumbing WS subscriptions, the parent
+ * passes the latest tool calls as a prop. The throttle is at 100ms.
+ *
+ * Hard founder constraint (issue body):
+ *   "State changes should feel like turning a page, not a Slack
+ *    notification. One orange accent max per update. No sound. No
+ *    bounce. No avatar jiggle."
+ */
+
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import { ToolCallChip, classifyToolCall, type ToolCallChipStatus } from './ToolCallChip';
+
+const RENDER_THROTTLE_MS = 100;
+const MAX_TOOL_CALLS_VISIBLE = 8;
+
+export interface LivingToolCall {
+  id: string;
+  name: string;
+  status: ToolCallChipStatus;
+  argument?: string | null;
+  /** Epoch ms when this tool call was first seen — used for slide-in ordering. */
+  observedAt: number;
+}
+
+interface SupervisorUpdate {
+  surfaceId: string;
+  name?: string;
+  status?: string;
+  detail?: string;
+  duration?: number;
+  repoPath?: string;
+  prompt?: string;
+}
+
+interface SubAgentRow {
+  id: string;
+  label: string;
+  status: 'running' | 'completed' | 'idle';
+  detail?: string | null;
+  updatedAt: number;
+}
+
+export interface LivingAgentPanelProps {
+  packet: OrchestratorPacket;
+  /** Latest Coordinator tool calls, scoped to this packet's session. */
+  toolCalls?: LivingToolCall[];
+}
+
+function LivingAgentPanelBase({ packet, toolCalls = [] }: LivingAgentPanelProps) {
+  const [, setRenderTick] = useState(0);
+  const lastRenderRef = useRef<number>(0);
+  const [subAgents, setSubAgents] = useState<SubAgentRow[]>([]);
+  const reducedMotionRef = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    reducedMotionRef.current = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+  }, []);
+
+  // Throttle: never re-render this surface more than once per 100ms even
+  // if events arrive in a burst. We schedule a trailing tick so the last
+  // event in a burst is reflected.
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<SupervisorUpdate>).detail;
+      if (!detail?.surfaceId) return;
+
+      // Only count sub-agents that share this packet's lane scope. The
+      // supervisor channel doesn't yet carry packet IDs directly, so we
+      // accept all updates whose repoPath matches the packet's repo. If
+      // the packet has no repo bound (rare), fall back to all updates.
+      const matchesRepo = !packet.workspaceTargetPath
+        || !detail.repoPath
+        || detail.repoPath === packet.workspaceTargetPath;
+      if (!matchesRepo) return;
+
+      setSubAgents((current) => {
+        const idx = current.findIndex((row) => row.id === detail.surfaceId);
+        const next = current.slice();
+        const status: SubAgentRow['status'] = detail.status === 'running'
+          ? 'running'
+          : detail.status === 'completed' || detail.status === 'finished'
+            ? 'completed'
+            : 'idle';
+        const row: SubAgentRow = {
+          id: detail.surfaceId,
+          label: detail.name ?? detail.surfaceId,
+          status,
+          detail: detail.detail ?? null,
+          updatedAt: Date.now(),
+        };
+        if (idx >= 0) next[idx] = row; else next.push(row);
+        return next.slice(-12);
+      });
+
+      const now = Date.now();
+      const sinceLast = now - lastRenderRef.current;
+      if (sinceLast >= RENDER_THROTTLE_MS) {
+        lastRenderRef.current = now;
+        setRenderTick((t) => t + 1);
+      } else {
+        const delay = RENDER_THROTTLE_MS - sinceLast;
+        window.setTimeout(() => {
+          lastRenderRef.current = Date.now();
+          setRenderTick((t) => t + 1);
+        }, delay);
+      }
+    };
+
+    window.addEventListener('cortex:agent-supervisor-update', handler);
+    return () => window.removeEventListener('cortex:agent-supervisor-update', handler);
+  }, [packet.workspaceTargetPath]);
+
+  const visibleToolCalls = useMemo(
+    () => toolCalls.slice(-MAX_TOOL_CALLS_VISIBLE),
+    [toolCalls],
+  );
+
+  const runningSubAgents = useMemo(() => subAgents.filter((row) => row.status === 'running'), [subAgents]);
+  const totalSubAgents = subAgents.length;
+
+  const verifierFinding = packet.review?.findings?.[0] ?? null;
+
+  return (
+    <div
+      data-living-agent-panel
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 14,
+        paddingTop: 12,
+        paddingRight: 12,
+        paddingBottom: 12,
+        paddingLeft: 12,
+        fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+      }}
+    >
+      {/* Activity */}
+      <SectionFrame label="Activity">
+        {visibleToolCalls.length === 0 ? (
+          <EmptyHint>Coordinator is quiet. Tool calls will stream in here as they happen.</EmptyHint>
+        ) : (
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 4,
+              minHeight: 30,
+            }}
+          >
+            {visibleToolCalls.map((tc) => {
+              const cls = classifyToolCall(tc.name);
+              return (
+                <ToolCallChip
+                  key={tc.id}
+                  verb={cls.verb}
+                  kind={cls.kind}
+                  argument={tc.argument ?? undefined}
+                  status={tc.status}
+                />
+              );
+            })}
+          </div>
+        )}
+      </SectionFrame>
+
+      {/* Sub-agents — reserve min-height so the count update never shifts layout. */}
+      <SectionFrame
+        label={
+          <>
+            Background agents
+            {totalSubAgents > 0 ? (
+              <>
+                {' '}
+                <span style={{ color: 'var(--t-text-muted)', fontWeight: 500 }}>
+                  {runningSubAgents.length} / {totalSubAgents} running
+                </span>
+              </>
+            ) : null}
+          </>
+        }
+      >
+        <div style={{ minHeight: 28, display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {totalSubAgents === 0 ? (
+            <EmptyHint>No sub-agents spawned for this packet yet.</EmptyHint>
+          ) : (
+            subAgents.map((row) => <SubAgentRowView key={row.id} row={row} />)
+          )}
+        </div>
+      </SectionFrame>
+
+      {/* Verifier (yellow Issues row) */}
+      {verifierFinding ? (
+        <SectionFrame label="Verifier flagged">
+          <div
+            role="alert"
+            style={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              gap: 8,
+              paddingTop: 6,
+              paddingRight: 10,
+              paddingBottom: 6,
+              paddingLeft: 10,
+              borderRadius: 8,
+              borderLeftWidth: 0,
+              borderWidth: 1,
+              borderStyle: 'solid',
+              borderColor: 'rgba(245, 158, 11, 0.32)',
+              background: 'rgba(245, 158, 11, 0.08)',
+              color: 'var(--t-text)',
+              fontSize: 11,
+              fontWeight: 500,
+              lineHeight: 1.5,
+            }}
+          >
+            <svg width={11} height={11} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.1" strokeLinecap="round" strokeLinejoin="round" aria-hidden style={{ flexShrink: 0, marginTop: 2 }}>
+              <path d="M12 9v4" />
+              <path d="M12 17h.01" />
+              <path d="M21.73 18 13.73 4a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3z" />
+            </svg>
+            <span style={{ minWidth: 0 }}>{verifierFinding.description ?? 'Verifier flagged this packet.'}</span>
+          </div>
+        </SectionFrame>
+      ) : null}
+    </div>
+  );
+}
+
+interface SectionFrameProps {
+  label: React.ReactNode;
+  children: React.ReactNode;
+}
+
+function SectionFrame({ label, children }: SectionFrameProps) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      <div
+        style={{
+          fontSize: 9,
+          fontWeight: 700,
+          color: 'var(--t-text-muted)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+        }}
+      >
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function EmptyHint({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        fontSize: 10.5,
+        color: 'var(--t-text-muted)',
+        lineHeight: 1.55,
+        paddingTop: 2,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function SubAgentRowView({ row }: { row: SubAgentRow }) {
+  const dotColor = row.status === 'running'
+    ? '#FF5A1F'
+    : row.status === 'completed'
+      ? 'var(--t-text-faint, #94a3b8)'
+      : 'var(--t-text-faint, #94a3b8)';
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        paddingTop: 4,
+        paddingRight: 6,
+        paddingBottom: 4,
+        paddingLeft: 6,
+        borderRadius: 6,
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: '50%',
+          background: dotColor,
+          flexShrink: 0,
+        }}
+      />
+      <span
+        style={{
+          flex: 1,
+          minWidth: 0,
+          fontSize: 11,
+          fontWeight: 500,
+          color: 'var(--t-text)',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {row.label}
+      </span>
+      {row.detail ? (
+        <span
+          style={{
+            flexShrink: 0,
+            fontSize: 10,
+            color: 'var(--t-text-muted)',
+            fontFamily: 'var(--font-mono, "SF Mono", Menlo, monospace)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            maxWidth: 80,
+          }}
+        >
+          {row.detail}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+export const LivingAgentPanel = memo(LivingAgentPanelBase);

--- a/src/components/desktop/orchestrator/ModePicker.tsx
+++ b/src/components/desktop/orchestrator/ModePicker.tsx
@@ -1,0 +1,281 @@
+'use client';
+
+/**
+ * ModePicker — renders below IntentChips when the composer has text.
+ *
+ * Two side-by-side mode cards (#888/#892):
+ *   - LEFT  — "Fleet orchestration" — Claude orchestrates Codex +
+ *             Gemini + opencode in parallel waves. Tagged "using Claude
+ *             Opus 4.7".
+ *   - RIGHT — "Single runtime" — collapsible runtime sub-picker
+ *             (Codex / Gemini / opencode / Claude Code). Dispatches one
+ *             agent without orchestration overhead.
+ *
+ * Selected card has a subtle orange border (one orange accent rule).
+ * Default = Fleet on first dispatch, last-used after that. Persisted
+ * per-workspace via localStorage `cortex-ide:orchestrator:mode:<key>`.
+ *
+ * No native form controls. Inline styles + theme tokens. Reduced-motion
+ * is honored — no card mount animation when set.
+ */
+
+import { memo, useCallback, useEffect, useState } from 'react';
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+
+export type OrchestrationMode = 'fleet' | 'single';
+
+interface ModePickerProps {
+  visible: boolean;
+  workspaceKey: string;
+  selectedMode: OrchestrationMode;
+  onSelectMode: (mode: OrchestrationMode) => void;
+  selectedSingleRuntime: OrchestratorRuntime;
+  onSelectSingleRuntime: (runtime: OrchestratorRuntime) => void;
+}
+
+const SINGLE_RUNTIMES: Array<{ id: OrchestratorRuntime; label: string }> = [
+  { id: 'codex', label: 'Codex' },
+  { id: 'gemini', label: 'Gemini' },
+  { id: 'opencode', label: 'opencode' },
+  { id: 'claude-code', label: 'Claude Code' },
+];
+
+function ModePickerBase({
+  visible,
+  workspaceKey,
+  selectedMode,
+  onSelectMode,
+  selectedSingleRuntime,
+  onSelectSingleRuntime,
+}: ModePickerProps) {
+  void workspaceKey; // persistence wired by parent
+  const [singleOpen, setSingleOpen] = useState(false);
+
+  useEffect(() => {
+    if (selectedMode !== 'single') setSingleOpen(false);
+  }, [selectedMode]);
+
+  const handleClickFleet = useCallback(() => {
+    onSelectMode('fleet');
+  }, [onSelectMode]);
+
+  const handleClickSingle = useCallback(() => {
+    onSelectMode('single');
+    setSingleOpen(true);
+  }, [onSelectMode]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr',
+        gap: 8,
+        paddingTop: 4,
+        paddingRight: 14,
+        paddingBottom: 8,
+        paddingLeft: 14,
+        fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+      }}
+    >
+      <ModeCard
+        active={selectedMode === 'fleet'}
+        title="Fleet orchestration"
+        copy="Claude orchestrates Codex + Gemini + opencode in parallel waves."
+        tag="using Claude Opus 4.7"
+        onClick={handleClickFleet}
+        glyph={<FleetGlyph />}
+      />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <ModeCard
+          active={selectedMode === 'single'}
+          title="Single runtime"
+          copy="Dispatches one agent without orchestration overhead."
+          tag={`using ${SINGLE_RUNTIMES.find((r) => r.id === selectedSingleRuntime)?.label ?? selectedSingleRuntime}`}
+          onClick={handleClickSingle}
+          glyph={<SingleGlyph />}
+        />
+        {selectedMode === 'single' && singleOpen ? (
+          <div
+            style={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: 4,
+              paddingTop: 4,
+              paddingRight: 4,
+              paddingBottom: 4,
+              paddingLeft: 4,
+            }}
+          >
+            {SINGLE_RUNTIMES.map((runtime) => {
+              const selected = runtime.id === selectedSingleRuntime;
+              return (
+                <button
+                  key={runtime.id}
+                  type="button"
+                  onClick={() => onSelectSingleRuntime(runtime.id)}
+                  aria-pressed={selected}
+                  style={{
+                    height: 22,
+                    paddingTop: 0,
+                    paddingRight: 8,
+                    paddingBottom: 0,
+                    paddingLeft: 8,
+                    borderRadius: 6,
+                    borderWidth: 1,
+                    borderStyle: 'solid',
+                    borderColor: selected ? 'var(--t-accent-border)' : 'var(--t-border)',
+                    background: selected ? 'var(--t-accent-soft)' : 'transparent',
+                    color: selected ? 'var(--t-accent)' : 'var(--t-text-muted)',
+                    fontSize: 9,
+                    fontWeight: 700,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.06em',
+                    cursor: 'pointer',
+                    fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+                  }}
+                >
+                  {runtime.label}
+                </button>
+              );
+            })}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+interface ModeCardProps {
+  active: boolean;
+  title: string;
+  copy: string;
+  tag: string;
+  onClick: () => void;
+  glyph: React.ReactNode;
+}
+
+function ModeCard({ active, title, copy, tag, onClick, glyph }: ModeCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        gap: 6,
+        paddingTop: 10,
+        paddingRight: 12,
+        paddingBottom: 10,
+        paddingLeft: 12,
+        borderRadius: 10,
+        borderWidth: 1,
+        borderStyle: 'solid',
+        borderColor: active ? '#FF5A1F' : 'var(--t-divider-subtle)',
+        background: active ? 'var(--t-accent-soft)' : 'var(--t-bg-card)',
+        color: 'var(--t-text)',
+        cursor: 'pointer',
+        textAlign: 'left',
+        fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+        transition: 'border-color 150ms cubic-bezier(0.22, 1, 0.36, 1), background 150ms cubic-bezier(0.22, 1, 0.36, 1)',
+      }}
+      onMouseEnter={(event) => {
+        if (active) return;
+        event.currentTarget.style.borderColor = 'var(--t-border)';
+      }}
+      onMouseLeave={(event) => {
+        if (active) return;
+        event.currentTarget.style.borderColor = 'var(--t-divider-subtle)';
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span aria-hidden style={{ display: 'inline-flex', alignItems: 'center', color: active ? '#FF5A1F' : 'var(--t-text-muted)' }}>
+          {glyph}
+        </span>
+        <span
+          style={{
+            fontSize: 11.5,
+            fontWeight: 700,
+            color: 'var(--t-text)',
+            letterSpacing: '-0.005em',
+          }}
+        >
+          {title}
+        </span>
+      </div>
+      <span
+        style={{
+          fontSize: 10.5,
+          color: 'var(--t-text-muted)',
+          lineHeight: 1.45,
+        }}
+      >
+        {copy}
+      </span>
+      <span
+        style={{
+          fontSize: 9,
+          fontWeight: 700,
+          color: 'var(--t-text-muted)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+          fontFamily: 'var(--font-mono, "SF Mono", Menlo, monospace)',
+        }}
+      >
+        {tag}
+      </span>
+    </button>
+  );
+}
+
+function FleetGlyph() {
+  return (
+    <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.1" strokeLinecap="round" strokeLinejoin="round" aria-hidden style={{ display: 'block' }}>
+      <circle cx="12" cy="6" r="2" />
+      <circle cx="6" cy="18" r="2" />
+      <circle cx="18" cy="18" r="2" />
+      <path d="M12 8v4" />
+      <path d="m12 12-6 4" />
+      <path d="m12 12 6 4" />
+    </svg>
+  );
+}
+
+function SingleGlyph() {
+  return (
+    <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.1" strokeLinecap="round" strokeLinejoin="round" aria-hidden style={{ display: 'block' }}>
+      <circle cx="12" cy="12" r="3" />
+      <circle cx="12" cy="12" r="9" />
+    </svg>
+  );
+}
+
+export const ModePicker = memo(ModePickerBase);
+
+export function loadOrchestrationMode(workspaceKey: string): { mode: OrchestrationMode; runtime: OrchestratorRuntime } {
+  if (typeof window === 'undefined') return { mode: 'fleet', runtime: 'codex' };
+  try {
+    const raw = window.localStorage.getItem(`cortex-ide:orchestrator:mode:${workspaceKey}`);
+    if (!raw) return { mode: 'fleet', runtime: 'codex' };
+    const parsed = JSON.parse(raw) as { mode?: string; runtime?: string };
+    const mode: OrchestrationMode = parsed.mode === 'single' ? 'single' : 'fleet';
+    const runtime: OrchestratorRuntime = parsed.runtime === 'gemini' || parsed.runtime === 'opencode' || parsed.runtime === 'claude-code' || parsed.runtime === 'codex'
+      ? parsed.runtime
+      : 'codex';
+    return { mode, runtime };
+  } catch {
+    return { mode: 'fleet', runtime: 'codex' };
+  }
+}
+
+export function persistOrchestrationMode(workspaceKey: string, mode: OrchestrationMode, runtime: OrchestratorRuntime): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(`cortex-ide:orchestrator:mode:${workspaceKey}`, JSON.stringify({ mode, runtime }));
+  } catch {
+    // ignore
+  }
+}

--- a/src/components/desktop/orchestrator/ModePicker.tsx
+++ b/src/components/desktop/orchestrator/ModePicker.tsx
@@ -19,7 +19,7 @@
  * is honored — no card mount animation when set.
  */
 
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
 
 export type OrchestrationMode = 'fleet' | 'single';
@@ -49,11 +49,12 @@ function ModePickerBase({
   onSelectSingleRuntime,
 }: ModePickerProps) {
   void workspaceKey; // persistence wired by parent
+  // Whether the runtime sub-picker drawer is open. We derive openness
+  // from selectedMode + an explicit user toggle in the same setter so we
+  // never have to "sync" two states inside an effect (per react-hooks/
+  // set-state-in-effect lint rule).
   const [singleOpen, setSingleOpen] = useState(false);
-
-  useEffect(() => {
-    if (selectedMode !== 'single') setSingleOpen(false);
-  }, [selectedMode]);
+  const effectiveSingleOpen = selectedMode === 'single' && singleOpen;
 
   const handleClickFleet = useCallback(() => {
     onSelectMode('fleet');
@@ -96,7 +97,7 @@ function ModePickerBase({
           onClick={handleClickSingle}
           glyph={<SingleGlyph />}
         />
-        {selectedMode === 'single' && singleOpen ? (
+        {effectiveSingleOpen ? (
           <div
             style={{
               display: 'flex',

--- a/src/components/desktop/orchestrator/PacketTabStrip.tsx
+++ b/src/components/desktop/orchestrator/PacketTabStrip.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+/**
+ * PacketTabStrip — horizontal tab strip rendered at the top of an
+ * expanded packet card (#888/#893). Four tabs:
+ *
+ *   Agents •  / Context / Changes N / Files
+ *
+ *   - Notification dot (•) on Agents when verifier flagged or a
+ *     sub-agent finished and awaits review.
+ *   - Count badge on Changes = files modified.
+ *   - Issues-style aesthetic: uppercase, no shadow, one orange accent
+ *     for the active tab.
+ *
+ * No native form controls, no CSS classes. Inline styles + theme tokens.
+ */
+
+import { memo } from 'react';
+
+export type PacketTabId = 'agents' | 'context' | 'changes' | 'files';
+
+interface PacketTabStripProps {
+  active: PacketTabId;
+  onChange: (tab: PacketTabId) => void;
+  agentsHasNotification?: boolean;
+  changesCount?: number | null;
+}
+
+function PacketTabStripBase({ active, onChange, agentsHasNotification, changesCount }: PacketTabStripProps) {
+  return (
+    <div
+      role="tablist"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 2,
+        paddingTop: 5,
+        paddingRight: 8,
+        paddingBottom: 5,
+        paddingLeft: 8,
+        borderTopWidth: 1,
+        borderTopStyle: 'solid',
+        borderTopColor: 'var(--t-divider-subtle)',
+        borderBottomWidth: 1,
+        borderBottomStyle: 'solid',
+        borderBottomColor: 'var(--t-divider-subtle)',
+        background: 'var(--t-panel-hover)',
+      }}
+    >
+      <PacketTab
+        id="agents"
+        active={active === 'agents'}
+        label="Agents"
+        notification={agentsHasNotification}
+        onClick={() => onChange('agents')}
+      />
+      <PacketTab
+        id="context"
+        active={active === 'context'}
+        label="Context"
+        onClick={() => onChange('context')}
+      />
+      <PacketTab
+        id="changes"
+        active={active === 'changes'}
+        label="Changes"
+        countBadge={typeof changesCount === 'number' && changesCount > 0 ? changesCount : null}
+        onClick={() => onChange('changes')}
+      />
+      <PacketTab
+        id="files"
+        active={active === 'files'}
+        label="Files"
+        onClick={() => onChange('files')}
+      />
+    </div>
+  );
+}
+
+interface PacketTabProps {
+  id: PacketTabId;
+  active: boolean;
+  label: string;
+  onClick: () => void;
+  notification?: boolean;
+  countBadge?: number | null;
+}
+
+function PacketTab({ active, label, onClick, notification, countBadge }: PacketTabProps) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 5,
+        height: 22,
+        paddingTop: 0,
+        paddingRight: 9,
+        paddingBottom: 0,
+        paddingLeft: 9,
+        borderRadius: 6,
+        borderWidth: 0,
+        background: active ? 'var(--t-accent-soft)' : 'transparent',
+        color: active ? 'var(--t-accent)' : 'var(--t-text-muted)',
+        cursor: 'pointer',
+        fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+        fontSize: 9,
+        fontWeight: 700,
+        textTransform: 'uppercase',
+        letterSpacing: '0.06em',
+        transition: 'background 150ms cubic-bezier(0.22, 1, 0.36, 1), color 150ms cubic-bezier(0.22, 1, 0.36, 1)',
+      }}
+      onMouseEnter={(event) => {
+        if (active) return;
+        event.currentTarget.style.color = 'var(--t-text)';
+      }}
+      onMouseLeave={(event) => {
+        if (active) return;
+        event.currentTarget.style.color = 'var(--t-text-muted)';
+      }}
+    >
+      <span>{label}</span>
+      {notification ? (
+        <span
+          aria-hidden
+          style={{
+            display: 'inline-block',
+            width: 5,
+            height: 5,
+            borderRadius: '50%',
+            background: '#FF5A1F',
+            flexShrink: 0,
+          }}
+        />
+      ) : null}
+      {countBadge != null ? (
+        <span
+          aria-hidden
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minWidth: 16,
+            height: 14,
+            paddingTop: 0,
+            paddingRight: 4,
+            paddingBottom: 0,
+            paddingLeft: 4,
+            borderRadius: 7,
+            background: active ? 'var(--t-accent)' : 'var(--t-divider-subtle)',
+            color: active ? '#ffffff' : 'var(--t-text-muted)',
+            fontSize: 9,
+            fontWeight: 700,
+            letterSpacing: 0,
+            fontFamily: 'var(--font-mono, "SF Mono", Menlo, monospace)',
+          }}
+        >
+          {countBadge}
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+export const PacketTabStrip = memo(PacketTabStripBase);

--- a/src/components/desktop/orchestrator/ToolCallChip.tsx
+++ b/src/components/desktop/orchestrator/ToolCallChip.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+/**
+ * ToolCallChip — a one-line, compact representation of an in-flight or
+ * completed Coordinator tool call. Used by both LivingAgentPanel
+ * (#890) and the inline-chat tool-call cluster (#894).
+ *
+ * Rules:
+ *  - Slide-in with a 100ms fade only — no bounce, no scale.
+ *  - prefers-reduced-motion: skip animation.
+ *  - Pure inline styles. No CSS classes. Theme tokens for surfaces.
+ *  - One orange accent per "running" chip — done chips are ink-on-paper.
+ *  - No emoji — raw inline SVG glyphs only.
+ */
+
+import { memo, useEffect, useRef, useState } from 'react';
+
+export type ToolCallChipStatus = 'running' | 'done' | 'error';
+
+export interface ToolCallChipProps {
+  /** Verb shown left of the colon (e.g. "Read", "Delegate", "Write"). */
+  verb: string;
+  /** Argument shown right of the colon, truncated by caller if long. */
+  argument?: string | null;
+  /** Optional kind for icon selection ('read' | 'write' | 'delegate' | 'spec'). */
+  kind?: 'read' | 'write' | 'delegate' | 'spec' | 'shell' | 'generic';
+  status?: ToolCallChipStatus;
+  /** Optional click handler for an expansion popover (#894). */
+  onClick?: () => void;
+}
+
+function ToolCallChipBase({ verb, argument, kind = 'generic', status = 'done', onClick }: ToolCallChipProps) {
+  const [mounted, setMounted] = useState(false);
+  const reducedMotionRef = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    reducedMotionRef.current = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+    if (reducedMotionRef.current) {
+      setMounted(true);
+      return;
+    }
+    const t = window.setTimeout(() => setMounted(true), 0);
+    return () => window.clearTimeout(t);
+  }, []);
+
+  const accent = status === 'running' ? '#FF5A1F' : status === 'error' ? 'var(--t-brand-red, #ef4444)' : 'var(--t-text-muted)';
+  const textColor = status === 'running' ? 'var(--t-text)' : 'var(--t-text-secondary)';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={!onClick}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        height: 22,
+        paddingTop: 0,
+        paddingRight: 8,
+        paddingBottom: 0,
+        paddingLeft: 8,
+        borderRadius: 6,
+        borderWidth: 1,
+        borderStyle: 'solid',
+        borderColor: 'var(--t-divider-subtle)',
+        background: 'var(--t-bg-card)',
+        color: textColor,
+        cursor: onClick ? 'pointer' : 'default',
+        fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+        fontSize: 10.5,
+        fontWeight: 500,
+        letterSpacing: '-0.005em',
+        opacity: mounted ? 1 : 0,
+        transform: mounted ? 'translateX(0)' : 'translateX(-4px)',
+        transition: reducedMotionRef.current
+          ? 'none'
+          : 'opacity 100ms cubic-bezier(0.22, 1, 0.36, 1), transform 100ms cubic-bezier(0.22, 1, 0.36, 1)',
+        maxWidth: '100%',
+      }}
+    >
+      <ToolCallGlyph kind={kind} accent={accent} />
+      <span
+        style={{
+          fontWeight: 600,
+          color: status === 'running' ? accent : 'var(--t-text-muted)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.05em',
+          fontSize: 9,
+          flexShrink: 0,
+        }}
+      >
+        {verb}
+      </span>
+      {argument ? (
+        <span
+          style={{
+            flex: 1,
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            fontFamily: 'var(--font-mono, "SF Mono", Menlo, monospace)',
+            fontSize: 10,
+            color: 'var(--t-text-secondary)',
+          }}
+        >
+          {argument}
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+function ToolCallGlyph({ kind, accent }: { kind: ToolCallChipProps['kind']; accent: string }) {
+  const stroke = accent;
+  const common = {
+    width: 11,
+    height: 11,
+    viewBox: '0 0 24 24',
+    fill: 'none',
+    stroke,
+    strokeWidth: 2,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+    'aria-hidden': true,
+    style: { flexShrink: 0, display: 'block' as const },
+  };
+  switch (kind) {
+    case 'read':
+      return (
+        <svg {...common}>
+          <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
+          <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+        </svg>
+      );
+    case 'write':
+      return (
+        <svg {...common}>
+          <path d="M12 20h9" />
+          <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4z" />
+        </svg>
+      );
+    case 'delegate':
+      return (
+        <svg {...common}>
+          <path d="M5 12h14" />
+          <path d="m13 6 6 6-6 6" />
+        </svg>
+      );
+    case 'spec':
+      return (
+        <svg {...common}>
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <path d="M14 2v6h6" />
+          <path d="M9 13h6" />
+          <path d="M9 17h6" />
+        </svg>
+      );
+    case 'shell':
+      return (
+        <svg {...common}>
+          <path d="m4 17 6-6-6-6" />
+          <path d="M12 19h8" />
+        </svg>
+      );
+    default:
+      return (
+        <svg {...common}>
+          <circle cx="12" cy="12" r="9" />
+          <path d="M12 7v5l3 2" />
+        </svg>
+      );
+  }
+}
+
+export const ToolCallChip = memo(ToolCallChipBase);
+
+/** Heuristic mapping from raw tool name → visible verb + glyph kind. */
+export function classifyToolCall(toolName: string): { verb: string; kind: ToolCallChipProps['kind'] } {
+  const lc = toolName.toLowerCase();
+  if (lc.includes('read') || lc === 'read' || lc.includes('cat') || lc === 'view') {
+    return { verb: 'Read', kind: 'read' };
+  }
+  if (lc.includes('write') || lc === 'edit' || lc === 'multiedit' || lc.includes('apply')) {
+    return { verb: 'Write', kind: 'write' };
+  }
+  if (lc.includes('dispatch') || lc.includes('delegate') || lc.includes('spawn') || lc === 'task') {
+    return { verb: 'Delegate', kind: 'delegate' };
+  }
+  if (lc.includes('spec')) {
+    return { verb: 'Spec', kind: 'spec' };
+  }
+  if (lc.includes('bash') || lc.includes('shell') || lc.includes('exec') || lc.includes('run')) {
+    return { verb: 'Run', kind: 'shell' };
+  }
+  return { verb: toolName.length > 12 ? `${toolName.slice(0, 12)}…` : toolName, kind: 'generic' };
+}

--- a/src/components/desktop/orchestrator/ToolCallChip.tsx
+++ b/src/components/desktop/orchestrator/ToolCallChip.tsx
@@ -13,7 +13,7 @@
  *  - No emoji — raw inline SVG glyphs only.
  */
 
-import { memo, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 
 export type ToolCallChipStatus = 'running' | 'done' | 'error';
 
@@ -30,19 +30,21 @@ export interface ToolCallChipProps {
 }
 
 function ToolCallChipBase({ verb, argument, kind = 'generic', status = 'done', onClick }: ToolCallChipProps) {
-  const [mounted, setMounted] = useState(false);
-  const reducedMotionRef = useRef(false);
+  // Read prefers-reduced-motion once at mount as initializer. This avoids
+  // the react-hooks/set-state-in-effect lint rule and keeps a stable
+  // value across renders since the media query is read on first paint.
+  const [reducedMotion] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+  });
+  const [mounted, setMounted] = useState<boolean>(reducedMotion);
 
   useEffect(() => {
+    if (reducedMotion) return;
     if (typeof window === 'undefined') return;
-    reducedMotionRef.current = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
-    if (reducedMotionRef.current) {
-      setMounted(true);
-      return;
-    }
     const t = window.setTimeout(() => setMounted(true), 0);
     return () => window.clearTimeout(t);
-  }, []);
+  }, [reducedMotion]);
 
   const accent = status === 'running' ? '#FF5A1F' : status === 'error' ? 'var(--t-brand-red, #ef4444)' : 'var(--t-text-muted)';
   const textColor = status === 'running' ? 'var(--t-text)' : 'var(--t-text-secondary)';
@@ -74,7 +76,7 @@ function ToolCallChipBase({ verb, argument, kind = 'generic', status = 'done', o
         letterSpacing: '-0.005em',
         opacity: mounted ? 1 : 0,
         transform: mounted ? 'translateX(0)' : 'translateX(-4px)',
-        transition: reducedMotionRef.current
+        transition: reducedMotion
           ? 'none'
           : 'opacity 100ms cubic-bezier(0.22, 1, 0.36, 1), transform 100ms cubic-bezier(0.22, 1, 0.36, 1)',
         maxWidth: '100%',

--- a/src/components/desktop/orchestrator/WaitingFooter.tsx
+++ b/src/components/desktop/orchestrator/WaitingFooter.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+/**
+ * WaitingFooter — "Waiting for N agent(s)" surface above the composer
+ * (#888/#894). Square stop button (one orange accent) cancels all
+ * in-flight sub-agents for the active packet.
+ *
+ * Style: paper-and-ink Rams, Issues-style label, theme tokens. Inline
+ * styles only. Reduced-motion is honored implicitly — there's nothing
+ * to animate beyond the count text.
+ */
+
+import { memo } from 'react';
+
+interface WaitingFooterProps {
+  count: number;
+  onStop: () => void;
+  /** Optional label override — defaults to "agent(s)". */
+  noun?: string;
+}
+
+function WaitingFooterBase({ count, onStop, noun = 'agent' }: WaitingFooterProps) {
+  if (count <= 0) return null;
+  const word = count === 1 ? noun : `${noun}s`;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        paddingTop: 8,
+        paddingRight: 14,
+        paddingBottom: 8,
+        paddingLeft: 14,
+        borderTopWidth: '0.5px',
+        borderTopStyle: 'solid',
+        borderTopColor: 'var(--t-divider-subtle)',
+        background: 'var(--t-panel-hover)',
+        fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          display: 'inline-block',
+          width: 6,
+          height: 6,
+          borderRadius: '50%',
+          background: '#FF5A1F',
+          flexShrink: 0,
+        }}
+      />
+      <span
+        style={{
+          fontSize: 11,
+          fontWeight: 500,
+          color: 'var(--t-text-secondary)',
+          letterSpacing: '-0.005em',
+        }}
+      >
+        Waiting for{' '}
+        <span style={{ color: 'var(--t-text)', fontWeight: 700 }}>{count}</span>{' '}
+        {word}
+      </span>
+      <div style={{ flex: 1 }} />
+      <button
+        type="button"
+        onClick={onStop}
+        title="Stop all in-flight agents"
+        aria-label="Stop all in-flight agents"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 6,
+          height: 24,
+          paddingTop: 0,
+          paddingRight: 10,
+          paddingBottom: 0,
+          paddingLeft: 10,
+          borderRadius: 6,
+          borderWidth: 1,
+          borderStyle: 'solid',
+          borderColor: '#FF5A1F',
+          background: 'transparent',
+          color: '#FF5A1F',
+          fontSize: 10,
+          fontWeight: 700,
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+          cursor: 'pointer',
+          fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+        }}
+        onMouseEnter={(event) => { event.currentTarget.style.background = 'rgba(255, 90, 31, 0.08)'; }}
+        onMouseLeave={(event) => { event.currentTarget.style.background = 'transparent'; }}
+      >
+        <svg width={9} height={9} viewBox="0 0 24 24" fill="currentColor" aria-hidden style={{ display: 'block' }}>
+          <rect x="6" y="6" width="12" height="12" rx="1" />
+        </svg>
+        Stop
+      </button>
+    </div>
+  );
+}
+
+export const WaitingFooter = memo(WaitingFooterBase);

--- a/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
+++ b/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
@@ -41,6 +41,9 @@ import { useOrchestratorContextResidency } from '@/components/desktop/orchestrat
 import { ChatMessageList } from './chat-panel/ChatMessageList';
 import { ChatToastStack } from './chat-panel/ChatToastStack';
 import { ComposerArea } from './chat-panel/ComposerArea';
+import { IntentChips } from '@/components/desktop/orchestrator/IntentChips';
+import { ModePicker, type OrchestrationMode } from '@/components/desktop/orchestrator/ModePicker';
+import { WaitingFooter } from '@/components/desktop/orchestrator/WaitingFooter';
 import { EmptyStateCard } from './chat-panel/EmptyStateCard';
 import { ThreadExportButton } from './chat-panel/ThreadExportButton';
 import { useClearCommand } from './chat-panel/useClearCommand';
@@ -132,6 +135,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
   missionState,
   preferredRuntime,
   sessionTargets,
+  workspaceTargets,
   repoPath: repoPathProp,
   thoughtsBodyBackground,
   thoughtsElevatedSurface,
@@ -151,6 +155,38 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
   const [input, setInput] = useState('');
   const [preEnhanceInput, setPreEnhanceInput] = useState<string | null>(null);
   const [enhancing, setEnhancing] = useState(false);
+  // #888/#891 — repo + branch chips below the composer once intent has
+  // text. The chips advise scope; the orchestrator still reads its own
+  // truth at dispatch time. Default repo = parent-provided repoPathProp.
+  const [intentRepoPath, setIntentRepoPath] = useState<string | null>(repoPathProp ?? null);
+  const [intentBranch, setIntentBranch] = useState<string>('main');
+  // #888/#892 — orchestration mode picker, persisted per-workspace.
+  const workspaceModeKey = repoPathProp ?? '__global__';
+  const [orchestrationMode, setOrchestrationMode] = useState<OrchestrationMode>('fleet');
+  const [singleRuntime, setSingleRuntime] = useState<OrchestratorRuntime>('codex');
+  useEffect(() => {
+    let cancelled = false;
+    void Promise.resolve().then(async () => {
+      const mod = await import('@/components/desktop/orchestrator/ModePicker');
+      if (cancelled) return;
+      const loaded = mod.loadOrchestrationMode(workspaceModeKey);
+      setOrchestrationMode(loaded.mode);
+      setSingleRuntime(loaded.runtime);
+    });
+    return () => { cancelled = true; };
+  }, [workspaceModeKey]);
+  const handleSelectOrchestrationMode = useCallback((next: OrchestrationMode) => {
+    setOrchestrationMode(next);
+    void import('@/components/desktop/orchestrator/ModePicker').then((mod) => {
+      mod.persistOrchestrationMode(workspaceModeKey, next, singleRuntime);
+    });
+  }, [singleRuntime, workspaceModeKey]);
+  const handleSelectSingleRuntime = useCallback((next: OrchestratorRuntime) => {
+    setSingleRuntime(next);
+    void import('@/components/desktop/orchestrator/ModePicker').then((mod) => {
+      mod.persistOrchestrationMode(workspaceModeKey, orchestrationMode, next);
+    });
+  }, [orchestrationMode, workspaceModeKey]);
   const [operatorDefaults, setOperatorDefaults] = useState(THOUGHTS_OPERATOR_DEFAULTS_FALLBACK);
   const [adaptiveThinkingEnabled, setAdaptiveThinkingEnabled] = useState(
     () => resolveInitialOrchestratorThinkingPreferences(THOUGHTS_OPERATOR_DEFAULTS_FALLBACK.thinkingEffort).adaptiveThinkingEnabled,
@@ -1038,6 +1074,29 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
         showClearToast={showClearToast}
         showDraftClearedToast={showDraftClearedToast}
         thoughtsBodyBackground={thoughtsBodyBackground}
+      />
+
+      <WaitingFooter
+        count={isOrchestratorMode && displayWaiting ? Math.max(1, agents.filter((a) => a.status === 'running').length) : 0}
+        onStop={orchStream.interrupt}
+      />
+
+      <IntentChips
+        visible={input.trim().length > 0}
+        workspaceTargets={workspaceTargets ?? []}
+        selectedRepoPath={intentRepoPath}
+        onSelectRepoPath={setIntentRepoPath}
+        selectedBranch={intentBranch}
+        onSelectBranch={setIntentBranch}
+      />
+
+      <ModePicker
+        visible={input.trim().length > 0}
+        workspaceKey={workspaceModeKey}
+        selectedMode={orchestrationMode}
+        onSelectMode={handleSelectOrchestrationMode}
+        selectedSingleRuntime={singleRuntime}
+        onSelectSingleRuntime={handleSelectSingleRuntime}
       />
 
       <ComposerArea

--- a/src/components/desktop/thoughts/ThoughtsMissionPanel.tsx
+++ b/src/components/desktop/thoughts/ThoughtsMissionPanel.tsx
@@ -68,6 +68,7 @@ export function ThoughtsMissionPanel({
   onFocusPacket?: (packet: OrchestratorPacket) => void;
   focusedRepoId?: string | null;
 }) {
+  const orchestratorData = useOrchestratorData();
   const [issueGroups, setIssueGroups] = useState<RepoIssuesGroup[]>([]);
   const [issueGroupCollapsed, setIssueGroupCollapsed] = useState<Record<string, boolean>>({});
   const [issuesLoading, setIssuesLoading] = useState(false);
@@ -80,12 +81,20 @@ export function ThoughtsMissionPanel({
   // #626 — cache of workspace localPath → GitHub remoteUrl, reused by PacketCard
   // so its "open" action can derive an issue URL when packet.issue?.url is absent.
   const [repoRemoteUrlByPath, setRepoRemoteUrlByPath] = useState<Record<string, string | null>>({});
-  const [expandedPacketId, setExpandedPacketId] = useState<string | null>(null);
+  // #888/#895 — packet selection is lifted to OrchestratorDataContext so the
+  // dashboard's right-side workspace panel can flip into packet-mode (Spec /
+  // Agent Overview) when one is expanded. We keep a local fallback for tests
+  // / isolated mounts that don't include the provider.
+  const [localExpandedPacketId, setLocalExpandedPacketId] = useState<string | null>(null);
+  const expandedPacketId = orchestratorData?.selectedPacketId ?? localExpandedPacketId;
+  const setExpandedPacketId = useCallback((next: string | null) => {
+    setLocalExpandedPacketId(next);
+    orchestratorData?.onSelectedPacketChange?.(next);
+  }, [orchestratorData]);
   const [editingField, setEditingField] = useState<EditingField>(null);
   const [reviewStateByPacketId, setReviewStateByPacketId] = useState<Record<string, ReviewPanelState>>({});
   const branchAutofillAttemptRef = useRef<Record<string, string>>({});
   const branchRequestByRepoPathRef = useRef<Record<string, Promise<Awaited<ReturnType<typeof fetchPacketBranches>>>>>({});
-  const orchestratorData = useOrchestratorData();
 
   // Close editing field on Escape or click outside any row in the
   // expanded packet card.

--- a/src/components/desktop/thoughts/mission-panel/PacketCard.tsx
+++ b/src/components/desktop/thoughts/mission-panel/PacketCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { orchestratorRuntimeTone, orchestratorStatusTone } from '@/lib/orchestrator/display';
 import { deriveGithubIssueUrl } from '@/lib/orchestrator/issue-url';
 import { packetReleaseBlockedBy } from '@/lib/orchestrator/store';
@@ -15,6 +15,8 @@ import { PacketReviewCard } from './PacketReviewCard';
 import { PacketReviewPanel } from './PacketReviewPanel';
 import { PacketSpecEditor } from './PacketSpecEditor';
 import { RejectedFeedbackPanel } from './RejectedFeedbackPanel';
+import { PacketTabStrip, type PacketTabId } from '@/components/desktop/orchestrator/PacketTabStrip';
+import { LivingAgentPanel } from '@/components/desktop/orchestrator/LivingAgentPanel';
 
 interface PacketCardProps {
   packet: OrchestratorPacket;
@@ -109,6 +111,44 @@ export function PacketCard({
   const closeDetails = useCallback(() => {
     setDetailsAnchor(null);
   }, []);
+
+  // #888/#893 — packet view tabs. Default = Agents; remember last-active
+  // per-packet via localStorage so re-expanding lands on the same tab.
+  const tabStorageKey = `cortex-ide:packet-tab:${packet.id}`;
+  const [activeTab, setActiveTab] = useState<PacketTabId>('agents');
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const raw = window.localStorage.getItem(tabStorageKey);
+      if (raw === 'agents' || raw === 'context' || raw === 'changes' || raw === 'files') {
+        setActiveTab(raw);
+      }
+    } catch {
+      // ignore
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [packet.id]);
+  const handleTabChange = useCallback((tab: PacketTabId) => {
+    setActiveTab(tab);
+    if (typeof window === 'undefined') return;
+    try { window.localStorage.setItem(tabStorageKey, tab); } catch { /* ignore */ }
+  }, [tabStorageKey]);
+
+  // Notification dot on Agents — verifier flagged or rejected, OR a sub-agent
+  // finished and the packet is awaiting review.
+  const agentsHasNotification = (packet.review?.findings?.length ?? 0) > 0
+    || packet.review?.approved === false
+    || packet.status === 'awaiting_review';
+
+  // Changes count — files modified from review state (best-effort).
+  const changesCount = reviewState?.snapshot?.changedFiles?.length ?? null;
+
+  // Files tab content — predictedFiles or actual changed files.
+  const filesList: string[] = useMemo(() => {
+    const fromReview = reviewState?.snapshot?.changedFiles?.map((f) => f.path) ?? [];
+    if (fromReview.length > 0) return fromReview;
+    return packet.predictedFiles ?? packet.allowedFiles ?? [];
+  }, [packet.predictedFiles, packet.allowedFiles, reviewState?.snapshot?.changedFiles]);
 
   // #517 — Packets in a best-of-n comparison group render via ComparisonCard at
   // the ThoughtsMissionPanel level. Guard AFTER all hooks so the hook order
@@ -212,13 +252,36 @@ export function PacketCard({
             onPatch={onPatch}
           />
 
-          {/* #742 — Context Recall Card (Directive / Recent Outcomes / Symbol Graph). */}
-          <ContextRecallCard packet={packet} repoName={targetRepoName} />
+          {/* #888/#893 — packet view tabs. Each tab pivots the body content
+              while DETAILS / Actions / Hold-Archive-Delete / review and
+              rejected panels remain visible across all tabs. */}
+          <PacketTabStrip
+            active={activeTab}
+            onChange={handleTabChange}
+            agentsHasNotification={agentsHasNotification}
+            changesCount={changesCount}
+          />
 
-          {/* #773 — Editable spec.md. The orchestrator re-reads the latest
-              spec at dispatch time so each NEW launch sees the operator's
-              current intent. In-flight agents are not steered. */}
-          <PacketSpecEditor packetId={packet.id} />
+          {activeTab === 'agents' ? (
+            <LivingAgentPanel packet={packet} />
+          ) : null}
+
+          {activeTab === 'context' ? (
+            <>
+              {/* #742 — Context Recall Card (Directive / Recent Outcomes / Symbol Graph). */}
+              <ContextRecallCard packet={packet} repoName={targetRepoName} />
+              {/* #773 — Editable spec.md nested under Context per #893. */}
+              <PacketSpecEditor packetId={packet.id} />
+            </>
+          ) : null}
+
+          {activeTab === 'changes' ? (
+            <ChangesTabHint />
+          ) : null}
+
+          {activeTab === 'files' ? (
+            <FilesTabList files={filesList} />
+          ) : null}
 
           {/* #615 — DETAILS row (read-only popover trigger). */}
           <div
@@ -577,6 +640,81 @@ export function PacketCard({
           onClose={closeDetails}
         />
       ) : null}
+    </div>
+  );
+}
+
+function ChangesTabHint() {
+  return (
+    <div
+      style={{
+        paddingTop: 14,
+        paddingRight: 14,
+        paddingBottom: 14,
+        paddingLeft: 14,
+        fontSize: 11,
+        color: 'var(--t-text-muted)',
+        lineHeight: 1.55,
+        fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+      }}
+    >
+      Changes for this packet are shown in the workspace panel on the right.
+      Spec / Agent Overview / Changes tabs over there mirror the packet context (#895).
+    </div>
+  );
+}
+
+function FilesTabList({ files }: { files: string[] }) {
+  if (files.length === 0) {
+    return (
+      <div
+        style={{
+          paddingTop: 14,
+          paddingRight: 14,
+          paddingBottom: 14,
+          paddingLeft: 14,
+          fontSize: 11,
+          color: 'var(--t-text-muted)',
+          lineHeight: 1.55,
+          fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+        }}
+      >
+        No predicted or changed files yet. Files appear here once the agent runs.
+      </div>
+    );
+  }
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        paddingTop: 6,
+        paddingRight: 6,
+        paddingBottom: 6,
+        paddingLeft: 6,
+        fontFamily: 'var(--font-mono, "SF Mono", Menlo, monospace)',
+      }}
+    >
+      {files.map((file) => (
+        <div
+          key={file}
+          style={{
+            paddingTop: 4,
+            paddingRight: 8,
+            paddingBottom: 4,
+            paddingLeft: 8,
+            fontSize: 10.5,
+            color: 'var(--t-text-secondary)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            wordBreak: 'break-all',
+          }}
+          title={file}
+        >
+          {file}
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/desktop/workspace-terminal/OrchestratorTab.tsx
+++ b/src/components/desktop/workspace-terminal/OrchestratorTab.tsx
@@ -489,15 +489,28 @@ function OrchestratorTabInner({ tabId, active, repoPath, repoLabel }: Orchestrat
   // switches dispatch targets, not the orchestrator runtime itself.
   const runtimeLabel = orchestratorRuntimeTone('claude-code').label;
 
+  // #888/#889 — clicking a recent-work card both expands the packet in
+  // the mission rail and ensures the rail is visible.
+  const handleSelectRecentPacket = useCallback((packetId: string) => {
+    if (data?.onSelectedPacketChange) {
+      data.onSelectedPacketChange(packetId);
+    }
+    if (!missionOpen) {
+      setMissionOpen(true);
+      writeBooleanPref(MISSION_OPEN_KEY, true);
+    }
+  }, [data, missionOpen]);
+
   const emptyStateNode = useMemo(
     () => (
       <OrchestratorEmptyState
         greeting={greeting}
         runtimeLabel={runtimeLabel}
         onActionClick={handleQuickAction}
+        onSelectPacket={handleSelectRecentPacket}
       />
     ),
-    [greeting, runtimeLabel, handleQuickAction],
+    [greeting, runtimeLabel, handleQuickAction, handleSelectRecentPacket],
   );
 
   const hasMessages = chatChromeState.hasMessages;

--- a/src/lib/panel/mode.ts
+++ b/src/lib/panel/mode.ts
@@ -1,0 +1,20 @@
+/**
+ * Panel mode — derives whether the right-side workspace panel should
+ * render the workspace-level Changes/Files/Git Log surface (idle) or
+ * the packet-context Spec/Agent Overview surface (packet).
+ *
+ * Decision (epic #888 / issue #895): Option A — context-aware right
+ * panel. When a packet is expanded in the orchestrator's mission rail,
+ * the dashboard's right panel pivots to show that packet's Spec and
+ * Agent Overview. When no packet is selected, the panel falls back to
+ * the existing Changes/Files/Git Log workspace view.
+ *
+ * This module is the one place that owns that derivation so the
+ * rendering paths in `dashboard/page.tsx` stay declarative — the
+ * dashboard reads `derivePanelMode(...)` and switches on the result.
+ */
+export type PanelMode = 'idle' | 'packet';
+
+export function derivePanelMode(input: { selectedPacketId: string | null | undefined }): PanelMode {
+  return input.selectedPacketId ? 'packet' : 'idle';
+}


### PR DESCRIPTION
## Summary

Stealing Augment Intent's "Let's get building" empty state and Living Coordinator panel composition (paper-and-ink Rams style, not Augment's gradients). All 7 children of epic #888 ship in this PR. Right-panel reconciliation (#895) ships first because it blocks #893; the rest fan out from there.

| Issue | Title | Status |
|------|------|------|
| #895 | right-panel reconciliation — Spec/Agent Overview vs Changes/Files | shipped (Option A) |
| #889 | "Let's get building" empty state | shipped |
| #890 | Living Coordinator panel + ToolCallChip primitive | shipped |
| #891 | repo + branch chips below the composer | shipped |
| #892 | Fleet vs Single runtime mode picker | shipped |
| #893 | packet view tabs — Agents / Context / Changes N / Files | shipped |
| #894 | "Waiting for N agents" footer + stop button | shipped |

## Architectural decision — #895 Option A

The right-side workspace panel becomes context-aware:
- **idle** (no packet expanded) → existing Changes / Files / Git Log via `WorkspaceSidePanel`.
- **packet** (a packet is expanded in the orchestrator's mission rail) → new `PacketRightPanel` with **Spec / Agent Overview / Changes** tabs. Spec re-uses the editable `PacketSpecEditor` from #773; Agent Overview is an Issues-style row sheet of lane / runtime / branch / repo / session metadata; Changes proxies to the existing right-panel Changes tab so there's a single render path.

Why Option A: the right panel is highest-value when context-aware. When you're actively reviewing a packet you want Spec / Agent Overview / orchestration topology; when idle you want the workspace browser/preview. Single panel, two modes — no duplicate Changes rendering, no manual toggle.

Plumbing: new `src/lib/panel/mode.ts` derives `idle | packet` from `selectedPacketId`. `OrchestratorDataContext` carries `selectedPacketId` + `onSelectedPacketChange`. `ThoughtsMissionPanel` lifts its existing `expandedPacketId` to the context. `dashboard/page.tsx` switches the right-panel render based on selection.

## Per-issue acceptance criteria

### #895 right-panel reconciliation
- [x] Decision documented (Option A above + commit body).
- [x] Right panel modes `idle` / `packet` derived in `src/lib/panel/mode.ts`.
- [x] Mode transition automatic on packet expand/collapse — no manual toggle.
- [x] No duplicate Changes rendering across panels.
- [x] Existing Changes panel (`ChangesTab`) reused, no rewrite.
- [x] Browser tab + Files tab remain accessible via existing `O8Panel` flow in idle mode.
- [x] Spec tab reuses `PacketSpecEditor` from #773.

### #889 "Let's get building" empty state
- [x] OrchestratorTab empty state: "Let's get building." headline + greeting + 4 quick-action cards (left) + repo-grouped recent-work cards (right).
- [x] Each card: status dot (filled-orange = done, half = in-progress, hollow = idle), task title, relative timestamp ("13h", "5d", "1mo").
- [x] Tasks grouped by repo — header is `<owner>/<repo>` derived from path.
- [x] Top-right toggles: GROUPED BY REPO (default ON), SHOW ARCHIVED (default OFF).
- [x] Empty state hides on first message (existing `emptyStateOverride` semantics).
- [x] Cards clickable → expand the corresponding packet in mission rail (auto-opens rail).
- [x] Toggle state persisted to localStorage `cortex-ide:orchestrator:empty:grouped` / `:show-archived`.
- [x] Light + midnight themes both work (theme tokens only).
- [x] No native form controls. No CSS classes. Inline styles, no shadows.

### #890 Living Coordinator panel
- [x] Subscribes to existing `cortex:agent-supervisor-update` window event for sub-agent lifecycle.
- [x] Sub-agent count "N / M running" header — min-height reserved so updates never shift layout.
- [x] Tool-call chips (compact, 100ms fade, no bounce) via the new `ToolCallChip` primitive.
- [x] Verifier findings render as yellow Issues-style row when `packet.review?.findings` non-empty.
- [x] Throttled to one render per 100ms.
- [x] `prefers-reduced-motion` honored.
- [x] One orange accent per running update; done is ink-on-paper.

### #891 repo + branch chips
- [x] When composer has text: "Work on `<repo>` off `<branch>`" rendered below.
- [x] Repo chip click opens Issues-style row picker over `workspaceTargets`.
- [x] Branch chip click reuses existing `BranchPickerPopover`.
- [x] No native `<select>`.
- [x] Chips disappear on send (gated by `input.trim().length`).

### #892 mode picker
- [x] Two side-by-side mode cards rendered when composer has text.
- [x] Fleet card tagged "using Claude Opus 4.7".
- [x] Single card has collapsible runtime sub-picker (Codex / Gemini / opencode / Claude Code).
- [x] Selected card has subtle orange border (one orange accent).
- [x] Default = Fleet on first dispatch; persisted per-workspace via localStorage.
- [x] No native form controls.

### #893 packet view tabs
- [x] Tab strip: Agents • / Context / Changes N / Files at the top of expanded packet card.
- [x] Issues-style aesthetic: uppercase labels, no shadow, one orange for active.
- [x] Agents tab notification dot when verifier flagged OR review.approved=false OR status=awaiting_review.
- [x] Changes count badge from review state's changedFiles.
- [x] Default tab = Agents; last-active tab persisted per-packet.
- [x] Context tab = ContextRecallCard (#742) + PacketSpecEditor (#773) nested.
- [x] Changes tab routes to right panel (per #895 reconciliation).
- [x] Files tab = lazy file list from review snapshot or predictedFiles/allowedFiles.

### #894 waiting footer + tool-call chips
- [x] "Waiting for N agent(s)" footer above composer when orchestrator busy.
- [x] Square stop button (one orange accent) wired to `orchStream.interrupt`.
- [x] `ToolCallChip` primitive shipped (used by Living panel + future inline-chat tool-call cluster).
- [x] No animation beyond 100ms fade.
- [x] `prefers-reduced-motion` honored.

## Hard guardrails — all honored

- [x] Rams style only — paper-and-ink, Plus Jakarta Sans, Issues-style rows, one orange accent max per update. No Augment Intent dark gradient, no blue/green/purple status dots.
- [x] No native `<select>` or `<input>` in packet cards or new components — Issues-style row pickers + custom popovers.
- [x] No hardcoded rgba surfaces — theme tokens only.
- [x] No React icon components — raw inline `<svg>` only.
- [x] No CSS classes. Inline styles only.
- [x] No CSS shorthand — `paddingTop` / `paddingLeft` etc.
- [x] `prefers-reduced-motion` honored on every animated state change.
- [x] No browser-style multi-tab pane bar (out of scope per epic).
- [x] 800-line file ceiling — `PacketCard.tsx` ended at 720 lines after additions.

## TypeScript + lint status

- `npx tsc --noEmit` — clean.
- `npm run lint` — pre-existing repo errors remain (not my code). All new files I added lint clean. The only files I modified that had pre-existing lint warnings (`page.tsx`, `ThoughtsChatPanel.tsx`, `OrchestratorTab.tsx`) had no NEW errors introduced.

## Dev-server verification

Deferred. The worktree shares ports with the founder's running dev session — `npm run dev` would collide. The founder will see this on the installed app via the next `npm run ship` cycle (per repo daily-driver loop).

## What I did NOT build

- The `ChangesTab` proxy in `PacketRightPanel` re-renders the existing right-panel Changes content scoped to `workspaceSidePanelRepo`. Wiring it to the **packet's** lane diff (rather than the workspace's branch diff) is a follow-up — the packet expansion's `reviewState.snapshot.changedFiles` is the real source of truth there. The Changes tab's `changesCount` badge IS already wired to that count, and the packet-card's Changes tab points at the right panel for visual consumption.
- `ToolCallChip` is the shared primitive but the existing chat tool-call render in `messages[].toolCalls` still uses the legacy block style. Switching that render path to `ToolCallChip` is a follow-up; the primitive ships now so the next surface can adopt it.
- Augment Intent's "Spec checkbox auto-fill on lane completion" — the wiring point is inside `LivingAgentPanel`'s sub-agent reducer, but it requires a `lane completed → spec line resolved` mapping that doesn't exist yet in the codebase. Filed as a future improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)