### PR TITLE
feat(canvas): quick-docs drawer — one-click global CLAUDE.md / AGENTS.md editing

### DIFF
--- a/src/app/api/v2/files/quick-docs/route.ts
+++ b/src/app/api/v2/files/quick-docs/route.ts
@@ -1,0 +1,30 @@
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { homedir } from 'node:os';
+import { getDefaultLlmRepoRoot, resolveRegisteredRepoScope } from '@/lib/llm/repo-scope';
+import { buildQuickDocs } from '@/lib/files/operator-config-docs';
+
+async function resolveRoot(workspace?: string | null) {
+  if (!workspace) return null;
+
+  const requestedPath = workspace.startsWith('~')
+    ? workspace.replace('~', homedir())
+    : workspace;
+
+  const { repoRoot } = await resolveRegisteredRepoScope(requestedPath);
+  return repoRoot;
+}
+
+export async function GET(request: NextRequest) {
+  let repoRoot: string | null = null;
+  const workspace = request.nextUrl.searchParams.get('workspace');
+
+  try {
+    repoRoot = workspace ? await resolveRoot(workspace) : await getDefaultLlmRepoRoot();
+  } catch {
+    repoRoot = null;
+  }
+
+  return NextResponse.json(buildQuickDocs(repoRoot));
+}

--- a/src/app/api/v2/files/route.ts
+++ b/src/app/api/v2/files/route.ts
@@ -9,9 +9,14 @@ export const dynamic = 'force-dynamic';
 
 import { NextRequest, NextResponse } from 'next/server';
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
-import { relative, dirname, resolve } from 'node:path';
+import { dirname, isAbsolute } from 'node:path';
 import { homedir } from 'node:os';
 import { getDefaultLlmRepoRoot, resolveRegisteredRepoScope } from '@/lib/llm/repo-scope';
+import {
+  ABSOLUTE_PATH_NOT_ALLOWLISTED,
+  resolveAllowedOperatorConfigPath,
+  resolveRepoRelativeFilePath,
+} from '@/lib/files/operator-config-docs';
 
 async function resolveRoot(workspace?: string | null) {
   if (!workspace) return getDefaultLlmRepoRoot();
@@ -24,11 +29,38 @@ async function resolveRoot(workspace?: string | null) {
   return repoRoot;
 }
 
-function safePath(root: string, path: string): string | null {
-  const resolved = resolve(root, path);
-  const rel = relative(root, resolved);
-  if (rel.startsWith('..') || rel.startsWith('/')) return null;
-  return resolved;
+async function resolveFileTarget(filePath: string, workspace?: string | null) {
+  if (isAbsolute(filePath)) {
+    const resolved = resolveAllowedOperatorConfigPath(filePath);
+    if (!resolved) {
+      return {
+        error: 'Absolute path is not allowlisted',
+        code: ABSOLUTE_PATH_NOT_ALLOWLISTED,
+        status: 400,
+      } as const;
+    }
+    return { resolved } as const;
+  }
+
+  const root = await resolveRoot(workspace);
+  if (!root) {
+    return {
+      error: 'Workspace is not registered',
+      code: 'workspace_not_registered',
+      status: 400,
+    } as const;
+  }
+
+  const resolved = resolveRepoRelativeFilePath(root, filePath);
+  if (!resolved) {
+    return {
+      error: 'Path outside repository',
+      code: 'path_outside_repository',
+      status: 400,
+    } as const;
+  }
+
+  return { resolved } as const;
 }
 
 export async function GET(request: NextRequest) {
@@ -37,22 +69,17 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'path required' }, { status: 400 });
   }
 
-  const root = await resolveRoot(request.nextUrl.searchParams.get('workspace'));
-  if (!root) {
-    return NextResponse.json({ error: 'Workspace is not registered' }, { status: 400 });
+  const target = await resolveFileTarget(path, request.nextUrl.searchParams.get('workspace'));
+  if ('error' in target) {
+    return NextResponse.json({ error: target.error, code: target.code }, { status: target.status });
   }
 
-  const resolved = safePath(root, path);
-  if (!resolved) {
-    return NextResponse.json({ error: 'Path outside repository' }, { status: 400 });
-  }
-
-  if (!existsSync(resolved)) {
+  if (!existsSync(target.resolved)) {
     return NextResponse.json({ error: 'File not found', exists: false }, { status: 404 });
   }
 
   try {
-    const content = readFileSync(resolved, 'utf-8');
+    const content = readFileSync(target.resolved, 'utf-8');
     return NextResponse.json({ content, path, exists: true });
   } catch (err) {
     return NextResponse.json({ error: String(err) }, { status: 500 });
@@ -68,28 +95,24 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'path and content required' }, { status: 400 });
     }
 
-    const root = await resolveRoot(workspace);
-    if (!root) {
-      return NextResponse.json({ error: 'Workspace is not registered' }, { status: 400 });
-    }
-    const resolved = safePath(root, path);
-    if (!resolved) {
-      return NextResponse.json({ error: 'Path outside repository' }, { status: 400 });
+    const target = await resolveFileTarget(path, workspace);
+    if ('error' in target) {
+      return NextResponse.json({ error: target.error, code: target.code }, { status: target.status });
     }
 
     // Read existing content for diff
     let oldContent: string | null = null;
-    if (existsSync(resolved)) {
-      oldContent = readFileSync(resolved, 'utf-8');
+    if (existsSync(target.resolved)) {
+      oldContent = readFileSync(target.resolved, 'utf-8');
     }
 
     // Ensure directory exists
-    const dir = dirname(resolved);
+    const dir = dirname(target.resolved);
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
     }
 
-    writeFileSync(resolved, content, 'utf-8');
+    writeFileSync(target.resolved, content, 'utf-8');
 
     return NextResponse.json({
       success: true,

--- a/src/components/desktop/o8-panel/workspace-rail/AllFilesTree.tsx
+++ b/src/components/desktop/o8-panel/workspace-rail/AllFilesTree.tsx
@@ -3,6 +3,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import type { FileNode } from '@/app/dashboard/types';
+import { QuickDocs } from './QuickDocs';
 
 const UI_FONT = 'var(--font-sans-system)';
 const MONO_FONT = '"SF Mono", ui-monospace, "Cascadia Code", Menlo, monospace';
@@ -235,6 +236,7 @@ export function AllFilesTree({
         {repoName}
       </div>
       <div className="cortex-scroll-fade-y cortex-themed-scroll" style={{ flex: 1, minHeight: 0, overflowY: 'auto', overflowX: 'hidden', paddingTop: 3, paddingBottom: 3 }}>
+        <QuickDocs repoPath={repoPath} selectedFile={selectedFile} onSelectFile={onSelectFile} />
         {!repoPath ? (
           <div style={{ paddingTop: 13, paddingRight: 12, paddingBottom: 13, paddingLeft: 12, color: 'var(--t-text-muted)', fontFamily: UI_FONT, fontSize: 12 }}>
             Select a repo to browse files.

--- a/src/components/desktop/o8-panel/workspace-rail/FileViewer.tsx
+++ b/src/components/desktop/o8-panel/workspace-rail/FileViewer.tsx
@@ -184,6 +184,7 @@ export function FileViewer({
     ? assetUrlFor(repoPath, selectedFile)
     : null;
   const fileName = selectedFile?.split('/').pop() ?? selectedFile ?? 'file';
+  const isAbsolutePath = selectedFile?.startsWith('/') ?? false;
 
   useEffect(() => {
     if (!selectedFile) {
@@ -194,7 +195,7 @@ export function FileViewer({
       setLoading(false);
       return;
     }
-    if (!repoPath) {
+    if (!repoPath && !isAbsolutePath) {
       setFileContent(null);
       setEditContent('');
       setError('Select a repo before loading file content.');
@@ -218,7 +219,8 @@ export function FileViewer({
     setFileContent(null);
     setEditContent('');
     setDirty(false);
-    const params = new URLSearchParams({ path: selectedFile, workspace: repoPath });
+    const params = new URLSearchParams({ path: selectedFile });
+    if (repoPath) params.set('workspace', repoPath);
     fetch(`/api/v2/files?${params.toString()}`)
       .then((response) => response.json() as Promise<FileResponse>)
       .then((data) => {
@@ -244,17 +246,20 @@ export function FileViewer({
       });
 
     return () => { cancelled = true; };
-  }, [fileKind, repoPath, selectedFile]);
+  }, [fileKind, isAbsolutePath, repoPath, selectedFile]);
 
   const handleSave = useCallback(async () => {
-    if (!selectedFile || !repoPath || !dirty) return;
+    if (!selectedFile || (!repoPath && !isAbsolutePath) || !dirty) return;
     setSaving(true);
     setError(null);
     try {
+      const body = repoPath
+        ? { path: selectedFile, content: editContent, workspace: repoPath }
+        : { path: selectedFile, content: editContent };
       const response = await fetch('/api/v2/files', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ path: selectedFile, content: editContent, workspace: repoPath }),
+        body: JSON.stringify(body),
       });
       const data = await response.json().catch(() => ({})) as FileResponse;
       if (!response.ok) throw new Error(data.error || 'Unable to save file');
@@ -265,7 +270,7 @@ export function FileViewer({
     } finally {
       setSaving(false);
     }
-  }, [dirty, editContent, repoPath, selectedFile]);
+  }, [dirty, editContent, isAbsolutePath, repoPath, selectedFile]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/src/components/desktop/o8-panel/workspace-rail/QuickDocs.tsx
+++ b/src/components/desktop/o8-panel/workspace-rail/QuickDocs.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+const UI_FONT = 'var(--font-sans-system)';
+const MONO_FONT = '"SF Mono", ui-monospace, "Cascadia Code", Menlo, monospace';
+
+interface QuickDocEntry {
+  label: string;
+  value: string;
+  path: string;
+}
+
+interface QuickDocGroup {
+  label: 'Global' | 'This repo';
+  entries: QuickDocEntry[];
+}
+
+interface QuickDocsResponse {
+  groups?: QuickDocGroup[];
+}
+
+function ChevronIcon({ size = 13 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
+      <polyline points="9 18 15 12 9 6" />
+    </svg>
+  );
+}
+
+export function QuickDocs({
+  repoPath,
+  selectedFile,
+  onSelectFile,
+}: {
+  repoPath?: string | null;
+  selectedFile: string | null;
+  onSelectFile: (filePath: string) => void;
+}) {
+  const [groups, setGroups] = useState<QuickDocGroup[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const params = new URLSearchParams();
+    if (repoPath) params.set('workspace', repoPath);
+    const query = params.toString();
+
+    fetch(`/api/v2/files/quick-docs${query ? `?${query}` : ''}`)
+      .then((response) => response.json() as Promise<QuickDocsResponse>)
+      .then((data) => {
+        if (!cancelled) setGroups(Array.isArray(data.groups) ? data.groups : []);
+      })
+      .catch(() => {
+        if (!cancelled) setGroups([]);
+      });
+
+    return () => { cancelled = true; };
+  }, [repoPath]);
+
+  const total = useMemo(
+    () => groups.reduce((sum, group) => sum + group.entries.length, 0),
+    [groups],
+  );
+
+  if (total === 0) return null;
+
+  return (
+    <div style={{ borderBottom: '1px solid var(--t-divider-subtle)', background: 'var(--t-bg-card)' }}>
+      <div style={{ minHeight: 32, display: 'flex', alignItems: 'center', gap: 8, paddingTop: 0, paddingRight: 10, paddingBottom: 0, paddingLeft: 10 }}>
+        <span style={{ color: 'var(--t-text-muted)', fontFamily: UI_FONT, fontSize: 10, fontWeight: 850, letterSpacing: 0, textTransform: 'uppercase' }}>
+          Quick docs
+        </span>
+        <span style={{ marginLeft: 'auto', color: 'var(--t-text-faint)', fontFamily: MONO_FONT, fontSize: 10, fontWeight: 650 }}>
+          {total}
+        </span>
+      </div>
+      {groups.map((group) => (
+        <div key={group.label} style={{ paddingBottom: 6 }}>
+          <div style={{ height: 20, display: 'flex', alignItems: 'center', paddingTop: 0, paddingRight: 10, paddingBottom: 0, paddingLeft: 10, color: 'var(--t-text-faint)', fontFamily: UI_FONT, fontSize: 9, fontWeight: 800, letterSpacing: 0, textTransform: 'uppercase' }}>
+            {group.label}
+          </div>
+          {group.entries.map((entry) => {
+            const selected = selectedFile === entry.path;
+            return (
+              <button
+                key={entry.path}
+                type="button"
+                onClick={() => onSelectFile(entry.path)}
+                style={{
+                  minHeight: 44,
+                  width: '100%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  border: 'none',
+                  borderRadius: 0,
+                  background: selected ? 'var(--t-input-bg)' : 'transparent',
+                  color: selected ? 'var(--t-text)' : 'var(--t-text-secondary)',
+                  cursor: 'pointer',
+                  fontFamily: UI_FONT,
+                  paddingTop: 4,
+                  paddingRight: 8,
+                  paddingBottom: 4,
+                  paddingLeft: 10,
+                  textAlign: 'left',
+                }}
+                onMouseEnter={(event) => { if (!selected) event.currentTarget.style.background = 'var(--t-hover)'; }}
+                onMouseLeave={(event) => { if (!selected) event.currentTarget.style.background = 'transparent'; }}
+              >
+                <span style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 3 }}>
+                  <span style={{ color: selected ? 'var(--t-text)' : 'var(--t-text-muted)', fontSize: 10, fontWeight: 850, letterSpacing: 0, lineHeight: 1.1, overflow: 'hidden', textOverflow: 'ellipsis', textTransform: 'uppercase', whiteSpace: 'nowrap' }}>
+                    {entry.label}
+                  </span>
+                  <span style={{ color: 'var(--t-text-faint)', fontFamily: MONO_FONT, fontSize: 10, fontWeight: 500, letterSpacing: 0, lineHeight: 1.15, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {entry.value}
+                  </span>
+                </span>
+                <ChevronIcon />
+              </button>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/files/operator-config-docs.ts
+++ b/src/lib/files/operator-config-docs.ts
@@ -1,0 +1,70 @@
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { isAbsolute, relative, resolve } from 'node:path';
+
+export const ABSOLUTE_PATH_NOT_ALLOWLISTED = 'absolute_path_not_allowlisted';
+
+export interface QuickDocEntry {
+  label: string;
+  value: string;
+  path: string;
+}
+
+export interface QuickDocGroup {
+  label: 'Global' | 'This repo';
+  entries: QuickDocEntry[];
+}
+
+const GLOBAL_DOCS: Array<{ label: string; value: string; parts: string[] }> = [
+  { label: 'Global CLAUDE.md', value: '~/.claude/CLAUDE.md', parts: ['.claude', 'CLAUDE.md'] },
+  { label: 'Home CLAUDE.md', value: '~/CLAUDE.md', parts: ['CLAUDE.md'] },
+  { label: 'Codex AGENTS.md', value: '~/.codex/AGENTS.md', parts: ['.codex', 'AGENTS.md'] },
+];
+
+const REPO_DOCS = ['CLAUDE.md', 'AGENTS.md'] as const;
+
+export function operatorConfigAllowlist(): string[] {
+  const home = homedir();
+  return GLOBAL_DOCS.map((entry) => resolve(home, ...entry.parts));
+}
+
+export function resolveAllowedOperatorConfigPath(filePath: string): string | null {
+  if (!isAbsolute(filePath)) return null;
+  const resolved = resolve(filePath);
+  return operatorConfigAllowlist().includes(resolved) ? resolved : null;
+}
+
+export function resolveRepoRelativeFilePath(root: string, filePath: string): string | null {
+  if (isAbsolute(filePath)) return null;
+  const resolved = resolve(root, filePath);
+  const rel = relative(root, resolved);
+  if (rel.startsWith('..') || isAbsolute(rel)) return null;
+  return resolved;
+}
+
+export function buildQuickDocs(repoRoot?: string | null): { groups: QuickDocGroup[] } {
+  const globalEntries = GLOBAL_DOCS.map((entry) => {
+    const path = resolve(homedir(), ...entry.parts);
+    return {
+      label: entry.label,
+      value: entry.value,
+      path,
+    };
+  }).filter((entry) => existsSync(entry.path));
+
+  const repoEntries: QuickDocEntry[] = repoRoot ? REPO_DOCS.map((fileName) => {
+    const resolved = resolveRepoRelativeFilePath(repoRoot, fileName);
+    if (!resolved || !existsSync(resolved)) return null;
+    const entry: QuickDocEntry = { label: fileName, value: fileName, path: fileName };
+    return entry;
+  }).filter((entry): entry is QuickDocEntry => entry !== null) : [];
+
+  const groups: QuickDocGroup[] = [
+    { label: 'Global', entries: globalEntries },
+    { label: 'This repo', entries: repoEntries },
+  ];
+
+  return {
+    groups: groups.filter((group) => group.entries.length > 0),
+  };
+}

--- a/tests/v2-files-operator-config-allowlist.test.ts
+++ b/tests/v2-files-operator-config-allowlist.test.ts
@@ -1,0 +1,78 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const REAL_HOME = process.env.HOME;
+
+let tmpHome = '';
+
+async function loadFilesRoute() {
+  return import('@/app/api/v2/files/route');
+}
+
+function request(url: string, init?: ConstructorParameters<typeof NextRequest>[1]) {
+  return new NextRequest(url, init);
+}
+
+describe('/api/v2/files operator config allowlist', () => {
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'o8-files-home-'));
+    process.env.HOME = tmpHome;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (REAL_HOME === undefined) delete process.env.HOME;
+    else process.env.HOME = REAL_HOME;
+    rmSync(tmpHome, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  it('rejects non-allowlisted absolute paths through the real GET handler', async () => {
+    const sshConfig = join(tmpHome, '.ssh', 'config');
+    mkdirSync(join(tmpHome, '.ssh'), { recursive: true });
+    writeFileSync(sshConfig, 'Host *\n  AddKeysToAgent yes\n', 'utf-8');
+
+    const { GET } = await loadFilesRoute();
+    const res = await GET(request(`http://localhost/api/v2/files?path=${encodeURIComponent(sshConfig)}`));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body).toMatchObject({
+      error: 'Absolute path is not allowlisted',
+      code: 'absolute_path_not_allowlisted',
+    });
+  });
+
+  it('reads and saves an allowlisted global CLAUDE.md through the real route handlers', async () => {
+    const claudeDir = join(tmpHome, '.claude');
+    const claudePath = join(claudeDir, 'CLAUDE.md');
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(claudePath, '# operator notes\n', 'utf-8');
+
+    const { GET, POST } = await loadFilesRoute();
+    const getRes = await GET(request(`http://localhost/api/v2/files?path=${encodeURIComponent(claudePath)}`));
+    const getBody = await getRes.json();
+
+    expect(getRes.status).toBe(200);
+    expect(getBody).toMatchObject({
+      content: '# operator notes\n',
+      path: claudePath,
+      exists: true,
+    });
+
+    const postRes = await POST(request('http://localhost/api/v2/files', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ path: claudePath, content: '# updated notes\n' }),
+    }));
+    const postBody = await postRes.json();
+
+    expect(postRes.status).toBe(200);
+    expect(postBody).toMatchObject({ success: true, path: claudePath, isNew: false });
+    expect(readFileSync(claudePath, 'utf-8')).toBe('# updated notes\n');
+  });
+});


### PR DESCRIPTION
Quick Docs section in the canvas documents tab: Global CLAUDE.md (~/.claude/CLAUDE.md), Home CLAUDE.md, Codex AGENTS.md + repo-level CLAUDE.md/AGENTS.md — one click to open, edit, and save in the canvas viewer.

Security: absolute paths gated by a fixed server-side allowlist (exact resolved-path match, homedir-derived); everything else 400s. Real-path tests through the route: ~/.ssh/config rejected, allowlisted read/write round-trip green. Repo-relative scope semantics preserved.

Codex worker, 10m22s dispatch-to-review. Orchestrator-reviewed raw and approved (1 info finding); gate 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xr8Bd6vaFFPiemavF2QoW