### PR TITLE
Phase 2 · OpenCode: o8 configures OpenCode — closes the "any CLI" set (one emitter + surface + wiring)

### DIFF
--- a/src/app/api/setup/opencode/route.ts
+++ b/src/app/api/setup/opencode/route.ts
@@ -1,0 +1,121 @@
+/**
+ * OpenCode CLI Auto-Register
+ *
+ * POST — merge o8's managed MCP servers (o8 operator + codebase-memory) into the
+ *        user's OpenCode config under `mcp`, without touching any other server or
+ *        top-level key. Mirrors /api/setup/gemini (merge-preserving read → atomic
+ *        write + .o8-backup-<ts>, reusing the shared claude-desktop-config-io).
+ * GET  — preview: current managed entries + whether they're up to date.
+ *
+ * TARGET: user-level global ~/.config/opencode/opencode.json (XDG-aware), the
+ * GLOBAL tool config — matching how o8 hits ~/.claude.json / ~/.gemini/settings.json.
+ * OpenCode also reads a PROJECT-level opencode.json (which OVERRIDES the global on
+ * conflicts) and honors an OPENCODE_CONFIG env override — both out of scope: o8's
+ * operator MCP is a global tool, not repo-scoped.
+ *
+ * The entry shapes come ENTIRELY from the Tool-Spine opencode emitter
+ * (toOpencodeJson): top key `mcp`; local = { type:'local', command:[cmd, ...args],
+ * [environment] }; remote = { type:'remote', url, [headers] }. Never hand-rolled.
+ */
+
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { readClaudeConfig, atomicWriteConfig, type ClaudeDesktopConfig } from '@/lib/mcp/claude-desktop-config-io';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { toOpencodeJson, toOpencodeJsonMerged } from '@/lib/mcp/tool-spine/emit-opencode';
+
+function getOpencodeConfigPath(): string {
+  const xdg = process.env.XDG_CONFIG_HOME?.trim();
+  const base = xdg || join(process.env.HOME || process.env.USERPROFILE || '', '.config');
+  return join(base, 'opencode', 'opencode.json');
+}
+
+// OpenCode's MCP servers live under the `mcp` top-level key, which ClaudeDesktopConfig
+// (the shared mergeable-JSON config) carries via its [key]: unknown index.
+function mcpOf(config: ClaudeDesktopConfig): Record<string, unknown> {
+  const mcp = config.mcp;
+  return mcp && typeof mcp === 'object' && !Array.isArray(mcp) ? (mcp as Record<string, unknown>) : {};
+}
+
+export async function GET() {
+  try {
+    const path = getOpencodeConfigPath();
+    const fileExists = existsSync(path);
+    const config = readClaudeConfig(path);
+    const existingServers = mcpOf(config);
+
+    const proposed = toOpencodeJson(buildToolRegistry(process.cwd())).mcp;
+    const managedNames = Object.keys(proposed);
+
+    const upToDate = managedNames.every(
+      (name) => existingServers[name] && JSON.stringify(existingServers[name]) === JSON.stringify(proposed[name]),
+    );
+
+    return NextResponse.json({
+      path,
+      fileExists,
+      proposed,
+      managedNames,
+      alreadyRegistered: managedNames.some((name) => name in existingServers),
+      alreadyUpToDate: fileExists && upToDate,
+      otherServers: Object.keys(existingServers).filter((k) => !managedNames.includes(k)),
+      size: fileExists ? statSync(path).size : 0,
+    });
+  } catch (error) {
+    console.error('[setup/opencode] GET error:', error);
+    return NextResponse.json(
+      { error: 'Failed to inspect OpenCode config', detail: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json().catch(() => ({}))) as { remove?: unknown };
+    const remove = body.remove === true;
+    const path = getOpencodeConfigPath();
+
+    const registry = buildToolRegistry(process.cwd());
+    const managedNames = Object.keys(toOpencodeJson(registry).mcp);
+    const config = readClaudeConfig(path);
+
+    if (remove) {
+      const servers = config.mcp && typeof config.mcp === 'object' ? (config.mcp as Record<string, unknown>) : null;
+      const removed: string[] = [];
+      if (servers) {
+        for (const name of managedNames) {
+          if (name in servers) {
+            delete servers[name];
+            removed.push(name);
+          }
+        }
+      }
+      if (removed.length > 0) {
+        atomicWriteConfig(path, config);
+        return NextResponse.json({ ok: true, action: 'removed', path, removed });
+      }
+      return NextResponse.json({ ok: true, action: 'no-op', path, detail: 'o8 was not registered' });
+    }
+
+    const merged = toOpencodeJsonMerged(registry, config);
+    atomicWriteConfig(path, merged);
+
+    return NextResponse.json({
+      ok: true,
+      action: 'installed',
+      path,
+      installed: managedNames,
+      detail: 'Restart the OpenCode CLI (or start a new session) to load the o8 tools.',
+    });
+  } catch (error) {
+    console.error('[setup/opencode] POST error:', error);
+    return NextResponse.json(
+      { ok: false, error: 'Failed to write OpenCode config', detail: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/mcp/tool-spine/build.ts
+++ b/src/lib/mcp/tool-spine/build.ts
@@ -184,8 +184,8 @@ export function buildToolRegistry(repoPath: string): ToolRegistry {
     name: 'operator',
     source: 'builtin',
     label: 'o8 Operator',
-    surfaces: ['claude-orchestrator', 'codex-orchestrator', 'claude-desktop', 'openclaw', 'gemini'],
-    surfaceNames: { 'claude-desktop': 'o8', openclaw: 'o8', gemini: 'o8' },
+    surfaces: ['claude-orchestrator', 'codex-orchestrator', 'claude-desktop', 'openclaw', 'gemini', 'opencode'],
+    surfaceNames: { 'claude-desktop': 'o8', openclaw: 'o8', gemini: 'o8', opencode: 'o8' },
     config: {
       type: 'stdio',
       command: operatorServer.command,
@@ -225,7 +225,7 @@ export function buildToolRegistry(repoPath: string): ToolRegistry {
       name: 'codebase-memory',
       source: 'builtin',
       label: 'Codebase Memory',
-      surfaces: ['claude-desktop', 'gemini'],
+      surfaces: ['claude-desktop', 'gemini', 'opencode'],
       config: {
         type: 'stdio',
         command: codebaseMemoryBin,

--- a/src/lib/mcp/tool-spine/emit-opencode.ts
+++ b/src/lib/mcp/tool-spine/emit-opencode.ts
@@ -1,0 +1,53 @@
+/**
+ * Emitter: OpenCode CLI `~/.config/opencode/opencode.json` `mcp` block (Set B).
+ *
+ * Schema verified against opencode.ai/config.json (the published JSON schema) +
+ * the live opencode 1.4.x CLI + opencode.ai/docs/mcp-servers:
+ *   - top key is `mcp` (NOT `mcpServers`), keyed by server name;
+ *   - local stdio = { type:'local', command:[cmd, ...args], environment?:{…} }
+ *     — OpenCode folds command+args into ONE array, and the env field is
+ *     `environment` (not `env`);
+ *   - remote = { type:'remote', url, headers?:{…} }.
+ * Empty `environment` is omitted to match the CLI's own minimal output.
+ *
+ * Surfaces: operator ("o8") + codebase-memory.
+ */
+
+import { entriesForSurface, type ToolRegistry } from './registry';
+import type { ClaudeDesktopConfig } from './emit-claude-desktop';
+
+export function toOpencodeJson(r: ToolRegistry): { mcp: Record<string, unknown> } {
+  const mcp: Record<string, unknown> = {};
+  for (const { name, config } of entriesForSurface(r, 'opencode')) {
+    mcp[name] = config.type === 'http'
+      ? { type: 'remote', url: config.url, ...(config.headers ? { headers: config.headers } : {}) }
+      : {
+          type: 'local',
+          command: [config.command, ...config.args],
+          ...(config.env && Object.keys(config.env).length ? { environment: config.env } : {}),
+        };
+  }
+  return { mcp };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Merge-preserving projection (mirrors `toClaudeDesktopJson` / `toGeminiSettingsMerged`):
+ * write ONLY o8's managed entries into the user's config under `mcp`, leaving
+ * every other server + every other top-level key byte-identical. `ClaudeDesktopConfig`
+ * is the shared mergeable-JSON-config shape — its `[key]: unknown` index holds
+ * OpenCode's `mcp` key. I/O (read, atomic write, `.o8-backup`, trailing newline)
+ * stays in the caller.
+ */
+export function toOpencodeJsonMerged(r: ToolRegistry, existing: ClaudeDesktopConfig): ClaudeDesktopConfig {
+  const next: ClaudeDesktopConfig = { ...existing };
+  const mcp: Record<string, unknown> = { ...(isRecord(existing.mcp) ? existing.mcp : {}) };
+  for (const [name, entry] of Object.entries(toOpencodeJson(r).mcp)) {
+    mcp[name] = entry;
+  }
+  next.mcp = mcp;
+  return next;
+}

--- a/src/lib/mcp/tool-spine/emitters.test.ts
+++ b/src/lib/mcp/tool-spine/emitters.test.ts
@@ -16,6 +16,7 @@ import { toCodexToml } from './emit-codex';
 import { toClaudeDesktopJson } from './emit-claude-desktop';
 import { toOpenclawJson } from './emit-openclaw';
 import { toGeminiSettings } from './emit-gemini';
+import { toOpencodeJson } from './emit-opencode';
 
 const fixture: ToolRegistry = {
   repoPath: '/repo',
@@ -41,8 +42,8 @@ const fixture: ToolRegistry = {
       name: 'operator',
       source: 'builtin',
       label: 'o8 Operator',
-      surfaces: ['claude-orchestrator', 'codex-orchestrator', 'claude-desktop', 'openclaw', 'gemini'],
-      surfaceNames: { 'claude-desktop': 'o8', openclaw: 'o8', gemini: 'o8' },
+      surfaces: ['claude-orchestrator', 'codex-orchestrator', 'claude-desktop', 'openclaw', 'gemini', 'opencode'],
+      surfaceNames: { 'claude-desktop': 'o8', openclaw: 'o8', gemini: 'o8', opencode: 'o8' },
       config: { type: 'stdio', command: 'npx', args: ['tsx', 'operator.ts'], env: { O8_API_BASE: 'http://127.0.0.1:3001' } },
     },
     {
@@ -63,7 +64,7 @@ const fixture: ToolRegistry = {
       name: 'codebase-memory',
       source: 'builtin',
       label: 'Codebase Memory',
-      surfaces: ['claude-desktop', 'gemini'],
+      surfaces: ['claude-desktop', 'gemini', 'opencode'],
       config: { type: 'stdio', command: '/bin/cm', args: [], env: {} },
     },
   ],
@@ -218,5 +219,33 @@ describe('toGeminiSettings', () => {
       ],
     };
     expect(toGeminiSettings(httpReg)).toEqual({ mcpServers: { remote: { httpUrl: 'https://h/mcp', headers: { A: 'b' } } } });
+  });
+});
+
+describe('toOpencodeJson', () => {
+  it('emits o8 + codebase-memory under `mcp`; type:local with folded command array; empty environment omitted', () => {
+    expect(toOpencodeJson(fixture)).toEqual({
+      mcp: {
+        o8: { type: 'local', command: ['npx', 'tsx', 'operator.ts'], environment: { O8_API_BASE: 'http://127.0.0.1:3001' } },
+        'codebase-memory': { type: 'local', command: ['/bin/cm'] },
+      },
+    });
+  });
+
+  it('maps http transport to type:remote with url (+headers)', () => {
+    const httpReg: ToolRegistry = {
+      repoPath: '/repo',
+      entries: [
+        {
+          id: 'external:remote',
+          name: 'remote',
+          source: 'external',
+          label: 'remote',
+          surfaces: ['opencode'],
+          config: { type: 'http', url: 'https://h/mcp', headers: { A: 'b' } },
+        },
+      ],
+    };
+    expect(toOpencodeJson(httpReg)).toEqual({ mcp: { remote: { type: 'remote', url: 'https://h/mcp', headers: { A: 'b' } } } });
   });
 });

--- a/src/lib/mcp/tool-spine/index.ts
+++ b/src/lib/mcp/tool-spine/index.ts
@@ -13,3 +13,4 @@ export * from './emit-codex';
 export * from './emit-claude-desktop';
 export * from './emit-openclaw';
 export * from './emit-gemini';
+export * from './emit-opencode';

--- a/src/lib/mcp/tool-spine/registry.ts
+++ b/src/lib/mcp/tool-spine/registry.ts
@@ -23,7 +23,8 @@ export type ToolSurface =
   | 'codex-orchestrator' //  Codex config.toml          (Set A)
   | 'claude-desktop' //      ~/.claude.json             (Set B)
   | 'openclaw' //            ~/.openclaw-o8/openclaw.json (Set B)
-  | 'gemini'; //             ~/.gemini/settings.json     (NEW — closes the gap)
+  | 'gemini' //              ~/.gemini/settings.json     (Set B)
+  | 'opencode'; //           ~/.config/opencode/opencode.json (Set B)
 
 /** Inert in Phase 1; the vault-phase credential-injection hook. */
 export interface SecretRef {

--- a/tests/smoke/tool-spine-opencode-consumer-smoke.ts
+++ b/tests/smoke/tool-spine-opencode-consumer-smoke.ts
@@ -1,0 +1,94 @@
+/**
+ * Tool-Spine Phase-2 OpenCode wiring test (live): the consumer that configures
+ * the OpenCode CLI (~/.config/opencode/opencode.json) from the registry.
+ *
+ * NEW behavior (OpenCode had no config surface) — proven by positive + preservation
+ * (opencode.json `mcp` format + merge), not a before/after baseline. PACKAGED mode
+ * so the o8 entry is the stable command:[<node>, <bundled .mjs>] shape.
+ *
+ *   CORTEX_IDE_DATA_DIR=$(mktemp -d) NODE_OPTIONS='--conditions=react-server' \
+ *     npx tsx tests/smoke/tool-spine-opencode-consumer-smoke.ts
+ */
+
+import assert from 'node:assert';
+import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+
+import { atomicWriteConfig, type ClaudeDesktopConfig } from '@/lib/mcp/claude-desktop-config-io';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { entriesForSurface, type ToolRegistry } from '@/lib/mcp/tool-spine/registry';
+import { toOpencodeJson, toOpencodeJsonMerged } from '@/lib/mcp/tool-spine/emit-opencode';
+
+// A realistic ~/.config/opencode/opencode.json: unrelated top-level keys + the
+// user's own MCP server under `mcp`.
+const EXISTING: ClaudeDesktopConfig = {
+  $schema: 'https://opencode.ai/config.json',
+  theme: 'opencode',
+  model: 'opencode/gpt-5-nano',
+  mcp: {
+    'my-tool': { type: 'local', command: ['my-mcp', '--flag'] },
+  },
+};
+
+function main(): void {
+  // Force PACKAGED resolution + make codebase-memory available.
+  const bundleDir = mkdtempSync(join(tmpdir(), 'oc-bundle-'));
+  const bundlePath = join(bundleDir, 'operator-mcp-server.mjs');
+  writeFileSync(bundlePath, '');
+  process.env.O8_BUNDLED_MCP_PATH = bundlePath;
+  process.env.O8_BUNDLED_MCP_DIR = bundleDir;
+  process.env.O8_NODE_BIN = '/usr/local/bin/node';
+  const cmBin = join(mkdtempSync(join(tmpdir(), 'oc-cm-')), 'codebase-memory-mcp');
+  writeFileSync(cmBin, '');
+  process.env.O8_CODEBASE_MEMORY_BIN = cmBin;
+
+  const registry = buildToolRegistry(process.cwd());
+
+  // Surface membership — operator (o8) + codebase-memory, NOT widened.
+  assert.deepStrictEqual(entriesForSurface(registry, 'opencode').map((e) => e.name), ['o8', 'codebase-memory'], 'opencode surface = o8 + codebase-memory');
+
+  const merged = toOpencodeJsonMerged(registry, EXISTING);
+  const mcp = merged.mcp as Record<string, Record<string, unknown>>;
+  const projection = toOpencodeJson(registry).mcp as Record<string, unknown>;
+
+  // ── Positive: managed entries match the emitter projection exactly ──
+  for (const name of Object.keys(projection)) {
+    assert.deepStrictEqual(mcp[name], projection[name], `${name} matches toOpencodeJson projection`);
+  }
+  // local shape: type:'local', folded command array, environment intact on o8.
+  assert.deepStrictEqual(mcp.o8, { type: 'local', command: ['/usr/local/bin/node', bundlePath], environment: { O8_API_BASE: 'http://127.0.0.1:3001' } }, 'o8 local shape (folded command + environment)');
+  assert.deepStrictEqual(mcp['codebase-memory'], { type: 'local', command: [cmBin] }, 'codebase-memory local shape (empty environment omitted)');
+
+  // ── Preservation: other servers + top-level keys byte-identical ──
+  assert.deepStrictEqual(mcp['my-tool'], { type: 'local', command: ['my-mcp', '--flag'] }, 'user server preserved');
+  assert.strictEqual(merged.$schema, 'https://opencode.ai/config.json', '$schema preserved');
+  assert.strictEqual(merged.theme, 'opencode', 'theme preserved');
+  assert.strictEqual(merged.model, 'opencode/gpt-5-nano', 'model preserved');
+  assert.deepStrictEqual(Object.keys(mcp), ['my-tool', 'o8', 'codebase-memory'], 'merge order: existing first');
+
+  // ── http → type:remote with url (not httpUrl) — via the merge path ──
+  const httpReg: ToolRegistry = {
+    repoPath: '/repo',
+    entries: [{ id: 'external:remote', name: 'remote', source: 'external', label: 'remote', surfaces: ['opencode'], config: { type: 'http', url: 'https://h/mcp', headers: { A: 'b' } } }],
+  };
+  const httpMerged = (toOpencodeJsonMerged(httpReg, {}).mcp) as Record<string, unknown>;
+  assert.deepStrictEqual(httpMerged.remote, { type: 'remote', url: 'https://h/mcp', headers: { A: 'b' } }, 'http maps to type:remote with url + headers');
+
+  // ── Real write: trailing newline + backup content == original (name globbed) ──
+  const cfgDir = mkdtempSync(join(tmpdir(), 'oc-cfg-'));
+  const cfgPath = join(cfgDir, 'opencode.json');
+  const originalOnDisk = JSON.stringify(EXISTING, null, 2) + '\n';
+  writeFileSync(cfgPath, originalOnDisk);
+  atomicWriteConfig(cfgPath, merged);
+
+  const written = readFileSync(cfgPath, 'utf-8');
+  assert.strictEqual(written, JSON.stringify(merged, null, 2) + '\n', 'written file = merged + trailing newline');
+  const backups = readdirSync(dirname(cfgPath)).filter((f) => f.startsWith(`${basename(cfgPath)}.o8-backup-`));
+  assert.strictEqual(backups.length, 1, 'one timestamped backup');
+  assert.strictEqual(readFileSync(join(cfgDir, backups[0]), 'utf-8'), originalOnDisk, 'backup content == pre-merge original');
+
+  console.log('[tool-spine-opencode-consumer-smoke] PASS (' + written.length + 'B written)');
+}
+
+main();


### PR DESCRIPTION
## Phase 2 · OpenCode — closes the "any CLI by popularity" set

The last CLI in the beachhead set, and the purest "add a CLI from scratch" demo: unlike Gemini (emitter pre-built in Phase 1), OpenCode is **net-new end to end**, so this one PR shows the whole cost — **one emitter + one surface + one wiring**. After this, **six CLIs run from one registry**: Claude orchestrator · Codex · Claude Desktop · OpenClaw · Gemini · OpenCode.

### ⚠️ New behavior (intended)
**o8 now configures the OpenCode CLI.** OpenCode had no MCP config surface; there's no before/after baseline, so this is proven against the opencode.json format + merge-preservation (like Gemini/F).

### The full cost, in one commit
1. **`emit-opencode` (the ~25-line emitter)** — top key `mcp`; local = `{type:'local', command:[cmd, ...args], [environment]}`; remote = `{type:'remote', url, [headers]}`. + `toOpencodeJsonMerged` (mirrors `toClaudeDesktopJson`/`toGeminiSettingsMerged`).
2. **One surface** — `'opencode'` added to the `ToolSurface` union + the operator (`o8`) + codebase-memory membership (the same install set as the others — **asserted, not widened**).
3. **One wiring** — new `/api/setup/opencode` route (GET preview + POST install/remove), merge-writing under `mcp`, reusing the shared `claude-desktop-config-io`.

### Verified, not guessed (against `opencode.ai/config.json` schema + live CLI 1.4.x + docs)
- Top key **`mcp`** (not `mcpServers`) — `Config.properties.mcp` = `anyOf[McpLocalConfig | McpRemoteConfig]`, keyed by server name.
- **`environment`** (not `env`) for local env vars; **`command` is a folded array** `[cmd, ...args]` (OpenCode's quirk vs the others' separate fields); remote URL field is `url`.
- Shapes come **entirely from the emitter** — never hand-rolled.

### The flagged choice
**Target = user-level global `~/.config/opencode/opencode.json`** (XDG-aware) — matching how o8 hits `~/.claude.json` / `~/.gemini/settings.json`. OpenCode also reads a **project** `opencode.json` (which *overrides* the global) and honors an `OPENCODE_CONFIG` override — both out of scope (o8's operator MCP is a global tool, not repo-scoped). Configs **merge** (project over global), so writing the global is safe.

### Proof (`tests/`, packaged mode)
- **Golden** (`emitters.test.ts`): `toOpencodeJson` — local folded-command + `environment`; empty-env omitted; http → `type:remote` `url`.
- **Wiring** (`tool-spine-opencode-consumer-smoke.ts`): managed entries match the projection; the user's own `mcp` server + every top-level key (`$schema`/`theme`/`model`) survive **byte-identical**; surface membership asserted; real `atomicWriteConfig` round-trip — trailing newline + `.o8-backup-<ts>` content == original (timestamp **globbed**, never byte-compared).

**Gate (local — CI billing-red as usual):** `tsc --noEmit` clean · `npm test` **329/329** (+2 new goldens) · the OpenCode emitter golden + wiring test green · **all of A–F + Gemini still green**.

### Closes the arc
Six CLIs, one registry — adding the Nth is now one emitter + one surface row + one wiring, each a byte-for-byte (or positive+preservation) proof. The tool-spine breadth arc is done; next thread is yours (the convergence backlog, or the Targeting Machine wedge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018akNs5xu63pWZA3SXaGha8
