### PR TITLE
feat(ui): /ask quick action in chat composer (#965)

### DIFF
--- a/src/components/desktop/CommandStripNode.tsx
+++ b/src/components/desktop/CommandStripNode.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { Fragment } from 'react';
 import { useState } from 'react';
-import type { MobileTranscriptCommand, MobileTranscriptCommandChip } from '@/lib/mobile/types';
+import type { BrainAnswerCitation, MobileTranscriptCommand, MobileTranscriptCommandChip } from '@/lib/mobile/types';
 
 const BODY_FONT = '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif';
 const MONO_FONT = '"SF Mono", ui-monospace, monospace';
@@ -45,6 +46,115 @@ function renderInlineText(text: string, keyPrefix: string) {
   });
 }
 
+const CITATION_MARKER = /\[CITATION:([a-zA-Z0-9_\-#.]+)\]/g;
+
+const KIND_SHORT: Record<string, string> = {
+  directive: 'D',
+  outcome: 'O',
+  pr: 'PR',
+  issue: 'I',
+  symbol: 'S',
+};
+
+function citationLabel(kind: string, rowId: string): string {
+  const short = KIND_SHORT[kind] ?? kind.slice(0, 2).toUpperCase();
+  const prefix = `${short}-`;
+  if (rowId.toUpperCase().startsWith(prefix)) return `[${rowId.toUpperCase()}]`;
+  return `[${short}-${rowId}]`;
+}
+
+function BrainAnswerBlock({
+  tokens,
+  citations,
+}: {
+  tokens: string;
+  citations: BrainAnswerCitation[];
+}) {
+  const citationMap = new Map<string, BrainAnswerCitation>();
+  for (const c of citations) {
+    citationMap.set(c.rowId, c);
+    citationMap.set(c.rowId.toUpperCase(), c);
+  }
+
+  const nodes: React.ReactNode[] = [];
+  let cursor = 0;
+  let key = 0;
+  CITATION_MARKER.lastIndex = 0;
+  let match: RegExpExecArray | null = null;
+  while ((match = CITATION_MARKER.exec(tokens)) !== null) {
+    const start = match.index;
+    if (start > cursor) {
+      nodes.push(<Fragment key={`t-${key++}`}>{tokens.slice(cursor, start)}</Fragment>);
+    }
+    const id = match[1];
+    const citation = citationMap.get(id) ?? citationMap.get(id.toUpperCase()) ?? null;
+    if (citation) {
+      const label = citationLabel(citation.kind, citation.rowId);
+      nodes.push(
+        <button
+          key={`c-${key++}-${id}`}
+          type="button"
+          title={citation.excerpt}
+          onClick={() => {
+            if (citation.url && typeof window !== 'undefined') {
+              window.open(citation.url, '_blank', 'noopener,noreferrer');
+            }
+          }}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            verticalAlign: 'baseline',
+            marginLeft: 3,
+            marginRight: 3,
+            paddingTop: 1,
+            paddingRight: 5,
+            paddingBottom: 1,
+            paddingLeft: 5,
+            borderRadius: 6,
+            borderWidth: 1,
+            borderStyle: 'solid',
+            borderColor: 'var(--t-divider-subtle)',
+            background: 'var(--t-accent-soft, rgba(37, 99, 235, 0.08))',
+            color: 'var(--t-accent, #2563eb)',
+            cursor: citation.url ? 'pointer' : 'default',
+            fontFamily: MONO_FONT,
+            fontSize: 10,
+            fontWeight: 600,
+            letterSpacing: '0.02em',
+            lineHeight: 1.2,
+          }}
+        >
+          {label}
+        </button>,
+      );
+    } else {
+      nodes.push(<Fragment key={`u-${key++}`}>{match[0]}</Fragment>);
+    }
+    cursor = start + match[0].length;
+  }
+  if (cursor < tokens.length) {
+    nodes.push(<Fragment key={`t-${key++}`}>{tokens.slice(cursor)}</Fragment>);
+  }
+
+  return (
+    <div
+      style={{
+        fontSize: 12,
+        lineHeight: 1.55,
+        color: 'var(--t-text)',
+        fontFamily: BODY_FONT,
+        letterSpacing: '-0.005em',
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word',
+        paddingTop: 4,
+        paddingBottom: 4,
+      }}
+    >
+      {nodes}
+    </div>
+  );
+}
+
 export function CommandStripNode({
   command,
   timestampLabel,
@@ -52,10 +162,11 @@ export function CommandStripNode({
   command: MobileTranscriptCommand;
   timestampLabel?: string;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const hasBrainAnswer = Boolean(command.brainAnswer?.tokens);
+  const [expanded, setExpanded] = useState(() => hasBrainAnswer);
   const details = command.details ?? [];
   const chips = command.chips ?? [];
-  const hasDetails = details.length > 0 || chips.length > 0 || Boolean(timestampLabel);
+  const hasDetails = details.length > 0 || chips.length > 0 || Boolean(timestampLabel) || hasBrainAnswer;
 
   return (
     <div
@@ -215,6 +326,13 @@ export function CommandStripNode({
                 </div>
               ))}
             </div>
+          ) : null}
+
+          {hasBrainAnswer && command.brainAnswer ? (
+            <BrainAnswerBlock
+              tokens={command.brainAnswer.tokens}
+              citations={command.brainAnswer.citations}
+            />
           ) : null}
 
           {timestampLabel ? (

--- a/src/components/desktop/thoughts/chat-panel/SlashCommandPicker.tsx
+++ b/src/components/desktop/thoughts/chat-panel/SlashCommandPicker.tsx
@@ -10,6 +10,13 @@ interface SlashCommandPickerProps {
 
 function commandIcon(name: OrchestratorSlashCommandDefinition['name']) {
   switch (name) {
+    case 'ask':
+      return (
+        <>
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+          <path d="M9 9h6M9 13h4" />
+        </>
+      );
     case 'compact':
       return (
         <path d="M6 7h12M8 12h8M10 17h4" />

--- a/src/lib/mobile/types.ts
+++ b/src/lib/mobile/types.ts
@@ -162,11 +162,23 @@ export interface MobileTranscriptCommandChip {
   tone?: 'blue' | 'amber' | 'emerald' | 'slate' | 'red';
 }
 
+export interface BrainAnswerCitation {
+  kind: string;
+  rowId: string;
+  excerpt: string;
+  url?: string | null;
+}
+
 export interface MobileTranscriptCommand {
   name: string;
   summary: string;
   details?: string[];
   chips?: MobileTranscriptCommandChip[];
+  /** Present on /ask command entries — the streamed Brain answer + citations. */
+  brainAnswer?: {
+    tokens: string;
+    citations: BrainAnswerCitation[];
+  };
 }
 
 // Shared transcript shape used across mobile history and runtime tails.

--- a/src/lib/slash-commands/ask.ts
+++ b/src/lib/slash-commands/ask.ts
@@ -1,0 +1,176 @@
+'use client';
+
+/**
+ * /ask <question> — Ask the Brain from the chat composer.
+ *
+ * Streams from /api/cortex/ask, collects tokens + citations, then appends
+ * two entries to the transcript: a user bubble with the question, and a
+ * command entry with the Brain answer and citation pills.
+ */
+
+import type { BrainAnswerCitation } from '@/lib/mobile/types';
+import { buildSlashCommandEntry } from './shared';
+import type { ParsedOrchestratorSlashCommand, SlashCommandContext, SlashCommandExecutionResult } from './types';
+
+interface SseFrame {
+  name: string;
+  data: unknown;
+}
+
+function parseSseFrames(buffer: string): { frames: SseFrame[]; rest: string } {
+  const frames: SseFrame[] = [];
+  const segments = buffer.split('\n\n');
+  const rest = segments.pop() ?? '';
+  for (const segment of segments) {
+    const lines = segment.split('\n');
+    let name = 'message';
+    const dataLines: string[] = [];
+    for (const line of lines) {
+      if (line.startsWith('event:')) {
+        name = line.slice(6).trim();
+      } else if (line.startsWith('data:')) {
+        dataLines.push(line.slice(5).trim());
+      }
+    }
+    if (dataLines.length === 0) continue;
+    const raw = dataLines.join('\n');
+    let data: unknown = raw;
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      data = raw;
+    }
+    frames.push({ name, data });
+  }
+  return { frames, rest };
+}
+
+function coerceCitation(payload: unknown): BrainAnswerCitation | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const obj = payload as Record<string, unknown>;
+  if (typeof obj.kind !== 'string' || typeof obj.rowId !== 'string' || !obj.rowId) return null;
+  return {
+    kind: obj.kind,
+    rowId: obj.rowId,
+    excerpt: typeof obj.excerpt === 'string' ? obj.excerpt : '',
+    url: typeof obj.url === 'string' ? obj.url : null,
+  };
+}
+
+async function streamBrainAnswer(
+  question: string,
+  repoPath: string | null,
+): Promise<{ tokens: string; citations: BrainAnswerCitation[]; error?: string }> {
+  let tokens = '';
+  const citations: BrainAnswerCitation[] = [];
+
+  try {
+    const res = await fetch('/api/cortex/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ question, repoPath }),
+    });
+
+    if (!res.ok || !res.body) {
+      return { tokens: '', citations: [], error: `HTTP ${res.status}` };
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const { frames, rest } = parseSseFrames(buffer);
+      buffer = rest;
+      for (const frame of frames) {
+        if (frame.name === 'token') {
+          const text =
+            typeof frame.data === 'object' && frame.data !== null
+              ? String((frame.data as Record<string, unknown>).text ?? '')
+              : '';
+          if (text) tokens += text;
+        } else if (frame.name === 'citation') {
+          const c = coerceCitation(frame.data);
+          if (c) citations.push(c);
+        } else if (frame.name === 'error') {
+          const message =
+            typeof frame.data === 'object' && frame.data !== null
+              ? String((frame.data as Record<string, unknown>).message ?? 'stream error')
+              : 'stream error';
+          return { tokens, citations, error: message };
+        }
+      }
+    }
+  } catch (err) {
+    return { tokens, citations, error: err instanceof Error ? err.message : 'request failed' };
+  }
+
+  return { tokens, citations };
+}
+
+export async function handleAskSlashCommand(
+  command: ParsedOrchestratorSlashCommand,
+  context: SlashCommandContext,
+): Promise<SlashCommandExecutionResult> {
+  const question = command.args.trim();
+  if (!question) {
+    context.appendEntries([
+      buildSlashCommandEntry({
+        name: 'ask',
+        summary: 'Ask needs a question — e.g. /ask what is the typecheck command?',
+        chips: [{ label: 'argument required', tone: 'amber' }],
+      }),
+    ]);
+    return { handled: true };
+  }
+
+  // Optimistic user bubble — shows the question immediately.
+  const ts = Date.now();
+  context.appendEntries([
+    {
+      id: `ask-q-${ts}`,
+      role: 'user',
+      text: question,
+      timestamp: ts,
+      timestampLabel: new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+    },
+  ]);
+
+  const { tokens, citations, error } = await streamBrainAnswer(question, context.repoPath);
+
+  if (error && !tokens) {
+    context.appendEntries([
+      buildSlashCommandEntry({
+        name: 'ask',
+        summary: `Brain unavailable: ${error}`,
+        chips: [{ label: 'error', tone: 'red' }],
+      }),
+    ]);
+    return { handled: true };
+  }
+
+  const answerTs = Date.now();
+  context.appendEntries([
+    {
+      id: `ask-a-${answerTs}`,
+      role: 'system',
+      type: 'command',
+      text: tokens || '(no answer)',
+      timestamp: answerTs,
+      timestampLabel: new Date(answerTs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      command: {
+        name: 'ask',
+        summary: tokens || '(no answer)',
+        chips: citations.length > 0
+          ? [{ label: `${citations.length} source${citations.length === 1 ? '' : 's'}`, tone: 'blue' }]
+          : [],
+        brainAnswer: { tokens, citations },
+      },
+    },
+  ]);
+
+  return { handled: true };
+}

--- a/src/lib/slash-commands/definitions.ts
+++ b/src/lib/slash-commands/definitions.ts
@@ -2,6 +2,14 @@ import type { OrchestratorSlashCommandDefinition } from './types';
 
 export const ORCHESTRATOR_SLASH_COMMANDS: OrchestratorSlashCommandDefinition[] = [
   {
+    command: '/ask',
+    name: 'ask',
+    title: 'Ask the Brain',
+    description: 'Query the Brain — directives, decisions, past outcomes.',
+    argHint: '<question>',
+    requiresArgument: true,
+  },
+  {
     command: '/compact',
     name: 'compact',
     title: 'Compact context',

--- a/src/lib/slash-commands/index.ts
+++ b/src/lib/slash-commands/index.ts
@@ -1,3 +1,4 @@
+import { handleAskSlashCommand } from './ask';
 import { handleClearSlashCommand } from './clear';
 import { handleCompactSlashCommand } from './compact';
 import { handleFocusSlashCommand } from './focus';
@@ -28,6 +29,7 @@ const HANDLERS: Record<ParsedOrchestratorSlashCommand['command']['name'], (
   command: ParsedOrchestratorSlashCommand,
   context: SlashCommandContext,
 ) => Promise<SlashCommandExecutionResult>> = {
+  ask: handleAskSlashCommand,
   clear: handleClearSlashCommand,
   compact: handleCompactSlashCommand,
   focus: handleFocusSlashCommand,

--- a/src/lib/slash-commands/types.ts
+++ b/src/lib/slash-commands/types.ts
@@ -2,6 +2,7 @@ import type { MobileTranscriptEntry } from '@/lib/mobile/types';
 import type { OrchestratorMissionState } from '@/lib/orchestrator/types';
 
 export type OrchestratorSlashCommandName =
+  | 'ask'
   | 'compact'
   | 'clear'
   | 'focus'


### PR DESCRIPTION
Closes #965

## Summary
- Type `/ask <question>` in the chat composer to query the Brain from the orchestrator panel
- Selecting `/ask` from the slash picker fills the input with `/ask ` (requiresArgument); user appends question and submits
- Handler streams SSE from `/api/cortex/ask`, collects all tokens + citations, then appends two entries: a user bubble (the question) and a system command entry (the Brain answer)
- Answer renders with clickable `[CITATION:xxx]` pills inline; clicking opens the source URL in a new tab
- `CommandStripNode` auto-expands when `brainAnswer` is present — no extra click needed to see the answer
- New `brainAnswer` field on `MobileTranscriptCommand` carries the tokens + citation list (typed via `BrainAnswerCitation` in `mobile/types.ts`)

## Smoke
6/6 PASS (46s total, p50=8084ms)