### PR TITLE
fix: harden orchestrator review-gate heuristics (#1154)

### DIFF
--- a/src/lib/lane/auto-review.ts
+++ b/src/lib/lane/auto-review.ts
@@ -238,6 +238,7 @@ interface ReviewDiffSummary {
   summary: string;
   changedFiles: string[];
   addedLines: string[];
+  cwd: string;
 }
 
 function extractAddedLines(diff: string): string[] {
@@ -273,18 +274,20 @@ function getDiffSummary(lane: Lane, depth: ReviewDepth): ReviewDiffSummary {
     const addedLines = extractAddedLines(diff);
 
     if (!stat && !diff) {
-      return { summary: 'No changes detected in the worktree.', changedFiles, addedLines };
+      return { summary: 'No changes detected in the worktree.', changedFiles, addedLines, cwd };
     }
     return {
       summary: `## Diff summary\n\n\`\`\`\n${stat}\n\`\`\`\n\n## Changes\n\n\`\`\`diff\n${diff}\n\`\`\``,
       changedFiles,
       addedLines,
+      cwd,
     };
   } catch {
     return {
       summary: 'Unable to generate diff — the worktree may not have commits yet.',
       changedFiles: [],
       addedLines: [],
+      cwd,
     };
   }
 }
@@ -434,6 +437,7 @@ function buildReviewPrompt(
   mechanicalChecksSummary?: string,
   mergeGateResult?: MergeGateResult,
   reviewScreenshot?: LaneReviewScreenshotReference | null,
+  reviewWorktreePath?: string,
 ): string {
   const depthGuidance = depth === 'deep-dive'
     ? 'This lane has low-confidence or missing self-review context. Perform a deep-dive review and challenge assumptions, edge cases, and missing validation.'
@@ -442,6 +446,7 @@ function buildReviewPrompt(
   const mergeGateSection = mergeGateResult ? formatMergeGateForReview(mergeGateResult) : null;
   const reviewRisk = classifyReviewRisk(changedFiles, addedLines);
   const adversarialReviewProtocol = buildAdversarialReviewProtocol(reviewRisk.tier);
+  const worktreePath = reviewWorktreePath || lane.worktreePath || lane.repoPath;
   const reviewScreenshotMetadata = reviewScreenshot
     ? [
         typeof reviewScreenshot.width === 'number' && reviewScreenshot.width > 0
@@ -452,6 +457,29 @@ function buildReviewPrompt(
         reviewScreenshot.capturedAt ? `captured ${reviewScreenshot.capturedAt}` : null,
       ].filter((value): value is string => Boolean(value)).join(' • ')
     : '';
+  const requiredTraceFormat = [
+    '## Required verification traces',
+    '',
+    'Before any verdict, recommendation, or submit_review call, emit a completed trace block in this exact format:',
+    `Worktree: ${worktreePath}`,
+    lane.packetId ? `Packet: ${lane.packetId}` : null,
+    '',
+    'SCOPE traces - required for every changed file that writes or mutates state:',
+    '`SCOPE: <file:line> partition=<repo|tenant|user|project|lane|packet|scope|slug|id|NONE>`',
+    'Then state the SINGLE intended destination and confirm the diff writes there and ONLY there. Flag output written to the wrong location or duplicated across locations.',
+    '',
+    'GUARD traces - required for every new guard, condition, or early return:',
+    '`GUARD: <file:line> fires-from=<file:line|INERT>`',
+    '',
+    'COVERAGE checklist - enumerate EACH sub-requirement from the packet scope:',
+    '`COVERAGE:`',
+    '`[x] <sub-requirement> - evidence <file:line|command output>`',
+    '`[ ] <sub-requirement> - gap <reason>`',
+    '',
+    'Hard approval rule: You may NOT approve if any guard is INERT, any write has partition=NONE, or any COVERAGE box is unchecked. Request changes instead.',
+    'To clear an intentional global write, cite the file:line that proves the global destination is correct.',
+    'Where the change has observable output (a file written, a command stdout, a function return), PREFER to run it in the worktree and inspect the ACTUAL output over reasoning about the diff.',
+  ].filter((value): value is string => value !== null).join('\n');
 
   return [
     `An agent has completed work on lane "${lane.label}" (branch: ${lane.branch}).`,
@@ -475,21 +503,20 @@ function buildReviewPrompt(
     reviewScreenshot ? `` : null,
     diffSummary,
     ``,
+    requiredTraceFormat,
+    ``,
     adversarialReviewProtocol || null,
     adversarialReviewProtocol ? `` : null,
     `## Your review should include:`,
     `1. What was changed (1-2 sentences)`,
-    `2. Verification protocol — complete ALL before verdict:`,
-    `   1. GUARD/PREDICATE TRACE — for each new guard/condition/early-return, name what fires it and cite an EXISTING file:line that produces that condition; if no code path fires it, call it INERT and flag it.`,
-    `   2. SCOPE/PARTITION TRACE — for each write/state mutation, state its partition key (repo/tenant/user) and confirm it does NOT leak global state into every repo; a write with no partition key is a DEFECT to flag — cite the file:line that scopes it.`,
-    `   3. SUB-REQUIREMENT COVERAGE — enumerate the issue's discrete sub-requirements and mark each covered/uncovered.`,
-    `   4. EXECUTION-PATH TRACE — trace the actual call path the change runs under, not the one its name implies.`,
-    mergeGateSection ? `3. Address each merge gate violation — these are enforcement-level findings` : null,
-    mechanicalChecksSummary ? `${mergeGateSection ? '4' : '3'}. Address each mechanical check finding — confirm or dismiss` : null,
-    `${mergeGateSection && mechanicalChecksSummary ? '5' : mergeGateSection || mechanicalChecksSummary ? '4' : '3'}. Your recommendation: approve or request changes`,
+    `2. The Required verification traces above, completed before the verdict`,
+    `3. EXECUTION-PATH TRACE — trace the actual call path the change runs under, not the one its name implies.`,
+    mergeGateSection ? `4. Address each merge gate violation — these are enforcement-level findings` : null,
+    mechanicalChecksSummary ? `${mergeGateSection ? '5' : '4'}. Address each mechanical check finding — confirm or dismiss` : null,
+    `${mergeGateSection && mechanicalChecksSummary ? '6' : mergeGateSection || mechanicalChecksSummary ? '5' : '4'}. Your recommendation: approve or request changes`,
     ``,
     `After reviewing, FIRST record your verdict by calling submit_review with`,
-    `approved=true (plus any findings) for this packet. This writes the durable`,
+    `approved=true only if all required traces clear; otherwise call it with approved=false and findings. This writes the durable`,
     `review record that authorizes merge/PR for the current HEAD. THEN call`,
     `lane_command with verb "merge" (or "create_pr") for lane "${lane.id}".`,
     `A merge or PR with no recorded approved review will surface an operator`,
@@ -546,6 +573,7 @@ async function performAutoReview(review: QueuedReview): Promise<void> {
     mechanicalChecks.summary || undefined,
     mergeGateResult,
     reviewScreenshot,
+    diffSummary.cwd,
   );
 
   // Dual-path routing (epic #1044): the `inAppOrchestratorEnabled` toggle is

--- a/src/lib/lane/merge-gate.ts
+++ b/src/lib/lane/merge-gate.ts
@@ -20,6 +20,7 @@
 import { execFileSync, execSync } from 'node:child_process';
 import type { PacketSelfReview } from '@/lib/orchestrator/types';
 import { checkUntrackedImports } from './check-untracked-imports';
+import { hasScopePartitionToken } from './review-risk';
 import type { Lane } from './types';
 
 // ── Budget Constants (shared with dispatch.ts preservation envelope) ──
@@ -61,6 +62,13 @@ const HARD_BLOCK_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
   // Prototype pollution
   { pattern: /__proto__/, label: '__proto__ access — prototype pollution risk' },
   { pattern: /constructor\s*\[\s*['"]prototype['"]/, label: 'constructor.prototype access — prototype pollution risk' },
+];
+
+const SCOPE_PARTITION_WRITE_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /\bwriteFile(?:Sync)?\s*\(/i, label: 'File write without partition token' },
+  { pattern: /\bmkdir\s*\(/i, label: 'Directory write without partition token' },
+  { pattern: /\b(?:INSERT|UPDATE)\b/i, label: 'Database write without partition token' },
+  { pattern: /\.(?:set|put)\s*\(/i, label: 'Store mutation without partition token' },
 ];
 
 // ── Types ──
@@ -331,6 +339,29 @@ function checkSecurityPatterns(addedLines: AddedDiffLine[]): MergeViolation[] {
   return violations;
 }
 
+function checkScopePartitionHeuristics(addedLines: AddedDiffLine[]): MergeViolation[] {
+  const violations: MergeViolation[] = [];
+
+  for (const { pattern, label } of SCOPE_PARTITION_WRITE_PATTERNS) {
+    for (const { file, text } of addedLines) {
+      if (!pattern.test(text) || hasScopePartitionToken(text)) {
+        continue;
+      }
+
+      violations.push({
+        category: 'integrity',
+        severity: 'warn',
+        label,
+        detail: `New write/mutation lacks an obvious partition token on the same line: ${text.slice(1).trim().slice(0, 120)}`,
+        file: file ?? undefined,
+      });
+      break; // One advisory finding per pattern
+    }
+  }
+
+  return violations;
+}
+
 // ── Check 2: Diff Budget Validation ──
 //
 // When `orchestratorApproved` is true, budget violations are downgraded
@@ -465,14 +496,21 @@ export function runMergeGate(
 
   const addedLines = getAddedLines(cwd, baseBranch);
   const securityViolations = checkSecurityPatterns(addedLines);
+  const scopePartitionViolations = checkScopePartitionHeuristics(addedLines);
   const budgetViolations = checkDiffBudgets(cwd, baseBranch, lane.repoPath, orchestratorApproved);
   const importViolations = checkUntrackedImportViolations(cwd, baseBranch);
   const integrityViolations = checkSelfReviewIntegrity(
     selfReview,
-    [...securityViolations, ...budgetViolations, ...importViolations],
+    [...securityViolations, ...scopePartitionViolations, ...budgetViolations, ...importViolations],
   );
 
-  const violations = [...securityViolations, ...budgetViolations, ...importViolations, ...integrityViolations];
+  const violations = [
+    ...securityViolations,
+    ...scopePartitionViolations,
+    ...budgetViolations,
+    ...importViolations,
+    ...integrityViolations,
+  ];
   const hasBlocks = violations.some((v) => v.severity === 'block');
 
   if (violations.length > 0) {

--- a/src/lib/lane/review-risk.ts
+++ b/src/lib/lane/review-risk.ts
@@ -11,11 +11,17 @@ const HIGH_RISK_PATH_RULES: Array<{ pattern: RegExp; reason: string }> = [
   { pattern: /migration/i, reason: 'path-glob: migration path' },
   { pattern: /(?:^|\/)(?:session[_-]?outcomes?|ledger)(?:\/|$)/i, reason: 'path-glob: session outcome or ledger writer' },
   { pattern: /(?:^|\/)(?:directives?|directive-store)(?:\/|$)/i, reason: 'path-glob: directive storage' },
+  { pattern: /^src\/lib\/lane\/(?:commands|reconcile|lifecycle|worktree-side-merge)\.ts$/i, reason: 'path-glob: live lane state machine' },
+  { pattern: /^src\/lib\/orchestrator\/.*(?:state|store|control-plane).*\.ts$/i, reason: 'path-glob: orchestrator state/control-plane' },
   {
     pattern: /^src\/lib\/cortex\/(?:spec-ingest|.*(?:store|writer|storage|persist|directive|ledger)).*\.ts$/i,
     reason: 'path-glob: cortex writer',
   },
   { pattern: /(?:getDataDir|\.o8|directives)/i, reason: 'path-glob: shared data directory writer' },
+];
+
+const HIGH_RISK_LINE_RULES: Array<{ pattern: RegExp; reason: string }> = [
+  { pattern: /\bsetLaneStatus\s*\(/, reason: 'code-symbol: lane status transition site' },
 ];
 
 const ADVISORY_LINE_RULES: Array<{ pattern: RegExp; reason: string }> = [
@@ -24,6 +30,12 @@ const ADVISORY_LINE_RULES: Array<{ pattern: RegExp; reason: string }> = [
   { pattern: /\.(?:set|put|append)\s*\(.*(?:global|all repos|every repo|getDataDir|\.o8|directives)/i, reason: 'advisory: global store mutation added' },
   { pattern: /['"`](?:global|all repos|every repo)['"`]/i, reason: 'advisory: global scope literal added' },
 ];
+
+const SCOPE_PARTITION_TOKEN_PATTERN = /\b(?:repo|tenant|user|project|lane|packet|scope|slug|id)\b/i;
+
+export function hasScopePartitionToken(line: string): boolean {
+  return SCOPE_PARTITION_TOKEN_PATTERN.test(line);
+}
 
 function addUnique(reasons: string[], seen: Set<string>, reason: string): void {
   if (seen.has(reason)) return;
@@ -53,6 +65,15 @@ export function classifyReviewRisk(
     }
   }
 
+  for (const rawLine of addedLines) {
+    const line = normalizeAddedLine(rawLine);
+    for (const rule of HIGH_RISK_LINE_RULES) {
+      if (rule.pattern.test(line)) {
+        addUnique(reasons, seen, rule.reason);
+      }
+    }
+  }
+
   const tier: ReviewRiskTier = reasons.length > 0 ? 'high' : 'standard';
   if (tier === 'high') {
     for (const rawLine of addedLines) {
@@ -64,7 +85,7 @@ export function classifyReviewRisk(
       }
       if (
         /\b(?:writeFile|writeFileSync|mkdir|mkdirSync)\s*\(/i.test(line)
-        && !/\b(?:repo|tenant|user|project|lane|packet|scope|slug|id)\b/i.test(line)
+        && !hasScopePartitionToken(line)
       ) {
         addUnique(reasons, seen, 'advisory: write added without an obvious partition key');
       }


### PR DESCRIPTION
Addresses #1154 (the independent-second-pass AGREE-gate is split to #1179).

The governance benchmark found the AI review tier confidently approved a subtly-broken diff (scope-partition/duplication) by rationalizing the defect as "VERIFIED correct." The heuristic *traces* already existed in the review prompt but were prose a model can reason past. This PR makes the slip-classes harder to rationalize and adds a deterministic signal the prompt can't talk its way around.

## Changes (low-risk slice)
**1a — structured, mandatory emit-format** (`auto-review.ts` `buildReviewPrompt`): the verification traces are now a required machine-checkable block — `SCOPE: <file:line> partition=<key|NONE>` (+ single-destination / no-duplication check), `GUARD: <file:line> fires-from=<…|INERT>`, and a per-sub-requirement `COVERAGE` checklist. Hard rule: **may not approve** with any INERT guard, `partition=NONE` write, or unchecked box; submit_review instruction tightened to "approved only if all traces clear." EXECUTION-PATH trace retained.

**3a/3b — behavior inspection**: "where the change has observable output, PREFER to run it in the worktree and inspect the ACTUAL output over reasoning about the diff" + the worktree path is now surfaced in the prompt (threaded through `getDiffSummary.cwd`). You can't rationalize where a file actually landed.

**1b — deterministic warn-tier partition check** (`merge-gate.ts` `checkScopePartitionHeuristics`): flags added `writeFile/mkdir/INSERT|UPDATE/.set|.put` lines lacking a partition token. **`severity: 'warn'` — never blocks** (FP-safe); it surfaces the finding into the review prompt via the existing `formatMergeGateForReview` path. Verified it cannot escalate: `checkSelfReviewIntegrity` only counts `block`-severity violations.

**Risk classifier extension** (`review-risk.ts`): adds live-state-machine paths (`lane/{commands,reconcile,lifecycle,worktree-side-merge}.ts`, `orchestrator/*{state,store,control-plane}*`) + a `setLaneStatus` line rule to the high-risk tier. Patterns are anchored/tight to avoid over-matching o8's own dogfood traffic. Sets up #1179.

## Verification
- `npx tsc --noEmit` → exit 0.
- Merge-gate preview: `wouldMerge: true`, all checks pass.
- Surgical: 3 files (+100/−13).
- **FP-safety**: the new partition check is `warn` only and cannot escalate to a block.

**⚠️ The governance benchmark is manual** (no automated runner — `tests/bench/`, `npm run bench:score`). Re-run the 5-diff governance set (must include the scope-partition diff that slipped) before/after merge to confirm `catch_rate` improves without `fpRate` rising past the ±0.05 band. The deferred independent second-pass (#1179) is the piece that structurally closes the single-reviewer-rationalizes hole.

Built by a Codex worker in an isolated worktree; orchestrator-reviewed. Not merged — PR-only dogfood mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
