### PR TITLE
feat(orchestrator): wire useFileDrop into ComposerArea — drag/drop + paste + file picker for images & PDFs

### DIFF
--- a/src/components/desktop/thoughts/AttachFilesButton.tsx
+++ b/src/components/desktop/thoughts/AttachFilesButton.tsx
@@ -1,0 +1,302 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface FileSuggestion {
+  path: string;
+  name?: string;
+}
+
+interface AttachFilesButtonProps {
+  onFileReferenceSelect?: (path: string) => void;
+  onUploadDiskFiles?: (files: FileList | File[]) => void;
+  repoPath?: string | null;
+}
+
+function PlusGlyph() {
+  return (
+    <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" style={{ display: 'block', flexShrink: 0 }}>
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
+    </svg>
+  );
+}
+
+function UploadGlyph() {
+  return (
+    <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
+      <path d="M12 16V4" />
+      <path d="m7 9 5-5 5 5" />
+      <path d="M5 20h14" />
+    </svg>
+  );
+}
+
+function SearchGlyph() {
+  return (
+    <svg width={13} height={13} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
+      <circle cx="11" cy="11" r="7" />
+      <path d="m16.5 16.5 3.5 3.5" />
+    </svg>
+  );
+}
+
+export function AttachFilesButton({
+  onFileReferenceSelect,
+  onUploadDiskFiles,
+  repoPath,
+}: AttachFilesButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [suggestions, setSuggestions] = useState<FileSuggestion[]>([]);
+  const [loading, setLoading] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleDocumentMouseDown = (event: MouseEvent) => {
+      if (rootRef.current?.contains(event.target as Node)) return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', handleDocumentMouseDown);
+    return () => document.removeEventListener('mousedown', handleDocumentMouseDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) {
+      setSuggestions([]);
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeout = window.setTimeout(async () => {
+      setLoading(true);
+      try {
+        const headers: Record<string, string> = {};
+        if (repoPath?.trim()) headers['x-cortex-repo-path'] = repoPath.trim();
+        const response = await fetch(`/api/v2/context/files?q=${encodeURIComponent(trimmedQuery)}`, {
+          headers,
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          setSuggestions([]);
+          return;
+        }
+        const data = await response.json() as { files?: FileSuggestion[] };
+        setSuggestions(data.files ?? []);
+      } catch {
+        if (!controller.signal.aborted) setSuggestions([]);
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    }, 120);
+
+    return () => {
+      window.clearTimeout(timeout);
+      controller.abort();
+    };
+  }, [open, query, repoPath]);
+
+  const selectFileReference = (path: string) => {
+    onFileReferenceSelect?.(path);
+    setQuery('');
+    setSuggestions([]);
+    setOpen(false);
+  };
+
+  return (
+    <div ref={rootRef} style={{ position: 'relative', display: 'inline-flex' }}>
+      <button
+        type="button"
+        title="Attach files"
+        aria-label="Attach files"
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 24,
+          height: 24,
+          borderRadius: 7,
+          borderWidth: 0,
+          background: open ? 'var(--t-bg-card)' : 'transparent',
+          color: open ? 'var(--t-text)' : 'var(--t-text-muted)',
+          cursor: 'pointer',
+          transition: 'color 120ms, background 120ms',
+        }}
+        onMouseEnter={(event) => {
+          event.currentTarget.style.color = 'var(--t-text)';
+          event.currentTarget.style.background = 'var(--t-bg-card)';
+        }}
+        onMouseLeave={(event) => {
+          event.currentTarget.style.color = open ? 'var(--t-text)' : 'var(--t-text-muted)';
+          event.currentTarget.style.background = open ? 'var(--t-bg-card)' : 'transparent';
+        }}
+      >
+        <PlusGlyph />
+      </button>
+
+      <input
+        ref={fileInputRef}
+        aria-label="Upload attachments from disk"
+        type="file"
+        accept="image/png,image/jpeg,image/gif,image/webp,application/pdf"
+        multiple
+        style={{ display: 'none' }}
+        onChange={(event) => {
+          const files = event.currentTarget.files;
+          if (files && files.length > 0) onUploadDiskFiles?.(files);
+          event.currentTarget.value = '';
+          setOpen(false);
+        }}
+      />
+
+      {open ? (
+        <div
+          style={{
+            position: 'absolute',
+            right: 0,
+            bottom: '100%',
+            marginBottom: 8,
+            width: 288,
+            maxWidth: 'min(288px, calc(100vw - 32px))',
+            borderRadius: 14,
+            border: '1px solid var(--t-panel-border)',
+            background: 'var(--t-panel-solid, var(--t-panel))',
+            boxShadow: 'var(--t-panel-shadow)',
+            zIndex: 200,
+            overflow: 'hidden',
+          }}
+        >
+          <div style={{
+            paddingTop: 10,
+            paddingRight: 10,
+            paddingBottom: 10,
+            paddingLeft: 10,
+            borderBottom: '1px solid var(--t-divider-subtle)',
+          }}>
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                width: '100%',
+                minHeight: 34,
+                paddingTop: 0,
+                paddingRight: 10,
+                paddingBottom: 0,
+                paddingLeft: 10,
+                borderRadius: 9,
+                border: '1px solid var(--t-input-border)',
+                background: 'var(--t-input-bg)',
+                color: 'var(--t-text)',
+                cursor: 'pointer',
+                fontSize: 12,
+                fontWeight: 650,
+                fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+              }}
+              onMouseEnter={(event) => { event.currentTarget.style.background = 'var(--t-bg-card)'; }}
+              onMouseLeave={(event) => { event.currentTarget.style.background = 'var(--t-input-bg)'; }}
+            >
+              <UploadGlyph />
+              Upload from disk
+            </button>
+          </div>
+
+          <div style={{
+            paddingTop: 10,
+            paddingRight: 10,
+            paddingBottom: 10,
+            paddingLeft: 10,
+          }}>
+            <div style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 7,
+              minHeight: 32,
+              paddingTop: 0,
+              paddingRight: 9,
+              paddingBottom: 0,
+              paddingLeft: 9,
+              borderRadius: 9,
+              border: '1px solid var(--t-input-border)',
+              background: 'var(--t-input-bg)',
+              color: 'var(--t-text-muted)',
+            }}>
+              <SearchGlyph />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.currentTarget.value)}
+                placeholder="Search repo files"
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  borderWidth: 0,
+                  outline: 'none',
+                  background: 'transparent',
+                  color: 'var(--t-text)',
+                  fontSize: 12,
+                  fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+                }}
+              />
+            </div>
+
+            <div style={{ marginTop: 8, maxHeight: 180, overflowY: 'auto' }}>
+              {query.trim() && suggestions.length === 0 ? (
+                <div style={{
+                  paddingTop: 8,
+                  paddingRight: 8,
+                  paddingBottom: 8,
+                  paddingLeft: 8,
+                  color: 'var(--t-text-faint)',
+                  fontSize: 11,
+                  fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+                }}>
+                  {loading ? 'Searching...' : 'No files found'}
+                </div>
+              ) : null}
+              {suggestions.map((file) => (
+                <button
+                  key={file.path}
+                  type="button"
+                  onClick={() => selectFileReference(file.path)}
+                  style={{
+                    display: 'block',
+                    width: '100%',
+                    paddingTop: 7,
+                    paddingRight: 8,
+                    paddingBottom: 7,
+                    paddingLeft: 8,
+                    borderWidth: 0,
+                    borderRadius: 8,
+                    background: 'transparent',
+                    color: 'var(--t-text)',
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    fontSize: 11,
+                    lineHeight: 1.35,
+                    fontFamily: "'iA Writer Mono', 'JetBrains Mono', 'SF Mono', Menlo, ui-monospace, monospace",
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                  onMouseEnter={(event) => { event.currentTarget.style.background = 'var(--t-bg-card)'; }}
+                  onMouseLeave={(event) => { event.currentTarget.style.background = 'transparent'; }}
+                >
+                  {file.path}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/desktop/thoughts/InputButtons.tsx
+++ b/src/components/desktop/thoughts/InputButtons.tsx
@@ -1,3 +1,4 @@
+import { AttachFilesButton } from './AttachFilesButton';
 import { SparklesIcon } from './ThoughtsIcons';
 import { type ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 
@@ -118,6 +119,9 @@ export function InputButtons({
   repoLabel,
   working = false,
   onStop,
+  onUploadDiskFiles,
+  onFileReferenceSelect,
+  repoPath,
 }: {
   input: string;
   enhancing: boolean;
@@ -138,6 +142,9 @@ export function InputButtons({
   repoLabel?: string | null;
   working?: boolean;
   onStop?: () => void;
+  onUploadDiskFiles?: (files: FileList | File[]) => void;
+  onFileReferenceSelect?: (path: string) => void;
+  repoPath?: string | null;
 }) {
   const canSubmit = Boolean(input.trim());
   const effortCycle: ThinkingEffort[] = adaptiveEnabled
@@ -308,31 +315,11 @@ export function InputButtons({
 
       <div style={{ flex: 1 }} />
 
-      {/* Attach files placeholder */}
-      <button
-        type="button"
-        title="Attach files"
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: 24,
-          height: 24,
-          borderRadius: 7,
-          borderWidth: 0,
-          background: 'transparent',
-          color: 'var(--t-text-muted)',
-          cursor: 'pointer',
-          fontSize: 16,
-          fontWeight: 300,
-          lineHeight: 1,
-          transition: 'color 120ms',
-        }}
-        onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--t-text)'; }}
-        onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--t-text-muted)'; }}
-      >
-        +
-      </button>
+      <AttachFilesButton
+        onUploadDiskFiles={onUploadDiskFiles}
+        onFileReferenceSelect={onFileReferenceSelect}
+        repoPath={repoPath}
+      />
 
       {/* Send — Rams pill matching ContextMeter/ThinkingChip aesthetic.
           Three states with 180ms morph: idle (hairline faint) → armed

--- a/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
+++ b/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
@@ -50,6 +50,7 @@ import { useClearCommand } from './chat-panel/useClearCommand';
 import { useOrchestratorReloadNotice } from './chat-panel/useOrchestratorReloadNotice';
 import { usePersistChatThread } from './chat-panel/usePersistChatThread';
 import { useSuggestedReplies } from './chat-panel/useSuggestedReplies';
+import { useThoughtsComposerAttachments } from './chat-panel/useThoughtsComposerAttachments';
 import type {
   ThoughtsChatPanelChromeState,
   ThoughtsChatPanelHandle,
@@ -217,6 +218,16 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
   const [exportState, setExportState] = useState<'idle' | 'copying' | 'copied' | 'error'>('idle');
   const { persistThread, persistThreadNow, cancelPendingPersist } = usePersistChatThread(resolvedRepoPath);
   const thinkingEffort: ThinkingEffort = thinkingOverride ?? (adaptiveThinkingEnabled ? 'adaptive' : 'max');
+  const {
+    attachedImages,
+    attachedFiles,
+    dragOver: attachmentDragOver,
+    dragHandlers: attachmentDragHandlers,
+    processFiles: processAttachmentFiles,
+    removeAttachedImage,
+    removeAttachedFile,
+    clearAttachments,
+  } = useThoughtsComposerAttachments();
 
   const isOrchestratorMode = targetAgentKey === '__claude__' || !sessionTargets.some((s) => s.key === targetAgentKey);
 
@@ -876,6 +887,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
 
     if (isOrchestratorMode) {
       orchStream.send(msg, { permissionMode, thinkingEffort, model: orchestratorModel });
+      clearAttachments();
       return;
     }
 
@@ -887,6 +899,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
       timestampLabel: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
     };
     setChatMessages((prev) => [...prev, userMsg]);
+    clearAttachments();
 
     const sessionKey = targetSessionKey;
     if (!sessionKey) return;
@@ -923,7 +936,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
       ]);
       setWaitingForReply(false);
     }
-  }, [captureServerSnapshot, input, isOrchestratorMode, orchStream, orchestratorModel, permissionMode, runLocalOrchestratorSlash, startPolling, targetAgent, targetSessionKey, thinkingEffort, waitingForReply]);
+  }, [captureServerSnapshot, clearAttachments, input, isOrchestratorMode, orchStream, orchestratorModel, permissionMode, runLocalOrchestratorSlash, startPolling, targetAgent, targetSessionKey, thinkingEffort, waitingForReply]);
 
   const sendNow = useCallback((text?: string) => {
     const msg = (typeof text === 'string' ? text : latestInputRef.current).trim();
@@ -940,6 +953,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
         setInput('');
         latestInputRef.current = '';
         orchStream.send(msg, { permissionMode, thinkingEffort, model: orchestratorModel });
+        clearAttachments();
       })();
       return;
     }
@@ -947,7 +961,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
     setInput(msg);
     latestInputRef.current = msg;
     setTimeout(() => { void handleTaskSend(msg); }, 0);
-  }, [handleTaskSend, isOrchestratorMode, orchStream, orchestratorModel, permissionMode, runLocalOrchestratorSlash, thinkingEffort]);
+  }, [clearAttachments, handleTaskSend, isOrchestratorMode, orchStream, orchestratorModel, permissionMode, runLocalOrchestratorSlash, thinkingEffort]);
 
   const handleCopyMarkdownRef = useRef<() => Promise<boolean>>(async () => false);
 
@@ -1046,27 +1060,41 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
         </div>
       ) : null}
 
-      <ChatMessageList
-        ref={chatEndRef}
-        displayMessages={displayMessages}
-        displayWaiting={displayWaiting}
-        repoPath={resolvedRepoPath}
-        activeTargetLabel={activeTargetLabel}
-        activeTargetColor={activeTargetColor}
-        thoughtsBodyBackground={thoughtsBodyBackground}
-        thoughtsMutedGlass={thoughtsMutedGlass}
-        thoughtsElevatedBorder={thoughtsElevatedBorder}
-        thoughtsElevatedShadow={thoughtsElevatedShadow}
-        emptyStateOverride={emptyStateOverride}
-        emptyStateFallback={fallbackEmptyState}
-        topContent={transcriptTopContent}
-        isOrchestratorMode={isOrchestratorMode}
-        suggestedReplyMessageId={suggestedReplyMessageId}
-        suggestedReplies={chipsForLastAssistant}
-        suggestedRepliesPending={suggestedRepliesPending}
-        onSelectSuggestion={(chip) => { sendNow(chip); }}
-        onDismissSuggestions={dismissSuggestedReplies}
-      />
+      <div
+        onDragOver={attachmentDragHandlers.onDragOver}
+        onDragLeave={attachmentDragHandlers.onDragLeave}
+        onDrop={attachmentDragHandlers.onDrop}
+        style={{
+          position: 'relative',
+          display: 'flex',
+          flex: 1,
+          minHeight: 0,
+          outline: attachmentDragOver ? '2px solid var(--t-accent)' : 'none',
+          outlineOffset: -2,
+        }}
+      >
+        <ChatMessageList
+          ref={chatEndRef}
+          displayMessages={displayMessages}
+          displayWaiting={displayWaiting}
+          repoPath={resolvedRepoPath}
+          activeTargetLabel={activeTargetLabel}
+          activeTargetColor={activeTargetColor}
+          thoughtsBodyBackground={thoughtsBodyBackground}
+          thoughtsMutedGlass={thoughtsMutedGlass}
+          thoughtsElevatedBorder={thoughtsElevatedBorder}
+          thoughtsElevatedShadow={thoughtsElevatedShadow}
+          emptyStateOverride={emptyStateOverride}
+          emptyStateFallback={fallbackEmptyState}
+          topContent={transcriptTopContent}
+          isOrchestratorMode={isOrchestratorMode}
+          suggestedReplyMessageId={suggestedReplyMessageId}
+          suggestedReplies={chipsForLastAssistant}
+          suggestedRepliesPending={suggestedRepliesPending}
+          onSelectSuggestion={(chip) => { sendNow(chip); }}
+          onDismissSuggestions={dismissSuggestedReplies}
+        />
+      </div>
 
       <ChatToastStack
         reloadNotice={reloadNotice}
@@ -1128,6 +1156,14 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
         displayMessagesCount={displayMessages.length}
         hasAssistantActivity={hasAssistantActivity}
         footerMeterSlot={footerMeterSlot}
+        attachedImages={attachedImages}
+        attachedFiles={attachedFiles}
+        dragOver={attachmentDragOver}
+        dragHandlers={attachmentDragHandlers}
+        onAttachedImageRemove={removeAttachedImage}
+        onAttachedFileRemove={removeAttachedFile}
+        onUploadDiskFiles={processAttachmentFiles}
+        repoPath={resolvedRepoPath}
       />
     </>
   );

--- a/src/components/desktop/thoughts/chat-panel/ComposerArea.tsx
+++ b/src/components/desktop/thoughts/chat-panel/ComposerArea.tsx
@@ -8,6 +8,7 @@ import type { ThoughtsChatPermissionMode } from './types';
 import type { MobileTranscriptEntry, MobileTranscriptToolCall } from '@/lib/mobile/types';
 import { getOrchestratorSlashCommandSuggestions, type OrchestratorSlashCommandDefinition } from '@/lib/slash-commands';
 import { formatTokens } from '@/lib/util/format-tokens';
+import type { ThoughtsAttachedImage, ThoughtsComposerDragHandlers } from './useThoughtsComposerAttachments';
 
 const compactUsdFormatter = new Intl.NumberFormat('en-US', {
   style: 'currency',
@@ -205,6 +206,14 @@ interface ComposerAreaProps {
   displayMessagesCount: number;
   hasAssistantActivity: boolean;
   footerMeterSlot?: React.ReactNode;
+  attachedImages?: ThoughtsAttachedImage[];
+  attachedFiles?: string[];
+  dragOver?: boolean;
+  dragHandlers?: ThoughtsComposerDragHandlers;
+  onAttachedImageRemove?: (index: number) => void;
+  onAttachedFileRemove?: (fileName: string) => void;
+  onUploadDiskFiles?: (files: FileList | File[]) => void;
+  repoPath?: string | null;
 }
 
 export const ComposerArea = forwardRef<HTMLTextAreaElement, ComposerAreaProps>(function ComposerArea({
@@ -235,6 +244,14 @@ export const ComposerArea = forwardRef<HTMLTextAreaElement, ComposerAreaProps>(f
   displayMessagesCount,
   hasAssistantActivity,
   footerMeterSlot,
+  attachedImages = [],
+  attachedFiles = [],
+  dragOver = false,
+  dragHandlers,
+  onAttachedImageRemove,
+  onAttachedFileRemove,
+  onUploadDiskFiles,
+  repoPath,
 }, inputRef) {
   const [activeSlashIndex, setActiveSlashIndex] = useState(0);
   const [dismissedSlashInput, setDismissedSlashInput] = useState<string | null>(null);
@@ -288,6 +305,57 @@ export const ComposerArea = forwardRef<HTMLTextAreaElement, ComposerAreaProps>(f
     onInputChange(nextValue);
   };
 
+  const getInputNode = () => (
+    inputRef && typeof inputRef !== 'function' && 'current' in inputRef ? inputRef.current : null
+  );
+
+  const handleTextareaPaste = (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = event.clipboardData?.items;
+    if (!items || !onUploadDiskFiles) return;
+
+    const files: File[] = [];
+    for (let index = 0; index < items.length; index += 1) {
+      if (items[index].kind !== 'file') continue;
+      const file = items[index].getAsFile();
+      if (file) files.push(file);
+    }
+
+    if (files.length === 0) return;
+    event.preventDefault();
+    onUploadDiskFiles(files);
+  };
+
+  const handleFileReferenceSelect = (filePath: string) => {
+    const node = getInputNode();
+    const cursorPos = node?.selectionStart ?? input.length;
+    const textBeforeCursor = input.slice(0, cursorPos);
+    const textAfterCursor = input.slice(cursorPos);
+    const atMatch = textBeforeCursor.match(/@[\w./-]*$/);
+
+    let nextValue: string;
+    let nextCursorPos: number;
+    if (atMatch && typeof atMatch.index === 'number') {
+      const beforeMatch = textBeforeCursor.slice(0, atMatch.index);
+      nextValue = `${beforeMatch}@${filePath} ${textAfterCursor}`;
+      nextCursorPos = beforeMatch.length + filePath.length + 2;
+    } else {
+      const spacer = textBeforeCursor.length === 0 || /\s$/.test(textBeforeCursor) ? '' : ' ';
+      nextValue = `${textBeforeCursor}${spacer}@${filePath} ${textAfterCursor}`;
+      nextCursorPos = textBeforeCursor.length + spacer.length + filePath.length + 2;
+    }
+
+    updateInput(nextValue);
+    requestAnimationFrame(() => {
+      const nextNode = getInputNode();
+      nextNode?.focus();
+      if (!nextNode) return;
+      nextNode.selectionStart = nextCursorPos;
+      nextNode.selectionEnd = nextCursorPos;
+      nextNode.style.height = 'auto';
+      nextNode.style.height = `${Math.min(nextNode.scrollHeight, 200)}px`;
+    });
+  };
+
   const handleSelectSlashCommand = (definition: OrchestratorSlashCommandDefinition) => {
     setDismissedSlashInput(null);
     if (definition.requiresArgument) {
@@ -305,7 +373,10 @@ export const ComposerArea = forwardRef<HTMLTextAreaElement, ComposerAreaProps>(f
 
   return (
     <div style={{
-      padding: '10px 12px 12px',
+      paddingTop: 10,
+      paddingRight: 12,
+      paddingBottom: 12,
+      paddingLeft: 12,
       borderTop: '1px solid var(--t-divider-subtle)',
       flexShrink: 0,
       background: thoughtsBodyBackground,
@@ -325,18 +396,146 @@ export const ComposerArea = forwardRef<HTMLTextAreaElement, ComposerAreaProps>(f
           onSelect={handleSelectSlashCommand}
         />
         <div
+          onDragOver={dragHandlers?.onDragOver}
+          onDragLeave={dragHandlers?.onDragLeave}
+          onDrop={dragHandlers?.onDrop}
           style={{
+            position: 'relative',
             borderRadius: 14,
             border: '1px solid var(--t-input-border)',
             background: 'var(--t-input-bg)',
             boxShadow: '0 14px 30px rgba(15, 23, 42, 0.08)',
             overflow: 'hidden',
             opacity: isDisabled ? 0.6 : 1,
+            outline: dragOver ? '2px solid var(--t-accent)' : 'none',
+            outlineOffset: -2,
           }}
         >
+          {attachedImages.length > 0 ? (
+            <div style={{
+              display: 'flex',
+              gap: 10,
+              paddingTop: 12,
+              paddingRight: 14,
+              paddingBottom: 6,
+              paddingLeft: 14,
+              overflowX: 'auto',
+            }}>
+              {attachedImages.map((image, index) => (
+                <div key={`${image.name}-${index}`} style={{ position: 'relative', width: 66, flexShrink: 0 }}>
+                  <img
+                    src={image.dataUri}
+                    alt={image.name}
+                    style={{
+                      display: 'block',
+                      width: 56,
+                      height: 56,
+                      objectFit: 'cover',
+                      borderRadius: 10,
+                      border: '1px solid var(--t-input-border)',
+                      background: 'var(--t-bg-card)',
+                    }}
+                  />
+                  <div style={{
+                    width: 60,
+                    marginTop: 4,
+                    color: 'var(--t-text-faint)',
+                    fontSize: 10,
+                    lineHeight: 1.15,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    fontFamily: '"Plus Jakarta Sans", -apple-system, system-ui, sans-serif',
+                  }}>
+                    {image.name}
+                  </div>
+                  <button
+                    type="button"
+                    aria-label={`Remove ${image.name}`}
+                    onClick={() => onAttachedImageRemove?.(index)}
+                    style={{
+                      position: 'absolute',
+                      top: -5,
+                      right: 4,
+                      width: 18,
+                      height: 18,
+                      borderRadius: 999,
+                      border: '1px solid var(--t-input-border)',
+                      background: 'var(--t-input-bg)',
+                      color: 'var(--t-text-muted)',
+                      cursor: 'pointer',
+                      fontSize: 11,
+                      lineHeight: '16px',
+                      textAlign: 'center',
+                      paddingTop: 0,
+                      paddingRight: 0,
+                      paddingBottom: 0,
+                      paddingLeft: 0,
+                      boxShadow: 'var(--t-panel-shadow)',
+                    }}
+                  >
+                    x
+                  </button>
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          {attachedFiles.length > 0 ? (
+            <div style={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: 6,
+              paddingTop: attachedImages.length > 0 ? 2 : 12,
+              paddingRight: 14,
+              paddingBottom: 6,
+              paddingLeft: 14,
+            }}>
+              {attachedFiles.map((fileName) => (
+                <span key={fileName} style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 5,
+                  maxWidth: '100%',
+                  paddingTop: 4,
+                  paddingRight: 7,
+                  paddingBottom: 4,
+                  paddingLeft: 8,
+                  borderRadius: 7,
+                  border: '1px solid var(--t-accent-border)',
+                  background: 'var(--t-accent-soft)',
+                  color: 'var(--t-accent)',
+                  fontSize: 11,
+                  fontFamily: "'iA Writer Mono', 'JetBrains Mono', 'SF Mono', Menlo, ui-monospace, monospace",
+                }}>
+                  <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {fileName.split('/').pop()}
+                  </span>
+                  <button
+                    type="button"
+                    aria-label={`Remove ${fileName}`}
+                    onClick={() => onAttachedFileRemove?.(fileName)}
+                    style={{
+                      borderWidth: 0,
+                      background: 'transparent',
+                      color: 'var(--t-accent)',
+                      cursor: 'pointer',
+                      paddingTop: 0,
+                      paddingRight: 0,
+                      paddingBottom: 0,
+                      paddingLeft: 0,
+                      lineHeight: 1,
+                    }}
+                  >
+                    x
+                  </button>
+                </span>
+              ))}
+            </div>
+          ) : null}
+
           <textarea
             ref={inputRef}
-            className={isOrchestratorMode ? 'thoughts-orchestrate-input' : undefined}
             value={input}
             onChange={(event) => {
               updateInput(event.target.value);
@@ -393,6 +592,7 @@ export const ComposerArea = forwardRef<HTMLTextAreaElement, ComposerAreaProps>(f
                 }
               }
             }}
+            onPaste={handleTextareaPaste}
             placeholder={
               isOrchestratorMode
                 ? 'Type a message...'
@@ -440,6 +640,9 @@ export const ComposerArea = forwardRef<HTMLTextAreaElement, ComposerAreaProps>(f
             repoLabel={isOrchestratorMode ? repoLabel : null}
             working={isOrchestratorMode && displayWaiting}
             onStop={isOrchestratorMode ? onStop : undefined}
+            onUploadDiskFiles={onUploadDiskFiles}
+            onFileReferenceSelect={handleFileReferenceSelect}
+            repoPath={repoPath}
           />
         </div>
       </div>
@@ -455,7 +658,6 @@ export const ComposerArea = forwardRef<HTMLTextAreaElement, ComposerAreaProps>(f
                   onClick={() => { footerMeterProps?.onClick?.(); }}
                   title={`Projected next turn: ${formatTokens(tokenEstimate.projectedTokens).replace(/K$/u, 'k')} tokens · ${tokenEstimate.projectedPercent}% of context`}
                   style={{
-                    padding: 0,
                     borderWidth: 0,
                     background: 'transparent',
                     color: tokenEstimate.warnAtContextThreshold ? '#FF5A1F' : 'var(--t-text-faint)',
@@ -469,6 +671,10 @@ export const ComposerArea = forwardRef<HTMLTextAreaElement, ComposerAreaProps>(f
                     whiteSpace: 'nowrap',
                     fontVariantNumeric: 'tabular-nums',
                     fontFamily: "'iA Writer Mono', 'JetBrains Mono', 'SF Mono', Menlo, ui-monospace, monospace",
+                    paddingTop: 0,
+                    paddingRight: 0,
+                    paddingBottom: 0,
+                    paddingLeft: 0,
                   }}
                 >
                   <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>

--- a/src/components/desktop/thoughts/chat-panel/useThoughtsComposerAttachments.ts
+++ b/src/components/desktop/thoughts/chat-panel/useThoughtsComposerAttachments.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import { useCallback, useEffect, useState, type DragEvent } from 'react';
+import { useFileDrop } from '@/lib/hooks/use-file-drop';
+
+export interface ThoughtsAttachedImage {
+  name: string;
+  dataUri: string;
+  mimeType: string;
+}
+
+export interface ThoughtsComposerDragHandlers {
+  onDragOver: (event: DragEvent) => void;
+  onDragLeave: (event: DragEvent) => void;
+  onDrop: (event: DragEvent) => void;
+}
+
+export function useThoughtsComposerAttachments() {
+  const [attachedImages, setAttachedImages] = useState<ThoughtsAttachedImage[]>([]);
+  const [attachedFiles, setAttachedFiles] = useState<string[]>([]);
+  const {
+    pendingFiles,
+    dragOver,
+    processFiles,
+    clearPendingFiles,
+    dragHandlers,
+  } = useFileDrop({ enablePaste: false });
+
+  useEffect(() => {
+    if (pendingFiles.length === 0) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      for (const file of pendingFiles) {
+        if (file.mimeType.startsWith('image/')) {
+          setAttachedImages((current) => {
+            if (current.length >= 4) return current;
+            return [
+              ...current,
+              {
+                name: file.name,
+                dataUri: `data:${file.mimeType};base64,${file.content}`,
+                mimeType: file.mimeType,
+              },
+            ];
+          });
+        } else {
+          setAttachedFiles((current) => (
+            current.includes(file.name) ? current : [...current, file.name]
+          ));
+        }
+      }
+      clearPendingFiles();
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [clearPendingFiles, pendingFiles]);
+
+  const removeAttachedImage = useCallback((index: number) => {
+    setAttachedImages((current) => current.filter((_, imageIndex) => imageIndex !== index));
+  }, []);
+
+  const removeAttachedFile = useCallback((fileName: string) => {
+    setAttachedFiles((current) => current.filter((name) => name !== fileName));
+  }, []);
+
+  const clearAttachments = useCallback(() => {
+    setAttachedImages([]);
+    setAttachedFiles([]);
+    clearPendingFiles();
+  }, [clearPendingFiles]);
+
+  return {
+    attachedImages,
+    attachedFiles,
+    dragOver,
+    dragHandlers,
+    processFiles,
+    removeAttachedImage,
+    removeAttachedFile,
+    clearAttachments,
+  };
+}

--- a/src/lib/usage/cli-scrape.ts
+++ b/src/lib/usage/cli-scrape.ts
@@ -160,8 +160,8 @@ export function readClaudeUsage(): CliUsage {
     return { runtime: 'claude', primary: null, secondary: null, source: null, available: false, error: 'no recent jsonl' };
   }
 
-  let fiveH = { input: 0, output: 0 };
-  let weekly = { input: 0, output: 0 };
+  const fiveH = { input: 0, output: 0 };
+  const weekly = { input: 0, output: 0 };
   let oldestTs = now;
 
   for (const file of files) {


### PR DESCRIPTION
## Summary
- Mirrors the Assistant tab's working `useFileDrop` attachment pipeline into the orchestrator composer.
- Drop zone + paste handler + file picker collect images and PDFs as base64 dataUris client-side.
- Preview chips above textarea (image thumbs, file name pills); 4-image cap, 5MB-per-file from the hook.
- DataUris collected but not yet sent through the orchestrator stream — that's the next packet.

## Test plan
- [ ] Drag PNG into orchestrator chat body → image chip preview above composer
- [ ] Drag PDF → filename chip in attached-files row
- [ ] Paste image from clipboard while focused in composer → same as drag
- [ ] Click \`+\` button → top "Upload from disk" section + repo file search underneath both work
- [ ] \`npx tsc --noEmit\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)