### PR TITLE
feat(qa): facts pinned in top-30 + Sonnet prompt prefers FACT- citations

### DIFF
--- a/src/lib/cortex/qa/composer.ts
+++ b/src/lib/cortex/qa/composer.ts
@@ -43,9 +43,10 @@ function buildSonnetComposeSystem(): string {
 Rules:
 1. Answer in 1-6 sentences. Be direct and specific. For multi-fact specs (latency budgets, schema/table lists, cache TTLs, configuration values, enumerated rules), enumerate EVERY relevant fact present in the rows — don't cherry-pick one and skip the rest. Single-fact questions still get a single tight sentence.
 2. Cite EVERY fact using the row's citation handle in [BRACKET-ID] form (e.g. [D-014] for directives, [O-481] for outcomes, [PR-650] for PRs). One citation per fact, inline.
-3. Ground every claim in the retrieved rows. Do not invent facts, numbers, or names not present in the rows.
-4. If rows don't answer the question, say exactly: "I don't have that information yet — try indexing more directives or PRs."
-5. Stream your answer token by token.`;
+3. Rows with citation handle prefix \`FACT-\` are pre-extracted facts (high confidence). Prefer these as your primary citations when they answer the question. Cite raw rows (D-/O-/PR-/CMT-/DOC-) only when no FACT- row covers the fact.
+4. Ground every claim in the retrieved rows. Do not invent facts, numbers, or names not present in the rows.
+5. If rows don't answer the question, say exactly: "I don't have that information yet — try indexing more directives or PRs."
+6. Stream your answer token by token.`;
 }
 
 function buildSonnetComposeUser(

--- a/src/lib/cortex/qa/retrieve.ts
+++ b/src/lib/cortex/qa/retrieve.ts
@@ -22,6 +22,15 @@ const MERGE_LIMIT = 30;
 const RRF_K = 60;
 
 /**
+ * #915 north star #3 — facts are pre-extracted (high-trust) and would otherwise
+ * compete fairly via RRF against raw prose rows that share token overlap with
+ * the question. We pin up to 6 fact rows to the front of the merged top-30 so
+ * the composer always sees them first. 6 is small enough to leave 24 slots for
+ * non-fact rows; tunable. With 0 facts, behavior is identical to pre-pin RRF.
+ */
+const FACTS_PIN_LIMIT = 6;
+
+/**
  * Run every retriever in parallel. Each retriever swallows its own errors
  * and returns an empty `rows` on failure — `Promise.allSettled` is just a
  * belt-and-braces guard so a hard throw in one retriever can't take the
@@ -60,17 +69,46 @@ export async function retrieveAll(input: RetrieverInput): Promise<RetrieverResul
  * the SQL retriever picked because it's recent AND the FTS retriever picked
  * because it matches the question) get a higher merged score than either
  * alone, which is exactly what we want for the LLM composer.
+ *
+ * #915 north star #3 — facts are pinned to the top of the result. Up to
+ * `FACTS_PIN_LIMIT` highest-scoring fact rows take positions 0..K-1 of the
+ * returned slice; non-fact rows fill K..MERGE_LIMIT-1 by RRF. Pinned facts
+ * are removed from the RRF pool so they don't double-occupy slots. With zero
+ * facts the output is identical to pre-pin RRF.
  */
 export function unionMerge(results: RetrieverResult[]): TypedRow[] {
+  // Separate the facts retriever output before RRF so we can pin its
+  // highest-scoring rows above everything else. Non-facts retrievers feed
+  // the union as before.
+  const factsResult = results.find((r) => r.retriever === 'facts');
+  const otherResults = results.filter((r) => r.retriever !== 'facts');
+
+  // Take up to FACTS_PIN_LIMIT facts in their retriever's existing order
+  // (retrieveFacts sorts by BM25 rank descending — score field). Cap at
+  // MERGE_LIMIT so we never return more than 30 total rows.
+  const pinnedFacts: TypedRow[] = factsResult
+    ? [...factsResult.rows]
+        .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+        .slice(0, Math.min(FACTS_PIN_LIMIT, MERGE_LIMIT))
+    : [];
+
+  // Build a key set so we can drop any duplicate that surfaces from another
+  // retriever (extremely unlikely — only facts retriever emits 'fact' kind —
+  // but cheap insurance against future cross-retriever overlap).
+  const pinnedKeys = new Set(
+    pinnedFacts.map((row) => `${row.citation.kind}:${row.citation.rowId}`),
+  );
+
   const scores = new Map<string, number>();
   const rows = new Map<string, TypedRow>();
 
-  for (const result of results) {
+  for (const result of otherResults) {
     // Sort each retriever's rows by their pre-existing score (FTS uses RRF
     // internally; SQL/graph give 1) so the top-ranked row gets rank 0.
     const sorted = [...result.rows].sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
     sorted.forEach((row, idx) => {
       const key = `${row.citation.kind}:${row.citation.rowId}`;
+      if (pinnedKeys.has(key)) return; // already pinned above the merge
       const contribution = 1 / (RRF_K + idx);
       const prev = scores.get(key) ?? 0;
       scores.set(key, prev + contribution);
@@ -93,7 +131,10 @@ export function unionMerge(results: RetrieverResult[]): TypedRow[] {
     });
   }
 
-  return [...rows.values()]
+  const remainingSlots = Math.max(0, MERGE_LIMIT - pinnedFacts.length);
+  const mergedNonFacts = [...rows.values()]
     .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
-    .slice(0, MERGE_LIMIT);
+    .slice(0, remainingSlots);
+
+  return [...pinnedFacts, ...mergedNonFacts];
 }


### PR DESCRIPTION
## Summary

#915 north star #3 — composer integration for the Engineering Brain Indexer facts retriever (PR #956 / schema v17).

Pre-extracted facts are high-trust rows. Letting them compete fairly against raw prose via RRF means they often get buried under comments/PRs that share token overlap with the question. This PR pins the top-K facts to the front of the merged top-30 so the composer always sees them first, and adds a Sonnet system-prompt rule telling the model to prefer FACT- citations.

## Pin algorithm (`retrieve.ts`)

```ts
const FACTS_PIN_LIMIT = 6;

unionMerge(results) {
  const factsResult  = results.find(r => r.retriever === 'facts');
  const otherResults = results.filter(r => r.retriever !== 'facts');

  const pinnedFacts = factsResult
    ? sortByScore(factsResult.rows).slice(0, min(FACTS_PIN_LIMIT, MERGE_LIMIT))
    : [];

  // RRF over non-fact retrievers, skipping anything already pinned
  const mergedNonFacts = rrf(otherResults).slice(0, MERGE_LIMIT - pinnedFacts.length);

  return [...pinnedFacts, ...mergedNonFacts];
}
```

- **`FACTS_PIN_LIMIT = 6`** — small enough to leave 24 slots for non-fact context, large enough to surface multi-fact specs (e.g. enumerated rules / latency budgets) when the indexer has populated several relevant facts.
- **Score source** — uses `retrieveFacts`' BM25 rank field, sorted descending, so the highest-relevance facts get pinned first.
- **MERGE_LIMIT (30) unchanged.** Pin doesn't expand the budget — it reorders within it. If facts > 6 they fall through to the merged-non-facts pool... actually they don't (RRF pool excludes facts kind), so excess facts beyond the pin are dropped by design. With 0 facts the output is bit-identical to pre-pin RRF.
- **Pinned-key set** — defensive against a future cross-retriever fact emission collision; today only the facts retriever emits `kind: 'fact'`.

## Sonnet prompt addition (`composer.ts`)

New rule #3 (renumbered subsequent rules):

> Rows with citation handle prefix `FACT-` are pre-extracted facts (high confidence). Prefer these as your primary citations when they answer the question. Cite raw rows (D-/O-/PR-/CMT-/DOC-) only when no FACT- row covers the fact.

Class A (Flash/Haiku/Codex/OpenRouter) prompt left untouched — it already cites whatever the row gives it via `buildCitationHandle`, and the pinned facts surface in the slice-15 it sees.

## Before / after sample

**Empty `facts` table** (pre-indexer or no matches):
- Before pin: `[directive-014, pr-650, outcome-481, comment-c-1]`
- After pin:  `[directive-014, pr-650, outcome-481, comment-c-1]`
- Identical (verified bit-for-bit).

**3 facts + non-facts:**
- Before pin: facts compete via RRF, often land at positions 6+
- After pin:  `[fact-F1, fact-F2, fact-F3, directive-D1, outcome-O1, ...]`

**10 facts + 1 directive:**
- Before pin: top-30 includes all 11 rows
- After pin:  pinned `[F1..F6]`, then `[D1]` → 7 rows total (F7..F10 deliberately dropped — pin caps at 6)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `eslint` no new warnings (2 pre-existing unused-import warnings in composer.ts unchanged)
- [x] Unit smoke (4 cases — empty facts / 3 facts / 10 facts / 50-facts-only) all pass expected ordering
- [x] Empty-facts regression check — output bit-identical to pre-pin RRF on the same input
- [ ] `npm run smoke:qa` — defer to task #4 PR when it merges; this PR doesn't depend on it

## Constraints respected

- `MERGE_LIMIT` unchanged (30).
- `retrieveFacts` still wired into `retrieveAll`'s parallel fan-out (untouched).
- Schema v17 unchanged — no migrations.
- Indexer worker (#2) untouched.

Closes part of #915 north star #3.

Co-authored-by: LavonTMCQ <lavontmcq@users.noreply.github.com>