### PR TITLE
feat(qa): Engineering Brain Indexer foundation — schema v17 + facts retriever

### DIFF
--- a/src/lib/cortex/qa/composer.ts
+++ b/src/lib/cortex/qa/composer.ts
@@ -101,6 +101,11 @@ function buildCitationHandle(row: TypedRow): string {
       // in an LLM bracket. Hash deterministically to a 10-char tag so the
       // handle stays bracket-safe and the lookup map can index both forms.
       return `DOC-${shortDocHandle(rowId)}`;
+    case 'fact':
+      // Engineering Brain Indexer (#915 north star #1). Fact rowIds are short
+      // ULIDs/uuids so we embed verbatim — no hashing needed. FACT- prefix
+      // avoids any collision with the existing handles above.
+      return `FACT-${rowId}`;
     default:
       return rowId;
   }

--- a/src/lib/cortex/qa/retrieve.ts
+++ b/src/lib/cortex/qa/retrieve.ts
@@ -12,6 +12,7 @@
 
 import 'server-only';
 
+import { retrieveFacts } from '@/lib/cortex/qa/retrievers/facts';
 import { ftsRetriever } from '@/lib/cortex/qa/retrievers/fts';
 import { graphRetriever } from '@/lib/cortex/qa/retrievers/graph';
 import { sqlRetriever } from '@/lib/cortex/qa/retrievers/sql';
@@ -27,15 +28,20 @@ const RRF_K = 60;
  * whole orchestrator down.
  */
 export async function retrieveAll(input: RetrieverInput): Promise<RetrieverResult[]> {
+  // #915 north star #1 — `retrieveFacts` joins the parallel fan-out as a peer
+  // retriever. It contributes rows to the same RRF union below; MERGE_LIMIT
+  // is unchanged so facts compete fairly. Composer-side high-rank injection
+  // (#3) is a separate agent.
   const settled = await Promise.allSettled([
     sqlRetriever(input),
     ftsRetriever(input),
     graphRetriever(input),
+    retrieveFacts(input),
   ]);
 
   return settled.map((entry, idx) => {
     if (entry.status === 'fulfilled') return entry.value;
-    const retriever: RetrieverResult['retriever'] = (['sql', 'fts', 'graph'] as const)[idx];
+    const retriever: RetrieverResult['retriever'] = (['sql', 'fts', 'graph', 'facts'] as const)[idx];
     console.warn(
       `[qa][retrieve] ${retriever} retriever rejected:`,
       entry.reason instanceof Error ? entry.reason.message : entry.reason,

--- a/src/lib/cortex/qa/retrievers/facts.ts
+++ b/src/lib/cortex/qa/retrievers/facts.ts
@@ -1,0 +1,208 @@
+/**
+ * Facts retriever — Engineering Brain Indexer surface (#915 north star #1).
+ *
+ * BM25 against `facts_fts`, joined back to the `facts` parent for confidence
+ * + source_excerpt + source_kind/source_id provenance. Returns top 8 rows
+ * with `confidence >= 0.6` so low-quality distillations don't poison the
+ * composer's prompt.
+ *
+ * Mirrors the per-table BM25 pattern from `retrievers/fts.ts` (`ftsSearch`
+ * helper), but lives in its own file because facts are surfaced into
+ * retrieve.ts as a sibling to `ftsRetriever`/`sqlRetriever`/`graphRetriever`,
+ * not as another sub-index inside the FTS retriever's internal RRF merge.
+ *
+ * Foundation only — no virtual-high-rank-row injection, no MERGE_LIMIT bump.
+ * Composer integration (#3) is a separate agent.
+ */
+
+import 'server-only';
+
+import type { RetrieverInput, RetrieverResult, TypedRow } from '@/lib/cortex/qa/types';
+import { getSqlite } from '@/lib/db';
+import { isFts5Available } from '@/lib/db/v14-fts5-migration';
+
+const DEFAULT_LIMIT = 8;
+const CONFIDENCE_FLOOR = 0.6;
+
+/** Sanitize a question for FTS5 MATCH — same shape as fts.ts so behaviour
+ *  matches across retrievers. Strips punctuation, splits on whitespace,
+ *  builds an OR-joined prefix-allowed phrase. */
+function buildMatchQuery(question: string): string | null {
+  if (!question?.trim()) return null;
+  const tokens = question
+    .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length >= 2);
+  if (tokens.length === 0) return null;
+  return tokens.map((t) => `"${t}"*`).join(' OR ');
+}
+
+interface FactsFtsHit {
+  rowId: string;
+  rank: number;
+  excerpt: string;
+}
+
+interface FactRow {
+  id: string;
+  kind: string;
+  content: string;
+  source_kind: string;
+  source_id: string;
+  source_excerpt: string;
+  repo_path: string | null;
+  confidence: number;
+  fingerprint: string;
+  created_at: string;
+  extracted_by: string;
+}
+
+/**
+ * BM25 search against `facts_fts`. Mirrors `ftsSearch` in retrievers/fts.ts
+ * but inlined so this retriever has no internal coupling to the FTS retriever.
+ * Returns rowIds + BM25 rank (negated, higher=better) + a snippet for the
+ * citation pill.
+ */
+function factsFtsSearch(
+  sqlite: ReturnType<typeof getSqlite>,
+  match: string,
+  limit: number,
+): FactsFtsHit[] {
+  try {
+    const sql = `
+      SELECT fact_id AS rowId,
+             -bm25(facts_fts) AS rank,
+             snippet(facts_fts, -1, '«', '»', '…', 8) AS excerpt
+      FROM facts_fts
+      WHERE facts_fts MATCH ?
+      ORDER BY bm25(facts_fts)
+      LIMIT ${limit}
+    `;
+    return sqlite.prepare(sql).all(match) as FactsFtsHit[];
+  } catch (error) {
+    // Likely the v17 migration hasn't been applied (FTS5 missing or migration
+    // skipped) — return empty so the rest of the retrieval pipeline still works.
+    console.warn(
+      `[qa][facts] facts_fts match failed for ${JSON.stringify(match)}:`,
+      error instanceof Error ? error.message : error,
+    );
+    return [];
+  }
+}
+
+/**
+ * `retrieveFacts` — top-N distilled facts that match the question, ranked by
+ * BM25 with a hard `confidence >= 0.6` floor. Multi-variant input is OR-merged
+ * (best rank per fact wins) before the floor + slice.
+ *
+ * Excerpt strategy: prefer the FTS5 snippet (it highlights the matched terms);
+ * fall back to the fact's `content` when the snippet is empty (rare — only
+ * happens when the matched terms appear only in `kind` and not `content`).
+ */
+export async function retrieveFacts(input: RetrieverInput): Promise<RetrieverResult> {
+  const start = Date.now();
+  const rows: TypedRow[] = [];
+
+  try {
+    const sqlite = getSqlite();
+    if (!isFts5Available(sqlite)) {
+      // FTS5 missing — facts_fts wasn't created. Worker writes still go to
+      // `facts`, but we have no BM25 index to search. Return empty.
+      return { retriever: 'facts', rows, durationMs: Date.now() - start };
+    }
+
+    const variants = input.bm25Variants?.length ? input.bm25Variants : [input.question];
+    const matches = variants
+      .map((v) => buildMatchQuery(v))
+      .filter((m): m is string => Boolean(m));
+    if (matches.length === 0) {
+      return { retriever: 'facts', rows, durationMs: Date.now() - start };
+    }
+
+    const limit = input.limit ?? DEFAULT_LIMIT;
+
+    // Multi-variant merge — keep the best rank per fact id across variants.
+    const hits = new Map<string, { rank: number; excerpt: string }>();
+    for (const match of matches) {
+      // Search a generous slice per variant so the post-confidence-filter
+      // population isn't starved when many low-confidence rows top the BM25
+      // ordering. limit*4 keeps us inside ~32 rows in the worst case.
+      const variantHits = factsFtsSearch(sqlite, match, limit * 4);
+      for (const hit of variantHits) {
+        const prev = hits.get(String(hit.rowId));
+        if (!prev || hit.rank > prev.rank) {
+          hits.set(String(hit.rowId), { rank: hit.rank, excerpt: hit.excerpt });
+        }
+      }
+    }
+
+    if (hits.size === 0) {
+      return { retriever: 'facts', rows, durationMs: Date.now() - start };
+    }
+
+    // Join back to `facts` for confidence + provenance. We sort by BM25 rank
+    // first, slice generously, then drop anything below the confidence floor,
+    // then re-slice to the final limit. Doing the floor cut after the join is
+    // fine — `facts` rows are small and we cap at ~32 ids.
+    const candidateIds = [...hits.entries()]
+      .sort((a, b) => b[1].rank - a[1].rank)
+      .map(([id]) => id);
+
+    const records = sqlite
+      .prepare(
+        `SELECT id, kind, content, source_kind, source_id, source_excerpt,
+                repo_path, confidence, fingerprint, created_at, extracted_by
+         FROM facts
+         WHERE id IN (${candidateIds.map(() => '?').join(',')})`,
+      )
+      .all(...candidateIds) as FactRow[];
+
+    const byId = new Map(records.map((r) => [r.id, r]));
+
+    for (const id of candidateIds) {
+      if (rows.length >= limit) break;
+      const record = byId.get(id);
+      if (!record) continue;
+      if (record.confidence < CONFIDENCE_FLOOR) continue;
+
+      const hit = hits.get(id)!;
+      const excerpt = hit.excerpt?.trim() ? hit.excerpt : record.content;
+
+      rows.push({
+        citation: {
+          kind: 'fact',
+          rowId: record.id,
+          table: 'facts',
+          excerpt,
+        },
+        fields: {
+          factKind: record.kind,
+          content: record.content,
+          sourceKind: record.source_kind,
+          sourceId: record.source_id,
+          sourceExcerpt: record.source_excerpt,
+          confidence: record.confidence,
+          repoPath: record.repo_path,
+          createdAt: record.created_at,
+          extractedBy: record.extracted_by,
+        },
+        // Use BM25 rank as the retriever-local score. retrieve.ts re-ranks
+        // via RRF over the per-retriever ordering, so absolute magnitudes
+        // don't matter as long as higher = better within this list.
+        score: hit.rank,
+      });
+    }
+  } catch (error) {
+    console.warn(
+      '[qa][facts] retriever failed:',
+      error instanceof Error ? error.message : error,
+    );
+  }
+
+  return {
+    retriever: 'facts',
+    rows,
+    durationMs: Date.now() - start,
+  };
+}

--- a/src/lib/cortex/qa/types.ts
+++ b/src/lib/cortex/qa/types.ts
@@ -19,9 +19,33 @@ export type CitationKind =
   | 'issue'
   | 'comment'
   | 'doc'
+  | 'fact'
   | 'symbol'
   | 'project'
   | 'project_repo';
+
+/**
+ * Engineering Brain Indexer typed-row shape (epic #915 north star #1).
+ *
+ * `factsRetriever` returns `TypedRow` with `citation.kind === 'fact'`. The
+ * fields below describe the distilled-fact payload the composer reads. Kept
+ * as a documentation-only interface so retrievers can spread it into the
+ * `fields` slot without forcing a discriminated union on TypedRow.
+ */
+export interface FactRowFields {
+  /** Distilled fact category (e.g. 'decision', 'spec', 'directive'). */
+  factKind: string;
+  /** The extracted fact content (≤500 chars). */
+  content: string;
+  /** Source substrate kind (e.g. 'comment', 'doc', 'outcome'). */
+  sourceKind: string;
+  /** Source row id within the substrate table. */
+  sourceId: string;
+  /** Verbatim substring of the source body the fact derives from. */
+  sourceExcerpt: string;
+  /** Distillation confidence (0.0-1.0). */
+  confidence: number;
+}
 
 export interface Citation {
   kind: CitationKind;
@@ -56,7 +80,7 @@ export interface TypedRow {
 }
 
 export interface RetrieverResult {
-  retriever: 'sql' | 'fts' | 'graph';
+  retriever: 'sql' | 'fts' | 'graph' | 'facts';
   rows: TypedRow[];
   durationMs: number;
 }

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -24,6 +24,7 @@ import { ensureSessionOutcomeRoutingColumns } from '@/lib/db/session-outcome-rou
 import { ensureV14Fts5Schema } from '@/lib/db/v14-fts5-migration';
 import { ensureV15CommentsFtsSchema } from '@/lib/db/v15-comments-fts-migration';
 import { ensureV16DocsFtsSchema } from '@/lib/db/v16-docs-fts-migration';
+import { ensureV17FactsFtsSchema } from '@/lib/db/v17-facts-fts-migration';
 
 // ── Data directory ──
 
@@ -37,7 +38,7 @@ const DATA_DIR = process.env.O8_DATA_DIR
 // second migration step with no user-facing benefit.
 const DB_PATH = process.env.CORTEX_IDE_DB_PATH || path.join(DATA_DIR, 'cortex-ide.db');
 // Bump when ensureTables() adds new schema or backfill work.
-const DB_SCHEMA_VERSION = 16;
+const DB_SCHEMA_VERSION = 17;
 
 function migrationMarkerPath(version: number): string {
   return path.join(DATA_DIR, `.db-migrated-v${version}`);
@@ -124,6 +125,11 @@ function ensureIdempotentColumnAdds(sqlite: Database.Database): void {
   // `docs_fts` FTS5 mirror for repo markdown (CLAUDE.md, README, AGENTS.md,
   // DESIGN/THEME, docs/**). Same skip-with-warning pattern when FTS5 is off.
   ensureV16DocsFtsSchema(sqlite);
+  // #915 north star #1 — Schema v17 — Engineering Brain Indexer foundation.
+  // `facts` table holds distilled facts with provenance + fingerprint upsert,
+  // `facts_fts` is the BM25 mirror, `facts_queue` is the worker's job table.
+  // Worker (#2), RRF merge (#3), and smoke eval (#4) ship separately.
+  ensureV17FactsFtsSchema(sqlite);
   // #835 — recover any session_outcomes rows whose `valid_from` was inserted
   // as NULL (legacy seeds, raw INSERTs that bypassed the Drizzle schema
   // default). The column-add backfill in `ensureSessionOutcomeColumns` only

--- a/src/lib/db/v17-facts-fts-migration.ts
+++ b/src/lib/db/v17-facts-fts-migration.ts
@@ -1,0 +1,122 @@
+/**
+ * Schema v17 — `facts` table + `facts_fts` FTS5 mirror + `facts_queue` work
+ * queue for the Engineering Brain Indexer (#915 north star #1 foundation).
+ *
+ * The background distiller reads raw substrate (comments, docs, outcomes,
+ * directives, PRs, issues), extracts structured facts via a Claude/Codex CLI
+ * call, and upserts each fact here. The Q&A retrievers then pull from
+ * `facts_fts` alongside the existing per-substrate indexes — facts are the
+ * highest-leverage row in the merged top-30 because they are the distilled
+ * answer, not the raw evidence.
+ *
+ * Tables:
+ *   facts         — distilled facts with provenance (source_kind+source_id).
+ *                   `fingerprint` makes upserts idempotent so re-running the
+ *                   distiller over the same substrate doesn't double-write.
+ *   facts_fts     — FTS5 virtual mirror over (id, kind, content) with AI/AD/AU
+ *                   triggers so writes to `facts` keep the index coherent.
+ *   facts_queue   — distillation work queue. The worker (#2) drains rows here
+ *                   FIFO with attempts tracking + last_error for poisoned items.
+ *
+ * This migration is the FOUNDATION ONLY. Worker (#2), composer RRF rebalance
+ * (#3), and smoke eval (#4) are sibling agents.
+ */
+
+import type Database from 'better-sqlite3';
+
+import { isFts5Available } from '@/lib/db/v14-fts5-migration';
+
+/**
+ * Idempotent. Creates `facts`, `facts_fts`, `facts_queue`, and the trigger
+ * trio. Safe on every boot — every statement is `IF NOT EXISTS`.
+ *
+ * Returns `{ applied }`. `applied=false` means FTS5 wasn't compiled in;
+ * the parent `facts` and `facts_queue` tables still get created (they're
+ * not FTS-dependent), but `facts_fts` and the BM25 retriever path are
+ * skipped with a warning. Worker writes still work, just without search.
+ */
+export function ensureV17FactsFtsSchema(sqlite: Database.Database): {
+  applied: boolean;
+} {
+  // `facts` and `facts_queue` are regular tables — create unconditionally so
+  // the worker can ingest even when FTS5 is missing. Only the FTS mirror +
+  // triggers are gated on FTS5 availability.
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS facts (
+      id TEXT PRIMARY KEY,
+      kind TEXT NOT NULL,
+      content TEXT NOT NULL,
+      source_kind TEXT NOT NULL,
+      source_id TEXT NOT NULL,
+      source_excerpt TEXT NOT NULL,
+      repo_path TEXT,
+      confidence REAL NOT NULL DEFAULT 0.0,
+      fingerprint TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      extracted_by TEXT NOT NULL DEFAULT 'claude-cli'
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_facts_fingerprint ON facts(fingerprint);
+    CREATE INDEX IF NOT EXISTS idx_facts_kind ON facts(kind);
+    CREATE INDEX IF NOT EXISTS idx_facts_source ON facts(source_kind, source_id);
+    CREATE INDEX IF NOT EXISTS idx_facts_repo_path ON facts(repo_path);
+    CREATE INDEX IF NOT EXISTS idx_facts_confidence ON facts(confidence);
+  `);
+
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS facts_queue (
+      id TEXT PRIMARY KEY,
+      source_kind TEXT NOT NULL,
+      source_id TEXT NOT NULL,
+      repo_path TEXT,
+      enqueued_at TEXT NOT NULL DEFAULT (datetime('now')),
+      started_at TEXT,
+      completed_at TEXT,
+      attempts INTEGER NOT NULL DEFAULT 0,
+      last_error TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_facts_queue_pending
+      ON facts_queue(completed_at, enqueued_at)
+      WHERE completed_at IS NULL;
+    CREATE INDEX IF NOT EXISTS idx_facts_queue_source
+      ON facts_queue(source_kind, source_id);
+  `);
+
+  if (!isFts5Available(sqlite)) {
+    console.warn(
+      '[db][v17] FTS5 not compiled into better-sqlite3 — skipping facts_fts schema. ' +
+        'Facts retriever will return empty rows; worker writes to `facts` still work.',
+    );
+    return { applied: false };
+  }
+
+  // FTS5 mirror — `id` is UNINDEXED so the retriever can join back to `facts`
+  // for source_excerpt + confidence at read time. `kind` and `content` are
+  // the searchable columns; BM25 ranks against the distilled content.
+  sqlite.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts USING fts5(
+      fact_id UNINDEXED,
+      kind,
+      content,
+      tokenize='porter unicode61'
+    );
+
+    CREATE TRIGGER IF NOT EXISTS facts_fts_ai AFTER INSERT ON facts BEGIN
+      INSERT INTO facts_fts(fact_id, kind, content)
+      VALUES (new.id, new.kind, new.content);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS facts_fts_ad AFTER DELETE ON facts BEGIN
+      DELETE FROM facts_fts WHERE fact_id = old.id;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS facts_fts_au AFTER UPDATE ON facts BEGIN
+      DELETE FROM facts_fts WHERE fact_id = old.id;
+      INSERT INTO facts_fts(fact_id, kind, content)
+      VALUES (new.id, new.kind, new.content);
+    END;
+  `);
+
+  return { applied: true };
+}


### PR DESCRIPTION
## Summary

Engineering Brain Indexer **north star #1 foundation only** — the substrate the background distiller writes into, and the BM25 surface the retriever reads back. Worker (#2), composer RRF rebalance (#3), and smoke eval (#4) are sibling agents.

## Schema v17

```
facts                                           facts_queue
┌────────────────────────────────┐              ┌──────────────────────────────┐
│ id              TEXT PK        │              │ id              TEXT PK      │
│ kind            TEXT           │              │ source_kind     TEXT         │
│ content         TEXT (≤500)    │              │ source_id       TEXT         │
│ source_kind     TEXT           │              │ repo_path       TEXT         │
│ source_id       TEXT           │              │ enqueued_at     TEXT         │
│ source_excerpt  TEXT           │              │ started_at      TEXT NULL    │
│ repo_path       TEXT           │              │ completed_at    TEXT NULL    │
│ confidence      REAL (0..1)    │              │ attempts        INT          │
│ fingerprint     TEXT UNIQUE    │              │ last_error      TEXT NULL    │
│ created_at      TEXT           │              └──────────────────────────────┘
│ extracted_by    TEXT           │
└──────────┬─────────────────────┘
           │ AI/AD/AU triggers
           ▼
   ┌─────────────────────────┐
   │ facts_fts (FTS5)        │
   │  fact_id UNINDEXED      │
   │  kind                   │
   │  content                │
   └─────────────────────────┘
```

- `fingerprint` is `UNIQUE` so the distiller's hash-of-content+source upsert is idempotent.
- `facts_queue` has a partial index on `(completed_at, enqueued_at) WHERE completed_at IS NULL` for fast FIFO pending-row pick.
- v9-style guard: `CREATE TABLE/VIRTUAL TABLE/INDEX/TRIGGER IF NOT EXISTS` everywhere; the migration is fully idempotent.
- `DB_SCHEMA_VERSION` bumped 16 → 17. Marker `~/.o8/.db-migrated-v17` written via the existing `writeAllMissingMigrationMarkers` walk.

## Retriever wiring

- `src/lib/cortex/qa/types.ts` — `CitationKind` gains `'fact'`. New `FactRowFields` interface documents the typed-row shape (`factKind`, `content`, `sourceKind`, `sourceId`, `sourceExcerpt`, `confidence`).
- `src/lib/cortex/qa/retrievers/facts.ts` — `retrieveFacts(input)` runs BM25 against `facts_fts`, joins back to `facts`, returns top-8 rows with `confidence >= 0.6`. Mirrors the `ftsSearch` pattern from `retrievers/fts.ts`. Multi-variant BM25 input is OR-merged (best rank per fact wins) before the floor + slice.
- `src/lib/cortex/qa/retrieve.ts` — `retrieveFacts` joins the parallel `Promise.allSettled` fan-out as a peer retriever. **`MERGE_LIMIT` is unchanged** — facts compete fairly with the other rows. Composer-side high-rank injection is #3's job.
- `src/lib/cortex/qa/composer.ts` — `buildCitationHandle('fact')` returns `FACT-${rowId}`. No collision with existing `D-`/`O-`/`PR-`/`ISS-`/`CMT-`/`SYM-`/`PROJ-`/`PRJREPO-`/`DOC-` handles.

## What's NOT here (deliberate)

- **No worker / distiller** — that's #2. The Claude/Codex CLI extractor that drains `facts_queue` and upserts `facts` ships separately.
- **No virtual-high-rank-row injection** — that's #3. The round-3 plan calls for facts to "enter as virtual high-rank rows" inside the composer's prompt; this PR just emits them in `retrieve.ts`.
- **No `MERGE_LIMIT` bump** — explicit constraint from the task brief.
- **No composer-prompt rebalance** — same.
- **No smoke eval changes** — that's #4.

## Test plan

- [ ] `npx tsc --noEmit` clean (verified locally).
- [ ] On an existing `~/.o8/cortex-ide.db`: `getDb()` writes `~/.o8/.db-migrated-v17` and creates `facts` / `facts_fts` / `facts_queue` without disturbing prior tables (`session_outcomes`, `docs`, `directives_fts`, etc. all intact).
- [ ] On a fresh DB: AI trigger fires (insert into `facts` propagates to `facts_fts`); AD trigger removes from FTS on delete.
- [ ] `sqlite3 ~/.o8/cortex-ide.db ".schema facts"`, `".schema facts_fts"`, `".schema facts_queue"` all return the expected shapes.
- [ ] FTS5-missing degraded path: `facts` and `facts_queue` still get created; `facts_fts` skipped with a `[db][v17]` warning; retriever returns empty rows without throwing.
- [ ] Retriever smoke: with zero rows in `facts`, `retrieveFacts` returns `{ retriever: 'facts', rows: [], durationMs: <small> }` and the rest of the QA pipeline is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)