### PR TITLE
feat(qa): repo docs ingestion + docs_fts retriever

### DIFF
--- a/scripts/ingest-repo-docs.ts
+++ b/scripts/ingest-repo-docs.ts
@@ -1,0 +1,54 @@
+/**
+ * Standalone ingestion script for repo markdown (epic #915 phase 1.7 #3).
+ *
+ *   npx tsx scripts/ingest-repo-docs.ts
+ *
+ * Walks every repo in `~/.o8/repos.json` and upserts CLAUDE.md / README /
+ * AGENTS.md / DESIGN.md / THEME.md / docs/**\/*.md / `*.md` at the repo root
+ * into the `docs` table (schema v16). The trigger keeps `docs_fts` in sync.
+ *
+ * Pretty-prints a per-repo + per-kind summary. Exit code 1 on any repo error
+ * so a future cron wrapper can detect partial failures.
+ */
+
+import { ingestAllRepos } from '@/lib/cortex/ingest/repo-docs';
+
+function main() {
+  const start = Date.now();
+  const summary = ingestAllRepos();
+  const elapsed = Date.now() - start;
+
+  console.log('');
+  console.log('[ingest-docs] per-repo:');
+  let anyErrors = false;
+  for (const repo of summary.repos) {
+    const errFlag = repo.errors.length > 0 ? ' ERR' : '';
+    console.log(
+      `  ${repo.repoName.padEnd(20)} scanned=${String(repo.scanned).padStart(3)} ` +
+        `upserted=${String(repo.upserted).padStart(3)} unchanged=${String(repo.unchanged).padStart(3)} ` +
+        `skipped=${String(repo.skipped).padStart(3)}${errFlag}`,
+    );
+    if (repo.errors.length > 0) {
+      anyErrors = true;
+      for (const e of repo.errors) {
+        console.log(`         - ${e}`);
+      }
+    }
+  }
+
+  console.log('');
+  console.log('[ingest-docs] per-kind in docs table:');
+  for (const kind of Object.keys(summary.byKind) as Array<keyof typeof summary.byKind>) {
+    console.log(`  ${kind.padEnd(12)} ${summary.byKind[kind]}`);
+  }
+
+  console.log('');
+  console.log(
+    `[ingest-docs] done — ${summary.totalUpserted} upserted, ${summary.totalUnchanged} unchanged, ` +
+      `${elapsed}ms`,
+  );
+
+  process.exitCode = anyErrors ? 1 : 0;
+}
+
+main();

--- a/src/lib/cortex/ingest/repo-docs.ts
+++ b/src/lib/cortex/ingest/repo-docs.ts
@@ -1,0 +1,461 @@
+/**
+ * Repo markdown ingestion (epic #915 path-to-70 phase 1.7 #3).
+ *
+ * Walks every repo registered in `~/.o8/repos.json` and upserts markdown
+ * files into the `docs` table. The schema-v16 trigger keeps `docs_fts`
+ * in sync automatically.
+ *
+ * What gets ingested:
+ *   - Top-level files: CLAUDE.md, README.md, AGENTS.md, DESIGN.md, THEME.md,
+ *     plus any `*.md` at the repo root (catches CHANGELOG.md, LICENSE.md, etc.)
+ *   - `docs/**\/*.md` recursively
+ *
+ * What gets skipped:
+ *   - node_modules / .next / dist / build / target / .git directories
+ *   - .claude/worktrees/** (agent worktrees create real branches and would
+ *     pollute the index with duplicates of the parent repo's markdown)
+ *
+ * Body cap: 50KB per doc — most files are far smaller, but CLAUDE.md sometimes
+ * accumulates well past that. Truncated bodies get a `[truncated at 50KB]`
+ * suffix so retrievers know they're seeing a partial.
+ */
+
+import 'server-only';
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { getSqlite } from '@/lib/db';
+import { isFts5Available } from '@/lib/db/v14-fts5-migration';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const MAX_BODY_BYTES = 50 * 1024; // 50KB
+const TRUNCATION_SUFFIX = '\n\n[truncated at 50KB]';
+
+const SKIP_DIRECTORIES = new Set([
+  'node_modules',
+  '.next',
+  '.turbo',
+  '.cache',
+  'dist',
+  'build',
+  'out',
+  'target',
+  '.git',
+  // .claude/worktrees gets its own check (nested) below.
+]);
+
+const TOP_LEVEL_NAMED_FILES = new Set([
+  'CLAUDE.md',
+  'README.md',
+  'AGENTS.md',
+  'DESIGN.md',
+  'THEME.md',
+]);
+
+export type DocKind =
+  | 'readme'
+  | 'claude_md'
+  | 'agents_md'
+  | 'design_md'
+  | 'theme_md'
+  | 'docs_md'
+  | 'other_md';
+
+export interface DocRow {
+  id: string;
+  repoPath: string;
+  repoName: string;
+  relPath: string;
+  kind: DocKind;
+  title: string;
+  body: string;
+  sizeBytes: number;
+  lastModified: string;
+  lastSynced: string;
+}
+
+interface RegisteredRepo {
+  name: string;
+  localPath: string;
+}
+
+interface IngestRepoResult {
+  repoName: string;
+  repoPath: string;
+  scanned: number;
+  upserted: number;
+  unchanged: number;
+  skipped: number;
+  errors: string[];
+}
+
+export interface IngestSummary {
+  repos: IngestRepoResult[];
+  totalUpserted: number;
+  totalUnchanged: number;
+  byKind: Record<DocKind, number>;
+}
+
+// ── Repo registry ─────────────────────────────────────────────────────────────
+
+/**
+ * Read `~/.o8/repos.json` and return a list of `{ name, localPath }`. Both
+ * legacy `path` and new `localPath` keys are accepted to match the rest of
+ * the codebase. Empty array if the file is missing — the ingest job no-ops
+ * cleanly on a fresh install.
+ */
+export function readRegisteredRepos(): RegisteredRepo[] {
+  const dataDir = process.env.O8_DATA_DIR
+    || process.env.CORTEX_IDE_DATA_DIR
+    || path.join(os.homedir(), '.o8');
+  const registryPath = path.join(dataDir, 'repos.json');
+  if (!existsSync(registryPath)) return [];
+
+  let raw: string;
+  try {
+    raw = readFileSync(registryPath, 'utf-8');
+  } catch {
+    return [];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  const list = Array.isArray(parsed)
+    ? parsed
+    : parsed && typeof parsed === 'object' && Array.isArray((parsed as { repos?: unknown }).repos)
+      ? (parsed as { repos: unknown[] }).repos
+      : [];
+
+  const out: RegisteredRepo[] = [];
+  for (const entry of list) {
+    if (!entry || typeof entry !== 'object') continue;
+    const record = entry as Record<string, unknown>;
+    const localPath = typeof record.localPath === 'string'
+      ? record.localPath
+      : typeof record.path === 'string'
+        ? record.path
+        : null;
+    if (!localPath) continue;
+    const name = typeof record.name === 'string' && record.name.trim()
+      ? record.name
+      : path.basename(localPath);
+    out.push({ name, localPath: path.resolve(localPath) });
+  }
+  return out;
+}
+
+// ── Walking + classification ──────────────────────────────────────────────────
+
+/** Map `<rel_path>` → DocKind. */
+function classifyKind(relPath: string): DocKind {
+  const base = path.basename(relPath);
+  // Top-level / well-known names first.
+  if (base === 'CLAUDE.md') return 'claude_md';
+  if (base === 'README.md' || base.toLowerCase() === 'readme.md') return 'readme';
+  if (base === 'AGENTS.md') return 'agents_md';
+  if (base === 'DESIGN.md') return 'design_md';
+  if (base === 'THEME.md') return 'theme_md';
+  // docs/** wins over generic *.md.
+  const segments = relPath.split(path.sep);
+  if (segments[0] === 'docs') return 'docs_md';
+  return 'other_md';
+}
+
+/** First H1 (`# heading`) in the body, falling back to the file basename. */
+function extractTitle(body: string, relPath: string): string {
+  const lines = body.split(/\r?\n/);
+  for (const line of lines) {
+    const m = /^#\s+(.+?)\s*$/.exec(line);
+    if (m) return m[1].slice(0, 200);
+  }
+  return path.basename(relPath, path.extname(relPath));
+}
+
+/**
+ * Walk a single repo and yield `{ relPath, absPath }` pairs for every
+ * markdown file that matches the ingest rules. Cheap recursive readdir —
+ * we don't shell out to `find` because Tauri/Node bundles can run on
+ * machines without it.
+ */
+function* walkRepo(repoPath: string): Generator<{ relPath: string; absPath: string }> {
+  // Top-level pass: any `*.md` lives at the root, plus `docs/` subtree.
+  let topEntries: string[];
+  try {
+    topEntries = readdirSync(repoPath);
+  } catch {
+    return;
+  }
+
+  for (const name of topEntries) {
+    const abs = path.join(repoPath, name);
+    let stat;
+    try {
+      stat = statSync(abs);
+    } catch {
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      // Drop into `docs/` recursively. Other top-level dirs are skipped.
+      if (name === 'docs') {
+        yield* walkDocsRecursive(repoPath, abs);
+      }
+      continue;
+    }
+
+    if (!stat.isFile()) continue;
+    if (!isMarkdown(name)) continue;
+    // Top-level: include named files always, plus any `*.md` (CHANGELOG, NOTES, etc.).
+    if (TOP_LEVEL_NAMED_FILES.has(name) || isMarkdown(name)) {
+      yield { relPath: name, absPath: abs };
+    }
+  }
+}
+
+function* walkDocsRecursive(
+  repoRoot: string,
+  dirAbs: string,
+): Generator<{ relPath: string; absPath: string }> {
+  let entries: string[];
+  try {
+    entries = readdirSync(dirAbs);
+  } catch {
+    return;
+  }
+
+  for (const name of entries) {
+    if (SKIP_DIRECTORIES.has(name)) continue;
+    const abs = path.join(dirAbs, name);
+
+    let stat;
+    try {
+      stat = statSync(abs);
+    } catch {
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      // Defensive against agent worktrees nested in docs/.
+      if (isClaudeWorktreesDir(abs)) continue;
+      yield* walkDocsRecursive(repoRoot, abs);
+      continue;
+    }
+    if (!stat.isFile()) continue;
+    if (!isMarkdown(name)) continue;
+
+    const relPath = path.relative(repoRoot, abs);
+    yield { relPath, absPath: abs };
+  }
+}
+
+function isMarkdown(name: string): boolean {
+  return /\.md$/i.test(name);
+}
+
+/** True for `<repo>/.claude/worktrees`. */
+function isClaudeWorktreesDir(absPath: string): boolean {
+  const segments = absPath.split(path.sep);
+  for (let i = 0; i < segments.length - 1; i += 1) {
+    if (segments[i] === '.claude' && segments[i + 1] === 'worktrees') return true;
+  }
+  return false;
+}
+
+// ── Body normalization ────────────────────────────────────────────────────────
+
+function normalizeBody(raw: string): string {
+  // Most repos store CRLF on Windows; normalize before truncation so the
+  // 50KB cap counts characters consistently.
+  const text = raw.replace(/\r\n/g, '\n');
+  if (text.length <= MAX_BODY_BYTES) return text;
+  return text.slice(0, MAX_BODY_BYTES) + TRUNCATION_SUFFIX;
+}
+
+// ── Persistence ───────────────────────────────────────────────────────────────
+
+interface ExistingDocRow {
+  id: string;
+  last_modified: string;
+  size_bytes: number;
+}
+
+/**
+ * Upsert one repo's worth of markdown. Returns counts so the caller can
+ * print a per-repo summary.
+ *
+ * Skip semantics: if the file's mtime + size match what's already in the
+ * `docs` table, we don't re-read or re-upsert. Cheap incremental refresh.
+ */
+export function ingestRepo(repo: RegisteredRepo): IngestRepoResult {
+  const result: IngestRepoResult = {
+    repoName: repo.name,
+    repoPath: repo.localPath,
+    scanned: 0,
+    upserted: 0,
+    unchanged: 0,
+    skipped: 0,
+    errors: [],
+  };
+
+  if (!existsSync(repo.localPath)) {
+    result.errors.push(`repo path missing: ${repo.localPath}`);
+    return result;
+  }
+
+  const sqlite = getSqlite();
+  if (!isFts5Available(sqlite)) {
+    result.errors.push('FTS5 unavailable — docs table may exist but docs_fts will be empty');
+  }
+
+  // Index existing rows for cheap mtime-based skip.
+  const existingRows = sqlite
+    .prepare('SELECT id, last_modified, size_bytes FROM docs WHERE repo_path = ?')
+    .all(repo.localPath) as ExistingDocRow[];
+  const existingById = new Map(existingRows.map((r) => [r.id, r]));
+
+  const upsertStmt = sqlite.prepare(
+    `INSERT INTO docs
+       (id, repo_path, repo_name, rel_path, kind, title, body, size_bytes, last_modified, last_synced)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       repo_name = excluded.repo_name,
+       rel_path = excluded.rel_path,
+       kind = excluded.kind,
+       title = excluded.title,
+       body = excluded.body,
+       size_bytes = excluded.size_bytes,
+       last_modified = excluded.last_modified,
+       last_synced = excluded.last_synced`,
+  );
+
+  const seenIds = new Set<string>();
+  const now = new Date().toISOString();
+
+  // Wrap the file walk in a transaction — bulk inserts on first ingest are
+  // ~10x faster, and incremental no-op runs still succeed.
+  sqlite.transaction(() => {
+    for (const { relPath, absPath } of walkRepo(repo.localPath)) {
+      result.scanned += 1;
+      const id = `${repo.localPath}:${relPath}`;
+      seenIds.add(id);
+
+      let stat;
+      try {
+        stat = statSync(absPath);
+      } catch (err) {
+        result.skipped += 1;
+        result.errors.push(`stat ${relPath}: ${err instanceof Error ? err.message : String(err)}`);
+        continue;
+      }
+
+      const lastModified = stat.mtime.toISOString();
+      const existing = existingById.get(id);
+      if (existing && existing.last_modified === lastModified && existing.size_bytes === stat.size) {
+        // Update last_synced only when the file is unchanged — keeps freshness
+        // tracking honest without re-reading the body.
+        sqlite.prepare('UPDATE docs SET last_synced = ? WHERE id = ?').run(now, id);
+        result.unchanged += 1;
+        continue;
+      }
+
+      let raw: string;
+      try {
+        raw = readFileSync(absPath, 'utf-8');
+      } catch (err) {
+        result.skipped += 1;
+        result.errors.push(`read ${relPath}: ${err instanceof Error ? err.message : String(err)}`);
+        continue;
+      }
+
+      const body = normalizeBody(raw);
+      const kind = classifyKind(relPath);
+      const title = extractTitle(body, relPath);
+
+      upsertStmt.run(
+        id,
+        repo.localPath,
+        repo.name,
+        relPath,
+        kind,
+        title,
+        body,
+        stat.size,
+        lastModified,
+        now,
+      );
+      result.upserted += 1;
+    }
+
+    // Optional: prune docs whose source file no longer exists. We keep this
+    // conservative — only delete rows the walk should have hit (same repo
+    // path, scoped to expected paths).
+    if (existingById.size > 0) {
+      const toDelete: string[] = [];
+      for (const id of existingById.keys()) {
+        if (!seenIds.has(id)) toDelete.push(id);
+      }
+      if (toDelete.length > 0) {
+        const del = sqlite.prepare('DELETE FROM docs WHERE id = ?');
+        for (const id of toDelete) {
+          del.run(id);
+        }
+      }
+    }
+  })();
+
+  return result;
+}
+
+/**
+ * Walk every registered repo and ingest. Top-level entrypoint for the cron
+ * / setup job. Emits a structured summary the CLI can pretty-print.
+ */
+export function ingestAllRepos(): IngestSummary {
+  const repos = readRegisteredRepos();
+  const summary: IngestSummary = {
+    repos: [],
+    totalUpserted: 0,
+    totalUnchanged: 0,
+    byKind: {
+      readme: 0,
+      claude_md: 0,
+      agents_md: 0,
+      design_md: 0,
+      theme_md: 0,
+      docs_md: 0,
+      other_md: 0,
+    },
+  };
+
+  for (const repo of repos) {
+    const res = ingestRepo(repo);
+    summary.repos.push(res);
+    summary.totalUpserted += res.upserted;
+    summary.totalUnchanged += res.unchanged;
+  }
+
+  // After ingest, gather per-kind counts from the live table for the report.
+  try {
+    const sqlite = getSqlite();
+    const rows = sqlite
+      .prepare('SELECT kind, COUNT(*) AS c FROM docs GROUP BY kind')
+      .all() as Array<{ kind: DocKind; c: number }>;
+    for (const r of rows) {
+      if (r.kind in summary.byKind) {
+        summary.byKind[r.kind] = r.c;
+      }
+    }
+  } catch {
+    // best-effort
+  }
+
+  return summary;
+}

--- a/src/lib/cortex/qa/retrievers/fts.ts
+++ b/src/lib/cortex/qa/retrievers/fts.ts
@@ -1,8 +1,8 @@
 /**
  * BM25 / FTS5 retriever (epic #915 sub-1).
  *
- * Runs the question (or pre-computed BM25 variants) against all four FTS5
- * indexes in parallel — outcomes, prs, issues, directives — then merges
+ * Runs the question (or pre-computed BM25 variants) against all five FTS5
+ * indexes in parallel — outcomes, prs, issues, directives, docs — then merges
  * the per-index top-20 hits via reciprocal rank fusion (RRF).
  *
  *   RRF score = sum over indexes of 1 / (60 + rank_in_index)
@@ -31,6 +31,12 @@ const PER_INDEX_LIMIT = 20;
 const PER_COMMENTS_LIMIT = 8;
 const DEFAULT_LIMIT = 30;
 const RRF_K = 60;
+// #915 path-to-70 phase 1.7 #3 — docs are typically large and would dominate
+// the merged top-30 if uncapped. 8 lets cross-repo questions that genuinely
+// hinge on CLAUDE.md / README content surface relevant pages without crowding
+// out directives/outcomes/PRs/issues. Tweak alongside MERGE_LIMIT in
+// retrieve.ts if recall starts slipping.
+const DOCS_PER_INDEX_LIMIT = 8;
 
 /** Sanitize a query string for FTS5 MATCH. FTS5 is picky:
  *   - Bare punctuation = parse error
@@ -136,6 +142,15 @@ interface CommentRow {
   updated_at: string | null;
 }
 
+/** docs has a real parent table (`docs`) — pull metadata from there. */
+interface DocRow {
+  id: string;
+  repo_name: string;
+  rel_path: string;
+  kind: string;
+  title: string;
+}
+
 export async function ftsRetriever(input: RetrieverInput): Promise<RetrieverResult> {
   const start = Date.now();
   const rows: TypedRow[] = [];
@@ -171,6 +186,7 @@ export async function ftsRetriever(input: RetrieverInput): Promise<RetrieverResu
     const issuesHits: TableHits = new Map();
     const directivesHits: TableHits = new Map();
     const commentsHits: TableHits = new Map();
+    const docsHits: TableHits = new Map();
 
     const merge = (target: TableHits, hits: FtsRow[]) => {
       for (const hit of hits) {
@@ -193,6 +209,12 @@ export async function ftsRetriever(input: RetrieverInput): Promise<RetrieverResu
         commentsHits,
         ftsSearch(sqlite, 'comments_fts', 'comment_id', match, PER_COMMENTS_LIMIT),
       );
+      // #915 path-to-70 phase 1.7 #3 — docs (CLAUDE.md / README / AGENTS.md /
+      // DESIGN/THEME / docs/**). Capped at the same PER_INDEX_LIMIT (20) by
+      // ftsSearch; we narrow to the top-N docs via DOCS_PER_INDEX_LIMIT below
+      // so docs don't crowd out directives/outcomes/PRs/issues in the merged
+      // top-30.
+      merge(docsHits, ftsSearch(sqlite, 'docs_fts', 'doc_id', match));
     }
 
     // Convert per-table maps into ranked lists, then RRF-merge into the
@@ -327,6 +349,46 @@ export async function ftsRetriever(input: RetrieverInput): Promise<RetrieverResu
           });
         });
       }
+    }
+
+    // docs — content-backed against the `docs` parent table. Hard-cap the
+    // contribution at DOCS_PER_INDEX_LIMIT so the unionMerge top-30 stays a
+    // fair mix across indexes (directives + outcomes + PRs + issues + docs).
+    if (docsHits.size > 0) {
+      const sortedIds = [...docsHits.entries()]
+        .sort((a, b) => b[1].rank - a[1].rank)
+        .map(([id]) => id)
+        .slice(0, DOCS_PER_INDEX_LIMIT);
+      const records = sqlite
+        .prepare(
+          `SELECT id, repo_name, rel_path, kind, title FROM docs
+           WHERE id IN (${sortedIds.map(() => '?').join(',')})`,
+        )
+        .all(...sortedIds) as DocRow[];
+      const byId = new Map(records.map((r) => [r.id, r]));
+      sortedIds.forEach((id, idx) => {
+        const record = byId.get(id);
+        if (!record) return;
+        const hit = docsHits.get(id)!;
+        const score = 1 / (RRF_K + idx);
+        accumulate(`doc:${id}`, score, {
+          citation: {
+            kind: 'doc',
+            rowId: id,
+            table: 'docs',
+            sourcePath: record.rel_path,
+            excerpt: hit.excerpt,
+          },
+          fields: {
+            id: record.id,
+            repoName: record.repo_name,
+            relPath: record.rel_path,
+            kind: record.kind,
+            title: record.title,
+          },
+          score: 0,
+        });
+      });
     }
 
     // directives — title/body live in the FTS index itself.

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -23,6 +23,7 @@ import { ensureUsageLogIndexes, ensureUsageLogSchema } from '@/lib/db/usage-log-
 import { ensureSessionOutcomeRoutingColumns } from '@/lib/db/session-outcome-routing-migration';
 import { ensureV14Fts5Schema } from '@/lib/db/v14-fts5-migration';
 import { ensureV15CommentsFtsSchema } from '@/lib/db/v15-comments-fts-migration';
+import { ensureV16DocsFtsSchema } from '@/lib/db/v16-docs-fts-migration';
 
 // ── Data directory ──
 
@@ -36,7 +37,7 @@ const DATA_DIR = process.env.O8_DATA_DIR
 // second migration step with no user-facing benefit.
 const DB_PATH = process.env.CORTEX_IDE_DB_PATH || path.join(DATA_DIR, 'cortex-ide.db');
 // Bump when ensureTables() adds new schema or backfill work.
-const DB_SCHEMA_VERSION = 15;
+const DB_SCHEMA_VERSION = 16;
 
 function migrationMarkerPath(version: number): string {
   return path.join(DATA_DIR, `.db-migrated-v${version}`);
@@ -119,6 +120,10 @@ function ensureIdempotentColumnAdds(sqlite: Database.Database): void {
   // live in epic-thread comments (e.g. epic #915's locked architecture
   // comment naming outcomes_fts/qa_eval_runs) become searchable.
   ensureV15CommentsFtsSchema(sqlite);
+  // #915 path-to-70 phase 1.7 #3 — Schema v16 — `docs` parent table +
+  // `docs_fts` FTS5 mirror for repo markdown (CLAUDE.md, README, AGENTS.md,
+  // DESIGN/THEME, docs/**). Same skip-with-warning pattern when FTS5 is off.
+  ensureV16DocsFtsSchema(sqlite);
   // #835 — recover any session_outcomes rows whose `valid_from` was inserted
   // as NULL (legacy seeds, raw INSERTs that bypassed the Drizzle schema
   // default). The column-add backfill in `ensureSessionOutcomeColumns` only

--- a/src/lib/db/v16-docs-fts-migration.ts
+++ b/src/lib/db/v16-docs-fts-migration.ts
@@ -1,0 +1,104 @@
+/**
+ * Schema v16 — `docs` table + `docs_fts` FTS5 index for repo markdown.
+ * (epic #915 path-to-70 phase 1.7 #3.)
+ *
+ * Round-2 brainstormer found cross-repo at 14% (qa-026/27/28/30 all 0.00) is
+ * substrate-empty: the questions ask about invariants that live in CLAUDE.md,
+ * README.md, AGENTS.md, DESIGN.md, THEME.md, and `docs/**` markdown across
+ * registered repos — files the retriever has never seen. BM25 over those
+ * files lets the FTS retriever return real rows, which is what the composer
+ * needs before it can stop saying "I don't have that information yet."
+ *
+ *   docs                — content-backed parent. Row per repo+rel_path file.
+ *   docs_fts            — FTS5 virtual mirror, kept in sync via AI/AD/AU triggers.
+ *
+ * Why a real parent table (vs the content-less directives_fts pattern):
+ *   - Markdown bodies can be large; we want a single place to read body/title
+ *     plus mtime metadata for incremental re-ingest.
+ *   - Triggers on `docs` keep `docs_fts` automatically coherent — no boot-time
+ *     backfill walk like directives. Ingest just upserts and the trigger fires.
+ *
+ * Why v16 (not v15): a sibling agent ships v15 (`comments_fts`) in parallel.
+ * Both migrations are pure additions (new tables, new triggers, no column
+ * mutations on existing tables) so they don't conflict on disk.
+ */
+
+import type Database from 'better-sqlite3';
+
+import { isFts5Available } from '@/lib/db/v14-fts5-migration';
+
+// ── Schema (v16) ──
+
+/**
+ * Idempotent. Creates `docs` + `docs_fts` + sync triggers. Safe on every
+ * boot — `CREATE TABLE/VIRTUAL TABLE/INDEX/TRIGGER IF NOT EXISTS` no-ops
+ * after the first run.
+ *
+ * Returns `{ applied }`. `applied=false` means FTS5 wasn't compiled in;
+ * Q&A doc retrieval will return zero rows but no other tables/code paths
+ * are affected.
+ */
+export function ensureV16DocsFtsSchema(sqlite: Database.Database): {
+  applied: boolean;
+} {
+  if (!isFts5Available(sqlite)) {
+    console.warn(
+      '[db][v16] FTS5 not compiled into better-sqlite3 — skipping docs_fts schema. ' +
+        'Doc retriever will return empty rows; rest of Q&A pipeline still works.',
+    );
+    return { applied: false };
+  }
+
+  // Parent table — content-backed. `id` is the composite `<repo_path>:<rel_path>`
+  // so an upsert from the ingester is a single INSERT OR REPLACE keyed on
+  // file identity.
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS docs (
+      id TEXT PRIMARY KEY,
+      repo_path TEXT NOT NULL,
+      repo_name TEXT NOT NULL,
+      rel_path TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      title TEXT NOT NULL,
+      body TEXT NOT NULL,
+      size_bytes INTEGER NOT NULL,
+      last_modified TEXT NOT NULL,
+      last_synced TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_docs_repo_path ON docs(repo_path);
+    CREATE INDEX IF NOT EXISTS idx_docs_kind ON docs(kind);
+    CREATE INDEX IF NOT EXISTS idx_docs_repo_kind ON docs(repo_path, kind);
+  `);
+
+  // FTS5 virtual table — `id` is UNINDEXED so we can join back to `docs`
+  // for body fetches without rebuilding the index. Title and body are the
+  // ranked columns; repo_name and kind are searchable but lower-priority.
+  sqlite.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS docs_fts USING fts5(
+      doc_id UNINDEXED,
+      repo_name,
+      kind,
+      title,
+      body,
+      tokenize='porter unicode61'
+    );
+
+    CREATE TRIGGER IF NOT EXISTS docs_fts_ai AFTER INSERT ON docs BEGIN
+      INSERT INTO docs_fts(doc_id, repo_name, kind, title, body)
+      VALUES (new.id, new.repo_name, new.kind, new.title, new.body);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS docs_fts_ad AFTER DELETE ON docs BEGIN
+      DELETE FROM docs_fts WHERE doc_id = old.id;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS docs_fts_au AFTER UPDATE ON docs BEGIN
+      DELETE FROM docs_fts WHERE doc_id = old.id;
+      INSERT INTO docs_fts(doc_id, repo_name, kind, title, body)
+      VALUES (new.id, new.repo_name, new.kind, new.title, new.body);
+    END;
+  `);
+
+  return { applied: true };
+}


### PR DESCRIPTION
## Summary
- Schema v16 introduces `docs` + `docs_fts` for repo markdown (CLAUDE.md / README / AGENTS.md / DESIGN.md / THEME.md / `docs/**`)
- Ingestion job walks every repo in `~/.o8/repos.json` and upserts markdown bodies (~78 docs across cortex-ide + o8-site on the founder's DB)
- FTS retriever runs `docs_fts` alongside the existing four indexes, capped at 8 hits/query so docs don't crowd out directives/outcomes/PRs/issues in the merged top-30

## Why
Round-2 brainstormer found cross-repo at 14% (qa-026/27/28/30 all 0.00) was substrate-empty: questions ask about invariants in the o8-site README, AGENTS.md, etc. — files the retriever had never seen. BM25 over those files lets the FTS retriever return real rows. `composer.ts` already had `case 'doc'` + `shortDocHandle()` (DOC- bracket form) from a previous commit — this is the missing schema/retriever/ingest half that makes those handles resolve to real rows.

## Docs ingested per repo (founder's DB)

| repo | docs | breakdown |
|------|------|-----------|
| cortex-ide | 74 | 1 README, 1 CLAUDE.md, 1 AGENTS.md, 1 DESIGN.md, 1 THEME.md, 65 `docs/**`, 5 other_md |
| o8-site | 4 | 1 README, 1 CLAUDE.md, 1 AGENTS.md, 1 THEME.md |

## Eval (before / after)

Baseline (last full eval pre-docs-ingest):

| category | factual_accuracy | citation_correctness |
|----------|------------------|----------------------|
| ownership | 30.0% | 45.0% |
| decisions | 54.0% | 60.0% |
| processes | 28.6% | 80.0% |
| incidents | 0.0% | 0.0% |
| specs | 0.0% | 0.0% |
| cross-repo | **0.0%** | **0.0%** |

After (re-eval with docs_fts active): **TBD — comment will follow when the in-flight eval finishes.**

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Schema v16 migration runs on boot — `~/.o8/.db-migrated-v16` written, `docs` + `docs_fts` tables present
- [x] `npx tsx scripts/ingest-repo-docs.ts` ingests 78 docs across cortex-ide + o8-site without errors
- [x] `sqlite3 ~/.o8/cortex-ide.db "SELECT COUNT(*), kind FROM docs GROUP BY kind"` returns the expected breakdown
- [x] `sqlite3 ~/.o8/cortex-ide.db "SELECT title FROM docs_fts WHERE docs_fts MATCH 'orchestrator' LIMIT 5"` returns real titles (CLAUDE.md, GEMINI.md, audit-snapshot-thoughts, etc.)
- [x] `.claude/worktrees/` skipped (no agent-* paths leaked into `docs.id`)
- [ ] Eval `O8_EVAL_MODE=1 npm run eval:qa` shows cross-repo lift (running)

## Constraints honored
- DOES NOT touch `comments_fts` (sibling agent owns schema v15)
- Schema v16 is a pure addition (new table + new virtual table + 3 triggers); doesn't alter v14 / v15
- `MERGE_LIMIT = 30` in `retrieve.ts` left untouched
- Docs retriever caps at top 8 (`DOCS_PER_INDEX_LIMIT`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)