### PR TITLE
feat(brain): qa-eval regression dashboard (#969)

### DIFF
--- a/src/app/api/panel/qa-evals/route.ts
+++ b/src/app/api/panel/qa-evals/route.ts
@@ -1,0 +1,87 @@
+/**
+ * GET /api/panel/qa-evals
+ *
+ * Returns qa_eval_runs rows for the regression dashboard (#969).
+ * Reads from the `qa_eval_runs` table (schema v14).
+ *
+ * Query params:
+ *   limit  — max rows (default 500, max 2000)
+ *   format — "json" (default) | "csv"
+ */
+
+export const dynamic = 'force-dynamic';
+
+import { NextResponse, type NextRequest } from 'next/server';
+import { getSqlite } from '@/lib/db';
+
+interface EvalRow {
+  id: string;
+  question_id: string;
+  category: string | null;
+  expected_answer: string;
+  actual_answer: string;
+  factual_accuracy: number | null;
+  citation_correctness: number | null;
+  hallucination_count: number | null;
+  run_at: number;
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const url = new URL(req.url);
+    const limitParam = parseInt(url.searchParams.get('limit') ?? '500', 10);
+    const limit = Math.min(isNaN(limitParam) ? 500 : limitParam, 2000);
+    const format = url.searchParams.get('format') ?? 'json';
+
+    const db = getSqlite();
+
+    // Check that the table exists (schema v14 may not have run yet on some installs).
+    const tableExists = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='qa_eval_runs'`)
+      .get();
+    if (!tableExists) {
+      return NextResponse.json({ runs: [], error: 'qa_eval_runs table not yet migrated (schema v14 required)' });
+    }
+
+    const rows = db
+      .prepare(
+        `SELECT id, question_id, category, expected_answer, actual_answer,
+                factual_accuracy, citation_correctness, hallucination_count, run_at
+         FROM qa_eval_runs
+         ORDER BY run_at DESC
+         LIMIT ?`,
+      )
+      .all(limit) as EvalRow[];
+
+    if (format === 'csv') {
+      const header = 'id,question_id,category,factual_accuracy,citation_correctness,hallucination_count,run_at\r\n';
+      const lines = rows.map((r) => [
+        csvEscape(r.id),
+        csvEscape(r.question_id),
+        csvEscape(r.category ?? ''),
+        r.factual_accuracy !== null ? r.factual_accuracy.toFixed(4) : '',
+        r.citation_correctness !== null ? r.citation_correctness.toFixed(4) : '',
+        r.hallucination_count !== null ? String(r.hallucination_count) : '',
+        String(r.run_at),
+      ].join(','));
+      const csv = header + lines.join('\r\n');
+      return new Response(csv, {
+        headers: {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': 'attachment; filename="qa-eval-runs.csv"',
+        },
+      });
+    }
+
+    return NextResponse.json({ runs: rows });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[qa-evals] GET failed:', msg);
+    return NextResponse.json({ runs: [], error: msg }, { status: 500 });
+  }
+}
+
+function csvEscape(val: string): string {
+  if (/[",\r\n]/.test(val)) return `"${val.replace(/"/g, '""')}"`;
+  return val;
+}

--- a/src/app/dashboard/qa-evals/CategoryCard.tsx
+++ b/src/app/dashboard/qa-evals/CategoryCard.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+/**
+ * CategoryCard + Sparkline sub-components for the QA eval regression dashboard (#969).
+ */
+
+export const SPARKLINE_W = 140;
+export const SPARKLINE_H = 36;
+
+// ── Sparkline ─────────────────────────────────────────────────────
+
+interface SparklineProps {
+  values: number[];
+  color: string;
+  regressed: boolean;
+}
+
+/** Normalise values into SVG y-coordinates. */
+function toPoints(vals: number[]): string {
+  if (vals.length === 0) return '';
+  const padX = 4;
+  const padY = 4;
+  const w = SPARKLINE_W - padX * 2;
+  const h = SPARKLINE_H - padY * 2;
+  const min = Math.min(...vals);
+  const max = Math.max(...vals);
+  const range = max - min || 1;
+  return vals
+    .map((v, i) => {
+      const x = padX + (vals.length === 1 ? w / 2 : (i / (vals.length - 1)) * w);
+      const y = padY + h - ((v - min) / range) * h;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(' ');
+}
+
+export function Sparkline({ values, color, regressed }: SparklineProps) {
+  const pts = toPoints(values);
+  const lineColor = regressed ? '#ef4444' : color;
+  const lastPtStr = pts ? pts.split(' ').pop() : null;
+  const lastCoords = lastPtStr ? lastPtStr.split(',').map(Number) : null;
+
+  return (
+    <svg
+      width={SPARKLINE_W}
+      height={SPARKLINE_H}
+      style={{ display: 'block', overflow: 'visible' }}
+      aria-hidden="true"
+    >
+      {pts && (
+        <polyline
+          points={pts}
+          fill="none"
+          stroke={lineColor}
+          strokeWidth={1.5}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          opacity={0.9}
+        />
+      )}
+      {lastCoords && (
+        <circle cx={lastCoords[0]} cy={lastCoords[1]} r={2.5} fill={lineColor} />
+      )}
+      {values.length === 0 && (
+        <text
+          x={SPARKLINE_W / 2}
+          y={SPARKLINE_H / 2 + 4}
+          textAnchor="middle"
+          style={{ fontSize: 10, fill: 'var(--t-text-muted, #9ca3af)' }}
+        >
+          no data
+        </text>
+      )}
+    </svg>
+  );
+}
+
+// ── CategoryCard ──────────────────────────────────────────────────
+
+export interface CategoryStats {
+  category: string;
+  runs: Array<{
+    factual_accuracy: number | null;
+    citation_correctness: number | null;
+    run_at: number;
+  }>;
+  avgFactual: number;
+  avgCitation: number;
+  factualRegressed: boolean;
+  citationRegressed: boolean;
+  lastRunAt: number | null;
+}
+
+function fmtPct(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+function fmtDate(ts: number | null): string {
+  if (!ts) return '--';
+  return new Date(ts).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+export function CategoryCard({ stat }: { stat: CategoryStats }) {
+  const factualVals = stat.runs
+    .map((r) => r.factual_accuracy)
+    .filter((v): v is number => v !== null);
+  const citationVals = stat.runs
+    .map((r) => r.citation_correctness)
+    .filter((v): v is number => v !== null);
+
+  const hasRegression = stat.factualRegressed || stat.citationRegressed;
+
+  return (
+    <div style={{
+      backgroundColor: 'var(--t-bg-card, rgba(255,255,255,0.82))',
+      borderRadius: 14,
+      paddingTop: 16,
+      paddingRight: 20,
+      paddingBottom: 16,
+      paddingLeft: 20,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 12,
+      position: 'relative',
+      outline: hasRegression ? '1.5px solid #ef4444' : '1px solid rgba(0,0,0,0.06)',
+    }}>
+      {/* Header row */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span style={{
+          fontSize: 11,
+          fontWeight: 500,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+          color: 'var(--t-text-muted, #5b6475)',
+        }}>
+          {stat.category}
+        </span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {hasRegression && (
+            <span style={{
+              fontSize: 10,
+              fontWeight: 600,
+              color: '#ef4444',
+              backgroundColor: 'rgba(239,68,68,0.1)',
+              paddingTop: 2,
+              paddingRight: 6,
+              paddingBottom: 2,
+              paddingLeft: 6,
+              borderRadius: 6,
+              letterSpacing: '0.04em',
+              textTransform: 'uppercase',
+            }}>
+              regression
+            </span>
+          )}
+          <span style={{ fontSize: 11, color: 'var(--t-text-muted, #9ca3af)' }}>
+            {stat.runs.length} run{stat.runs.length !== 1 ? 's' : ''}
+          </span>
+        </div>
+      </div>
+
+      {/* Metric rows */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {/* Factual accuracy */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 100 }}>
+            <span style={{ fontSize: 10, color: 'var(--t-text-muted, #9ca3af)', letterSpacing: '0.04em' }}>
+              FACTUAL ACC.
+            </span>
+            <span style={{
+              fontSize: 18,
+              fontWeight: 600,
+              color: stat.factualRegressed ? '#ef4444' : 'var(--t-text, #111827)',
+              letterSpacing: '-0.02em',
+            }}>
+              {factualVals.length > 0 ? fmtPct(stat.avgFactual) : '--'}
+            </span>
+          </div>
+          <Sparkline values={factualVals} color="#2563eb" regressed={stat.factualRegressed} />
+        </div>
+
+        {/* Citation correctness */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 100 }}>
+            <span style={{ fontSize: 10, color: 'var(--t-text-muted, #9ca3af)', letterSpacing: '0.04em' }}>
+              CITATION CORR.
+            </span>
+            <span style={{
+              fontSize: 18,
+              fontWeight: 600,
+              color: stat.citationRegressed ? '#ef4444' : 'var(--t-text, #111827)',
+              letterSpacing: '-0.02em',
+            }}>
+              {citationVals.length > 0 ? fmtPct(stat.avgCitation) : '--'}
+            </span>
+          </div>
+          <Sparkline values={citationVals} color="#22c55e" regressed={stat.citationRegressed} />
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div style={{ fontSize: 11, color: 'var(--t-text-muted, #9ca3af)' }}>
+        Last run: {fmtDate(stat.lastRunAt)}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/qa-evals/CategoryCard.tsx
+++ b/src/app/dashboard/qa-evals/CategoryCard.tsx
@@ -122,7 +122,7 @@ export function CategoryCard({ stat }: { stat: CategoryStats }) {
       flexDirection: 'column',
       gap: 12,
       position: 'relative',
-      outline: hasRegression ? '1.5px solid #ef4444' : '1px solid rgba(0,0,0,0.06)',
+      outline: hasRegression ? '1.5px solid #ef4444' : '1px solid var(--t-divider-subtle, rgba(15,23,42,0.05))',
     }}>
       {/* Header row */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>

--- a/src/app/dashboard/qa-evals/page.tsx
+++ b/src/app/dashboard/qa-evals/page.tsx
@@ -159,7 +159,7 @@ export default function QaEvalsPage() {
       paddingRight: 32,
       paddingBottom: 32,
       paddingLeft: 32,
-      fontFamily: 'system-ui, -apple-system, sans-serif',
+      fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
     }}>
       {/* Page header */}
       <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: 32 }}>
@@ -210,7 +210,7 @@ export default function QaEvalsPage() {
               paddingLeft: 14,
               borderRadius: 8,
               backgroundColor: 'var(--t-bg-card, rgba(255,255,255,0.82))',
-              border: '1px solid rgba(0,0,0,0.08)',
+              border: '1px solid var(--t-border, rgba(15,23,42,0.1))',
               fontSize: 13,
               fontWeight: 500,
               color: 'var(--t-text, #111827)',
@@ -241,7 +241,7 @@ export default function QaEvalsPage() {
                 paddingBottom: 14,
                 paddingLeft: 20,
                 minWidth: 140,
-                outline: item.warn ? '1.5px solid #ef4444' : '1px solid rgba(0,0,0,0.06)',
+                outline: item.warn ? '1.5px solid #ef4444' : '1px solid var(--t-divider-subtle, rgba(15,23,42,0.05))',
               }}
             >
               <div style={{

--- a/src/app/dashboard/qa-evals/page.tsx
+++ b/src/app/dashboard/qa-evals/page.tsx
@@ -1,0 +1,370 @@
+'use client';
+
+/**
+ * Brain quality regression dashboard (#969)
+ *
+ * Reads qa_eval_runs from /api/panel/qa-evals and renders:
+ *   - Per-category sparklines for factual_accuracy + citation_correctness
+ *   - Regression highlights (drop > 10pp from rolling avg of prior runs)
+ *   - CSV export via a blob <a download>
+ *
+ * Sparkline + CategoryCard are in ./CategoryCard.tsx to stay under the
+ * 800-line ceiling.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { CategoryCard, type CategoryStats } from './CategoryCard';
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const CATEGORIES = ['ownership', 'decisions', 'processes', 'incidents', 'specs', 'cross-repo'] as const;
+type Category = typeof CATEGORIES[number];
+
+const REGRESSION_THRESHOLD = 0.10; // 10 percentage points
+const ROLLING_WINDOW = 5; // runs to average for regression baseline
+
+// ── Types ──────────────────────────────────────────────────────────
+
+interface EvalRow {
+  id: string;
+  question_id: string;
+  category: string | null;
+  factual_accuracy: number | null;
+  citation_correctness: number | null;
+  hallucination_count: number | null;
+  run_at: number;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function mean(vals: number[]): number {
+  if (vals.length === 0) return 0;
+  return vals.reduce((a, b) => a + b, 0) / vals.length;
+}
+
+function detectRegression(sortedAscByTime: number[]): boolean {
+  if (sortedAscByTime.length < 2) return false;
+  const latest = sortedAscByTime[sortedAscByTime.length - 1];
+  const priorWindow = sortedAscByTime.slice(
+    Math.max(0, sortedAscByTime.length - 1 - ROLLING_WINDOW),
+    sortedAscByTime.length - 1,
+  );
+  if (priorWindow.length === 0) return false;
+  return mean(priorWindow) - latest > REGRESSION_THRESHOLD;
+}
+
+function groupByCategory(rows: EvalRow[]): CategoryStats[] {
+  return CATEGORIES.map((cat): CategoryStats => {
+    const catRows = rows
+      .filter((r) => r.category === cat)
+      .sort((a, b) => a.run_at - b.run_at);
+
+    const factualVals = catRows.map((r) => r.factual_accuracy).filter((v): v is number => v !== null);
+    const citationVals = catRows.map((r) => r.citation_correctness).filter((v): v is number => v !== null);
+
+    return {
+      category: cat,
+      runs: catRows,
+      avgFactual: mean(factualVals),
+      avgCitation: mean(citationVals),
+      factualRegressed: detectRegression(factualVals),
+      citationRegressed: detectRegression(citationVals),
+      lastRunAt: catRows.length > 0 ? catRows[catRows.length - 1].run_at : null,
+    };
+  });
+}
+
+function buildCsvUrl(rows: EvalRow[]): string {
+  const header = 'id,question_id,category,factual_accuracy,citation_correctness,hallucination_count,run_at_iso\r\n';
+  const lines = rows.map((r) => {
+    const cells = [
+      csvEsc(r.id),
+      csvEsc(r.question_id),
+      csvEsc(r.category ?? ''),
+      r.factual_accuracy !== null ? r.factual_accuracy.toFixed(4) : '',
+      r.citation_correctness !== null ? r.citation_correctness.toFixed(4) : '',
+      r.hallucination_count !== null ? String(r.hallucination_count) : '',
+      csvEsc(new Date(r.run_at).toISOString()),
+    ];
+    return cells.join(',');
+  });
+  return URL.createObjectURL(new Blob([header + lines.join('\r\n')], { type: 'text/csv' }));
+}
+
+function csvEsc(val: string): string {
+  if (/[",\r\n]/.test(val)) return `"${val.replace(/"/g, '""')}"`;
+  return val;
+}
+
+function fmtPct(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+// ── Page ──────────────────────────────────────────────────────────
+
+export default function QaEvalsPage() {
+  const [rows, setRows] = useState<EvalRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const csvUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch('/api/panel/qa-evals?limit=2000');
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const json = await res.json() as { runs: EvalRow[]; error?: string };
+        if (cancelled) return;
+        if (json.error && json.runs.length === 0) setError(json.error);
+        setRows(json.runs);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    void load();
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    if (csvUrlRef.current) {
+      URL.revokeObjectURL(csvUrlRef.current);
+      csvUrlRef.current = null;
+    }
+    if (rows.length > 0) csvUrlRef.current = buildCsvUrl(rows);
+  }, [rows]);
+
+  const stats = groupByCategory(rows);
+  const regressions = stats.filter((s) => s.factualRegressed || s.citationRegressed);
+  const totalRuns = rows.length;
+  const overallFactual = mean(rows.map((r) => r.factual_accuracy).filter((v): v is number => v !== null));
+  const overallCitation = mean(rows.map((r) => r.citation_correctness).filter((v): v is number => v !== null));
+
+  const summaryItems: Array<{ label: string; value: string; warn?: boolean }> = [
+    { label: 'Avg factual accuracy', value: fmtPct(overallFactual), warn: overallFactual < 0.7 },
+    { label: 'Avg citation correctness', value: fmtPct(overallCitation), warn: overallCitation < 0.7 },
+    { label: 'Categories tracked', value: String(CATEGORIES.length) },
+    { label: 'Regressions', value: String(regressions.length), warn: regressions.length > 0 },
+  ];
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      backgroundColor: 'var(--t-bg, #f5f7fb)',
+      paddingTop: 32,
+      paddingRight: 32,
+      paddingBottom: 32,
+      paddingLeft: 32,
+      fontFamily: 'system-ui, -apple-system, sans-serif',
+    }}>
+      {/* Page header */}
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: 32 }}>
+        <div>
+          <div style={{
+            fontSize: 11,
+            fontWeight: 500,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            color: 'var(--t-text-muted, #5b6475)',
+            marginBottom: 6,
+          }}>
+            Brain quality
+          </div>
+          <h1 style={{
+            fontSize: 24,
+            fontWeight: 600,
+            letterSpacing: '-0.02em',
+            color: 'var(--t-text, #111827)',
+            margin: 0,
+          }}>
+            QA Eval Regression Dashboard
+          </h1>
+          {!loading && !error && (
+            <div style={{ fontSize: 13, color: 'var(--t-text-muted, #5b6475)', marginTop: 6 }}>
+              {totalRuns} run{totalRuns !== 1 ? 's' : ''} recorded
+              {regressions.length > 0 && (
+                <span style={{ color: '#ef4444', marginLeft: 12 }}>
+                  {regressions.length} categor{regressions.length === 1 ? 'y' : 'ies'} regressed
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* CSV export */}
+        {csvUrlRef.current && (
+          <a
+            href={csvUrlRef.current}
+            download="qa-eval-runs.csv"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              paddingTop: 8,
+              paddingRight: 14,
+              paddingBottom: 8,
+              paddingLeft: 14,
+              borderRadius: 8,
+              backgroundColor: 'var(--t-bg-card, rgba(255,255,255,0.82))',
+              border: '1px solid rgba(0,0,0,0.08)',
+              fontSize: 13,
+              fontWeight: 500,
+              color: 'var(--t-text, #111827)',
+              textDecoration: 'none',
+              cursor: 'pointer',
+            }}
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path d="M8 2v8m0 0L5 7m3 3 3-3M2 12h12" stroke="currentColor" strokeWidth="1.5"
+                strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+            Export CSV
+          </a>
+        )}
+      </div>
+
+      {/* Summary bar */}
+      {!loading && !error && totalRuns > 0 && (
+        <div style={{ display: 'flex', gap: 16, marginBottom: 28, flexWrap: 'wrap' }}>
+          {summaryItems.map((item) => (
+            <div
+              key={item.label}
+              style={{
+                backgroundColor: 'var(--t-bg-card, rgba(255,255,255,0.82))',
+                borderRadius: 12,
+                paddingTop: 14,
+                paddingRight: 20,
+                paddingBottom: 14,
+                paddingLeft: 20,
+                minWidth: 140,
+                outline: item.warn ? '1.5px solid #ef4444' : '1px solid rgba(0,0,0,0.06)',
+              }}
+            >
+              <div style={{
+                fontSize: 10,
+                color: 'var(--t-text-muted, #9ca3af)',
+                letterSpacing: '0.06em',
+                textTransform: 'uppercase',
+                marginBottom: 4,
+              }}>
+                {item.label}
+              </div>
+              <div style={{
+                fontSize: 22,
+                fontWeight: 600,
+                letterSpacing: '-0.02em',
+                color: item.warn ? '#ef4444' : 'var(--t-text, #111827)',
+              }}>
+                {item.value}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Loading */}
+      {loading && (
+        <div style={{ color: 'var(--t-text-muted, #9ca3af)', fontSize: 14, marginTop: 40, textAlign: 'center' }}>
+          Loading eval runs...
+        </div>
+      )}
+
+      {/* Error */}
+      {!loading && error && (
+        <div style={{
+          backgroundColor: 'rgba(239,68,68,0.08)',
+          borderRadius: 10,
+          paddingTop: 16,
+          paddingRight: 20,
+          paddingBottom: 16,
+          paddingLeft: 20,
+          color: '#ef4444',
+          fontSize: 14,
+        }}>
+          {error}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && !error && totalRuns === 0 && (
+        <div style={{ textAlign: 'center', paddingTop: 64, color: 'var(--t-text-muted, #9ca3af)', fontSize: 14 }}>
+          No eval runs recorded yet. Run the QA eval harness to populate this dashboard.
+        </div>
+      )}
+
+      {/* Category grid */}
+      {!loading && totalRuns > 0 && (
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
+          gap: 16,
+        }}>
+          {stats.map((stat) => <CategoryCard key={stat.category} stat={stat} />)}
+        </div>
+      )}
+
+      {/* Regression detail */}
+      {!loading && regressions.length > 0 && (
+        <div style={{ marginTop: 32 }}>
+          <div style={{
+            fontSize: 11,
+            fontWeight: 500,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            color: '#ef4444',
+            marginBottom: 12,
+          }}>
+            Regression detail
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {regressions.map((stat) => {
+              const factualVals = stat.runs.map((r) => r.factual_accuracy).filter((v): v is number => v !== null);
+              const citationVals = stat.runs.map((r) => r.citation_correctness).filter((v): v is number => v !== null);
+              const priorF = factualVals.slice(Math.max(0, factualVals.length - 1 - ROLLING_WINDOW), factualVals.length - 1);
+              const priorC = citationVals.slice(Math.max(0, citationVals.length - 1 - ROLLING_WINDOW), citationVals.length - 1);
+              const latestF = factualVals[factualVals.length - 1];
+              const latestC = citationVals[citationVals.length - 1];
+              return (
+                <div
+                  key={stat.category}
+                  style={{
+                    backgroundColor: 'rgba(239,68,68,0.06)',
+                    borderRadius: 10,
+                    paddingTop: 12,
+                    paddingRight: 16,
+                    paddingBottom: 12,
+                    paddingLeft: 16,
+                    fontSize: 13,
+                    color: 'var(--t-text, #111827)',
+                    display: 'flex',
+                    gap: 24,
+                    flexWrap: 'wrap',
+                    alignItems: 'center',
+                  }}
+                >
+                  <span style={{ fontWeight: 600, minWidth: 80 }}>{stat.category}</span>
+                  {stat.factualRegressed && priorF.length > 0 && latestF !== undefined && (
+                    <span>
+                      factual: {fmtPct(mean(priorF))} baseline &#8594; {fmtPct(latestF)} latest
+                      ({fmtPct(mean(priorF) - latestF)} drop)
+                    </span>
+                  )}
+                  {stat.citationRegressed && priorC.length > 0 && latestC !== undefined && (
+                    <span>
+                      citation: {fmtPct(mean(priorC))} baseline &#8594; {fmtPct(latestC)} latest
+                      ({fmtPct(mean(priorC) - latestC)} drop)
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #969

## Summary

- New page at `/dashboard/qa-evals` charts `factual_accuracy` and `citation_correctness` over time from the `qa_eval_runs` table (schema v14), broken down by the 6 eval categories: ownership, decisions, processes, incidents, specs, cross-repo
- Regression detection: if the latest run drops >10pp vs the rolling 5-run mean, the category card gets a red outline + "regression" badge, and a detail row appears at the bottom showing baseline vs latest with the exact drop
- Raw SVG sparklines via `<polyline>` — no Recharts, Chart.js, or D3
- CSV export via a client-side blob URL `<a download>` — no new deps
- API route `GET /api/panel/qa-evals` lives under the already-gated `/api/panel/` prefix; supports `?limit` and `?format=csv`
- `CategoryCard.tsx` extracted to keep `page.tsx` under 500 lines (370 + 207 = 577 total)
- Cron runner deferred to follow-up issue as specified

## Test plan

- [x] `npx tsc --noEmit` exit 0
- [x] `node scripts/smoke.mjs` 2/2 PASS (typecheck + production build)
- [ ] Navigate to `/dashboard/qa-evals` in the running app — empty state until eval runner populates `qa_eval_runs`
- [ ] After running `npm run eval:qa`, reload the page and verify sparklines + summary bar appear
- [ ] Click "Export CSV" and verify download

Cron runner (`npm run eval:qa` on a schedule) is a follow-up issue per spec.

---
Smoke result: 2/2 PASS (typecheck 5.8s + build 56.4s)

Generated with [Claude Code](https://claude.com/claude-code)