### PR TITLE
chore(entitlement): client provider + Gate/UpgradePrompt (M2)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -16,6 +16,7 @@ import { useLeftPanelProjectFocus } from '@/components/desktop/repo-focus/useLef
 import type { CanvasTab } from '@/components/desktop/Canvas';
 import type { SettingsTab } from '@/components/desktop/SettingsPage';
 import { AlertProvider, useAlerts } from '@/lib/alerts/context';
+import { EntitlementProvider } from '@/lib/entitlement/context';
 // ConnectionBanner retired — ConnectionPill in AgentPanel surfaces WS state.
 import { ThemeProvider, useTheme } from '@/lib/theme/context';
 import { AlertToast } from '@/components/shared/AlertToast';
@@ -556,11 +557,13 @@ export default function DashboardPage() {
   return (
     <ThemeProvider>
       <AlertProvider>
-        <ReactiveQueryProvider>
-          <DesktopWebSocketProvider>
-            <DashboardInner />
-          </DesktopWebSocketProvider>
-        </ReactiveQueryProvider>
+        <EntitlementProvider>
+          <ReactiveQueryProvider>
+            <DesktopWebSocketProvider>
+              <DashboardInner />
+            </DesktopWebSocketProvider>
+          </ReactiveQueryProvider>
+        </EntitlementProvider>
       </AlertProvider>
     </ThemeProvider>
   );

--- a/src/lib/entitlement/Gate.tsx
+++ b/src/lib/entitlement/Gate.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+/**
+ * <Gate flag="..."> — renders children only when the entitlement flag is on,
+ * otherwise renders `fallback` (or null). Tiny, pure. No feature is wired to a
+ * Gate yet (M2 ships the primitive; gating lands in later milestones).
+ */
+
+import { useEntitlement } from './context';
+import type { EntitlementFlags } from './types';
+
+interface GateProps {
+  flag: keyof EntitlementFlags;
+  fallback?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export function Gate({ flag, fallback = null, children }: GateProps) {
+  const { flags } = useEntitlement();
+  return <>{flags[flag] ? children : fallback}</>;
+}

--- a/src/lib/entitlement/UpgradePrompt.tsx
+++ b/src/lib/entitlement/UpgradePrompt.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+/**
+ * <UpgradePrompt feature="..."> — a small, tasteful inline upgrade affordance
+ * shown where a Pro/Team-only feature would otherwise render. Inline styles +
+ * var(--t-*) tokens only (themed surfaces never get hardcoded rgba). Raw-SVG
+ * lock glyph reused from settings/shared.tsx (no React icon components in the
+ * Tauri webview).
+ *
+ * The Upgrade button is a stub for M2 — it deep-links to the Billing tab which
+ * ships in M3. See onClick below.
+ */
+
+import { motion } from 'framer-motion';
+
+import { LockIcon, THEME_ACCENT } from '@/components/desktop/settings/shared';
+
+interface UpgradePromptProps {
+  feature: string;
+}
+
+export function UpgradePrompt({ feature }: UpgradePromptProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+      style={
+        {
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 10,
+          paddingTop: 8,
+          paddingBottom: 8,
+          paddingLeft: 12,
+          paddingRight: 12,
+          borderRadius: 10,
+          backgroundColor: 'var(--t-bg-card)',
+          borderWidth: 1,
+          borderStyle: 'solid',
+          borderColor: 'var(--t-panel-border, var(--t-divider-subtle))',
+        } as React.CSSProperties
+      }
+    >
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: THEME_ACCENT,
+          flexShrink: 0,
+        }}
+      >
+        <LockIcon />
+      </span>
+      <span
+        style={{
+          fontSize: 12.5,
+          color: 'var(--t-text-muted)',
+          lineHeight: 1.35,
+        }}
+      >
+        <span style={{ color: 'var(--t-text)', fontWeight: 500 }}>{feature}</span>
+        {' is a Pro feature.'}
+      </span>
+      <button
+        type="button"
+        onClick={() => {
+          // TODO(M3): deep-link to the Billing tab (Settings → Billing) once it
+          // lands. No-op for M2 — the entitlement rendering layer only.
+        }}
+        style={{
+          appearance: 'none',
+          cursor: 'pointer',
+          fontSize: 12.5,
+          fontWeight: 500,
+          color: THEME_ACCENT,
+          backgroundColor: 'transparent',
+          borderWidth: 1,
+          borderStyle: 'solid',
+          borderColor: 'var(--t-panel-border, var(--t-divider-subtle))',
+          borderRadius: 7,
+          paddingTop: 4,
+          paddingBottom: 4,
+          paddingLeft: 10,
+          paddingRight: 10,
+          flexShrink: 0,
+        }}
+      >
+        Upgrade
+      </button>
+    </motion.div>
+  );
+}

--- a/src/lib/entitlement/context.tsx
+++ b/src/lib/entitlement/context.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+/**
+ * EntitlementProvider — client-side entitlement state.
+ *
+ * Fetches GET /api/panel/entitlement once on mount and exposes the resolved
+ * plan + flags to the dashboard tree. Modeled on src/lib/theme/context.tsx
+ * (createContext + provider + hook). The /api/panel/* route is loopback-gated
+ * in src/middleware.ts; the Tauri webview runs same-origin so a plain relative
+ * fetch passes the gate — no auth header to add (matches every other
+ * /api/panel/* client caller, e.g. UpdateCard / ApprovalBanner).
+ *
+ * Defaults to free + loading=true until the fetch resolves, and falls back to
+ * free if the fetch fails (never crashes the dashboard). No feature is gated
+ * here — this is the rendering layer only (M2).
+ */
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useMemo,
+} from 'react';
+
+import { resolveFlags } from './flags';
+import type { EntitlementFlags, Plan } from './types';
+
+interface EntitlementContextValue {
+  plan: Plan;
+  flags: EntitlementFlags;
+  isPro: boolean;
+  isTeam: boolean;
+  loading: boolean;
+}
+
+const FREE_FLAGS = resolveFlags('free');
+
+const EntitlementContext = createContext<EntitlementContextValue>({
+  plan: 'free',
+  flags: FREE_FLAGS,
+  isPro: false,
+  isTeam: false,
+  loading: true,
+});
+
+export function useEntitlement() {
+  return useContext(EntitlementContext);
+}
+
+interface EntitlementResponse {
+  plan?: unknown;
+  flags?: unknown;
+}
+
+function coercePlan(value: unknown): Plan {
+  return value === 'pro' || value === 'team' ? value : 'free';
+}
+
+export function EntitlementProvider({ children }: { children: React.ReactNode }) {
+  const [plan, setPlan] = useState<Plan>('free');
+  const [flags, setFlags] = useState<EntitlementFlags>(FREE_FLAGS);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const res = await fetch('/api/panel/entitlement', { cache: 'no-store' });
+        if (!res.ok) throw new Error(`entitlement fetch failed: ${res.status}`);
+        const data = (await res.json()) as EntitlementResponse;
+        if (cancelled) return;
+        const nextPlan = coercePlan(data.plan);
+        setPlan(nextPlan);
+        // Re-derive flags from the plan so the client always agrees with the
+        // single source of truth (flags.ts), even if the payload is partial.
+        setFlags(resolveFlags(nextPlan));
+      } catch (error) {
+        // Never crash the dashboard — fall back to free.
+        console.error('[entitlement] client fetch failed, defaulting to free:', error);
+        if (cancelled) return;
+        setPlan('free');
+        setFlags(FREE_FLAGS);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const value = useMemo<EntitlementContextValue>(
+    () => ({
+      plan,
+      flags,
+      isPro: plan === 'pro' || plan === 'team',
+      isTeam: plan === 'team',
+      loading,
+    }),
+    [plan, flags, loading],
+  );
+
+  return (
+    <EntitlementContext.Provider value={value}>{children}</EntitlementContext.Provider>
+  );
+}


### PR DESCRIPTION
M2 of epic hurttlocker/o8-business#3. Client EntitlementProvider + useEntitlement + <Gate> + <UpgradePrompt>. No feature gated yet. tsc+lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)