### PR TITLE
fix(orchestrator): hide archived-lane orphan packets from swarm card (#1188)

### DIFF
--- a/src/components/desktop/thoughts/chat-panel/SwarmStatusCard.tsx
+++ b/src/components/desktop/thoughts/chat-panel/SwarmStatusCard.tsx
@@ -73,7 +73,18 @@ function SwarmGlyph({ size = 13, color = SWARM_ACCENT }: { size?: number; color?
 }
 
 export function SwarmStatusCard({ packets }: { packets: OrchestratorPacket[] }) {
-  const active = packets.filter((packet) => ACTIVE_STATUSES.has(packet.status));
+  const active = packets.filter((packet) => {
+    if (!ACTIVE_STATUSES.has(packet.status)) return false;
+    if (packet.archivedAt) return false;
+    if (packet.releaseState === 'released') return false;
+    // Pre-dispatch packets only belong to the live crew once a lane is bound.
+    // Otherwise an archived lane hidden from the client's active-lane reconcile
+    // can revive an orphaned packet as a phantom "Queued" swarm card.
+    if ((packet.status === 'queued' || packet.status === 'launching') && !packet.lane?.laneId) {
+      return false;
+    }
+    return true;
+  });
   if (active.length === 0) return null;
 
   // Runtime breakdown for the header ("Codex 3").


### PR DESCRIPTION
Closes #1188.

Fixes phantom 'Queued' swarm cards: an archived lane hidden from the client's active-lane reconcile could revive an orphaned packet as a phantom Queued card. `SwarmStatusCard` now excludes packets that are archived, released, or pre-dispatch (queued/launching) without a bound lane.

- Single file: `SwarmStatusCard.tsx` (+12/-1)
- All four new guard fields verified present on `OrchestratorPacket`
- Typecheck: pass • Merge gates: all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)