### PR TITLE
fix(qa): lift Class B answer length cap to 1-6 sentences

### DIFF
--- a/src/lib/cortex/qa/composer.ts
+++ b/src/lib/cortex/qa/composer.ts
@@ -38,9 +38,9 @@ function buildSonnetComposeSystem(): string {
   return `You are a concise engineering assistant answering questions using ONLY provided typed rows as sources.
 
 Rules:
-1. Answer in 1-3 sentences. Be direct and specific.
-2. Cite EVERY fact using the row's citation handle in [BRACKET-ID] form (e.g. [D-014] for directives, [O-481] for outcomes, [PR-650] for PRs).
-3. Do not invent facts not present in the rows.
+1. Answer in 1-6 sentences. Be direct and specific. For multi-fact specs (latency budgets, schema/table lists, cache TTLs, configuration values, enumerated rules), enumerate EVERY relevant fact present in the rows — don't cherry-pick one and skip the rest. Single-fact questions still get a single tight sentence.
+2. Cite EVERY fact using the row's citation handle in [BRACKET-ID] form (e.g. [D-014] for directives, [O-481] for outcomes, [PR-650] for PRs). One citation per fact, inline.
+3. Ground every claim in the retrieved rows. Do not invent facts, numbers, or names not present in the rows.
 4. If rows don't answer the question, say exactly: "I don't have that information yet — try indexing more directives or PRs."
 5. Stream your answer token by token.`;
 }


### PR DESCRIPTION
## Summary

Class B Sonnet system prompt at `composer.ts:41` previously capped answers at 1-3 sentences, mechanically forbidding multi-fact responses. Specs scored 0% on the eval because spec questions ask for 5+ facts (Class A latency budgets, FTS5 virtual tables, 30s cache TTL) and the prompt forced cherry-picking.

This lifts the cap to 1-6 sentences with explicit "enumerate EVERY relevant fact" guidance for multi-fact specs (latency budgets, schema/table lists, cache TTLs, configuration values, enumerated rules). Single-fact questions still get a single tight sentence. Citation discipline + grounding rules unchanged (re-emphasized "ground every claim in the retrieved rows" so the longer answer doesn't slip into hallucination).

Class A (Flash lookup) prompt is untouched — it stays one-sentence as designed.

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Run Q&A eval against fixture set — expect specs 0% → 50%+, decisions 53% → 70%+ (brainstormer projection for #915 path-to-70 phase 1.2)
- [ ] Spot-check that single-fact questions still return tight one-sentence answers (no inflation regression)
- [ ] Spot-check that 5-fact spec questions now enumerate all 5 facts with citations

Refs #915.