### PR TITLE
Orchestrator Backend Step 1: orchestratorBackend setting — makes OpenClaw selectable (auto = byte-identical)

### DIFF
--- a/src/app/api/panel/operator-defaults/route.ts
+++ b/src/app/api/panel/operator-defaults/route.ts
@@ -177,6 +177,14 @@ function normalizeUpdate(body: Record<string, unknown>): Partial<OperatorDefault
     update.workersUseBrain = raw;
   }
 
+  if (body.orchestratorBackend !== undefined) {
+    const raw = body.orchestratorBackend;
+    if (raw !== 'auto' && raw !== 'codex' && raw !== 'claude' && raw !== 'openclaw') {
+      throw new Error('orchestratorBackend must be one of "auto", "codex", "claude", "openclaw".');
+    }
+    update.orchestratorBackend = raw;
+  }
+
   return update;
 }
 

--- a/src/components/desktop/settings/OperatorDefaultsTab.tsx
+++ b/src/components/desktop/settings/OperatorDefaultsTab.tsx
@@ -30,6 +30,7 @@ type SettingSource = 'env' | 'file' | 'default';
 type DispatchRuntime = 'codex' | 'gemini' | 'opencode';
 type ClassAComposer = 'auto' | 'haiku-cli' | 'sonnet-cli' | 'fastest';
 type WorkersUseBrain = 'off' | 'auto' | 'all';
+type OrchestratorBackendSetting = 'auto' | 'codex' | 'claude' | 'openclaw';
 
 interface OperatorDefaults {
   parallelCap: number;
@@ -53,6 +54,7 @@ interface OperatorDefaults {
   inAppOrchestratorEnabled: boolean;
   brainUseClaudeCli: boolean;
   workersUseBrain: WorkersUseBrain;
+  orchestratorBackend: OrchestratorBackendSetting;
 }
 
 interface OperatorDefaultsResponse {
@@ -854,6 +856,33 @@ export function OperatorDefaultsTab() {
           <span style={{ fontFamily: MONO_FONT_STACK, fontSize: 12 }}>O8_IN_APP_ORCHESTRATOR_ENABLED</span>{' '}
           overrides.
         </p>
+        <Row
+          label="Orchestrator backend"
+          description={
+            values.orchestratorBackend === 'openclaw'
+              ? 'OpenClaw — the governed openclaw orchestrator drives chat + background turns and dispatches Codex workers through o8. A per-request backend (e.g. mobile) still overrides.'
+              : values.orchestratorBackend === 'codex'
+                ? 'Codex — forces Codex GPT-5.5 xhigh as the orchestrator brain (ignores the toggle below).'
+                : values.orchestratorBackend === 'claude'
+                  ? 'Claude — forces the Claude Code REPL as the orchestrator brain (ignores the toggle below).'
+                  : 'Auto (default) — follow the in-app orchestrator toggle below (Claude when on, Codex when off). Byte-identical to prior behavior.'
+          }
+          source={sources.orchestratorBackend}
+          disabledReason={sources?.orchestratorBackend === 'env' ? envDisabledReason : undefined}
+          right={
+            <SegmentedControl<OrchestratorBackendSetting>
+              value={values.orchestratorBackend}
+              options={[
+                { value: 'auto', label: 'Auto' },
+                { value: 'codex', label: 'Codex' },
+                { value: 'claude', label: 'Claude' },
+                { value: 'openclaw', label: 'OpenClaw' },
+              ]}
+              onChange={(next) => { void updateField('orchestratorBackend', next); }}
+              disabled={sources?.orchestratorBackend === 'env' || busyField === 'orchestratorBackend'}
+            />
+          }
+        />
         <Row
           label="In-app orchestrator runtime"
           description={values.inAppOrchestratorEnabled ? 'On — chat + background features use Claude Opus 4.8 via the claude CLI interactive REPL. Bills your Claude Code MAX subscription pool (same as running claude in Terminal). No API key, no per-token charge.' : 'Off (default) — chat + background features use Codex GPT-5.5 xhigh (free with Codex sub). Auto-review writes verdicts to log but does not create approval cards yet (#1045).'}

--- a/src/lib/lane/orchestrator-backends/registry.ts
+++ b/src/lib/lane/orchestrator-backends/registry.ts
@@ -22,7 +22,7 @@ import {
   getOrchestratorSession,
   sendToOrchestrator,
 } from '@/lib/lane/orchestrator-session';
-import { resolveInAppOrchestratorEnabledSync } from '@/lib/operator/defaults';
+import { resolveInAppOrchestratorEnabledSync, resolveOrchestratorBackendSync } from '@/lib/operator/defaults';
 import { openclawBackend } from './openclaw';
 import type { OrchestratorBackend, OrchestratorBackendId } from './types';
 
@@ -87,15 +87,19 @@ export function getOrchestratorBackend(id: OrchestratorBackendId): OrchestratorB
 /**
  * Resolve the active orchestrator backend id.
  *
- * Until the openclaw backend ships there is no dedicated operator setting, so
- * this derives directly from the legacy `inAppOrchestratorEnabled` boolean —
- * behavior is byte-identical to the pre-registry dual-path branches:
- *   - toggle OFF (default) → Codex GPT-5.5 xhigh
- *   - toggle ON            → Claude
- * The openclaw step swaps this for an `orchestratorBackend` operator setting
- * that falls back to this same derivation.
+ * The `orchestratorBackend` operator setting picks the backend:
+ *   - **'auto' (default)** → defer to the legacy `inAppOrchestratorEnabled`
+ *     boolean, BYTE-IDENTICAL to the pre-setting behavior:
+ *       · toggle OFF (default) → Codex GPT-5.5 xhigh
+ *       · toggle ON            → Claude
+ *   - a specific id ('codex' | 'claude' | 'openclaw') → forces that backend,
+ *     which is how OpenClaw becomes selectable from the desktop.
+ * A per-request `msg.backend` still overrides this (see ws-server's
+ * `resolveMsgBackendId`).
  */
 export function resolveOrchestratorBackendId(): OrchestratorBackendId {
+  const setting = resolveOrchestratorBackendSync();
+  if (setting !== 'auto') return setting;
   return resolveInAppOrchestratorEnabledSync() ? 'claude' : 'codex';
 }
 

--- a/src/lib/operator/defaults.ts
+++ b/src/lib/operator/defaults.ts
@@ -58,6 +58,14 @@ function isWorkersUseBrain(value: unknown): value is WorkersUseBrain {
   return value === 'off' || value === 'auto' || value === 'all';
 }
 
+/** Which backend drives the in-app Orchestrator. 'auto' = the legacy
+ *  inAppOrchestratorEnabled derivation; a specific id forces that backend. */
+export type OrchestratorBackendSetting = 'auto' | 'codex' | 'claude' | 'openclaw';
+
+function isOrchestratorBackendSetting(value: unknown): value is OrchestratorBackendSetting {
+  return value === 'auto' || value === 'codex' || value === 'claude' || value === 'openclaw';
+}
+
 export interface OperatorDefaults {
   parallelCap: number;
   overlapGate: OverlapGateMode;
@@ -156,6 +164,15 @@ export interface OperatorDefaults {
   brainUseClaudeCli: boolean;
   /** See {@link WorkersUseBrain}. Default 'auto'. */
   workersUseBrain: WorkersUseBrain;
+  /**
+   * Which backend drives the in-app Orchestrator. **'auto' (default)** = the
+   * legacy derivation from {@link inAppOrchestratorEnabled} (toggle ON → Claude,
+   * OFF → Codex), byte-identical to pre-setting behavior. A specific value forces
+   * that backend — including **'openclaw'** (the governed openclaw orchestrator,
+   * previously reachable only via a per-request mobile `backend` field). A
+   * per-request `msg.backend` still overrides this. Env: `O8_ORCHESTRATOR_BACKEND`.
+   */
+  orchestratorBackend: OrchestratorBackendSetting;
 }
 
 export interface OperatorDefaultsWithSources {
@@ -194,6 +211,9 @@ export const OPERATOR_DEFAULTS_FALLBACK: OperatorDefaults = {
   // anyone with a Claude sub. Independent of the orchestrator toggle (2026-06-22).
   brainUseClaudeCli: true,
   workersUseBrain: 'auto',
+  // 'auto' → defer to inAppOrchestratorEnabled (legacy claude/codex derivation),
+  // so the default is byte-identical to pre-setting behavior.
+  orchestratorBackend: 'auto',
 };
 
 export const CLASS_A_COMPOSER_OPTIONS: Array<{ value: ClassAComposer; label: string; detail: string }> = [
@@ -207,6 +227,13 @@ export const DISPATCH_RUNTIME_OPTIONS: Array<{ value: OrchestratorRuntime; label
   { value: 'claude-code', label: 'Claude Code', detail: 'Anthropic CLI — use when you have a Claude sub.' },
   { value: 'gemini', label: 'Gemini', detail: 'Google Gemini 3.1 Pro CLI — fastest for parallel fan-out.' },
   { value: 'opencode', label: 'opencode', detail: 'OSS CLI — routes through your configured provider keys.' },
+];
+
+export const ORCHESTRATOR_BACKEND_OPTIONS: Array<{ value: OrchestratorBackendSetting; label: string; detail: string }> = [
+  { value: 'auto', label: 'Auto', detail: 'Follow the in-app orchestrator toggle below (Claude when on, Codex when off).' },
+  { value: 'codex', label: 'Codex', detail: 'Codex GPT-5.5 xhigh — free for ChatGPT Plus / Codex subscribers.' },
+  { value: 'claude', label: 'Claude', detail: 'Claude Code REPL — subscription-billed (Claude Max pool).' },
+  { value: 'openclaw', label: 'OpenClaw', detail: 'Governed openclaw orchestrator — dispatches Codex workers through o8.' },
 ];
 
 export const PARALLEL_CAP_PRESETS: Array<{ key: 'conservative' | 'balanced' | 'power-user'; label: string; value: number }> = [
@@ -369,6 +396,12 @@ function envWorkersUseBrain(): WorkersUseBrain | null {
   return null;
 }
 
+function envOrchestratorBackend(): OrchestratorBackendSetting | null {
+  const raw = process.env.O8_ORCHESTRATOR_BACKEND?.trim();
+  if (raw && isOrchestratorBackendSetting(raw)) return raw;
+  return null;
+}
+
 // ── File helpers ──
 
 interface StoredOperatorDefaults {
@@ -393,6 +426,7 @@ interface StoredOperatorDefaults {
   inAppOrchestratorEnabled?: boolean;
   brainUseClaudeCli?: boolean;
   workersUseBrain?: WorkersUseBrain;
+  orchestratorBackend?: OrchestratorBackendSetting;
 }
 
 function parseStoredDefaults(raw: string): StoredOperatorDefaults {
@@ -477,6 +511,9 @@ function resolveFromFile(stored: StoredOperatorDefaults): Partial<OperatorDefaul
   if (isWorkersUseBrain(stored.workersUseBrain)) {
     result.workersUseBrain = stored.workersUseBrain;
   }
+  if (isOrchestratorBackendSetting(stored.orchestratorBackend)) {
+    result.orchestratorBackend = stored.orchestratorBackend;
+  }
   return result;
 }
 
@@ -504,6 +541,7 @@ function resolveDefaults(fileValues: Partial<OperatorDefaults>): OperatorDefault
   const envInApp = envInAppOrchestratorEnabled();
   const envBrainCli = envBrainUseClaudeCli();
   const envBrain = envWorkersUseBrain();
+  const envOrchBackend = envOrchestratorBackend();
 
   const resolved: OperatorDefaults = {
     parallelCap: envCap ?? fileValues.parallelCap ?? OPERATOR_DEFAULTS_FALLBACK.parallelCap,
@@ -531,6 +569,7 @@ function resolveDefaults(fileValues: Partial<OperatorDefaults>): OperatorDefault
     brainUseClaudeCli:
       envBrainCli ?? fileValues.brainUseClaudeCli ?? OPERATOR_DEFAULTS_FALLBACK.brainUseClaudeCli,
     workersUseBrain: envBrain ?? fileValues.workersUseBrain ?? OPERATOR_DEFAULTS_FALLBACK.workersUseBrain,
+    orchestratorBackend: envOrchBackend ?? fileValues.orchestratorBackend ?? OPERATOR_DEFAULTS_FALLBACK.orchestratorBackend,
   };
 
   const sources: Record<keyof OperatorDefaults, SettingSource> = {
@@ -559,6 +598,7 @@ function resolveDefaults(fileValues: Partial<OperatorDefaults>): OperatorDefault
     brainUseClaudeCli:
       envBrainCli !== null ? 'env' : fileValues.brainUseClaudeCli !== undefined ? 'file' : 'default',
     workersUseBrain: envBrain !== null ? 'env' : fileValues.workersUseBrain !== undefined ? 'file' : 'default',
+    orchestratorBackend: envOrchBackend !== null ? 'env' : fileValues.orchestratorBackend !== undefined ? 'file' : 'default',
   };
 
   return { values: resolved, sources };
@@ -699,6 +739,12 @@ export async function updateOperatorDefaults(update: Partial<OperatorDefaults>):
     }
     stored.workersUseBrain = update.workersUseBrain;
   }
+  if (update.orchestratorBackend !== undefined) {
+    if (!isOrchestratorBackendSetting(update.orchestratorBackend)) {
+      throw new Error('orchestratorBackend must be one of "auto", "codex", "claude", "openclaw".');
+    }
+    stored.orchestratorBackend = update.orchestratorBackend;
+  }
 
   await mkdir(path.dirname(filePath), { recursive: true });
   await writeFile(filePath, `${JSON.stringify(stored, null, 2)}\n`, 'utf8');
@@ -777,4 +823,14 @@ export function resolveBrainUseClaudeCliSync(): boolean {
 
 export function resolveWorkersUseBrainSync(): WorkersUseBrain {
   return getOperatorDefaultsSync().values.workersUseBrain;
+}
+
+/**
+ * Which backend drives the in-app Orchestrator. 'auto' means "defer to
+ * {@link resolveInAppOrchestratorEnabledSync}" — the registry's
+ * `resolveOrchestratorBackendId` applies that fallback so 'auto' is byte-identical
+ * to the pre-setting derivation.
+ */
+export function resolveOrchestratorBackendSync(): OrchestratorBackendSetting {
+  return getOperatorDefaultsSync().values.orchestratorBackend;
 }

--- a/tests/smoke/orchestrator-backend-setting-smoke.ts
+++ b/tests/smoke/orchestrator-backend-setting-smoke.ts
@@ -1,0 +1,68 @@
+/**
+ * Orchestrator backend setting — derivation test (live).
+ *
+ * Proves resolveOrchestratorBackendId() honors the new `orchestratorBackend`
+ * operator setting:
+ *   - 'auto' (default) → BYTE-IDENTICAL to the legacy inAppOrchestratorEnabled
+ *     derivation (toggle ON → 'claude', OFF → 'codex');
+ *   - an explicit id ('codex' | 'claude' | 'openclaw') → passthrough, overriding
+ *     the toggle. This is how OpenClaw becomes selectable from the desktop.
+ *
+ * Controlled via env (O8_ORCHESTRATOR_BACKEND / O8_IN_APP_ORCHESTRATOR_ENABLED),
+ * which take precedence over file/fallback; a temp data dir keeps it hermetic.
+ *
+ *   CORTEX_IDE_DATA_DIR=$(mktemp -d) NODE_OPTIONS='--conditions=react-server' \
+ *     npx tsx tests/smoke/orchestrator-backend-setting-smoke.ts
+ */
+
+import assert from 'node:assert';
+
+import { resolveOrchestratorBackendId } from '@/lib/lane/orchestrator-backends/registry';
+import { resolveInAppOrchestratorEnabledSync } from '@/lib/operator/defaults';
+
+function setEnv(backend: string | undefined, inApp: string | undefined): void {
+  if (backend === undefined) delete process.env.O8_ORCHESTRATOR_BACKEND;
+  else process.env.O8_ORCHESTRATOR_BACKEND = backend;
+  if (inApp === undefined) delete process.env.O8_IN_APP_ORCHESTRATOR_ENABLED;
+  else process.env.O8_IN_APP_ORCHESTRATOR_ENABLED = inApp;
+}
+
+/** The exact pre-setting derivation — the byte-identical contract for 'auto'. */
+function legacy(): 'claude' | 'codex' {
+  return resolveInAppOrchestratorEnabledSync() ? 'claude' : 'codex';
+}
+
+function main(): void {
+  // ── 'auto' (default): byte-identical to the legacy derivation ──
+  // Default fallback: orchestratorBackend 'auto', inAppOrchestratorEnabled true.
+  setEnv(undefined, undefined);
+  assert.strictEqual(resolveOrchestratorBackendId(), 'claude', 'default (auto + inApp default true) → claude');
+  assert.strictEqual(resolveOrchestratorBackendId(), legacy(), 'default is byte-identical to legacy');
+
+  setEnv('auto', '1');
+  assert.strictEqual(resolveOrchestratorBackendId(), 'claude', 'auto + toggle ON → claude');
+  assert.strictEqual(resolveOrchestratorBackendId(), legacy(), 'auto+ON byte-identical to legacy');
+
+  setEnv('auto', '0');
+  assert.strictEqual(resolveOrchestratorBackendId(), 'codex', 'auto + toggle OFF → codex');
+  assert.strictEqual(resolveOrchestratorBackendId(), legacy(), 'auto+OFF byte-identical to legacy');
+
+  // ── explicit id: passthrough, overrides the toggle ──
+  setEnv('openclaw', '1');
+  assert.strictEqual(resolveOrchestratorBackendId(), 'openclaw', 'explicit openclaw → openclaw (toggle ignored)');
+  setEnv('openclaw', '0');
+  assert.strictEqual(resolveOrchestratorBackendId(), 'openclaw', 'explicit openclaw → openclaw regardless of toggle');
+
+  setEnv('codex', '1');
+  assert.strictEqual(resolveOrchestratorBackendId(), 'codex', 'explicit codex overrides toggle ON');
+  setEnv('claude', '0');
+  assert.strictEqual(resolveOrchestratorBackendId(), 'claude', 'explicit claude overrides toggle OFF');
+
+  // An explicit id is NOT the legacy derivation (proves the new path is live).
+  setEnv('openclaw', '1');
+  assert.notStrictEqual(resolveOrchestratorBackendId(), legacy(), 'explicit openclaw diverges from legacy');
+
+  console.log('[orchestrator-backend-setting-smoke] PASS — auto = legacy (byte-identical); explicit = passthrough');
+}
+
+main();


### PR DESCRIPTION
## Orchestrator Backend Step 1 — the `orchestratorBackend` setting (makes OpenClaw selectable)

Different axis from the tool-spine breadth: this is the **orchestrator-backend layer** (`src/lib/lane/orchestrator-backends/`), where o8 drives a runtime *as* the orchestrator. The governed **OpenClaw** backend is already fully built + wired (`openclaw.ts` → ws-server → registry) but was reachable **only** via a per-request `backend:'openclaw'` field from mobile — stranded behind a missing desktop picker. This adds the one setting that surfaces it.

### The setting
`orchestratorBackend: 'auto' | 'codex' | 'claude' | 'openclaw'` (default **`'auto'`**):
- **`'auto'`** → `resolveOrchestratorBackendId()` defers to the legacy `inAppOrchestratorEnabled` derivation (toggle ON → `claude`, OFF → `codex`) — **byte-identical** to pre-setting behavior. The registry comment literally anticipated this swap.
- **a specific id** → forces that backend, including **`'openclaw'`**.

A per-request `msg.backend` still overrides it (`ws-server` `resolveMsgBackendId`, **untouched**).

### What changed (5 files)
- **`operator/defaults.ts`** — the field, mirroring `workersUseBrain` exactly: interface + stored shape + fallback (`'auto'`) + env (`O8_ORCHESTRATOR_BACKEND`) + file resolver + `resolveDefaults` value/source + `updateOperatorDefaults` validation + `resolveOrchestratorBackendSync` + an options array.
- **`orchestrator-backends/registry.ts`** — `resolveOrchestratorBackendId()` consults the setting, falling through to the **exact** legacy expression on `'auto'`.
- **`/api/panel/operator-defaults`** — the validation allowlist gains the field (the route's `normalizeUpdate` would otherwise silently drop it).
- **Settings → Operator → "07"** — a `SegmentedControl` picker (Auto / Codex / Claude / OpenClaw) above the toggle it supersedes.

### Scope honored (your constraints)
- **Setting + OpenClaw picker only.** No Hermes, no ACP.
- **`OrchestratorBackendId` union UNTOUCHED** — `openclaw` was already in it, so no guard changes.
- **Background consumers UNTOUCHED** — auto-review, github-intake, supervisor escalation, heal-bot, auto-compact all route through `getActiveOrchestratorBackend()`, so `'auto'` (default) keeps them byte-identical to today. Verified: `types.ts`, `openclaw.ts`, `auto-review.ts`, `github-intake.ts`, `ws-server.ts`, `auto-compact.ts` have **zero** changes.

### Proof
`tests/smoke/orchestrator-backend-setting-smoke.ts` (env-controlled, hermetic):
- **Zero-regression** — `'auto'` resolves **byte-identical** to `inAppOrchestratorEnabled ? 'claude' : 'codex'` for both toggle states (asserted against the live legacy expression).
- **New path** — explicit `'openclaw'`/`'codex'`/`'claude'` pass through and override the toggle; explicit `'openclaw'` provably diverges from legacy (the new path is live). So a desktop Orchestrator turn with the setting = `openclaw` routes to the openclaw backend.

**Gate (local — CI billing-red as usual):** `tsc --noEmit` clean · `npm test` **329/329** · the setting smoke green · **all 9 tool-spine smokes (A–F + Gemini + OpenCode) still green**.

### Out of scope (flagged)
Exposing `orchestratorBackend` on the `o8_operator_defaults` MCP tool — it's not there today (`inAppOrchestratorEnabled` isn't either), so adding it would be a new surface beyond "picker." Clean follow-up.

### Next
Hermes via the ACP backend — once its install + `hermes acp` probe are confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018akNs5xu63pWZA3SXaGha8
