### PR TITLE
Tool-Spine Phase 1: one source of truth for MCP server config (A–E, zero behavior change)

### DIFF
--- a/src/app/api/setup/claude-desktop/route.ts
+++ b/src/app/api/setup/claude-desktop/route.ts
@@ -21,10 +21,12 @@
 export const dynamic = 'force-dynamic';
 
 import { NextResponse } from 'next/server';
-import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync, statSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { execSync } from 'node:child_process';
-import { getApiBase } from '@/lib/panel/api-port';
+import { existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { readClaudeConfig, atomicWriteConfig } from '@/lib/mcp/claude-desktop-config-io';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { entriesForSurface } from '@/lib/mcp/tool-spine/registry';
+import { toClaudeDesktopJson } from '@/lib/mcp/tool-spine/emit-claude-desktop';
 
 // ── Config path resolution ──
 
@@ -48,135 +50,13 @@ function getTargetConfigPath(target: Target): string {
   return join(home, '.claude.json');
 }
 
-// ── Server config builder (mirrors /api/setup/mcp-config) ──
-
-function findCommand(name: string): string | null {
-  try {
-    const which = execSync(`command -v ${name} 2>/dev/null`, { encoding: 'utf-8' }).trim();
-    return which || null;
-  } catch {
-    return null;
-  }
-}
-
-interface McpServerConfig {
-  command: string;
-  args: string[];
-  env: Record<string, string>;
-}
-
-function buildServerConfig(): McpServerConfig {
-  const bundled = process.env.O8_BUNDLED_MCP_PATH;
-  if (bundled && existsSync(bundled)) {
-    // Prefer the node path the Tauri sidecar resolved via login shell
-    // (handles nvm/fnm/volta that Finder's minimal PATH misses).
-    const nodeBin = process.env.O8_NODE_BIN || findCommand('node') || 'node';
-    return {
-      command: nodeBin,
-      args: [bundled],
-      env: { O8_API_BASE: getApiBase() },
-    };
-  }
-
-  const repoRoot = process.cwd();
-  const tsSource = join(repoRoot, 'src', 'lib', 'mcp', 'operator-mcp-server.ts');
-  const tsxBin = findCommand('tsx');
-
-  if (existsSync(tsSource) && tsxBin) {
-    return {
-      command: tsxBin,
-      args: [tsSource],
-      env: { O8_API_BASE: getApiBase() },
-    };
-  }
-
-  return {
-    command: 'npx',
-    args: ['tsx', tsSource],
-    env: { O8_API_BASE: getApiBase() },
-  };
-}
-
-/**
- * Resolve the codebase-memory-mcp binary, falling back from the env var the
- * Tauri sidecar sets (#739) to the deterministic install path. Returns null
- * when neither resolves — in which case the caller MUST omit the entry so
- * cold first launch doesn't break Claude Code session boot.
- */
-function resolveCodebaseMemoryBin(): string | null {
-  const fromEnv = process.env.O8_CODEBASE_MEMORY_BIN;
-  if (fromEnv && fromEnv.trim() && existsSync(fromEnv)) {
-    return fromEnv;
-  }
-
-  const home = process.env.HOME || process.env.USERPROFILE || '';
-  if (!home) return null;
-
-  const fileName = process.platform === 'win32'
-    ? 'codebase-memory-mcp.exe'
-    : 'codebase-memory-mcp';
-  const deterministic = join(home, '.o8', 'bin', fileName);
-  if (existsSync(deterministic)) {
-    return deterministic;
-  }
-
-  return null;
-}
-
-function buildCodebaseMemoryConfig(): McpServerConfig | null {
-  const bin = resolveCodebaseMemoryBin();
-  if (!bin) return null;
-  return {
-    command: bin,
-    args: [],
-    env: {},
-  };
-}
-
-// ── Tolerant JSON read ──
-
-interface ClaudeConfig {
-  mcpServers?: Record<string, unknown>;
-  [key: string]: unknown;
-}
-
-function readClaudeConfig(path: string): ClaudeConfig {
-  if (!existsSync(path)) return {};
-  try {
-    const raw = readFileSync(path, 'utf-8').trim();
-    if (!raw) return {};
-    return JSON.parse(raw) as ClaudeConfig;
-  } catch {
-    // Malformed — return empty so the caller can decide whether to bail or
-    // overwrite with a fresh file.
-    return {};
-  }
-}
-
-function atomicWriteConfig(path: string, config: ClaudeConfig): void {
-  const dir = dirname(path);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
-
-  // Back up the existing file before overwriting.
-  if (existsSync(path)) {
-    const backupPath = `${path}.o8-backup-${Date.now()}`;
-    try {
-      copyFileSync(path, backupPath);
-    } catch {
-      // Don't block the write on a failed backup.
-    }
-  }
-
-  const tmpPath = `${path}.o8-tmp`;
-  writeFileSync(tmpPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
-
-  // On Unix we could rename() atomically, but on all supported platforms
-  // Node's writeFileSync + rename is good enough for a config file.
-  const { renameSync } = require('node:fs') as typeof import('node:fs');
-  renameSync(tmpPath, path);
-}
+// ── Server config: the Tool-Spine claude-desktop projection ──
+//
+// The operator ("o8") + codebase-memory entries (type stripped for stdio) come
+// from one registry projection — `toClaudeDesktopJson` for the merge write,
+// `entriesForSurface(..., 'claude-desktop')` for the install list. repoPath is
+// irrelevant to this surface (cortex/externals are filtered out), so any path
+// works; process.cwd() keeps the resolver inputs identical to the old builder.
 
 // ── Routes ──
 
@@ -199,8 +79,9 @@ export async function GET(request: Request) {
     const existingEntry = existingServers['o8'];
     const existingCodebaseMemoryEntry = existingServers['codebase-memory'];
 
-    const proposed = buildServerConfig();
-    const proposedCodebaseMemory = buildCodebaseMemoryConfig();
+    const projected = toClaudeDesktopJson(buildToolRegistry(process.cwd()), {}).mcpServers as Record<string, unknown>;
+    const proposed = projected['o8'];
+    const proposedCodebaseMemory = projected['codebase-memory'] ?? null;
 
     const alreadyUpToDate = Boolean(
       existingEntry
@@ -274,19 +155,14 @@ export async function POST(request: Request) {
       return NextResponse.json({ ok: true, action: 'no-op', path, detail: 'o8 was not registered' });
     }
 
-    servers['o8'] = buildServerConfig();
-
-    // codebase-memory is opt-in: only register when the binary resolves.
-    // Cold first launch (binary not yet downloaded) skips this gracefully so
-    // session boot doesn't break.
-    const codebaseMemory = buildCodebaseMemoryConfig();
-    const installed: string[] = ['o8'];
-    if (codebaseMemory) {
-      servers['codebase-memory'] = codebaseMemory;
-      installed.push('codebase-memory');
-    }
-
-    atomicWriteConfig(path, config);
+    // Merge via the Tool-Spine claude-desktop projection: spreads every existing
+    // server + top-level key, overwrites only o8 + codebase-memory, strips the
+    // stdio `type`. codebase-memory is opt-in — the registry omits it when its
+    // binary is absent (cold first launch), so it's simply not in `installed`.
+    const registry = buildToolRegistry(process.cwd());
+    const installed = entriesForSurface(registry, 'claude-desktop').map((entry) => entry.name);
+    const merged = toClaudeDesktopJson(registry, config);
+    atomicWriteConfig(path, merged);
 
     return NextResponse.json({
       ok: true,
@@ -294,7 +170,7 @@ export async function POST(request: Request) {
       target,
       path,
       installed,
-      codebaseMemoryAvailable: Boolean(codebaseMemory),
+      codebaseMemoryAvailable: installed.includes('codebase-memory'),
       detail:
         target === 'claude-desktop'
           ? 'Restart Claude Desktop to load the o8 tools.'

--- a/src/app/api/setup/external-client/route.ts
+++ b/src/app/api/setup/external-client/route.ts
@@ -28,7 +28,9 @@ import { existsSync } from 'node:fs';
 import { execFile, execFileSync, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { join } from 'node:path';
-import { getApiBase } from '@/lib/panel/api-port';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { toClaudeDesktopJson } from '@/lib/mcp/tool-spine/emit-claude-desktop';
+import { hermesAddArgs, openclawSetPayload } from '@/lib/mcp/external-client-args';
 
 const execFileAsync = promisify(execFile);
 
@@ -87,19 +89,7 @@ function resolveCli(name: string): string | null {
   return null;
 }
 
-// ── o8 MCP server config (mirrors /api/setup/claude-desktop) ──
-
-function findCommand(name: string): string | null {
-  try {
-    const which = execFileSync('command', ['-v', name], {
-      encoding: 'utf-8',
-      shell: '/bin/sh',
-    } as never).trim();
-    return which || null;
-  } catch {
-    return null;
-  }
-}
+// ── o8 MCP server config: the Tool-Spine claude-desktop projection ──
 
 interface McpServerConfig {
   command: string;
@@ -107,34 +97,14 @@ interface McpServerConfig {
   env: Record<string, string>;
 }
 
+// external-client forwards ONLY the operator entry (named "o8") — never
+// codebase-memory or DB externals — so it picks the `o8` key out of the Set-B
+// projection. repoPath is irrelevant to this surface (cortex/externals filtered
+// out); process.cwd() keeps resolver inputs identical to the old builder.
 function buildServerConfig(): McpServerConfig {
-  const bundled = process.env.O8_BUNDLED_MCP_PATH;
-  if (bundled && existsSync(bundled)) {
-    const nodeBin = process.env.O8_NODE_BIN || findCommand('node') || 'node';
-    return {
-      command: nodeBin,
-      args: [bundled],
-      env: { O8_API_BASE: getApiBase() },
-    };
-  }
-
-  const repoRoot = process.cwd();
-  const tsSource = join(repoRoot, 'src', 'lib', 'mcp', 'operator-mcp-server.ts');
-  const tsxBin = findCommand('tsx');
-
-  if (existsSync(tsSource) && tsxBin) {
-    return {
-      command: tsxBin,
-      args: [tsSource],
-      env: { O8_API_BASE: getApiBase() },
-    };
-  }
-
-  return {
-    command: 'npx',
-    args: ['tsx', tsSource],
-    env: { O8_API_BASE: getApiBase() },
-  };
+  const projected = toClaudeDesktopJson(buildToolRegistry(process.cwd()), {}).mcpServers as Record<string, unknown>;
+  const o8 = projected['o8'] as { command: string; args: string[]; env?: Record<string, string> };
+  return { command: o8.command, args: o8.args, env: o8.env ?? {} };
 }
 
 // ── Hermes ──
@@ -164,13 +134,7 @@ async function hermesInstall(cliPath: string, server: McpServerConfig): Promise<
   // `hermes mcp add` connects to the server, lists its tools, and then prompts
   // `Enable all N tools? [Y/n/select]:` interactively. We write `Y\n` to stdin
   // so the install runs unattended.
-  const args = ['mcp', 'add', 'o8', '--command', server.command];
-  if (server.args.length > 0) {
-    args.push('--args', ...server.args);
-  }
-  for (const [k, v] of Object.entries(server.env)) {
-    args.push('--env', `${k}=${v}`);
-  }
+  const args = hermesAddArgs(server);
 
   await new Promise<void>((resolve, reject) => {
     const child = spawn(cliPath, args, { stdio: ['pipe', 'pipe', 'pipe'] });
@@ -243,11 +207,7 @@ async function openclawStatus(cliPath: string): Promise<{ registered: boolean; r
 }
 
 async function openclawInstall(cliPath: string, server: McpServerConfig): Promise<void> {
-  const payload = JSON.stringify({
-    command: server.command,
-    args: server.args,
-    env: server.env,
-  });
+  const payload = openclawSetPayload(server);
   await execFileAsync(cliPath, ['mcp', 'set', 'o8', payload], {
     timeout: 30000,
     maxBuffer: 4 * 1024 * 1024,

--- a/src/app/api/setup/mcp-config/route.ts
+++ b/src/app/api/setup/mcp-config/route.ts
@@ -33,9 +33,11 @@ export const dynamic = 'force-dynamic';
 import { NextResponse } from 'next/server';
 import { existsSync, statSync } from 'node:fs';
 import { userInfo } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join } from 'node:path';
 import { execSync } from 'node:child_process';
 import { getApiBase, resolvePortInfo } from '@/lib/panel/api-port';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { toClaudeDesktopJson } from '@/lib/mcp/tool-spine/emit-claude-desktop';
 
 function findCommand(name: string): string | null {
   try {
@@ -46,95 +48,10 @@ function findCommand(name: string): string | null {
   }
 }
 
-function buildServerConfig(): { command: string; args: string[]; env: Record<string, string> } {
-  // Bundled packaged app signals this via env var written by the Tauri Rust sidecar.
-  const bundled = process.env.O8_BUNDLED_MCP_PATH;
-  if (bundled && existsSync(bundled)) {
-    // Prefer the node path the Tauri sidecar resolved via login shell
-    // (handles nvm/fnm/volta that Finder's minimal PATH misses).
-    const nodeBin = process.env.O8_NODE_BIN || findCommand('node') || 'node';
-    return {
-      command: nodeBin,
-      args: [bundled],
-      env: { O8_API_BASE: getApiBase() },
-    };
-  }
-
-  // Dev checkout: use tsx against the TS source.
-  const repoRoot = resolve(process.cwd());
-  const tsSource = join(repoRoot, 'src', 'lib', 'mcp', 'operator-mcp-server.ts');
-  if (!existsSync(tsSource)) {
-    // Running outside the repo and no bundled binary — this is a broken install.
-    return {
-      command: 'npx',
-      args: ['tsx', 'src/lib/mcp/operator-mcp-server.ts'],
-      env: { O8_API_BASE: getApiBase() },
-    };
-  }
-
-  const tsxBin = findCommand('tsx');
-  if (tsxBin) {
-    return {
-      command: tsxBin,
-      args: [tsSource],
-      env: { O8_API_BASE: getApiBase() },
-    };
-  }
-
-  return {
-    command: 'npx',
-    args: ['tsx', tsSource],
-    env: { O8_API_BASE: getApiBase() },
-  };
-}
-
-/**
- * Resolve the codebase-memory-mcp binary path.
- *
- * #739 (the Tauri sidecar) downloads the static binary on first launch into
- * `~/.o8/bin/codebase-memory-mcp` (`.exe` on Windows) and sets
- * `O8_CODEBASE_MEMORY_BIN` to the resolved path. Because the env var only
- * inherits into children spawned AFTER the download completes, we also fall
- * back to the deterministic path so external installs (Claude Desktop /
- * Claude Code outside the o8 process) can still locate the binary.
- *
- * Returns null when neither source resolves to a real executable. Callers
- * MUST treat null as "skip the entry" so cold first launch (binary not yet
- * downloaded) doesn't break Claude Code session boot.
- */
-function resolveCodebaseMemoryBin(): string | null {
-  const fromEnv = process.env.O8_CODEBASE_MEMORY_BIN;
-  if (fromEnv && fromEnv.trim() && existsSync(fromEnv)) {
-    return fromEnv;
-  }
-
-  const home = process.env.HOME || process.env.USERPROFILE || '';
-  if (!home) return null;
-
-  const fileName = process.platform === 'win32'
-    ? 'codebase-memory-mcp.exe'
-    : 'codebase-memory-mcp';
-  const deterministic = join(home, '.o8', 'bin', fileName);
-  if (existsSync(deterministic)) {
-    return deterministic;
-  }
-
-  return null;
-}
-
-/**
- * Build the codebase-memory MCP server entry, or null if the binary isn't
- * available. The binary defaults to MCP-stdio mode when invoked with no args.
- */
-function buildCodebaseMemoryConfig(): { command: string; args: string[]; env: Record<string, string> } | null {
-  const bin = resolveCodebaseMemoryBin();
-  if (!bin) return null;
-  return {
-    command: bin,
-    args: [],
-    env: {},
-  };
-}
+// The o8 + codebase-memory server config comes from the Tool-Spine
+// claude-desktop projection (Set B) — see the GET handler. repoPath is
+// irrelevant to this surface (cortex/externals filtered out); process.cwd()
+// keeps resolver inputs identical to the old builder.
 
 function buildInstructions(): { claudeDesktop: string; claudeCode: string } {
   const home = process.env.HOME || '';
@@ -161,13 +78,9 @@ function buildInstructions(): { claudeDesktop: string; claudeCode: string } {
 
 export async function GET() {
   try {
-    const server = buildServerConfig();
-    const codebaseMemory = buildCodebaseMemoryConfig();
-
-    const mcpServers: Record<string, unknown> = { o8: server };
-    if (codebaseMemory) {
-      mcpServers['codebase-memory'] = codebaseMemory;
-    }
+    const mcpServers = toClaudeDesktopJson(buildToolRegistry(process.cwd()), {}).mcpServers as Record<string, unknown>;
+    const server = mcpServers['o8'];
+    const codebaseMemory = mcpServers['codebase-memory'] ?? null;
     const fullConfig = { mcpServers };
 
     const nodeBin = findCommand('node');

--- a/src/lib/lane/codex-orchestrator-session.ts
+++ b/src/lib/lane/codex-orchestrator-session.ts
@@ -15,8 +15,9 @@ import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, writeFile
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import type { OrchestratorEvent } from './orchestrator-stream-events';
-import { getMcpServersConfig } from './orchestrator-mcp-config';
 import type { OrchestratorMcpServersConfig } from './orchestrator-mcp-config';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { serializeCodexMcpServers, toCodexServersMap } from '@/lib/mcp/tool-spine/emit-codex';
 import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import {
   readOrchestratorBackendSessionId,
@@ -101,16 +102,12 @@ function historyThreadKey(threadId?: string | null): string | null {
   return normalized ? normalized.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 96) : null;
 }
 
+// tomlKey is retained here because the managed-section STRIP logic
+// (isManagedMcpSection/stripManagedMcpSections) below quotes server names the
+// same way the serializer does. The serializer + its other TOML helpers moved
+// to @/lib/mcp/tool-spine/emit-codex (Step C).
 function tomlKey(key: string): string {
   return /^[A-Za-z0-9_-]+$/.test(key) ? key : JSON.stringify(key);
-}
-
-function tomlString(value: string): string {
-  return JSON.stringify(value);
-}
-
-function tomlStringArray(values: string[]): string {
-  return `[${values.map((value) => tomlString(value)).join(', ')}]`;
 }
 
 function isManagedMcpSection(sectionName: string, serverNames: string[]): boolean {
@@ -146,51 +143,9 @@ function stripManagedMcpSections(configToml: string, serverNames: string[]): str
   return nextLines.join('\n').trimEnd();
 }
 
-function serializeStringMap(sectionName: string, values: Record<string, string> | undefined): string[] {
-  if (!values || Object.keys(values).length === 0) {
-    return [];
-  }
-
-  return [
-    `[${sectionName}]`,
-    ...Object.entries(values)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, value]) => `${tomlKey(key)} = ${tomlString(value)}`),
-  ];
-}
-
-function serializeCodexMcpServers(servers: OrchestratorMcpServersConfig): string {
-  const lines: string[] = [];
-
-  for (const [name, server] of Object.entries(servers)) {
-    if (lines.length > 0) {
-      lines.push('');
-    }
-
-    const serverSection = `mcp_servers.${tomlKey(name)}`;
-    lines.push(`[${serverSection}]`);
-    if (server.type === 'http') {
-      lines.push('type = "http"');
-      lines.push(`url = ${tomlString(server.url)}`);
-      const headerLines = serializeStringMap(`${serverSection}.headers`, server.headers);
-      if (headerLines.length > 0) {
-        lines.push('', ...headerLines);
-      }
-      continue;
-    }
-
-    lines.push(`command = ${tomlString(server.command)}`);
-    lines.push(`args = ${tomlStringArray(server.args)}`);
-    const envLines = serializeStringMap(`${serverSection}.env`, server.env);
-    if (envLines.length > 0) {
-      lines.push('', ...envLines);
-    }
-  }
-
-  return lines.join('\n');
-}
-
-function mergeCodexMcpConfig(baseConfigToml: string, servers: OrchestratorMcpServersConfig): string {
+// Exported for the Step-C parity smoke — the parity unit is the full merged
+// config.toml (strip + join + trailing newline), not just the serialized blocks.
+export function mergeCodexMcpConfig(baseConfigToml: string, servers: OrchestratorMcpServersConfig): string {
   const serverNames = Object.keys(servers);
   const retainedConfig = stripManagedMcpSections(baseConfigToml, serverNames);
   const mcpConfig = serializeCodexMcpServers(servers);
@@ -222,7 +177,7 @@ export function ensureCodexHome(repoPath: string): string {
     : '';
   const mergedConfig = mergeCodexMcpConfig(
     userConfigToml,
-    getMcpServersConfig(normalizedRepoPath),
+    toCodexServersMap(buildToolRegistry(normalizedRepoPath)),
   );
   const configPath = join(codexHome, 'config.toml');
   writeFileSync(configPath, mergedConfig, { encoding: 'utf8', mode: 0o600 });

--- a/src/lib/lane/codex-orchestrator-session.ts
+++ b/src/lib/lane/codex-orchestrator-session.ts
@@ -110,6 +110,12 @@ function tomlKey(key: string): string {
   return /^[A-Za-z0-9_-]+$/.test(key) ? key : JSON.stringify(key);
 }
 
+// TODO(tool-spine-convergence): orphaned-managed-section leak. This only strips
+// sections whose name is in the CURRENT server set. A section o8 wrote on a
+// previous run for a server since removed/disabled (e.g. a deleted external)
+// is NOT recognized as managed, so it lingers as if it were user config. Fix in
+// the convergence phase (after A-F parity) — not here; the parity steps are
+// behavior-preserving by contract.
 function isManagedMcpSection(sectionName: string, serverNames: string[]): boolean {
   return serverNames.some((name) => {
     const bare = `mcp_servers.${name}`;

--- a/src/lib/lane/orchestrator-mcp-config.ts
+++ b/src/lib/lane/orchestrator-mcp-config.ts
@@ -1,133 +1,21 @@
-import { execSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { externalServerToMcpConfig, listEnabledExternalMcpServers } from '@/lib/mcp/external-servers';
+/**
+ * Back-compat shim over the Tool-Spine registry.
+ *
+ * `getMcpServersConfig` used to assemble the orchestrator MCP server map inline
+ * (operator + cortex + DB externals). That assembly — and its resolvers — moved
+ * to `@/lib/mcp/tool-spine/build.ts`; this now re-derives the identical map via
+ * the Claude-orchestrator projection of the registry. Output is key-for-key
+ * byte-identical to the legacy implementation (golden-locked in
+ * `tests/smoke/tool-spine-parity-smoke.ts`). The two existing callers
+ * (orchestrator-session.ts, codex-orchestrator-session.ts) are untouched.
+ */
+
 import type { OrchestratorMcpServerConfig } from '@/lib/mcp/external-servers';
-import { getOrCreateWsToken } from '@/lib/ws-auth';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { toClaudeServersMap } from '@/lib/mcp/tool-spine/emit-claude';
 
 export type OrchestratorMcpServersConfig = Record<string, OrchestratorMcpServerConfig>;
 
-/** Resolve repo slug from git remote, cached per session. */
-function detectRepoSlug(repoPath: string): string {
-  try {
-    const remote = execSync('git remote get-url origin', { cwd: repoPath, timeout: 3000, encoding: 'utf-8' }).trim();
-    const match = remote.match(/[:/]([^/]+\/[^/.]+?)(?:\.git)?$/);
-    return match?.[1] ?? '';
-  } catch { return ''; }
-}
-
-function findBundledMcpServer(fileName: string): string | null {
-  if (fileName === 'operator-mcp-server.mjs') {
-    const explicitOperatorPath = process.env.O8_BUNDLED_MCP_PATH;
-    if (explicitOperatorPath && existsSync(explicitOperatorPath)) {
-      return explicitOperatorPath;
-    }
-  }
-
-  const bundledDir =
-    process.env.O8_BUNDLED_MCP_DIR
-    || (process.env.O8_BUNDLED_MCP_PATH ? dirname(process.env.O8_BUNDLED_MCP_PATH) : null);
-  if (!bundledDir) {
-    return null;
-  }
-
-  const bundled = join(bundledDir, fileName);
-  return existsSync(bundled) ? bundled : null;
-}
-
-/**
- * Resolve the Cortex MCP server entry point.
- *
- * In a packaged Tauri app the TS source isn't shipped — only the esbuild
- * output in `resource_dir/server/cortex-mcp-server.mjs`. The Rust sidecar
- * sets `O8_BUNDLED_MCP_PATH` and `O8_BUNDLED_MCP_DIR` before spawning Next, so
- * we prefer bundled .mjs files when they exist.
- *
- * Dev checkout falls back to the TS source run under `tsx`.
- */
-function resolveCortexMcpServerPath(): { command: string; path: string } {
-  const bundled = findBundledMcpServer('cortex-mcp-server.mjs');
-  if (bundled) {
-    const nodeBin = process.env.O8_NODE_BIN || 'node';
-    return { command: nodeBin, path: bundled };
-  }
-
-  const devSource = resolve(dirname(fileURLToPath(import.meta.url)), '../mcp/cortex-mcp-server.ts');
-  return { command: 'npx', path: devSource };
-}
-
-function resolveOperatorMcpServerPath(): { command: string; path: string } {
-  const bundled = findBundledMcpServer('operator-mcp-server.mjs');
-  if (bundled) {
-    const nodeBin = process.env.O8_NODE_BIN || 'node';
-    return { command: nodeBin, path: bundled };
-  }
-
-  const devSource = resolve(dirname(fileURLToPath(import.meta.url)), '../mcp/operator-mcp-server.ts');
-  return { command: 'npx', path: devSource };
-}
-
-function argsForMcpServer(server: { command: string; path: string }): string[] {
-  return server.command === 'npx' ? ['tsx', server.path] : [server.path];
-}
-
-function resolveWsPort(): string {
-  try {
-    const dataDir = process.env.CORTEX_IDE_DATA_DIR || join(homedir(), '.o8');
-    const portFile = join(dataDir, 'ws-port');
-    if (existsSync(portFile)) {
-      const raw = readFileSync(portFile, 'utf-8').trim();
-      const n = parseInt(raw, 10);
-      if (Number.isInteger(n) && n > 0 && n < 65536) {
-        return String(n);
-      }
-    }
-  } catch { /* fall through */ }
-  return process.env.O8_WS_PORT?.trim() || process.env.WS_PORT?.trim() || '3002';
-}
-
 export function getMcpServersConfig(repoPath: string): OrchestratorMcpServersConfig {
-  const repoSlug = detectRepoSlug(repoPath);
-  const { getApiBase } = require('@/lib/panel/api-port') as typeof import('@/lib/panel/api-port');
-  const apiBase = getApiBase();
-
-  const cortexServer = resolveCortexMcpServerPath();
-  const operatorServer = resolveOperatorMcpServerPath();
-
-  const externalServers: OrchestratorMcpServersConfig = {};
-  try {
-    for (const server of listEnabledExternalMcpServers()) {
-      externalServers[server.name] = externalServerToMcpConfig(server);
-    }
-  } catch (error) {
-    console.warn(
-      `[orchestrator-mcp-config] Failed to load external MCP servers: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-
-  return {
-    ...externalServers,
-    operator: {
-      type: 'stdio',
-      command: operatorServer.command,
-      args: argsForMcpServer(operatorServer),
-      env: {
-        O8_API_BASE: apiBase,
-      },
-    },
-    cortex: {
-      type: 'stdio',
-      command: cortexServer.command,
-      args: argsForMcpServer(cortexServer),
-      env: {
-        CORTEX_API_BASE: apiBase,
-        CORTEX_REPO_PATH: repoPath,
-        CORTEX_REPO_SLUG: repoSlug,
-        WS_PORT: resolveWsPort(),
-        WS_TOKEN: getOrCreateWsToken(),
-      },
-    },
-  };
+  return toClaudeServersMap(buildToolRegistry(repoPath));
 }

--- a/src/lib/lane/orchestrator-session.ts
+++ b/src/lib/lane/orchestrator-session.ts
@@ -39,7 +39,8 @@ import {
 } from '@/lib/lane/orchestrator-stream-events';
 import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import { getRuntime, type RuntimeSession } from '@/lib/runtimes';
-import { getMcpServersConfig } from './orchestrator-mcp-config';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { toClaudeJson } from '@/lib/mcp/tool-spine/emit-claude';
 
 // ── Types ──
 
@@ -297,9 +298,11 @@ function ensureMcpConfig(repoPath: string): string {
   if (!existsSync(MCP_CONFIG_DIR)) mkdirSync(MCP_CONFIG_DIR, { recursive: true });
 
   const configPath = join(MCP_CONFIG_DIR, `orchestrator-${repoHash(repoPath)}.json`);
-  const config = {
-    mcpServers: getMcpServersConfig(repoPath),
-  };
+  // Tool-Spine: the Claude orchestrator surface projection. toClaudeJson emits
+  // the full `{ mcpServers }` envelope; the stringify (2-space, no trailing
+  // newline) is unchanged, so the written file is byte-identical to the legacy
+  // `{ mcpServers: getMcpServersConfig(repoPath) }` form (Step B).
+  const config = toClaudeJson(buildToolRegistry(repoPath));
 
   writeFileSync(configPath, JSON.stringify(config, null, 2));
   console.log(`[orchestrator-session] MCP config written to ${configPath}`);

--- a/src/lib/mcp/claude-desktop-config-io.ts
+++ b/src/lib/mcp/claude-desktop-config-io.ts
@@ -1,0 +1,52 @@
+/**
+ * Claude Desktop / Claude Code config file I/O — tolerant read + atomic,
+ * backup-preserving write.
+ *
+ * Extracted from `app/api/setup/claude-desktop/route.ts` (Step D) so the merge
+ * write — including the `.o8-backup-<ts>` side file — is unit-testable. The
+ * route still owns WHEN to write and WHAT to merge (via the Tool-Spine
+ * `toClaudeDesktopJson` projection); this owns HOW the bytes hit disk. Behavior
+ * is preserved verbatim: tolerant JSON parse, timestamped backup of the prior
+ * file, `JSON.stringify(config, null, 2) + '\n'` (trailing newline), tmp+rename.
+ */
+
+import { copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import type { ClaudeDesktopConfig } from '@/lib/mcp/tool-spine/emit-claude-desktop';
+
+export type { ClaudeDesktopConfig };
+
+export function readClaudeConfig(path: string): ClaudeDesktopConfig {
+  if (!existsSync(path)) return {};
+  try {
+    const raw = readFileSync(path, 'utf-8').trim();
+    if (!raw) return {};
+    return JSON.parse(raw) as ClaudeDesktopConfig;
+  } catch {
+    // Malformed — return empty so the caller can decide whether to bail or
+    // overwrite with a fresh file.
+    return {};
+  }
+}
+
+export function atomicWriteConfig(path: string, config: ClaudeDesktopConfig): void {
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  // Back up the existing file before overwriting. The backup name carries a
+  // timestamp — callers/tests must not byte-compare the NAME, only its content.
+  if (existsSync(path)) {
+    const backupPath = `${path}.o8-backup-${Date.now()}`;
+    try {
+      copyFileSync(path, backupPath);
+    } catch {
+      // Don't block the write on a failed backup.
+    }
+  }
+
+  const tmpPath = `${path}.o8-tmp`;
+  writeFileSync(tmpPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+  renameSync(tmpPath, path);
+}

--- a/src/lib/mcp/external-client-args.ts
+++ b/src/lib/mcp/external-client-args.ts
@@ -1,0 +1,40 @@
+/**
+ * external-client forwarding serializers — the two wire shapes o8's operator
+ * server is handed to the Hermes / OpenClaw MCP CLIs.
+ *
+ * Extracted verbatim from `app/api/setup/external-client/route.ts` (Step E2) so
+ * both shapes are unit-testable WITHOUT spawning the CLIs. The route still owns
+ * the spawn; this owns only the argument/payload serialization. external-client
+ * forwards ONLY the operator entry (named "o8") — never codebase-memory or DB
+ * externals.
+ *
+ *   hermes   → `hermes mcp add o8 --command <cmd> [--args <a>...] [--env K=V]...`
+ *   openclaw → `openclaw mcp set o8 '<json>'`  (json = {command, args, env})
+ */
+
+export interface ForwardedServer {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+/** Build the `hermes mcp add o8 …` argv (everything after the cli path). */
+export function hermesAddArgs(server: ForwardedServer): string[] {
+  const args = ['mcp', 'add', 'o8', '--command', server.command];
+  if (server.args.length > 0) {
+    args.push('--args', ...server.args);
+  }
+  for (const [k, v] of Object.entries(server.env)) {
+    args.push('--env', `${k}=${v}`);
+  }
+  return args;
+}
+
+/** Build the JSON blob for `openclaw mcp set o8 '<json>'`. */
+export function openclawSetPayload(server: ForwardedServer): string {
+  return JSON.stringify({
+    command: server.command,
+    args: server.args,
+    env: server.env,
+  });
+}

--- a/src/lib/mcp/tool-spine/build.ts
+++ b/src/lib/mcp/tool-spine/build.ts
@@ -85,6 +85,19 @@ function resolveOperatorMcpServerPath(): { command: string; path: string } {
   return { command: 'npx', path: devSource };
 }
 
+// Binary-resolution shape — read this before any new emission surface that
+// resolves the operator/cortex binary (Set-B routes, Gemini/OpenClaw wiring).
+//
+//   PACKAGED (O8_BUNDLED_MCP_PATH set): { command: <O8_NODE_BIN|node>, args: [<bundled .mjs>] }
+//   DEV      (no bundled binary):       { command: "npx",             args: ["tsx", <src .ts>] }
+//
+// "tsx-vs-npx / spec risk #3": the legacy Set-B builders preferred a resolved
+// tsx path (`{command: "/abs/tsx", args: [src]}`) — same server under tsx, a
+// different invocation. The registry standardizes on the npx/tsx form, so in DEV
+// the emitted shape differs from the old Set-B output (cosmetic, functionally
+// equivalent); in PACKAGED mode both collapse to the identical node+bundled
+// form. THEREFORE every byte-for-byte parity proof runs in PACKAGED mode — the
+// shape that actually ships. (Spec risk register item #3.)
 function argsForMcpServer(server: { command: string; path: string }): string[] {
   return server.command === 'npx' ? ['tsx', server.path] : [server.path];
 }

--- a/src/lib/mcp/tool-spine/build.ts
+++ b/src/lib/mcp/tool-spine/build.ts
@@ -1,0 +1,226 @@
+/**
+ * buildToolRegistry — promote o8's live MCP config into the registry shape.
+ *
+ * This is the ONE place the catalog is assembled. The resolvers below were moved
+ * verbatim from `lane/orchestrator-mcp-config.ts` (only the `import.meta.url`
+ * relative paths shifted for the new directory depth) + `resolveCodebaseMemoryBin`
+ * from the setup routes. Entry order matches today's `getMcpServersConfig`:
+ * DB externals first, then operator, then cortex, then codebase-memory.
+ *
+ * @/lib boundary: this imports DB/ws/api-port, so it must ONLY ever be called
+ * from the Next server runtime — never from a standalone `tsx` MCP process
+ * (which duplicates `resolveApiBase`). The emitters stay import-pure so they can
+ * be copied into such a process if ever needed.
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { externalServerToMcpConfig, listEnabledExternalMcpServers } from '@/lib/mcp/external-servers';
+import { getOrCreateWsToken } from '@/lib/ws-auth';
+import type { ServerEntry, ToolRegistry } from './registry';
+
+/** Resolve repo slug from git remote. */
+function detectRepoSlug(repoPath: string): string {
+  try {
+    const remote = execSync('git remote get-url origin', { cwd: repoPath, timeout: 3000, encoding: 'utf-8' }).trim();
+    const match = remote.match(/[:/]([^/]+\/[^/.]+?)(?:\.git)?$/);
+    return match?.[1] ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function findBundledMcpServer(fileName: string): string | null {
+  if (fileName === 'operator-mcp-server.mjs') {
+    const explicitOperatorPath = process.env.O8_BUNDLED_MCP_PATH;
+    if (explicitOperatorPath && existsSync(explicitOperatorPath)) {
+      return explicitOperatorPath;
+    }
+  }
+
+  const bundledDir =
+    process.env.O8_BUNDLED_MCP_DIR
+    || (process.env.O8_BUNDLED_MCP_PATH ? dirname(process.env.O8_BUNDLED_MCP_PATH) : null);
+  if (!bundledDir) {
+    return null;
+  }
+
+  const bundled = join(bundledDir, fileName);
+  return existsSync(bundled) ? bundled : null;
+}
+
+/**
+ * Resolve the Cortex MCP server entry point.
+ *
+ * In a packaged Tauri app the TS source isn't shipped — only the esbuild output
+ * in `resource_dir/server/cortex-mcp-server.mjs`. The Rust sidecar sets
+ * `O8_BUNDLED_MCP_PATH` and `O8_BUNDLED_MCP_DIR` before spawning Next, so we
+ * prefer bundled .mjs files when they exist. Dev checkout falls back to the TS
+ * source run under `tsx`.
+ */
+function resolveCortexMcpServerPath(): { command: string; path: string } {
+  const bundled = findBundledMcpServer('cortex-mcp-server.mjs');
+  if (bundled) {
+    const nodeBin = process.env.O8_NODE_BIN || 'node';
+    return { command: nodeBin, path: bundled };
+  }
+
+  // From src/lib/mcp/tool-spine/ → src/lib/mcp/cortex-mcp-server.ts
+  const devSource = resolve(dirname(fileURLToPath(import.meta.url)), '../cortex-mcp-server.ts');
+  return { command: 'npx', path: devSource };
+}
+
+function resolveOperatorMcpServerPath(): { command: string; path: string } {
+  const bundled = findBundledMcpServer('operator-mcp-server.mjs');
+  if (bundled) {
+    const nodeBin = process.env.O8_NODE_BIN || 'node';
+    return { command: nodeBin, path: bundled };
+  }
+
+  // From src/lib/mcp/tool-spine/ → src/lib/mcp/operator-mcp-server.ts
+  const devSource = resolve(dirname(fileURLToPath(import.meta.url)), '../operator-mcp-server.ts');
+  return { command: 'npx', path: devSource };
+}
+
+function argsForMcpServer(server: { command: string; path: string }): string[] {
+  return server.command === 'npx' ? ['tsx', server.path] : [server.path];
+}
+
+function resolveWsPort(): string {
+  try {
+    const dataDir = process.env.CORTEX_IDE_DATA_DIR || join(homedir(), '.o8');
+    const portFile = join(dataDir, 'ws-port');
+    if (existsSync(portFile)) {
+      const raw = readFileSync(portFile, 'utf-8').trim();
+      const n = parseInt(raw, 10);
+      if (Number.isInteger(n) && n > 0 && n < 65536) {
+        return String(n);
+      }
+    }
+  } catch {
+    /* fall through */
+  }
+  return process.env.O8_WS_PORT?.trim() || process.env.WS_PORT?.trim() || '3002';
+}
+
+/**
+ * Resolve the codebase-memory-mcp binary, falling back from the env var the
+ * Tauri sidecar sets (#739) to the deterministic install path. Returns null
+ * when neither resolves — the caller omits the entry so cold first launch
+ * (binary not yet downloaded) doesn't break session boot.
+ */
+function resolveCodebaseMemoryBin(): string | null {
+  const fromEnv = process.env.O8_CODEBASE_MEMORY_BIN;
+  if (fromEnv && fromEnv.trim() && existsSync(fromEnv)) {
+    return fromEnv;
+  }
+
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  if (!home) return null;
+
+  const fileName = process.platform === 'win32' ? 'codebase-memory-mcp.exe' : 'codebase-memory-mcp';
+  const deterministic = join(home, '.o8', 'bin', fileName);
+  if (existsSync(deterministic)) {
+    return deterministic;
+  }
+
+  return null;
+}
+
+/**
+ * Assemble the catalog. Order is load-bearing (emitters preserve it):
+ *   1. DB externals     — orchestrator surfaces only
+ *   2. operator         — ALL surfaces (renamed "o8" on external surfaces)
+ *   3. cortex           — orchestrator surfaces only
+ *   4. codebase-memory  — external surfaces only, omitted when the binary is absent
+ */
+export function buildToolRegistry(repoPath: string): ToolRegistry {
+  const repoSlug = detectRepoSlug(repoPath);
+  const { getApiBase } = require('@/lib/panel/api-port') as typeof import('@/lib/panel/api-port');
+  const apiBase = getApiBase();
+
+  const cortexServer = resolveCortexMcpServerPath();
+  const operatorServer = resolveOperatorMcpServerPath();
+
+  const entries: ServerEntry[] = [];
+
+  // 1. DB externals first — matches `{ ...externalServers, operator, cortex }`.
+  try {
+    for (const server of listEnabledExternalMcpServers()) {
+      entries.push({
+        id: `external:${server.name}`,
+        name: server.name,
+        source: 'external',
+        label: server.name,
+        surfaces: ['claude-orchestrator', 'codex-orchestrator'],
+        config: externalServerToMcpConfig(server),
+      });
+    }
+  } catch (error) {
+    console.warn(
+      `[tool-spine] Failed to load external MCP servers: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  // 2. operator — all surfaces; "o8" on the external-facing ones.
+  entries.push({
+    id: 'builtin:operator',
+    name: 'operator',
+    source: 'builtin',
+    label: 'o8 Operator',
+    surfaces: ['claude-orchestrator', 'codex-orchestrator', 'claude-desktop', 'openclaw', 'gemini'],
+    surfaceNames: { 'claude-desktop': 'o8', openclaw: 'o8', gemini: 'o8' },
+    config: {
+      type: 'stdio',
+      command: operatorServer.command,
+      args: argsForMcpServer(operatorServer),
+      env: {
+        O8_API_BASE: apiBase,
+      },
+    },
+  });
+
+  // 3. cortex — orchestrator surfaces only.
+  entries.push({
+    id: 'builtin:cortex',
+    name: 'cortex',
+    source: 'builtin',
+    label: 'Cortex Memory',
+    surfaces: ['claude-orchestrator', 'codex-orchestrator'],
+    config: {
+      type: 'stdio',
+      command: cortexServer.command,
+      args: argsForMcpServer(cortexServer),
+      env: {
+        CORTEX_API_BASE: apiBase,
+        CORTEX_REPO_PATH: repoPath,
+        CORTEX_REPO_SLUG: repoSlug,
+        WS_PORT: resolveWsPort(),
+        WS_TOKEN: getOrCreateWsToken(),
+      },
+    },
+  });
+
+  // 4. codebase-memory — external surfaces only, omitted when the binary is absent.
+  const codebaseMemoryBin = resolveCodebaseMemoryBin();
+  if (codebaseMemoryBin) {
+    entries.push({
+      id: 'builtin:codebase-memory',
+      name: 'codebase-memory',
+      source: 'builtin',
+      label: 'Codebase Memory',
+      surfaces: ['claude-desktop', 'gemini'],
+      config: {
+        type: 'stdio',
+        command: codebaseMemoryBin,
+        args: [],
+        env: {},
+      },
+    });
+  }
+
+  return { repoPath, entries };
+}

--- a/src/lib/mcp/tool-spine/emit-claude-desktop.ts
+++ b/src/lib/mcp/tool-spine/emit-claude-desktop.ts
@@ -1,0 +1,46 @@
+/**
+ * Emitter: Claude Desktop / Claude Code `~/.claude.json` (Set B) — merge-preserving.
+ *
+ * This is the outage fix. `toClaudeDesktopJson` writes ONLY the keys this
+ * registry names onto the claude-desktop surface; every unknown server
+ * (`filesystem`, `playwright`, …) and every top-level key survives via the
+ * spreads. The desktop `o8`/codebase-memory entries carry NO `type` field —
+ * `toClaudeDesktopEntry` strips it for stdio → `{ command, args, env }`.
+ *
+ * I/O (readClaudeConfig, atomic write + `.o8-backup-<ts>` + trailing newline)
+ * stays in the route; this module is pure.
+ */
+
+import type { OrchestratorMcpServerConfig } from '@/lib/mcp/external-servers';
+import { entriesForSurface, type ToolRegistry } from './registry';
+
+export interface ClaudeDesktopConfig {
+  mcpServers?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Project one server config into the Claude Desktop wire shape. stdio servers
+ * are written WITHOUT the `type` discriminator (`{ command, args, env }`),
+ * matching the legacy `buildServerConfig` / `buildCodebaseMemoryConfig` output.
+ */
+export function toClaudeDesktopEntry(config: OrchestratorMcpServerConfig): Record<string, unknown> {
+  if (config.type === 'http') {
+    return { url: config.url, ...(config.headers ? { headers: config.headers } : {}) };
+  }
+  return { command: config.command, args: config.args, env: config.env ?? {} };
+}
+
+export function toClaudeDesktopJson(r: ToolRegistry, existing: ClaudeDesktopConfig): ClaudeDesktopConfig {
+  const next: ClaudeDesktopConfig = { ...existing };
+  const servers: Record<string, unknown> = { ...(isRecord(existing.mcpServers) ? existing.mcpServers : {}) };
+  for (const { name, config } of entriesForSurface(r, 'claude-desktop')) {
+    servers[name] = toClaudeDesktopEntry(config);
+  }
+  next.mcpServers = servers;
+  return next;
+}

--- a/src/lib/mcp/tool-spine/emit-claude.ts
+++ b/src/lib/mcp/tool-spine/emit-claude.ts
@@ -1,0 +1,22 @@
+/**
+ * Emitter: Claude orchestrator `--mcp-config` JSON (Set A).
+ *
+ * Identity passthrough of `config` under the per-surface key, in entry order,
+ * with `type` retained. The writer (orchestrator-session.ts) owns the
+ * no-trailing-newline detail.
+ */
+
+import type { OrchestratorMcpServerConfig } from '@/lib/mcp/external-servers';
+import { entriesForSurface, type ToolRegistry } from './registry';
+
+export function toClaudeServersMap(r: ToolRegistry): Record<string, OrchestratorMcpServerConfig> {
+  const out: Record<string, OrchestratorMcpServerConfig> = {};
+  for (const { name, config } of entriesForSurface(r, 'claude-orchestrator')) {
+    out[name] = config;
+  }
+  return out;
+}
+
+export function toClaudeJson(r: ToolRegistry): { mcpServers: Record<string, OrchestratorMcpServerConfig> } {
+  return { mcpServers: toClaudeServersMap(r) };
+}

--- a/src/lib/mcp/tool-spine/emit-codex.ts
+++ b/src/lib/mcp/tool-spine/emit-codex.ts
@@ -1,0 +1,81 @@
+/**
+ * Emitter: Codex orchestrator `config.toml` mcp_servers blocks (Set A).
+ *
+ * `serializeCodexMcpServers` + the TOML helpers are reproduced here verbatim
+ * from `lane/codex-orchestrator-session.ts` (Step C will repoint that file to
+ * import from here and delete the local copy). Byte-for-byte invariants the
+ * golden test pins: a blank line between blocks, `type = "http"` discriminator
+ * for HTTP servers, env/headers sorted via `localeCompare`, `tomlKey` quoting,
+ * and NO trailing newline (the caller's `mergeCodexMcpConfig` adds it).
+ */
+
+import type { OrchestratorMcpServerConfig } from '@/lib/mcp/external-servers';
+import { entriesForSurface, type ToolRegistry } from './registry';
+
+function tomlKey(key: string): string {
+  return /^[A-Za-z0-9_-]+$/.test(key) ? key : JSON.stringify(key);
+}
+
+function tomlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function tomlStringArray(values: string[]): string {
+  return `[${values.map((value) => tomlString(value)).join(', ')}]`;
+}
+
+function serializeStringMap(sectionName: string, values: Record<string, string> | undefined): string[] {
+  if (!values || Object.keys(values).length === 0) {
+    return [];
+  }
+
+  return [
+    `[${sectionName}]`,
+    ...Object.entries(values)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, value]) => `${tomlKey(key)} = ${tomlString(value)}`),
+  ];
+}
+
+export function serializeCodexMcpServers(servers: Record<string, OrchestratorMcpServerConfig>): string {
+  const lines: string[] = [];
+
+  for (const [name, server] of Object.entries(servers)) {
+    if (lines.length > 0) {
+      lines.push('');
+    }
+
+    const serverSection = `mcp_servers.${tomlKey(name)}`;
+    lines.push(`[${serverSection}]`);
+    if (server.type === 'http') {
+      lines.push('type = "http"');
+      lines.push(`url = ${tomlString(server.url)}`);
+      const headerLines = serializeStringMap(`${serverSection}.headers`, server.headers);
+      if (headerLines.length > 0) {
+        lines.push('', ...headerLines);
+      }
+      continue;
+    }
+
+    lines.push(`command = ${tomlString(server.command)}`);
+    lines.push(`args = ${tomlStringArray(server.args)}`);
+    const envLines = serializeStringMap(`${serverSection}.env`, server.env);
+    if (envLines.length > 0) {
+      lines.push('', ...envLines);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function toCodexServersMap(r: ToolRegistry): Record<string, OrchestratorMcpServerConfig> {
+  const out: Record<string, OrchestratorMcpServerConfig> = {};
+  for (const { name, config } of entriesForSurface(r, 'codex-orchestrator')) {
+    out[name] = config;
+  }
+  return out;
+}
+
+export function toCodexToml(r: ToolRegistry): string {
+  return serializeCodexMcpServers(toCodexServersMap(r));
+}

--- a/src/lib/mcp/tool-spine/emit-gemini.ts
+++ b/src/lib/mcp/tool-spine/emit-gemini.ts
@@ -1,0 +1,29 @@
+/**
+ * Emitter: Gemini CLI `~/.gemini/settings.json` mcpServers (NEW — closes the gap).
+ *
+ * The Gemini runtime had no MCP injection. This ships it. Schema verified
+ * against the installed Gemini CLI + `google-gemini/gemini-cli`
+ * docs/tools/mcp-server.md (2026-06): top key `mcpServers`; stdio is implied by
+ * `command` (NO `type` field) with optional `args`/`env`; the streamable-HTTP
+ * URL field is `httpUrl` (NOT `url` — `url` is the SSE field), with `headers`.
+ * o8's operator server is streamable-HTTP-or-stdio, so it maps to `httpUrl`/
+ * `command` accordingly. Empty `env` is omitted to match the CLI's own format.
+ *
+ * Surfaces: operator ("o8") + codebase-memory.
+ */
+
+import { entriesForSurface, type ToolRegistry } from './registry';
+
+export function toGeminiSettings(r: ToolRegistry): { mcpServers: Record<string, unknown> } {
+  const mcpServers: Record<string, unknown> = {};
+  for (const { name, config } of entriesForSurface(r, 'gemini')) {
+    mcpServers[name] = config.type === 'http'
+      ? { httpUrl: config.url, ...(config.headers ? { headers: config.headers } : {}) }
+      : {
+          command: config.command,
+          args: config.args,
+          ...(config.env && Object.keys(config.env).length ? { env: config.env } : {}),
+        };
+  }
+  return { mcpServers };
+}

--- a/src/lib/mcp/tool-spine/emit-openclaw.ts
+++ b/src/lib/mcp/tool-spine/emit-openclaw.ts
@@ -1,0 +1,25 @@
+/**
+ * Emitter: OpenClaw governed-profile `mcp` block (Set B).
+ *
+ * Returns `{ servers: { o8: <stdio-stripped config> } }` — the caller assigns it
+ * to the profile's `mcp` key (`o8Config.mcp = toOpenclawJson(r)`). This REPLACES
+ * the current "read whatever the user pre-registered + throw if missing"
+ * passthrough with a registry-derived entry. The openclaw surface carries only
+ * the operator (renamed "o8"); cortex / codebase-memory / DB externals are not
+ * part of the governed profile.
+ *
+ * Phase 1 emits the current stdio shape (byte-identical to what
+ * `openclaw mcp set o8` wrote). The stdio→http convergence is a flagged
+ * fast-follow — one field swap, registry unchanged.
+ */
+
+import { entriesForSurface, type ToolRegistry } from './registry';
+import { toClaudeDesktopEntry } from './emit-claude-desktop';
+
+export function toOpenclawJson(r: ToolRegistry): { servers: Record<string, unknown> } {
+  const servers: Record<string, unknown> = {};
+  for (const { name, config } of entriesForSurface(r, 'openclaw')) {
+    servers[name] = toClaudeDesktopEntry(config);
+  }
+  return { servers };
+}

--- a/src/lib/mcp/tool-spine/emitters.test.ts
+++ b/src/lib/mcp/tool-spine/emitters.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tool-Spine emitter golden snapshots (Step A regression lock, pure).
+ *
+ * One shared fixture registry (one stdio external + one http external + operator
+ * + cortex + codebase-memory) → assert each emitter's EXACT bytes/shape. These
+ * pin the byte-level invariants every emission site relied on before any
+ * consumer was repointed: entry order, the desktop `type`-strip, the codex TOML
+ * layout, the gemini `httpUrl` key, surface filtering, and merge-preservation.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { entriesForSurface, type ToolRegistry } from './registry';
+import { toClaudeServersMap, toClaudeJson } from './emit-claude';
+import { toCodexToml } from './emit-codex';
+import { toClaudeDesktopJson } from './emit-claude-desktop';
+import { toOpenclawJson } from './emit-openclaw';
+import { toGeminiSettings } from './emit-gemini';
+
+const fixture: ToolRegistry = {
+  repoPath: '/repo',
+  entries: [
+    {
+      id: 'external:ext-stdio',
+      name: 'ext-stdio',
+      source: 'external',
+      label: 'ext-stdio',
+      surfaces: ['claude-orchestrator', 'codex-orchestrator'],
+      config: { type: 'stdio', command: 'node', args: ['ext.js'], env: { FOO: 'bar' } },
+    },
+    {
+      id: 'external:ext-http',
+      name: 'ext-http',
+      source: 'external',
+      label: 'ext-http',
+      surfaces: ['claude-orchestrator', 'codex-orchestrator'],
+      config: { type: 'http', url: 'https://ext.example/mcp', headers: { Authorization: 'Bearer x' } },
+    },
+    {
+      id: 'builtin:operator',
+      name: 'operator',
+      source: 'builtin',
+      label: 'o8 Operator',
+      surfaces: ['claude-orchestrator', 'codex-orchestrator', 'claude-desktop', 'openclaw', 'gemini'],
+      surfaceNames: { 'claude-desktop': 'o8', openclaw: 'o8', gemini: 'o8' },
+      config: { type: 'stdio', command: 'npx', args: ['tsx', 'operator.ts'], env: { O8_API_BASE: 'http://127.0.0.1:3001' } },
+    },
+    {
+      id: 'builtin:cortex',
+      name: 'cortex',
+      source: 'builtin',
+      label: 'Cortex Memory',
+      surfaces: ['claude-orchestrator', 'codex-orchestrator'],
+      config: {
+        type: 'stdio',
+        command: 'npx',
+        args: ['tsx', 'cortex.ts'],
+        env: { CORTEX_API_BASE: 'http://127.0.0.1:3001', WS_TOKEN: 'tok' },
+      },
+    },
+    {
+      id: 'builtin:codebase-memory',
+      name: 'codebase-memory',
+      source: 'builtin',
+      label: 'Codebase Memory',
+      surfaces: ['claude-desktop', 'gemini'],
+      config: { type: 'stdio', command: '/bin/cm', args: [], env: {} },
+    },
+  ],
+};
+
+describe('entriesForSurface', () => {
+  it('filters by surface, in registry order, applying surfaceNames', () => {
+    expect(entriesForSurface(fixture, 'claude-orchestrator').map((e) => e.name)).toEqual([
+      'ext-stdio',
+      'ext-http',
+      'operator',
+      'cortex',
+    ]);
+    // operator renamed to "o8"; cortex + externals excluded from gemini.
+    expect(entriesForSurface(fixture, 'gemini').map((e) => e.name)).toEqual(['o8', 'codebase-memory']);
+    expect(entriesForSurface(fixture, 'openclaw').map((e) => e.name)).toEqual(['o8']);
+  });
+
+  it('does not leak an entry to a surface it does not list', () => {
+    expect(entriesForSurface(fixture, 'claude-desktop').map((e) => e.name)).not.toContain('cortex');
+    expect(entriesForSurface(fixture, 'claude-desktop').map((e) => e.name)).not.toContain('ext-stdio');
+  });
+});
+
+describe('toClaudeServersMap / toClaudeJson', () => {
+  it('identity passthrough, type retained, externals→operator→cortex order, no codebase-memory', () => {
+    const map = toClaudeServersMap(fixture);
+    expect(Object.keys(map)).toEqual(['ext-stdio', 'ext-http', 'operator', 'cortex']);
+    expect(map).toEqual({
+      'ext-stdio': { type: 'stdio', command: 'node', args: ['ext.js'], env: { FOO: 'bar' } },
+      'ext-http': { type: 'http', url: 'https://ext.example/mcp', headers: { Authorization: 'Bearer x' } },
+      operator: { type: 'stdio', command: 'npx', args: ['tsx', 'operator.ts'], env: { O8_API_BASE: 'http://127.0.0.1:3001' } },
+      cortex: {
+        type: 'stdio',
+        command: 'npx',
+        args: ['tsx', 'cortex.ts'],
+        env: { CORTEX_API_BASE: 'http://127.0.0.1:3001', WS_TOKEN: 'tok' },
+      },
+    });
+    expect(toClaudeJson(fixture)).toEqual({ mcpServers: map });
+  });
+});
+
+describe('toCodexToml', () => {
+  it('exact TOML: blank-line-separated blocks, type="http", sorted env/headers, no trailing newline', () => {
+    const expected = [
+      '[mcp_servers.ext-stdio]',
+      'command = "node"',
+      'args = ["ext.js"]',
+      '',
+      '[mcp_servers.ext-stdio.env]',
+      'FOO = "bar"',
+      '',
+      '[mcp_servers.ext-http]',
+      'type = "http"',
+      'url = "https://ext.example/mcp"',
+      '',
+      '[mcp_servers.ext-http.headers]',
+      'Authorization = "Bearer x"',
+      '',
+      '[mcp_servers.operator]',
+      'command = "npx"',
+      'args = ["tsx", "operator.ts"]',
+      '',
+      '[mcp_servers.operator.env]',
+      'O8_API_BASE = "http://127.0.0.1:3001"',
+      '',
+      '[mcp_servers.cortex]',
+      'command = "npx"',
+      'args = ["tsx", "cortex.ts"]',
+      '',
+      '[mcp_servers.cortex.env]',
+      'CORTEX_API_BASE = "http://127.0.0.1:3001"',
+      'WS_TOKEN = "tok"',
+    ].join('\n');
+    expect(toCodexToml(fixture)).toBe(expected);
+  });
+});
+
+describe('toClaudeDesktopJson', () => {
+  it('strips type for stdio, includes codebase-memory, preserves unknown servers + top-level keys', () => {
+    const existing = {
+      theme: 'dark',
+      mcpServers: {
+        filesystem: { command: 'fs', args: ['/'] },
+        playwright: { command: 'pw' },
+      },
+    };
+    const out = toClaudeDesktopJson(fixture, existing);
+
+    // Unknown servers + top-level key untouched (merge-preserve proof).
+    expect(out.theme).toBe('dark');
+    expect(out.mcpServers!.filesystem).toEqual({ command: 'fs', args: ['/'] });
+    expect(out.mcpServers!.playwright).toEqual({ command: 'pw' });
+
+    // o8 entry carries NO `type` field.
+    expect(out.mcpServers!.o8).toEqual({ command: 'npx', args: ['tsx', 'operator.ts'], env: { O8_API_BASE: 'http://127.0.0.1:3001' } });
+    expect(out.mcpServers!.o8).not.toHaveProperty('type');
+
+    // codebase-memory present, env {} retained (matches legacy buildCodebaseMemoryConfig).
+    expect(out.mcpServers!['codebase-memory']).toEqual({ command: '/bin/cm', args: [], env: {} });
+
+    // Key order: existing first, then o8, then codebase-memory.
+    expect(Object.keys(out.mcpServers!)).toEqual(['filesystem', 'playwright', 'o8', 'codebase-memory']);
+  });
+
+  it('does not mutate the input config', () => {
+    const existing = { mcpServers: { filesystem: { command: 'fs' } } };
+    const snapshot = JSON.stringify(existing);
+    toClaudeDesktopJson(fixture, existing);
+    expect(JSON.stringify(existing)).toBe(snapshot);
+  });
+
+  it('starts a fresh mcpServers map when existing has none', () => {
+    const out = toClaudeDesktopJson(fixture, {});
+    expect(Object.keys(out.mcpServers!)).toEqual(['o8', 'codebase-memory']);
+  });
+});
+
+describe('toOpenclawJson', () => {
+  it('emits only o8 (operator), stdio-stripped, no codebase-memory', () => {
+    expect(toOpenclawJson(fixture)).toEqual({
+      servers: {
+        o8: { command: 'npx', args: ['tsx', 'operator.ts'], env: { O8_API_BASE: 'http://127.0.0.1:3001' } },
+      },
+    });
+  });
+});
+
+describe('toGeminiSettings', () => {
+  it('emits o8 + codebase-memory; stdio implied by command (no type); empty env omitted', () => {
+    expect(toGeminiSettings(fixture)).toEqual({
+      mcpServers: {
+        o8: { command: 'npx', args: ['tsx', 'operator.ts'], env: { O8_API_BASE: 'http://127.0.0.1:3001' } },
+        'codebase-memory': { command: '/bin/cm', args: [] },
+      },
+    });
+  });
+
+  it('maps http transport to the httpUrl key (NOT url), with headers', () => {
+    const httpReg: ToolRegistry = {
+      repoPath: '/repo',
+      entries: [
+        {
+          id: 'external:remote',
+          name: 'remote',
+          source: 'external',
+          label: 'remote',
+          surfaces: ['gemini'],
+          config: { type: 'http', url: 'https://h/mcp', headers: { A: 'b' } },
+        },
+      ],
+    };
+    expect(toGeminiSettings(httpReg)).toEqual({ mcpServers: { remote: { httpUrl: 'https://h/mcp', headers: { A: 'b' } } } });
+  });
+});

--- a/src/lib/mcp/tool-spine/index.ts
+++ b/src/lib/mcp/tool-spine/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Tool-Spine barrel — registry types + the pure emitters.
+ *
+ * `build.ts` is deliberately NOT re-exported here: it imports DB/ws/api-port and
+ * must only run in the Next server runtime, whereas everything exported below is
+ * import-pure (no fs, no DB) and safe to copy into a standalone process. Server
+ * callers import `buildToolRegistry` directly from `./build`.
+ */
+
+export * from './registry';
+export * from './emit-claude';
+export * from './emit-codex';
+export * from './emit-claude-desktop';
+export * from './emit-openclaw';
+export * from './emit-gemini';

--- a/src/lib/mcp/tool-spine/registry.ts
+++ b/src/lib/mcp/tool-spine/registry.ts
@@ -1,0 +1,74 @@
+/**
+ * Tool-Spine Registry — the single neutral source of truth for MCP server config.
+ *
+ * o8 used to hand-maintain the same server list in ~7 places across 4+ runtimes
+ * (Claude orchestrator, Codex orchestrator, Claude Desktop, OpenClaw, Gemini).
+ * That duplication caused a real config-drift outage. This module is the catalog;
+ * the `emit-*.ts` files are pure projections of it into each runtime's native
+ * format. Adding a new CLI is one ~25-line emitter, not a 7-file change.
+ *
+ * `source` (provenance/trust) is orthogonal to transport (stdio/http, inside
+ * `config`) — a future gateway is just `source:'gateway', config:{type:'http'}`,
+ * zero schema change. `surfaceNames` is the drift killer: the operator→"o8"
+ * rename (previously implicit across 3 copies) becomes data. `secretRefs` is
+ * inert in Phase 1 but reserves the vault-phase join point.
+ */
+
+import type { OrchestratorMcpServerConfig } from '@/lib/mcp/external-servers';
+
+export type ServerSource = 'builtin' | 'external' | 'gateway';
+
+export type ToolSurface =
+  | 'claude-orchestrator' // Claude --mcp-config JSON   (Set A)
+  | 'codex-orchestrator' //  Codex config.toml          (Set A)
+  | 'claude-desktop' //      ~/.claude.json             (Set B)
+  | 'openclaw' //            ~/.openclaw-o8/openclaw.json (Set B)
+  | 'gemini'; //             ~/.gemini/settings.json     (NEW — closes the gap)
+
+/** Inert in Phase 1; the vault-phase credential-injection hook. */
+export interface SecretRef {
+  vaultKey: string;
+  inject: { kind: 'env'; name: string } | { kind: 'header'; name: string };
+}
+
+export interface ServerEntry {
+  /** Stable identity, NOT the wire key. */
+  id: string;
+  /** Default wire key. */
+  name: string;
+  source: ServerSource;
+  label: string;
+  /** Which emitters include this entry. */
+  surfaces: ToolSurface[];
+  /** Per-surface key override (e.g. operator→"o8" on external surfaces). */
+  surfaceNames?: Partial<Record<ToolSurface, string>>;
+  /** The SAME stdio|http union the DB already uses. */
+  config: OrchestratorMcpServerConfig;
+  /** Undefined in Phase 1. */
+  secretRefs?: SecretRef[];
+}
+
+/** Entry order is load-bearing — emitters preserve it. */
+export interface ToolRegistry {
+  repoPath: string;
+  entries: ServerEntry[];
+}
+
+export interface ResolvedEntry {
+  /** The per-surface wire key (surfaceNames override applied). */
+  name: string;
+  config: OrchestratorMcpServerConfig;
+  entry: ServerEntry;
+}
+
+/**
+ * Project the registry onto a single surface: filter to entries that list the
+ * surface, in registry order, with the per-surface name applied. An entry can't
+ * leak to a surface it doesn't list — the gate is data on the catalog, evaluated
+ * identically by every emitter.
+ */
+export function entriesForSurface(registry: ToolRegistry, surface: ToolSurface): ResolvedEntry[] {
+  return registry.entries
+    .filter((e) => e.surfaces.includes(surface))
+    .map((e) => ({ name: e.surfaceNames?.[surface] ?? e.name, config: e.config, entry: e }));
+}

--- a/tests/smoke/tool-spine-claude-consumer-smoke.ts
+++ b/tests/smoke/tool-spine-claude-consumer-smoke.ts
@@ -1,0 +1,64 @@
+/**
+ * Tool-Spine Step-B regression lock (live, DB-touching): the Claude orchestrator
+ * consumer's WRITTEN FILE BODY.
+ *
+ * `ensureMcpConfig` (orchestrator-session.ts) was repointed from
+ *   JSON.stringify({ mcpServers: getMcpServersConfig(repo) }, null, 2)
+ * to
+ *   JSON.stringify(toClaudeJson(buildToolRegistry(repo)), null, 2)
+ *
+ * The parity unit is the file body, not the servers map. This asserts the two
+ * expressions produce byte-identical output (in one run → same registry, same
+ * token, same order), plus the envelope invariants the consumer relied on: the
+ * `{ mcpServers }` wrapper, NO trailing newline, `type` retained, and externals
+ * carried + slotted first. `getMcpServersConfig` is untouched by Step B, so it
+ * stays a faithful stand-in for the pre-repoint consumer body.
+ *
+ *   CORTEX_IDE_DATA_DIR=$(mktemp -d) NODE_OPTIONS='--conditions=react-server' \
+ *     npx tsx tests/smoke/tool-spine-claude-consumer-smoke.ts
+ */
+
+import assert from 'node:assert';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { getMcpServersConfig } from '@/lib/lane/orchestrator-mcp-config';
+import { insertExternalMcpServer } from '@/lib/mcp/external-servers';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { toClaudeJson } from '@/lib/mcp/tool-spine/emit-claude';
+
+function main(): void {
+  const dataDir = process.env.CORTEX_IDE_DATA_DIR;
+  assert(dataDir && existsSync(dataDir), 'CORTEX_IDE_DATA_DIR must be set to a temp dir');
+  writeFileSync(join(dataDir, 'ws-token'), 'consumer-smoke-fixed-token\n');
+  writeFileSync(join(dataDir, 'ws-port'), '3002\n');
+
+  // Externals present — the path that drifts (ordering + passthrough through the envelope).
+  insertExternalMcpServer({ name: 'zeta-stdio', transport: 'stdio', command: 'zeta', args: ['--x'], env: { K: 'v' }, enabled: true });
+  insertExternalMcpServer({ name: 'alpha-http', transport: 'http', command: 'https://a/mcp', url: 'https://a/mcp', oauthToken: 'tok123', enabled: true });
+
+  const repo = mkdtempSync(join(tmpdir(), 'claude-consumer-repo-'));
+
+  // before: the legacy consumer body (orchestrator-session.ts pre-Step-B).
+  const oldBody = JSON.stringify({ mcpServers: getMcpServersConfig(repo) }, null, 2);
+  // after: the repointed consumer body (orchestrator-session.ts post-Step-B).
+  const newBody = JSON.stringify(toClaudeJson(buildToolRegistry(repo)), null, 2);
+
+  assert.strictEqual(newBody, oldBody, 'repointed file body is byte-identical to the legacy body');
+
+  // Envelope invariants the consumer depends on.
+  assert(!newBody.endsWith('\n'), 'no trailing newline (JSON.stringify(..., null, 2) only)');
+  const parsed = JSON.parse(newBody) as { mcpServers: Record<string, { type?: string }> };
+  assert.deepStrictEqual(Object.keys(parsed), ['mcpServers'], 'top-level envelope is exactly { mcpServers }');
+  assert.strictEqual(parsed.mcpServers.operator.type, 'stdio', 'type field retained (not stripped for the orchestrator surface)');
+  assert.deepStrictEqual(
+    Object.keys(parsed.mcpServers),
+    ['zeta-stdio', 'alpha-http', 'operator', 'cortex'],
+    'externals slot first, then operator, cortex',
+  );
+
+  console.log('[tool-spine-claude-consumer-smoke] PASS (' + newBody.length + ' bytes)');
+}
+
+main();

--- a/tests/smoke/tool-spine-claude-desktop-consumer-smoke.ts
+++ b/tests/smoke/tool-spine-claude-desktop-consumer-smoke.ts
@@ -1,0 +1,92 @@
+/**
+ * Tool-Spine Step-D regression lock (live): the Claude Desktop consumer's
+ * WRITTEN ~/.claude.json + its backup.
+ *
+ * claude-desktop/route.ts (GET preview + POST write) was repointed onto the
+ * Tool-Spine claude-desktop projection (toClaudeDesktopJson); the file I/O moved
+ * to claude-desktop-config-io.ts. The parity unit is the merged file content.
+ * Runs in PACKAGED mode (set inline) so resolution is deterministic — the dev
+ * tsx-vs-npx divergence is spec risk #3, proven byte-identical in packaged mode
+ * by the one-time ceremony.
+ *
+ *   CORTEX_IDE_DATA_DIR=$(mktemp -d) NODE_OPTIONS='--conditions=react-server' \
+ *     npx tsx tests/smoke/tool-spine-claude-desktop-consumer-smoke.ts
+ */
+
+import assert from 'node:assert';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+
+import { atomicWriteConfig } from '@/lib/mcp/claude-desktop-config-io';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { entriesForSurface } from '@/lib/mcp/tool-spine/registry';
+import { toClaudeDesktopJson } from '@/lib/mcp/tool-spine/emit-claude-desktop';
+
+// A realistic ~/.claude.json: several unrelated top-level keys + a non-o8 server.
+const EXISTING = {
+  $schema: 'https://example/schema.json',
+  theme: 'dark',
+  globalShortcut: 'Cmd+E',
+  mcpServers: {
+    filesystem: { command: 'fs-mcp', args: ['/Users/me'] },
+    github: { command: 'gh-mcp', env: { GH_TOKEN: 'x' } },
+  },
+};
+
+function main(): void {
+  // Force PACKAGED resolution so o8/codebase-memory entries are deterministic.
+  const bundleDir = mkdtempSync(join(tmpdir(), 'cd-bundle-'));
+  const bundlePath = join(bundleDir, 'operator-mcp-server.mjs');
+  writeFileSync(bundlePath, '');
+  process.env.O8_BUNDLED_MCP_PATH = bundlePath;
+  process.env.O8_BUNDLED_MCP_DIR = bundleDir;
+  process.env.O8_NODE_BIN = '/usr/local/bin/node';
+  const cmBin = join(mkdtempSync(join(tmpdir(), 'cd-cm-')), 'codebase-memory-mcp');
+  writeFileSync(cmBin, '');
+  process.env.O8_CODEBASE_MEMORY_BIN = cmBin;
+
+  const registry = buildToolRegistry(process.cwd());
+  const installed = entriesForSurface(registry, 'claude-desktop').map((e) => e.name);
+  assert.deepStrictEqual(installed, ['o8', 'codebase-memory'], 'claude-desktop surface = o8 + codebase-memory');
+
+  const merged = toClaudeDesktopJson(registry, EXISTING);
+  const servers = merged.mcpServers as Record<string, Record<string, unknown>>;
+
+  // #2 — merge preservation: top-level keys + non-o8 servers survive byte-identical.
+  assert.strictEqual(merged.$schema, 'https://example/schema.json', '$schema preserved');
+  assert.strictEqual(merged.theme, 'dark', 'theme preserved');
+  assert.strictEqual(merged.globalShortcut, 'Cmd+E', 'globalShortcut preserved');
+  assert.deepStrictEqual(servers.filesystem, { command: 'fs-mcp', args: ['/Users/me'] }, 'filesystem untouched');
+  assert.deepStrictEqual(servers.github, { command: 'gh-mcp', env: { GH_TOKEN: 'x' } }, 'github untouched');
+
+  // #3 — type-strip: o8 + codebase-memory are {command,args,env} with NO type.
+  assert(!('type' in servers.o8), 'o8 entry has no type field');
+  assert(!('type' in servers['codebase-memory']), 'codebase-memory entry has no type field');
+  assert.deepStrictEqual(servers.o8, { command: '/usr/local/bin/node', args: [bundlePath], env: { O8_API_BASE: 'http://127.0.0.1:3001' } }, 'o8 stdio shape');
+  assert.deepStrictEqual(servers['codebase-memory'], { command: cmBin, args: [], env: {} }, 'codebase-memory stdio shape');
+
+  // Key order: existing first, then o8, then codebase-memory.
+  assert.deepStrictEqual(Object.keys(servers), ['filesystem', 'github', 'o8', 'codebase-memory'], 'merge order');
+
+  // #4 + #1 — real write: trailing newline + backup content == original (name ignored).
+  const cfgDir = mkdtempSync(join(tmpdir(), 'cd-cfg-'));
+  const cfgPath = join(cfgDir, 'claude_desktop_config.json');
+  const originalOnDisk = JSON.stringify(EXISTING, null, 2) + '\n';
+  writeFileSync(cfgPath, originalOnDisk);
+
+  atomicWriteConfig(cfgPath, merged);
+
+  const written = readFileSync(cfgPath, 'utf-8');
+  assert.strictEqual(written, JSON.stringify(merged, null, 2) + '\n', 'written file = merged content + trailing newline');
+  assert(written.endsWith('\n'), 'trailing newline preserved');
+
+  // Backup: timestamped NAME is ignored (glob); only its CONTENT is asserted.
+  const backups = readdirSync(dirname(cfgPath)).filter((f) => f.startsWith(`${basename(cfgPath)}.o8-backup-`));
+  assert.strictEqual(backups.length, 1, 'exactly one timestamped backup written');
+  assert.strictEqual(readFileSync(join(cfgDir, backups[0]), 'utf-8'), originalOnDisk, 'backup content == pre-merge original');
+
+  console.log('[tool-spine-claude-desktop-consumer-smoke] PASS (' + written.length + 'B written, backup ' + backups[0].replace(/o8-backup-\d+/, 'o8-backup-<ts>') + ')');
+}
+
+main();

--- a/tests/smoke/tool-spine-codex-consumer-smoke.ts
+++ b/tests/smoke/tool-spine-codex-consumer-smoke.ts
@@ -1,0 +1,79 @@
+/**
+ * Tool-Spine Step-C regression lock (live, DB-touching): the Codex orchestrator
+ * consumer's WRITTEN FILE — the full config.toml from mergeCodexMcpConfig.
+ *
+ * ensureCodexHome was repointed from getMcpServersConfig(repo) to
+ * toCodexServersMap(buildToolRegistry(repo)); the serializer moved to
+ * emit-codex.ts. The strip + merge + trailing-newline stay in the consumer.
+ * The parity unit is the merged config.toml, covering BOTH branches of
+ * `${[retained, managed].filter(Boolean).join('\n\n')}\n`:
+ *   - retained-present → retained\n\nmanaged\n  (user section kept, stale o8
+ *     block stripped — the idempotency the merge exists for)
+ *   - retained-absent  → managed\n             (fresh install)
+ *
+ *   CORTEX_IDE_DATA_DIR=$(mktemp -d) NODE_OPTIONS='--conditions=react-server' \
+ *     npx tsx tests/smoke/tool-spine-codex-consumer-smoke.ts
+ */
+
+import assert from 'node:assert';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { getMcpServersConfig } from '@/lib/lane/orchestrator-mcp-config';
+import { mergeCodexMcpConfig } from '@/lib/lane/codex-orchestrator-session';
+import { insertExternalMcpServer } from '@/lib/mcp/external-servers';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { serializeCodexMcpServers, toCodexServersMap } from '@/lib/mcp/tool-spine/emit-codex';
+
+// A user's own non-o8 section (must be retained) + a STALE o8-managed block
+// (must be stripped, not duplicated).
+const RETAINED_FIXTURE = [
+  '[user_tool]',
+  'enabled = true',
+  '',
+  '[mcp_servers.operator]',
+  'command = "STALE"',
+  'args = ["old"]',
+  '',
+].join('\n');
+
+function main(): void {
+  const dataDir = process.env.CORTEX_IDE_DATA_DIR;
+  assert(dataDir && existsSync(dataDir), 'CORTEX_IDE_DATA_DIR must be set to a temp dir');
+  writeFileSync(join(dataDir, 'ws-token'), 'codex-consumer-fixed-token\n');
+  writeFileSync(join(dataDir, 'ws-port'), '3002\n');
+
+  insertExternalMcpServer({ name: 'zeta-stdio', transport: 'stdio', command: 'zeta', args: ['--x'], env: { K: 'v' }, enabled: true });
+  insertExternalMcpServer({ name: 'alpha-http', transport: 'http', command: 'https://a/mcp', url: 'https://a/mcp', oauthToken: 'tok123', enabled: true });
+
+  const repo = mkdtempSync(join(tmpdir(), 'codex-consumer-repo-'));
+
+  // The map fed to the consumer is byte-identical to the legacy getMcpServersConfig.
+  const registry = buildToolRegistry(repo);
+  const servers = toCodexServersMap(registry);
+  assert.deepStrictEqual(servers, getMcpServersConfig(repo), 'codex servers map == legacy getMcpServersConfig');
+
+  const managed = serializeCodexMcpServers(servers);
+  assert(managed.startsWith('[mcp_servers.zeta-stdio]'), 'externals serialize first');
+  assert(managed.includes('[mcp_servers.operator]') && managed.includes('[mcp_servers.cortex]'), 'operator + cortex present');
+  assert(!managed.endsWith('\n'), 'serializer adds no trailing newline');
+
+  // ── Fresh branch: retained empty → managed\n ──
+  const fresh = mergeCodexMcpConfig('', servers);
+  assert.strictEqual(fresh, `${managed}\n`, 'fresh install = managed blocks + single trailing newline');
+
+  // ── Retained branch: user section kept, stale o8 block stripped ──
+  const retained = mergeCodexMcpConfig(RETAINED_FIXTURE, servers);
+  // Strip removes [mcp_servers.operator] (and its env) but keeps [user_tool].
+  const expectedRetainedPrefix = '[user_tool]\nenabled = true';
+  assert.strictEqual(retained, `${expectedRetainedPrefix}\n\n${managed}\n`, 'retained\\n\\nmanaged\\n with trailing newline');
+  assert(retained.includes('[user_tool]'), 'user section retained');
+  assert(!retained.includes('STALE'), 'stale o8-managed block stripped (no duplication)');
+  // Exactly one operator block survives (the fresh one), proving the strip.
+  assert.strictEqual(retained.match(/\[mcp_servers\.operator]/g)?.length, 1, 'exactly one operator block after merge');
+
+  console.log('[tool-spine-codex-consumer-smoke] PASS (retained ' + retained.length + 'B, fresh ' + fresh.length + 'B)');
+}
+
+main();

--- a/tests/smoke/tool-spine-external-client-consumer-smoke.ts
+++ b/tests/smoke/tool-spine-external-client-consumer-smoke.ts
@@ -1,0 +1,80 @@
+/**
+ * Tool-Spine Step-E2 regression lock (live): the external-client forwarded
+ * server object + BOTH serialized wire shapes.
+ *
+ * external-client/route.ts forwards o8's operator entry to the Hermes / OpenClaw
+ * MCP CLIs — hermes as an argv (`mcp add o8 --command … --args … --env K=V`),
+ * openclaw as a JSON blob (`mcp set o8 '<json>'`). The builder now comes from the
+ * Tool-Spine claude-desktop projection (the THIRD/last buildServerConfig copy
+ * gone). This tests the OBJECT + both shapes; it does NOT spawn the CLIs.
+ *
+ * SURFACE-SPECIFIC behavior (verified, not inferred from E1): external-client
+ * forwards ONLY o8 — never codebase-memory, never externals — EVEN WHEN the
+ * codebase-memory binary is available. PACKAGED mode (spec risk #3).
+ *
+ *   CORTEX_IDE_DATA_DIR=$(mktemp -d) NODE_OPTIONS='--conditions=react-server' \
+ *     npx tsx tests/smoke/tool-spine-external-client-consumer-smoke.ts
+ */
+
+import assert from 'node:assert';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { insertExternalMcpServer } from '@/lib/mcp/external-servers';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { toClaudeDesktopJson } from '@/lib/mcp/tool-spine/emit-claude-desktop';
+import { hermesAddArgs, openclawSetPayload, type ForwardedServer } from '@/lib/mcp/external-client-args';
+
+function main(): void {
+  // Force PACKAGED resolution, AND make codebase-memory AVAILABLE — to prove
+  // external-client still forwards o8 ONLY (it never forwarded codebase-memory).
+  const bundleDir = mkdtempSync(join(tmpdir(), 'ec-bundle-'));
+  const bundlePath = join(bundleDir, 'operator-mcp-server.mjs');
+  writeFileSync(bundlePath, '');
+  process.env.O8_BUNDLED_MCP_PATH = bundlePath;
+  process.env.O8_BUNDLED_MCP_DIR = bundleDir;
+  process.env.O8_NODE_BIN = '/usr/local/bin/node';
+  const cmBin = join(mkdtempSync(join(tmpdir(), 'ec-cm-')), 'codebase-memory-mcp');
+  writeFileSync(cmBin, '');
+  process.env.O8_CODEBASE_MEMORY_BIN = cmBin;
+
+  // Externals in the DB must not leak into the forwarded shapes.
+  insertExternalMcpServer({ name: 'zeta-stdio', transport: 'stdio', command: 'zeta', args: ['--x'], env: { K: 'v' }, enabled: true });
+
+  // The exact buildServerConfig() expression (external-client/route.ts).
+  const projected = toClaudeDesktopJson(buildToolRegistry(process.cwd()), {}).mcpServers as Record<string, unknown>;
+  const o8 = projected['o8'] as { command: string; args: string[]; env?: Record<string, string> };
+  const server: ForwardedServer = { command: o8.command, args: o8.args, env: o8.env ?? {} };
+
+  // Forwarded object = the operator entry, no type.
+  assert.deepStrictEqual(server, { command: '/usr/local/bin/node', args: [bundlePath], env: { O8_API_BASE: 'http://127.0.0.1:3001' } }, 'forwarded object = operator stdio entry');
+
+  // Shape 1 — hermes argv.
+  const hermes = hermesAddArgs(server);
+  assert.deepStrictEqual(
+    hermes,
+    ['mcp', 'add', 'o8', '--command', '/usr/local/bin/node', '--args', bundlePath, '--env', 'O8_API_BASE=http://127.0.0.1:3001'],
+    'hermes argv shape',
+  );
+
+  // Shape 2 — openclaw JSON blob.
+  const openclaw = openclawSetPayload(server);
+  assert.strictEqual(
+    openclaw,
+    JSON.stringify({ command: '/usr/local/bin/node', args: [bundlePath], env: { O8_API_BASE: 'http://127.0.0.1:3001' } }),
+    'openclaw JSON shape',
+  );
+
+  // o8-ONLY: codebase-memory is AVAILABLE in the projection but must NOT appear
+  // in either forwarded shape; externals must not appear either.
+  assert(projected['codebase-memory'], 'codebase-memory IS available in the projection (precondition)');
+  for (const shape of [hermes.join(' '), openclaw]) {
+    assert(!shape.includes('codebase-memory'), 'forwarded shape must not contain codebase-memory');
+    assert(!shape.includes('zeta'), 'forwarded shape must not contain externals');
+  }
+
+  console.log('[tool-spine-external-client-consumer-smoke] PASS (hermes ' + hermes.length + ' args, openclaw ' + openclaw.length + 'B)');
+}
+
+main();

--- a/tests/smoke/tool-spine-mcp-config-consumer-smoke.ts
+++ b/tests/smoke/tool-spine-mcp-config-consumer-smoke.ts
@@ -1,0 +1,60 @@
+/**
+ * Tool-Spine Step-E1 regression lock (live): the mcp-config GET response server
+ * objects.
+ *
+ * mcp-config/route.ts GET returned { server, codebaseMemory, fullConfig } from
+ * its own buildServerConfig copy; it now derives them from the Tool-Spine
+ * claude-desktop projection (Set B). No file write — the parity unit is the
+ * returned object. PACKAGED mode (set inline) so resolution is deterministic
+ * (dev tsx-vs-npx is spec risk #3).
+ *
+ *   CORTEX_IDE_DATA_DIR=$(mktemp -d) NODE_OPTIONS='--conditions=react-server' \
+ *     npx tsx tests/smoke/tool-spine-mcp-config-consumer-smoke.ts
+ */
+
+import assert from 'node:assert';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { insertExternalMcpServer } from '@/lib/mcp/external-servers';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { toClaudeDesktopJson } from '@/lib/mcp/tool-spine/emit-claude-desktop';
+
+function main(): void {
+  // Force PACKAGED resolution.
+  const bundleDir = mkdtempSync(join(tmpdir(), 'mc-bundle-'));
+  const bundlePath = join(bundleDir, 'operator-mcp-server.mjs');
+  writeFileSync(bundlePath, '');
+  process.env.O8_BUNDLED_MCP_PATH = bundlePath;
+  process.env.O8_BUNDLED_MCP_DIR = bundleDir;
+  process.env.O8_NODE_BIN = '/usr/local/bin/node';
+  const cmBin = join(mkdtempSync(join(tmpdir(), 'mc-cm-')), 'codebase-memory-mcp');
+  writeFileSync(cmBin, '');
+  process.env.O8_CODEBASE_MEMORY_BIN = cmBin;
+
+  // Externals in the DB MUST NOT leak into this Set-B surface.
+  insertExternalMcpServer({ name: 'zeta-stdio', transport: 'stdio', command: 'zeta', args: ['--x'], env: { K: 'v' }, enabled: true });
+  insertExternalMcpServer({ name: 'alpha-http', transport: 'http', command: 'https://a/mcp', url: 'https://a/mcp', oauthToken: 'tok', enabled: true });
+
+  // The exact GET-handler expression (mcp-config/route.ts).
+  const mcpServers = toClaudeDesktopJson(buildToolRegistry(process.cwd()), {}).mcpServers as Record<string, Record<string, unknown>>;
+  const server = mcpServers['o8'];
+  const codebaseMemory = mcpServers['codebase-memory'] ?? null;
+  const fullConfig = { mcpServers };
+
+  // Set-B shape: o8 + codebase-memory, NO externals leak, NO type field.
+  assert.deepStrictEqual(Object.keys(mcpServers), ['o8', 'codebase-memory'], 'only o8 + codebase-memory (externals filtered out)');
+  assert(!('type' in server), 'server (o8) has no type field');
+  assert.deepStrictEqual(server, { command: '/usr/local/bin/node', args: [bundlePath], env: { O8_API_BASE: 'http://127.0.0.1:3001' } }, 'o8 stdio shape');
+  assert(codebaseMemory && !('type' in codebaseMemory), 'codebaseMemory present, no type');
+  assert.deepStrictEqual(codebaseMemory, { command: cmBin, args: [], env: {} }, 'codebase-memory stdio shape');
+
+  // fullConfig wraps the same map.
+  assert.deepStrictEqual(fullConfig, { mcpServers }, 'fullConfig = { mcpServers }');
+  assert.strictEqual(JSON.stringify(fullConfig.mcpServers.o8), JSON.stringify(server), 'fullConfig.o8 === server');
+
+  console.log('[tool-spine-mcp-config-consumer-smoke] PASS');
+}
+
+main();

--- a/tests/smoke/tool-spine-parity-smoke.ts
+++ b/tests/smoke/tool-spine-parity-smoke.ts
@@ -1,0 +1,127 @@
+/**
+ * Tool-Spine Step-A regression lock (live, DB-touching).
+ *
+ * Proves the registry shim reproduces the legacy `getMcpServersConfig` output
+ * byte-for-byte under controlled env, and that every emitter runs over the live
+ * `buildToolRegistry` without throwing. Run:
+ *
+ *   CORTEX_IDE_DATA_DIR=$(mktemp -d) NODE_OPTIONS='--conditions=react-server' \
+ *     npx tsx tests/smoke/tool-spine-parity-smoke.ts
+ *
+ * The temp data dir gives a fresh DB (no externals), a fixed ws-token/ws-port,
+ * and a non-git repo (slug = ''), making the output deterministic.
+ */
+
+import assert from 'node:assert';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { getMcpServersConfig } from '@/lib/lane/orchestrator-mcp-config';
+import { externalServerToMcpConfig, insertExternalMcpServer, listEnabledExternalMcpServers } from '@/lib/mcp/external-servers';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { toClaudeServersMap, toClaudeJson } from '@/lib/mcp/tool-spine/emit-claude';
+import { toCodexToml } from '@/lib/mcp/tool-spine/emit-codex';
+import { toClaudeDesktopJson } from '@/lib/mcp/tool-spine/emit-claude-desktop';
+import { toOpenclawJson } from '@/lib/mcp/tool-spine/emit-openclaw';
+import { toGeminiSettings } from '@/lib/mcp/tool-spine/emit-gemini';
+
+function main(): void {
+  const dataDir = process.env.CORTEX_IDE_DATA_DIR;
+  assert(dataDir && existsSync(dataDir), 'CORTEX_IDE_DATA_DIR must be set to a temp dir');
+
+  // Pin the env-derived values so the golden is deterministic.
+  writeFileSync(join(dataDir, 'ws-token'), 'test-ws-token-fixed\n');
+  writeFileSync(join(dataDir, 'ws-port'), '3002\n');
+
+  const repo = mkdtempSync(join(tmpdir(), 'tool-spine-repo-')); // non-git → slug ''
+  const repoRoot = process.cwd();
+  const operatorPath = join(repoRoot, 'src/lib/mcp/operator-mcp-server.ts');
+  const cortexPath = join(repoRoot, 'src/lib/mcp/cortex-mcp-server.ts');
+
+  // ── 1. Byte-for-byte parity: the shim reproduces the legacy output ──
+  const expected = {
+    operator: {
+      type: 'stdio',
+      command: 'npx',
+      args: ['tsx', operatorPath],
+      env: { O8_API_BASE: 'http://127.0.0.1:3001' },
+    },
+    cortex: {
+      type: 'stdio',
+      command: 'npx',
+      args: ['tsx', cortexPath],
+      env: {
+        CORTEX_API_BASE: 'http://127.0.0.1:3001',
+        CORTEX_REPO_PATH: repo,
+        CORTEX_REPO_SLUG: '',
+        WS_PORT: '3002',
+        WS_TOKEN: 'test-ws-token-fixed',
+      },
+    },
+  };
+
+  const actual = getMcpServersConfig(repo);
+  assert.deepStrictEqual(actual, expected, 'shim output must match the legacy golden byte-for-byte');
+  assert.deepStrictEqual(Object.keys(actual), ['operator', 'cortex'], 'key order is [operator, cortex]');
+
+  // The registry projection IS the shim — prove they agree explicitly.
+  const registry = buildToolRegistry(repo);
+  assert.deepStrictEqual(toClaudeServersMap(registry), expected, 'toClaudeServersMap == legacy map');
+  assert.deepStrictEqual(toClaudeJson(registry), { mcpServers: expected }, 'toClaudeJson wraps in mcpServers');
+
+  // ── 2. Every other emitter runs over the LIVE registry without throwing ──
+  const codexToml = toCodexToml(registry);
+  assert(codexToml.includes('[mcp_servers.operator]'), 'codex TOML has operator block');
+  assert(codexToml.includes('[mcp_servers.cortex]'), 'codex TOML has cortex block');
+  assert(!codexToml.endsWith('\n'), 'codex serializer adds no trailing newline (caller does)');
+
+  const desktop = toClaudeDesktopJson(registry, { mcpServers: { filesystem: { command: 'fs' } } });
+  assert.deepStrictEqual((desktop.mcpServers as Record<string, unknown>).filesystem, { command: 'fs' }, 'unknown server preserved');
+  const o8Entry = (desktop.mcpServers as Record<string, unknown>).o8 as Record<string, unknown>;
+  assert(o8Entry && !('type' in o8Entry), 'desktop o8 entry has no type field');
+  assert(o8Entry.command === 'npx', 'desktop o8 entry is the operator stdio config');
+
+  const openclaw = toOpenclawJson(registry);
+  assert.deepStrictEqual(Object.keys(openclaw.servers), ['o8'], 'openclaw emits only o8');
+  assert(!('type' in (openclaw.servers.o8 as Record<string, unknown>)), 'openclaw o8 entry has no type');
+
+  const gemini = toGeminiSettings(registry);
+  const gemO8 = (gemini.mcpServers as Record<string, unknown>).o8 as Record<string, unknown>;
+  assert(gemO8 && gemO8.command === 'npx' && !('type' in gemO8), 'gemini o8 entry is stdio with no type');
+
+  // ── 3. Externals-present parity (the path that drifts: ordering + passthrough) ──
+  // Production always carries externals; this is the only case that exercises
+  // "externals slot first" and external-config passthrough. Insert ≥1 stdio + ≥1
+  // http external, then assert the shim places them first in DB (createdAt =
+  // insertion) order and passes each through byte-identically.
+  insertExternalMcpServer({ name: 'zeta-stdio', transport: 'stdio', command: 'zeta', args: ['--x'], env: { K: 'v' }, enabled: true });
+  insertExternalMcpServer({ name: 'alpha-http', transport: 'http', command: 'https://a/mcp', url: 'https://a/mcp', oauthToken: 'tok123', enabled: true });
+
+  const withExternals = getMcpServersConfig(repo);
+  assert.deepStrictEqual(
+    Object.keys(withExternals),
+    ['zeta-stdio', 'alpha-http', 'operator', 'cortex'],
+    'externals slot first (insertion order), then operator, cortex',
+  );
+  // Byte-identical passthrough: each external entry equals externalServerToMcpConfig(record).
+  const records = listEnabledExternalMcpServers();
+  for (const record of records) {
+    assert.deepStrictEqual(
+      withExternals[record.name],
+      externalServerToMcpConfig(record),
+      `external "${record.name}" config passes through unchanged`,
+    );
+  }
+  // The stdio external keeps env; the http external folds oauth into a Bearer header.
+  assert.deepStrictEqual(withExternals['zeta-stdio'], { type: 'stdio', command: 'zeta', args: ['--x'], env: { K: 'v' } }, 'stdio external passthrough');
+  assert.deepStrictEqual(withExternals['alpha-http'], { type: 'http', url: 'https://a/mcp', headers: { Authorization: 'Bearer tok123' } }, 'http external passthrough');
+  // operator/cortex builtins still trail the externals, unchanged.
+  assert.deepStrictEqual(withExternals.operator, expected.operator, 'operator unchanged with externals present');
+  assert.deepStrictEqual(withExternals.cortex, expected.cortex, 'cortex unchanged with externals present');
+
+  console.log('[tool-spine-parity-smoke] PASS');
+  console.log(JSON.stringify(withExternals, null, 2));
+}
+
+main();


### PR DESCRIPTION
## Tool-Spine Phase 1 — one source of truth for MCP server config (A–E)

**What.** o8 hand-maintained the same MCP server list in ~7 places across every runtime (Claude orchestrator, Codex orchestrator, Claude Desktop, the config-generator, the Hermes/OpenClaw installer) — a duplication that already caused a real config-drift outage. This collapses all of it onto **one neutral registry + pure per-runtime emitters**: the canonical builder (`getMcpServersConfig`) and **all three** copy-pasted `buildServerConfig` blocks now derive from a single `buildToolRegistry()` projection. Adding the Nth CLI becomes one ~25-line emitter instead of a 7-file change.

**Guarantee: zero behavior change.** Every consumer was repointed under the same discipline — capture today's exact output → repoint → assert byte-identical — and each is locked by a committed parity smoke. Proofs run in **packaged mode** (the shipped shape; dev `tsx`-vs-`npx` resolution is the spec's known risk #3, documented at `argsForMcpServer`). Externals are carried through every relevant proof (ordering + passthrough where they belong; surface-isolation where they don't).

### The registry (new — `src/lib/mcp/tool-spine/`)
- `registry.ts` — catalog model + `entriesForSurface`. `surfaceNames` makes the operator→`o8` rename **data** (previously implicit across 3 copies); `source` is orthogonal to transport; `secretRefs` reserved (inert) for the vault phase.
- `build.ts` — `buildToolRegistry()`; resolvers moved verbatim (import.meta.url depth adjusted).
- `emit-claude` / `emit-codex` / `emit-claude-desktop` / `emit-openclaw` / `emit-gemini` — pure projections (no `@/lib`/fs/DB), one per surface.
- `emitters.test.ts` — 10 pure golden snapshots.

### Consumers repointed (one commit each, each gated)
| Step | Consumer | Parity unit |
|---|---|---|
| A | registry + emitters + `getMcpServersConfig` shim | servers map, byte-identical to git-`HEAD` baseline (externals present) |
| B | Claude orchestrator (`ensureMcpConfig`) | written `--mcp-config` JSON envelope, no trailing newline, `type` retained |
| C | Codex orchestrator (`mergeCodexMcpConfig`) | full `config.toml` — both merge branches (retained+stale-stripped / fresh) |
| D | Claude Desktop route (GET+POST) | merged `~/.claude.json` + backup-content==original (timestamp globbed); `type`-stripped; unknown servers/keys preserved |
| E1 | mcp-config GET response | returned Set-B object; externals don't leak |
| E2 | external-client (hermes/openclaw) | both wire shapes (argv + JSON blob); forwards **o8 only**, even when codebase-memory is available |

Supporting verbatim extractions for testability: `claude-desktop-config-io.ts` (D), `external-client-args.ts` (E2).

**Gate (on this branch, synced to `main`):** `tsc --noEmit` clean · `npm test` 327/327 · all six A–E parity smokes green.

### Explicitly deferred
- **Convergence phase** (where the single source of truth actually *fixes* drift — separate from these behavior-preserving steps): the repo-root `.mcp.json` static `http`-vs-`stdio` disagreement; the orphaned-managed-section strip bug (`TODO(tool-spine-convergence)` at `isManagedMcpSection`); the OpenClaw `mcp.servers.o8` self-heal/throw.
- **Phase 2** (new capability, not drift-collapse): **F** — OpenClaw passthrough→emit (genuine behavior change, no legacy baseline); **Gemini wiring** (the `toGeminiSettings` emitter ships here, golden-tested, but unwired); **OpenCode**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018akNs5xu63pWZA3SXaGha8
