### PR TITLE
Phase 2 · F: OpenClaw o8 entry from the registry, not passthrough (behavior change)

### DIFF
--- a/src/lib/lane/orchestrator-backends/openclaw.ts
+++ b/src/lib/lane/orchestrator-backends/openclaw.ts
@@ -35,6 +35,8 @@ import type {
   OrchestratorSessionInfo,
   OrchestratorTurnOptions,
 } from './types';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { toOpenclawJson } from '@/lib/mcp/tool-spine/emit-openclaw';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -426,6 +428,42 @@ function linkProfileDir(name: string): void {
 }
 
 /**
+ * Build the governed o8 profile object from the operator's source openclaw
+ * config: headless (channels/bindings dropped), agents governed (#1075), gateway
+ * on the dedicated o8 port, and `mcp.servers` locked to o8 ONLY (every other
+ * source mcp server is dropped — the governed profile exposes only o8's tools).
+ *
+ * The o8 entry is supplied by the caller. Post-F that's the Tool-Spine registry
+ * projection (o8 owns its own entry) rather than the source passthrough — that
+ * is the ONLY value that differs between the old and new behavior; everything
+ * else here is a pure function of `source` and is unchanged. Exported for the
+ * Step-F containment test.
+ */
+export function buildGovernedO8Profile(source: Record<string, unknown>, o8Entry: unknown): Record<string, unknown> {
+  const sourceAgents = (source.agents as Record<string, unknown> | undefined) ?? {};
+  const sourceAgentList = Array.isArray(sourceAgents.list)
+    ? (sourceAgents.list as Array<Record<string, unknown>>)
+    : [];
+  const sourceGateway = (source.gateway as Record<string, unknown> | undefined) ?? {};
+
+  return {
+    ...source,
+    // Headless orchestrator — drop the operator's messaging surface so the o8
+    // gateway never starts their Telegram/Discord. `undefined` keys are omitted
+    // by JSON.stringify.
+    channels: undefined,
+    bindings: undefined,
+    agents: {
+      ...sourceAgents,
+      list: sourceAgentList.map(governOpenclawAgent),
+    },
+    mcp: { servers: { o8: o8Entry } },
+    // Dedicated gateway port — never the operator's personal gateway (:18789).
+    gateway: { ...sourceGateway, port: readOpenclawGatewayPort() ?? OPENCLAW_GATEWAY_PORT_BASE },
+  };
+}
+
+/**
  * Ensure the isolated `o8` openclaw profile exists at ~/.openclaw-o8.
  *
  * Derives the profile config from the operator's working openclaw config —
@@ -479,24 +517,18 @@ export function ensureOpenclawProfile(): void {
         + 'Register it via o8 Settings -> MCP before using the openclaw orchestrator.',
     );
   }
+  // TODO(tool-spine-convergence): this throw is vestigial post-F — o8's mcp entry
+  // is now EMITTED from the registry below, not the read sourceMcpServers.o8 (the
+  // read survives only as a presence check). Removing the throw = the self-heal
+  // (auto-register o8 from the registry), which the spec gates separately.
 
-  const sourceGateway = (source.gateway as Record<string, unknown> | undefined) ?? {};
-
-  const o8Config = {
-    ...source,
-    // Headless orchestrator — drop the operator's messaging surface so the o8
-    // gateway never starts their Telegram/Discord. `undefined` keys are omitted
-    // by JSON.stringify.
-    channels: undefined,
-    bindings: undefined,
-    agents: {
-      ...sourceAgents,
-      list: sourceAgentList.map(governOpenclawAgent),
-    },
-    mcp: { servers: { o8: o8McpServer } },
-    // Dedicated gateway port — never the operator's personal gateway (:18789).
-    gateway: { ...sourceGateway, port: readOpenclawGatewayPort() ?? OPENCLAW_GATEWAY_PORT_BASE },
-  };
+  // o8 owns its own mcp entry: emit it from the Tool-Spine registry instead of
+  // passing through whatever the user pre-registered. repoPath is irrelevant to
+  // the openclaw surface (operator-only; cortex/externals filtered out).
+  const o8Config = buildGovernedO8Profile(
+    source,
+    toOpenclawJson(buildToolRegistry(process.cwd())).servers.o8,
+  );
 
   writeFileSync(OPENCLAW_O8_CONFIG, `${JSON.stringify(o8Config, null, 2)}\n`, { mode: 0o600 });
   // Schema marker — sidecar in ~/.o8, NOT in the config (openclaw rejects

--- a/tests/smoke/tool-spine-openclaw-consumer-smoke.ts
+++ b/tests/smoke/tool-spine-openclaw-consumer-smoke.ts
@@ -1,0 +1,93 @@
+/**
+ * Tool-Spine Step-F containment test (live): OpenClaw passthrough → registry emit.
+ *
+ * F is the one DELIBERATE behavior change — the governed o8 profile's mcp entry
+ * now comes from the registry projection, not the user's pre-registered passthrough.
+ * There is NO byte baseline, so the proof is CONTAINMENT: build the profile both
+ * ways from the SAME source and prove F touched ONLY mcp.servers.o8.
+ *
+ * PACKAGED mode (the registry o8 = the stable {command:<node>, args:[<bundled>]}
+ * shape — the dev tsx-vs-npx divergence is spec risk #3).
+ *
+ *   CORTEX_IDE_DATA_DIR=$(mktemp -d) NODE_OPTIONS='--conditions=react-server' \
+ *     npx tsx tests/smoke/tool-spine-openclaw-consumer-smoke.ts
+ */
+
+import assert from 'node:assert';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { buildGovernedO8Profile } from '@/lib/lane/orchestrator-backends/openclaw';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { toOpenclawJson } from '@/lib/mcp/tool-spine/emit-openclaw';
+
+// A realistic source openclaw.json: agents, gateway, channels/bindings (to be
+// stripped), unrelated top-level keys (to be preserved), and mcp.servers with a
+// HAND-CUSTOMIZED o8 (different from the registry) PLUS another server `foo`.
+const SOURCE = {
+  agents: { list: [{ id: 'main', model: 'codex', toolPolicy: 'all' }], defaults: { x: 1 } },
+  gateway: { host: '127.0.0.1', extra: 'keep-me' },
+  channels: { telegram: { token: 'SECRET' } },
+  bindings: { discord: 'guild-123' },
+  auth: { provider: 'oauth', token: 'KEEP' },
+  models: { default: 'gpt-5.5' },
+  mcp: {
+    servers: {
+      o8: { command: '/custom/tsx', args: ['/custom/operator.ts'], env: { O8_API_BASE: 'http://127.0.0.1:9999' } },
+      foo: { command: 'foo-mcp', args: [] },
+    },
+  },
+};
+
+function stripMcp(profile: Record<string, unknown>): Record<string, unknown> {
+  const clone = JSON.parse(JSON.stringify(profile)) as Record<string, unknown>; // normalizes (drops undefined)
+  delete clone.mcp;
+  return clone;
+}
+
+function main(): void {
+  // Force PACKAGED resolution for the registry o8 entry.
+  const bundleDir = mkdtempSync(join(tmpdir(), 'oc-bundle-'));
+  const bundlePath = join(bundleDir, 'operator-mcp-server.mjs');
+  writeFileSync(bundlePath, '');
+  process.env.O8_BUNDLED_MCP_PATH = bundlePath;
+  process.env.O8_BUNDLED_MCP_DIR = bundleDir;
+  process.env.O8_NODE_BIN = '/usr/local/bin/node';
+
+  const passthroughO8 = SOURCE.mcp.servers.o8; // what the OLD code used
+  const registryO8 = toOpenclawJson(buildToolRegistry(process.cwd())).servers['o8']; // what the NEW code uses
+
+  const before = buildGovernedO8Profile(SOURCE as unknown as Record<string, unknown>, passthroughO8);
+  const after = buildGovernedO8Profile(SOURCE as unknown as Record<string, unknown>, registryO8);
+
+  // ── Containment: F touched NOTHING outside mcp.servers.o8 ──
+  assert.deepStrictEqual(stripMcp(before), stripMcp(after), 'everything outside mcp is byte-identical (governed agents, gateway, strips, top-level keys)');
+
+  // Defensive spot-checks of the unchanged blast radius (both profiles).
+  for (const [label, p] of [['before', before], ['after', after]] as const) {
+    assert.strictEqual((p as { channels?: unknown }).channels, undefined, `${label}: channels stripped`);
+    assert.strictEqual((p as { bindings?: unknown }).bindings, undefined, `${label}: bindings stripped`);
+    assert.deepStrictEqual((p.auth as unknown), { provider: 'oauth', token: 'KEEP' }, `${label}: unrelated top-level key preserved`);
+    assert.strictEqual((p.gateway as { host?: string }).host, '127.0.0.1', `${label}: gateway base preserved`);
+    // mcp.servers is o8-ONLY by construction — source `foo` is dropped (governance).
+    assert.deepStrictEqual(Object.keys((p.mcp as { servers: Record<string, unknown> }).servers), ['o8'], `${label}: mcp.servers is o8-only (foo dropped)`);
+    assert(!JSON.stringify(p.mcp).includes('foo-mcp'), `${label}: other source mcp servers do not leak`);
+  }
+
+  const beforeO8 = (before.mcp as { servers: Record<string, unknown> }).servers.o8;
+  const afterO8 = (after.mcp as { servers: Record<string, unknown> }).servers.o8;
+
+  // Old used the passthrough; new uses the registry projection (the intended delta).
+  assert.deepStrictEqual(beforeO8, passthroughO8, 'before: o8 = the source passthrough');
+  assert.deepStrictEqual(afterO8, registryO8, 'after: o8 = the registry openclaw projection');
+  assert.deepStrictEqual(afterO8, { command: '/usr/local/bin/node', args: [bundlePath], env: { O8_API_BASE: 'http://127.0.0.1:3001' } }, 'registry o8 = operator stdio entry (packaged)');
+  assert(!('type' in (afterO8 as Record<string, unknown>)), 'registry o8 entry has no type field');
+  assert.notStrictEqual(JSON.stringify(beforeO8), JSON.stringify(afterO8), 'the o8 entry IS the one intended change');
+
+  console.log('[tool-spine-openclaw-consumer-smoke] PASS — containment holds; only mcp.servers.o8 changed');
+  console.log('  o8 BEFORE (passthrough):', JSON.stringify(beforeO8));
+  console.log('  o8 AFTER  (registry)   :', JSON.stringify(afterO8));
+}
+
+main();


### PR DESCRIPTION
## Phase 2 · Step F — OpenClaw o8 entry from the registry, not passthrough

First Phase 2 step. Phase 1 (A–E) collapsed every MCP-config consumer onto the registry with **zero behavior change**. F is the one **deliberate behavior change** flagged back in Step A — so it's proven differently (containment, not a byte baseline).

### ⚠️ Behavior change (operator-facing, intended)
`ensureOpenclawProfile` no longer passes the user's **pre-registered** `o8` server through verbatim. The governed o8 profile's `mcp.servers.o8` now comes from `toOpenclawJson(buildToolRegistry())` — **o8 owns its own entry**.

**Net effect:** anyone who hand-customized their `~/.openclaw/openclaw.json` `o8` entry now gets the registry's version instead. This is the point — o8 emits its own operator entry rather than trusting whatever was there. The governed profile is `o8`-only by construction (other source `mcp.servers` were always dropped — unchanged by F).

### What changed, precisely
- The read of `sourceMcpServers.o8` **and** the `mcp.servers.o8 missing` throw **stay exactly as-is** — now purely a presence check.
- Only the **value** used to build the profile switches: read entry → registry projection (operator-only, stdio, `type`-stripped).
- The `o8Config` construction is extracted verbatim to an exported `buildGovernedO8Profile` so the containment test exercises the real path; `ensureOpenclawProfile` calls it.

### Proof: containment (no legacy baseline, packaged mode)
`tests/smoke/tool-spine-openclaw-consumer-smoke.ts` builds the profile **both ways from one source** and asserts:
- **Blast radius** — byte-identical on *everything* except `mcp.servers.o8`: governed agents, gateway port, channel/binding strip, every unrelated top-level key (`auth`, `models`, …).
- **Positive** — the new `o8` deep-equals the registry openclaw projection `{command:<node>, args:[<bundled .mjs>], env}`, with **no `type`**.
- **o8-only** — `mcp.servers` keys are exactly `['o8']` in both; a source `foo` server is dropped (governance), verified not assumed.
- **The intended delta** — `o8` before (passthrough) ≠ after (registry); both surfaced in the test output.

**Gate (local — CI shows billing-red from the org Actions block, unrelated to this code):** `tsc --noEmit` clean · `npm test` 327/327 · the F containment test green · **all six A–E parity smokes still green** (F sits on Phase 1; the zero-change guarantee underneath survives).

### Deferred
- `TODO(tool-spine-convergence)` — the throw is now vestigial (o8 is *emitted*, not *read* for value); removing it = the self-heal, gated separately for the convergence phase.
- Phase 2 continues after F: **Gemini wiring** (emitter already built + golden-tested in Phase 1 — the "adding a CLI is now ~one wiring change" demo), then **OpenCode**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018akNs5xu63pWZA3SXaGha8
