### PR TITLE
feat(dispatch): thread reasoning-effort to the worker (Targeting fast-follow)

### DIFF
--- a/src/app/api/panel/targets/dispatch/route.ts
+++ b/src/app/api/panel/targets/dispatch/route.ts
@@ -49,11 +49,16 @@ export async function POST(request: Request) {
     ].join('\n');
 
     const mission = await createMission({
-      issues: [{ number: 0, title: `Targeting: ${filePath}`, body: brief, url: '' }],
+      // Inline issues require a positive synthetic number (normalizeLoadedIssue
+      // rejects 0); mirror the create_mission MCP convention (90001+).
+      issues: [{ number: 90001, title: `Targeting: ${filePath}`, body: brief, url: '' }],
       repoPath,
       runtime: routing.runtime,
       requestedRuntime: routing.runtime,
       requestedModel: routing.model || null,
+      // Close the loop: the tier's effort now reaches the worker launch (cheap
+      // triage → low, premium action → high). A no-op for gemini/opencode tiers.
+      requestedEffort: routing.effort,
       constraints: '',
       workerIntent: routing.tier === 'triage' ? 'light_worker' : 'heavy_worker',
     });

--- a/src/lib/agents/routing-effort.test.ts
+++ b/src/lib/agents/routing-effort.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Worker reasoning-effort routing. Two must-proves:
+ *  1. PARITY — no requested effort ⇒ selectedEffort/requestedEffort are null and
+ *     nothing else changes (the blast radius is zero unless effort is set).
+ *  2. PER-RUNTIME — effort is honored only for runtimes with a reasoning-effort
+ *     surface (codex/claude-code); gemini/opencode → clean no-op (null).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { resolveWorkerRouting } from './routing';
+
+describe('resolveWorkerRouting — effort parity (unset)', () => {
+  it('no requested effort ⇒ both effort fields null, other fields unchanged', () => {
+    const r = resolveWorkerRouting({});
+    expect(r.requestedEffort).toBeNull();
+    expect(r.selectedEffort).toBeNull();
+    // Untouched: default codex selection, no model.
+    expect(r.selectedRuntime).toBe('codex');
+    expect(r.selectedModel).toBeNull();
+  });
+
+  it("'adaptive' is treated as no explicit effort (runtime default) ⇒ null", () => {
+    const r = resolveWorkerRouting({ requestedRuntime: 'codex', requestedEffort: 'adaptive' });
+    expect(r.selectedEffort).toBeNull();
+  });
+
+  it('a bogus effort value ⇒ null (fails safe to runtime default)', () => {
+    const r = resolveWorkerRouting({ requestedRuntime: 'codex', requestedEffort: 'turbo' });
+    expect(r.selectedEffort).toBeNull();
+  });
+});
+
+describe('resolveWorkerRouting — effort per-runtime', () => {
+  it('codex honors the effort', () => {
+    const r = resolveWorkerRouting({ requestedRuntime: 'codex', requestedEffort: 'high' });
+    expect(r.selectedEffort).toBe('high');
+    expect(r.requestedEffort).toBe('high');
+  });
+
+  it('default (no runtime) → codex → effort honored', () => {
+    expect(resolveWorkerRouting({ requestedEffort: 'low' }).selectedEffort).toBe('low');
+  });
+
+  it('gemini has no reasoning-effort surface → selectedEffort null (no-op), request still recorded', () => {
+    const r = resolveWorkerRouting({ requestedRuntime: 'gemini', requestedEffort: 'high' });
+    expect(r.selectedRuntime).toBe('gemini');
+    expect(r.selectedEffort).toBeNull();
+    expect(r.requestedEffort).toBe('high'); // the ask is preserved even though it's a no-op
+  });
+
+  it('opencode → no-op too', () => {
+    const r = resolveWorkerRouting({ requestedRuntime: 'opencode', requestedEffort: 'max' });
+    // opencode may fall back to codex if not dispatchable; either way effort is
+    // only applied on an effort-capable runtime.
+    expect(r.selectedEffort === null || (r.selectedRuntime === 'codex' && r.selectedEffort === 'max')).toBe(true);
+  });
+});
+
+describe('resolveWorkerRouting — effort round-trip (persist → normalize)', () => {
+  it('feeding requestedEffort back in re-derives the same selectedEffort', () => {
+    const first = resolveWorkerRouting({ requestedRuntime: 'codex', requestedEffort: 'high' });
+    // Simulate normalizeWorkerRouting: re-resolve from the persisted request.
+    const restored = resolveWorkerRouting({
+      requestedRuntime: first.requestedRuntime ?? undefined,
+      requestedModel: first.requestedModel ?? undefined,
+      requestedEffort: first.requestedEffort ?? undefined,
+    });
+    expect(restored.selectedEffort).toBe('high');
+  });
+});

--- a/src/lib/agents/routing.ts
+++ b/src/lib/agents/routing.ts
@@ -6,6 +6,12 @@ import type {
   WorkerRoutingConfidence,
 } from '@/lib/orchestrator/types';
 import { listDispatchableRuntimes } from '@/lib/orchestrator/runtime-capabilities';
+import { isThinkingEffort, type ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
+
+// Runtimes with a reasoning-effort surface. codex → `-c model_reasoning_effort`,
+// claude-code → `--effort`. gemini/opencode have none, so a requested effort is a
+// clean no-op there (selectedEffort stays null and no launch flag is emitted).
+const EFFORT_CAPABLE_RUNTIMES: readonly OrchestratorRuntime[] = ['codex', 'claude-code'];
 
 // Codex stays the always-on fallback workhorse when no dispatchable runtime is
 // requested. Other runtimes (Gemini today) are honored when the capability map
@@ -54,9 +60,17 @@ export interface ResolveWorkerRoutingInput {
   requestedProvider?: unknown;
   requestedRuntime?: unknown;
   requestedModel?: unknown;
+  requestedEffort?: unknown;
   source?: string;
   confidence?: WorkerRoutingConfidence;
   reason?: string;
+}
+
+function normalizeEffort(value: unknown): ThinkingEffort | null {
+  // 'adaptive' means "let the runtime decide" — treat as no explicit effort so
+  // the launch stays at the runtime default (parity). Only a concrete tier is
+  // carried.
+  return isThinkingEffort(value) && value !== 'adaptive' ? value : null;
 }
 
 export function normalizeWorkerIntent(value: unknown): WorkerIntent {
@@ -105,6 +119,7 @@ export function resolveWorkerRouting(input: ResolveWorkerRoutingInput = {}): Wor
   const requestedProvider = normalizeWorkerProvider(input.requestedProvider);
   const requestedRuntime = normalizeRequestedRuntime(input.requestedRuntime);
   const requestedModel = normalizeModel(input.requestedModel);
+  const requestedEffort = normalizeEffort(input.requestedEffort);
 
   // Honor a requested runtime when the capability map marks it dispatchable
   // (Codex + Gemini today). Anything else — including a request for a
@@ -121,14 +136,22 @@ export function resolveWorkerRouting(input: ResolveWorkerRoutingInput = {}): Wor
     && (requestedRuntime === null || requestedRuntime === selectedRuntime)
     && (requestedProvider === null || requestedProvider === selectedProvider);
 
+  // Effort applies only when the selected runtime has a reasoning-effort surface;
+  // on gemini/opencode it's a clean no-op (null → no launch flag).
+  const selectedEffort = requestedEffort && EFFORT_CAPABLE_RUNTIMES.includes(selectedRuntime)
+    ? requestedEffort
+    : null;
+
   return {
     workerIntent,
     requestedProvider,
     requestedRuntime,
     requestedModel,
+    requestedEffort,
     selectedProvider,
     selectedRuntime,
     selectedModel: modelTargetsSelected ? requestedModel : null,
+    selectedEffort,
     enforcement: PRODUCTION_AGENT_ENFORCEMENT,
     confidence: input.confidence ?? routingConfidence(workerIntent),
     reason: input.reason ?? routingReason({

--- a/src/lib/codex/owned-launch-effort.test.ts
+++ b/src/lib/codex/owned-launch-effort.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Worker reasoning-effort at the CODEX launch surface. Two must-proves:
+ *  1. PARITY — no effort ⇒ NO model_reasoning_effort flag; launch args are
+ *     byte-identical to before this feature.
+ *  2. PER-RUNTIME (codex) — an explicit tier ⇒ `-c model_reasoning_effort=<x>`
+ *     (max → xhigh); adaptive/unset stay at the runtime default.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { codexLaunchArgs, codexReasoningEffortArgs } from './owned';
+
+describe('codexReasoningEffortArgs', () => {
+  it('unset / adaptive ⇒ [] (no flag — parity, runtime default)', () => {
+    expect(codexReasoningEffortArgs(undefined)).toEqual([]);
+    expect(codexReasoningEffortArgs('adaptive')).toEqual([]);
+  });
+
+  it('explicit tiers ⇒ the -c model_reasoning_effort flag; max → xhigh', () => {
+    expect(codexReasoningEffortArgs('low')).toEqual(['-c', 'model_reasoning_effort=low']);
+    expect(codexReasoningEffortArgs('high')).toEqual(['-c', 'model_reasoning_effort=high']);
+    expect(codexReasoningEffortArgs('xhigh')).toEqual(['-c', 'model_reasoning_effort=xhigh']);
+    expect(codexReasoningEffortArgs('max')).toEqual(['-c', 'model_reasoning_effort=xhigh']);
+  });
+});
+
+describe('codexLaunchArgs — effort', () => {
+  const base = { cwd: '/repo', prompt: 'do the thing' };
+
+  it('PARITY: no effort ⇒ launch args identical to effort:undefined, and NO reasoning flag', () => {
+    const noArg = codexLaunchArgs({ ...base, model: 'gpt-5.5' });
+    const explicitUndefined = codexLaunchArgs({ ...base, model: 'gpt-5.5', effort: undefined });
+    expect(noArg).toEqual(explicitUndefined);
+    expect(noArg.join(' ')).not.toContain('model_reasoning_effort');
+  });
+
+  it('adaptive ⇒ still no reasoning flag (runtime default)', () => {
+    expect(codexLaunchArgs({ ...base, effort: 'adaptive' }).join(' ')).not.toContain('model_reasoning_effort');
+  });
+
+  it('explicit effort ⇒ the flag is present, once', () => {
+    const args = codexLaunchArgs({ ...base, model: 'gpt-5.5', effort: 'high' });
+    expect(args).toContain('model_reasoning_effort=high');
+    expect(args.filter((a) => a.startsWith('model_reasoning_effort='))).toHaveLength(1);
+    // prompt is still last (flag inserted before it, not after)
+    expect(args[args.length - 1]).toBe('do the thing');
+  });
+});

--- a/src/lib/codex/owned.ts
+++ b/src/lib/codex/owned.ts
@@ -41,6 +41,7 @@ import {
   type ParsedRunLog,
 } from '@/lib/runtimes/shared/owned-session';
 import { codexModelArgs } from './local-model';
+import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 
 // Re-export the fleet additions shape under its original Codex name.
 export type { OwnedCodexFleetAdditions } from '@/lib/runtimes/shared/owned-session';
@@ -51,6 +52,7 @@ export type OwnedCodexLaunchRequest = {
   cwd: string;
   prompt: string;
   model?: string;
+  effort?: ThinkingEffort;
 };
 
 export type OwnedCodexLaunchResponse = {
@@ -228,7 +230,19 @@ function toolOutputPreview(value: unknown) {
 // to o8-dispatched workers; the user's interactive Codex.app is untouched.
 const DISABLE_IMAGE_TOOL = ['-c', 'tools.image_generation=false'];
 
-function codexLaunchArgs(ctx: { cwd: string; prompt: string; model?: string }): string[] {
+/**
+ * Codex reasoning-effort flag. Emitted ONLY for an explicit tier — undefined /
+ * 'adaptive' → [] so the launch stays at Codex's default (parity: unset effort
+ * produces byte-identical args to before this feature). `max` → `xhigh` (Codex's
+ * top tier), mirroring the orchestrator's reasoningEffortFromThinkingEffort.
+ */
+export function codexReasoningEffortArgs(effort?: ThinkingEffort): string[] {
+  if (!effort || effort === 'adaptive') return [];
+  const mapped = effort === 'max' ? 'xhigh' : effort; // low | medium | high | xhigh
+  return ['-c', `model_reasoning_effort=${mapped}`];
+}
+
+export function codexLaunchArgs(ctx: { cwd: string; prompt: string; model?: string; effort?: ThinkingEffort }): string[] {
   return [
     'exec',
     '--json',
@@ -241,6 +255,8 @@ function codexLaunchArgs(ctx: { cwd: string; prompt: string; model?: string }): 
     // `ollama:<model>` / `lmstudio:<model>` → run this worker on a LOCAL model
     // (--oss --local-provider …); a plain name → --model; empty → Codex default.
     ...codexModelArgs(ctx.model),
+    // Per-runtime effort surface — no-op unless an explicit tier was requested.
+    ...codexReasoningEffortArgs(ctx.effort),
     ctx.prompt,
   ];
 }

--- a/src/lib/lane/commands.ts
+++ b/src/lib/lane/commands.ts
@@ -403,6 +403,7 @@ export async function dispatch(command: LaneCommand): Promise<LaneCommandResult>
           branchName: lane.branch,
           baseBranch: lane.baseBranch,
           model: command.model,
+          effort: command.effort,
           isolate: !lane.worktreePath,
           skipSetup: true,
           existingLaneId: command.laneId,

--- a/src/lib/lane/types.ts
+++ b/src/lib/lane/types.ts
@@ -13,6 +13,8 @@
  * without breaking the user's mental model of the work in progress.
  */
 
+import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
+
 // ── Lane Status ──
 
 /**
@@ -106,6 +108,7 @@ export type LaneCommand =
       laneId: string;
       prompt: string;
       model?: string;
+      effort?: ThinkingEffort;
       actor?: LaneEventActor;
     }
   | {

--- a/src/lib/orchestrator/operator-mission-service/mission.ts
+++ b/src/lib/orchestrator/operator-mission-service/mission.ts
@@ -80,6 +80,7 @@ export async function createMission(input: CreateMissionInput) {
     requestedProvider: input.requestedProvider,
     requestedRuntime: input.requestedRuntime ?? input.runtime,
     requestedModel: input.requestedModel,
+    requestedEffort: input.requestedEffort,
     source: 'mission-create',
   });
   const branchPreparation = await prepareMissionBranches({
@@ -108,6 +109,7 @@ export async function createMission(input: CreateMissionInput) {
           requestedProvider: input.requestedProvider,
           requestedRuntime: issue.runtime,
           requestedModel: input.requestedModel,
+          requestedEffort: input.requestedEffort,
           source: 'mission-create-packet',
         })
       : workerRouting;

--- a/src/lib/orchestrator/operator-mission-service/types.ts
+++ b/src/lib/orchestrator/operator-mission-service/types.ts
@@ -1,6 +1,7 @@
 import type { OrchestratorReviewFinding } from '@/lib/approvals/types';
 import type { MergeCheckResult } from '@/lib/lane/preview-merge';
 import type { OrchestratorRuntime, WorkerIntent, WorkerProvider } from '@/lib/orchestrator/types';
+import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 
 export interface LoadedIssue {
   number: number;
@@ -25,6 +26,10 @@ export interface CreateMissionInput {
   requestedProvider?: WorkerProvider | null;
   requestedRuntime?: OrchestratorRuntime | null;
   requestedModel?: string | null;
+  /** Requested worker reasoning effort. Applied at launch only for runtimes with
+   *  a reasoning-effort surface (codex/claude-code); a no-op elsewhere. Omit for
+   *  today's behavior (runtime default). */
+  requestedEffort?: ThinkingEffort | null;
   constraints: string;
   /** When true, packets are chained sequentially (P2 after P1, etc.). Default: false (parallel). */
   sequential?: boolean;

--- a/src/lib/orchestrator/scheduling.ts
+++ b/src/lib/orchestrator/scheduling.ts
@@ -230,6 +230,7 @@ async function dispatchPacket(
     // This ensures Gemini/opencode dispatches actually pin the flagship model
     // from the capability map instead of letting the CLI pick a cheaper default.
     model: (workerRouting.selectedModel ?? getRuntimeCapability(workerRouting.selectedRuntime).defaultModel) ?? undefined,
+    effort: workerRouting.selectedEffort ?? undefined,
     actor: 'orchestrator',
   });
 

--- a/src/lib/orchestrator/store.ts
+++ b/src/lib/orchestrator/store.ts
@@ -250,6 +250,9 @@ function normalizeWorkerRouting(value: unknown, runtime: OrchestratorRuntime, wo
     requestedProvider: normalizeWorkerProvider(routing.requestedProvider),
     requestedRuntime: normalizeRequestedRuntime(routing.requestedRuntime) ?? runtime,
     requestedModel: routing.requestedModel,
+    // Carry requestedEffort through the round-trip so selectedEffort survives a
+    // reload before launch (normalize re-derives via resolveWorkerRouting).
+    requestedEffort: routing.requestedEffort,
     confidence,
     source: 'orchestrator-state',
   });

--- a/src/lib/orchestrator/types.ts
+++ b/src/lib/orchestrator/types.ts
@@ -1,5 +1,6 @@
 // Orchestrator domain types — runtimes, packets, lanes
 import type { OrchestratorReviewFinding } from '@/lib/approvals/types';
+import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 
 export type OrchestratorRuntime = 'codex' | 'claude-code' | 'gemini' | 'opencode';
 export type OrchestrationMode = 'fleet' | 'single' | 'chat';
@@ -13,9 +14,15 @@ export interface WorkerRouting {
   requestedProvider: WorkerProvider | null;
   requestedRuntime: OrchestratorRuntime | null;
   requestedModel: string | null;
+  /** Requested reasoning effort — carried through so it survives round-trips. */
+  requestedEffort: ThinkingEffort | null;
   selectedProvider: WorkerProvider;
   selectedRuntime: OrchestratorRuntime;
   selectedModel: string | null;
+  /** Effort actually applied — the request when the selected runtime supports a
+   *  reasoning-effort surface (codex / claude-code), else null (gemini/opencode
+   *  don't, so it's a clean no-op). */
+  selectedEffort: ThinkingEffort | null;
   enforcement: 'codex_only_production' | 'dispatchable_runtimes';
   confidence: WorkerRoutingConfidence;
   reason: string;

--- a/src/lib/runtime/actions.ts
+++ b/src/lib/runtime/actions.ts
@@ -1,4 +1,5 @@
 import type { AgentSummary } from '@/lib/fleet/types';
+import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import { continueOwnedCodexSession, interruptOwnedCodexSession, setOwnedCodexReviewDisposition } from '@/lib/codex/owned';
 import { markRepoOriginConfigured, markRepoOriginMissing } from '@/lib/repos/origin-readiness';
 import { getRuntimeInventorySnapshot } from '@/lib/runtime/inventory';
@@ -51,6 +52,8 @@ export interface RuntimeLaunchRequest {
   runtime: RuntimeId;
   prompt: string;
   model?: string;
+  /** Requested reasoning effort — passed to the runtime's launch; per-runtime no-op. */
+  effort?: ThinkingEffort;
   clientMutationId?: string;
   cwd?: string;
   repoPath?: string;
@@ -395,6 +398,7 @@ export async function launchRuntimeSurface(payload: RuntimeLaunchRequest): Promi
     cwd,
     prompt: launchPrompt,
     model: payload.model,
+    effort: payload.effort,
     worktreeFlag: launchWorktree?.claudeWorktreeFlag,
     worktreePath: launchWorktree?.worktree?.path,
     laneId: payload.existingLaneId ?? undefined,

--- a/src/lib/runtimes/codex.ts
+++ b/src/lib/runtimes/codex.ts
@@ -232,7 +232,7 @@ export const codexRuntime: AgentRuntime = {
     // `ollama:`/`lmstudio:` default) reaches every dispatch path, scoped to o8
     // workers. A per-mission model still wins.
     const model = opts.model ?? (resolveDefaultDispatchModelSync() || undefined);
-    const result = await launchOwnedCodexSession({ cwd: opts.cwd, prompt: opts.prompt, model });
+    const result = await launchOwnedCodexSession({ cwd: opts.cwd, prompt: opts.prompt, model, effort: opts.effort });
     if (result.ok && result.surfaceId) {
       scheduleCodexUsageDispatch(result.surfaceId, startedAtMs, undefined, opts.laneId, model, () =>
         waitForOwnedRunToFinish(result.surfaceId, startedAtMs));

--- a/src/lib/runtimes/shared/owned-session/store.ts
+++ b/src/lib/runtimes/shared/owned-session/store.ts
@@ -515,7 +515,7 @@ export function createOwnedSessionStore(adapter: OwnedRuntimeAdapter): OwnedSess
 
     let args: string[];
     if (mode === 'launch') {
-      args = adapter.launchArgs({ cwd: session.repoPath, prompt, model: session.model });
+      args = adapter.launchArgs({ cwd: session.repoPath, prompt, model: session.model, effort: session.effort });
     } else {
       const built = adapter.resumeArgs({ threadId: session.threadId ?? '', prompt, model: session.model });
       if (!built) {
@@ -668,6 +668,7 @@ export function createOwnedSessionStore(adapter: OwnedRuntimeAdapter): OwnedSess
       latestPrompt: prompt,
       latestSummary: compactText(prompt, 140) || `Owned ${adapter.squadShortName} session launched from o8.`,
       model: request.model?.trim() || adapter.defaultModel || undefined,
+      effort: request.effort,
       reviewDisposition: 'watching',
       reviewDispositionUpdatedAt: nowIso(),
       recentRuns: [],

--- a/src/lib/runtimes/shared/owned-session/types.ts
+++ b/src/lib/runtimes/shared/owned-session/types.ts
@@ -12,6 +12,7 @@ import type {
   RuntimeReviewCommandEvidence,
   SquadSummary,
 } from '@/lib/fleet/types';
+import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 
 // ── Run / session primitives ─────────────────────────────────────────────────
 
@@ -56,6 +57,8 @@ export interface OwnedSessionRecord {
   latestPrompt: string;
   latestSummary: string;
   model?: string;
+  /** Requested reasoning effort — applied per-runtime at launch (codex only today). */
+  effort?: ThinkingEffort;
   reviewDisposition?: OwnedReviewDisposition;
   reviewDispositionUpdatedAt?: string;
   activeRun?: OwnedRunRecord;
@@ -122,6 +125,8 @@ export interface OwnedLaunchRequest {
   cwd: string;
   prompt: string;
   model?: string;
+  /** Requested reasoning effort — a per-runtime no-op unless the adapter uses it. */
+  effort?: ThinkingEffort;
 }
 
 export interface OwnedLaunchResponse {
@@ -195,7 +200,7 @@ export interface OwnedRuntimeAdapter {
   defaultModel?: string;
 
   /** Build argv for a fresh (launch) run. */
-  launchArgs(ctx: { cwd: string; prompt: string; model?: string }): string[];
+  launchArgs(ctx: { cwd: string; prompt: string; model?: string; effort?: ThinkingEffort }): string[];
 
   /**
    * Build argv for a resume run. Return null to signal this runtime cannot

--- a/src/lib/runtimes/types.ts
+++ b/src/lib/runtimes/types.ts
@@ -1,6 +1,7 @@
 import type { BrowserSurfaceSummary } from '@/lib/browser/types';
 import type { CompactionEvent } from '@/lib/runtimes/compaction-detector';
 import type { DispatchCapability } from '@/lib/runtimes/shared/turn-dispatcher';
+import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 
 /**
  * Universal Agent Runtime Contract
@@ -161,6 +162,8 @@ export interface LaunchOptions {
   cwd: string;
   prompt: string;
   model?: string;
+  /** Requested reasoning effort — applied per-runtime (codex today); a no-op elsewhere. */
+  effort?: ThinkingEffort;
   worktreeFlag?: string;
   worktreePath?: string;
   laneId?: string;

--- a/src/lib/tasks/actions.ts
+++ b/src/lib/tasks/actions.ts
@@ -439,6 +439,7 @@ export async function dispatchTask(taskId: string, input: TaskDispatchInput = {}
     laneId: lane.id,
     prompt: buildDispatchPrompt(task, workerRouting, input.message),
     model: workerRouting.selectedModel ?? undefined,
+    effort: workerRouting.selectedEffort ?? undefined,
     actor,
   });
 

--- a/tests/smoke/worker-effort-e2e-smoke.ts
+++ b/tests/smoke/worker-effort-e2e-smoke.ts
@@ -1,0 +1,43 @@
+/**
+ * effort→worker END-TO-END (Commit 3). Proves createMission threads
+ * requestedEffort through routing onto the persisted packet's
+ * workerRouting.selectedEffort — codex honors it, gemini is a per-runtime no-op,
+ * and unset stays null (parity). Touches the orchestrator store, so it runs as a
+ * tsx smoke against a fresh data dir (not vitest).
+ *
+ *   CORTEX_IDE_DATA_DIR=$(mktemp -d) NODE_OPTIONS='--conditions=react-server' \
+ *     npx tsx tests/smoke/worker-effort-e2e-smoke.ts
+ */
+
+import assert from 'node:assert';
+
+import { createMission } from '@/lib/orchestrator/operator-mission-service';
+import { currentMissionState } from '@/lib/orchestrator/operator-mission-service/shared';
+import type { WorkerRouting } from '@/lib/orchestrator/types';
+
+async function dispatch(over: Record<string, unknown>): Promise<WorkerRouting> {
+  await createMission({
+    issues: [{ number: 90001, title: 'x', body: '', url: '' }],
+    repoPath: process.cwd(), runtime: 'codex', constraints: '', ...over,
+  } as never);
+  const routing = currentMissionState().packets[0]?.workerRouting;
+  if (!routing) throw new Error('mission produced no packet routing');
+  return routing;
+}
+
+async function main(): Promise<void> {
+  const codex = await dispatch({ requestedRuntime: 'codex', requestedEffort: 'high' });
+  assert.strictEqual(codex.selectedEffort, 'high', `codex/high → ${codex.selectedEffort}`);
+  assert.strictEqual(codex.requestedEffort, 'high');
+
+  const parity = await dispatch({ requestedRuntime: 'codex' });
+  assert.strictEqual(parity.selectedEffort, null, `no effort must be null (parity) → ${parity.selectedEffort}`);
+
+  const gemini = await dispatch({ requestedRuntime: 'gemini', requestedEffort: 'high' });
+  assert.strictEqual(gemini.selectedEffort, null, `gemini no-op → ${gemini.selectedEffort}`);
+  assert.strictEqual(gemini.requestedEffort, 'high', 'the request is still recorded');
+
+  console.log('[worker-effort-e2e-smoke] PASS — createMission threads effort → packet routing (codex honors, gemini no-op, unset=null)');
+}
+
+void main().then(() => process.exit(0)).catch((err) => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## effort → worker — the Targeting Machine fast-follow

The one deferred piece from #1306: the tier's **effort** dimension was config-resolved + carried through routing, but the create-mission passthrough only carried runtime+model, so a worker launched at Codex's default reasoning effort. This threads effort the whole way — and since it changes **every** dispatched worker (not just targeting), the two must-proves are the point.

**1 — Parity on existing dispatch (blast radius zero unless effort is set).**
Effort rides inside `WorkerRouting` (like `selectedModel`), already persisted on every packet, and every layer uses optional fields defaulting to `undefined`:
- `resolveWorkerRouting({})` ⇒ `requestedEffort`/`selectedEffort` null, nothing else changes.
- `codexLaunchArgs` with no effort **=== with effort:undefined**, and neither contains `model_reasoning_effort` — byte-identical launch args to before.
- `'adaptive'` and bogus values ⇒ null (runtime default). A mission with no explicit effort behaves exactly as today across every dispatch path.

**2 — Per-runtime, explicit.**
- **codex** → `-c model_reasoning_effort=<tier>` (max → xhigh, mirroring the orchestrator mapping). Only `codexLaunchArgs` consumes `ctx.effort`.
- **gemini / opencode** → clean no-op by construction: their owned adapters have their own `launchArgs` that never reference effort; the widened ctx field is optional and ignored. `resolveWorkerRouting` also gates `selectedEffort` to null for them (the ask is still recorded).
- **resume** needs no change: `codexResumeArgs` applies neither model nor effort — `codex exec resume` continues the thread with its launch-time config (consistent with how model already works).

### The chain (one commit per logical step)
1. **Routing data model** — `WorkerRouting.requestedEffort`/`selectedEffort`; `resolveWorkerRouting` honors it (effort-capable runtimes only); `normalizeWorkerRouting` carries `requestedEffort` through the persist→restore round-trip (the normalize-drops-fields trap, avoided); `CreateMissionInput.requestedEffort`.
2. **Launch threading** — scheduling/tasks dispatch → lane `launch_session` command → `launchRuntimeSurface` → `LaunchOptions` → codex adapter → `OwnedLaunchRequest` → the owned session → `codexLaunchArgs`.
3. **Targeting closes the loop** — the dispatch route passes the tier's effort. **Also fixes a latent bug the e2e smoke caught in the merged dispatch route**: the inline issue used `number: 0`, which `normalizeLoadedIssue` rejects — the Dispatch button would have thrown. Corrected to the 90001+ synthetic-number convention.

### Proof
- `routing-effort.test.ts` (8) — parity (unset/adaptive/bogus → null), per-runtime (codex honors, gemini no-op), round-trip.
- `owned-launch-effort.test.ts` (5) — `codexReasoningEffortArgs` parity + tier mapping; `codexLaunchArgs` no-effort byte-identical + explicit-effort flag present once, prompt still last.
- `worker-effort-e2e-smoke.ts` — `createMission` threads effort onto the persisted packet's `workerRouting.selectedEffort` (codex 'high', gemini null, unset null).

### Gate (local — CI billing-red as usual)
tsc clean · full vitest **411/411** · effort tests 13 · e2e smoke PASS · lint 0 errors (one pre-existing `isLaneAutoReviewInProgress` warning left per surgical-changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018akNs5xu63pWZA3SXaGha8
