### PR TITLE
chore(entitlement): tier flag-reader foundation (M1)

### DIFF
--- a/docs/monetization-build-plan.md
+++ b/docs/monetization-build-plan.md
@@ -1,0 +1,41 @@
+# o8 Monetization — Build Plan (open-core)
+
+**Status:** canonical build plan · 2026-06-07 · **internal** (exclude from the OSS mirror — see M7). Pairs with `docs/monetization-tiers.md` (the Free/Pro matrix).
+
+## Architecture (the load-bearing insight)
+o8 ships as a signed `.dmg` — a runtime `if(plan==='pro')` protects nothing (untar the `.app`, read the JS). So **the moats must be PHYSICALLY ABSENT from the public OSS artifact**, not flag-hidden. Open-core resolves to: **one private monorepo (source of truth) + a scripted, allowlist-driven public mirror** (`hurttlocker/o8`) that copies only free-core paths. Pro dirs are never listed → never mirrored. Extends the existing `sync-changelog.yml` one-way push.
+
+**Entitlement = dual-layer:** Layer 1 (truth) — a verifier in the OSS core checks a signed license JWT against a public key baked into source (same trust model as the Tauri updater; private key on Railway). Layer 2 (UX) — a client `EntitlementProvider` + `<Gate flag fallback={<UpgradePrompt/>}>`. In the OSS build the Pro modules are absent → dynamic import throws → falls back to free. **Server-gate the genuinely-valuable surfaces** (team, license validation, future cloud) — a cracked client can't fake those.
+
+**Verified, de-risking the build:** Clerk middleware already wired (`src/middleware.ts`); `users.plan` enum + `subscriptions` table already in `schema.ts` (`plan` read in exactly one place, a token-budget check — no enforcement to rip out); the FREE single-pass review gate is cleanly separable (the Pro second-pass is only reached via `requiresSecondPass`/`tier==='high'`). `src/lib/entitlement/` + `src/lib/pro/` are greenfield.
+
+## Milestones (~9, ~6-9 weeks before public GTM)
+| # | Milestone | Est | Deps |
+|---|---|---|---|
+| **M1** | Entitlement reader + flag derivation (`src/lib/entitlement/` store/flags/types + `GET /api/panel/entitlement`) — gating-independent, ZERO behavior change | small | none |
+| M2 | Client `EntitlementProvider` + `<Gate>`/`<UpgradePrompt>` | small | M1 |
+| M3 | Settings Plan/Billing tab + finish Clerk profile wiring | medium | M2 |
+| M4 | License verifier (offline-first, 30-day grace, signed JWT) | medium | M1 |
+| M5 | Railway entitlement server + Stripe checkout (the payment stack) | large | M3, M4 |
+| M6 | Gate the Pro features (dual-layer: server 402 + client `<Gate>`); fresh-free-DB smoke proving single-pass still blocks | large | M4, M5 |
+| M7 | OSS-core carve: `oss-manifest.json` allowlist + `build-oss-mirror.mjs` + cleaning + standalone OSS CI | large | M6 |
+| M8 | README-as-storefront + o8.run landing tie | medium | M7 |
+| M9 | Launch (Show HN on the gate moment, Reddit wedge, 90-day activation loop) | medium | M5, M8 |
+
+Each ships independently on the existing `npm version patch && npm run ship` loop. **Build native (Claude workflows + me); conserve Codex.** Governance on the diff: PR → CI → validate → merge.
+
+## Open decisions (operator — needed by M5/M8, NOT blocking M1-M4)
+1. **Pricing** — floated $29/mo solo Pro · $49/seat team (unvalidated). Provisional number needed before M8; lock by ~day 75 from paid betas.
+2. **Trial shape** — rec: **none, Free IS the trial** (moats are depth, not time). Confirm before M5.
+3. **OSS license** — rec: **BUSL-1.1** (source-available, blocks competitor resale) vs MIT (max stars). Blocks M8.
+4. **Clerk vs license-key auth** — rec: **Clerk login for Pro purchase** (maps stripeCustomerId→userId), license-key works offline thereafter. Affects M3/M5.
+5. **Telemetry** — rec: **opt-in aggregate, OFF by default, no PII** (install + first-dispatch activation). Approve payload + copy before M9.
+6. **Windows/Linux** — rec: **macOS-first + transparent "v2"** (caps launch reach ~40%).
+
+## Top risks (mitigations baked into the milestones)
+- Desktop binaries inspectable → **accept**; physical absence + server-gate, not client DRM.
+- M7 seam refactor invasive → standalone OSS CI is the forcing function; gate per-domain.
+- License-server outage must not brick Pro → **offline grace from day one (M4)**.
+- Activation regression → M6 fresh-free-DB smoke proving single-pass still blocks a bad merge.
+- Activation depends on real bugs → seed betas with messy refactors; headline the gate moment.
+- Brain ingestion / codename leak on mirror → ship OSS-safe spec files; allowlist + blocklist grep gate.

--- a/docs/monetization-tiers.md
+++ b/docs/monetization-tiers.md
@@ -1,0 +1,48 @@
+# o8 Monetization — Free / Pro tiers (DRAFT)
+
+**Status:** draft for operator review · 2026-06-07 · **internal strategy** (not for the public/OSS repo).
+
+## Principle — gate the moats, give away the commodity
+Per our doctrine ("don't build what models will commoditize"), orchestration quality, cost dashboards, and prompt tools are **table stakes** → they go in **Free** to win adoption. The **moats** — governance, organizational memory, fleet, mobile/teams — are **Pro**.
+
+> **The load-bearing rule: activation lives in Free, depth lives in Pro.**
+> Free users must *feel* governance catch a real bug on first run, or the funnel leaks at the top. Pro is what they upgrade to once they trust o8 on real work.
+
+---
+
+## FREE — *"stretch your plan, locally, with a taste of governance"*
+The wedge for the quota-burning + local-first crowd (r/LocalLLaMA, r/ClaudeAI, r/cursor).
+
+| Capability | Why Free |
+|---|---|
+| Local-first desktop app · **BYO-key** (Claude / Codex / Gemini / OpenAI / OpenRouter) · data in `~/.o8` | The local-first trust pitch; acquisition |
+| **Orchestrator** (Claude orchestrates) + **dispatch Codex** in isolated worktrees | The core loop = the "stretch your plan" hook |
+| **Single repo / single workspace** · terminals · chat · tile workspace | Enough to be genuinely useful, not crippleware |
+| **Single-pass review gate** | ← **the activation** — watch governance catch a bug before merge |
+| Basic approvals inbox (approve / reject) · manual merge | Feel the operator surface |
+| Cost / usage visibility | Table stakes (models commoditize this) |
+
+## PRO — *"govern a fleet, with memory, on the go, as a team"*
+Each bucket is one of the four moats.
+
+| Bucket | What's gated |
+|---|---|
+| **Deep governance** | AI second-pass review + the AGREE-gate · approval policies · full audit trail · merge + pre-ship boot gate |
+| **Organizational memory** | Cortex directives + session ledger + the **Engineering Brain** Q&A |
+| **Fleet** | Multi-repo orchestration · parallel agent swarms · fleet view |
+| **Mobile operator control** | Approve / dispatch / steer from your phone |
+| **Teams** | Profiles · shared directives · cross-repo governance · team audit |
+
+---
+
+## Why this split holds
+- Forking the Free core gives a competitor the **commodity loop, not the moats** (and the moats need the license server + ongoing dev). Nothing defensible is lost by open-sourcing the core.
+- Free is real (drives adoption + GitHub stars), but the **depth** that makes o8 indispensable on real/team work is Pro.
+
+## Open questions (operator)
+- Exact gating line *within* governance — how much second-pass / audit shows in Free as the "taste"?
+- Pricing — solo Pro $/mo · team $/seat.
+- Trial — time-limited Pro trial vs. usage-limited.
+
+## Plumbing (our defaults, once gating is locked)
+Stripe billing + license key → Clerk profiles/auth → Railway entitlement server (Stripe webhook issues/revokes keys) → app validates key → flips Pro feature flags. Desktop licensing, not seat-based SaaS login.

--- a/src/app/api/panel/entitlement/route.ts
+++ b/src/app/api/panel/entitlement/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+
+import { resolveFlags } from '@/lib/entitlement/flags';
+import { getEntitlement } from '@/lib/entitlement/store';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/panel/entitlement — returns the resolved { plan, flags, source }.
+ * Already loopback+token gated via GATED_PREFIXES ('/api/panel/') in
+ * src/middleware.ts. Never throws (repo rule): falls back to free on any error.
+ */
+export async function GET() {
+  try {
+    const entitlement = await getEntitlement();
+    return NextResponse.json(entitlement);
+  } catch (error) {
+    console.error('[entitlement] route failed:', error);
+    return NextResponse.json({ plan: 'free', flags: resolveFlags('free'), source: 'default' });
+  }
+}

--- a/src/lib/entitlement/flags.ts
+++ b/src/lib/entitlement/flags.ts
@@ -1,0 +1,24 @@
+import type { EntitlementFlags, Plan } from './types';
+
+/**
+ * The SINGLE source of truth for the Free / Pro / Team tier matrix.
+ *
+ * Pure function, no I/O. Every entitlement decision in the app derives from
+ * here — gating code should check a resolved flag, never branch on `plan`.
+ *
+ *  - free: all moats locked.
+ *  - pro:  governance second-pass, Engineering Brain, multi-repo fleet, and
+ *          mobile operator control unlocked; team sharing stays locked.
+ *  - team: everything pro unlocks, plus shared/team governance.
+ */
+export function resolveFlags(plan: Plan): EntitlementFlags {
+  const pro = plan === 'pro' || plan === 'team';
+  const team = plan === 'team';
+  return {
+    'governance.secondPass': pro,
+    'memory.brain': pro,
+    'fleet.multiRepo': pro,
+    'mobile.control': pro,
+    'team.shared': team,
+  };
+}

--- a/src/lib/entitlement/store.ts
+++ b/src/lib/entitlement/store.ts
@@ -1,0 +1,91 @@
+import 'server-only';
+
+import { readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { resolveFlags } from './flags';
+import type { EntitlementState, Plan } from './types';
+
+/**
+ * Entitlement reader — resolves the active plan with env > file > default
+ * precedence, modeled on src/lib/worker/feature-flags.ts. ENOENT-tolerant
+ * (a missing file is the common free case, not an error). Never throws.
+ *
+ * The license/Stripe path (M4/M5) writes the file; M1 only reads it.
+ */
+
+const ENTITLEMENT_FILE = 'entitlement.json';
+const VALID_PLANS: readonly Plan[] = ['free', 'pro', 'team'];
+
+interface EntitlementFile {
+  plan?: unknown;
+  licenseKey?: string;
+  status?: string;
+  expiresAt?: string;
+}
+
+function getEntitlementPath() {
+  return path.join(
+    process.env.CORTEX_IDE_DATA_DIR || path.join(os.homedir(), '.cortex-ide'),
+    ENTITLEMENT_FILE,
+  );
+}
+
+function coercePlan(value: unknown): Plan | null {
+  return typeof value === 'string' && (VALID_PLANS as readonly string[]).includes(value)
+    ? (value as Plan)
+    : null;
+}
+
+function getEnvPlan(): Plan | null {
+  return coercePlan(process.env.O8_PLAN);
+}
+
+function readFilePlan(raw: string): Plan | null {
+  const parsed = JSON.parse(raw) as EntitlementFile;
+  return coercePlan(parsed.plan);
+}
+
+function isMissingFile(error: unknown) {
+  return (error as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
+function toState(plan: Plan, source: EntitlementState['source']): EntitlementState {
+  return { plan, flags: resolveFlags(plan), source };
+}
+
+export async function getEntitlement(): Promise<EntitlementState> {
+  const envPlan = getEnvPlan();
+  if (envPlan) return toState(envPlan, 'env');
+
+  try {
+    const raw = await readFile(getEntitlementPath(), 'utf8');
+    const filePlan = readFilePlan(raw);
+    if (filePlan) return toState(filePlan, 'file');
+  } catch (error) {
+    if (!isMissingFile(error)) {
+      console.error('[entitlement] Failed to read entitlement:', error);
+    }
+  }
+
+  return toState('free', 'default');
+}
+
+export function getEntitlementSync(): EntitlementState {
+  const envPlan = getEnvPlan();
+  if (envPlan) return toState(envPlan, 'env');
+
+  try {
+    const raw = readFileSync(getEntitlementPath(), 'utf8');
+    const filePlan = readFilePlan(raw);
+    if (filePlan) return toState(filePlan, 'file');
+  } catch (error) {
+    if (!isMissingFile(error)) {
+      console.error('[entitlement] Failed to read entitlement during startup:', error);
+    }
+  }
+
+  return toState('free', 'default');
+}

--- a/src/lib/entitlement/types.ts
+++ b/src/lib/entitlement/types.ts
@@ -1,0 +1,30 @@
+/**
+ * Entitlement types — the open-core Free/Pro/Team tier model.
+ *
+ * This module is the type substrate for the entitlement layer. It is pure
+ * (no I/O, not server-only) so both server code (store.ts) and the future
+ * client provider can import it.
+ */
+
+export type Plan = 'free' | 'pro' | 'team';
+
+/**
+ * The Pro/Team feature flags. Each key maps to a moat surface that the free
+ * tier does not unlock. `resolveFlags()` (flags.ts) is the single place that
+ * derives these from a Plan — never branch on `plan` directly elsewhere.
+ */
+export interface EntitlementFlags {
+  'governance.secondPass': boolean;
+  'memory.brain': boolean;
+  'fleet.multiRepo': boolean;
+  'mobile.control': boolean;
+  'team.shared': boolean;
+}
+
+export type EntitlementSource = 'env' | 'file' | 'default';
+
+export interface EntitlementState {
+  plan: Plan;
+  flags: EntitlementFlags;
+  source: EntitlementSource;
+}


### PR DESCRIPTION
**M1 of the open-core monetization build (epic hurttlocker/o8-business#3).** Gating-independent foundation — **zero behavior change** (no feature consumes these flags yet).

Adds `src/lib/entitlement/`:
- `types.ts` — `Plan` ('free'|'pro'|'team'), `EntitlementFlags`, `EntitlementState`.
- `flags.ts` — `resolveFlags(plan)`: the single source of the tier matrix (free=all off; pro=governance.secondPass/memory.brain/fleet.multiRepo/mobile.control; team=+team.shared). Pure, no I/O.
- `store.ts` (`server-only`) — env (`O8_PLAN`) > file (`~/.o8/entitlement.json`) > default `free`, sync + async readers, ENOENT-tolerant, never throws. Mirrors `src/lib/worker/feature-flags.ts`.
- `GET /api/panel/entitlement` — returns `{plan,flags,source}`; already loopback+token gated via `/api/panel/` in middleware; never throws (falls back to free).

**Validated:** `tsc --noEmit` clean; eslint clean; smoke (`O8_PLAN=pro` → `governance.secondPass:true`; empty dir → `free`/all-off). No `schema.ts`/DB/feature changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
