### PR TITLE
fix(review-gate): match camelCase partition tokens to cut warn FP noise (#1184)

### DIFF
--- a/src/lib/lane/review-risk.ts
+++ b/src/lib/lane/review-risk.ts
@@ -32,9 +32,13 @@ const ADVISORY_LINE_RULES: Array<{ pattern: RegExp; reason: string }> = [
 ];
 
 const SCOPE_PARTITION_TOKEN_PATTERN = /\b(?:repo|tenant|user|project|lane|packet|scope|slug|id)\b/i;
+const CAMEL_CASE_BOUNDARY_PATTERN = /([a-z0-9])([A-Z])/g;
 
 export function hasScopePartitionToken(line: string): boolean {
-  return SCOPE_PARTITION_TOKEN_PATTERN.test(line);
+  return (
+    SCOPE_PARTITION_TOKEN_PATTERN.test(line)
+    || SCOPE_PARTITION_TOKEN_PATTERN.test(line.replace(CAMEL_CASE_BOUNDARY_PATTERN, '$1 $2'))
+  );
 }
 
 function addUnique(reasons: string[], seen: Set<string>, reason: string): void {


### PR DESCRIPTION
Closes #1184.

`hasScopePartitionToken` matched only whole-word tokens (`\b(repo|tenant|user|project|lane|packet|scope|slug|id)\b`), which **misses camelCase identifiers** — `\buser\b` does not match inside `userId` (no word boundary between `r` and `I`). The scope-partition write heuristic at `merge-gate.ts:347` treats a present partition token as 'properly scoped' and **suppresses** the advisory warn, so missing camelCase tokens produced false-positive warnings on correctly-scoped writes (`repoId`, `tenantId`, `laneId`, `projectSlug`, …).

**Fix:** also run the pattern against a camelCase-split copy of the line (`userId` → `user Id`), so those identifiers register and the FP warn is suppressed.

- Single file: `src/lib/lane/review-risk.ts` (+5/-1)
- `tsc --noEmit` → 0; no test runner in repo. Consumer: `merge-gate.ts` (suppression direction confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)