### PR TITLE
Orchestrator Backend Step 3: Hermes via a generic ACP backend (+ guard consolidation, governed lockout)

### DIFF
--- a/src/app/api/panel/operator-defaults/route.ts
+++ b/src/app/api/panel/operator-defaults/route.ts
@@ -179,8 +179,8 @@ function normalizeUpdate(body: Record<string, unknown>): Partial<OperatorDefault
 
   if (body.orchestratorBackend !== undefined) {
     const raw = body.orchestratorBackend;
-    if (raw !== 'auto' && raw !== 'codex' && raw !== 'claude' && raw !== 'openclaw') {
-      throw new Error('orchestratorBackend must be one of "auto", "codex", "claude", "openclaw".');
+    if (raw !== 'auto' && raw !== 'codex' && raw !== 'claude' && raw !== 'openclaw' && raw !== 'hermes') {
+      throw new Error('orchestratorBackend must be one of "auto", "codex", "claude", "openclaw", "hermes".');
     }
     update.orchestratorBackend = raw;
   }

--- a/src/app/api/setup/orchestrator-backends/route.ts
+++ b/src/app/api/setup/orchestrator-backends/route.ts
@@ -1,0 +1,23 @@
+/**
+ * Orchestrator-backend availability — drives which backends the desktop picker
+ * offers. Today only the ACP-based Hermes backend needs a presence check (its
+ * binary may not be installed); the built-in codex/claude/openclaw are always
+ * available. GET-only, under the setup read-only allowlist.
+ */
+
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+
+import { isHermesAvailable } from '@/lib/lane/orchestrator-backends/acp';
+
+export async function GET() {
+  try {
+    return NextResponse.json({ hermes: isHermesAvailable() });
+  } catch (error) {
+    return NextResponse.json(
+      { hermes: false, error: error instanceof Error ? error.message : String(error) },
+      { status: 200 },
+    );
+  }
+}

--- a/src/app/api/v2/chat-history/route.ts
+++ b/src/app/api/v2/chat-history/route.ts
@@ -12,7 +12,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { performance } from 'node:perf_hooks';
 import { extractPlanFromTranscript } from '@/lib/llm/plan-extractor';
-import { isOrchestratorBackendId } from '@/lib/lane/orchestrator-backends/types';
+import { isOrchestratorBackendId, type OrchestratorBackendId } from '@/lib/lane/orchestrator-backends/types';
 import { mergeChatMessages } from '@/lib/llm/merge-chat-messages';
 
 const HISTORY_DIR = join(homedir(), '.o8', 'chat-history');
@@ -41,7 +41,7 @@ function normalizeNullableDate(value: unknown): string | null | undefined {
 }
 
 /** The orchestrator backend that produced this thread, if the client tagged it. */
-function normalizeBackend(value: unknown): 'codex' | 'claude' | 'openclaw' | undefined {
+function normalizeBackend(value: unknown): OrchestratorBackendId | undefined {
   return isOrchestratorBackendId(value) ? value : undefined;
 }
 
@@ -78,7 +78,7 @@ function isThoughtsThread(tabId: unknown): tabId is string {
   return typeof tabId === 'string' && tabId.startsWith('thoughts-');
 }
 
-function inferBackendFromModel(model: string | undefined): 'codex' | 'claude' | 'openclaw' | undefined {
+function inferBackendFromModel(model: string | undefined): OrchestratorBackendId | undefined {
   const normalized = model?.toLowerCase();
   if (!normalized) return undefined;
   if (normalized.includes('openclaw')) return 'openclaw';
@@ -96,7 +96,7 @@ function inferBackendFromSessionIds(
 }
 
 function defaultModelForBackend(
-  backend: 'codex' | 'claude' | 'openclaw' | undefined | null,
+  backend: OrchestratorBackendId | undefined | null,
 ): string | undefined {
   if (backend === 'claude') return 'claude-code';
   if (backend === 'codex') return 'codex';
@@ -162,7 +162,7 @@ export async function POST(request: NextRequest) {
   let repoPath: string | undefined;
   let repoBranch: string | undefined;
   let remoteUrl: string | null | undefined;
-  let backend: 'codex' | 'claude' | 'openclaw' | undefined;
+  let backend: OrchestratorBackendId | undefined;
   let agent: string | undefined;
   let archivedAt: string | null | undefined;
   let orchestratorVisible: boolean | undefined;

--- a/src/app/api/v2/chat-history/route.ts
+++ b/src/app/api/v2/chat-history/route.ts
@@ -12,6 +12,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { performance } from 'node:perf_hooks';
 import { extractPlanFromTranscript } from '@/lib/llm/plan-extractor';
+import { isOrchestratorBackendId } from '@/lib/lane/orchestrator-backends/types';
 import { mergeChatMessages } from '@/lib/llm/merge-chat-messages';
 
 const HISTORY_DIR = join(homedir(), '.o8', 'chat-history');
@@ -41,7 +42,7 @@ function normalizeNullableDate(value: unknown): string | null | undefined {
 
 /** The orchestrator backend that produced this thread, if the client tagged it. */
 function normalizeBackend(value: unknown): 'codex' | 'claude' | 'openclaw' | undefined {
-  return value === 'codex' || value === 'claude' || value === 'openclaw' ? value : undefined;
+  return isOrchestratorBackendId(value) ? value : undefined;
 }
 
 /** The openclaw agent id that produced this thread, if the client tagged it. */

--- a/src/components/desktop/settings/OperatorDefaultsTab.tsx
+++ b/src/components/desktop/settings/OperatorDefaultsTab.tsx
@@ -30,7 +30,7 @@ type SettingSource = 'env' | 'file' | 'default';
 type DispatchRuntime = 'codex' | 'gemini' | 'opencode';
 type ClassAComposer = 'auto' | 'haiku-cli' | 'sonnet-cli' | 'fastest';
 type WorkersUseBrain = 'off' | 'auto' | 'all';
-type OrchestratorBackendSetting = 'auto' | 'codex' | 'claude' | 'openclaw';
+type OrchestratorBackendSetting = 'auto' | 'codex' | 'claude' | 'openclaw' | 'hermes';
 
 interface OperatorDefaults {
   parallelCap: number;
@@ -341,6 +341,16 @@ function PickerMenu<T extends string>({ value, options, onChange, disabled, minW
 export function OperatorDefaultsTab() {
   const [data, setData] = useState<OperatorDefaultsResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  // Hermes (ACP backend) only appears in the backend picker when its binary is present.
+  const [hermesAvailable, setHermesAvailable] = useState(false);
+  useEffect(() => {
+    let alive = true;
+    fetch('/api/setup/orchestrator-backends')
+      .then((r) => r.json())
+      .then((d) => { if (alive) setHermesAvailable(Boolean(d?.hermes)); })
+      .catch(() => { /* picker just omits Hermes */ });
+    return () => { alive = false; };
+  }, []);
   const [notice, setNotice] = useState<string | null>(null);
   const [busyField, setBusyField] = useState<keyof OperatorDefaults | null>(null);
 
@@ -861,11 +871,13 @@ export function OperatorDefaultsTab() {
           description={
             values.orchestratorBackend === 'openclaw'
               ? 'OpenClaw — the governed openclaw orchestrator drives chat + background turns and dispatches Codex workers through o8. A per-request backend (e.g. mobile) still overrides.'
-              : values.orchestratorBackend === 'codex'
-                ? 'Codex — forces Codex GPT-5.5 xhigh as the orchestrator brain (ignores the toggle below).'
-                : values.orchestratorBackend === 'claude'
-                  ? 'Claude — forces the Claude Code REPL as the orchestrator brain (ignores the toggle below).'
-                  : 'Auto (default) — follow the in-app orchestrator toggle below (Claude when on, Codex when off). Byte-identical to prior behavior.'
+              : values.orchestratorBackend === 'hermes'
+                ? 'Hermes — the governed Hermes agent (via ACP) drives turns and dispatches Codex workers through o8. Needs a model provider configured (hermes setup).'
+                : values.orchestratorBackend === 'codex'
+                  ? 'Codex — forces Codex GPT-5.5 xhigh as the orchestrator brain (ignores the toggle below).'
+                  : values.orchestratorBackend === 'claude'
+                    ? 'Claude — forces the Claude Code REPL as the orchestrator brain (ignores the toggle below).'
+                    : 'Auto (default) — follow the in-app orchestrator toggle below (Claude when on, Codex when off). Byte-identical to prior behavior.'
           }
           source={sources.orchestratorBackend}
           disabledReason={sources?.orchestratorBackend === 'env' ? envDisabledReason : undefined}
@@ -877,6 +889,7 @@ export function OperatorDefaultsTab() {
                 { value: 'codex', label: 'Codex' },
                 { value: 'claude', label: 'Claude' },
                 { value: 'openclaw', label: 'OpenClaw' },
+                ...(hermesAvailable || values.orchestratorBackend === 'hermes' ? [{ value: 'hermes' as const, label: 'Hermes' }] : []),
               ]}
               onChange={(next) => { void updateField('orchestratorBackend', next); }}
               disabled={sources?.orchestratorBackend === 'env' || busyField === 'orchestratorBackend'}

--- a/src/lib/acp/client.test.ts
+++ b/src/lib/acp/client.test.ts
@@ -1,0 +1,67 @@
+/**
+ * ACP session/update → OrchestratorEvent mapping (Step 3b, pure).
+ *
+ * Pins the mapping verified against the published spec + live hermes acp v0.17.0:
+ * text / thinking / tool_use / tool_result, the stopReason→done/error rule, and
+ * graceful ignore of unknown variants (hermes's `usage_update`, plan, command
+ * lists, in-flight tool ticks).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { mapAcpUpdate, mapStopReason } from './client';
+
+describe('mapAcpUpdate', () => {
+  it('agent_message_chunk → text', () => {
+    expect(mapAcpUpdate({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'hello' } }))
+      .toEqual({ type: 'text', text: 'hello' });
+  });
+
+  it('agent_thought_chunk → thinking', () => {
+    expect(mapAcpUpdate({ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: 'let me think' } }))
+      .toEqual({ type: 'thinking', text: 'let me think' });
+  });
+
+  it('tool_call → tool_use (title preferred, kind fallback, rawInput as input)', () => {
+    expect(mapAcpUpdate({ sessionUpdate: 'tool_call', toolCallId: 'c1', title: 'Read utils.py', kind: 'read', status: 'pending', rawInput: { path: 'utils.py' } }))
+      .toEqual({ type: 'tool_use', id: 'c1', name: 'Read utils.py', input: { path: 'utils.py' } });
+    expect(mapAcpUpdate({ sessionUpdate: 'tool_call', toolCallId: 'c2', kind: 'execute', status: 'pending' }))
+      .toEqual({ type: 'tool_use', id: 'c2', name: 'execute', input: null });
+  });
+
+  it('tool_call_update completed → tool_result (ToolCallContent[] flattened)', () => {
+    expect(mapAcpUpdate({ sessionUpdate: 'tool_call_update', toolCallId: 'c1', status: 'completed', content: [{ type: 'content', content: { type: 'text', text: 'def add' } }] }))
+      .toEqual({ type: 'tool_result', id: 'c1', name: '', output: 'def add' });
+  });
+
+  it('tool_call_update in-progress → null (not surfaced)', () => {
+    expect(mapAcpUpdate({ sessionUpdate: 'tool_call_update', toolCallId: 'c1', status: 'in_progress' })).toBeNull();
+  });
+
+  it('unknown / non-event variants → null (graceful)', () => {
+    expect(mapAcpUpdate({ sessionUpdate: 'usage_update', size: 256000, used: 27021 })).toBeNull(); // hermes-specific
+    expect(mapAcpUpdate({ sessionUpdate: 'available_commands_update', availableCommands: [] })).toBeNull();
+    expect(mapAcpUpdate({ sessionUpdate: 'user_message_chunk', content: { type: 'text', text: 'echo' } })).toBeNull();
+    expect(mapAcpUpdate({ sessionUpdate: 'plan', entries: [] })).toBeNull();
+    expect(mapAcpUpdate({ sessionUpdate: 'current_mode_update', currentModeId: 'default' })).toBeNull();
+    expect(mapAcpUpdate(null)).toBeNull();
+    expect(mapAcpUpdate('nope')).toBeNull();
+    expect(mapAcpUpdate({})).toBeNull();
+  });
+
+  it('missing/odd content → empty text, never throws', () => {
+    expect(mapAcpUpdate({ sessionUpdate: 'agent_message_chunk' })).toEqual({ type: 'text', text: '' });
+    expect(mapAcpUpdate({ sessionUpdate: 'agent_message_chunk', content: 42 })).toEqual({ type: 'text', text: '' });
+  });
+});
+
+describe('mapStopReason', () => {
+  it('refusal → error (the no-provider case)', () => {
+    expect(mapStopReason('refusal', 'sess-1').type).toBe('error');
+  });
+  it('end_turn / other → done with sessionId', () => {
+    expect(mapStopReason('end_turn', 'sess-1')).toEqual({ type: 'done', sessionId: 'sess-1', cost: null });
+    expect(mapStopReason('max_tokens', 'sess-2')).toEqual({ type: 'done', sessionId: 'sess-2', cost: null });
+    expect(mapStopReason('cancelled', null)).toEqual({ type: 'done', sessionId: null, cost: null });
+  });
+});

--- a/src/lib/acp/client.ts
+++ b/src/lib/acp/client.ts
@@ -1,0 +1,282 @@
+/**
+ * Agent Client Protocol (ACP) stdio client.
+ *
+ * ACP is the protocol Zed / VS Code / JetBrains use to drive AI coding agents
+ * (agentclientprotocol.com — NOT MCP). o8 uses it as the generic orchestrator-
+ * backend transport: one client → any ACP agent (Hermes now; openclaw acpx / Zed
+ * later). This module owns the wire (spawn + JSON-RPC 2.0 over newline-delimited
+ * JSON) and the `session/update` → `OrchestratorEvent` mapping. The backend
+ * (`orchestrator-backends/acp.ts`) owns sessions / lifecycle on top of it.
+ *
+ * Wire facts verified against the published spec AND live `hermes acp` v0.17.0:
+ *   - framing is NDJSON (one JSON-RPC object per line) — NOT Content-Length;
+ *   - lifecycle: initialize → session/new → session/prompt; the prompt REQUEST's
+ *     result carries `stopReason` and IS the end-of-turn signal;
+ *   - streaming arrives as `session/update` notifications in between;
+ *   - session/cancel is a NOTIFICATION (no id);
+ *   - agents emit non-standard update variants (hermes: `usage_update`) — unknown
+ *     variants are ignored, never fatal.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+
+import type { OrchestratorEvent } from '@/lib/lane/orchestrator-stream-events';
+
+// ── ACP wire types (the subset o8 uses) ──
+
+/** stdio MCP server entry for `session/new` — note `env` is an ARRAY of {name,value}. */
+export interface AcpMcpServer {
+  name: string;
+  command: string;
+  args: string[];
+  env: Array<{ name: string; value: string }>;
+}
+
+export interface AcpInitializeResult {
+  protocolVersion: number;
+  agentCapabilities?: Record<string, unknown>;
+  agentInfo?: { name?: string; version?: string };
+  authMethods?: Array<{ id: string; name?: string; description?: string }>;
+}
+
+export type AcpStopReason = 'end_turn' | 'max_tokens' | 'max_turn_requests' | 'refusal' | 'cancelled' | string;
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+const ACP_PROTOCOL_VERSION = 1;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function str(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+/** Extract the text from an ACP ContentBlock ({type:'text', text}) defensively. */
+function contentText(content: unknown): string {
+  const block = asRecord(content);
+  if (block && typeof block.text === 'string') return block.text;
+  // Some agents wrap tool output as ToolCallContent[] ({type:'content', content: ContentBlock}).
+  if (Array.isArray(content)) {
+    return content
+      .map((item) => {
+        const rec = asRecord(item);
+        if (!rec) return '';
+        if (typeof rec.text === 'string') return rec.text;
+        return contentText(rec.content);
+      })
+      .join('');
+  }
+  return '';
+}
+
+/**
+ * Map one ACP `session/update` payload (`update`) to an OrchestratorEvent, or
+ * null when the variant has no o8 event (user echo, plan, command lists, the
+ * hermes-specific `usage_update`, in-flight tool progress). PURE — unit-tested.
+ */
+export function mapAcpUpdate(update: unknown): OrchestratorEvent | null {
+  const u = asRecord(update);
+  if (!u) return null;
+  switch (u.sessionUpdate) {
+    case 'agent_message_chunk':
+      return { type: 'text', text: contentText(u.content) };
+    case 'agent_thought_chunk':
+      return { type: 'thinking', text: contentText(u.content) };
+    case 'tool_call':
+      return {
+        type: 'tool_use',
+        id: str(u.toolCallId),
+        name: str(u.title) ?? str(u.kind) ?? 'tool',
+        input: u.rawInput ?? null,
+      };
+    case 'tool_call_update':
+      // Only surface a tool RESULT on completion; in-progress ticks are skipped.
+      if (u.status === 'completed') {
+        return { type: 'tool_result', id: str(u.toolCallId), name: str(u.title) ?? '', output: contentText(u.content) };
+      }
+      return null;
+    default:
+      return null; // user_message_chunk · plan · available_commands_update · usage_update · current_mode_update · …
+  }
+}
+
+/** Map a terminal stopReason to the o8 `done`/`error` event. */
+export function mapStopReason(stopReason: AcpStopReason, sessionId: string | null): OrchestratorEvent {
+  if (stopReason === 'refusal') {
+    return { type: 'error', error: 'ACP agent refused the turn (no model/provider configured, or the request was declined).' };
+  }
+  return { type: 'done', sessionId, cost: null };
+}
+
+export interface AcpClientOptions {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+  /** Called for every session/update notification's OrchestratorEvent (mapped). */
+  onEvent?: (event: OrchestratorEvent) => void;
+  /** Raw stderr lines from the agent (logs) — optional, for diagnostics. */
+  onStderr?: (chunk: string) => void;
+}
+
+/**
+ * A live ACP agent subprocess speaking JSON-RPC 2.0 over NDJSON stdio. One client
+ * = one agent process = (typically) one ACP session, reused across turns.
+ */
+export class AcpClient {
+  private proc: ChildProcess;
+  private nextId = 1;
+  private readonly pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+  private buf = '';
+  private readonly onEvent?: (event: OrchestratorEvent) => void;
+  private closed = false;
+
+  constructor(opts: AcpClientOptions) {
+    this.onEvent = opts.onEvent;
+    this.proc = spawn(opts.command, opts.args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, ...(opts.env ?? {}) },
+    });
+    this.proc.stdout?.setEncoding('utf8');
+    this.proc.stdout?.on('data', (chunk: string) => this.onStdout(chunk));
+    if (opts.onStderr) this.proc.stderr?.on('data', (c: Buffer) => opts.onStderr!(c.toString('utf8')));
+    this.proc.on('close', () => this.onClose());
+    this.proc.on('error', (err) => this.failAll(err instanceof Error ? err : new Error(String(err))));
+  }
+
+  private onStdout(chunk: string): void {
+    this.buf += chunk;
+    let nl: number;
+    while ((nl = this.buf.indexOf('\n')) >= 0) {
+      const line = this.buf.slice(0, nl).trim();
+      this.buf = this.buf.slice(nl + 1);
+      if (!line) continue;
+      let msg: Record<string, unknown> | null;
+      try {
+        msg = asRecord(JSON.parse(line));
+      } catch {
+        continue; // non-JSON log line on stdout — ignore
+      }
+      if (!msg) continue;
+      this.dispatch(msg);
+    }
+  }
+
+  private dispatch(msg: Record<string, unknown>): void {
+    // Response to one of our requests (has a matching id).
+    if (typeof msg.id === 'number' && (('result' in msg) || ('error' in msg))) {
+      const entry = this.pending.get(msg.id);
+      if (!entry) return;
+      this.pending.delete(msg.id);
+      const res = msg as unknown as JsonRpcResponse;
+      if (res.error) entry.reject(new Error(`ACP error ${res.error.code}: ${res.error.message}`));
+      else entry.resolve(res.result);
+      return;
+    }
+    // session/update notification → mapped OrchestratorEvent.
+    if (msg.method === 'session/update') {
+      const params = asRecord(msg.params);
+      const event = params ? mapAcpUpdate(params.update) : null;
+      if (event && this.onEvent) this.onEvent(event);
+    }
+    // Agent→client requests (fs/read, permission prompts, …) are not handled in
+    // v1 — Hermes runs with --accept-hooks so it doesn't block on them.
+  }
+
+  private onClose(): void {
+    this.closed = true;
+    this.failAll(new Error('ACP agent process exited'));
+  }
+
+  private failAll(err: Error): void {
+    for (const { reject } of this.pending.values()) reject(err);
+    this.pending.clear();
+  }
+
+  private write(obj: Record<string, unknown>): void {
+    if (this.closed) throw new Error('ACP client is closed');
+    this.proc.stdin?.write(JSON.stringify(obj) + '\n');
+  }
+
+  private request(method: string, params: unknown): Promise<unknown> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      try {
+        this.write({ jsonrpc: '2.0', id, method, params });
+      } catch (err) {
+        this.pending.delete(id);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+  }
+
+  private notify(method: string, params: unknown): void {
+    this.write({ jsonrpc: '2.0', method, params });
+  }
+
+  async initialize(clientName = 'o8', clientVersion = '0.1.0'): Promise<AcpInitializeResult> {
+    const r = asRecord(await this.request('initialize', {
+      protocolVersion: ACP_PROTOCOL_VERSION,
+      clientCapabilities: { fs: { readTextFile: true, writeTextFile: true }, terminal: true },
+      clientInfo: { name: clientName, version: clientVersion },
+    })) ?? {};
+    return {
+      protocolVersion: typeof r.protocolVersion === 'number' ? r.protocolVersion : ACP_PROTOCOL_VERSION,
+      agentCapabilities: asRecord(r.agentCapabilities) ?? undefined,
+      agentInfo: (asRecord(r.agentInfo) ?? undefined) as AcpInitializeResult['agentInfo'],
+      authMethods: (Array.isArray(r.authMethods) ? r.authMethods : undefined) as AcpInitializeResult['authMethods'],
+    };
+  }
+
+  async newSession(cwd: string, mcpServers: AcpMcpServer[] = []): Promise<string> {
+    const result = asRecord(await this.request('session/new', { cwd, mcpServers }));
+    const sessionId = result ? str(result.sessionId) : null;
+    if (!sessionId) throw new Error('ACP session/new returned no sessionId');
+    return sessionId;
+  }
+
+  /** Run one prompt turn. Resolves with the stopReason when the agent finishes;
+   *  streaming arrives via onEvent in between. */
+  async prompt(sessionId: string, text: string): Promise<AcpStopReason> {
+    const result = asRecord(await this.request('session/prompt', {
+      sessionId,
+      prompt: [{ type: 'text', text }],
+    }));
+    return (result && str(result.stopReason)) || 'end_turn';
+  }
+
+  /** Abort the in-flight turn (notification — the agent ends it with stopReason 'cancelled'). */
+  cancel(sessionId: string): void {
+    if (!this.closed) {
+      try {
+        this.notify('session/cancel', { sessionId });
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+
+  get pid(): number | undefined {
+    return this.proc.pid;
+  }
+
+  get alive(): boolean {
+    return !this.closed;
+  }
+
+  kill(): void {
+    this.closed = true;
+    try {
+      this.proc.kill('SIGTERM');
+    } catch {
+      /* already dead */
+    }
+  }
+}

--- a/src/lib/lane/orchestrator-backends/acp.ts
+++ b/src/lib/lane/orchestrator-backends/acp.ts
@@ -1,0 +1,264 @@
+/**
+ * Generic ACP orchestrator backend.
+ *
+ * Drives ANY Agent-Client-Protocol agent (agentclientprotocol.com) as an o8
+ * orchestrator backend, on top of `@/lib/acp/client`. Parameterized by launch
+ * command, so Hermes (`hermes acp`) is just the first agent — openclaw acpx /
+ * Zed / any ACP agent ride the same backend via a different launch config.
+ *
+ * Session model: one long-lived agent subprocess (an AcpClient) per
+ * repo+thread, reused across turns (the ACP `sessionId` persists the
+ * conversation). The handshake (initialize → session/new, injecting o8's
+ * operator MCP server) runs lazily on the first turn; subsequent turns are just
+ * `session/prompt`. Abort SIGTERM-cancels the in-flight turn; a watchdog kills a
+ * hung subprocess. Mirrors openclaw's lifecycle realtime-publish for mobile.
+ *
+ * The #1075 orchestrator≠worker lockout is enforced separately by the governed
+ * profile (`governHermesProfile`) — an ACP client can't strip an agent's native
+ * tools, so Hermes runs against a profile that denies native spawn.
+ */
+
+import { existsSync } from 'node:fs';
+
+import { AcpClient, mapStopReason, type AcpMcpServer } from '@/lib/acp/client';
+import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
+import { toOpenclawJson } from '@/lib/mcp/tool-spine/emit-openclaw';
+import type { OrchestratorEvent } from '@/lib/lane/orchestrator-stream-events';
+import { publishRealtimeMutation } from '@/lib/realtime/publisher';
+import type { RealtimeMutationRecord } from '@/lib/realtime/types';
+import { governHermesProfile } from './hermes-profile';
+import type {
+  OrchestratorBackend,
+  OrchestratorBackendId,
+  OrchestratorSessionInfo,
+  OrchestratorTurnOptions,
+} from './types';
+
+/** Hang watchdog (not a work budget) — mirrors the other backends' 4h ceiling. */
+const ACP_PROCESS_TIMEOUT_MS = 14_400_000;
+
+interface AcpSession {
+  key: string;
+  sessionName: string;
+  repoPath: string;
+  client: AcpClient;
+  sessionId: string | null;
+  status: 'ready' | 'busy' | 'dead';
+  createdAt: number;
+  /** The current turn's event sink — set by sendTurn, cleared on completion. */
+  onEvent?: (event: OrchestratorEvent) => void;
+}
+
+const sessions = new Map<string, AcpSession>();
+let acpRealtimeSeq = 0;
+
+function sessionKey(backendId: string, repoPath: string, threadId?: string | null): string {
+  return `${backendId}::${repoPath}::${threadId ?? 'default'}`;
+}
+
+/** o8's operator MCP server in ACP's session/new shape (env as {name,value}[]). */
+function o8McpServersForAcp(repoPath: string): AcpMcpServer[] {
+  try {
+    const o8 = toOpenclawJson(buildToolRegistry(repoPath)).servers['o8'] as
+      | { command: string; args: string[]; env?: Record<string, string> }
+      | undefined;
+    if (!o8) return [];
+    return [{
+      name: 'o8',
+      command: o8.command,
+      args: o8.args,
+      env: Object.entries(o8.env ?? {}).map(([name, value]) => ({ name, value })),
+    }];
+  } catch {
+    return [];
+  }
+}
+
+function publishAcpLifecycle(backendId: string, session: AcpSession, event: OrchestratorEvent): void {
+  const base = { backendId, threadKey: session.key };
+  const realtime = event.type === 'text'
+    ? { event: 'output' as const, action: 'orchestrator-output', status: 'completed' as const, note: `${backendId} assistant output (${event.text.length} chars)`, data: { ...base, text: event.text, thinking: false } }
+    : event.type === 'error'
+      ? { event: 'error' as const, action: 'orchestrator-error', status: 'failed' as const, note: event.error.slice(0, 240), data: { ...base, error: event.error } }
+      : event.type === 'done'
+        ? { event: 'status' as const, action: 'orchestrator-status', status: 'completed' as const, note: `${backendId} orchestrator turn completed`, data: { ...base, status: 'ready' as const, sessionId: event.sessionId, cost: event.cost } }
+        : null;
+  if (!realtime) return;
+  const createdAt = new Date().toISOString();
+  const mutation = {
+    mutationId: `${backendId}-${realtime.event}-${Date.now()}-${acpRealtimeSeq += 1}`,
+    source: 'server',
+    action: realtime.action,
+    status: realtime.status,
+    runtime: backendId,
+    surfaceId: session.sessionName,
+    sessionKey: session.sessionName,
+    repoPath: session.repoPath,
+    note: realtime.note,
+    createdAt,
+    settledAt: createdAt,
+    channel: 'orchestrator',
+    event: realtime.event,
+    data: realtime.data,
+  } as RealtimeMutationRecord;
+  void publishRealtimeMutation({ mutation, fresh: true });
+}
+
+export interface AcpLaunch {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+export interface AcpBackendConfig {
+  id: OrchestratorBackendId;
+  label: string;
+  /** Resolve the launch command; null when the agent isn't available/configured. */
+  resolveLaunch: (repoPath: string) => AcpLaunch | null;
+}
+
+export function makeAcpBackend(config: AcpBackendConfig): OrchestratorBackend {
+  const { id, label } = config;
+
+  function spawnSession(repoPath: string, threadId?: string | null): AcpSession {
+    const launch = config.resolveLaunch(repoPath);
+    if (!launch) throw new Error(`${label} (ACP) is not available — its agent binary/profile could not be resolved.`);
+    const key = sessionKey(id, repoPath, threadId);
+    const session: AcpSession = {
+      key,
+      sessionName: key,
+      repoPath,
+      sessionId: null,
+      status: 'ready',
+      createdAt: Date.now(),
+      client: new AcpClient({
+        command: launch.command,
+        args: launch.args,
+        env: launch.env,
+        onEvent: (event) => session.onEvent?.(event),
+      }),
+    };
+    sessions.set(key, session);
+    return session;
+  }
+
+  function ensureSync(repoPath: string, threadId?: string | null): AcpSession {
+    const key = sessionKey(id, repoPath, threadId);
+    const existing = sessions.get(key);
+    if (existing && existing.status !== 'dead' && existing.client.alive) return existing;
+    if (existing) sessions.delete(key);
+    return spawnSession(repoPath, threadId);
+  }
+
+  async function ensureHandshake(session: AcpSession): Promise<string> {
+    if (session.sessionId) return session.sessionId;
+    await session.client.initialize();
+    session.sessionId = await session.client.newSession(session.repoPath, o8McpServersForAcp(session.repoPath));
+    return session.sessionId;
+  }
+
+  return {
+    id,
+    label,
+    peekSession(repoPath, _agent, threadId): OrchestratorSessionInfo | null {
+      const session = sessions.get(sessionKey(id, repoPath, threadId));
+      return session && session.client.alive ? { sessionName: session.sessionName, status: session.status } : null;
+    },
+    ensureSession(repoPath, _agent, threadId): OrchestratorSessionInfo {
+      const session = ensureSync(repoPath, threadId);
+      return { sessionName: session.sessionName, status: session.status };
+    },
+    async sendTurn(repoPath, message, onEvent, options?: OrchestratorTurnOptions): Promise<void> {
+      const session = ensureSync(repoPath, options?.threadId);
+      session.status = 'busy';
+      session.onEvent = onEvent;
+
+      const watchdog = setTimeout(() => {
+        session.status = 'dead';
+        session.client.kill();
+      }, ACP_PROCESS_TIMEOUT_MS);
+
+      const onAbort = () => {
+        if (session.sessionId) session.client.cancel(session.sessionId);
+      };
+      options?.signal?.addEventListener('abort', onAbort, { once: true });
+
+      try {
+        const sessionId = await ensureHandshake(session);
+        const stopReason = await session.client.prompt(sessionId, message);
+        const doneOrError = mapStopReason(stopReason, sessionId);
+        onEvent(doneOrError);
+        publishAcpLifecycle(id, session, doneOrError);
+      } catch (err) {
+        const errorEvent: OrchestratorEvent = { type: 'error', error: err instanceof Error ? err.message : String(err) };
+        onEvent(errorEvent);
+        publishAcpLifecycle(id, session, errorEvent);
+        session.status = 'dead';
+        session.client.kill();
+      } finally {
+        clearTimeout(watchdog);
+        options?.signal?.removeEventListener('abort', onAbort);
+        session.onEvent = undefined;
+        if (session.status !== 'dead') session.status = 'ready';
+      }
+    },
+  };
+}
+
+// ── Concrete backends ──────────────────────────────────────────────────────────
+
+/** Resolve the `hermes` binary (PATH); null when not installed. */
+function resolveHermesBinary(): string | null {
+  for (const candidate of [
+    process.env.O8_HERMES_BIN,
+    `${process.env.HOME ?? ''}/.local/bin/hermes`,
+    '/opt/homebrew/bin/hermes',
+    '/usr/local/bin/hermes',
+    `${process.env.HOME ?? ''}/.npm-global/bin/hermes`,
+  ]) {
+    if (candidate && existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Hermes via `hermes acp`, run against the GOVERNED profile (3d): an isolated
+ * HOME whose config denies Hermes's native work toolsets (delegation = the
+ * native spawn, terminal/file/code_execution/browser/computer_use) so the
+ * orchestrator can only dispatch through o8. SAFETY INTERLOCK: if the profile
+ * can't be governed, resolveLaunch throws — Hermes NEVER runs ungoverned.
+ */
+export const hermesBackend: OrchestratorBackend = makeAcpBackend({
+  id: 'hermes',
+  label: 'Hermes',
+  resolveLaunch: () => {
+    const bin = resolveHermesBinary();
+    if (!bin) return null;
+    const governed = governHermesProfile(bin);
+    if (!governed) {
+      throw new Error(
+        'Hermes orchestrator refused: could not establish the governed profile (deny native toolsets + o8-MCP-only). '
+          + 'Hermes must be configured (hermes setup) and govern cleanly before it can orchestrate — running ungoverned '
+          + 'would break the orchestrator≠worker guarantee (#1075).',
+      );
+    }
+    return { command: bin, args: ['acp', '--accept-hooks'], env: { HOME: governed.home } };
+  },
+});
+
+/** Generic ACP escape hatch — any ACP agent via O8_ACP_COMMAND / O8_ACP_ARGS. */
+export const acpBackend: OrchestratorBackend = makeAcpBackend({
+  id: 'acp',
+  label: 'ACP',
+  resolveLaunch: () => {
+    const command = process.env.O8_ACP_COMMAND?.trim();
+    if (!command) return null;
+    const args = (process.env.O8_ACP_ARGS ?? '').split(' ').map((a) => a.trim()).filter(Boolean);
+    return { command, args };
+  },
+});
+
+/** Whether the Hermes ACP agent is available (binary present). */
+export function isHermesAvailable(): boolean {
+  return resolveHermesBinary() !== null;
+}

--- a/src/lib/lane/orchestrator-backends/hermes-profile.test.ts
+++ b/src/lib/lane/orchestrator-backends/hermes-profile.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Governed Hermes profile (Step 3d) — the disabled_toolsets parser + the
+ * lockout invariant (pure). The live end-to-end (copy + `hermes tools disable`)
+ * is exercised by tests/smoke/hermes-governed-profile-smoke.ts when hermes is
+ * installed.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { HERMES_DENIED_TOOLSETS, parseDisabledFromToolsList } from './hermes-profile';
+
+describe('HERMES_DENIED_TOOLSETS', () => {
+  it('denies the native spawn (delegation) + the direct-work toolsets', () => {
+    // delegation = Hermes's native sub-agent spawn — the #1075-critical one.
+    expect(HERMES_DENIED_TOOLSETS).toContain('delegation');
+    for (const t of ['terminal', 'file', 'code_execution', 'browser', 'computer_use']) {
+      expect(HERMES_DENIED_TOOLSETS).toContain(t);
+    }
+  });
+});
+
+describe('parseDisabledFromToolsList', () => {
+  // Real `hermes tools list` shape (verified against hermes v0.17.0).
+  const sample = [
+    'Built-in toolsets (cli):',
+    '  ✓ enabled  web  🔍 Web Search & Scraping',
+    '  ✗ disabled  terminal  💻 Terminal & Processes',
+    '  ✗ disabled  file  📁 File Operations',
+    '  ✓ enabled  memory  💾 Memory',
+    '  ✗ disabled  delegation  👥 Task Delegation',
+    '',
+    'MCP servers:',
+    '  o8  all tools enabled',
+  ].join('\n');
+
+  it('extracts exactly the ✗ disabled toolsets', () => {
+    const set = parseDisabledFromToolsList(sample);
+    expect(set.has('terminal')).toBe(true);
+    expect(set.has('file')).toBe(true);
+    expect(set.has('delegation')).toBe(true);
+    expect(set.has('web')).toBe(false); // enabled
+    expect(set.has('memory')).toBe(false);
+    expect(set.has('o8')).toBe(false); // MCP server line, not a ✗ disabled toolset
+  });
+
+  it('empty → empty set', () => {
+    expect(parseDisabledFromToolsList('Built-in toolsets (cli):\n  ✓ enabled  web  🔍\n').size).toBe(0);
+  });
+});

--- a/src/lib/lane/orchestrator-backends/hermes-profile.ts
+++ b/src/lib/lane/orchestrator-backends/hermes-profile.ts
@@ -1,0 +1,111 @@
+/**
+ * Governed Hermes profile — the #1075 orchestrator≠worker lockout for Hermes.
+ *
+ * As an ACP CLIENT, o8 can't strip a Hermes agent's native tools the way it
+ * rewrites ~/.openclaw-o8 for OpenClaw. So o8 runs `hermes acp` against an
+ * ISOLATED Hermes home (~/.o8/hermes-o8) whose config DENIES Hermes's native
+ * work toolsets — most importantly `delegation` (Hermes's native sub-agent
+ * spawn, the direct analogue of openclaw's `sessions_spawn`), plus terminal /
+ * file / code_execution / browser / computer_use. With those denied, the only
+ * way the Hermes orchestrator can do work is the o8 MCP server (dispatch a Codex
+ * worker through o8) — a STRUCTURAL lockout, not prompt-framing.
+ *
+ * Isolation is via HOME (Hermes reads $HOME/.hermes). The operator's own config
+ * + credentials are COPIED in (mirrors openclaw's credential copy) so the
+ * governed profile authenticates with whatever provider THEY configured — o8
+ * never creates or stores provider keys itself.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/** Hermes built-in toolsets that let the agent do work DIRECTLY — denied so the
+ *  orchestrator can only dispatch through o8. `delegation` is the native spawn. */
+export const HERMES_DENIED_TOOLSETS = ['delegation', 'terminal', 'file', 'code_execution', 'browser', 'computer_use'];
+
+function o8DataDir(): string {
+  return process.env.CORTEX_IDE_DATA_DIR || join(homedir(), '.o8');
+}
+
+function userHermesDir(): string {
+  return join(homedir(), '.hermes');
+}
+
+/** The isolated governed Hermes home — `hermes acp` runs with HOME set here. */
+export function governedHermesHome(): string {
+  return join(o8DataDir(), 'hermes-o8');
+}
+
+/**
+ * Generate (or refresh) the governed Hermes profile. Returns the HOME to launch
+ * `hermes acp` against, or null when Hermes isn't configured on this machine
+ * (no ~/.hermes/config.yaml) or the governance step fails — in which case the
+ * caller MUST refuse to run Hermes (never fall back to the ungoverned profile).
+ */
+export function governHermesProfile(hermesBin: string): { home: string } | null {
+  const userDir = userHermesDir();
+  if (!existsSync(join(userDir, 'config.yaml'))) return null; // hermes not set up
+
+  const home = governedHermesHome();
+  const governedHermes = join(home, '.hermes');
+  mkdirSync(governedHermes, { recursive: true });
+
+  // Carry the operator's own config + credentials (their provider, not ours).
+  for (const file of ['config.yaml', '.env', 'auth.json', 'models_dev_cache.json']) {
+    const src = join(userDir, file);
+    if (existsSync(src)) {
+      try { cpSync(src, join(governedHermes, file)); } catch { /* best-effort */ }
+    }
+  }
+
+  // Apply the deny via Hermes's own CLI against the ISOLATED home — never touches
+  // the user's ~/.hermes. (Hermes persists the disabled state internally, not in
+  // config.yaml's `disabled_toolsets`, so we verify via `hermes tools list`.)
+  try {
+    execFileSync(hermesBin, ['tools', 'disable', ...HERMES_DENIED_TOOLSETS], {
+      env: { ...process.env, HOME: home },
+      stdio: 'ignore',
+      timeout: 20000,
+    });
+  } catch {
+    return null; // governance couldn't be applied → caller refuses to run
+  }
+
+  // Verify the lockout actually landed (authoritatively) before declaring governed.
+  if (!isHermesProfileGoverned(home, hermesBin)) return null;
+  return { home };
+}
+
+/**
+ * True iff the governed home denies EVERY native work toolset, per Hermes's own
+ * authoritative `hermes tools list` (run HOME-isolated). We trust the agent's
+ * view rather than parsing config.yaml — Hermes stores the disabled state
+ * internally, not under `disabled_toolsets`.
+ */
+export function isHermesProfileGoverned(home: string, hermesBin: string): boolean {
+  if (!existsSync(join(home, '.hermes', 'config.yaml'))) return false;
+  try {
+    const out = execFileSync(hermesBin, ['tools', 'list'], {
+      env: { ...process.env, HOME: home },
+      encoding: 'utf8',
+      timeout: 20000,
+    });
+    const disabled = parseDisabledFromToolsList(out);
+    return HERMES_DENIED_TOOLSETS.every((t) => disabled.has(t));
+  } catch {
+    return false;
+  }
+}
+
+/** Parse the disabled toolset names from `hermes tools list` output
+ *  (lines like `  ✗ disabled  terminal  💻 Terminal & Processes`). */
+export function parseDisabledFromToolsList(output: string): Set<string> {
+  const out = new Set<string>();
+  for (const line of output.split('\n')) {
+    const m = line.match(/✗\s+disabled\s+(\S+)/);
+    if (m) out.add(m[1]);
+  }
+  return out;
+}

--- a/src/lib/lane/orchestrator-backends/registry.ts
+++ b/src/lib/lane/orchestrator-backends/registry.ts
@@ -24,6 +24,7 @@ import {
 } from '@/lib/lane/orchestrator-session';
 import { resolveInAppOrchestratorEnabledSync, resolveOrchestratorBackendSync } from '@/lib/operator/defaults';
 import { openclawBackend } from './openclaw';
+import { acpBackend, hermesBackend } from './acp';
 import type { OrchestratorBackend, OrchestratorBackendId } from './types';
 
 // ── Delegate backends ────────────────────────────────────────────────────────
@@ -75,6 +76,8 @@ const BACKENDS: Partial<Record<OrchestratorBackendId, OrchestratorBackend>> = {
   claude: claudeBackend,
   codex: codexBackend,
   openclaw: openclawBackend,
+  hermes: hermesBackend,
+  acp: acpBackend,
 };
 
 /** The default backend — also the fallback for any unregistered id. */

--- a/src/lib/lane/orchestrator-backends/types.test.ts
+++ b/src/lib/lane/orchestrator-backends/types.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Guard consolidation (Step 3a) — zero behavior change.
+ *
+ * The 'codex'|'claude'|'openclaw' union was re-validated inline in ~3 spots
+ * (ws-server resolveMsgBackendId, the chat-history route, mobile thread history).
+ * isOrchestratorBackendId is the single point now. This proves it's BYTE-IDENTICAL
+ * to the inlined literal it replaced, so repointing those callers changed nothing.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { isOrchestratorBackendId } from './types';
+
+/** The exact expression that lived inline at every call site, pre-3a. */
+const legacy = (v: unknown): boolean => v === 'codex' || v === 'claude' || v === 'openclaw';
+
+describe('isOrchestratorBackendId', () => {
+  it('accepts exactly the three existing ids', () => {
+    expect(isOrchestratorBackendId('codex')).toBe(true);
+    expect(isOrchestratorBackendId('claude')).toBe(true);
+    expect(isOrchestratorBackendId('openclaw')).toBe(true);
+  });
+
+  it('rejects everything else (including the Step-1 "auto" and the not-yet-added "hermes")', () => {
+    for (const v of ['auto', 'hermes', 'acp', 'Codex', 'CLAUDE', '', ' codex', 'codex ', null, undefined, 0, 1, {}, [], true, false]) {
+      expect(isOrchestratorBackendId(v)).toBe(false);
+    }
+  });
+
+  it('matches the legacy inlined expression for arbitrary inputs', () => {
+    for (const v of ['codex', 'claude', 'openclaw', 'auto', 'hermes', 'acp', '', null, undefined, 42, {}, [], 'CLAUDE', ' openclaw']) {
+      expect(isOrchestratorBackendId(v)).toBe(legacy(v));
+    }
+  });
+});

--- a/src/lib/lane/orchestrator-backends/types.test.ts
+++ b/src/lib/lane/orchestrator-backends/types.test.ts
@@ -11,25 +11,26 @@ import { describe, it, expect } from 'vitest';
 
 import { isOrchestratorBackendId } from './types';
 
-/** The exact expression that lived inline at every call site, pre-3a. */
-const legacy = (v: unknown): boolean => v === 'codex' || v === 'claude' || v === 'openclaw';
+/** The full union, inlined — the single source the guard must equal. */
+const inlined = (v: unknown): boolean =>
+  v === 'codex' || v === 'claude' || v === 'openclaw' || v === 'hermes' || v === 'acp';
 
 describe('isOrchestratorBackendId', () => {
-  it('accepts exactly the three existing ids', () => {
-    expect(isOrchestratorBackendId('codex')).toBe(true);
-    expect(isOrchestratorBackendId('claude')).toBe(true);
-    expect(isOrchestratorBackendId('openclaw')).toBe(true);
+  it('accepts exactly the registered backend ids', () => {
+    for (const id of ['codex', 'claude', 'openclaw', 'hermes', 'acp']) {
+      expect(isOrchestratorBackendId(id)).toBe(true);
+    }
   });
 
-  it('rejects everything else (including the Step-1 "auto" and the not-yet-added "hermes")', () => {
-    for (const v of ['auto', 'hermes', 'acp', 'Codex', 'CLAUDE', '', ' codex', 'codex ', null, undefined, 0, 1, {}, [], true, false]) {
+  it('rejects everything else (including the Step-1 setting "auto")', () => {
+    for (const v of ['auto', 'Codex', 'CLAUDE', 'HERMES', '', ' codex', 'codex ', null, undefined, 0, 1, {}, [], true, false]) {
       expect(isOrchestratorBackendId(v)).toBe(false);
     }
   });
 
-  it('matches the legacy inlined expression for arbitrary inputs', () => {
-    for (const v of ['codex', 'claude', 'openclaw', 'auto', 'hermes', 'acp', '', null, undefined, 42, {}, [], 'CLAUDE', ' openclaw']) {
-      expect(isOrchestratorBackendId(v)).toBe(legacy(v));
+  it('matches the inlined union expression for arbitrary inputs (single validation point)', () => {
+    for (const v of ['codex', 'claude', 'openclaw', 'hermes', 'acp', 'auto', '', null, undefined, 42, {}, [], 'CLAUDE', ' openclaw']) {
+      expect(isOrchestratorBackendId(v)).toBe(inlined(v));
     }
   });
 });

--- a/src/lib/lane/orchestrator-backends/types.ts
+++ b/src/lib/lane/orchestrator-backends/types.ts
@@ -17,8 +17,11 @@
 import type { OrchestratorEvent } from '@/lib/lane/orchestrator-stream-events';
 import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 
-/** The set of orchestrator backends. `openclaw` is registered in a later step. */
-export type OrchestratorBackendId = 'codex' | 'claude' | 'openclaw';
+/**
+ * The set of orchestrator backends. `hermes` drives Hermes via the generic ACP
+ * backend; `acp` is the generic escape hatch for any other ACP agent.
+ */
+export type OrchestratorBackendId = 'codex' | 'claude' | 'openclaw' | 'hermes' | 'acp';
 
 /**
  * The single runtime validation point for the backend-id union. Callers that
@@ -27,7 +30,7 @@ export type OrchestratorBackendId = 'codex' | 'claude' | 'openclaw';
  * comparison — so adding a backend is one edit here (union + guard), not N.
  */
 export function isOrchestratorBackendId(value: unknown): value is OrchestratorBackendId {
-  return value === 'codex' || value === 'claude' || value === 'openclaw';
+  return value === 'codex' || value === 'claude' || value === 'openclaw' || value === 'hermes' || value === 'acp';
 }
 
 export type OrchestratorSessionStatus = 'ready' | 'busy' | 'dead';

--- a/src/lib/lane/orchestrator-backends/types.ts
+++ b/src/lib/lane/orchestrator-backends/types.ts
@@ -20,6 +20,16 @@ import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 /** The set of orchestrator backends. `openclaw` is registered in a later step. */
 export type OrchestratorBackendId = 'codex' | 'claude' | 'openclaw';
 
+/**
+ * The single runtime validation point for the backend-id union. Callers that
+ * accept an untrusted `backend` value (ws-server, the chat-history routes,
+ * mobile thread history) narrow through this instead of re-inlining the literal
+ * comparison — so adding a backend is one edit here (union + guard), not N.
+ */
+export function isOrchestratorBackendId(value: unknown): value is OrchestratorBackendId {
+  return value === 'codex' || value === 'claude' || value === 'openclaw';
+}
+
 export type OrchestratorSessionStatus = 'ready' | 'busy' | 'dead';
 
 export interface OrchestratorTurnOptions {

--- a/src/lib/mobile/orchestrator-thread-history.ts
+++ b/src/lib/mobile/orchestrator-thread-history.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { homedir } from 'node:os';
+import { isOrchestratorBackendId } from '@/lib/lane/orchestrator-backends/types';
 import type { MobileOrchestratorBackend, MobileOrchestratorThread } from '@/lib/mobile/types';
 
 export const ORCHESTRATOR_HISTORY_DIR = join(homedir(), '.o8', 'chat-history');
@@ -168,7 +169,7 @@ function normalizeSessionIds(value: unknown): Record<string, string | null> {
 }
 
 function normalizeBackend(value: unknown): MobileOrchestratorBackend | null {
-  return value === 'openclaw' || value === 'codex' || value === 'claude' ? value : null;
+  return isOrchestratorBackendId(value) ? value : null;
 }
 
 function normalizeAgent(value: unknown): string | null {

--- a/src/lib/mobile/types.ts
+++ b/src/lib/mobile/types.ts
@@ -6,6 +6,7 @@ import type {
   ReviewPullRequestSummary,
 } from '@/lib/fleet/types';
 import type { MobileApprovalCard } from '@/lib/approvals/types';
+import type { OrchestratorBackendId } from '@/lib/lane/orchestrator-backends/types';
 import type { ClaudeCodeStreamJsonChatEvent } from '@/lib/claude-code/stream-json-parser';
 import type { CompactionTrigger } from '@/lib/runtimes/compaction-detector';
 
@@ -278,8 +279,9 @@ export interface MobileActionResponse {
 
 export type MobileOrchestratorRuntime = 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'unknown';
 
-/** The orchestrator backend that ran a thread — distinct from the worker `runtime`. */
-export type MobileOrchestratorBackend = 'codex' | 'claude' | 'openclaw';
+/** The orchestrator backend that ran a thread — distinct from the worker `runtime`.
+ *  Derived from the single backend-id source so it tracks new backends (hermes/acp). */
+export type MobileOrchestratorBackend = OrchestratorBackendId;
 
 export type MobileOrchestratorThreadStatus = 'idle' | 'ready' | 'busy';
 

--- a/src/lib/operator/defaults.ts
+++ b/src/lib/operator/defaults.ts
@@ -60,10 +60,10 @@ function isWorkersUseBrain(value: unknown): value is WorkersUseBrain {
 
 /** Which backend drives the in-app Orchestrator. 'auto' = the legacy
  *  inAppOrchestratorEnabled derivation; a specific id forces that backend. */
-export type OrchestratorBackendSetting = 'auto' | 'codex' | 'claude' | 'openclaw';
+export type OrchestratorBackendSetting = 'auto' | 'codex' | 'claude' | 'openclaw' | 'hermes';
 
 function isOrchestratorBackendSetting(value: unknown): value is OrchestratorBackendSetting {
-  return value === 'auto' || value === 'codex' || value === 'claude' || value === 'openclaw';
+  return value === 'auto' || value === 'codex' || value === 'claude' || value === 'openclaw' || value === 'hermes';
 }
 
 export interface OperatorDefaults {
@@ -234,6 +234,7 @@ export const ORCHESTRATOR_BACKEND_OPTIONS: Array<{ value: OrchestratorBackendSet
   { value: 'codex', label: 'Codex', detail: 'Codex GPT-5.5 xhigh — free for ChatGPT Plus / Codex subscribers.' },
   { value: 'claude', label: 'Claude', detail: 'Claude Code REPL — subscription-billed (Claude Max pool).' },
   { value: 'openclaw', label: 'OpenClaw', detail: 'Governed openclaw orchestrator — dispatches Codex workers through o8.' },
+  { value: 'hermes', label: 'Hermes', detail: 'Hermes via ACP — needs Hermes installed + a model provider configured (hermes setup).' },
 ];
 
 export const PARALLEL_CAP_PRESETS: Array<{ key: 'conservative' | 'balanced' | 'power-user'; label: string; value: number }> = [

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -82,7 +82,7 @@ import {
   getOrchestratorBackend,
   resolveOrchestratorBackendId,
 } from './lib/lane/orchestrator-backends/registry';
-import type { OrchestratorBackendId } from './lib/lane/orchestrator-backends/types';
+import { isOrchestratorBackendId, type OrchestratorBackendId } from './lib/lane/orchestrator-backends/types';
 import type { OrchestratorEvent } from './lib/lane/orchestrator-stream-events';
 import {
   startSupervisorLoop,
@@ -869,7 +869,7 @@ function orchestratorRouteSessionName(sessionName: string, threadId: string | nu
  */
 function resolveMsgBackendId(msg: Record<string, unknown>): OrchestratorBackendId {
   const raw = msg.backend;
-  if (raw === 'codex' || raw === 'claude' || raw === 'openclaw') return raw;
+  if (isOrchestratorBackendId(raw)) return raw;
   return resolveOrchestratorBackendId();
 }
 

--- a/tests/smoke/acp-backend-smoke.ts
+++ b/tests/smoke/acp-backend-smoke.ts
@@ -1,0 +1,61 @@
+/**
+ * ACP backend (Step 3c) — implements the OrchestratorBackend contract; a turn
+ * streams events. Drives makeAcpBackend against the mock ACP agent (no provider).
+ *
+ *   CORTEX_IDE_DATA_DIR=$(mktemp -d) NODE_OPTIONS='--conditions=react-server' \
+ *     npx tsx tests/smoke/acp-backend-smoke.ts
+ */
+
+import assert from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { makeAcpBackend } from '@/lib/lane/orchestrator-backends/acp';
+import type { OrchestratorEvent } from '@/lib/lane/orchestrator-stream-events';
+
+const MOCK = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'mock-acp-agent.mjs');
+
+async function main(): Promise<void> {
+  const backend = makeAcpBackend({
+    id: 'acp',
+    label: 'ACP-test',
+    resolveLaunch: () => ({ command: process.execPath, args: [MOCK] }),
+  });
+
+  assert.strictEqual(backend.id, 'acp', 'backend id');
+
+  // peek before ensure → null (no session yet).
+  assert.strictEqual(backend.peekSession('/repo', undefined, 'thread-1'), null, 'peek before ensure is null');
+
+  const info = backend.ensureSession('/repo', undefined, 'thread-1');
+  assert(info.sessionName.includes('/repo'), 'ensureSession returns a session name');
+  assert.strictEqual(info.status, 'ready', 'session starts ready');
+  assert(backend.peekSession('/repo', undefined, 'thread-1') !== null, 'peek after ensure is non-null');
+
+  const events: OrchestratorEvent[] = [];
+  await backend.sendTurn('/repo', 'do it', (e) => events.push(e), { threadId: 'thread-1' });
+
+  const types = events.map((e) => e.type);
+  assert.deepStrictEqual(types, ['thinking', 'tool_use', 'tool_result', 'text', 'text', 'done'], 'turn streams the mapped event sequence');
+  assert.deepStrictEqual(events[events.length - 1], { type: 'done', sessionId: 'mock-sess', cost: null }, 'turn ends with done');
+
+  // Session is reusable for a second turn (same subprocess / ACP sessionId).
+  const events2: OrchestratorEvent[] = [];
+  await backend.sendTurn('/repo', 'again', (e) => events2.push(e), { threadId: 'thread-1' });
+  assert(events2.some((e) => e.type === 'done'), 'second turn on the reused session completes');
+  assert.strictEqual(backend.peekSession('/repo', undefined, 'thread-1')?.status, 'ready', 'session ready after turns');
+
+  console.log('[acp-backend-smoke] PASS — contract implemented; turn streams events; session reused');
+}
+
+// Watchdog: the backend keeps session subprocesses alive, so exit explicitly.
+const watchdog = setTimeout(() => {
+  console.error('[acp-backend-smoke] FAIL — timed out');
+  process.exit(2);
+}, 15000);
+watchdog.unref();
+
+void main().then(() => process.exit(0)).catch((err) => {
+  console.error('[acp-backend-smoke] FAIL', err);
+  process.exit(1);
+});

--- a/tests/smoke/acp-client-smoke.ts
+++ b/tests/smoke/acp-client-smoke.ts
@@ -1,0 +1,88 @@
+/**
+ * ACP client (Step 3b) — full-turn against a mock peer + live hermes acp handshake.
+ *
+ *   CORTEX_IDE_DATA_DIR=$(mktemp -d) NODE_OPTIONS='--conditions=react-server' \
+ *     npx tsx tests/smoke/acp-client-smoke.ts
+ *
+ * Part A drives the real AcpClient through initialize → session/new → session/prompt
+ * against a scripted mock ACP agent and asserts the streamed OrchestratorEvents.
+ * Part B does a live initialize + session/new against the installed `hermes acp`
+ * (no model turn — that needs the operator's provider) to prove the client speaks
+ * the REAL protocol, not just the spec.
+ */
+
+import assert from 'node:assert';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { AcpClient, mapStopReason, type AcpInitializeResult } from '@/lib/acp/client';
+import type { OrchestratorEvent } from '@/lib/lane/orchestrator-stream-events';
+
+const MOCK = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'mock-acp-agent.mjs');
+
+async function partA(): Promise<void> {
+  const events: OrchestratorEvent[] = [];
+  const client = new AcpClient({ command: process.execPath, args: [MOCK], onEvent: (e) => events.push(e) });
+  try {
+    const init = await client.initialize();
+    assert.strictEqual(init.protocolVersion, 1, 'mock initialize → protocolVersion 1');
+
+    const sessionId = await client.newSession(process.cwd(), []);
+    assert.strictEqual(sessionId, 'mock-sess', 'mock session/new → sessionId');
+
+    const stop = await client.prompt(sessionId, 'do it');
+    assert.strictEqual(stop, 'end_turn', 'prompt resolves with stopReason');
+    events.push(mapStopReason(stop, sessionId));
+
+    const types = events.map((e) => e.type);
+    assert.deepStrictEqual(types, ['thinking', 'tool_use', 'tool_result', 'text', 'text', 'done'], 'event stream order (usage_update ignored)');
+    assert.strictEqual((events[0] as { text: string }).text, 'planning', 'thinking text');
+    assert.strictEqual((events[1] as { name: string }).name, 'Read file', 'tool_use name');
+    assert.strictEqual((events[2] as { output: string }).output, 'file body', 'tool_result output');
+    assert.strictEqual((events[3] as { text: string }).text + (events[4] as { text: string }).text, 'Done. Bye.', 'text chunks concatenate');
+    assert.deepStrictEqual(events[5], { type: 'done', sessionId: 'mock-sess', cost: null }, 'done event');
+    console.log('[acp-client-smoke] Part A (mock turn) PASS');
+  } finally {
+    client.kill();
+  }
+}
+
+function hermesAvailable(): boolean {
+  try {
+    execSync('hermes acp --check', { stdio: 'ignore', timeout: 10000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function partB(): Promise<void> {
+  if (!hermesAvailable()) {
+    console.log('[acp-client-smoke] Part B SKIPPED — hermes acp --check not OK on this machine');
+    return;
+  }
+  const client = new AcpClient({ command: 'hermes', args: ['acp', '--accept-hooks'] });
+  try {
+    const init: AcpInitializeResult = await client.initialize();
+    assert.strictEqual(init.protocolVersion, 1, 'live hermes initialize → protocolVersion 1');
+    assert(init.agentInfo?.name?.includes('hermes'), 'live hermes agentInfo.name is hermes');
+
+    const sessionId = await client.newSession(process.cwd(), []);
+    assert(typeof sessionId === 'string' && sessionId.length > 0, 'live hermes session/new → sessionId');
+    console.log(`[acp-client-smoke] Part B (live hermes handshake) PASS — agent=${init.agentInfo?.name} v${init.agentInfo?.version}, session=${sessionId.slice(0, 8)}…`);
+  } finally {
+    client.kill();
+  }
+}
+
+async function main(): Promise<void> {
+  await partA();
+  await partB();
+  console.log('[acp-client-smoke] PASS');
+}
+
+void main().catch((err) => {
+  console.error('[acp-client-smoke] FAIL', err);
+  process.exit(1);
+});

--- a/tests/smoke/fixtures/mock-acp-agent.mjs
+++ b/tests/smoke/fixtures/mock-acp-agent.mjs
@@ -1,0 +1,50 @@
+// Minimal mock ACP agent — speaks JSON-RPC 2.0 over NDJSON stdio, enough to
+// drive AcpClient through a full turn without a real model/provider. Used by
+// tests/smoke/acp-client-smoke.ts.
+
+let buf = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  buf += chunk;
+  let nl;
+  while ((nl = buf.indexOf('\n')) >= 0) {
+    const line = buf.slice(0, nl).trim();
+    buf = buf.slice(nl + 1);
+    if (line) handle(JSON.parse(line));
+  }
+});
+
+function send(obj) {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+function update(sessionId, u) {
+  send({ jsonrpc: '2.0', method: 'session/update', params: { sessionId, update: u } });
+}
+
+function handle(msg) {
+  if (msg.method === 'initialize') {
+    send({ jsonrpc: '2.0', id: msg.id, result: { protocolVersion: 1, agentCapabilities: { loadSession: true }, agentInfo: { name: 'mock-agent', version: '0.0.1' }, authMethods: [] } });
+    return;
+  }
+  if (msg.method === 'session/new') {
+    send({ jsonrpc: '2.0', id: msg.id, result: { sessionId: 'mock-sess', models: {}, modes: {} } });
+    return;
+  }
+  if (msg.method === 'session/prompt') {
+    const sid = msg.params.sessionId;
+    // Scripted stream: thinking → tool_call → tool_call_update(completed) → text x2,
+    // plus a hermes-style unknown variant that must be ignored.
+    update(sid, { sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: 'planning' } });
+    update(sid, { sessionUpdate: 'usage_update', size: 256000, used: 10 }); // unknown → ignored
+    update(sid, { sessionUpdate: 'tool_call', toolCallId: 't1', title: 'Read file', kind: 'read', status: 'pending', rawInput: { path: 'x.ts' } });
+    update(sid, { sessionUpdate: 'tool_call_update', toolCallId: 't1', status: 'completed', content: [{ type: 'content', content: { type: 'text', text: 'file body' } }] });
+    update(sid, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'Done. ' } });
+    update(sid, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'Bye.' } });
+    send({ jsonrpc: '2.0', id: msg.id, result: { stopReason: 'end_turn' } });
+    return;
+  }
+  if (msg.method === 'session/cancel') {
+    // notification — no reply
+    return;
+  }
+}

--- a/tests/smoke/hermes-governed-profile-smoke.ts
+++ b/tests/smoke/hermes-governed-profile-smoke.ts
@@ -1,0 +1,54 @@
+/**
+ * Governed Hermes profile (Step 3d) — LIVE lockout proof. Gated on hermes being
+ * installed; SKIPS otherwise. Generates the governed profile and asserts the
+ * native work toolsets (delegation = native spawn, terminal/file/code_execution/
+ * browser/computer_use) are denied in the ISOLATED config — never touching the
+ * user's ~/.hermes.
+ *
+ *   CORTEX_IDE_DATA_DIR=$(mktemp -d) NODE_OPTIONS='--conditions=react-server' \
+ *     npx tsx tests/smoke/hermes-governed-profile-smoke.ts
+ */
+
+import assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { governHermesProfile, isHermesProfileGoverned, parseDisabledFromToolsList, HERMES_DENIED_TOOLSETS } from '@/lib/lane/orchestrator-backends/hermes-profile';
+
+function resolveHermes(): string | null {
+  for (const c of [process.env.O8_HERMES_BIN, `${homedir()}/.local/bin/hermes`, '/opt/homebrew/bin/hermes', '/usr/local/bin/hermes', `${homedir()}/.npm-global/bin/hermes`]) {
+    if (c && existsSync(c)) return c;
+  }
+  try {
+    return execFileSync('command', ['-v', 'hermes'], { encoding: 'utf8', shell: '/bin/sh' } as never).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function main(): void {
+  const bin = resolveHermes();
+  if (!bin || !existsSync(join(homedir(), '.hermes', 'config.yaml'))) {
+    console.log('[hermes-governed-profile-smoke] SKIPPED — hermes not installed/configured on this machine');
+    return;
+  }
+
+  const governed = governHermesProfile(bin);
+  assert(governed, 'governHermesProfile returns a governed home');
+  assert(isHermesProfileGoverned(governed.home, bin), 'profile reports governed');
+
+  // Authoritative check via the governed home's `hermes tools list`.
+  const list = execFileSync(bin, ['tools', 'list'], { env: { ...process.env, HOME: governed.home }, encoding: 'utf8', timeout: 20000 });
+  const denied = parseDisabledFromToolsList(list);
+  for (const t of HERMES_DENIED_TOOLSETS) {
+    assert(denied.has(t), `governed profile denies "${t}" (per hermes tools list)`);
+  }
+  assert(/\bo8\b/.test(list), 'o8 MCP server is retained in the governed profile');
+  assert(governed.home !== homedir() && governed.home.includes('hermes-o8'), 'governed home is isolated (~/.o8/hermes-o8)');
+
+  console.log(`[hermes-governed-profile-smoke] PASS — governed at ${governed.home}; denied: ${HERMES_DENIED_TOOLSETS.join(', ')}; o8 MCP retained`);
+}
+
+main();


### PR DESCRIPTION
## Orchestrator Backend Step 3 — Hermes via a generic ACP backend

The strategic one: not a Hermes fork, but a **generic Agent-Client-Protocol backend** so o8 can drive *any* ACP-speaking agent as an orchestrator — Hermes now, openclaw acpx / Zed / others later via one launch config. Built against the published ACP spec **and reconciled against live `hermes acp` v0.17.0** (Hermes is installed here, so the handshake was exercised for real, not coded blind).

When this lands you pick **Claude / Codex / OpenClaw / Hermes** from one desktop menu.

### 3a — Guard consolidation (its own commit, zero behavior change)
The `codex|claude|openclaw` union was re-validated inline in three spots (ws-server `resolveMsgBackendId`, the chat-history route, mobile thread history). Landed a single `isOrchestratorBackendId()` and repointed them. `types.test.ts` proves it byte-identical to the inlined literal. So adding a backend is one edit at the union+guard, not N.

### 3b — ACP client (`src/lib/acp/client.ts`)
stdio JSON-RPC 2.0 over **NDJSON** (confirmed live — *not* Content-Length). `initialize → session/new → session/prompt`; the prompt result's `stopReason` **is** the end-of-turn; streaming arrives as `session/update` notifications. Pure `mapAcpUpdate` → `OrchestratorEvent` (text / thinking / tool_use / tool_result); unknown variants (hermes's `usage_update`) ignored. **Proof:** 9-case mapper unit test + a full turn against a mock peer + a **live `hermes acp` initialize/session/new handshake**.

### 3c — ACP backend (`orchestrator-backends/acp.ts`)
Implements the `OrchestratorBackend` contract on the client: session registry (one agent subprocess per repo+thread, reused across turns), `sendTurn`, abort→`session/cancel`, watchdog, realtime publish. `makeAcpBackend` is parameterized by launch command → `hermesBackend` + a generic `acpBackend` (`O8_ACP_COMMAND`). Registered in `BACKENDS`; `'hermes'`+`'acp'` added to `OrchestratorBackendId` via the 3a guard (one edit); the Step-1 picker gains **Hermes, gated on availability** (`/api/setup/orchestrator-backends`). **Proof:** a dispatched turn streams the mapped event sequence against the mock peer; session reused across turns.

*(Adding the union ids surfaced two more parallel narrow unions — `MobileOrchestratorBackend`, chat-history's local type — now derived from the single source. The 3a consolidation paying off.)*

### 3d — Governed Hermes profile (`hermes-profile.ts`) — the #1075 lockout
An ACP client can't strip an agent's native tools the way o8 rewrites `~/.openclaw-o8`. So o8 runs `hermes acp` against an **isolated HOME** (`~/.o8/hermes-o8`) whose config **denies Hermes's native work toolsets** — `delegation` (Hermes's native sub-agent spawn, the direct analogue of openclaw's `sessions_spawn`) plus `terminal`/`file`/`code_execution`/`browser`/`computer_use` — leaving **only the o8 MCP**. Structural lockout, not prompt-framing. **SAFETY INTERLOCK:** `hermesBackend` refuses to launch if the profile can't be governed — **Hermes never runs ungoverned.**

**Verify-don't-guess caught a real trap:** `hermes tools disable` reports success but does *not* write `config.yaml`'s `disabled_toolsets` (it persists the state internally). Governance is therefore verified against Hermes's own authoritative `hermes tools list`. The live smoke confirms all six toolsets denied + o8 retained + the user's `~/.hermes` untouched.

### ⚠️ Provider caveat (flagged, doesn't block this)
Hermes was installed `--skip-setup` → **no model provider configured**, so a live model turn refuses (`stopReason: 'refusal'`, reproduced in the probe). The **protocol + governance layers are built and proven** without one; the live Hermes model-turn dogfood is gated on the operator wiring a provider (`hermes setup` — their keys, never o8's).

### Out of scope (noted, not built)
Surfacing Hermes's **MoA** (Mixture-of-Agents) virtual models as o8 virtual models — a separate future feature. Driving Hermes as a backend brings MoA along; exposing it in o8 is its own build.

**Gate (local — CI billing-red as usual):** `tsc --noEmit` clean · `npm test` **344/344** · the ACP client/backend/governed-profile + Step-1 setting + all 9 tool-spine smokes green · the live hermes handshake + governance smokes pass.

### Next
Hermes's live model turn once its provider is wired — then we dogfood the whole **Claude / Codex / OpenClaw / Hermes** set on this machine (both runtimes are installed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018akNs5xu63pWZA3SXaGha8
