### PR TITLE
fix(mcp): #932 eval_and_await structural redesign

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "o8",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "o8",
-      "version": "0.1.91",
+      "version": "0.1.92",
       "hasInstallScript": true,
       "dependencies": {
         "@assistant-ui/react": "^0.12.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o8",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "description": "o8 — governance layer for autonomous engineering teams. Approvals, audit, organizational memory.",
   "productName": "o8",
   "private": true,

--- a/src-tauri/.gitignore
+++ b/src-tauri/.gitignore
@@ -2,3 +2,7 @@
 # will have compiled files and executables
 /target/
 /gen/schemas
+
+# #932 — capabilities/mcp.json is materialized by build.rs from
+# capabilities/mcp.json.in only when --features dev-mcp-plugin is on.
+capabilities/mcp.json

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "o8"
-version = "0.1.91"
+version = "0.1.92"
 dependencies = [
  "hex",
  "libc",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "o8"
-version = "0.1.90"
+version = "0.1.91"
 dependencies = [
  "hex",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "o8"
-version = "0.1.91"
+version = "0.1.92"
 description = "o8 — governance layer for autonomous engineering teams"
 authors = ["hurttlocker"]
 license = "MIT"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,29 @@
+use std::fs;
+use std::path::Path;
+
 fn main() {
+  // #932: tauri-plugin-mcp permissions are only registered when the
+  // `dev-mcp-plugin` Cargo feature is on. Tauri's compile-time capability
+  // resolver needs the permission identifier (`mcp:*`) to exist at build
+  // time, so we materialize `capabilities/mcp.json` only when the feature
+  // is active. Without the feature, the file is removed so the build
+  // doesn't fail on an unknown permission.
+  let cap_dir = Path::new("capabilities");
+  let template = cap_dir.join("mcp.json.in");
+  let target = cap_dir.join("mcp.json");
+  let feature_on = std::env::var("CARGO_FEATURE_DEV_MCP_PLUGIN").is_ok();
+
+  println!("cargo:rerun-if-changed={}", template.display());
+  println!("cargo:rerun-if-env-changed=CARGO_FEATURE_DEV_MCP_PLUGIN");
+
+  if feature_on {
+    if template.exists() {
+      let contents = fs::read_to_string(&template).expect("read capabilities/mcp.json.in");
+      let _ = fs::write(&target, contents);
+    }
+  } else if target.exists() {
+    let _ = fs::remove_file(&target);
+  }
+
   tauri_build::build()
 }

--- a/src-tauri/capabilities/mcp.json.in
+++ b/src-tauri/capabilities/mcp.json.in
@@ -1,0 +1,9 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "mcp",
+  "description": "tauri-plugin-mcp eval_and_await JS bridge — only active when built with --features dev-mcp-plugin (#932)",
+  "windows": ["main", "dispatch-popover"],
+  "permissions": [
+    "mcp:default"
+  ]
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "o8",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "identifier": "ai.o8.desktop",
   "build": {
     "frontendDist": "../out/frontend",

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -177,8 +177,8 @@ function DashboardInner() {
   const [inTauri, setInTauri] = useState(false);
   useEffect(() => {
     setInTauri(isTauri());
-    // initMcpPlugin() now lives in NavigationBridge so it runs on every
-    // route, not just /dashboard (#932). Don't re-init here.
+    // tauri-plugin-mcp no longer needs JS-side init — the eval_and_await
+    // protocol shipped in #932 phase 2 invokes JS from Rust per call.
     // Schedule the "interactive" mark on the first idle tick after mount.
     // requestIdleCallback is unavailable in some webview / older browser
     // environments, so we fall back to setTimeout(_, 0). Either way the

--- a/src/components/NavigationBridge.tsx
+++ b/src/components/NavigationBridge.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { initMcpPlugin } from '@/lib/tauri/bridge';
 
 /**
  * Renderer-side navigation bridge for the o8 webview MCP tools.
@@ -15,19 +14,16 @@ import { initMcpPlugin } from '@/lib/tauri/bridge';
  * /dashboard — and leaves Next.js mid-route, freezing the JS thread
  * for 10–30s of hydration).
  *
- * Mounted once in the root layout. See issue #863. Also (#932) the
- * single boot site for tauri-plugin-mcp listener registration —
- * previously wired only to /dashboard, which left the click/eval/
- * snapshot tools dead whenever the app booted into Settings or any
- * non-dashboard route.
+ * Mounted once in the root layout. See issue #863. The previous boot
+ * site for tauri-plugin-mcp listener registration was retired in #932
+ * phase 2 — the eval_and_await protocol invokes JS from Rust each call
+ * instead of holding persistent listeners, so no JS-side init is needed.
  */
 export default function NavigationBridge() {
   const router = useRouter();
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
-
-    initMcpPlugin();
 
     const navigate = (path: string) => {
       // router.push handles same-origin paths; absolute URLs fall back

--- a/src/lib/tauri/bridge.ts
+++ b/src/lib/tauri/bridge.ts
@@ -19,35 +19,11 @@ export function isTauri(): boolean {
   return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
 }
 
-// ── MCP Plugin Init ──
-// Register the Tauri MCP event handlers so query_page, execute_js, etc. work.
-// Must run once on page load inside the Tauri webview.
-//
-// #932: Use a STATIC import so the plugin bundles into the same chunk as
-// this module, avoiding webpack code-splitting + chunk-load races that
-// silently broke listener registration in the prod build.
-import { setupPluginListeners as setupTauriMcpListeners } from 'tauri-plugin-mcp';
-
-let _mcpInitialized = false;
-let _mcpInitAttempts = 0;
-export async function initMcpPlugin(): Promise<void> {
-  if (_mcpInitialized || !isTauri()) return;
-  _mcpInitAttempts += 1;
-  try {
-    if (typeof setupTauriMcpListeners !== 'function') {
-      throw new Error(`tauri-plugin-mcp.setupPluginListeners is ${typeof setupTauriMcpListeners}`);
-    }
-    await setupTauriMcpListeners();
-    _mcpInitialized = true;
-    console.log(`[tauri-bridge] MCP plugin listeners registered (attempt ${_mcpInitAttempts})`);
-  } catch (err) {
-    const msg = err instanceof Error ? `${err.message}\n${err.stack ?? ''}` : String(err);
-    console.error(`[tauri-bridge] MCP plugin init failed (attempt ${_mcpInitAttempts}):`, msg);
-    if (_mcpInitAttempts < 5) {
-      setTimeout(() => { void initMcpPlugin(); }, 500 * _mcpInitAttempts);
-    }
-  }
-}
+// #932 phase 2: tauri-plugin-mcp's old setupPluginListeners() init dance
+// was deleted. The eval_and_await protocol invokes JS from Rust per call
+// (via webview.eval()) instead of holding persistent JS-side listeners,
+// so no client-side init is required. The plugin loads automatically
+// when the dev-mcp-plugin Cargo feature is on.
 
 // ── Types ──
 


### PR DESCRIPTION
## Summary
Closes #932. Replaces tauri-plugin-mcp's emit_and_wait correlation pattern (broken in Tauri v2 per #10182 + #7835) with eval_and_await — Rust calls webview.eval() and JS calls back via __TAURI_INTERNALS__.invoke('plugin:tauri-mcp|mcp_result').

## What's in the bundle
- Plugin foundation: PendingResults registry + eval_and_await helper + mcp_result tauri::command (997e4bb on plugin master)
- Plugin tool ports: execute_js (1011e0d), manage_zoom, navigate_back, get_page_state, navigate_webview, local_storage, type_into_focused, wait_for
- Cortex-ide: ACL capability grant via feature-gated mcp.json (1a97858e), initMcpPlugin removed (0e412a84)

## Verification
After ship + force-install, mcp__o8__o8_view_eval('1+1') should return {ok:true, value:2} (was 100% timeout on v0.1.91).

## Outstanding (follow-up)
6 webview tools still on emit_and_wait: get_page_map, get_element_position, get_dom, send_text_to_element, scroll_page, fill_form. Will port in a follow-up; doesn't block o8_view_eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)