### PR TITLE
fix(qa): bypass answer cache during eval runs

### DIFF
--- a/src/lib/cortex/qa/ask.ts
+++ b/src/lib/cortex/qa/ask.ts
@@ -76,21 +76,29 @@ export interface AskCortexResult {
 /**
  * Run the full Q&A pipeline and collect the result (non-streaming).
  * Used by the eval runner and smoke tests.
+ *
+ * @param bypassCache  When true, skip both the cache lookup and the cache
+ *                     write. Used by the eval runner so sequential runs don't
+ *                     reuse stale answers.
  */
 export async function askCortex(
   question: string,
   repoPath: string | undefined,
+  options: { bypassCache?: boolean } = {},
 ): Promise<AskCortexResult> {
+  const { bypassCache = false } = options;
   const key = cacheKey(question, repoPath);
-  const cached = getCached(key);
-  if (cached) {
-    return {
-      answer: cached.answer,
-      citations: cached.citations,
-      class: 'A', // cached result — class doesn't matter
-      retrievalMs: 0,
-      classifyMs: 0,
-    };
+  if (!bypassCache) {
+    const cached = getCached(key);
+    if (cached) {
+      return {
+        answer: cached.answer,
+        citations: cached.citations,
+        class: 'A', // cached result — class doesn't matter
+        retrievalMs: 0,
+        classifyMs: 0,
+      };
+    }
   }
 
   // 1. Classify
@@ -162,7 +170,9 @@ export async function askCortex(
     classifyMs,
   };
 
-  setCache(key, { answer: result.answer, citations });
+  if (!bypassCache) {
+    setCache(key, { answer: result.answer, citations });
+  }
   return result;
 }
 

--- a/src/lib/cortex/qa/eval/runner.ts
+++ b/src/lib/cortex/qa/eval/runner.ts
@@ -245,7 +245,7 @@ export async function runEval(): Promise<RunSummary> {
 
     let actual: AskCortexResult;
     try {
-      const result = await askCortex(qaCase.question, qaCase.repoPath);
+      const result = await askCortex(qaCase.question, qaCase.repoPath, { bypassCache: true });
       actual = {
         answer: result.answer,
         citations: result.citations.map((c) => ({


### PR DESCRIPTION
## Summary

- Add `{ bypassCache?: boolean }` options arg to `askCortex()` that skips both cache lookup and cache write
- Eval runner (`src/lib/cortex/qa/eval/runner.ts`) now passes `bypassCache: true` on every call
- Default behavior unchanged for production streaming and smoke tests

## Why

The 30s in-process answer cache in `askCortex()` was reusing stale answers across sequential eval runs, making the headline 19.2% factual_accuracy score suspect — some "passes" were cache hits from earlier runs rather than fresh pipeline output. With this fix every eval case re-runs the full classifier → retriever → composer pipeline.

Phase 1 task 1.1 of the Cortex Q&A path-to-70% plan (#915).

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Re-run eval (`npx tsx src/lib/cortex/qa/eval/runner.ts`) and confirm scores no longer fluctuate based on prior-run cache state
- [ ] Confirm production streaming via `/api/cortex/ask` still hits the cache (the route calls `runAskPipeline`, not `askCortex` — unaffected)
- [ ] Smoke test still passes: `npx tsx scripts/smoke-qa-ask.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)