### PR TITLE
feat(qa): smoke:qa fast eval as ship gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "typecheck": "rm -rf .next/types .next/dev/types && next typegen && tsc --noEmit",
     "rule-check": "tsx scripts/rule-check.ts",
     "eval:qa": "tsx src/lib/cortex/qa/eval/runner.ts",
+    "smoke:qa": "tsx tests/qa-eval/smoke.ts",
     "validate:qa-cases": "tsx scripts/validate-qa-cases.ts",
     "smoke": "node scripts/smoke.mjs",
     "seed:demo": "node scripts/seed-demo-state.mjs",

--- a/tests/qa-eval/cases.json
+++ b/tests/qa-eval/cases.json
@@ -126,6 +126,11 @@
         "Mentions ThoughtsMissionPanel as the reference implementation",
         "Mentions packet-meta-rows pattern"
       ],
+      "smokeExpectedFacts": [
+        "no-native-form-controls-in-packets",
+        "packet metadata",
+        "thoughtsmissionpanel"
+      ],
       "expectedCitations": [
         {
           "kind": "directive",
@@ -171,6 +176,11 @@
         "Names Tauri webview rendering as the cause",
         "Mentions extracting from @phosphor-icons/react/dist/defs/",
         "Mentions src/lib/icons/ shim system or 85 icons"
+      ],
+      "smokeExpectedFacts": [
+        "tauri webview",
+        "@phosphor-icons/react/dist/defs",
+        "src/lib/icons"
       ],
       "expectedCitations": [
         {
@@ -257,6 +267,11 @@
       "expectedFacts": [
         "Names npx tsc --noEmit",
         "References the typecheck directive OR npm run typecheck variant"
+      ],
+      "smokeExpectedFacts": [
+        "npx tsc --noemit",
+        "typecheck-before-commit",
+        "every commit"
       ],
       "expectedCitations": [
         {
@@ -415,6 +430,11 @@
         "Names the runtime as opencode",
         "Names the outcome as polish/orchestrator-empty-state-copy",
         "States that the reviewer flagged it as off-brand vs the locked design language"
+      ],
+      "smokeExpectedFacts": [
+        "orchestrator-empty-state-copy",
+        "off-brand",
+        "design language"
       ],
       "expectedCitations": [
         {
@@ -581,6 +601,11 @@
         "Names 30 questions / 5 per category",
         "Names the rubric fields factual_accuracy, citation_correctness, hallucination_count"
       ],
+      "smokeExpectedFacts": [
+        "70%",
+        "factual_accuracy",
+        "5 per category"
+      ],
       "expectedCitations": [
         {
           "kind": "issue",
@@ -654,6 +679,11 @@
         "States it's an explicit decision, not coincidence",
         "References the o8-site stack note OR the cortex-ide typography decision",
         "Optionally names the /text specimen page"
+      ],
+      "smokeExpectedFacts": [
+        "plus jakarta sans",
+        "explicit",
+        "o8-site"
       ],
       "expectedCitations": [],
       "rubric": {

--- a/tests/qa-eval/smoke.ts
+++ b/tests/qa-eval/smoke.ts
@@ -1,0 +1,260 @@
+/**
+ * Cortex Q&A smoke eval — `npm run smoke:qa`
+ *
+ * 6-case ship gate, runs in <2 min, exits 0/1 on PASS/FAIL. Replaces the
+ * 30-case heavy eval (`npm run eval:qa`) as the ship gate; the heavy eval
+ * is demoted to a nightly cron.
+ *
+ * Pure substring rubric — no Sonnet judge — so latency stays low.
+ *
+ * The 6 cases are picked from cases.json (one per category):
+ *   - All have substrate today (no knownGap).
+ *   - Picked by best recent factual_accuracy in qa_eval_runs. Where a
+ *     category has no case scoring ≥0.6 we pick the highest scorer and
+ *     mark it "weakest link" so a regression there is the canary.
+ *
+ * Environment:
+ *   OPENROUTER_API_KEY  — recommended. Sets O8_EVAL_MODE=1 so the pipeline
+ *                         routes through OpenRouter instead of the slow CLI
+ *                         bootstrap. Without it, smoke still runs but may
+ *                         fall through to heuristics (slower, may fail).
+ *
+ * Exit codes:
+ *   0 — all 6 cases passed
+ *   1 — any case failed
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+import { askCortex } from '@/lib/cortex/qa/ask';
+
+// ── Locked smoke case set ─────────────────────────────────────────────────────
+
+interface SmokeCaseEntry {
+  id: string;
+  weakestLink?: boolean; // true when category has no ≥0.6 case to pick from
+}
+
+// One per category. Order: ownership / decisions / processes / incidents / specs / cross-repo.
+// Picks justified in PR body; rationale lives in /tmp/cortex-engineering-brain-indexer-round3.md.
+const SMOKE_CASES: SmokeCaseEntry[] = [
+  { id: 'qa-005', weakestLink: true }, // ownership — best non-gap (avg 0.29)
+  { id: 'qa-007' }, // decisions — perfect (avg 1.0)
+  { id: 'qa-011' }, // processes — best non-gap (avg 0.61)
+  { id: 'qa-018' }, // incidents — best non-gap (avg 0.73)
+  { id: 'qa-025', weakestLink: true }, // specs — best non-gap (avg 0.05)
+  { id: 'qa-028', weakestLink: true }, // cross-repo — best non-gap (avg 0.29)
+];
+
+// ── Loader ────────────────────────────────────────────────────────────────────
+
+interface RawCase {
+  id: string;
+  category: string;
+  repoPath: string;
+  question: string;
+  expectedAnswer: string | null;
+  smokeExpectedFacts?: string[];
+  knownGap?: string;
+}
+
+async function loadCases(): Promise<RawCase[]> {
+  const casesPath = path.resolve(process.cwd(), 'tests/qa-eval/cases.json');
+  const raw = await fs.readFile(casesPath, 'utf-8');
+  const file = JSON.parse(raw) as { cases: RawCase[] };
+  const wanted = new Set(SMOKE_CASES.map((s) => s.id));
+  const found = file.cases.filter((c) => wanted.has(c.id));
+  if (found.length !== SMOKE_CASES.length) {
+    const missing = SMOKE_CASES.map((s) => s.id).filter(
+      (id) => !found.find((c) => c.id === id),
+    );
+    throw new Error(
+      `[smoke:qa] cases.json is missing ${missing.length} smoke cases: ${missing.join(', ')}`,
+    );
+  }
+  return found;
+}
+
+// ── Rubric ────────────────────────────────────────────────────────────────────
+
+interface CheckResult {
+  passed: boolean;
+  reason: string;
+}
+
+function checkAnswer(rawCase: RawCase, answer: string, citationCount: number): CheckResult {
+  // Rule 1: non-empty (>10 chars after trim)
+  const trimmed = answer.trim();
+  if (trimmed.length <= 10) {
+    return { passed: false, reason: `empty/short answer (${trimmed.length} chars)` };
+  }
+
+  // Rule 3: must NOT contain the no-row fallback string
+  const lower = trimmed.toLowerCase();
+  if (lower.includes("i don't have that information yet")) {
+    return { passed: false, reason: 'no-row fallback string detected' };
+  }
+
+  // Rule 2: must contain at least one smokeExpectedFacts substring (case-insensitive)
+  const facts = rawCase.smokeExpectedFacts ?? [];
+  if (facts.length === 0) {
+    return {
+      passed: false,
+      reason: 'case is missing smokeExpectedFacts (smoke harness misconfigured)',
+    };
+  }
+  const hit = facts.find((f) => lower.includes(f.toLowerCase()));
+  if (!hit) {
+    return {
+      passed: false,
+      reason: `none of [${facts.join(' | ')}] found in answer`,
+    };
+  }
+
+  // Rule 4: at least 1 citation
+  if (citationCount < 1) {
+    return { passed: false, reason: 'zero citations' };
+  }
+
+  return { passed: true, reason: `hit "${hit}", citations=${citationCount}` };
+}
+
+// ── Reporting ─────────────────────────────────────────────────────────────────
+
+interface RowReport {
+  caseId: string;
+  category: string;
+  weakestLink: boolean;
+  passed: boolean;
+  latencyMs: number;
+  preview: string;
+  reason: string;
+}
+
+function previewAnswer(answer: string, n = 80): string {
+  const flat = answer.replace(/\s+/g, ' ').trim();
+  if (flat.length <= n) return flat;
+  return flat.slice(0, n - 1) + '…';
+}
+
+function pad(s: string, n: number): string {
+  if (s.length >= n) return s.slice(0, n);
+  return s + ' '.repeat(n - s.length);
+}
+
+function printTable(rows: RowReport[]): void {
+  console.log('');
+  console.log(
+    `| ${pad('case_id', 8)} | ${pad('category', 11)} | ${pad('passed', 6)} | ${pad('latency', 8)} | answer (first 80 chars)`,
+  );
+  console.log(
+    `| ${pad('-', 8).replace(/ /g, '-')} | ${pad('-', 11).replace(/ /g, '-')} | ${pad('-', 6).replace(/ /g, '-')} | ${pad('-', 8).replace(/ /g, '-')} | ${'-'.repeat(80)}`,
+  );
+  for (const r of rows) {
+    const passCell = r.passed ? 'PASS' : 'FAIL';
+    const flag = r.weakestLink ? '*' : ' ';
+    const latency = `${r.latencyMs}ms`;
+    console.log(
+      `|${flag}${pad(r.caseId, 7)} | ${pad(r.category, 11)} | ${pad(passCell, 6)} | ${pad(latency, 8)} | ${r.preview}`,
+    );
+    if (!r.passed) {
+      console.log(`|         |             |        |          | ↳ ${r.reason}`);
+    }
+  }
+  console.log('');
+  console.log('* = weakest link (category has no case scoring ≥0.6 historically)');
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  // Force eval mode so pipeline uses OpenRouter (fast) instead of CLI bootstrap.
+  // Without OPENROUTER_API_KEY the pipeline falls through to heuristics — emit a
+  // warning but still run.
+  process.env.O8_EVAL_MODE = process.env.O8_EVAL_MODE ?? '1';
+
+  if (!process.env.OPENROUTER_API_KEY) {
+    console.warn(
+      '[smoke:qa] WARN: OPENROUTER_API_KEY is unset. Pipeline will fall through to heuristics — runs may be slower or fail.',
+    );
+  }
+
+  const cases = await loadCases();
+  const meta = new Map<string, SmokeCaseEntry>(
+    SMOKE_CASES.map((c) => [c.id, c]),
+  );
+
+  // Order rows in the table the same way the smoke list is locked.
+  const ordered = SMOKE_CASES.map((s) => cases.find((c) => c.id === s.id)!);
+
+  const rows: RowReport[] = [];
+  const latencies: number[] = [];
+
+  for (const c of ordered) {
+    const entry = meta.get(c.id)!;
+    const start = Date.now();
+    let answer = '';
+    let citations = 0;
+    let reason = '';
+    let passed = false;
+
+    try {
+      const result = await askCortex(c.question, c.repoPath, { bypassCache: true });
+      answer = result.answer;
+      citations = result.citations.length;
+      const check = checkAnswer(c, answer, citations);
+      passed = check.passed;
+      reason = check.reason;
+    } catch (err) {
+      reason = `askCortex threw: ${err instanceof Error ? err.message : String(err)}`;
+      passed = false;
+    }
+
+    const latencyMs = Date.now() - start;
+    latencies.push(latencyMs);
+
+    rows.push({
+      caseId: c.id,
+      category: c.category,
+      weakestLink: !!entry.weakestLink,
+      passed,
+      latencyMs,
+      preview: previewAnswer(answer),
+      reason,
+    });
+
+    console.log(
+      `[smoke:qa] ${c.id} ${c.category} ${passed ? 'PASS' : 'FAIL'} ${latencyMs}ms`,
+    );
+  }
+
+  printTable(rows);
+
+  // p50 latency
+  const sorted = [...latencies].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const p50 =
+    sorted.length % 2 === 0
+      ? Math.round((sorted[mid - 1] + sorted[mid]) / 2)
+      : sorted[mid];
+  const total = latencies.reduce((a, b) => a + b, 0);
+  const passCount = rows.filter((r) => r.passed).length;
+
+  console.log(`[smoke:qa] result: ${passCount}/${rows.length} passed`);
+  console.log(`[smoke:qa] latency: total=${total}ms p50=${p50}ms`);
+
+  if (passCount === rows.length) {
+    console.log('[smoke:qa] PASS');
+    process.exitCode = 0;
+  } else {
+    console.error('[smoke:qa] FAIL');
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error('[smoke:qa] unexpected failure:', err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

The 30-case Sonnet-judged eval (`npm run eval:qa`) takes ~6 hrs and currently gates ship at ~30% factual accuracy — too slow to run before every release and too noisy as a regression signal. This adds `npm run smoke:qa`: 6 hand-picked cases (one per category), pure substring rubric, exit 0/1 on PASS/FAIL, runs in ~60 seconds.

The 30-case eval is **not deleted** — it gets demoted to a nightly cron. Smoke is the new ship gate.

## The 6 picks

Picked from `tests/qa-eval/cases.json`. Selection rule: best recent `factual_accuracy` per category in `qa_eval_runs`, no `knownGap`, reads quickly. Where a category has no case averaging ≥0.6 historically, picked the highest scorer and flagged it as the **weakest link** (marked `*` in the table).

| Pick | Category | Avg | Why |
|---|---|---|---|
| qa-005 * | ownership | 0.29 | `no-native-form-controls-in-packets` directive — best non-gap (qa-003 is knownGap) |
| qa-007 | decisions | 1.0 | `phosphor-svg-only` rationale — solid green for many runs |
| qa-011 | processes | 0.61 | `npx tsc --noEmit` before commit |
| qa-018 | incidents | 0.73 | `orchestrator-empty-state-copy` off-brand reviewer flag |
| qa-025 * | specs | 0.05 | Q&A eval rubric — entire specs category is below 0.1 (substrate gap) |
| qa-028 * | cross-repo | 0.29 | Plus Jakarta Sans cross-repo decision (qa-029 is knownGap) |

The two `*` cases are honest signals that the substrate isn't there yet for those categories. Once the engineering-brain indexer (#915 north star #1/#2/#3) lands, qa-025 should start passing — that's the canary the smoke is waiting for.

## Rubric (no Sonnet judge)

For each case (case-insensitive substring match throughout):
1. Answer must be non-empty (>10 chars after trim)
2. Answer must contain ≥1 substring from the case's new `smokeExpectedFacts` array (3 distinctive substrings each)
3. Answer must NOT contain `"I don't have that information yet"` (the no-row fallback)
4. At least 1 citation in the result

No LLM judge — that's why this is fast. Pure substring match.

## Runtime measured

Local run with `OPENROUTER_API_KEY` set:

```
[smoke:qa] qa-005 ownership PASS 10341ms
[smoke:qa] qa-007 decisions PASS 8592ms
[smoke:qa] qa-011 processes PASS 8653ms
[smoke:qa] qa-018 incidents PASS 11925ms
[smoke:qa] qa-025 specs FAIL 10632ms     <- weakest link, no substrate
[smoke:qa] qa-028 cross-repo PASS 9679ms

[smoke:qa] result: 5/6 passed
[smoke:qa] latency: total=59822ms p50=10010ms
[smoke:qa] FAIL                          <- exit 1
```

~60s total, well under the 2-min budget.

## Exit-code semantics

- `0` — all 6 cases pass
- `1` — any case fails (including weakest-link cases)

This is intentional. The two weakest-link cases dragging the gate red is the smoke being honest about current capability. The gate goes green when retrieval can answer all 6 — that's the milestone the indexer is targeting.

If `OPENROUTER_API_KEY` is unset, smoke still runs but warns up front and falls through to the heuristic path (slower, may fail). Acceptable per task spec.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `OPENROUTER_API_KEY=… npm run smoke:qa` runs in <2 min
- [x] Exit code 1 when any case fails (current state, with qa-025 honestly red)
- [ ] Sanity-check exit code 0 once the indexer lands and qa-025 starts passing
- [x] Table is readable with PASS/FAIL/latency/preview columns

## Constraints respected

- 30-case `runner.ts` is untouched (only docs allude to it being demoted)
- No Sonnet judge in smoke
- No coupling to the indexer (smoke works today at ~30% retrieval level)
- Substring match is case-insensitive (lowercases both sides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)