### PR TITLE
feat(qa): Haiku CLI fallback for Class A + classifier

### DIFF
--- a/src/lib/cortex/qa/classifier.ts
+++ b/src/lib/cortex/qa/classifier.ts
@@ -1,20 +1,22 @@
 /**
- * Flash classifier for the Cortex Q&A composer (epic #915 sub-2).
+ * Question classifier for the Cortex Q&A composer (epic #915 sub-2,
+ * Haiku CLI fallback added in path-to-70 phase 1.6).
  *
- * One Gemini Flash JSON-mode call to:
- *   - Classify the question as Class A (lookup) or Class B (reasoning)
- *   - Generate 3-5 BM25 query variants for the retrieval layer
+ * Three-tier provider chain — all return the same { class, bm25Variants } shape:
+ *   1. Gemini Flash JSON-mode (fast: ~50ms p50, ~200ms p95)
+ *   2. Claude Haiku CLI       (Claude Max sub — kicks in when Flash 503s)
+ *   3. Heuristic fallback     (lexical "why/how/explain" → Class B)
  *
  * Class A = lookup: "who/when/where/what" — expects a 1-2 fact answer
  * Class B = reasoning: "why/how/explain" — expects multi-fact composition
  *
- * The BM25 variants are passed directly to `retrieveAll()` as `bm25Variants`
- * so the FTS5 retriever can search with synonym/phrasing expansion.
- *
- * Target latency: 50ms p50 / 200ms p95 (Flash is fast; JSON-mode is cheap).
+ * BM25 variants are passed directly to `retrieveAll()` so the FTS5 retriever
+ * can search with synonym/phrasing expansion.
  */
 
 import 'server-only';
+
+import { callHaiku } from '@/lib/cortex/qa/llm/haiku-adapter';
 
 export type QuestionClass = 'A' | 'B';
 
@@ -30,16 +32,40 @@ Class B = reasoning ("why/how/explain"), multi-fact composition required
 bm25_variants: 3-5 alternate phrasings using synonyms and rephrasings of the question`;
 
 /**
- * Call Gemini Flash in JSON mode to classify the question.
- * Falls back to Class B (safer: prefers Sonnet compose) on any error.
+ * Classify the question with a 3-tier provider chain:
+ *   1. Gemini Flash (fast, JSON-mode)
+ *   2. Claude Haiku CLI (Claude Max subscription — no per-token cost)
+ *   3. Heuristic fallback (lexical "why/how/explain" → Class B)
+ *
+ * Returns the classification + BM25 variants. Never throws; on full failure
+ * returns the heuristic Class B so retrieval still gets at least one variant.
  */
 export async function classifyQuestion(question: string): Promise<ClassifierResult> {
+  // Tier 1: Flash (when a Google AI key is present).
   const apiKey = process.env.GOOGLE_AI_API_KEY ?? process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? process.env.GEMINI_API_KEY;
-  if (!apiKey) {
-    // No key — default to Class B so we always use the Anthropic path if available.
-    return fallback(question);
+  if (apiKey) {
+    const flashResult = await tryFlash(question, apiKey);
+    if (flashResult) {
+      console.info('[qa][classifier] resolved via flash');
+      return flashResult;
+    }
+    // Flash failed — fall through to Haiku CLI.
   }
 
+  // Tier 2: Haiku CLI (Claude Max subscription).
+  const haikuResult = await tryHaiku(question);
+  if (haikuResult) {
+    console.info('[qa][classifier] resolved via haiku-cli');
+    return haikuResult;
+  }
+
+  // Tier 3: heuristic.
+  console.info('[qa][classifier] resolved via heuristic');
+  return fallback(question);
+}
+
+/** Tier 1: Flash JSON-mode call. Returns null on any failure so caller can chain. */
+async function tryFlash(question: string, apiKey: string): Promise<ClassifierResult | null> {
   try {
     const body = {
       contents: [
@@ -70,8 +96,8 @@ export async function classifyQuestion(question: string): Promise<ClassifierResu
     );
 
     if (!res.ok) {
-      console.warn(`[qa][classifier] Flash API error ${res.status} — defaulting to Class B`);
-      return fallback(question);
+      console.warn(`[qa][classifier] Flash API error ${res.status} — trying Haiku CLI`);
+      return null;
     }
 
     const json = await res.json() as {
@@ -81,50 +107,66 @@ export async function classifyQuestion(question: string): Promise<ClassifierResu
     };
 
     const rawText = json.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
-    if (!rawText.trim()) {
-      return fallback(question);
-    }
+    if (!rawText.trim()) return null;
 
-    // Strip any preamble text and markdown code fences.
-    // Flash sometimes returns "Here is the JSON:\n```json\n{...}\n```"
-    let text = rawText.trim();
-    // Extract JSON from inside a code fence if present.
-    const fenceMatch = text.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
-    if (fenceMatch) {
-      text = fenceMatch[1].trim();
-    } else {
-      // Try to extract the first JSON object directly from the text.
-      const objMatch = text.match(/\{[\s\S]*\}/);
-      if (objMatch) {
-        text = objMatch[0].trim();
-      }
-    }
-
-    let parsed: { class?: unknown; bm25_variants?: unknown };
-    try {
-      parsed = JSON.parse(text) as { class?: unknown; bm25_variants?: unknown };
-    } catch {
-      // Flash returned non-JSON even after extraction — use heuristic fallback.
-      // This is common when the model adds explanatory prose despite JSON-mode.
-      console.info('[qa][classifier] Non-JSON Flash response after extraction — using heuristic fallback');
-      return fallback(question);
-    }
-
-    const cls = parsed.class === 'A' ? 'A' : 'B';
-    const variants = Array.isArray(parsed.bm25_variants)
-      ? (parsed.bm25_variants as unknown[])
-          .filter((v): v is string => typeof v === 'string' && v.trim().length > 0)
-          .slice(0, 5)
-      : [];
-
-    return {
-      class: cls,
-      bm25Variants: variants.length > 0 ? variants : [question],
-    };
+    return parseClassifierJson(rawText, question);
   } catch (err) {
-    console.warn('[qa][classifier] error:', err instanceof Error ? err.message : err);
-    return fallback(question);
+    console.warn('[qa][classifier] Flash threw:', err instanceof Error ? err.message : err);
+    return null;
   }
+}
+
+/** Tier 2: Haiku CLI call. Mirrors Flash JSON shape; returns null on failure. */
+async function tryHaiku(question: string): Promise<ClassifierResult | null> {
+  try {
+    const prompt = `${CLASSIFIER_PROMPT}\n\nQuestion: ${question}`;
+    // 12s — Haiku CLI bootstrap (login-shell + node start) takes ~6-8s before
+    // the model even runs. Flash already had its 8s shot above; this is the
+    // slower fallback so a slightly-longer ceiling is fine.
+    const text = await callHaiku(prompt, { timeoutMs: 12_000 });
+    return parseClassifierJson(text, question);
+  } catch (err) {
+    console.warn('[qa][classifier] Haiku CLI failed:', err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+/**
+ * Parse a classifier JSON response (Flash or Haiku). Strips markdown fences
+ * + preamble text. Returns null if the payload can't be coerced.
+ */
+function parseClassifierJson(rawText: string, question: string): ClassifierResult | null {
+  let text = rawText.trim();
+  // Strip markdown code fence if present.
+  const fenceMatch = text.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+  if (fenceMatch) {
+    text = fenceMatch[1].trim();
+  } else {
+    // Try to extract the first JSON object directly.
+    const objMatch = text.match(/\{[\s\S]*\}/);
+    if (objMatch) {
+      text = objMatch[0].trim();
+    }
+  }
+
+  let parsed: { class?: unknown; bm25_variants?: unknown };
+  try {
+    parsed = JSON.parse(text) as { class?: unknown; bm25_variants?: unknown };
+  } catch {
+    return null;
+  }
+
+  const cls: QuestionClass = parsed.class === 'A' ? 'A' : 'B';
+  const variants = Array.isArray(parsed.bm25_variants)
+    ? (parsed.bm25_variants as unknown[])
+        .filter((v): v is string => typeof v === 'string' && v.trim().length > 0)
+        .slice(0, 5)
+    : [];
+
+  return {
+    class: cls,
+    bm25Variants: variants.length > 0 ? variants : [question],
+  };
 }
 
 /** Safe fallback when Flash is unavailable or returns garbage. */

--- a/src/lib/cortex/qa/composer.ts
+++ b/src/lib/cortex/qa/composer.ts
@@ -21,6 +21,7 @@
 import 'server-only';
 
 import { detectContradictions } from '@/lib/cortex/qa/contradictions';
+import { callHaiku } from '@/lib/cortex/qa/llm/haiku-adapter';
 import { callSonnet } from '@/lib/cortex/qa/llm/sonnet-adapter';
 import type { TypedRow } from '@/lib/cortex/qa/types';
 
@@ -157,19 +158,26 @@ function sseFrame(name: string, payload: unknown): string {
 
 export type SseEmit = (name: string, payload: unknown) => void;
 
-// ── Class A composer (Flash, non-streaming) ───────────────────────────────────
+// ── Class A composer (Flash → Haiku CLI → Sonnet CLI → heuristic) ────────────
 
+/**
+ * Class A compose chain:
+ *   1. Flash       — fast (200-500ms) JSON answer when Google AI key + service available
+ *   2. Haiku CLI   — falls in when Flash 503s / errors. Claude Max subscription, no token cost.
+ *   3. Sonnet CLI  — last LLM tier; slower (5-12s) but reuses the same CLI plumbing.
+ *   4. Heuristic   — final fallback when all LLMs are unavailable.
+ *
+ * Each tier returns a raw answer string (or null on failure). After we get
+ * an answer, we translate bracket citations → CITATION markers, emit tokens
+ * and verified citations, then `done`. The path that resolved is logged so
+ * we can track tier health in production.
+ */
 export async function composeClassA(
   question: string,
   repoPath: string | undefined,
   topRows: TypedRow[],
   emit: SseEmit,
 ): Promise<void> {
-  const apiKey =
-    process.env.GOOGLE_AI_API_KEY ??
-    process.env.GOOGLE_GENERATIVE_AI_API_KEY ??
-    process.env.GEMINI_API_KEY;
-
   const lookup = buildCitationLookup(topRows);
   const rowsJson = JSON.stringify(
     topRows.slice(0, 15).map((r) => ({
@@ -177,13 +185,45 @@ export async function composeClassA(
       excerpt: r.citation.excerpt ?? '',
     })),
   );
+  const flashPrompt = buildFlashComposePrompt(question, rowsJson);
 
-  if (!apiKey) {
-    // Degrade to a "no key" message so the UI still shows something.
-    emit('token', { text: 'No Google AI key configured. Answer unavailable.' });
-    emit('done', {});
+  // Tier 1: Flash.
+  const flashAnswer = await tryComposeFlash(flashPrompt);
+  if (flashAnswer) {
+    console.info('[qa][composer-A] resolved via flash');
+    emitClassAAnswer(flashAnswer, lookup, emit);
     return;
   }
+
+  // Tier 2: Haiku CLI.
+  const haikuAnswer = await tryComposeHaiku(flashPrompt);
+  if (haikuAnswer) {
+    console.info('[qa][composer-A] resolved via haiku-cli');
+    emitClassAAnswer(haikuAnswer, lookup, emit);
+    return;
+  }
+
+  // Tier 3: Sonnet CLI (callSonnet's CLI tier — slow but reliable).
+  const sonnetAnswer = await tryComposeSonnet(question, repoPath, topRows);
+  if (sonnetAnswer) {
+    console.info('[qa][composer-A] resolved via sonnet-cli');
+    emitClassAAnswer(sonnetAnswer, lookup, emit);
+    return;
+  }
+
+  // Tier 4: heuristic.
+  console.info('[qa][composer-A] resolved via heuristic');
+  emit('token', { text: 'I don\'t have that information yet.' });
+  emit('done', {});
+}
+
+/** Tier 1: Flash. Returns answer text or null on any failure. */
+async function tryComposeFlash(prompt: string): Promise<string | null> {
+  const apiKey =
+    process.env.GOOGLE_AI_API_KEY ??
+    process.env.GOOGLE_GENERATIVE_AI_API_KEY ??
+    process.env.GEMINI_API_KEY;
+  if (!apiKey) return null;
 
   try {
     const res = await fetch(
@@ -192,16 +232,8 @@ export async function composeClassA(
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          contents: [
-            {
-              role: 'user',
-              parts: [{ text: buildFlashComposePrompt(question, rowsJson) }],
-            },
-          ],
-          generationConfig: {
-            temperature: 0.1,
-            maxOutputTokens: 300,
-          },
+          contents: [{ role: 'user', parts: [{ text: prompt }] }],
+          generationConfig: { temperature: 0.1, maxOutputTokens: 300 },
         }),
         signal: AbortSignal.timeout(8_000),
       },
@@ -209,42 +241,90 @@ export async function composeClassA(
 
     if (!res.ok) {
       const errText = await res.text().catch(() => '');
-      emit('token', { text: `Answer unavailable (API error ${res.status}).` });
-      console.warn(`[qa][composer-A] Flash error ${res.status}: ${errText.slice(0, 200)}`);
-      emit('done', {});
-      return;
+      console.warn(`[qa][composer-A] Flash error ${res.status}: ${errText.slice(0, 200)} — trying Haiku CLI`);
+      return null;
     }
 
     const json = await res.json() as {
       candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
     };
-    const rawAnswer = json.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
-    if (!rawAnswer.trim()) {
-      emit('token', { text: 'I don\'t have that information yet.' });
-      emit('done', {});
-      return;
-    }
-
-    const { translatedAnswer, verifiedRows } = translateCitations(rawAnswer, lookup);
-
-    // Emit token then verified citations.
-    emit('token', { text: translatedAnswer });
-    for (const row of verifiedRows) {
-      emit('citation', {
-        kind: row.citation.kind,
-        rowId: `${row.citation.kind}-${row.citation.rowId}`,
-        table: row.citation.table,
-        excerpt: row.citation.excerpt,
-        url: row.citation.url,
-      });
-    }
-    emit('done', {});
+    const text = json.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+    return text.trim() ? text : null;
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'composer-A error';
-    console.warn('[qa][composer-A] error:', message);
-    emit('token', { text: 'I don\'t have that information yet.' });
-    emit('done', {});
+    console.warn('[qa][composer-A] Flash threw:', err instanceof Error ? err.message : err);
+    return null;
   }
+}
+
+/** Tier 2: Haiku CLI. Same prompt shape as Flash. */
+async function tryComposeHaiku(prompt: string): Promise<string | null> {
+  try {
+    // 12s — Haiku CLI bootstrap (login-shell + node start) takes ~6-8s before
+    // the model even runs. Flash already had its 8s shot above; this is the
+    // slower fallback so a slightly-longer ceiling is fine.
+    const text = await callHaiku(prompt, { timeoutMs: 12_000 });
+    return text.trim() ? text : null;
+  } catch (err) {
+    console.warn('[qa][composer-A] Haiku CLI failed:', err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+/**
+ * Tier 3: Sonnet CLI via callSonnet (non-streaming).
+ *
+ * Reuses Class B's prompt shape (system + user) since Sonnet works best
+ * with the structured rows JSON. We only fall here when both Flash and
+ * Haiku failed, so the slower latency is acceptable.
+ *
+ * Returns null when callSonnet itself errors OR when the resolved tier is
+ * Flash (we already tried Flash in tier 1 — no point looping back).
+ */
+async function tryComposeSonnet(
+  question: string,
+  repoPath: string | undefined,
+  topRows: TypedRow[],
+): Promise<string | null> {
+  try {
+    const result = await callSonnet({
+      system: buildSonnetComposeSystem(),
+      messages: [
+        {
+          role: 'user',
+          content: buildSonnetComposeUser(question, repoPath, topRows),
+        },
+      ],
+      stream: false,
+    });
+    if (result.tier === 'flash') {
+      // callSonnet degraded back to Flash; we already tried Flash in tier 1.
+      return null;
+    }
+    return result.text.trim() ? result.text : null;
+  } catch (err) {
+    console.warn('[qa][composer-A] Sonnet CLI failed:', err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+/**
+ * Translate bracket citations, emit token + citations + done. Shared by all
+ * three LLM tiers so the SSE shape stays identical regardless of which
+ * provider answered.
+ */
+function emitClassAAnswer(rawAnswer: string, lookup: Map<string, TypedRow>, emit: SseEmit): void {
+  const { translatedAnswer, verifiedRows } = translateCitations(rawAnswer, lookup);
+  emit('token', { text: translatedAnswer });
+  for (const row of verifiedRows) {
+    emit('citation', {
+      kind: row.citation.kind,
+      rowId: `${row.citation.kind}-${row.citation.rowId}`,
+      table: row.citation.table,
+      excerpt: row.citation.excerpt,
+      url: row.citation.url,
+    });
+  }
+  emit('done', {});
 }
 
 // ── Class B composer (Sonnet via CLI > API > Flash) ──────────────────────────

--- a/src/lib/cortex/qa/llm/haiku-adapter.ts
+++ b/src/lib/cortex/qa/llm/haiku-adapter.ts
@@ -1,0 +1,226 @@
+/**
+ * Haiku CLI adapter for the Cortex Q&A layer (epic #915 path-to-70 phase 1.6).
+ *
+ * Single-purpose, non-streaming wrapper around `claude --print --model
+ * claude-haiku-4-5-20251001`. Used as the second-tier fallback on hot paths
+ * that previously degraded straight from Gemini Flash → heuristic:
+ *
+ *   composeClassA():  Flash → Haiku CLI → Sonnet CLI → heuristic
+ *   classifyQuestion: Flash → Haiku CLI → heuristic
+ *
+ * Why CLI specifically:
+ *   - Uses the founder's Claude Max subscription. Zero per-token cost.
+ *   - No ANTHROPIC_API_KEY required. No OpenRouter required.
+ *   - Mirrors src/lib/cortex/qa/llm/sonnet-adapter.ts's CLI tier exactly,
+ *     so binary detection survives Finder-launched Tauri apps via login-shell.
+ *
+ * Why a separate adapter (vs. extending sonnet-adapter):
+ *   - Callers want a dead-simple `callHaiku(prompt) → string` shape with a
+ *     short timeout (8s default). Haiku is fast; long timeouts mean the
+ *     CLI is wedged and we should fall through.
+ *   - The Sonnet adapter has a 3-tier (CLI/API/Flash) cascade plus
+ *     streaming. Haiku here is CLI-only and non-streaming on purpose.
+ */
+
+import 'server-only';
+
+import { execFile, spawn } from 'node:child_process';
+import os from 'node:os';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+// ── Shared binary detection ──────────────────────────────────────────────────
+
+let cachedClaudeBin: string | null | undefined;
+
+/**
+ * Resolve the `claude` binary the same way sonnet-adapter does:
+ * env override → which → login-shell probe (zsh -lic 'command -v claude').
+ *
+ * Result is cached per-process. `undefined` = not yet probed,
+ * `null` = probed and not found.
+ */
+async function resolveClaudeBin(): Promise<string | null> {
+  if (cachedClaudeBin !== undefined) return cachedClaudeBin;
+
+  // 1. Explicit env override (same keys as the runtime adapter + Sonnet adapter).
+  for (const envKey of ['O8_CLAUDE_CODE_BIN', 'CLAUDE_BIN']) {
+    const val = process.env[envKey];
+    if (val) {
+      cachedClaudeBin = val;
+      return cachedClaudeBin;
+    }
+  }
+
+  // 2. which claude
+  try {
+    const { stdout } = await execFileAsync('which', ['claude'], { timeout: 3_000 });
+    const found = stdout.trim();
+    if (found) {
+      cachedClaudeBin = found;
+      return cachedClaudeBin;
+    }
+  } catch {
+    // not on PATH — try login shell
+  }
+
+  // 3. Login-shell probe (catches nvm/fnm/volta binaries — same as Sonnet adapter).
+  const userShell = process.env.SHELL ?? 'zsh';
+  for (const sh of [userShell, 'zsh', 'bash', 'sh']) {
+    try {
+      const { stdout } = await execFileAsync(sh, ['-l', '-c', 'command -v claude'], {
+        timeout: 10_000,
+        env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
+      });
+      const found = stdout.trim();
+      if (found) {
+        cachedClaudeBin = found;
+        return cachedClaudeBin;
+      }
+    } catch {
+      // shell not available or command failed
+    }
+  }
+
+  cachedClaudeBin = null;
+  return null;
+}
+
+/** Force re-detection on next call (useful for testing). */
+export function resetHaikuProviderCache(): void {
+  cachedClaudeBin = undefined;
+}
+
+// ── stream-json parser (result event only — non-streaming) ───────────────────
+
+/**
+ * Scan Claude CLI stream-json output for the terminal `result` event and
+ * return its text. Mirrors extractCliFullText in sonnet-adapter.ts so any
+ * future shape change in one adapter is easy to mirror in the other.
+ */
+function extractResultText(output: string): string {
+  const lines = output.split('\n').filter(Boolean);
+  // Prefer the terminal `result` event (complete answer, no double-counting).
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    try {
+      const evt = JSON.parse(line) as Record<string, unknown>;
+      if (evt['type'] === 'result' && typeof evt['result'] === 'string') {
+        return evt['result'];
+      }
+    } catch {
+      // not JSON — skip
+    }
+  }
+  // Fallback: stitch assistant events if no terminal result was emitted.
+  const parts: string[] = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    try {
+      const evt = JSON.parse(line) as Record<string, unknown>;
+      if (evt['type'] === 'assistant' && typeof evt['message'] === 'object' && evt['message'] !== null) {
+        const msg = evt['message'] as Record<string, unknown>;
+        const content = msg['content'];
+        if (Array.isArray(content)) {
+          for (const block of content) {
+            if (
+              typeof block === 'object' &&
+              block !== null &&
+              (block as Record<string, unknown>)['type'] === 'text' &&
+              typeof (block as Record<string, unknown>)['text'] === 'string'
+            ) {
+              parts.push((block as Record<string, unknown>)['text'] as string);
+            }
+          }
+        }
+      }
+    } catch {
+      // not JSON — skip
+    }
+  }
+  return parts.join('');
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+export interface CallHaikuOptions {
+  /** CLI invocation timeout. Default 8s — Haiku is fast; long waits mean wedged. */
+  timeoutMs?: number;
+}
+
+/**
+ * Call Claude Haiku via the CLI with `prompt` on stdin.
+ *
+ * Throws on:
+ *   - claude binary not found
+ *   - CLI exit code non-zero with empty stdout
+ *   - timeout exceeded
+ *   - empty result text
+ *
+ * Caller is responsible for the fallback chain (composer/classifier each
+ * have their own next-step on failure — Sonnet CLI or heuristic).
+ */
+export async function callHaiku(prompt: string, opts: CallHaikuOptions = {}): Promise<string> {
+  const timeoutMs = opts.timeoutMs ?? 8_000;
+
+  const claudeBin = await resolveClaudeBin();
+  if (!claudeBin) {
+    throw new Error('[qa][haiku] claude CLI not found on PATH or login shell');
+  }
+
+  // --verbose required when combining --print + --output-format stream-json.
+  // Prompt fed via stdin so multi-line content isn't mangled by argv parsing.
+  const cliArgs = [
+    '--print',
+    '--verbose',
+    '--dangerously-skip-permissions',
+    '--output-format', 'stream-json',
+    '--model', 'claude-haiku-4-5-20251001',
+  ];
+
+  // tmpdir cwd so no project .claude/ config bleeds in.
+  const cwd = os.tmpdir();
+  const env = { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' };
+
+  const stdout = await new Promise<string>((resolve, reject) => {
+    const child = spawn(claudeBin, cliArgs, {
+      cwd,
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    child.stdin!.write(prompt, 'utf-8');
+    child.stdin!.end();
+
+    let outBuf = '';
+    let errBuf = '';
+    child.stdout!.on('data', (chunk: Buffer) => { outBuf += chunk.toString(); });
+    child.stderr!.on('data', (chunk: Buffer) => { errBuf += chunk.toString(); });
+
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error(`[qa][haiku] CLI timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(new Error(`[qa][haiku] CLI spawn error: ${err.message}`));
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (code !== 0 && outBuf.trim() === '') {
+        reject(new Error(`[qa][haiku] CLI exited ${code}: ${errBuf.slice(0, 400)}`));
+      } else {
+        resolve(outBuf);
+      }
+    });
+  });
+
+  const text = extractResultText(stdout).trim();
+  if (!text) {
+    throw new Error('[qa][haiku] CLI returned empty result');
+  }
+  return text;
+}


### PR DESCRIPTION
## Summary

Phase 1.6 of [epic #915 path-to-70](https://github.com/hurttlocker/cortex-ide/issues/915). Phase 1 substrate fixes (#946-#950) moved citation_correctness 0% → 23.3% but factual_accuracy stayed flat at 19.3%. Diagnostic logs showed Gemini Flash 503ing across the run -- the entire fast lookup path was degrading straight to the heuristic with no answer text.

This patch adds a Claude Haiku CLI fallback between Flash and the heuristic on the two Flash-backed hot paths.

**Four-tier chain — composeClassA:**
```
Flash → Haiku CLI → Sonnet CLI → heuristic
```

**Three-tier chain — classifyQuestion:**
```
Flash → Haiku CLI → heuristic
```

The Haiku CLI tier uses the founder's Claude Max subscription. **Zero per-token cost** — no `ANTHROPIC_API_KEY`, no OpenRouter, no new env vars. Same `claude --print --output-format stream-json` plumbing already proven by `sonnet-adapter.ts`, just pinned to `claude-haiku-4-5-20251001` for ~3-8s latency on lookups.

## Implementation

- `src/lib/cortex/qa/llm/haiku-adapter.ts` (new) — `callHaiku(prompt, opts?)` mirrors `sonnet-adapter.ts`'s binary detection (env override → which → login-shell probe) so Finder-launched Tauri apps still resolve `claude`. Spawns the CLI with prompt on stdin, parses the terminal `result` stream-json event, returns text. Throws on timeout/empty/spawn errors so the caller controls the fallback chain.
- `src/lib/cortex/qa/composer.ts` — `composeClassA` refactored from a single Flash try-block into a four-tier chain. Each tier is a small function returning `string | null`; the resolved tier is logged (`[qa][composer-A] resolved via flash | haiku-cli | sonnet-cli | heuristic`) so we can track tier health in production.
- `src/lib/cortex/qa/classifier.ts` — Same chain shape (Flash → Haiku → heuristic). JSON-mode prompt is reused unchanged across both providers; `parseClassifierJson` handles markdown fences + preamble text from either source.

## Eval results (30-case set, Flash partially throttling)

| Metric | Phase 1.5 (baseline) | Phase 1.6 (this PR) |
|---|---|---|
| factual_accuracy | 19.3% | **33.3%** |
| citation_correctness | 23.3% | **45.0%** |

**Per-category factual_accuracy:**

| Category | Phase 1.5 | Phase 1.6 |
|---|---|---|
| ownership | <20% | 35.0% |
| decisions | ~20% | 42.0% |
| processes | <20% | 24.0% |
| incidents | <20% | **68.6%** (one point off 70% threshold) |
| specs | <20% | 4.0% |
| cross-repo | <20% | 26.0% |

The eval logs confirm the chain activates as designed -- many `Flash error 503` events resolve via `haiku-cli`, and `sonnet-cli` catches the remainder when Haiku also stalls. Specs is still low because most spec questions need multi-row reasoning that Class B handles better; that's a separate problem from the Flash-throttle fix this PR targets.

## Constraints respected

- CLI only -- no `ANTHROPIC_API_KEY`, no OpenRouter, no provider config.
- No new env vars or feature flags. Haiku is purely a fallback in the existing chain.
- Eval runner unchanged.
- All cost stays on the Claude Max subscription.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` on the three changed files clean (only pre-existing warnings remain)
- [x] Standalone smoke: `callHaiku('Reply with the single word: working')` returns `"working"` in ~7s
- [x] Classifier smoke with forced-bad Google AI key → logs `[qa][classifier] Flash API error 400 — trying Haiku CLI` → `[qa][classifier] resolved via haiku-cli` → returns valid classification + 5 BM25 variants
- [x] Composer smoke with forced-bad Google AI key → emits valid `token`/`citation`/`done` SSE events with citation translation intact
- [x] Full `npm run eval:qa` run completed end-to-end; per-category scores above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)