### PR TITLE
fix: dogfood pass — merged-packet ready-count parity, Re-scan overlap (#1309), Collide tooltip

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3426,8 +3426,20 @@ function DashboardInner() {
       .map((l) => ({ laneId: l.id, packetId: l.packetId, status: l.status, sessionKey: l.sessionKey, lastEventLabel: l.lastEventLabel, branch: l.branch, repoPath: l.repoPath, label: l.label }));
   }, [domainLanesRaw]);
   // Footer merge beacon — fleet-wide "parked, needs you" lanes (review +
-  // escalation gates), derived from the same already-live lanes poll.
-  const parkedLanes = useMemo(() => deriveParkedLanes(domainLanes), [domainLanes]);
+  // escalation gates), derived from the same already-live lanes poll. Exclude
+  // lanes whose PACKET has merged/released/archived — the lane summary status can
+  // lag (stale-stuck at 'reviewing' after the packet closed), which left a
+  // just-merged packet counting as "1 ready" in the beacon.
+  const closedPacketIds = useMemo(() => {
+    const closed = new Set<string>();
+    for (const packet of thoughtsMissionState.packets) {
+      if (packet.releaseState === 'released' || packet.archivedAt || packet.status === 'archived') {
+        closed.add(packet.id);
+      }
+    }
+    return closed;
+  }, [thoughtsMissionState.packets]);
+  const parkedLanes = useMemo(() => deriveParkedLanes(domainLanes, closedPacketIds), [domainLanes, closedPacketIds]);
 
   useEffect(() => {
     if (!tileLayoutHydrated) return;

--- a/src/components/desktop/merge-beacon/derive.test.ts
+++ b/src/components/desktop/merge-beacon/derive.test.ts
@@ -37,4 +37,20 @@ describe('deriveParkedLanes', () => {
     ]);
     expect(parked[0]).toMatchObject({ branch: 'feat/x', repoPath: '/r', label: 'Fix x' });
   });
+
+  it('excludes a lane whose PACKET is closed even if the lane status is stale-stuck at reviewing (the "1 ready" bug)', () => {
+    const lanes = [
+      lane({ laneId: 'merged', status: 'reviewing', packetId: 'pkt-merged' }), // packet merged+archived, lane status lagged
+      lane({ laneId: 'live', status: 'reviewing', packetId: 'pkt-live' }),     // genuinely still parked
+    ];
+    const closed = new Set(['pkt-merged']);
+    const parked = deriveParkedLanes(lanes, closed);
+    expect(parked.map((p) => p.laneId)).toEqual(['live']); // the merged one dropped
+  });
+
+  it('with no closed set, behaves exactly as before (parity)', () => {
+    const lanes = [lane({ laneId: 'a', status: 'reviewing' })];
+    expect(deriveParkedLanes(lanes).map((p) => p.laneId)).toEqual(['a']);
+    expect(deriveParkedLanes(lanes, new Set()).map((p) => p.laneId)).toEqual(['a']);
+  });
 });

--- a/src/components/desktop/merge-beacon/derive.ts
+++ b/src/components/desktop/merge-beacon/derive.ts
@@ -26,9 +26,21 @@ export interface ParkedLane {
   label?: string;
 }
 
-export function deriveParkedLanes(lanes: DomainLaneSummary[]): ParkedLane[] {
+/**
+ * @param closedPacketIds packetIds whose packet is merged / released / archived
+ *   (terminal). A lane's `status` can lag behind its packet — a packet merges +
+ *   archives while the lane summary is still stale-stuck at 'reviewing' — which
+ *   left the just-merged lane counting as "1 ready" in the footer beacon. Gating
+ *   on the PACKET's terminal state (which IS updated on merge) drops it: a
+ *   closed/merged/archived lane must never count as ready.
+ */
+export function deriveParkedLanes(
+  lanes: DomainLaneSummary[],
+  closedPacketIds?: ReadonlySet<string>,
+): ParkedLane[] {
   return lanes
     .filter((l) => PARKED_STATUSES.has(l.status))
+    .filter((l) => !closedPacketIds?.has(l.packetId))
     .map((l) => ({
       laneId: l.laneId,
       packetId: l.packetId,

--- a/src/components/desktop/o8-panel/TargetsPanel.tsx
+++ b/src/components/desktop/o8-panel/TargetsPanel.tsx
@@ -110,10 +110,13 @@ export function TargetsPanel({ repoPath, active }: { repoPath?: string | null; a
 
   return (
     <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', background: 'var(--t-bg)' }}>
-      {/* Header */}
+      {/* Header. Right padding reserves room for the floating Ask-o8 icon that
+          O8Panel renders over the top-right of non-excluded tabs (position
+          absolute, right:12, 26px button → occupies the rightmost 38px; +6 gap
+          = 44). Without this the Re-scan button sits under the sparkle (#1309). */}
       <div style={{
         display: 'flex', alignItems: 'center', gap: 10,
-        paddingTop: 10, paddingRight: 14, paddingBottom: 10, paddingLeft: 14,
+        paddingTop: 10, paddingRight: 44, paddingBottom: 10, paddingLeft: 14,
         borderBottomWidth: 1, borderBottomStyle: 'solid', borderBottomColor: 'var(--t-divider)',
       }}>
         <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 1 }}>

--- a/src/components/desktop/thoughts/InputButtons.tsx
+++ b/src/components/desktop/thoughts/InputButtons.tsx
@@ -928,9 +928,9 @@ export function InputButtons({
         <button
           type="button"
           onClick={() => onSetCollide(!collideEnabled)}
-          title={collideEnabled
-            ? 'Collide ON — Claude + Codex propose, Claude synthesizes. Click to turn off.'
-            : 'Collide — Claude + Codex propose independently, Claude synthesizes the upgraded answer.'}
+          aria-label={`Collide (Claude + Codex)${collideEnabled ? ' — on' : ''}`}
+          aria-pressed={collideEnabled}
+          title={`Collide — Claude and Codex each take a pass independently, then Claude fuses the best of both into one answer. Two frontier models thinking together, on your own subscriptions. Sharper when the problem's worth it, a touch slower. Toggle per message.${collideEnabled ? ' (On — click to turn off.)' : ''}`}
           style={{
             display: 'inline-flex',
             alignItems: 'center',


### PR DESCRIPTION
## Dogfood fix pass — 3 small ones (state + polish)

Just the remaining bugs + polish from dogfooding — NOT the o8.md product ideas (panel revamp / loops-workflows / symon parity are features for later). One reviewable commit each. All UI/state, no safety surface.

### 1. "1 ready" state parity (bug)
After a dispatched packet merges + closes ("Merged · read-only — lane merged and archived"), the footer merge-beacon still showed **"1 ready"** (orange dot). The beacon counts lanes in parked states (`reviewing`/`awaiting_orchestrator`/`awaiting_human`) via `deriveParkedLanes`. `listActiveLanes` already drops `archived`/`completed` lanes — so the culprit is a just-merged lane whose `DomainLaneSummary.status` **lags** its packet: the packet flipped to released/archived while the lane summary is stale-stuck at `reviewing`. Same parity class as the earlier failed-inline-lane clutter. **Fix:** gate `deriveParkedLanes` on the **packet's** terminal state (`releaseState === 'released' || archivedAt || status === 'archived'`) — which *is* updated on merge — so a closed/merged/archived lane never counts, even with a stale lane status. Test proves a closed-packet lane is dropped while a genuinely-parked one stays; no-set parity. *(Analysis-confirmed, not live-repro'd — release is behind the billing wall.)*

### 2. Re-scan overlap (#1309)
The Targeting panel's "Re-scan" button overlapped the floating Ask-o8 sparkle O8Panel renders at the top-right. That icon is `absolute; right:12` with a 26px button → occupies the rightmost **38px**; the header's `paddingRight:14` put Re-scan under it. Bumped header `paddingRight` to **44** (38 + 6px gap) — derived from the icon's real geometry, not a magic number.

### 3. Collide tooltip
The Collide toggle was icon-only with a terse title. Added your value-prop copy as the hover tooltip (native `title`, per "fine for v1"; appends "On — click to turn off." when active) + `aria-label`/`aria-pressed` so the icon-only toggle has a real accessible name/state.

### Gate
tsc clean · full vitest **425/425** · derive 5 · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018akNs5xu63pWZA3SXaGha8
