### PR TITLE
fix: require second-pass agreement for high-risk reviews (#1179 stage 1)

### DIFF
--- a/scripts/smoke-merge-requires-review.ts
+++ b/scripts/smoke-merge-requires-review.ts
@@ -9,6 +9,7 @@ import type * as ApprovalsStore from '../src/lib/approvals/store';
 import type * as LaneCommands from '../src/lib/lane/commands';
 import type * as LaneRegistry from '../src/lib/lane/registry';
 import type * as HeadShaLock from '../src/lib/lane/head-sha-lock';
+import type * as DurableReviewApproval from '../src/lib/lane/durable-review-approval';
 import type * as OperatorMissionService from '../src/lib/orchestrator/operator-mission-service';
 
 const execFileAsync = promisify(execFile);
@@ -18,10 +19,12 @@ let tempHome = '';
 interface SmokeApi {
   createApproval: typeof ApprovalsStore.createApproval;
   listApprovalsForContext: typeof ApprovalsStore.listApprovalsForContext;
+  markSecondPassAgreed: typeof ApprovalsStore.markSecondPassAgreed;
   recordApprovalAudit: typeof ApprovalsStore.recordApprovalAudit;
   dispatch: typeof LaneCommands.dispatch;
   createLane: typeof LaneRegistry.createLane;
   submitPacketReview: typeof OperatorMissionService.submitPacketReview;
+  hasDurableApprovedReview: typeof DurableReviewApproval.hasDurableApprovedReview;
   readHeadSha: typeof HeadShaLock.readHeadSha;
 }
 
@@ -92,7 +95,7 @@ async function writeProjectLedger(projects: Array<{ id: string; name: string; re
   }, null, 2));
 }
 
-async function createCaseRepo(caseId: string, opts: { projectId?: string } = {}): Promise<CaseRepo> {
+async function createCaseRepo(caseId: string, opts: { highRisk?: boolean; projectId?: string } = {}): Promise<CaseRepo> {
   const root = await mkdtemp(join(tmpdir(), `o8-governance-${caseId}-`));
   const repoPath = join(root, 'repo');
   await mkdir(repoPath, { recursive: true });
@@ -139,8 +142,11 @@ async function createCaseRepo(caseId: string, opts: { projectId?: string } = {})
 
   const branch = `lane/${caseId}`;
   await git(repoPath, ['checkout', '-b', branch]);
-  const markerPath = `src/${caseId}.ts`;
+  const markerPath = opts.highRisk ? 'src/lib/db/schema.ts' : `src/${caseId}.ts`;
   const markerValue = `marker-${caseId}`;
+  if (opts.highRisk) {
+    await mkdir(join(repoPath, 'src', 'lib', 'db'), { recursive: true });
+  }
   await writeFile(
     join(repoPath, markerPath),
     `export const ${safeIdentifier(caseId)} = ${JSON.stringify(markerValue)};\n`,
@@ -201,12 +207,13 @@ function approvalsFor(repo: CaseRepo) {
   });
 }
 
-async function submitReview(repo: CaseRepo, approved: boolean): Promise<void> {
-  await api.submitPacketReview({
+async function submitReview(repo: CaseRepo, approved: boolean): Promise<string | null> {
+  const result = await api.submitPacketReview({
     packetId: repo.packetId,
     approved,
     findings: [],
   });
+  return result.auditApprovalId ?? null;
 }
 
 async function assertMainUnchanged(caseName: string, repo: CaseRepo): Promise<void> {
@@ -336,6 +343,41 @@ async function caseF(): Promise<void> {
   }
 }
 
+async function caseG(): Promise<void> {
+  const repo = await createCaseRepo('case-g', { highRisk: true });
+  try {
+    const approvalId = await submitReview(repo, true);
+    expectTruthy('CASE G', approvalId, 'orchestrator review approval id');
+    const reviewApproval = approvalsFor(repo).find((approval) => approval.id === approvalId);
+    expectEqual('CASE G', reviewApproval?.args?.requiresSecondPass, true, 'high-risk approval requires second pass');
+    expectEqual('CASE G', reviewApproval?.args?.secondPassAgreed, false, 'second pass starts unagreed');
+
+    const result = await api.dispatch({ verb: 'merge', laneId: repo.lane.id, actor: 'orchestrator' });
+    expectEqual('CASE G', result.ok, false, 'high-risk first-pass-only merge result.ok');
+    expectTruthy('CASE G', result.approvalId, 'approval card id');
+    await assertMainUnchanged('CASE G', repo);
+    expectEqual('CASE G', await api.hasDurableApprovedReview(repo.lane), false, 'first-pass high-risk review is not durable approval');
+  } finally {
+    await repo.cleanup();
+  }
+}
+
+async function caseH(): Promise<void> {
+  const repo = await createCaseRepo('case-h', { highRisk: true });
+  try {
+    const approvalId = await submitReview(repo, true);
+    expectTruthy('CASE H', approvalId, 'orchestrator review approval id');
+    api.markSecondPassAgreed(approvalId!);
+    expectEqual('CASE H', await api.hasDurableApprovedReview(repo.lane), true, 'second-pass agreement makes review durable');
+
+    const result = await api.dispatch({ verb: 'merge', laneId: repo.lane.id, actor: 'orchestrator' });
+    expectEqual('CASE H', result.ok, true, 'high-risk second-pass-agreed merge result.ok');
+    await assertMainAdvanced('CASE H', repo);
+  } finally {
+    await repo.cleanup();
+  }
+}
+
 async function main(): Promise<void> {
   tempHome = await mkdtemp(join(tmpdir(), 'o8-governance-home-'));
   const tempDataDir = process.env.CORTEX_IDE_DATA_DIR || await mkdtemp(join(tmpdir(), 'o8-governance-data-'));
@@ -353,20 +395,24 @@ async function main(): Promise<void> {
     laneRegistry,
     operatorMissionService,
     headShaLock,
+    durableReviewApproval,
   ] = await Promise.all([
     import('@/lib/approvals/store'),
     import('@/lib/lane/commands'),
     import('@/lib/lane/registry'),
     import('@/lib/orchestrator/operator-mission-service'),
     import('@/lib/lane/head-sha-lock'),
+    import('@/lib/lane/durable-review-approval'),
   ]);
   api = {
     createApproval: approvalsStore.createApproval,
     listApprovalsForContext: approvalsStore.listApprovalsForContext,
+    markSecondPassAgreed: approvalsStore.markSecondPassAgreed,
     recordApprovalAudit: approvalsStore.recordApprovalAudit,
     dispatch: laneCommands.dispatch,
     createLane: laneRegistry.createLane,
     submitPacketReview: operatorMissionService.submitPacketReview,
+    hasDurableApprovedReview: durableReviewApproval.hasDurableApprovedReview,
     readHeadSha: headShaLock.readHeadSha,
   };
 
@@ -376,7 +422,9 @@ async function main(): Promise<void> {
   await caseD();
   await caseE();
   await caseF();
-  console.log('smoke-merge-requires-review passed: 6/6 cases');
+  await caseG();
+  await caseH();
+  console.log('smoke-merge-requires-review passed: 8/8 cases');
 }
 
 void main().catch((error) => {

--- a/src/lib/approvals/store.ts
+++ b/src/lib/approvals/store.ts
@@ -391,6 +391,20 @@ export function getApproval(id: string) {
   return mapApprovalRow(row);
 }
 
+export function markSecondPassAgreed(approvalId: string): void {
+  const existing = getApproval(approvalId);
+  if (!existing) return;
+
+  updateApprovalRecord({
+    ...existing,
+    args: {
+      ...existing.args,
+      secondPassAgreed: true,
+    },
+    updatedAt: Date.now(),
+  });
+}
+
 function mapApprovalRows(rows: ApprovalRow[]) {
   return rows
     .map((row) => mapApprovalRow(row)!)

--- a/src/lib/lane/auto-review.ts
+++ b/src/lib/lane/auto-review.ts
@@ -14,6 +14,7 @@ import { execSync } from 'node:child_process';
 import { capturePacketCompletionContext, readPacketCompletionContext } from '@/lib/orchestrator/context-relay';
 import type { PacketSelfReview } from '@/lib/orchestrator/types';
 import { runMergeGate, formatMergeGateForReview, type MergeGateResult } from './merge-gate';
+import { extractAddedLines, getLaneDiffFacts, parseDiffStat } from './lane-diff-facts';
 import { buildAdversarialReviewProtocol, classifyReviewRisk } from './review-risk';
 import { resolveLaneReviewScreenshotReference, type LaneReviewScreenshotReference } from './review-screenshot';
 import type { Lane } from './types';
@@ -241,16 +242,11 @@ interface ReviewDiffSummary {
   cwd: string;
 }
 
-function extractAddedLines(diff: string): string[] {
-  return diff
-    .split('\n')
-    .filter((line) => line.startsWith('+') && !line.startsWith('+++'));
-}
-
 function getDiffSummary(lane: Lane, depth: ReviewDepth): ReviewDiffSummary {
   const cwd = lane.worktreePath || lane.repoPath;
   const maxDiffLines = REVIEW_DIFF_LINES[depth];
   try {
+    const facts = getLaneDiffFacts(lane);
     let stat = '';
     try {
       stat = execSync(`git diff --stat ${lane.baseBranch}...HEAD`, { cwd, timeout: 10_000, encoding: 'utf-8' }).trim();
@@ -259,7 +255,6 @@ function getDiffSummary(lane: Lane, depth: ReviewDepth): ReviewDiffSummary {
         stat = execSync('git diff --stat HEAD~1', { cwd, timeout: 10_000, encoding: 'utf-8' }).trim();
       } catch { /* no commits yet */ }
     }
-    const changedFiles = stat ? parseDiffStat(stat).map((entry) => entry.file) : [];
 
     let diff = '';
     try {
@@ -271,15 +266,14 @@ function getDiffSummary(lane: Lane, depth: ReviewDepth): ReviewDiffSummary {
         diff = rawDiff.split('\n').slice(0, maxDiffLines).join('\n').trim();
       } catch { /* no commits yet */ }
     }
-    const addedLines = extractAddedLines(diff);
 
     if (!stat && !diff) {
-      return { summary: 'No changes detected in the worktree.', changedFiles, addedLines, cwd };
+      return { summary: 'No changes detected in the worktree.', changedFiles: facts.changedFiles, addedLines: facts.addedLines, cwd };
     }
     return {
       summary: `## Diff summary\n\n\`\`\`\n${stat}\n\`\`\`\n\n## Changes\n\n\`\`\`diff\n${diff}\n\`\`\``,
-      changedFiles,
-      addedLines,
+      changedFiles: facts.changedFiles,
+      addedLines: facts.addedLines,
       cwd,
     };
   } catch {
@@ -313,32 +307,6 @@ const SECURITY_PATTERNS: Array<{ pattern: RegExp; label: string; severity: 'high
   { pattern: /path\.join\s*\([^)]*(?:req\.|params\.|query\.|body\.)/, label: 'path.join on user input without bounds check', severity: 'high' },
   { pattern: /\.innerHTML\s*=/, label: 'direct innerHTML assignment', severity: 'warning' },
 ];
-
-/** Parse `git diff --stat` output into per-file insertion/deletion counts. */
-function parseDiffStat(stat: string): Array<{ file: string; insertions: number; deletions: number }> {
-  const results: Array<{ file: string; insertions: number; deletions: number }> = [];
-  for (const line of stat.split('\n')) {
-    // Format: " src/foo.ts | 42 +++++-----"  or  " src/foo.ts | 10 ++++"
-    const match = line.match(/^\s*(.+?)\s*\|\s*(\d+)\s/);
-    if (!match) continue;
-    const file = match[1].trim();
-    const plusMatch = line.match(/(\d+)\s*insertion/);
-    const minusMatch = line.match(/(\d+)\s*deletion/);
-    // Fallback: count + and - symbols in the bar chart
-    const barMatch = line.match(/\|\s*\d+\s+([\s+\-]+)$/);
-    let insertions = plusMatch ? parseInt(plusMatch[1], 10) : 0;
-    let deletions = minusMatch ? parseInt(minusMatch[1], 10) : 0;
-    if (!plusMatch && !minusMatch && barMatch) {
-      const bar = barMatch[1];
-      insertions = (bar.match(/\+/g) || []).length;
-      deletions = (bar.match(/-/g) || []).length;
-    }
-    if (file && (insertions > 0 || deletions > 0)) {
-      results.push({ file, insertions, deletions });
-    }
-  }
-  return results;
-}
 
 function runMechanicalChecks(lane: Lane): { findings: MechanicalFinding[]; summary: string } {
   const cwd = lane.worktreePath || lane.repoPath;
@@ -388,9 +356,7 @@ function runMechanicalChecks(lane: Lane): { findings: MechanicalFinding[]; summa
 
   if (rawDiff) {
     // Only scan added lines (lines starting with +, excluding +++ headers)
-    const addedLines = rawDiff
-      .split('\n')
-      .filter((line) => line.startsWith('+') && !line.startsWith('+++'));
+    const addedLines = extractAddedLines(rawDiff);
 
     for (const { pattern, label, severity } of SECURITY_PATTERNS) {
       for (const line of addedLines) {
@@ -582,10 +548,9 @@ async function performAutoReview(review: QueuedReview): Promise<void> {
   //     ChatGPT Plus / Codex sub users; no Anthropic Agent SDK draw.
   //   - toggle ON              → Claude Opus 4.8 runs the review (existing
   //     behavior, bills against the user's Agent SDK credit pool).
-  // Codex path lacks MCP wiring in this ship — codex writes its review verdict
-  // to the log but cannot call `submit_review` / `lane_command`, so the new
-  // durable-row gate safely falls through to an operator card. #1045 tracks
-  // the MCP plumbing follow-up.
+  // Both backends can call `submit_review` and `lane_command`. Fail-closed
+  // approval is enforced by the durable review gate (`requiresSecondPass`),
+  // not by backend capability asymmetry.
   // Backend selected via the orchestrator-backend registry (#1075). Behavior
   // is byte-identical to the prior dual-path branch — see registry.ts.
   const { getActiveOrchestratorBackend } = await import('./orchestrator-backends/registry');

--- a/src/lib/lane/durable-review-approval.ts
+++ b/src/lib/lane/durable-review-approval.ts
@@ -44,7 +44,9 @@ export async function hasDurableApprovedReview(
 
     return approved.some((approval) => {
       const reviewed = normalizeHeadSha(reviewedHeadForApproval(approval));
-      return reviewed !== undefined && reviewed === currentHead;
+      return reviewed !== undefined
+        && reviewed === currentHead
+        && !(approval.args?.requiresSecondPass === true && approval.args?.secondPassAgreed !== true);
     });
   } catch {
     return false;

--- a/src/lib/lane/lane-diff-facts.ts
+++ b/src/lib/lane/lane-diff-facts.ts
@@ -1,0 +1,86 @@
+import { execFileSync } from 'node:child_process';
+import type { Lane } from '@/lib/lane/types';
+
+export interface LaneDiffFacts {
+  changedFiles: string[];
+  addedLines: string[];
+}
+
+export function extractAddedLines(diff: string): string[] {
+  return diff
+    .split('\n')
+    .filter((line) => line.startsWith('+') && !line.startsWith('+++'));
+}
+
+/** Parse `git diff --stat` output into per-file insertion/deletion counts. */
+export function parseDiffStat(stat: string): Array<{ file: string; insertions: number; deletions: number }> {
+  const results: Array<{ file: string; insertions: number; deletions: number }> = [];
+  for (const line of stat.split('\n')) {
+    // Format: " src/foo.ts | 42 +++++-----"  or  " src/foo.ts | 10 ++++"
+    const match = line.match(/^\s*(.+?)\s*\|\s*(\d+)\s/);
+    if (!match) continue;
+    const file = match[1].trim();
+    const plusMatch = line.match(/(\d+)\s*insertion/);
+    const minusMatch = line.match(/(\d+)\s*deletion/);
+    // Fallback: count + and - symbols in the bar chart
+    const barMatch = line.match(/\|\s*\d+\s+([\s+\-]+)$/);
+    let insertions = plusMatch ? parseInt(plusMatch[1], 10) : 0;
+    let deletions = minusMatch ? parseInt(minusMatch[1], 10) : 0;
+    if (!plusMatch && !minusMatch && barMatch) {
+      const bar = barMatch[1];
+      insertions = (bar.match(/\+/g) || []).length;
+      deletions = (bar.match(/-/g) || []).length;
+    }
+    if (file && (insertions > 0 || deletions > 0)) {
+      results.push({ file, insertions, deletions });
+    }
+  }
+  return results;
+}
+
+function readGitOutput(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    timeout: 10_000,
+    encoding: 'utf-8',
+    maxBuffer: 10 * 1024 * 1024,
+  }).trim();
+}
+
+function readGitOutputWithFallback(cwd: string, primaryArgs: string[], fallbackArgs: string[]): string {
+  try {
+    return readGitOutput(cwd, primaryArgs);
+  } catch {
+    try {
+      return readGitOutput(cwd, fallbackArgs);
+    } catch {
+      return '';
+    }
+  }
+}
+
+export function getLaneDiffFacts(
+  lane: Pick<Lane, 'baseBranch' | 'worktreePath' | 'repoPath'>,
+): LaneDiffFacts {
+  const cwd = lane.worktreePath || lane.repoPath;
+  if (!cwd) {
+    throw new Error('Lane has no repository path for diff facts.');
+  }
+
+  const baseRange = `${lane.baseBranch}...HEAD`;
+  const stat = readGitOutputWithFallback(
+    cwd,
+    ['diff', '--stat', baseRange],
+    ['diff', '--stat', 'HEAD~1'],
+  );
+  const diff = readGitOutputWithFallback(
+    cwd,
+    ['diff', baseRange, '--no-color', '-U2'],
+    ['diff', 'HEAD~1', '--no-color', '-U2'],
+  );
+
+  return {
+    changedFiles: stat ? parseDiffStat(stat).map((entry) => entry.file) : [],
+    addedLines: extractAddedLines(diff),
+  };
+}

--- a/src/lib/orchestrator/operator-mission-service/review.ts
+++ b/src/lib/orchestrator/operator-mission-service/review.ts
@@ -1,7 +1,9 @@
 import { createApproval, recordApprovalAudit, resolveApproval } from '@/lib/approvals/store';
 import type { OrchestratorReviewFinding } from '@/lib/approvals/types';
+import { getLaneDiffFacts } from '@/lib/lane/lane-diff-facts';
 import { normalizeHeadSha, readHeadSha } from '@/lib/lane/head-sha-lock';
 import { findLaneByPacket, findLatestLaneByPacket } from '@/lib/lane/registry';
+import { classifyReviewRisk } from '@/lib/lane/review-risk';
 import type { Lane } from '@/lib/lane/types';
 import { writeOrchestratorControlPlaneState } from '@/lib/orchestrator/control-plane';
 import { synthesizePacketFromLane } from '@/lib/orchestrator/synthesize-packet';
@@ -107,8 +109,23 @@ function deriveApprovalRisk(findings: OrchestratorReviewFinding[], approved: boo
   return 'low' as const;
 }
 
+function requiresSecondPassForLane(lane: Lane | null, approved: boolean) {
+  if (!approved || !lane?.worktreePath) {
+    return false;
+  }
+
+  try {
+    const facts = getLaneDiffFacts(lane);
+    return classifyReviewRisk(facts.changedFiles, facts.addedLines).tier === 'high';
+  } catch (error) {
+    console.warn(`[review] Failed to classify second-pass requirement for lane ${lane.id}:`, error);
+    return false;
+  }
+}
+
 function recordPacketReviewAudit(packet: OrchestratorPacket, findings: OrchestratorReviewFinding[], approved: boolean, summary: string, reviewedHeadSha?: string) {
   const lane = findLaneByPacket(packet.id);
+  const requiresSecondPass = requiresSecondPassForLane(lane, approved);
   const approval = createApproval({
     source: 'runtime',
     runtime: lane?.runtime ?? packet.runtime,
@@ -123,6 +140,8 @@ function recordPacketReviewAudit(packet: OrchestratorPacket, findings: Orchestra
       approved,
       findings,
       reviewedHeadSha,
+      requiresSecondPass,
+      secondPassAgreed: false,
     },
     risk: deriveApprovalRisk(findings, approved),
     metadata: {


### PR DESCRIPTION
Addresses #1179 **Stage 1 — the fail-closed AGREE-gate** (the AI blind second-pass reviewer is Stage 2, #1185).

High-risk approved diffs now require a **distinct second-pass agreement** before a non-user (orchestrator) merge is authorized — closing the #1164 "approve-and-merge in one breath" class. Until the AI reviewer (#1185) lands, the operator is the second reviewer (a `actor:'user'` merge always bypasses).

## Changes (surgical, chokepoint-aware)
- **Mark** (`review.ts` `recordPacketReviewAudit`): on `approved:true`, classify the lane diff (`classifyReviewRisk`) and stamp `requiresSecondPass = (tier === 'high')` + `secondPassAgreed: false` onto the approval `args`. Fail-OPEN on classification error (a diff-read glitch must not wedge merges — the human backstop remains). No DB migration (`args` is `Record<string,unknown>`).
- **Enforce** (`durable-review-approval.ts` — the single merge-authorizing signal): one added clause — a row only authorizes if NOT (`requiresSecondPass === true && secondPassAgreed !== true`). **Back-compat by construction**: legacy + non-high-risk rows have no `requiresSecondPass`, so they authorize exactly as before.
- **Stamp seam** (`store.ts`): `markSecondPassAgreed(approvalId)` (used by the smoke test + Stage 2; no MCP verb yet).
- **Shared helper** (`lane-diff-facts.ts`): extracted the git diff-facts logic out of `auto-review.ts` so `review.ts` can classify risk without importing the heavy review module — and switched to `execFileSync` (args array) instead of string-interpolated `execSync` (safer).
- **Fixed a stale-comment landmine** (`auto-review.ts`): the old comment claimed Codex can't call `submit_review` (so it'd "fail closed naturally"). That's no longer true — Codex wires the operator MCP now. Replaced with: fail-closed is enforced by *our* gate logic, not a backend capability gap.

## Validation (I ran it — not just reviewed)
- `npx tsc --noEmit` → exit 0.
- **`smoke-merge-requires-review` → 8/8** (`NODE_OPTIONS='--conditions=react-server' npx tsx scripts/smoke-merge-requires-review.ts`):
  - **caseG** (new): high-risk + first-pass approve + no agreement → orchestrator merge `ok:false` + operator card + main unchanged + `hasDurableApprovedReview === false`.
  - **caseH** (new): + `markSecondPassAgreed` → merge `ok:true`, main advances (gate is satisfiable).
  - **caseA–F** (existing): still pass → no regression on the chokepoint.
- Merge-gate preview: `wouldMerge: true`, all checks pass.

## Risk
This edits the merge chokepoint. The back-compat default-allow + the 8/8 smoke (esp. A–F unchanged) are the guards. In PR-only dogfood mode the orchestrator can't merge anyway, so this lands behind the wall.

Built by a Codex worker; orchestrator-reviewed + smoke-validated. Stage 2 (the AI blind second-pass that auto-stamps agreement) is #1185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
