### PR TITLE
Phase 2 · Gemini wiring: o8 configures the Gemini CLI from the registry (new behavior)

### DIFF
--- a/src/app/api/setup/gemini/route.ts
+++ b/src/app/api/setup/gemini/route.ts
@@ -1,0 +1,115 @@
+/**
+ * Gemini CLI Auto-Register
+ *
+ * POST — merge o8's managed MCP servers (o8 operator + codebase-memory) into the
+ *        user's Gemini CLI config without touching any other server or top-level
+ *        key. Mirrors /api/setup/claude-desktop (merge-preserving read → atomic
+ *        write + .o8-backup-<ts>, reusing the shared claude-desktop-config-io).
+ * GET  — preview: current managed entries + whether they're up to date.
+ *
+ * TARGET: user-level ~/.gemini/settings.json (the GLOBAL tool config, like Claude
+ * Desktop's ~/.claude.json). Gemini ALSO reads a PROJECT-level .gemini/settings.json
+ * for per-project overrides — deliberately out of scope: o8's operator MCP is a
+ * global tool, not repo-scoped, so it belongs in the user config.
+ *
+ * The entry shapes come ENTIRELY from the Tool-Spine gemini emitter
+ * (toGeminiSettings): stdio = { command, args, [env] } with NO `type`;
+ * streamable-HTTP = { httpUrl, [headers] }. We never hand-roll the Gemini shape.
+ */
+
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { readClaudeConfig, atomicWriteConfig } from '@/lib/mcp/claude-desktop-config-io';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { toGeminiSettings, toGeminiSettingsMerged } from '@/lib/mcp/tool-spine/emit-gemini';
+
+function getGeminiConfigPath(): string {
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  return join(home, '.gemini', 'settings.json');
+}
+
+export async function GET() {
+  try {
+    const path = getGeminiConfigPath();
+    const fileExists = existsSync(path);
+    const config = readClaudeConfig(path);
+    const existingServers = config.mcpServers && typeof config.mcpServers === 'object'
+      ? (config.mcpServers as Record<string, unknown>)
+      : {};
+
+    const proposed = toGeminiSettings(buildToolRegistry(process.cwd())).mcpServers as Record<string, unknown>;
+    const managedNames = Object.keys(proposed);
+
+    const upToDate = managedNames.every(
+      (name) => existingServers[name] && JSON.stringify(existingServers[name]) === JSON.stringify(proposed[name]),
+    );
+
+    return NextResponse.json({
+      path,
+      fileExists,
+      proposed,
+      managedNames,
+      alreadyRegistered: managedNames.some((name) => name in existingServers),
+      alreadyUpToDate: fileExists && upToDate,
+      otherServers: Object.keys(existingServers).filter((k) => !managedNames.includes(k)),
+      size: fileExists ? statSync(path).size : 0,
+    });
+  } catch (error) {
+    console.error('[setup/gemini] GET error:', error);
+    return NextResponse.json(
+      { error: 'Failed to inspect Gemini config', detail: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json().catch(() => ({}))) as { remove?: unknown };
+    const remove = body.remove === true;
+    const path = getGeminiConfigPath();
+
+    const registry = buildToolRegistry(process.cwd());
+    const managedNames = Object.keys(toGeminiSettings(registry).mcpServers);
+    const config = readClaudeConfig(path);
+
+    if (remove) {
+      const servers =
+        config.mcpServers && typeof config.mcpServers === 'object' ? (config.mcpServers as Record<string, unknown>) : null;
+      const removed: string[] = [];
+      if (servers) {
+        for (const name of managedNames) {
+          if (name in servers) {
+            delete servers[name];
+            removed.push(name);
+          }
+        }
+      }
+      if (removed.length > 0) {
+        atomicWriteConfig(path, config);
+        return NextResponse.json({ ok: true, action: 'removed', path, removed });
+      }
+      return NextResponse.json({ ok: true, action: 'no-op', path, detail: 'o8 was not registered' });
+    }
+
+    const merged = toGeminiSettingsMerged(registry, config);
+    atomicWriteConfig(path, merged);
+
+    return NextResponse.json({
+      ok: true,
+      action: 'installed',
+      path,
+      installed: managedNames,
+      detail: 'Restart the Gemini CLI (or start a new session) to load the o8 tools.',
+    });
+  } catch (error) {
+    console.error('[setup/gemini] POST error:', error);
+    return NextResponse.json(
+      { ok: false, error: 'Failed to write Gemini config', detail: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/mcp/tool-spine/emit-gemini.ts
+++ b/src/lib/mcp/tool-spine/emit-gemini.ts
@@ -27,3 +27,29 @@ export function toGeminiSettings(r: ToolRegistry): { mcpServers: Record<string, 
   }
   return { mcpServers };
 }
+
+/** A Gemini CLI settings.json — mcpServers + arbitrary other top-level keys. */
+export interface GeminiSettings {
+  mcpServers?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Merge-preserving projection (mirrors `toClaudeDesktopJson`): write ONLY o8's
+ * managed entries into the user's settings, leaving every other server + every
+ * other top-level key (security / general / ui / tools …) byte-identical. I/O
+ * (read, atomic write, `.o8-backup`, trailing newline) stays in the caller.
+ */
+export function toGeminiSettingsMerged(r: ToolRegistry, existing: GeminiSettings): GeminiSettings {
+  const next: GeminiSettings = { ...existing };
+  const servers: Record<string, unknown> = { ...(isRecord(existing.mcpServers) ? existing.mcpServers : {}) };
+  for (const [name, entry] of Object.entries(toGeminiSettings(r).mcpServers)) {
+    servers[name] = entry;
+  }
+  next.mcpServers = servers;
+  return next;
+}

--- a/tests/smoke/tool-spine-gemini-consumer-smoke.ts
+++ b/tests/smoke/tool-spine-gemini-consumer-smoke.ts
@@ -1,0 +1,96 @@
+/**
+ * Tool-Spine Phase-2 Gemini wiring test (live): the consumer that configures the
+ * Gemini CLI (~/.gemini/settings.json) from the registry.
+ *
+ * NEW behavior (Gemini had no config surface) — proven by positive + preservation
+ * (gemini-cli format + merge), not a before/after baseline. PACKAGED mode so the
+ * o8 entry is the stable {command:<node>, args:[<bundled .mjs>]} shape.
+ *
+ *   CORTEX_IDE_DATA_DIR=$(mktemp -d) NODE_OPTIONS='--conditions=react-server' \
+ *     npx tsx tests/smoke/tool-spine-gemini-consumer-smoke.ts
+ */
+
+import assert from 'node:assert';
+import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+
+import { atomicWriteConfig } from '@/lib/mcp/claude-desktop-config-io';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { entriesForSurface, type ToolRegistry } from '@/lib/mcp/tool-spine/registry';
+import { toGeminiSettings, toGeminiSettingsMerged } from '@/lib/mcp/tool-spine/emit-gemini';
+
+// A realistic ~/.gemini/settings.json: o8-unrelated top-level keys + the user's
+// own MCP server.
+const EXISTING = {
+  security: { auth: { selectedType: 'gemini-api-key' } },
+  general: { vimMode: false },
+  ui: { showLineNumbers: false },
+  mcpServers: {
+    'chrome-devtools': { command: 'npx', args: ['chrome-devtools-mcp@latest'] },
+  },
+};
+
+function main(): void {
+  // Force PACKAGED resolution + make codebase-memory available.
+  const bundleDir = mkdtempSync(join(tmpdir(), 'gm-bundle-'));
+  const bundlePath = join(bundleDir, 'operator-mcp-server.mjs');
+  writeFileSync(bundlePath, '');
+  process.env.O8_BUNDLED_MCP_PATH = bundlePath;
+  process.env.O8_BUNDLED_MCP_DIR = bundleDir;
+  process.env.O8_NODE_BIN = '/usr/local/bin/node';
+  const cmBin = join(mkdtempSync(join(tmpdir(), 'gm-cm-')), 'codebase-memory-mcp');
+  writeFileSync(cmBin, '');
+  process.env.O8_CODEBASE_MEMORY_BIN = cmBin;
+
+  const registry = buildToolRegistry(process.cwd());
+
+  // Surface membership — operator (o8) + codebase-memory, NOT widened.
+  assert.deepStrictEqual(entriesForSurface(registry, 'gemini').map((e) => e.name), ['o8', 'codebase-memory'], 'gemini surface = o8 + codebase-memory');
+
+  const merged = toGeminiSettingsMerged(registry, EXISTING);
+  const servers = merged.mcpServers as Record<string, Record<string, unknown>>;
+  const projection = toGeminiSettings(registry).mcpServers as Record<string, unknown>;
+
+  // ── Positive: managed entries match the emitter projection exactly ──
+  for (const name of Object.keys(projection)) {
+    assert.deepStrictEqual(servers[name], projection[name], `${name} matches toGeminiSettings projection`);
+  }
+  // stdio shape: no `type`; env intact on o8; empty env omitted on codebase-memory.
+  assert.deepStrictEqual(servers.o8, { command: '/usr/local/bin/node', args: [bundlePath], env: { O8_API_BASE: 'http://127.0.0.1:3001' } }, 'o8 stdio shape (env intact)');
+  assert(!('type' in servers.o8), 'o8 has no type field');
+  assert.deepStrictEqual(servers['codebase-memory'], { command: cmBin, args: [] }, 'codebase-memory stdio shape (empty env omitted)');
+  assert(!('type' in servers['codebase-memory']), 'codebase-memory has no type field');
+
+  // ── Preservation: other servers + top-level keys byte-identical ──
+  assert.deepStrictEqual(servers['chrome-devtools'], { command: 'npx', args: ['chrome-devtools-mcp@latest'] }, 'user server preserved');
+  assert.deepStrictEqual(merged.security, { auth: { selectedType: 'gemini-api-key' } }, 'security preserved');
+  assert.deepStrictEqual(merged.general, { vimMode: false }, 'general preserved');
+  assert.deepStrictEqual(merged.ui, { showLineNumbers: false }, 'ui preserved');
+  assert.deepStrictEqual(Object.keys(servers), ['chrome-devtools', 'o8', 'codebase-memory'], 'merge order: existing first');
+
+  // ── http → httpUrl (not url) — the streamable-HTTP branch, via the merge path ──
+  const httpReg: ToolRegistry = {
+    repoPath: '/repo',
+    entries: [{ id: 'external:remote', name: 'remote', source: 'external', label: 'remote', surfaces: ['gemini'], config: { type: 'http', url: 'https://h/mcp', headers: { A: 'b' } } }],
+  };
+  const httpMerged = toGeminiSettingsMerged(httpReg, {}).mcpServers as Record<string, unknown>;
+  assert.deepStrictEqual(httpMerged.remote, { httpUrl: 'https://h/mcp', headers: { A: 'b' } }, 'http maps to httpUrl with headers');
+
+  // ── Real write: trailing newline + backup content == original (name globbed) ──
+  const cfgDir = mkdtempSync(join(tmpdir(), 'gm-cfg-'));
+  const cfgPath = join(cfgDir, 'settings.json');
+  const originalOnDisk = JSON.stringify(EXISTING, null, 2) + '\n';
+  writeFileSync(cfgPath, originalOnDisk);
+  atomicWriteConfig(cfgPath, merged);
+
+  const written = readFileSync(cfgPath, 'utf-8');
+  assert.strictEqual(written, JSON.stringify(merged, null, 2) + '\n', 'written file = merged + trailing newline');
+  const backups = readdirSync(dirname(cfgPath)).filter((f) => f.startsWith(`${basename(cfgPath)}.o8-backup-`));
+  assert.strictEqual(backups.length, 1, 'one timestamped backup');
+  assert.strictEqual(readFileSync(join(cfgDir, backups[0]), 'utf-8'), originalOnDisk, 'backup content == pre-merge original');
+
+  console.log('[tool-spine-gemini-consumer-smoke] PASS (' + written.length + 'B written)');
+}
+
+main();


### PR DESCRIPTION
## Phase 2 · Gemini wiring — the "adding a CLI is now trivial" demo

The `toGeminiSettings` emitter was built + golden-tested in Phase 1 (Step A). This is the **wiring**: the consumer that actually configures the Gemini CLI from the registry. It's the beachhead proof — **integrating a new CLI = one emitter (done) + one wiring (this).**

### ⚠️ New behavior (intended)
**o8 now configures the Gemini CLI.** Gemini had no MCP config surface before; there's no before/after baseline, so this is proven against the gemini-cli format + merge-preservation (like F), not byte-identity.

### What
- **New `/api/setup/gemini` route** — GET preview + POST install/remove — merge-writes o8's managed servers into the user's Gemini config, reusing the shared `claude-desktop-config-io` (merge-preserving read → atomic write + `.o8-backup-<ts>`).
- **`emit-gemini` gains `toGeminiSettingsMerged`** (mirrors `toClaudeDesktopJson`): spreads the user's settings, overwrites **only** o8's managed entries. The existing golden-tested `toGeminiSettings` is unchanged.

### Confirmed against the live `~/.gemini/settings.json` + gemini-cli docs
- Top key `mcpServers`; stdio = `{command, args, [env]}` with **no `type`**; streamable-HTTP = **`httpUrl`** (not `url`); empty `env` omitted. The shapes come **entirely from the emitter** — never hand-rolled.

### The two flagged choices
- **Target = user-level `~/.gemini/settings.json`** (the global tool config, like Claude Desktop's `~/.claude.json`). Gemini also reads a **project-level** `.gemini/settings.json` for per-project overrides — deliberately out of scope: o8's operator MCP is a global tool, not repo-scoped. (Real choice, called out — none exists at project level here.)
- **Surface = the registry's existing gemini set: operator (`o8`) + codebase-memory.** Asserted in the test, **not** silently widened.

### Proof (`tests/smoke/tool-spine-gemini-consumer-smoke.ts`, packaged mode)
- **Positive** — managed entries match the `toGeminiSettings` projection exactly: `o8` stdio no-`type` with env intact; codebase-memory empty-env-omitted; a synthetic http entry → `httpUrl` (+headers) through the merge path.
- **Preservation** — the user's `chrome-devtools` server + every top-level key (`security`/`general`/`ui`) survive **byte-identical**; merge order = existing first.
- **Backup determinism** — real `atomicWriteConfig` round-trip: trailing newline + the `.o8-backup-<ts>` content == pre-merge original (timestamped name globbed, never byte-compared).

**Gate (local — CI billing-red as usual, org Actions block):** `tsc --noEmit` clean · `npm test` 327/327 · the Gemini wiring test green · **all six A–E parity smokes still green** (Gemini sits on Phase 1).

### Isolation
Touches no `openclaw.ts` — independent of F (PR #1300). Both branch off `main` and merge independently; cut from `main` since F isn't merged yet.

### Next
**OpenCode** (the ~25-line emitter + its wiring) closes the beachhead "any CLI by popularity" set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018akNs5xu63pWZA3SXaGha8
