### PR TITLE
fix: catch camelCase partition tokens in review-gate heuristic (#1184)

### DIFF
--- a/src/lib/lane/review-risk.ts
+++ b/src/lib/lane/review-risk.ts
@@ -32,9 +32,13 @@ const ADVISORY_LINE_RULES: Array<{ pattern: RegExp; reason: string }> = [
 ];
 
 const SCOPE_PARTITION_TOKEN_PATTERN = /\b(?:repo|tenant|user|project|lane|packet|scope|slug|id)\b/i;
+const CAMEL_CASE_BOUNDARY_PATTERN = /([a-z0-9])([A-Z])/g;
 
 export function hasScopePartitionToken(line: string): boolean {
-  return SCOPE_PARTITION_TOKEN_PATTERN.test(line);
+  return (
+    SCOPE_PARTITION_TOKEN_PATTERN.test(line)
+    || SCOPE_PARTITION_TOKEN_PATTERN.test(line.replace(CAMEL_CASE_BOUNDARY_PATTERN, '$1 $2'))
+  );
 }
 
 function addUnique(reasons: string[], seen: Set<string>, reason: string): void {


### PR DESCRIPTION
Fixes #1184.

`hasScopePartitionToken` (`src/lib/lane/review-risk.ts`) used `\b(?:repo|…|id)\b`, so camelCase partition tokens (`repoId`, `perRepoPath`) were missed — a genuinely-partitioned write got flagged as unpartitioned (warn FP), eroding the `checkScopePartitionHeuristics` signal.

**Fix:** test both the line and its de-camelCased form (`line.replace(/([a-z0-9])([A-Z])/g, '$1 $2')`). Catches `perRepoPath`→"per Repo Path", `repoId`→"repo Id" without reintroducing false negatives ("id" inside "considered" still doesn't match).

**Validated:** functional check ALL PASS (camelCase now detected; no FN regression on `considered`/`globalLedgerPath`); `tsc --noEmit` clean; warn-only so no merge-gate behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
