### PR TITLE
feat(qa): GitHub comments ingestion + comments_fts retriever

### DIFF
--- a/scripts/ingest-github-comments.ts
+++ b/scripts/ingest-github-comments.ts
@@ -1,0 +1,45 @@
+/**
+ * One-shot ingestion runner for GitHub issue + PR review comments.
+ *
+ * Walks every repo in ~/.o8/repos.json, pulls comments via the GitHub App
+ * installation, upserts into `github_comments`, lets the FTS5 triggers
+ * keep `comments_fts` coherent.
+ *
+ * Usage:
+ *   npx tsx scripts/ingest-github-comments.ts
+ *
+ * Re-run anytime — the cursor in `comments_sync` makes follow-up runs
+ * incremental (only fetches comments updated since the last successful run).
+ */
+
+import { ingestAllRepoComments } from '@/lib/cortex/ingest/github-comments';
+
+async function main() {
+  const start = Date.now();
+  const summary = await ingestAllRepoComments();
+  const elapsed = Date.now() - start;
+
+  console.log('');
+  console.log('[ingest-github-comments] summary:');
+  console.log(`  repos scanned : ${summary.reposScanned}`);
+  console.log(`  repos skipped : ${summary.reposSkipped}`);
+  console.log(`  issue comments: ${summary.totalIssueComments}`);
+  console.log(`  pr comments   : ${summary.totalPrReviewComments}`);
+  console.log(`  elapsed       : ${elapsed}ms`);
+  console.log('');
+
+  for (const repo of summary.perRepo) {
+    console.log(
+      `  ${repo.repoFullName.padEnd(40)} issue=${repo.issueCommentsIngested} pr=${repo.prReviewCommentsIngested}` +
+        (repo.errors.length > 0 ? ` errors=${repo.errors.length}` : ''),
+    );
+    for (const error of repo.errors) {
+      console.log(`    - ${error}`);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error('[ingest-github-comments] FAIL', error);
+  process.exit(1);
+});

--- a/src/lib/cortex/ingest/github-comments.ts
+++ b/src/lib/cortex/ingest/github-comments.ts
@@ -1,0 +1,459 @@
+/**
+ * GitHub comment ingestion job (epic #915 phase 1.7 #2).
+ *
+ * Walks every repo in `~/.o8/repos.json` and fetches:
+ *   - issue comments     GET /repos/{o}/{r}/issues/comments
+ *   - pull review        GET /repos/{o}/{r}/pulls/comments
+ *
+ * Both endpoints support `since=<ISO>` for incremental polling. We track the
+ * cursor per (repo_full_name, resource) in the `comments_sync` table created
+ * by schema v15.
+ *
+ * Comments upsert into `github_comments` keyed on
+ * `<parent_kind>-<parent_number>-<gh_comment_id>`, so re-fetching the same
+ * comment is idempotent and the FTS triggers keep `comments_fts` coherent.
+ *
+ * Auth: routed through the same GitHub App installation token path that
+ * github-broker uses (15k/hr per installation). When the App isn't
+ * configured, the job logs a warning and exits 0 — fresh clones boot fine.
+ */
+
+import 'server-only';
+
+import { existsSync, readFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { getSqlite } from '@/lib/db';
+import { githubInstallationFetch } from '@/lib/github-broker/auth';
+import { getGitHubAppConfig } from '@/lib/github-broker/env';
+
+// ── Repo registry loader (duplicated to avoid pulling in 'server-only' imports) ──
+//
+// We can't import @/lib/repos/registry directly because it pulls in
+// 'server-only' and our smoke script runs as a standalone tsx process.
+// Reading the registry JSON is cheap; mirroring the loader keeps the
+// ingestion job dependency-free.
+
+interface RepoRegistryRow {
+  id: string;
+  name: string;
+  localPath: string;
+  remoteUrl: string | null;
+  defaultBranch: string;
+}
+
+interface RepoRegistry {
+  version: number;
+  repos: RepoRegistryRow[];
+}
+
+function getDataDir(): string {
+  return (
+    process.env.O8_DATA_DIR ||
+    process.env.CORTEX_IDE_DATA_DIR ||
+    path.join(os.homedir(), '.o8')
+  );
+}
+
+function loadRepos(): RepoRegistryRow[] {
+  const registryPath = path.join(getDataDir(), 'repos.json');
+  if (!existsSync(registryPath)) return [];
+  try {
+    const raw = readFileSync(registryPath, 'utf-8');
+    const parsed = JSON.parse(raw) as RepoRegistry;
+    return Array.isArray(parsed.repos) ? parsed.repos : [];
+  } catch (error) {
+    console.warn(
+      '[ingest][comments] failed to read repos.json:',
+      error instanceof Error ? error.message : error,
+    );
+    return [];
+  }
+}
+
+/** Pull `<owner>/<repo>` out of a remote url. Returns null when the url is
+ *  missing or doesn't look like a github.com remote. */
+function parseRepoFullName(remoteUrl: string | null): string | null {
+  if (!remoteUrl) return null;
+  // Match both git@github.com:owner/repo and https://github.com/owner/repo
+  const match = remoteUrl.match(/github\.com[:/]([^/]+)\/([^/.]+?)(?:\.git)?$/i);
+  if (!match) return null;
+  return `${match[1]}/${match[2]}`;
+}
+
+// ── Sync cursor ──
+
+interface SyncCursor {
+  lastSyncedAt: string | null;
+}
+
+function readSyncCursor(repoFullName: string, resource: string): SyncCursor {
+  const sqlite = getSqlite();
+  const row = sqlite
+    .prepare(
+      'SELECT last_synced_at FROM comments_sync WHERE repo_full_name = ? AND resource = ?',
+    )
+    .get(repoFullName, resource) as { last_synced_at: string | null } | undefined;
+  return { lastSyncedAt: row?.last_synced_at ?? null };
+}
+
+function writeSyncCursor(
+  repoFullName: string,
+  resource: string,
+  lastSyncedAt: string,
+  lastSeenUpdatedAt: string | null,
+  lastError: string | null,
+): void {
+  const sqlite = getSqlite();
+  sqlite
+    .prepare(
+      `INSERT INTO comments_sync (repo_full_name, resource, last_synced_at, last_seen_updated_at, last_error, updated_at)
+       VALUES (?, ?, ?, ?, ?, datetime('now'))
+       ON CONFLICT(repo_full_name, resource) DO UPDATE SET
+         last_synced_at = excluded.last_synced_at,
+         last_seen_updated_at = excluded.last_seen_updated_at,
+         last_error = excluded.last_error,
+         updated_at = excluded.updated_at`,
+    )
+    .run(repoFullName, resource, lastSyncedAt, lastSeenUpdatedAt, lastError);
+}
+
+// ── GitHub payload shapes ──
+
+interface GitHubIssueCommentPayload {
+  id: number;
+  body?: string | null;
+  html_url?: string;
+  created_at?: string;
+  updated_at?: string;
+  user?: { login?: string | null } | null;
+  // /repos/.../issues/comments returns issue_url like
+  //   https://api.github.com/repos/owner/repo/issues/123
+  issue_url?: string;
+}
+
+interface GitHubPrReviewCommentPayload {
+  id: number;
+  body?: string | null;
+  html_url?: string;
+  created_at?: string;
+  updated_at?: string;
+  user?: { login?: string | null } | null;
+  // pull_request_url like https://api.github.com/repos/owner/repo/pulls/123
+  pull_request_url?: string;
+}
+
+function extractParentNumber(url: string | undefined): number | null {
+  if (!url) return null;
+  const match = url.match(/\/(?:issues|pulls)\/(\d+)$/);
+  if (!match) return null;
+  const n = Number(match[1]);
+  return Number.isFinite(n) ? n : null;
+}
+
+// ── Upsert ──
+
+interface CommentUpsertRow {
+  id: string;
+  ghCommentId: string;
+  parentKind: 'issue' | 'pull_request';
+  parentNumber: number;
+  parentId: string | null;
+  repoFullName: string;
+  repoOwner: string;
+  repoName: string;
+  repoPath: string | null;
+  authorLogin: string | null;
+  body: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+  url: string | null;
+}
+
+function upsertComments(rows: CommentUpsertRow[]): number {
+  if (rows.length === 0) return 0;
+  const sqlite = getSqlite();
+  const stmt = sqlite.prepare(
+    `INSERT INTO github_comments
+       (id, gh_comment_id, parent_kind, parent_number, parent_id,
+        repo_full_name, repo_owner, repo_name, repo_path,
+        author_login, body, created_at, updated_at, url)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       body = excluded.body,
+       updated_at = excluded.updated_at,
+       author_login = excluded.author_login,
+       url = excluded.url,
+       parent_id = excluded.parent_id,
+       repo_path = excluded.repo_path`,
+  );
+  let inserted = 0;
+  sqlite.transaction((all: CommentUpsertRow[]) => {
+    for (const row of all) {
+      stmt.run(
+        row.id,
+        row.ghCommentId,
+        row.parentKind,
+        row.parentNumber,
+        row.parentId,
+        row.repoFullName,
+        row.repoOwner,
+        row.repoName,
+        row.repoPath,
+        row.authorLogin,
+        row.body,
+        row.createdAt,
+        row.updatedAt,
+        row.url,
+      );
+      inserted += 1;
+    }
+  })(rows);
+  return inserted;
+}
+
+// ── Resolve parent ids from existing tables ──
+
+function lookupParentId(
+  parentKind: 'issue' | 'pull_request',
+  repoFullName: string,
+  parentNumber: number,
+): string | null {
+  const sqlite = getSqlite();
+  if (parentKind === 'issue') {
+    const row = sqlite
+      .prepare(
+        'SELECT issue_id FROM github_issues WHERE repo_full_name = ? AND number = ?',
+      )
+      .get(repoFullName, parentNumber) as { issue_id: number } | undefined;
+    return row?.issue_id != null ? String(row.issue_id) : null;
+  }
+  const row = sqlite
+    .prepare(
+      'SELECT pull_request_id FROM github_pull_requests WHERE repo_full_name = ? AND number = ?',
+    )
+    .get(repoFullName, parentNumber) as { pull_request_id: number } | undefined;
+  return row?.pull_request_id != null ? String(row.pull_request_id) : null;
+}
+
+// ── Fetch loops ──
+
+const PER_PAGE = 100;
+const MAX_PAGES = 20; // guardrail — 2000 comments/resource per ingest run
+
+async function fetchIssueComments(
+  repoFullName: string,
+  since: string | null,
+): Promise<GitHubIssueCommentPayload[]> {
+  const all: GitHubIssueCommentPayload[] = [];
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const params = new URLSearchParams({
+      per_page: String(PER_PAGE),
+      sort: 'updated',
+      direction: 'asc',
+      page: String(page),
+    });
+    if (since) params.set('since', since);
+    const target = `/repos/${repoFullName}/issues/comments?${params.toString()}`;
+    const { response } = await githubInstallationFetch(repoFullName, target);
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(`issue-comments page ${page} failed (${response.status}): ${text.slice(0, 200)}`);
+    }
+    const items = JSON.parse(text) as GitHubIssueCommentPayload[];
+    all.push(...items);
+    if (items.length < PER_PAGE) break;
+  }
+  return all;
+}
+
+async function fetchPrReviewComments(
+  repoFullName: string,
+  since: string | null,
+): Promise<GitHubPrReviewCommentPayload[]> {
+  const all: GitHubPrReviewCommentPayload[] = [];
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const params = new URLSearchParams({
+      per_page: String(PER_PAGE),
+      sort: 'updated',
+      direction: 'asc',
+      page: String(page),
+    });
+    if (since) params.set('since', since);
+    const target = `/repos/${repoFullName}/pulls/comments?${params.toString()}`;
+    const { response } = await githubInstallationFetch(repoFullName, target);
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(`pr-review-comments page ${page} failed (${response.status}): ${text.slice(0, 200)}`);
+    }
+    const items = JSON.parse(text) as GitHubPrReviewCommentPayload[];
+    all.push(...items);
+    if (items.length < PER_PAGE) break;
+  }
+  return all;
+}
+
+// ── Per-repo orchestrator ──
+
+export interface RepoIngestStats {
+  repoFullName: string;
+  issueCommentsIngested: number;
+  prReviewCommentsIngested: number;
+  errors: string[];
+}
+
+async function ingestRepoComments(
+  repo: { localPath: string; remoteUrl: string | null },
+): Promise<RepoIngestStats | null> {
+  const repoFullName = parseRepoFullName(repo.remoteUrl);
+  if (!repoFullName) {
+    console.warn(
+      `[ingest][comments] skipping ${repo.localPath} — no parseable remote (${repo.remoteUrl ?? 'null'})`,
+    );
+    return null;
+  }
+  const [repoOwner, repoName] = repoFullName.split('/');
+
+  const stats: RepoIngestStats = {
+    repoFullName,
+    issueCommentsIngested: 0,
+    prReviewCommentsIngested: 0,
+    errors: [],
+  };
+
+  // ── Issue comments ──
+  const issueCursor = readSyncCursor(repoFullName, 'issue_comments');
+  const issueRunStartedAt = new Date().toISOString();
+  let issueLastSeen: string | null = issueCursor.lastSyncedAt;
+  try {
+    const items = await fetchIssueComments(repoFullName, issueCursor.lastSyncedAt);
+    const rows: CommentUpsertRow[] = [];
+    for (const item of items) {
+      const parentNumber = extractParentNumber(item.issue_url);
+      if (parentNumber == null) continue;
+      const ghCommentId = String(item.id);
+      const id = `issue-${parentNumber}-${ghCommentId}`;
+      const updatedAt = item.updated_at ?? null;
+      if (updatedAt && (!issueLastSeen || updatedAt > issueLastSeen)) {
+        issueLastSeen = updatedAt;
+      }
+      rows.push({
+        id,
+        ghCommentId,
+        parentKind: 'issue',
+        parentNumber,
+        parentId: lookupParentId('issue', repoFullName, parentNumber),
+        repoFullName,
+        repoOwner,
+        repoName,
+        repoPath: repo.localPath,
+        authorLogin: item.user?.login ?? null,
+        body: item.body ?? '',
+        createdAt: item.created_at ?? null,
+        updatedAt,
+        url: item.html_url ?? null,
+      });
+    }
+    stats.issueCommentsIngested = upsertComments(rows);
+    writeSyncCursor(repoFullName, 'issue_comments', issueRunStartedAt, issueLastSeen, null);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    stats.errors.push(`issue_comments: ${message}`);
+    writeSyncCursor(repoFullName, 'issue_comments', issueRunStartedAt, issueLastSeen, message);
+  }
+
+  // ── PR review comments ──
+  const prCursor = readSyncCursor(repoFullName, 'pr_review_comments');
+  const prRunStartedAt = new Date().toISOString();
+  let prLastSeen: string | null = prCursor.lastSyncedAt;
+  try {
+    const items = await fetchPrReviewComments(repoFullName, prCursor.lastSyncedAt);
+    const rows: CommentUpsertRow[] = [];
+    for (const item of items) {
+      const parentNumber = extractParentNumber(item.pull_request_url);
+      if (parentNumber == null) continue;
+      const ghCommentId = String(item.id);
+      const id = `pr-${parentNumber}-${ghCommentId}`;
+      const updatedAt = item.updated_at ?? null;
+      if (updatedAt && (!prLastSeen || updatedAt > prLastSeen)) {
+        prLastSeen = updatedAt;
+      }
+      rows.push({
+        id,
+        ghCommentId,
+        parentKind: 'pull_request',
+        parentNumber,
+        parentId: lookupParentId('pull_request', repoFullName, parentNumber),
+        repoFullName,
+        repoOwner,
+        repoName,
+        repoPath: repo.localPath,
+        authorLogin: item.user?.login ?? null,
+        body: item.body ?? '',
+        createdAt: item.created_at ?? null,
+        updatedAt,
+        url: item.html_url ?? null,
+      });
+    }
+    stats.prReviewCommentsIngested = upsertComments(rows);
+    writeSyncCursor(repoFullName, 'pr_review_comments', prRunStartedAt, prLastSeen, null);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    stats.errors.push(`pr_review_comments: ${message}`);
+    writeSyncCursor(repoFullName, 'pr_review_comments', prRunStartedAt, prLastSeen, message);
+  }
+
+  return stats;
+}
+
+// ── Public entry point ──
+
+export interface IngestSummary {
+  reposScanned: number;
+  reposSkipped: number;
+  totalIssueComments: number;
+  totalPrReviewComments: number;
+  perRepo: RepoIngestStats[];
+}
+
+/**
+ * Ingest comments for every repo in the registry. Best-effort — a single
+ * repo's failure is logged into its `errors[]` and the loop moves on.
+ */
+export async function ingestAllRepoComments(): Promise<IngestSummary> {
+  const summary: IngestSummary = {
+    reposScanned: 0,
+    reposSkipped: 0,
+    totalIssueComments: 0,
+    totalPrReviewComments: 0,
+    perRepo: [],
+  };
+
+  if (!getGitHubAppConfig()) {
+    console.warn(
+      '[ingest][comments] GitHub App not configured — set GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY (or ~/.o8/github-app.pem). Exiting.',
+    );
+    return summary;
+  }
+
+  const repos = loadRepos();
+  if (repos.length === 0) {
+    console.warn('[ingest][comments] no repos found in ~/.o8/repos.json — nothing to ingest.');
+    return summary;
+  }
+
+  for (const repo of repos) {
+    const stats = await ingestRepoComments(repo);
+    if (!stats) {
+      summary.reposSkipped += 1;
+      continue;
+    }
+    summary.reposScanned += 1;
+    summary.totalIssueComments += stats.issueCommentsIngested;
+    summary.totalPrReviewComments += stats.prReviewCommentsIngested;
+    summary.perRepo.push(stats);
+  }
+
+  return summary;
+}

--- a/src/lib/cortex/qa/composer.ts
+++ b/src/lib/cortex/qa/composer.ts
@@ -84,6 +84,11 @@ function buildCitationHandle(row: TypedRow): string {
       return `PR-${rowId}`;
     case 'issue':
       return `ISS-${rowId}`;
+    case 'comment':
+      // CMT- prefix avoids collision with the rest. The rowId is the
+      // composite `<parent_kind>-<parent_number>-<gh_comment_id>` from the
+      // ingestion job.
+      return `CMT-${rowId}`;
     case 'symbol':
       return `SYM-${rowId}`;
     case 'project':

--- a/src/lib/cortex/qa/retrievers/fts.ts
+++ b/src/lib/cortex/qa/retrievers/fts.ts
@@ -24,6 +24,11 @@ import { getSqlite } from '@/lib/db';
 import { isFts5Available } from '@/lib/db/v14-fts5-migration';
 
 const PER_INDEX_LIMIT = 20;
+// Comments compete with the rest of the indexes inside the FTS retriever's
+// own RRF merge, then again in retrieve.ts. Capping the per-table input at
+// 8 keeps comment hits from flooding the top-30 — they should be substrate
+// for decisions/specs, not the dominant voice.
+const PER_COMMENTS_LIMIT = 8;
 const DEFAULT_LIMIT = 30;
 const RRF_K = 60;
 
@@ -62,6 +67,7 @@ function ftsSearch(
   table: string,
   rowIdCol: string,
   match: string,
+  limit: number = PER_INDEX_LIMIT,
 ): FtsRow[] {
   try {
     // bm25() returns a negative rank — lower is better. We negate so higher
@@ -73,7 +79,7 @@ function ftsSearch(
       FROM ${table}
       WHERE ${table} MATCH ?
       ORDER BY bm25(${table})
-      LIMIT ${PER_INDEX_LIMIT}
+      LIMIT ${limit}
     `;
     return sqlite.prepare(sql).all(match) as FtsRow[];
   } catch (error) {
@@ -119,6 +125,17 @@ interface DirectiveRow {
   body: string;
 }
 
+interface CommentRow {
+  id: string;
+  parent_kind: 'issue' | 'pull_request';
+  parent_number: number;
+  repo_full_name: string;
+  author_login: string | null;
+  body: string;
+  url: string | null;
+  updated_at: string | null;
+}
+
 export async function ftsRetriever(input: RetrieverInput): Promise<RetrieverResult> {
   const start = Date.now();
   const rows: TypedRow[] = [];
@@ -153,6 +170,7 @@ export async function ftsRetriever(input: RetrieverInput): Promise<RetrieverResu
     const prsHits: TableHits = new Map();
     const issuesHits: TableHits = new Map();
     const directivesHits: TableHits = new Map();
+    const commentsHits: TableHits = new Map();
 
     const merge = (target: TableHits, hits: FtsRow[]) => {
       for (const hit of hits) {
@@ -168,6 +186,13 @@ export async function ftsRetriever(input: RetrieverInput): Promise<RetrieverResu
       merge(prsHits, ftsSearch(sqlite, 'prs_fts', 'pr_id', match));
       merge(issuesHits, ftsSearch(sqlite, 'issues_fts', 'issue_id', match));
       merge(directivesHits, ftsSearch(sqlite, 'directives_fts', 'directive_id', match));
+      // Comments table may not exist on installs that haven't applied schema
+      // v15 yet — ftsSearch swallows the error and returns []. The retriever
+      // stays no-op in that case and the rest of the FTS5 path keeps working.
+      merge(
+        commentsHits,
+        ftsSearch(sqlite, 'comments_fts', 'comment_id', match, PER_COMMENTS_LIMIT),
+      );
     }
 
     // Convert per-table maps into ranked lists, then RRF-merge into the
@@ -337,6 +362,58 @@ export async function ftsRetriever(input: RetrieverInput): Promise<RetrieverResu
           score: 0,
         });
       });
+    }
+
+    // comments — join back to github_comments for author + url metadata.
+    // The table may not exist on installs that haven't applied v15 yet;
+    // wrap in try/catch so the rest of the retriever still returns rows.
+    if (commentsHits.size > 0) {
+      try {
+        const sortedIds = [...commentsHits.entries()]
+          .sort((a, b) => b[1].rank - a[1].rank)
+          .map(([id]) => id);
+        const records = sqlite
+          .prepare(
+            `SELECT id, parent_kind, parent_number, repo_full_name, author_login,
+                    body, url, updated_at
+             FROM github_comments
+             WHERE id IN (${sortedIds.map(() => '?').join(',')})`,
+          )
+          .all(...sortedIds) as CommentRow[];
+        const byId = new Map(records.map((r) => [r.id, r]));
+        sortedIds.forEach((id, idx) => {
+          const record = byId.get(id);
+          if (!record) return;
+          const hit = commentsHits.get(id)!;
+          const score = 1 / (RRF_K + idx);
+          accumulate(`comment:${id}`, score, {
+            citation: {
+              kind: 'comment',
+              rowId: id,
+              table: 'github_comments',
+              url: record.url ?? undefined,
+              excerpt: hit.excerpt,
+            },
+            fields: {
+              id: record.id,
+              parentKind: record.parent_kind,
+              parentNumber: record.parent_number,
+              repoFullName: record.repo_full_name,
+              author: record.author_login,
+              body: record.body,
+              url: record.url,
+              updatedAt: record.updated_at,
+            },
+            score: 0,
+          });
+        });
+      } catch (error) {
+        // github_comments missing — pre-v15 install. Quietly skip.
+        console.warn(
+          '[qa][fts] comments join skipped:',
+          error instanceof Error ? error.message : error,
+        );
+      }
     }
 
     // Final pass — sort by RRF score, slice to limit. Caller can re-sort

--- a/src/lib/cortex/qa/types.ts
+++ b/src/lib/cortex/qa/types.ts
@@ -17,6 +17,8 @@ export type CitationKind =
   | 'outcome'
   | 'pr'
   | 'issue'
+  | 'comment'
+  | 'doc'
   | 'symbol'
   | 'project'
   | 'project_repo';

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -22,6 +22,7 @@ import { migrateLegacyLaneStoreIfNeeded } from '@/lib/lane/storage-migration';
 import { ensureUsageLogIndexes, ensureUsageLogSchema } from '@/lib/db/usage-log-migration';
 import { ensureSessionOutcomeRoutingColumns } from '@/lib/db/session-outcome-routing-migration';
 import { ensureV14Fts5Schema } from '@/lib/db/v14-fts5-migration';
+import { ensureV15CommentsFtsSchema } from '@/lib/db/v15-comments-fts-migration';
 
 // ── Data directory ──
 
@@ -35,7 +36,7 @@ const DATA_DIR = process.env.O8_DATA_DIR
 // second migration step with no user-facing benefit.
 const DB_PATH = process.env.CORTEX_IDE_DB_PATH || path.join(DATA_DIR, 'cortex-ide.db');
 // Bump when ensureTables() adds new schema or backfill work.
-const DB_SCHEMA_VERSION = 14;
+const DB_SCHEMA_VERSION = 15;
 
 function migrationMarkerPath(version: number): string {
   return path.join(DATA_DIR, `.db-migrated-v${version}`);
@@ -113,6 +114,11 @@ function ensureIdempotentColumnAdds(sqlite: Database.Database): void {
   // warning when FTS5 isn't compiled in. Always-on via the same idempotent
   // pattern as the rest of this function.
   ensureV14Fts5Schema(sqlite);
+  // #915 phase 1.7 #2 — Schema v15 — github_comments + comments_fts. Brings
+  // issue/PR comment bodies into the FTS surface so decisions/specs that
+  // live in epic-thread comments (e.g. epic #915's locked architecture
+  // comment naming outcomes_fts/qa_eval_runs) become searchable.
+  ensureV15CommentsFtsSchema(sqlite);
   // #835 — recover any session_outcomes rows whose `valid_from` was inserted
   // as NULL (legacy seeds, raw INSERTs that bypassed the Drizzle schema
   // default). The column-add backfill in `ensureSessionOutcomeColumns` only

--- a/src/lib/db/v15-comments-fts-migration.ts
+++ b/src/lib/db/v15-comments-fts-migration.ts
@@ -1,0 +1,126 @@
+/**
+ * Schema v15 — `github_comments` table + `comments_fts` virtual table.
+ *
+ * Phase 1.7 #2 of epic #915 — round-2 brainstormer found that decisions
+ * (qa-008/9/10) and specs (qa-021..025) bottom out at substrate-empty
+ * because the locked-architecture decisions live as comments on issues/PRs,
+ * never as standalone bodies. Searching `comments_fts` for "outcomes_fts"
+ * surfaces the actual comment that names the four FTS5 tables, which the
+ * existing `issues_fts` (title + body only) never could.
+ *
+ * Mirrors v14's structure: idempotent create, FTS5-availability probe,
+ * AI/AD/AU triggers to keep the FTS in sync with the parent. Unlike v14,
+ * we do NOT backfill from the parent on first migration — comments are
+ * populated by the ingestion job in `src/lib/cortex/ingest/github-comments.ts`.
+ *
+ * Why a dedicated table instead of stuffing comments into issues_fts/prs_fts:
+ *   - Each comment carries its own author + timestamp + url that the citation
+ *     pill needs to render correctly.
+ *   - One comment per row keeps BM25 ranking sharp; concatenating into the
+ *     parent body would dilute matches against long threads.
+ *   - The retriever can cap comment hits independently (8) so they compete
+ *     fairly with directives/outcomes/PRs/issues without flooding top-30.
+ */
+
+import type Database from 'better-sqlite3';
+
+import { isFts5Available } from '@/lib/db/v14-fts5-migration';
+
+/**
+ * Idempotent. Creates `github_comments`, `comments_fts`, sync triggers,
+ * and a small `comments_sync` table that tracks the last-seen `updated_at`
+ * per repo (so the ingestion job can do incremental polls instead of
+ * paginating from the start every run).
+ *
+ * Returns `{ applied }` so the caller can log when the schema was created
+ * for the first time vs already existed.
+ */
+export function ensureV15CommentsFtsSchema(sqlite: Database.Database): {
+  applied: boolean;
+} {
+  if (!isFts5Available(sqlite)) {
+    console.warn(
+      '[db][v15] FTS5 not compiled into better-sqlite3 — skipping comments FTS schema. ' +
+        'comments_fts retriever will return empty rows; the rest of the Q&A path still works.',
+    );
+    return { applied: false };
+  }
+
+  // ── github_comments ──
+  // `id` is a composite key `<parent_kind>-<parent_number>-<gh_comment_id>`
+  // so re-fetching the same comment from a paginated list is a no-op upsert.
+  // `gh_comment_id` is the raw GitHub comment id (numeric, but TEXT here so
+  // PR review threads with non-numeric ids stay representable).
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS github_comments (
+      id TEXT PRIMARY KEY,
+      gh_comment_id TEXT NOT NULL,
+      parent_kind TEXT NOT NULL,
+      parent_number INTEGER NOT NULL,
+      parent_id TEXT,
+      repo_full_name TEXT NOT NULL,
+      repo_owner TEXT NOT NULL,
+      repo_name TEXT NOT NULL,
+      repo_path TEXT,
+      author_login TEXT,
+      body TEXT NOT NULL DEFAULT '',
+      created_at TEXT,
+      updated_at TEXT,
+      url TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_github_comments_parent
+      ON github_comments(parent_kind, parent_number, repo_full_name);
+    CREATE INDEX IF NOT EXISTS idx_github_comments_updated
+      ON github_comments(repo_full_name, updated_at DESC);
+  `);
+
+  // ── comments_fts ──
+  // We index `body` as the searchable column. `parent_number` and
+  // `parent_kind` ride along UNINDEXED so the retriever can render citation
+  // pills + "issue #915 comment" labels without a join when it doesn't need
+  // the full row.
+  sqlite.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS comments_fts USING fts5(
+      comment_id UNINDEXED,
+      parent_number UNINDEXED,
+      parent_kind UNINDEXED,
+      body,
+      tokenize='porter unicode61'
+    );
+
+    CREATE TRIGGER IF NOT EXISTS comments_fts_ai AFTER INSERT ON github_comments BEGIN
+      INSERT INTO comments_fts(comment_id, parent_number, parent_kind, body)
+      VALUES (new.id, new.parent_number, new.parent_kind, new.body);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS comments_fts_ad AFTER DELETE ON github_comments BEGIN
+      DELETE FROM comments_fts WHERE comment_id = old.id;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS comments_fts_au AFTER UPDATE ON github_comments BEGIN
+      DELETE FROM comments_fts WHERE comment_id = old.id;
+      INSERT INTO comments_fts(comment_id, parent_number, parent_kind, body)
+      VALUES (new.id, new.parent_number, new.parent_kind, new.body);
+    END;
+  `);
+
+  // ── comments_sync ──
+  // Per-repo, per-resource cursor (issue-comments vs pr-review-comments) so
+  // the ingestion job can pass `since=<last_synced_at>` to GitHub. Resources:
+  //   - 'issue_comments' → /repos/{o}/{r}/issues/comments
+  //   - 'pr_review_comments' → /repos/{o}/{r}/pulls/comments
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS comments_sync (
+      repo_full_name TEXT NOT NULL,
+      resource TEXT NOT NULL,
+      last_synced_at TEXT,
+      last_seen_updated_at TEXT,
+      last_error TEXT,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (repo_full_name, resource)
+    );
+  `);
+
+  return { applied: true };
+}


### PR DESCRIPTION
## Summary

Phase 1.7 #2 of epic #915 path-to-70. Round-2 brainstormer found qa-008/9/10 (decisions) and qa-021..025 (specs) were **substrate-empty**: their expected answers reference content that lives only in GitHub issue/PR comments — never ingested. Specifically epic #915's locked architecture comment names "outcomes_fts", "Class A latency 250ms", "memory mode", "qa_eval_runs" — facts the eval expects but the composer correctly says "I don't have that information yet" because no row contains them.

This brings comment bodies into the FTS5 surface so they compete with directives/outcomes/PRs/issues in BM25 retrieval.

## Schema v15 (idempotent, mirrors v14)

- `github_comments` — composite key `<parent_kind>-<parent_number>-<gh_comment_id>`, joins to `github_issues` / `github_pull_requests` via repo_full_name + number
- `comments_fts` — virtual FTS5 with porter+unicode61 tokenizer, AI/AD/AU triggers keep it coherent with the parent
- `comments_sync` — per-repo cursor for incremental polling (since=)

## Ingestion

`scripts/ingest-github-comments.ts` walks `~/.o8/repos.json`:
- `/repos/{o}/{r}/issues/comments` and `/pulls/comments` via GitHub App auth
- Pagination capped at 20 pages (2000 comments/resource per run)
- Incremental via `since=<last_synced_at>` cursor in `comments_sync`
- Best-effort: per-repo failures recorded in `errors[]` but loop continues

## Retriever

- `ftsRetriever` joins `comments_fts` into the existing FTS5 path with `PER_COMMENTS_LIMIT=8` (vs `PER_INDEX_LIMIT=20`) so comments don't flood the top-30 — substrate, not dominant voice
- New `'comment'` citation kind with `[CMT-<id>]` handle in composer.ts. Format: `CMT-issue-915-4347800077`
- `'doc'` also added to `CitationKind` union to fix a pre-existing typecheck error from sibling docs work that landed in main

## Substrate verification

Post-ingest state (~/.o8/cortex-ide.db):
- **668 comments ingested** across hurttlocker/cortex-ide + o8-site
- `comments_fts MATCH 'outcomes_fts'` returns `issue-915-4347800077` (the locked-architecture epic comment naming all four FTS5 tables)
- Same row hit by `qa_eval_runs`, `silent fallbacks`, `BM25 vector`, `FTS5` MATCH queries

Sample qa-008 answer post-ingest (factual_accuracy 0.1 → 1.0):
> The team locked in FTS5 + structured SQL + symbol graph + LLM compose over vectors after auditing open-source Cortex's failures: 88/501 real embeddings with 413 silent zero-vector fallbacks ("edges weren't good")...[CMT-issue-915-4347800077]

## Eval scores (latest run per case, structural before/after)

| Category | Before | After | Δ |
|---|---|---|---|
| decisions | 39.0% | 60.0% | **+21.0pp** |
| ownership | 1.0% | 26.6% | **+25.6pp** |
| incidents | 65.4% | 56.0% | -9.4pp |
| processes | 27.6% | 28.6% | +1.0pp |

specs and cross-repo not yet in the latest run window — second eval still running for qa-021..030. Decisions improvement matches brainstormer projection (~30% → ~55%+); the locked architecture comment is now retrievable. The ownership jump came from comments substrate too (e.g. `## Locked` headers naming owners).

## Notes

- Citation_correctness is sometimes 0 even when factual_accuracy is 1.0 because `expectedCitations` in `cases.json` references `kind='issue'` for the parent issue but the actual answer cites `kind='comment'`. That's a separate test-data fix, not part of this work.
- `incidents` regression looks like sample variance on 5 cases — needs more eval volume to confirm.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Schema v15 applied idempotently (verified `~/.o8/.db-migrated-v15` marker)
- [x] `github_comments` populated (668 rows)
- [x] `comments_fts` triggers fire (counts match: 668=668)
- [x] `comments_fts MATCH 'outcomes_fts'` returns the locked architecture comment
- [x] qa-008 score improves 0.1 → 1.0 (decisions)
- [ ] specs (qa-021..025) score improves — eval still running

🤖 Generated with [Claude Code](https://claude.com/claude-code)