### PR TITLE
feat: blind second-pass auto-review (#1185, #1179 stage 2)

### DIFF
--- a/src/lib/lane/auto-review.ts
+++ b/src/lib/lane/auto-review.ts
@@ -17,6 +17,7 @@ import { runMergeGate, formatMergeGateForReview, type MergeGateResult } from './
 import { extractAddedLines, getLaneDiffFacts, parseDiffStat } from './lane-diff-facts';
 import { buildAdversarialReviewProtocol, classifyReviewRisk } from './review-risk';
 import { resolveLaneReviewScreenshotReference, type LaneReviewScreenshotReference } from './review-screenshot';
+import { buildBlindSecondPassPrompt, findPendingSecondPassApproval, parseSecondPassVerdict } from './blind-second-pass-review';
 import type { Lane } from './types';
 
 const MAX_REVIEW_ATTEMPTS = 5;
@@ -578,5 +579,100 @@ async function performAutoReview(review: QueuedReview): Promise<void> {
     }
   });
 
+  const reviewRisk = classifyReviewRisk(diffSummary.changedFiles, diffSummary.addedLines);
+  if (reviewRisk.tier !== 'high') {
+    console.log(`[auto-review] Review complete for lane ${lane.id}`);
+    return;
+  }
+
+  const pendingSecondPass = await findPendingSecondPassApproval(lane);
+  if (!pendingSecondPass) {
+    console.log(`[auto-review] High-risk lane ${lane.id} has no current-head approval awaiting second pass`);
+    console.log(`[auto-review] Review complete for lane ${lane.id}`);
+    return;
+  }
+
+  const blindPrompt = buildBlindSecondPassPrompt(lane, diffSummary, reviewRisk.reasons);
+  const secondPassThreadId = `thoughts-second-pass-${lane.id}-${randomUUID().slice(0, 8)}`;
+  let secondPassText = '';
+  const secondPassErrors: string[] = [];
+
+  console.log(`[auto-review] Sending blind second-pass review to ${backend.label} for lane ${lane.id}`);
+  try {
+    await backend.sendTurn(lane.repoPath, blindPrompt, (event) => {
+      if (event.type === 'text') {
+        secondPassText += event.text;
+        console.log(`[auto-review] ${backend.label} second-pass: ${event.text.slice(0, 100)}`);
+      } else if (event.type === 'tool_use') {
+        console.log(`[auto-review] ${backend.label} second-pass called tool: ${event.name}`);
+      } else if (event.type === 'error') {
+        secondPassErrors.push(event.error);
+        console.error(`[auto-review] ${backend.label} second-pass error: ${event.error}`);
+      }
+    }, { threadId: secondPassThreadId });
+  } catch (error) {
+    secondPassErrors.push(error instanceof Error ? error.message : String(error));
+  }
+
+  const [{ normalizeHeadSha, readHeadSha }, { createApproval, markSecondPassAgreed }] = await Promise.all([
+    import('@/lib/lane/head-sha-lock'),
+    import('@/lib/approvals/store'),
+  ]);
+  let currentHeadSha: string | undefined;
+  try {
+    currentHeadSha = normalizeHeadSha(await readHeadSha(lane.worktreePath || lane.repoPath));
+  } catch (error) {
+    console.warn(`[auto-review] Failed to re-read HEAD after second pass for lane ${lane.id}:`, error);
+    return;
+  }
+  if (currentHeadSha !== pendingSecondPass.reviewedHeadSha) {
+    console.warn(`[auto-review] Second pass refused to stamp lane ${lane.id}: HEAD moved from ${pendingSecondPass.reviewedHeadSha} to ${currentHeadSha ?? '(unknown)'}`);
+    return;
+  }
+
+  const verdict = secondPassErrors.length > 0
+    ? { verdict: 'inconclusive' as const, reason: `turn error: ${secondPassErrors.join('; ').slice(0, 500)}` }
+    : parseSecondPassVerdict(secondPassText);
+
+  if (verdict.verdict === 'agree') {
+    markSecondPassAgreed(pendingSecondPass.approval.id);
+    const { dispatch } = await import('@/lib/lane/commands');
+    const mergeResult = await dispatch({ verb: 'merge', laneId: lane.id, actor: 'orchestrator' });
+    console.log(`[auto-review] Second-pass agreed for lane ${lane.id}; merge result ok=${mergeResult.ok} note=${mergeResult.note}`);
+    console.log(`[auto-review] Review complete for lane ${lane.id}`);
+    return;
+  }
+
+  const finding = verdict.verdict === 'disagree' ? verdict.finding : verdict.reason;
+  createApproval({
+    projectId: lane.projectId,
+    source: 'runtime',
+    runtime: lane.runtime,
+    agent: lane.label || lane.branch,
+    sessionKey: lane.sessionKey || `lane:${lane.id}`,
+    title: verdict.verdict === 'disagree' ? 'Second-pass reviewer disagreed' : 'Second-pass reviewer inconclusive',
+    description: `Blind second-pass review did not agree at HEAD ${pendingSecondPass.reviewedHeadSha}. Merge remains blocked until an operator reviews the finding.`,
+    summary: finding,
+    toolName: 'orchestrator_second_pass',
+    args: {
+      approvalId: pendingSecondPass.approval.id,
+      laneId: lane.id,
+      packetId: lane.packetId,
+      reviewedHeadSha: pendingSecondPass.reviewedHeadSha,
+      verdict: verdict.verdict,
+      finding,
+    },
+    editable: false,
+    risk: 'high',
+    metadata: {
+      Lane: lane.id,
+      Branch: lane.branch,
+      Base: lane.baseBranch,
+      Runtime: lane.runtime,
+      ...(lane.packetId ? { Packet: lane.packetId } : {}),
+      'Reviewed HEAD': pendingSecondPass.reviewedHeadSha,
+    },
+  });
+  console.warn(`[auto-review] Second pass blocked lane ${lane.id}: ${finding}`);
   console.log(`[auto-review] Review complete for lane ${lane.id}`);
 }

--- a/src/lib/lane/blind-second-pass-review.ts
+++ b/src/lib/lane/blind-second-pass-review.ts
@@ -1,0 +1,125 @@
+import type { ApprovalRecord } from '@/lib/approvals/types';
+import type { Lane } from './types';
+
+export interface BlindSecondPassDiffSummary {
+  summary: string;
+  changedFiles: string[];
+  addedLines: string[];
+  cwd: string;
+}
+
+export type SecondPassVerdict =
+  | { verdict: 'agree' }
+  | { verdict: 'disagree'; finding: string }
+  | { verdict: 'inconclusive'; reason: string };
+
+function reviewedHeadForApproval(approval: ApprovalRecord): string | undefined {
+  const argsHead = approval.args?.reviewedHeadSha;
+  return typeof argsHead === 'string' ? argsHead : approval.metadata?.['Reviewed HEAD'];
+}
+
+export async function findPendingSecondPassApproval(lane: Lane) {
+  try {
+    const [{ listApprovalsForContext }, { normalizeHeadSha, readHeadSha }] = await Promise.all([
+      import('@/lib/approvals/store'),
+      import('@/lib/lane/head-sha-lock'),
+    ]);
+    const currentHeadSha = normalizeHeadSha(await readHeadSha(lane.worktreePath || lane.repoPath));
+    if (!currentHeadSha) return null;
+    const approvals = listApprovalsForContext({
+      packetId: lane.packetId ?? undefined,
+      laneId: lane.id,
+      sessionKey: lane.sessionKey ?? undefined,
+      projectId: null,
+    });
+    const approval = approvals.find((candidate) => {
+      const reviewedHeadSha = normalizeHeadSha(reviewedHeadForApproval(candidate));
+      return candidate.toolName === 'orchestrator_review'
+        && candidate.status === 'approved'
+        && candidate.args?.requiresSecondPass === true
+        && candidate.args?.secondPassAgreed !== true
+        && reviewedHeadSha === currentHeadSha;
+    });
+    const reviewedHeadSha = approval ? normalizeHeadSha(reviewedHeadForApproval(approval)) : undefined;
+    const alreadyBlocked = approval && reviewedHeadSha && approvals.some((candidate) => (
+      candidate.toolName === 'orchestrator_second_pass'
+      && candidate.args?.approvalId === approval.id
+      && candidate.args?.reviewedHeadSha === reviewedHeadSha
+    ));
+    if (alreadyBlocked) return null;
+    return approval && reviewedHeadSha ? { approval, reviewedHeadSha } : null;
+  } catch (error) {
+    console.warn(`[auto-review] Failed to find pending second-pass approval for lane ${lane.id}:`, error);
+    return null;
+  }
+}
+
+export function buildBlindSecondPassPrompt(
+  lane: Lane,
+  diffSummary: BlindSecondPassDiffSummary,
+  highRiskReasons: string[],
+): string {
+  const reasons = highRiskReasons.length > 0
+    ? highRiskReasons.map((reason) => `- ${reason}`).join('\n')
+    : '- high-risk classification returned no structured reason';
+  return [
+    `You are the blind, independent second-pass reviewer for lane "${lane.label}" (branch: ${lane.branch}).`,
+    'Do not rely on any prior review, prior verdict, approval card, summary, or finding. Evaluate only the diff and protocol below.',
+    '',
+    `## High-risk reasons\n${reasons}`,
+    '',
+    diffSummary.summary,
+    '',
+    '## Required verification protocol',
+    `Worktree: ${diffSummary.cwd}`,
+    lane.packetId ? `Packet: ${lane.packetId}` : null,
+    'SCOPE traces: for every changed file that writes or mutates state, cite `SCOPE: <file:line> partition=<repo|tenant|user|project|lane|packet|scope|slug|id|NONE>` and confirm the single intended destination.',
+    'GUARD traces: for every new guard, condition, or early return, cite `GUARD: <file:line> fires-from=<file:line|INERT>`.',
+    'COVERAGE checklist: enumerate each packet sub-requirement as `[x] <sub-requirement> - evidence <file:line|command output>` or `[ ] <sub-requirement> - gap <reason>`.',
+    'EXECUTION-PATH TRACE: trace the actual call path the change runs under, not the one its name implies.',
+    'You may agree only if every guard is live, every write is partitioned correctly, every sub-requirement is covered, and the execution path reaches the changed code.',
+    '',
+    'Do NOT call submit_review. Do NOT call lane_command. Do not stamp or merge anything yourself.',
+    'End your output with EXACTLY one final line:',
+    'SECOND_PASS_VERDICT: agree',
+    'OR',
+    'SECOND_PASS_VERDICT: disagree - <file:line> <reason>',
+  ].filter((value): value is string => value !== null).join('\n');
+}
+
+export function parseSecondPassVerdict(rawText: string): SecondPassVerdict {
+  let text = rawText.trim();
+  if (!text) return { verdict: 'inconclusive', reason: 'empty second-pass response' };
+  if (text.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(text) as Record<string, unknown>;
+      const result = parsed.result && typeof parsed.result === 'object'
+        ? parsed.result as Record<string, unknown>
+        : parsed;
+      const payloadText = Array.isArray(result.payloads)
+        ? result.payloads.map((payload) => (
+          payload && typeof payload === 'object' && typeof (payload as { text?: unknown }).text === 'string'
+            ? (payload as { text: string }).text
+            : ''
+        )).filter(Boolean).join('\n\n')
+        : '';
+      const meta = result.meta && typeof result.meta === 'object' ? result.meta as Record<string, unknown> : {};
+      text = payloadText
+        || (typeof meta.finalAssistantVisibleText === 'string' ? meta.finalAssistantVisibleText : '')
+        || (typeof result.text === 'string' ? result.text : '');
+      if (!text.trim()) return { verdict: 'inconclusive', reason: 'JSON second-pass response had no assistant text' };
+    } catch {
+      return { verdict: 'inconclusive', reason: 'unparseable JSON second-pass response' };
+    }
+  }
+  const lines = text.trim().split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  const finalLine = lines[lines.length - 1] ?? '';
+  if (/^SECOND_PASS_VERDICT:\s*agree$/i.test(finalLine)) return { verdict: 'agree' };
+  const disagree = finalLine.match(/^SECOND_PASS_VERDICT:\s*disagree\s*-\s+(.+)$/i);
+  if (!disagree) return { verdict: 'inconclusive', reason: `missing structured SECOND_PASS_VERDICT tail: ${finalLine.slice(0, 200) || '(none)'}` };
+  const finding = disagree[1].trim();
+  if (!/\b[\w./@-]+:\d+\b/.test(finding)) {
+    return { verdict: 'inconclusive', reason: `disagree lacked a concrete file:line citation: ${finding.slice(0, 200)}` };
+  }
+  return { verdict: 'disagree', finding };
+}


### PR DESCRIPTION
Fixes #1185 — Stage 2 of #1179: the **independent AI blind second-pass reviewer** that satisfies the Stage-1 AGREE-gate (#1186, already in main). This completes the review-gate moat.

## Behavior
After the first-pass review, when the diff is **high-risk** (`classifyReviewRisk().tier === 'high'`) and a first-pass approval is pending second pass at the current HEAD:
- Runs a **second, BLIND** `backend.sendTurn` — a prompt with only the diff + high-risk reasons + the 4 verification traces (guard / scope-partition / sub-requirement / execution-path). It deliberately excludes the first pass's verdict/summary/findings — independence is the point; anchoring on pass-1 defeats it.
- The blind pass returns `SECOND_PASS_VERDICT: agree | disagree - <file:line> <reason>`.
- **agree** → `markSecondPassAgreed` (satisfies the gate) → re-dispatches the merge (now authorized).
- **disagree / inconclusive / error / empty / unparseable / no-citation** → **FAIL CLOSED**: never stamps; surfaces an operator card (`orchestrator_second_pass`) with the finding so the merge stays blocked with a visible reason.

## Safety (the load-bearing bits)
- **Stamp only on a clean `agree`** — every uncertainty path fails closed (no stamp).
- **Same-HEAD guard**: re-reads HEAD after the second pass; if it moved from the reviewed HEAD, refuses to stamp.
- **Idempotent**: won't re-run if a second-pass card already exists for the approval+HEAD, and the `!secondPassAgreed` filter stops re-runs after agreement.
- **All backends**: openclaw's single-blob JSON is parsed; any parse failure fails closed.
- **Cost ceiling**: only runs on high-risk + first-pass-approved lanes.
- In PR-only dogfood mode the re-dispatched merge is still blocked by the wall — correct.

## Verification
- `npx tsc --noEmit` → exit 0 (confirms the `sendTurn` options, event types, `createApproval` shape). Merge-gate preview: `wouldMerge: true`.
- Logic reviewed for fail-closed correctness. **Caveat:** the live model second-pass turn isn't unit-testable (no backend in the harness) — the Stage-1 gate is smoke-proven (8/8, #1186); this Stage-2 turn-logic is review+tsc-validated. Watch the first real high-risk merge in normal (wall-down) operation.

Built by a Codex worker; orchestrator-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
