### PR TITLE
test(qa): re-anchor expected citations to deduped DB IDs (#915 phase 1.5)

### DIFF
--- a/scripts/qa-eval-capture-citations.ts
+++ b/scripts/qa-eval-capture-citations.ts
@@ -1,0 +1,108 @@
+/**
+ * Capture actual citations the retriever returns for each case in
+ * tests/qa-eval/cases.json — dumps to /tmp/qa-eval-actuals.json so
+ * scripts/qa-eval-rewrite-citations.ts can re-anchor expectedCitations.
+ *
+ * One-shot helper for #915 path-to-70 phase 1.5 (re-anchor citations).
+ *
+ * Usage:
+ *   npx tsx scripts/qa-eval-capture-citations.ts
+ */
+
+import 'server-only';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { askCortex } from '@/lib/cortex/qa/ask';
+
+interface ExpectedCitation {
+  kind: string;
+  rowId: string;
+}
+
+interface CaseFile {
+  cases: Array<{
+    id: string;
+    category: string;
+    repoPath: string;
+    question: string;
+    expectedAnswer: string | null;
+    expectedCitations: ExpectedCitation[];
+    knownGap?: string;
+  }>;
+}
+
+interface ActualEntry {
+  id: string;
+  category: string;
+  knownGap: boolean;
+  question: string;
+  expectedAnswer: string | null;
+  expectedCitations: ExpectedCitation[];
+  class: 'A' | 'B';
+  retrievalMs: number;
+  classifyMs: number;
+  answer: string;
+  actualCitations: Array<{ kind: string; rowId: string; table: string }>;
+}
+
+async function main() {
+  const casesPath = path.resolve(process.cwd(), 'tests/qa-eval/cases.json');
+  const raw = await fs.readFile(casesPath, 'utf-8');
+  const file = JSON.parse(raw) as CaseFile;
+
+  const out: ActualEntry[] = [];
+
+  for (const c of file.cases) {
+    process.stderr.write(`[capture] ${c.id} (${c.category}) ...\n`);
+    try {
+      const result = await askCortex(c.question, c.repoPath, { bypassCache: true });
+      out.push({
+        id: c.id,
+        category: c.category,
+        knownGap: Boolean(c.knownGap),
+        question: c.question,
+        expectedAnswer: c.expectedAnswer,
+        expectedCitations: c.expectedCitations,
+        class: result.class,
+        retrievalMs: result.retrievalMs,
+        classifyMs: result.classifyMs,
+        answer: result.answer,
+        actualCitations: result.citations.map((cit) => ({
+          kind: cit.kind,
+          rowId: cit.rowId,
+          table: cit.table,
+        })),
+      });
+      process.stderr.write(
+        `  → class=${result.class} citations=${result.citations.length} answer.len=${result.answer.length}\n`,
+      );
+    } catch (err) {
+      process.stderr.write(
+        `  → ERROR: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      out.push({
+        id: c.id,
+        category: c.category,
+        knownGap: Boolean(c.knownGap),
+        question: c.question,
+        expectedAnswer: c.expectedAnswer,
+        expectedCitations: c.expectedCitations,
+        class: 'B',
+        retrievalMs: 0,
+        classifyMs: 0,
+        answer: `(error) ${err instanceof Error ? err.message : String(err)}`,
+        actualCitations: [],
+      });
+    }
+  }
+
+  const dest = '/tmp/qa-eval-actuals.json';
+  await fs.writeFile(dest, JSON.stringify(out, null, 2), 'utf-8');
+  process.stderr.write(`[capture] wrote ${out.length} entries to ${dest}\n`);
+}
+
+main().catch((err) => {
+  console.error('[capture] fatal:', err);
+  process.exit(1);
+});

--- a/scripts/qa-eval-citation-overlap.mjs
+++ b/scripts/qa-eval-citation-overlap.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Compute citation overlap (set intersection / union, Jaccard) between the
+ * expectedCitations on each case and the actualCitations the retriever
+ * returned. Compares two cases.json snapshots so we can quantify how much
+ * the phase 1.5 re-anchor moved citation correctness.
+ *
+ * Usage:
+ *   node scripts/qa-eval-citation-overlap.mjs <before.json> <after.json> <actuals.json>
+ *
+ * Where:
+ *   before.json  — original cases.json (pre-rewrite)
+ *   after.json   — current cases.json (post-rewrite)
+ *   actuals.json — output of qa-eval-capture-citations.ts
+ */
+
+import { promises as fs } from 'node:fs';
+
+const [, , beforeArg, afterArg, actualsArg] = process.argv;
+if (!beforeArg || !afterArg || !actualsArg) {
+  console.error('usage: node scripts/qa-eval-citation-overlap.mjs <before.json> <after.json> <actuals.json>');
+  process.exit(1);
+}
+
+const before = JSON.parse(await fs.readFile(beforeArg, 'utf-8'));
+const after = JSON.parse(await fs.readFile(afterArg, 'utf-8'));
+const actuals = JSON.parse(await fs.readFile(actualsArg, 'utf-8'));
+
+const actualsById = new Map(actuals.map((a) => [a.id, a]));
+
+function pairKey(c) {
+  return `${c.kind}::${c.rowId}`;
+}
+function jaccard(a, b) {
+  if (a.size === 0 && b.size === 0) return 1;
+  let inter = 0;
+  for (const x of a) if (b.has(x)) inter += 1;
+  const union = new Set([...a, ...b]).size;
+  return union === 0 ? 0 : inter / union;
+}
+
+const categories = new Set(before.cases.map((c) => c.category));
+const perCat = {};
+for (const cat of categories) {
+  perCat[cat] = { beforeSum: 0, afterSum: 0, count: 0 };
+}
+
+for (const b of before.cases) {
+  const a = after.cases.find((x) => x.id === b.id);
+  const act = actualsById.get(b.id);
+  if (!a || !act) continue;
+  if (b.expectedCitations.length === 0 && a.expectedCitations.length === 0) {
+    // gap-style cases — both 0, perfect overlap with empty actuals.
+    perCat[b.category].count += 1;
+    perCat[b.category].beforeSum += jaccard(
+      new Set(b.expectedCitations.map(pairKey)),
+      new Set(act.actualCitations.map(pairKey)),
+    );
+    perCat[b.category].afterSum += jaccard(
+      new Set(a.expectedCitations.map(pairKey)),
+      new Set(act.actualCitations.map(pairKey)),
+    );
+    continue;
+  }
+  perCat[b.category].count += 1;
+  perCat[b.category].beforeSum += jaccard(
+    new Set(b.expectedCitations.map(pairKey)),
+    new Set(act.actualCitations.map(pairKey)),
+  );
+  perCat[b.category].afterSum += jaccard(
+    new Set(a.expectedCitations.map(pairKey)),
+    new Set(act.actualCitations.map(pairKey)),
+  );
+}
+
+console.log('| Category   | Before Jaccard | After Jaccard | Δ      |');
+console.log('|------------|----------------|---------------|--------|');
+for (const cat of [...categories].sort()) {
+  const p = perCat[cat];
+  const before = p.count ? p.beforeSum / p.count : 0;
+  const after = p.count ? p.afterSum / p.count : 0;
+  console.log(
+    `| ${cat.padEnd(10)} | ${(before * 100).toFixed(1).padStart(13)}% | ${(after * 100).toFixed(1).padStart(12)}% | ${(after - before >= 0 ? '+' : '') + ((after - before) * 100).toFixed(1)}% |`,
+  );
+}

--- a/scripts/qa-eval-rewrite-citations.mjs
+++ b/scripts/qa-eval-rewrite-citations.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * Re-anchor expectedCitations in tests/qa-eval/cases.json so the rowIds match
+ * the format the Q&A composer actually emits.
+ *
+ * #915 path-to-70 phase 1.5.
+ *
+ * Two fixes:
+ *
+ * 1. The composer emits citations with rowId prefixed by kind:
+ *      directive  → "directive-<bare-id>"
+ *      outcome    → "outcome-<bare-id>"
+ *      pr         → "pr-<pull_request_id>"
+ *      issue      → "issue-<issue_id>"
+ *      project    → "project-<bare-id>"
+ *      project_repo → "project_repo-<repo_uuid>"
+ *
+ *    Before this script ran, cases.json had bare rowIds (e.g. "seed-cortex-ide-...")
+ *    so citation_correctness was always ~0 even when the right row was cited.
+ *
+ * 2. Phase 1.3 (#948) deduped runtime directives that duplicated seeds via
+ *    upsert-by-slug. Two legacy runtime IDs in cases.json no longer exist:
+ *      d-1775763867817-183404ef  (was a runtime dupe of seed-cortex-ide-inline-styles-only)
+ *      d-1775763668585-fba2ce0b  (was a runtime dupe of seed-global-typecheck-before-commit)
+ *    Drop those — the seed citation already covers the same content.
+ *
+ * 3. Issue rowIds: the cases.json had GH issue NUMBERS (e.g. "915") but the
+ *    retriever cites the integer issue_id from github_issues (e.g. "4353815519").
+ *    Map by number → issue_id from the live DB.
+ *
+ * Usage:
+ *   node scripts/qa-eval-rewrite-citations.mjs --dry-run
+ *   node scripts/qa-eval-rewrite-citations.mjs --apply
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import Database from 'better-sqlite3';
+
+const APPLY = process.argv.includes('--apply');
+
+// --- DB-backed lookups -------------------------------------------------------
+
+const dbPath = path.join(
+  process.env.O8_DATA_DIR || process.env.CORTEX_IDE_DATA_DIR || path.join(os.homedir(), '.o8'),
+  'cortex-ide.db',
+);
+const db = new Database(dbPath, { readonly: true });
+
+// number → issue_id, used for "issue" citations.
+const issueNumberToId = new Map();
+for (const row of db.prepare('SELECT number, issue_id FROM github_issues').all()) {
+  issueNumberToId.set(String(row.number), String(row.issue_id));
+}
+
+// id set, used to drop dead outcome rowIds (we keep ones that exist).
+const liveOutcomeIds = new Set();
+for (const row of db.prepare('SELECT id FROM session_outcomes').all()) {
+  liveOutcomeIds.add(row.id);
+}
+
+// id set, used for projects.
+const liveProjectIds = new Set();
+for (const row of db.prepare('SELECT id FROM projects').all()) {
+  liveProjectIds.add(row.id);
+}
+
+// repo_id set, used for project_repos.
+const liveProjectRepoIds = new Set();
+for (const row of db.prepare('SELECT repo_id FROM project_repos').all()) {
+  liveProjectRepoIds.add(row.repo_id);
+}
+
+// directive slug set from disk (~/.o8/directives/*.md).
+const directivesDir = path.join(
+  process.env.O8_DATA_DIR || process.env.CORTEX_IDE_DATA_DIR || path.join(os.homedir(), '.o8'),
+  'directives',
+);
+const liveDirectiveIds = new Set(
+  (await fs.readdir(directivesDir).catch(() => []))
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => f.replace(/\.md$/, '')),
+);
+
+// IDs that were in cases.json but were deduped away.
+const DEAD_DIRECTIVE_IDS = new Set([
+  'd-1775763867817-183404ef',
+  'd-1775763668585-fba2ce0b',
+]);
+
+// --- Citation rewrite --------------------------------------------------------
+
+/**
+ * Translate one expectedCitation entry into the kind-prefixed shape, dropping
+ * any rowId that no longer resolves on the live DB.
+ *
+ * @returns the rewritten citation, or null if the row is dead and should be dropped.
+ */
+function rewriteCitation(cit, caseId) {
+  const { kind, rowId } = cit;
+
+  if (DEAD_DIRECTIVE_IDS.has(rowId)) {
+    return null; // deduped away
+  }
+
+  let bare = rowId;
+  // Strip prefix if already prefixed (idempotent).
+  if (rowId.startsWith(`${kind}-`)) {
+    bare = rowId.slice(kind.length + 1);
+  }
+
+  let resolved = bare;
+  let alive = false;
+
+  switch (kind) {
+    case 'directive':
+      alive = liveDirectiveIds.has(bare);
+      break;
+    case 'outcome':
+      alive = liveOutcomeIds.has(bare);
+      break;
+    case 'project':
+      alive = liveProjectIds.has(bare);
+      break;
+    case 'project_repo':
+      alive = liveProjectRepoIds.has(bare);
+      break;
+    case 'issue': {
+      // If `bare` is a GH issue NUMBER (small int), translate to issue_id.
+      const numericProbe = issueNumberToId.get(bare);
+      if (numericProbe) {
+        resolved = numericProbe;
+        alive = true;
+      } else if (/^\d{8,}$/.test(bare)) {
+        // Already an issue_id — accept if present.
+        const found = db
+          .prepare('SELECT 1 AS hit FROM github_issues WHERE issue_id = ?')
+          .get(bare);
+        alive = Boolean(found);
+        resolved = bare;
+      }
+      break;
+    }
+    case 'pr': {
+      // bare may be number or pull_request_id.
+      const found = db
+        .prepare('SELECT 1 AS hit FROM github_pull_requests WHERE pull_request_id = ? OR number = ?')
+        .get(bare, Number(bare));
+      alive = Boolean(found);
+      resolved = bare;
+      break;
+    }
+  }
+
+  if (!alive) {
+    process.stderr.write(
+      `[rewrite] ${caseId}: drop ${kind}/${rowId} (not in live DB / disk)\n`,
+    );
+    return null;
+  }
+
+  return { kind, rowId: `${kind}-${resolved}` };
+}
+
+// --- Main --------------------------------------------------------------------
+
+const casesPath = path.resolve(process.cwd(), 'tests/qa-eval/cases.json');
+const raw = await fs.readFile(casesPath, 'utf-8');
+const file = JSON.parse(raw);
+
+let totalBefore = 0;
+let totalAfter = 0;
+let droppedCount = 0;
+let prefixedCount = 0;
+
+for (const c of file.cases) {
+  totalBefore += c.expectedCitations.length;
+  const next = [];
+  for (const cit of c.expectedCitations) {
+    const r = rewriteCitation(cit, c.id);
+    if (r === null) {
+      droppedCount += 1;
+      continue;
+    }
+    if (r.rowId !== cit.rowId) prefixedCount += 1;
+    next.push(r);
+  }
+  c.expectedCitations = next;
+  totalAfter += next.length;
+}
+
+// Bump the comment + version-stamp to flag the rewrite.
+file.$comment = (file.$comment ?? '') +
+  ` Phase 1.5 (#915 path-to-70): expectedCitations rewritten so rowIds match the kind-prefixed format the composer emits (e.g. "directive-seed-cortex-ide-..."). Dead runtime IDs (d-17757638..., d-17757636...) deduped via #948 were dropped — the seed citation already covers the same content. Issue numbers translated to issue_ids per github_issues.issue_id.`;
+
+process.stderr.write(
+  `[rewrite] cases=${file.cases.length} citations: ${totalBefore} → ${totalAfter} (prefixed=${prefixedCount}, dropped=${droppedCount})\n`,
+);
+
+if (APPLY) {
+  await fs.writeFile(casesPath, JSON.stringify(file, null, 2) + '\n', 'utf-8');
+  process.stderr.write(`[rewrite] wrote ${casesPath}\n`);
+} else {
+  process.stderr.write(`[rewrite] DRY RUN — pass --apply to write.\n`);
+}
+
+db.close();

--- a/scripts/validate-qa-cases.ts
+++ b/scripts/validate-qa-cases.ts
@@ -156,8 +156,10 @@ interface RowProbe {
 const CITATION_PROBE: Record<ExpectedCitation['kind'], RowProbe | null> = {
   outcome: { table: 'session_outcomes', column: 'id' },
   directive: null, // directives live as files in ~/.o8/directives/, not the DB
-  pr: { table: 'github_pull_requests', column: 'number' },
-  issue: { table: 'github_issues', column: 'number' },
+  // Cases use pull_request_id / issue_id (the canonical row id the composer cites),
+  // not GH numbers. The retriever joins on the *_id columns.
+  pr: { table: 'github_pull_requests', column: 'pull_request_id' },
+  issue: { table: 'github_issues', column: 'issue_id' },
   project: { table: 'projects', column: 'id' },
   project_repo: { table: 'project_repos', column: 'repo_id' },
 };
@@ -214,11 +216,18 @@ async function probeCitations(
     }
   }
 
+  // expectedCitations rowIds are stored kind-prefixed (e.g. "directive-seed-foo")
+  // so they match the format the composer emits. Strip the "<kind>-" prefix
+  // before probing the DB / disk for the bare ID.
+  const stripPrefix = (kind: string, rowId: string): string =>
+    rowId.startsWith(`${kind}-`) ? rowId.slice(kind.length + 1) : rowId;
+
   for (const qaCase of cases) {
     for (const cit of qaCase.expectedCitations) {
+      const bare = stripPrefix(cit.kind, cit.rowId);
       if (cit.kind === 'directive') {
         if (directiveFiles.size === 0) continue;
-        if (!directiveFiles.has(cit.rowId)) {
+        if (!directiveFiles.has(bare)) {
           warnings.push(
             `case ${qaCase.id}: expectedCitations rowId '${cit.rowId}' (kind=directive) not found in ${directivesDir}`,
           );
@@ -230,7 +239,7 @@ async function probeCitations(
       try {
         const row = db
           .prepare(`SELECT 1 AS hit FROM ${probe.table} WHERE ${probe.column} = ? LIMIT 1`)
-          .get(cit.rowId);
+          .get(bare);
         if (!row) {
           warnings.push(
             `case ${qaCase.id}: expectedCitations rowId '${cit.rowId}' (kind=${cit.kind}) not found in ${probe.table}.${probe.column}`,

--- a/tests/qa-eval/cases.json
+++ b/tests/qa-eval/cases.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "30-question Q&A eval set for the Cortex Engineering Brain (epic #915 sub-issue 3 wave A). 5 questions per category over 6 categories: ownership / decisions / processes / incidents / specs / cross-repo. Ground truth pulled from ~/.o8/cortex-ide.db (session_outcomes, github_pull_requests, projects, project_repos), ~/.o8/directives/*.md, and the locked architecture comment on epic #915 itself. Questions marked knownGap are designed to surface ingestion holes — the runner classifies them as gaps, not failures. expectedCitations rowIds reference real rows where applicable; the validator warns if a rowId can't be resolved against a live DB but does NOT fail the build (DBs differ across machines).",
+  "$comment": "30-question Q&A eval set for the Cortex Engineering Brain (epic #915 sub-issue 3 wave A). 5 questions per category over 6 categories: ownership / decisions / processes / incidents / specs / cross-repo. Ground truth pulled from ~/.o8/cortex-ide.db (session_outcomes, github_pull_requests, projects, project_repos), ~/.o8/directives/*.md, and the locked architecture comment on epic #915 itself. Questions marked knownGap are designed to surface ingestion holes — the runner classifies them as gaps, not failures. expectedCitations rowIds reference real rows where applicable; the validator warns if a rowId can't be resolved against a live DB but does NOT fail the build (DBs differ across machines). Phase 1.5 (#915 path-to-70): expectedCitations rewritten so rowIds match the kind-prefixed format the composer emits (e.g. \"directive-seed-cortex-ide-...\"). Dead runtime IDs (d-17757638..., d-17757636...) deduped via #948 were dropped — the seed citation already covers the same content. Issue numbers translated to issue_ids per github_issues.issue_id.",
   "version": 1,
   "generatedAt": "2026-04-29",
   "cases": [
@@ -16,12 +16,28 @@
         "Identifies typecheck-before-commit and surgical-changes as global scope"
       ],
       "expectedCitations": [
-        { "kind": "directive", "rowId": "seed-cortex-ide-800-line-ceiling" },
-        { "kind": "directive", "rowId": "seed-cortex-ide-inline-styles-only" },
-        { "kind": "directive", "rowId": "seed-cortex-ide-phosphor-svg-only" },
-        { "kind": "directive", "rowId": "seed-global-typecheck-before-commit" }
+        {
+          "kind": "directive",
+          "rowId": "directive-seed-cortex-ide-800-line-ceiling"
+        },
+        {
+          "kind": "directive",
+          "rowId": "directive-seed-cortex-ide-inline-styles-only"
+        },
+        {
+          "kind": "directive",
+          "rowId": "directive-seed-cortex-ide-phosphor-svg-only"
+        },
+        {
+          "kind": "directive",
+          "rowId": "directive-seed-global-typecheck-before-commit"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.5, "max_hallucinations": 1 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.5,
+        "max_hallucinations": 1
+      }
     },
     {
       "id": "qa-002",
@@ -35,11 +51,24 @@
         "References the project_repos linking table or projects table"
       ],
       "expectedCitations": [
-        { "kind": "project", "rowId": "proj-5d0d9e02-015" },
-        { "kind": "project_repo", "rowId": "70954348-8e56-41dd-ac10-5b4e91964fc2" },
-        { "kind": "project_repo", "rowId": "a1c35bf5-ed73-44cf-a7d9-30c6ccb1eb84" }
+        {
+          "kind": "project",
+          "rowId": "project-proj-5d0d9e02-015"
+        },
+        {
+          "kind": "project_repo",
+          "rowId": "project_repo-70954348-8e56-41dd-ac10-5b4e91964fc2"
+        },
+        {
+          "kind": "project_repo",
+          "rowId": "project_repo-a1c35bf5-ed73-44cf-a7d9-30c6ccb1eb84"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.5, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.5,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-003",
@@ -53,7 +82,11 @@
         "Does not invent fictional GitHub usernames"
       ],
       "expectedCitations": [],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.0, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-004",
@@ -67,10 +100,20 @@
         "References the runtime column in session_outcomes"
       ],
       "expectedCitations": [
-        { "kind": "outcome", "rowId": "seed-Users-marquisehurtt-cortex-ide-1d-codex-feat-dispatch-context-injection-743" },
-        { "kind": "outcome", "rowId": "seed-Users-marquisehurtt-cortex-ide-2d-gemini-feat-auto-index-repos-741" }
+        {
+          "kind": "outcome",
+          "rowId": "outcome-seed-Users-marquisehurtt-cortex-ide-1d-codex-feat-dispatch-context-injection-743"
+        },
+        {
+          "kind": "outcome",
+          "rowId": "outcome-seed-Users-marquisehurtt-cortex-ide-2d-gemini-feat-auto-index-repos-741"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.5, "max_hallucinations": 1 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.5,
+        "max_hallucinations": 1
+      }
     },
     {
       "id": "qa-005",
@@ -84,9 +127,16 @@
         "Mentions packet-meta-rows pattern"
       ],
       "expectedCitations": [
-        { "kind": "directive", "rowId": "seed-cortex-ide-no-native-form-controls-in-packets" }
+        {
+          "kind": "directive",
+          "rowId": "directive-seed-cortex-ide-no-native-form-controls-in-packets"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.7, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.7,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-006",
@@ -100,10 +150,16 @@
         "References the seed-cortex-ide-inline-styles-only directive (or seed-cortex-ide-inline-styles-only or d-1775763867817-183404ef)"
       ],
       "expectedCitations": [
-        { "kind": "directive", "rowId": "seed-cortex-ide-inline-styles-only" },
-        { "kind": "directive", "rowId": "d-1775763867817-183404ef" }
+        {
+          "kind": "directive",
+          "rowId": "directive-seed-cortex-ide-inline-styles-only"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.5, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.5,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-007",
@@ -117,9 +173,16 @@
         "Mentions src/lib/icons/ shim system or 85 icons"
       ],
       "expectedCitations": [
-        { "kind": "directive", "rowId": "seed-cortex-ide-phosphor-svg-only" }
+        {
+          "kind": "directive",
+          "rowId": "directive-seed-cortex-ide-phosphor-svg-only"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.7, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.7,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-008",
@@ -133,9 +196,16 @@
         "Names the three retrievers (SQL, FTS5, graph / codebase-memory-mcp)"
       ],
       "expectedCitations": [
-        { "kind": "issue", "rowId": "915" }
+        {
+          "kind": "issue",
+          "rowId": "issue-4353815519"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.5, "max_hallucinations": 1 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.5,
+        "max_hallucinations": 1
+      }
     },
     {
       "id": "qa-009",
@@ -149,7 +219,11 @@
         "References the .dmg/installer flow OR the local-Next-backend nature"
       ],
       "expectedCitations": [],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.0, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-010",
@@ -163,9 +237,16 @@
         "Mentions the Flash classifier OR the local opencode/gpt-5-nano fallback"
       ],
       "expectedCitations": [
-        { "kind": "issue", "rowId": "915" }
+        {
+          "kind": "issue",
+          "rowId": "issue-4353815519"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.5, "max_hallucinations": 1 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.5,
+        "max_hallucinations": 1
+      }
     },
     {
       "id": "qa-011",
@@ -178,10 +259,16 @@
         "References the typecheck directive OR npm run typecheck variant"
       ],
       "expectedCitations": [
-        { "kind": "directive", "rowId": "seed-global-typecheck-before-commit" },
-        { "kind": "directive", "rowId": "d-1775763668585-fba2ce0b" }
+        {
+          "kind": "directive",
+          "rowId": "directive-seed-global-typecheck-before-commit"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.5, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.5,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-012",
@@ -195,9 +282,16 @@
         "Names src/ws-server.ts as waived"
       ],
       "expectedCitations": [
-        { "kind": "directive", "rowId": "seed-cortex-ide-800-line-ceiling" }
+        {
+          "kind": "directive",
+          "rowId": "directive-seed-cortex-ide-800-line-ceiling"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.7, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.7,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-013",
@@ -211,9 +305,16 @@
         "Forbids silent rewrites of adjacent code"
       ],
       "expectedCitations": [
-        { "kind": "directive", "rowId": "seed-global-surgical-changes" }
+        {
+          "kind": "directive",
+          "rowId": "directive-seed-global-surgical-changes"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.7, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.7,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-014",
@@ -228,7 +329,11 @@
         "References the auto-update flow / UpdateBanner / GitHub Releases"
       ],
       "expectedCitations": [],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.0, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-015",
@@ -242,7 +347,11 @@
         "References the allowlist or /api/setup/* GET-only carve-out"
       ],
       "expectedCitations": [],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.0, "max_hallucinations": 1 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0,
+        "max_hallucinations": 1
+      }
     },
     {
       "id": "qa-016",
@@ -257,10 +366,20 @@
         "Optionally mentions the resulting glass-chrome-preserved directive"
       ],
       "expectedCitations": [
-        { "kind": "outcome", "rowId": "seed-Users-marquisehurtt-cortex-ide-7d-gemini-fix-midnight-blob-rgba-sweep" },
-        { "kind": "directive", "rowId": "seed-cortex-ide-glass-chrome-preserved" }
+        {
+          "kind": "outcome",
+          "rowId": "outcome-seed-Users-marquisehurtt-cortex-ide-7d-gemini-fix-midnight-blob-rgba-sweep"
+        },
+        {
+          "kind": "directive",
+          "rowId": "directive-seed-cortex-ide-glass-chrome-preserved"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.5, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.5,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-017",
@@ -275,9 +394,16 @@
         "Mentions the native-select-to-popover migration"
       ],
       "expectedCitations": [
-        { "kind": "outcome", "rowId": "seed-Users-marquisehurtt-cortex-ide-6d-codex-feat-packet-meta-rows-restyle" }
+        {
+          "kind": "outcome",
+          "rowId": "outcome-seed-Users-marquisehurtt-cortex-ide-6d-codex-feat-packet-meta-rows-restyle"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.7, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.7,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-018",
@@ -291,9 +417,16 @@
         "States that the reviewer flagged it as off-brand vs the locked design language"
       ],
       "expectedCitations": [
-        { "kind": "outcome", "rowId": "seed-Users-marquisehurtt-cortex-ide-5d-opencode-polish-orchestrator-empty-state-copy" }
+        {
+          "kind": "outcome",
+          "rowId": "outcome-seed-Users-marquisehurtt-cortex-ide-5d-opencode-polish-orchestrator-empty-state-copy"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.7, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.7,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-019",
@@ -307,10 +440,20 @@
         "Mentions either the idle-between-runs symptom OR the git-refused-commit symptom"
       ],
       "expectedCitations": [
-        { "kind": "outcome", "rowId": "so-1776188979528-a3yz23te" },
-        { "kind": "outcome", "rowId": "so-1776188344936-92de5fx8" }
+        {
+          "kind": "outcome",
+          "rowId": "outcome-so-1776188979528-a3yz23te"
+        },
+        {
+          "kind": "outcome",
+          "rowId": "outcome-so-1776188344936-92de5fx8"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.5, "max_hallucinations": 1 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.5,
+        "max_hallucinations": 1
+      }
     },
     {
       "id": "qa-020",
@@ -324,9 +467,16 @@
         "Either cites commit 929ffdf OR explicitly states the commit history is not available in the substrate"
       ],
       "expectedCitations": [
-        { "kind": "directive", "rowId": "seed-cortex-ide-palette-vars" }
+        {
+          "kind": "directive",
+          "rowId": "directive-seed-cortex-ide-palette-vars"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.5, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.5,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-021",
@@ -340,9 +490,16 @@
         "Mentions the qa_eval_runs eval harness table"
       ],
       "expectedCitations": [
-        { "kind": "issue", "rowId": "915" }
+        {
+          "kind": "issue",
+          "rowId": "issue-4353815519"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.5, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.5,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-022",
@@ -356,9 +513,16 @@
         "Names Class B 2.0s TTFT / 4s TTLT / 6s ceiling"
       ],
       "expectedCitations": [
-        { "kind": "issue", "rowId": "915" }
+        {
+          "kind": "issue",
+          "rowId": "issue-4353815519"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.5, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.5,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-023",
@@ -372,9 +536,16 @@
         "Mentions invalidation on directive write or outcome insert"
       ],
       "expectedCitations": [
-        { "kind": "issue", "rowId": "915" }
+        {
+          "kind": "issue",
+          "rowId": "issue-4353815519"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.5, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.5,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-024",
@@ -388,9 +559,16 @@
         "States that the mode is picked by class, not by user"
       ],
       "expectedCitations": [
-        { "kind": "issue", "rowId": "915" }
+        {
+          "kind": "issue",
+          "rowId": "issue-4353815519"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.5, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.5,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-025",
@@ -404,9 +582,16 @@
         "Names the rubric fields factual_accuracy, citation_correctness, hallucination_count"
       ],
       "expectedCitations": [
-        { "kind": "issue", "rowId": "915" }
+        {
+          "kind": "issue",
+          "rowId": "issue-4353815519"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.5, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.5,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-026",
@@ -421,10 +606,20 @@
         "Names glass tokens / palette vars"
       ],
       "expectedCitations": [
-        { "kind": "directive", "rowId": "seed-cortex-ide-inline-styles-only" },
-        { "kind": "directive", "rowId": "seed-cortex-ide-palette-vars" }
+        {
+          "kind": "directive",
+          "rowId": "directive-seed-cortex-ide-inline-styles-only"
+        },
+        {
+          "kind": "directive",
+          "rowId": "directive-seed-cortex-ide-palette-vars"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.3, "max_hallucinations": 1 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.3,
+        "max_hallucinations": 1
+      }
     },
     {
       "id": "qa-027",
@@ -438,9 +633,16 @@
         "References the o8-site README or the explicit 'one and only Vercel surface' wording"
       ],
       "expectedCitations": [
-        { "kind": "project", "rowId": "proj-5d0d9e02-015" }
+        {
+          "kind": "project",
+          "rowId": "project-proj-5d0d9e02-015"
+        }
       ],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.3, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0.3,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-028",
@@ -454,7 +656,11 @@
         "Optionally names the /text specimen page"
       ],
       "expectedCitations": [],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.0, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-029",
@@ -468,7 +674,11 @@
         "Does not invent fictional o8-site outcome rows"
       ],
       "expectedCitations": [],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.0, "max_hallucinations": 0 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0,
+        "max_hallucinations": 0
+      }
     },
     {
       "id": "qa-030",
@@ -482,7 +692,11 @@
         "Mentions reading node_modules/next/dist/docs/ before writing code"
       ],
       "expectedCitations": [],
-      "rubric": { "factual_accuracy_threshold": 0.7, "citation_correctness_threshold": 0.0, "max_hallucinations": 1 }
+      "rubric": {
+        "factual_accuracy_threshold": 0.7,
+        "citation_correctness_threshold": 0,
+        "max_hallucinations": 1
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Phase 1 #5 of the Cortex Q&A path-to-70% plan. The composer emits citations with `kind`-prefixed rowIds (e.g. `directive-seed-cortex-ide-inline-styles-only`, `issue-4353815519`) but `cases.json` stored bare rowIds (`seed-cortex-ide-inline-styles-only`, `915`). Citation correctness scored ~0 even when the retriever cited the correct row.

This PR re-anchors `expectedCitations` so the rowIds match the format the composer actually emits, plus two related cleanups:

- **Drops 2 legacy runtime directive IDs** that were deduped away in #948: `d-1775763867817-183404ef` and `d-1775763668585-fba2ce0b`. Their seed counterparts already cover the same content.
- **Translates GH issue numbers to issue_ids** (`915` → `issue-4353815519`) per `github_issues.issue_id` since that's the canonical row id the retriever cites.
- Updates `scripts/validate-qa-cases.ts` to strip the `kind-` prefix before probing the DB / disk so it stays in sync with the new case format. `pr` + `issue` probes also switched from `number` to `pull_request_id` / `issue_id`.

Helpers under `scripts/` for future re-anchor passes:
- `qa-eval-capture-citations.ts` — runs `askCortex` per case, dumps actual citations
- `qa-eval-rewrite-citations.mjs` — applies the kind-prefix + dead-id drop in one pass
- `qa-eval-citation-overlap.mjs` — quantifies before/after Jaccard overlap

## Citation overlap (Jaccard, expected ∩ actual / union)

Computed on a captured `askCortex` run against the live DB. Class B (Sonnet) cases are the ones where the rewrite shows up; Class A cases hit Flash 503 throughout the run so their `actualCitations` were empty and no overlap movement is visible until Flash recovers.

| Category   | Before | After  | Δ      |
|------------|-------:|-------:|-------:|
| ownership  |  20.0% |  20.0% |   +0.0 |
| decisions  |   0.0% |  24.0% |  +24.0 |
| processes  |  20.0% |  20.0% |   +0.0 |
| incidents  |   0.0% |  20.0% |  +20.0 |
| specs      |   0.0% |   0.0% |   +0.0 |
| cross-repo |  60.0% |  60.0% |   +0.0 |

The +0 categories aren't a regression — they're cases where the captured run got Flash 503 so the actuals were empty regardless of the expected format.

## Eval results (post-rewrite, full `npm run eval:qa`)

Note: factual_accuracy is bottlenecked by Flash 503 hammering the Class A composer in this run. That's a separate phase (Class B fallback / model swap) — outside the scope of phase 1.5.

| Category   | Factual | Hallucinations |
|------------|--------:|---------------:|
| ownership  |  10.0%  |  0 |
| decisions  |  42.0%  |  3 |
| processes  |  12.0%  |  0 |
| incidents  |  27.0%  |  2 |
| specs      |   0.0%  |  0 |
| cross-repo |  18.0%  |  0 |
| **Overall** | **18.2%** | 5 |

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run validate:qa-cases` — OK, 30 cases, 5/category, no warnings (was 2 warnings pre-PR for the dead `d-*` IDs)
- [x] `npm run eval:qa` runs to completion (the citation_correctness column on the printed summary now reflects real overlap when Class B fires)
- [ ] Re-run eval once Flash availability stabilizes — citation_correctness should jump on the +24 / +20 categories without any further changes to cases.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)