### PR TITLE
test: cover scoreTelemetryPath (exact / suffix / basename / no-match)

### DIFF
--- a/src/components/desktop/thoughts/use-orchestrator-stream/shared.test.ts
+++ b/src/components/desktop/thoughts/use-orchestrator-stream/shared.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { scoreTelemetryPath } from './shared';
+
+describe('scoreTelemetryPath', () => {
+  it('scores an exact match highest', () => {
+    expect(scoreTelemetryPath('/Users/marquisehurtt/o8', '/Users/marquisehurtt/o8')).toBe(4);
+  });
+
+  it('scores a suffix overlap below an exact match', () => {
+    expect(scoreTelemetryPath('marquisehurtt/o8', '/Users/marquisehurtt/o8')).toBe(3);
+  });
+
+  it('scores a basename-only match below a suffix overlap', () => {
+    expect(scoreTelemetryPath('/tmp/work/o8', '/Users/marquisehurtt/o8')).toBe(1);
+  });
+
+  it('scores unrelated paths as no match', () => {
+    expect(scoreTelemetryPath('/tmp/work/o8-mobile', '/Users/marquisehurtt/o8')).toBe(0);
+  });
+});


### PR DESCRIPTION
Adds 4 vitest cases for `scoreTelemetryPath` in `use-orchestrator-stream/shared.ts` — exact match, suffix overlap, basename-only match, and no-match.

Built by a Codex worker dispatched and reviewed through the o8 governance loop: worker committed in an isolated worktree, orchestrator review verdict **approve** (tsc clean, 818 tests green, directives applied; one accepted info nit on literal home paths in fixtures), merge gate passed all four checks and routed here per PR-only dogfood mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xr8Bd6vaFFPiemavF2QoW