### PR TITLE
feat(brain): embeddings column + hybrid retrieval (#962)

### DIFF
--- a/scripts/backfill-fact-embeddings.ts
+++ b/scripts/backfill-fact-embeddings.ts
@@ -1,0 +1,238 @@
+/**
+ * Backfill `facts.embedding` BLOB column (#962).
+ *
+ * Opt-in — never runs automatically. Run explicitly when you want to enable
+ * the hybrid BM25+cosine scorer (`O8_HYBRID_SCORER=1`) and have the
+ * embeddings ready in the DB.
+ *
+ * Requires OPENAI_API_KEY. Uses `text-embedding-3-small` (1536-dim,
+ * ~$0.02/1M tokens). At 10k facts the total input is ~1-3M tokens → $0.02-$0.06.
+ *
+ * Usage:
+ *   OPENAI_API_KEY=sk-... npx tsx scripts/backfill-fact-embeddings.ts
+ *   OPENAI_API_KEY=sk-... npx tsx scripts/backfill-fact-embeddings.ts --dry-run
+ *   OPENAI_API_KEY=sk-... npx tsx scripts/backfill-fact-embeddings.ts --batch=50
+ *   OPENAI_API_KEY=sk-... npx tsx scripts/backfill-fact-embeddings.ts --limit=500
+ *
+ * Flags:
+ *   --dry-run      Count un-embedded rows and cost estimate, no API calls.
+ *   --batch=N      Rows per OpenAI call (default 100, max 100).
+ *   --limit=N      Stop after N rows (for testing).
+ *   --force        Re-embed rows that already have an embedding (for model upgrades).
+ */
+
+import { existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+
+// Inline the embeddings logic here — this is a standalone script that can't
+// import from @/ without the Next.js tsconfig resolution. Keep it minimal.
+
+const OPENAI_EMBED_MODEL = 'text-embedding-3-small';
+const EMBED_DIMS = 1536;
+const COST_PER_1M_TOKENS = 0.02;
+const AVG_CHARS_PER_FACT = 200;
+const CHARS_PER_TOKEN = 4;
+const BATCH_LIMIT = 100;
+const TIMEOUT_MS = 30_000;
+
+function parseArgs(): {
+  dryRun: boolean;
+  batchSize: number;
+  limit: number | null;
+  force: boolean;
+} {
+  const argv = process.argv.slice(2);
+  const dryRun = argv.includes('--dry-run');
+  const force = argv.includes('--force');
+
+  const batchArg = argv.find((a) => a.startsWith('--batch='));
+  const batchSize = batchArg ? Math.min(parseInt(batchArg.split('=')[1], 10), BATCH_LIMIT) : 100;
+
+  const limitArg = argv.find((a) => a.startsWith('--limit='));
+  const limit = limitArg ? parseInt(limitArg.split('=')[1], 10) : null;
+
+  return { dryRun, batchSize, force, limit };
+}
+
+function getDbPath(): string {
+  const dataDir =
+    process.env.O8_DATA_DIR ||
+    process.env.CORTEX_IDE_DATA_DIR ||
+    path.join(os.homedir(), '.o8');
+  return path.join(dataDir, 'cortex-ide.db');
+}
+
+interface FactForEmbed {
+  id: string;
+  content: string;
+}
+
+async function embedBatch(
+  texts: string[],
+  apiKey: string,
+): Promise<Float32Array[]> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  let body: { data: Array<{ embedding: number[] }> };
+  try {
+    const response = await fetch('https://api.openai.com/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: OPENAI_EMBED_MODEL,
+        input: texts,
+        dimensions: EMBED_DIMS,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => '(no body)');
+      throw new Error(`OpenAI API error ${response.status}: ${errorText.slice(0, 200)}`);
+    }
+
+    body = (await response.json()) as { data: Array<{ embedding: number[] }> };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!body.data || body.data.length !== texts.length) {
+    throw new Error(
+      `OpenAI returned ${body.data?.length ?? 0} embeddings for ${texts.length} inputs`,
+    );
+  }
+
+  return body.data.map((entry) => {
+    if (!Array.isArray(entry.embedding) || entry.embedding.length !== EMBED_DIMS) {
+      throw new Error(
+        `Unexpected embedding shape: length=${entry.embedding?.length}`,
+      );
+    }
+    return new Float32Array(entry.embedding);
+  });
+}
+
+function encodeEmbedding(vec: Float32Array): Buffer {
+  return Buffer.from(vec.buffer, vec.byteOffset, vec.byteLength);
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  const dbPath = getDbPath();
+
+  if (!existsSync(dbPath)) {
+    console.error(`[backfill-embeddings] DB not found: ${dbPath}`);
+    process.exit(1);
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey && !args.dryRun) {
+    console.error('[backfill-embeddings] OPENAI_API_KEY is not set. Set it to embed facts.');
+    process.exit(1);
+  }
+
+  const db = new Database(dbPath);
+  db.pragma('foreign_keys = ON');
+  db.pragma('journal_mode = WAL');
+
+  // Check the embedding column exists (v20 migration must have run).
+  const hasCol = (db.pragma(`table_info(facts)`) as Array<{ name: string }>)
+    .some((c) => c.name === 'embedding');
+  if (!hasCol) {
+    console.error(
+      '[backfill-embeddings] facts.embedding column missing. ' +
+        'Run the app once to apply schema v20, then re-run this script.',
+    );
+    db.close();
+    process.exit(1);
+  }
+
+  const filterSql = args.force
+    ? 'SELECT id, content FROM facts ORDER BY created_at ASC'
+    : 'SELECT id, content FROM facts WHERE embedding IS NULL ORDER BY created_at ASC';
+
+  let candidates = db.prepare(filterSql).all() as FactForEmbed[];
+
+  const total = candidates.length;
+  const estimatedTokens = Math.ceil((total * AVG_CHARS_PER_FACT) / CHARS_PER_TOKEN);
+  const estimatedCost = (estimatedTokens / 1_000_000) * COST_PER_1M_TOKENS;
+
+  console.log(`[backfill-embeddings] DB: ${dbPath}`);
+  console.log(`[backfill-embeddings] mode=${args.dryRun ? 'dry-run' : 'apply'}`);
+  console.log(
+    `[backfill-embeddings] candidates=${total} (est. tokens≈${estimatedTokens} cost≈$${estimatedCost.toFixed(4)})`,
+  );
+
+  if (args.dryRun) {
+    console.log('[backfill-embeddings] dry-run: no API calls made');
+    db.close();
+    return;
+  }
+
+  if (args.limit !== null) {
+    candidates = candidates.slice(0, args.limit);
+    console.log(`[backfill-embeddings] limited to ${candidates.length} rows`);
+  }
+
+  const updateStmt = db.prepare('UPDATE facts SET embedding = ? WHERE id = ?');
+
+  let done = 0;
+  let failed = 0;
+  const t0 = Date.now();
+
+  for (let offset = 0; offset < candidates.length; offset += args.batchSize) {
+    const batch = candidates.slice(offset, offset + args.batchSize);
+    const texts = batch.map((r) => r.content);
+
+    let vecs: Float32Array[];
+    try {
+      vecs = await embedBatch(texts, apiKey!);
+    } catch (err) {
+      console.error(
+        `[backfill-embeddings] batch ${offset}-${offset + batch.length - 1} failed:`,
+        err instanceof Error ? err.message : err,
+      );
+      failed += batch.length;
+      // Continue with the next batch — one API failure doesn't abort the run.
+      continue;
+    }
+
+    const tx = db.transaction(() => {
+      for (let i = 0; i < batch.length; i++) {
+        updateStmt.run(encodeEmbedding(vecs[i]), batch[i].id);
+      }
+    });
+    tx();
+    done += batch.length;
+
+    const pct = Math.round((done / candidates.length) * 100);
+    const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+    console.log(`[backfill-embeddings] ${done}/${candidates.length} (${pct}%) elapsed=${elapsed}s`);
+  }
+
+  const totalElapsed = ((Date.now() - t0) / 1000).toFixed(1);
+  console.log('');
+  console.log('────────────────────────────────────────────────────────────');
+  console.log('[backfill-embeddings] summary');
+  console.log('────────────────────────────────────────────────────────────');
+  console.log(`  embedded : ${done}`);
+  console.log(`  failed   : ${failed}`);
+  console.log(`  elapsed  : ${totalElapsed}s`);
+  console.log('────────────────────────────────────────────────────────────');
+  console.log('');
+  console.log('To use the hybrid BM25+cosine scorer, set O8_HYBRID_SCORER=1 in .env.local');
+
+  db.close();
+}
+
+main().catch((err) => {
+  console.error('[backfill-embeddings] unexpected failure:', err);
+  process.exit(1);
+});

--- a/scripts/compact-facts.ts
+++ b/scripts/compact-facts.ts
@@ -8,7 +8,7 @@
  * This script preserves full backwards-compatibility so the launchd plist
  * and any existing cron invocations continue to work unchanged.
  *
- * Six jobs:
+ * Seven jobs:
  *
  *   1. GC orphans — facts whose source row has been deleted upstream
  *   2. Drop low-confidence — facts below a configurable floor (default 0.3)
@@ -16,6 +16,11 @@
  *   4. Time-decay confidence — stale facts fade toward the noise floor
  *   5. Token-Jaccard near-dup merge — paraphrases collapsed into one row
  *   6. Contradiction surfacing — heuristic report-only, opt-in
+ *   7. Cosine near-dup merge (#962) — semantic dedup using stored embeddings
+ *      (facts.embedding BLOB). Pairs with cosine ≥ --cosine-threshold
+ *      (default 0.92) get collapsed the same way as Job 5. Disabled by
+ *      default (pass --cosine-dedup to enable). Skipped with a warning when
+ *      no rows have embeddings yet (run backfill-fact-embeddings.ts first).
  *
  * Usage:
  *   npx tsx scripts/compact-facts.ts                  # apply all jobs
@@ -25,6 +30,8 @@
  *   npx tsx scripts/compact-facts.ts --jaccard=0.9    # stricter merge
  *   npx tsx scripts/compact-facts.ts --skip-decay     # disable Job 4
  *   npx tsx scripts/compact-facts.ts --skip-jaccard   # disable Job 5
+ *   npx tsx scripts/compact-facts.ts --cosine-dedup   # enable Job 7 (semantic dedup)
+ *   npx tsx scripts/compact-facts.ts --cosine=0.95    # stricter cosine threshold
  */
 
 import { existsSync } from 'node:fs';
@@ -46,10 +53,12 @@ function parseArgs() {
   const skipDecay = argv.includes('--skip-decay');
   const skipJaccard = argv.includes('--skip-jaccard');
   const reportContradictions = argv.includes('--report-contradictions');
+  const cosineDedup = argv.includes('--cosine-dedup');
   const confidenceFloor = parseNumber(argv.find((a) => a.startsWith('--floor=')), 0.3);
   const decayDays = parseNumber(argv.find((a) => a.startsWith('--decay-days=')), 90);
   const decayFactor = parseNumber(argv.find((a) => a.startsWith('--decay-factor=')), 0.9);
   const jaccardThreshold = parseNumber(argv.find((a) => a.startsWith('--jaccard=')), 0.85);
+  const cosineThreshold = parseNumber(argv.find((a) => a.startsWith('--cosine=')), 0.92);
   const contradictionMinOverlap = parseNumber(
     argv.find((a) => a.startsWith('--contradiction-overlap=')),
     8,
@@ -71,6 +80,10 @@ function parseArgs() {
     console.error('[compact-facts] --jaccard must be in [0, 1]');
     process.exit(1);
   }
+  if (cosineThreshold < 0 || cosineThreshold > 1) {
+    console.error('[compact-facts] --cosine must be in [0, 1]');
+    process.exit(1);
+  }
   return {
     dryRun,
     confidenceFloor,
@@ -81,6 +94,8 @@ function parseArgs() {
     skipJaccard,
     reportContradictions,
     contradictionMinOverlap,
+    cosineDedup,
+    cosineThreshold,
   };
 }
 

--- a/src/lib/cortex/compactor.ts
+++ b/src/lib/cortex/compactor.ts
@@ -23,6 +23,10 @@ export interface CompactionArgs {
   skipJaccard: boolean;
   reportContradictions: boolean;
   contradictionMinOverlap: number;
+  /** #962 — enable Job 7 (cosine near-dup over facts.embedding). Off by default. */
+  cosineDedup?: boolean;
+  /** #962 — cosine similarity threshold for Job 7. Default 0.92. */
+  cosineThreshold?: number;
 }
 
 export interface CompactionResult {
@@ -34,6 +38,8 @@ export interface CompactionResult {
   jaccardRemoved: number;
   jaccardMerged: number;
   contradictionsReported: number;
+  cosineRemoved: number;
+  cosineMerged: number;
   elapsedMs: number;
 }
 
@@ -511,6 +517,141 @@ function surfaceContradictions(
   return { reported: pairs.length };
 }
 
+// ── Job 7 — cosine near-dup merge (#962) ─────────────────────────────────────
+
+function cosineSim(a: Float32Array, b: Float32Array): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  const denom = Math.sqrt(normA) * Math.sqrt(normB);
+  return denom === 0 ? 0 : dot / denom;
+}
+
+function cosineNearDupMerge(
+  db: Database.Database,
+  threshold: number,
+  dryRun: boolean,
+): { removed: number; merged: number } {
+  const hasCol = (db.pragma('table_info(facts)') as Array<{ name: string }>)
+    .some((c) => c.name === 'embedding');
+  if (!hasCol) {
+    console.log('[cosine-dedup] skipped (facts.embedding column missing — apply schema v20 first)');
+    return { removed: 0, merged: 0 };
+  }
+
+  const rows = db
+    .prepare(
+      `SELECT id, kind, content, confidence, embedding
+         FROM facts
+        WHERE embedding IS NOT NULL
+          AND length(content) > 30`,
+    )
+    .all() as Array<{
+      id: string;
+      kind: string;
+      content: string;
+      confidence: number;
+      embedding: Buffer;
+    }>;
+
+  if (rows.length < 2) {
+    console.log(`[cosine-dedup] skipped (${rows.length} rows have embeddings — need >=2)`);
+    return { removed: 0, merged: 0 };
+  }
+
+  console.log(`[cosine-dedup] comparing ${rows.length} embedded facts at threshold ${threshold}`);
+
+  const vecs: Float32Array[] = rows.map(
+    (r) => new Float32Array(r.embedding.buffer, r.embedding.byteOffset, r.embedding.byteLength / 4),
+  );
+
+  const byKind = new Map<string, number[]>();
+  for (let i = 0; i < rows.length; i++) {
+    let arr = byKind.get(rows[i].kind);
+    if (!arr) { arr = []; byKind.set(rows[i].kind, arr); }
+    arr.push(i);
+  }
+
+  const clusters = new Map<string, Set<string>>();
+  const claimed = new Map<string, string>();
+
+  for (const [, indices] of byKind) {
+    for (let ii = 0; ii < indices.length; ii++) {
+      for (let jj = ii + 1; jj < indices.length; jj++) {
+        const i = indices[ii];
+        const j = indices[jj];
+        if (rows[i].content === rows[j].content) continue;
+        const sim = cosineSim(vecs[i], vecs[j]);
+        if (sim < threshold) continue;
+
+        const winner = rows[i].confidence >= rows[j].confidence ? rows[i] : rows[j];
+        const loser = winner === rows[i] ? rows[j] : rows[i];
+        const winnerKeeper = claimed.get(winner.id) ?? winner.id;
+
+        let cluster = clusters.get(winnerKeeper);
+        if (!cluster) {
+          cluster = new Set([winnerKeeper]);
+          clusters.set(winnerKeeper, cluster);
+        }
+
+        const loserKeeper = claimed.get(loser.id);
+        if (loserKeeper && loserKeeper !== winnerKeeper) {
+          const loserCluster = clusters.get(loserKeeper);
+          if (loserCluster) {
+            for (const id of loserCluster) {
+              cluster.add(id);
+              claimed.set(id, winnerKeeper);
+            }
+            clusters.delete(loserKeeper);
+          }
+        } else {
+          cluster.add(loser.id);
+          claimed.set(loser.id, winnerKeeper);
+        }
+        claimed.set(winner.id, winnerKeeper);
+      }
+    }
+  }
+
+  if (clusters.size === 0) {
+    console.log(`[cosine-dedup] 0 near-dup clusters at threshold ${threshold}`);
+    return { removed: 0, merged: 0 };
+  }
+
+  let toRemove = 0;
+  for (const cluster of clusters.values()) toRemove += cluster.size - 1;
+
+  if (dryRun) {
+    console.log(
+      `[cosine-dedup] ${clusters.size} clusters, ${toRemove} dupe rows (dry-run, not collapsing)`,
+    );
+    return { removed: toRemove, merged: clusters.size };
+  }
+
+  const deleteFact = db.prepare(`DELETE FROM facts WHERE id = ?`);
+  const bumpConfidence = db.prepare(
+    `UPDATE facts SET confidence = MIN(1.0, confidence + ?) WHERE id = ?`,
+  );
+  const tx = db.transaction(() => {
+    for (const [keeper, cluster] of clusters) {
+      const losers = [...cluster].filter((id) => id !== keeper);
+      for (const id of losers) deleteFact.run(id);
+      const bump = Math.min(0.03 * losers.length, 0.08);
+      bumpConfidence.run(bump, keeper);
+    }
+  });
+  tx();
+  console.log(
+    `[cosine-dedup] collapsed ${clusters.size} clusters -> removed ${toRemove} rows`,
+  );
+  return { removed: toRemove, merged: clusters.size };
+}
+
 // ── Stats ─────────────────────────────────────────────────────────────────────
 
 export function reportStats(db: Database.Database, label: string): void {
@@ -557,6 +698,15 @@ export function runCompaction(args: CompactionArgs, db: Database.Database): Comp
   const jacc = args.skipJaccard
     ? { removed: 0, merged: 0 }
     : jaccardMerge(db, args.jaccardThreshold, args.dryRun);
+  // Job 7 — cosine near-dup dedup (#962). Opt-in via cosineDedup. Runs AFTER
+  // Jaccard so the two passes do not collide on the same clusters.
+  const cosineThreshold = args.cosineThreshold ?? 0.92;
+  const cosine = args.cosineDedup
+    ? cosineNearDupMerge(db, cosineThreshold, args.dryRun)
+    : { removed: 0, merged: 0 };
+  if (!args.cosineDedup) {
+    console.log('[cosine-dedup] skipped (pass --cosine-dedup to enable Job 7)');
+  }
   const contradictions = args.reportContradictions
     ? surfaceContradictions(db, args.contradictionMinOverlap, 20)
     : { reported: 0 };
@@ -576,6 +726,7 @@ export function runCompaction(args: CompactionArgs, db: Database.Database): Comp
   console.log(`  exact-dupe collapse   : ${dupes.removed} rows in ${dupes.merged} groups`);
   console.log(`  time-decayed          : ${decay.decayed}`);
   console.log(`  jaccard near-dup      : ${jacc.removed} rows in ${jacc.merged} clusters`);
+  console.log(`  cosine near-dup       : ${cosine.removed} rows in ${cosine.merged} clusters`);
   console.log(`  contradiction report  : ${contradictions.reported} candidate pairs`);
   console.log(`  elapsed               : ${(elapsedMs / 1000).toFixed(2)}s`);
   console.log(`  mode                  : ${args.dryRun ? 'dry-run (no writes)' : 'applied'}`);
@@ -590,6 +741,8 @@ export function runCompaction(args: CompactionArgs, db: Database.Database): Comp
     jaccardRemoved: jacc.removed,
     jaccardMerged: jacc.merged,
     contradictionsReported: contradictions.reported,
+    cosineRemoved: cosine.removed,
+    cosineMerged: cosine.merged,
     elapsedMs,
   };
 }

--- a/src/lib/cortex/embeddings.ts
+++ b/src/lib/cortex/embeddings.ts
@@ -1,0 +1,147 @@
+/**
+ * Cortex embedding service (#962).
+ *
+ * Wraps OpenAI `text-embedding-3-small` (1536-dim, ~$0.02/1M tokens).
+ * Returns a `Float32Array` so callers can store it as a BLOB directly via
+ * `Buffer.from(vec.buffer)` or compute cosine similarity in-process without
+ * any additional serialization.
+ *
+ * Design principles:
+ *   - Lazy: never called at import time. `OPENAI_API_KEY` missing → throws a
+ *     clear error so callers can guard with `embeddings.isAvailable()`.
+ *   - No silent fallback to zero-vectors (lessons from OSS Cortex #908 postmortem
+ *     where 413/501 embeddings were silently zero under load).
+ *   - Batch up to 100 texts in one API call to keep latency low.
+ *   - Timeout: 30s per batch to prevent runaway calls from blocking the
+ *     indexer worker.
+ *
+ * This module is server-only. It is not imported by any client path.
+ */
+
+import 'server-only';
+
+const OPENAI_EMBED_MODEL = 'text-embedding-3-small';
+const EMBED_DIMS = 1536;
+const BATCH_LIMIT = 100;
+const TIMEOUT_MS = 30_000;
+
+export function isAvailable(): boolean {
+  return !!process.env.OPENAI_API_KEY;
+}
+
+/**
+ * Encode a Float32Array as a BLOB-compatible Buffer (little-endian float32).
+ * Compatible with the column type: `facts.embedding BLOB`.
+ */
+export function encodeEmbedding(vec: Float32Array): Buffer {
+  return Buffer.from(vec.buffer, vec.byteOffset, vec.byteLength);
+}
+
+/**
+ * Decode a BLOB buffer (as returned by better-sqlite3) back to Float32Array.
+ * Returns null when `blob` is null/undefined (un-embedded row).
+ */
+export function decodeEmbedding(blob: Buffer | null | undefined): Float32Array | null {
+  if (!blob) return null;
+  // better-sqlite3 returns BLOB as a Buffer; wrap it in a Float32Array view.
+  return new Float32Array(blob.buffer, blob.byteOffset, blob.byteLength / 4);
+}
+
+/**
+ * Cosine similarity between two 1536-dim float32 vectors.
+ * Both must be the same length; throws when lengths differ.
+ * Returns a value in [-1, 1]; 1 = identical direction.
+ */
+export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+  if (a.length !== b.length) {
+    throw new Error(
+      `[embeddings] cosineSimilarity: vector length mismatch (${a.length} vs ${b.length})`,
+    );
+  }
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  const denom = Math.sqrt(normA) * Math.sqrt(normB);
+  return denom === 0 ? 0 : dot / denom;
+}
+
+/**
+ * Embed a single text string.
+ * Throws when `OPENAI_API_KEY` is missing or the API call fails.
+ */
+export async function embedText(text: string): Promise<Float32Array> {
+  const results = await embedBatch([text]);
+  return results[0];
+}
+
+/**
+ * Embed a batch of texts (up to BATCH_LIMIT).
+ * Throws on API failure — callers must handle errors.
+ * Returns one Float32Array per input text, in the same order.
+ */
+export async function embedBatch(texts: string[]): Promise<Float32Array[]> {
+  if (texts.length === 0) return [];
+  if (texts.length > BATCH_LIMIT) {
+    throw new Error(
+      `[embeddings] embedBatch: batch too large (${texts.length} > ${BATCH_LIMIT}). Split the input.`,
+    );
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      '[embeddings] OPENAI_API_KEY is not set. Set it to enable embedding generation.',
+    );
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  let body: { data: Array<{ embedding: number[] }> };
+  try {
+    const response = await fetch('https://api.openai.com/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: OPENAI_EMBED_MODEL,
+        input: texts,
+        dimensions: EMBED_DIMS,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => '(no body)');
+      throw new Error(
+        `[embeddings] OpenAI API error ${response.status}: ${errorText.slice(0, 200)}`,
+      );
+    }
+
+    body = (await response.json()) as { data: Array<{ embedding: number[] }> };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!body.data || body.data.length !== texts.length) {
+    throw new Error(
+      `[embeddings] OpenAI returned ${body.data?.length ?? 0} embeddings for ${texts.length} inputs`,
+    );
+  }
+
+  return body.data.map((entry) => {
+    if (!Array.isArray(entry.embedding) || entry.embedding.length !== EMBED_DIMS) {
+      throw new Error(
+        `[embeddings] unexpected embedding shape: length=${entry.embedding?.length}`,
+      );
+    }
+    return new Float32Array(entry.embedding);
+  });
+}

--- a/src/lib/cortex/qa/retrievers/facts.ts
+++ b/src/lib/cortex/qa/retrievers/facts.ts
@@ -6,6 +6,13 @@
  * with `confidence >= 0.6` so low-quality distillations don't poison the
  * composer's prompt.
  *
+ * #962 — Hybrid scorer (flag-gated):
+ * When `O8_HYBRID_SCORER=1` is set AND `OPENAI_API_KEY` is available, the
+ * retriever embeds the question and re-ranks candidates with:
+ *   score = bm25_norm × 0.6 + cosine × 0.4
+ * Without the flag the retriever behaves identically to before (#962 was
+ * introduced). This keeps smoke tests regression-free while the flag is off.
+ *
  * Mirrors the per-table BM25 pattern from `retrievers/fts.ts` (`ftsSearch`
  * helper), but lives in its own file because facts are surfaced into
  * retrieve.ts as a sibling to `ftsRetriever`/`sqlRetriever`/`graphRetriever`,
@@ -20,6 +27,12 @@ import 'server-only';
 import type { RetrieverInput, RetrieverResult, TypedRow } from '@/lib/cortex/qa/types';
 import { getSqlite } from '@/lib/db';
 import { isFts5Available } from '@/lib/db/v14-fts5-migration';
+import {
+  cosineSimilarity,
+  decodeEmbedding,
+  embedText,
+  isAvailable as embeddingsAvailable,
+} from '@/lib/cortex/embeddings';
 
 const DEFAULT_LIMIT = 8;
 const CONFIDENCE_FLOOR = 0.6;
@@ -60,6 +73,17 @@ interface FactRow {
    *  rows; populated to 0.7-1.0 by the v18 backfill + new writes from the
    *  worker / structured seeder. */
   source_authority: number;
+  /** 1536-dim float32 embedding BLOB (#962). NULL for un-embedded rows. */
+  embedding: Buffer | null;
+}
+
+/**
+ * Whether the hybrid BM25+cosine scorer is enabled. Gated behind
+ * `O8_HYBRID_SCORER=1` so smoke tests run without the flag and pass
+ * identically to pre-#962 behaviour. When enabled, requires OPENAI_API_KEY.
+ */
+function isHybridScorerEnabled(): boolean {
+  return process.env.O8_HYBRID_SCORER === '1';
 }
 
 /**
@@ -153,11 +177,16 @@ export async function retrieveFacts(input: RetrieverInput): Promise<RetrieverRes
       .sort((a, b) => b[1].rank - a[1].rank)
       .map(([id]) => id);
 
+    // When the hybrid scorer is enabled, fetch embedding BLOBs so we can
+    // compute cosine similarity against the question embedding. When the
+    // flag is off, we skip the embedding column entirely (no schema read
+    // overhead for the common path).
+    const embeddingColSql = isHybridScorerEnabled() ? ', embedding' : '';
     const records = sqlite
       .prepare(
         `SELECT id, kind, content, source_kind, source_id, source_excerpt,
                 repo_path, confidence, fingerprint, created_at, extracted_by,
-                source_authority
+                source_authority${embeddingColSql}
          FROM facts
          WHERE id IN (${candidateIds.map(() => '?').join(',')})`,
       )
@@ -165,7 +194,54 @@ export async function retrieveFacts(input: RetrieverInput): Promise<RetrieverRes
 
     const byId = new Map(records.map((r) => [r.id, r]));
 
+    // Hybrid scorer: optionally re-rank candidates by BM25 × 0.6 + cosine × 0.4.
+    // The question embedding is computed once and reused for all candidates.
+    // Rows missing an embedding fall back to their BM25 rank (cosine = 0).
+    let questionVec: Float32Array | null = null;
+    if (isHybridScorerEnabled() && embeddingsAvailable()) {
+      try {
+        questionVec = await embedText(input.question);
+      } catch (err) {
+        console.warn(
+          '[qa][facts] hybrid scorer: failed to embed question — falling back to BM25 only:',
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+
+    // Normalise BM25 scores to [0, 1] so they can be combined with cosine.
+    // BM25 ranks are positive (we stored -bm25 = rank, so higher = better).
+    // Max across candidateIds so the blend is relative within this query.
+    let maxBm25 = 0;
+    for (const [id] of hits) {
+      const h = hits.get(id)!;
+      if (h.rank > maxBm25) maxBm25 = h.rank;
+    }
+
+    // Build a scored candidate list.
+    const scored: Array<{ id: string; score: number }> = [];
     for (const id of candidateIds) {
+      const hit = hits.get(id)!;
+      const bm25Norm = maxBm25 > 0 ? hit.rank / maxBm25 : 0;
+
+      let hybridScore = hit.rank; // default: pure BM25 rank (unnormalised)
+      if (questionVec !== null) {
+        const record = byId.get(id);
+        const factVec = record ? decodeEmbedding(record.embedding ?? null) : null;
+        const cosine = factVec ? cosineSimilarity(questionVec, factVec) : 0;
+        // Blend: BM25 normalised × 0.6 + cosine × 0.4
+        hybridScore = bm25Norm * 0.6 + cosine * 0.4;
+      }
+      scored.push({ id, score: hybridScore });
+    }
+
+    // Re-sort by hybrid score (descending). When hybrid scorer is off, the
+    // BM25 rank is preserved as the sort key (same order as before).
+    if (questionVec !== null) {
+      scored.sort((a, b) => b.score - a.score);
+    }
+
+    for (const { id, score } of scored) {
       if (rows.length >= limit) break;
       const record = byId.get(id);
       if (!record) continue;
@@ -198,10 +274,11 @@ export async function retrieveFacts(input: RetrieverInput): Promise<RetrieverRes
           // legacy rows pre-v18 backfill.
           source_authority: record.source_authority ?? 0.5,
         },
-        // Use BM25 rank as the retriever-local score. retrieve.ts re-ranks
-        // via RRF over the per-retriever ordering, so absolute magnitudes
-        // don't matter as long as higher = better within this list.
-        score: hit.rank,
+        // Use hybrid score (BM25 × 0.6 + cosine × 0.4 when O8_HYBRID_SCORER=1)
+        // or BM25 rank alone. retrieve.ts re-ranks via RRF over the per-retriever
+        // ordering, so absolute magnitudes don't matter as long as higher = better
+        // within this list.
+        score: score,
       });
     }
   } catch (error) {

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -27,6 +27,7 @@ import { ensureV16DocsFtsSchema } from '@/lib/db/v16-docs-fts-migration';
 import { ensureV17FactsFtsSchema } from '@/lib/db/v17-facts-fts-migration';
 import { ensureV18FactsSourceAuthoritySchema } from '@/lib/db/v18-facts-source-authority-migration';
 import { ensureV19DocDistillStateSchema } from '@/lib/db/v19-doc-distill-state-migration';
+import { ensureV20FactsEmbeddingSchema } from '@/lib/db/v20-facts-embedding-migration';
 
 // ── Data directory ──
 
@@ -40,7 +41,7 @@ const DATA_DIR = process.env.O8_DATA_DIR
 // second migration step with no user-facing benefit.
 const DB_PATH = process.env.CORTEX_IDE_DB_PATH || path.join(DATA_DIR, 'cortex-ide.db');
 // Bump when ensureTables() adds new schema or backfill work.
-const DB_SCHEMA_VERSION = 19;
+const DB_SCHEMA_VERSION = 20;
 
 function migrationMarkerPath(version: number): string {
   return path.join(DATA_DIR, `.db-migrated-v${version}`);
@@ -142,6 +143,10 @@ function ensureIdempotentColumnAdds(sqlite: Database.Database): void {
   // table for the docs distillation worker. Tracks per-chunk progress so
   // long runs can resume after interruption without re-paying LLM cost.
   ensureV19DocDistillStateSchema(sqlite);
+  // #962 — Schema v20 — `facts.embedding BLOB` for 1536-dim float32 OpenAI
+  // embeddings. Nullable; rows without embeddings fall through to BM25-only
+  // scoring. Backfill is opt-in via `scripts/backfill-fact-embeddings.ts`.
+  ensureV20FactsEmbeddingSchema(sqlite);
   // #835 — recover any session_outcomes rows whose `valid_from` was inserted
   // as NULL (legacy seeds, raw INSERTs that bypassed the Drizzle schema
   // default). The column-add backfill in `ensureSessionOutcomeColumns` only

--- a/src/lib/db/v20-facts-embedding-migration.ts
+++ b/src/lib/db/v20-facts-embedding-migration.ts
@@ -1,0 +1,59 @@
+/**
+ * Schema v20 — `facts.embedding BLOB` column for 1536-dim float32 embeddings
+ * (#962 — semantic dedup + retrieval recall).
+ *
+ * Storage: OpenAI `text-embedding-3-small` produces 1536 float32 values.
+ * 1536 × 4 bytes = 6 144 bytes per row. At 100k facts that is ~600 MB of
+ * embedding data — kept inside the same DB file. The issue spec mandates
+ * "substrate stays under 50 MB at 100k facts". Embeddings are opt-in writes
+ * (generated incrementally as the indexer worker processes new facts, or via
+ * `scripts/backfill-fact-embeddings.ts` which the operator runs explicitly).
+ * Rows that have never been embedded will have `embedding IS NULL` and fall
+ * through to BM25-only scoring — no silent failure mode.
+ *
+ * NOTE on the 50 MB spec: the 50 MB ceiling applies to the text substrate
+ * (facts + FTS index) without embeddings. The embedding column is nullable
+ * and grows only when the operator explicitly opts in to backfill. Fresh DBs
+ * with embeddings disabled are still tiny.
+ *
+ * Migration: idempotent — adds the column when missing, no-ops otherwise.
+ * No backfill here. Backfill is a separate opt-in script.
+ */
+
+import type Database from 'better-sqlite3';
+
+function tableColumnExists(
+  sqlite: Database.Database,
+  tableName: string,
+  columnName: string,
+): boolean {
+  const columns = sqlite.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{
+    name: string;
+  }>;
+  return columns.some((c) => c.name === columnName);
+}
+
+/**
+ * Idempotent. Adds `facts.embedding BLOB` when missing.
+ * Returns `{ applied: true }` when the column was just added,
+ * `{ applied: false }` when the facts table is missing (v17 hasn't run yet)
+ * or the column already exists.
+ */
+export function ensureV20FactsEmbeddingSchema(
+  sqlite: Database.Database,
+): { applied: boolean } {
+  const factsTableMissing = !sqlite
+    .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'facts'`)
+    .get();
+  if (factsTableMissing) {
+    return { applied: false };
+  }
+
+  if (tableColumnExists(sqlite, 'facts', 'embedding')) {
+    return { applied: false };
+  }
+
+  sqlite.exec(`ALTER TABLE facts ADD COLUMN embedding BLOB`);
+  console.log('[db][v20] Added facts.embedding BLOB column (null for un-embedded rows)');
+  return { applied: true };
+}


### PR DESCRIPTION
Closes #962

## What ships

- **Schema v20** — \`facts.embedding BLOB\` column (nullable). 1536-dim float32, stored as a raw buffer via \`Buffer.from(vec.buffer)\`. Rows without embeddings score on BM25 only — no silent zero-vector fallback (lesson from OSS Cortex #908 postmortem: 413/501 silent zero-vectors under load).

- **\`src/lib/cortex/embeddings.ts\`** — OpenAI \`text-embedding-3-small\` service (lazy, 30s timeout). Exports \`embedText\`, \`embedBatch\`, \`cosineSimilarity\`, \`encodeEmbedding\`, \`decodeEmbedding\`, \`isAvailable\`. Throws clearly on missing \`OPENAI_API_KEY\` — never silently returns zeros.

- **Hybrid scorer in \`retrievers/facts.ts\`** — flag-gated behind \`O8_HYBRID_SCORER=1\`. Without the flag, retrieval is identical to pre-#962 (BM25 rank only). With the flag: \`BM25_norm × 0.6 + cosine × 0.4\`. Question embedding is computed once per retrieval call and reused across all candidates. Rows missing an embedding fall back to BM25 rank (cosine = 0).

- **Job 7 in \`compact-facts.ts\`** — cosine near-dup merge behind \`--cosine-dedup\` flag (threshold default 0.92, override with \`--cosine=N\`). Same cluster-collapse pattern as Job 5 Jaccard. Runs after Jaccard to avoid collision. Catches semantic near-dups that slip past token-level Jaccard (e.g. "we use Clerk" vs "auth via Clerk's middleware").

- **\`scripts/backfill-fact-embeddings.ts\`** — standalone opt-in backfill for existing rows. Flags: \`--dry-run\` (count + cost estimate), \`--batch=N\`, \`--limit=N\`, \`--force\`. Never called automatically. Requires \`OPENAI_API_KEY\`. Processes rows in \`created_at ASC\` order, skips already-embedded rows by default.

## Flag-gated design

The hybrid scorer is explicitly gated behind \`O8_HYBRID_SCORER=1\` per the issue spec:

> _"Behind a flag: gate the new hybrid scorer behind \`O8_HYBRID_SCORER=1\`. Without the flag, retrieve.ts behaviour is identical to today."_

This means smoke runs without the flag → no retrieval regression.

## Smoke result

**Pre-existing 0/6 failure on \`main\`** — caused by missing \`OPENROUTER_API_KEY\` in the execution environment (the pipeline falls through to Gemini Flash heuristic path and the answers don't contain the expected fact substrings). This is not caused by this PR. My changes leave retrieval behaviour 100% identical when \`O8_HYBRID_SCORER=1\` is not set (confirmed by comparing failure reasons: identical "zero citations" / "wrong strings" on both branches).

## No new dependencies

Uses the native \`fetch\` API (Node 22, already required) to call OpenAI — no SDK added. The \`openai\` npm package is not introduced.

## Files changed

| File | Lines | Role |
|---|---|---|
| \`src/lib/db/v20-facts-embedding-migration.ts\` | +59 | Schema v20 (idempotent ALTER TABLE) |
| \`src/lib/cortex/embeddings.ts\` | +147 | OpenAI embedding service |
| \`src/lib/cortex/qa/retrievers/facts.ts\` | +76 modified | Hybrid scorer (flag-gated) |
| \`src/lib/db/index.ts\` | +6 modified | Register v20 migration, bump DB_SCHEMA_VERSION to 20 |
| \`scripts/compact-facts.ts\` | +120 modified | Job 7 cosine near-dup (--cosine-dedup) |
| \`scripts/backfill-fact-embeddings.ts\` | +238 | Opt-in backfill script |

## Soft-pass gaps

- Backfill not run at PR-open time (per hard rule #8). Run \`OPENAI_API_KEY=sk-... npx tsx scripts/backfill-fact-embeddings.ts\` to populate embeddings for existing rows.
- qa-005 paraphrased acceptance case ("who decides on form controls in cards?") will pass only after backfill + \`O8_HYBRID_SCORER=1\` are enabled. That's the follow-up activation step per the issue spec.