### PR TITLE
feat(codex-orch): Brain-first codex orchestrator — prompt section, prewarm at turn start

### DIFF
--- a/src/lib/cortex/qa/compose-class-a.test.ts
+++ b/src/lib/cortex/qa/compose-class-a.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TypedRow } from '@/lib/cortex/qa/types';
+
+const callOrder: string[] = [];
+
+vi.mock('@/lib/cortex/qa/llm/byok-keys', () => ({
+  isByokRequired: vi.fn(async () => false),
+}));
+
+vi.mock('@/lib/cortex/qa/llm/codex-adapter', () => ({
+  CODEX_DEFAULT_MODEL: 'gpt-5.5',
+  callCodex: vi.fn(),
+}));
+
+vi.mock('@/lib/cortex/qa/llm/haiku-adapter', () => ({
+  callHaiku: vi.fn(),
+}));
+
+vi.mock('@/lib/cortex/qa/llm/openrouter-adapter', () => ({
+  OPENROUTER_PRIMARY_MODEL: 'google/gemini-2.5-flash-lite',
+  callOpenRouter: vi.fn(),
+}));
+
+vi.mock('@/lib/cortex/qa/llm/sonnet-adapter', () => ({
+  callSonnet: vi.fn(),
+}));
+
+vi.mock('@/lib/entitlement/store', () => ({
+  getEntitlementSync: vi.fn(),
+}));
+
+vi.mock('@/lib/operator/defaults', () => ({
+  getOperatorDefaultsSync: vi.fn(),
+  resolveBrainUseClaudeCliSync: vi.fn(),
+}));
+
+import { composeClassA } from '@/lib/cortex/qa/compose-class-a';
+import { callCodex } from '@/lib/cortex/qa/llm/codex-adapter';
+import { callHaiku } from '@/lib/cortex/qa/llm/haiku-adapter';
+import { callOpenRouter } from '@/lib/cortex/qa/llm/openrouter-adapter';
+import { callSonnet } from '@/lib/cortex/qa/llm/sonnet-adapter';
+import { getEntitlementSync } from '@/lib/entitlement/store';
+import { getOperatorDefaultsSync, resolveBrainUseClaudeCliSync } from '@/lib/operator/defaults';
+
+const directiveRow: TypedRow = {
+  citation: {
+    kind: 'directive',
+    rowId: 'brain-first',
+    table: 'directives',
+    excerpt: 'Use the Brain first.',
+  },
+  fields: {
+    title: 'Brain-first directive',
+    body: 'Use cortex_ask before broad repo search.',
+  },
+};
+
+function makeEmit() {
+  const events: Array<{ name: string; payload: unknown }> = [];
+  return {
+    events,
+    emit: (name: string, payload: unknown) => {
+      events.push({ name, payload });
+    },
+  };
+}
+
+describe('composeClassA provider order', () => {
+  beforeEach(() => {
+    callOrder.length = 0;
+    vi.mocked(callCodex).mockReset();
+    vi.mocked(callHaiku).mockReset();
+    vi.mocked(callOpenRouter).mockReset();
+    vi.mocked(callSonnet).mockReset();
+    vi.mocked(getOperatorDefaultsSync).mockReturnValue({
+      values: { classAComposer: 'auto' },
+    } as ReturnType<typeof getOperatorDefaultsSync>);
+    vi.mocked(resolveBrainUseClaudeCliSync).mockReturnValue(false);
+    vi.mocked(getEntitlementSync).mockReturnValue({
+      flags: {},
+    } as ReturnType<typeof getEntitlementSync>);
+  });
+
+  it('uses Codex CLI as the default subscription tier when the Claude Brain CLI is off', async () => {
+    vi.mocked(callCodex).mockImplementation(async () => {
+      callOrder.push('codex');
+      return 'Use cortex_ask first. [D-brain-first]';
+    });
+    vi.mocked(callOpenRouter).mockImplementation(async () => {
+      callOrder.push('openrouter');
+      return 'paid fallback';
+    });
+
+    const { events, emit } = makeEmit();
+    await composeClassA('How should the orchestrator learn repo conventions?', '/repo/o8', [directiveRow], emit);
+
+    expect(callOrder).toEqual(['codex']);
+    expect(callHaiku).not.toHaveBeenCalled();
+    expect(callOpenRouter).not.toHaveBeenCalled();
+    expect(events).toContainEqual({ name: 'done', payload: {} });
+  });
+
+  it('uses the managed fast tier before subscription CLIs without changing the cascade fallback', async () => {
+    vi.mocked(getEntitlementSync).mockReturnValue({
+      flags: { 'proxy.inference': true },
+    } as ReturnType<typeof getEntitlementSync>);
+    vi.mocked(callOpenRouter).mockImplementation(async () => {
+      callOrder.push('openrouter');
+      return 'Fast answer. [D-brain-first]';
+    });
+    vi.mocked(callCodex).mockImplementation(async () => {
+      callOrder.push('codex');
+      return 'subscription fallback';
+    });
+
+    const { events, emit } = makeEmit();
+    await composeClassA('What is the Brain-first rule?', '/repo/o8', [directiveRow], emit);
+
+    expect(callOrder).toEqual(['openrouter']);
+    expect(callCodex).not.toHaveBeenCalled();
+    expect(events).toContainEqual({ name: 'done', payload: {} });
+  });
+});

--- a/src/lib/lane/codex-orchestrator-session.test.ts
+++ b/src/lib/lane/codex-orchestrator-session.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
-import { codexOrchestratorModelFlags } from './codex-orchestrator-session';
+import { BRAIN_PROMPT_SECTION } from '@/lib/orchestrator/brain-access';
+import { buildCodexOrchestratorPrompt, codexOrchestratorModelFlags } from './codex-orchestrator-session';
 
 describe('codexOrchestratorModelFlags', () => {
   it('keeps the cloud path verbatim (gpt-5.5 default unchanged)', () => {
@@ -31,5 +32,22 @@ describe('codexOrchestratorModelFlags', () => {
       '--model',
       'qwen2.5-coder',
     ]);
+  });
+});
+
+describe('buildCodexOrchestratorPrompt', () => {
+  it('assembles the real orchestrator prompt with the Brain-first section', () => {
+    const prompt = buildCodexOrchestratorPrompt(
+      '/tmp/o8-test-repo',
+      'Review the latest packet.',
+    );
+
+    expect(prompt).toContain('You are the orchestrator for o8');
+    expect(prompt).toContain('o8-test-repo');
+    expect(prompt).toContain(BRAIN_PROMPT_SECTION);
+    expect(prompt).toContain('## ENGINEERING BRAIN');
+    expect(prompt).toContain('cortex_ask');
+    expect(prompt).toContain('before grepping or re-reading broad files');
+    expect(prompt).toContain('## USER MESSAGE\n\nReview the latest packet.');
   });
 });

--- a/src/lib/lane/codex-orchestrator-session.ts
+++ b/src/lib/lane/codex-orchestrator-session.ts
@@ -35,6 +35,8 @@ import {
 } from '@/lib/mobile/orchestrator-thread-history';
 import { parseLocalModel } from '@/lib/codex/local-model';
 import { resolveDefaultDispatchModelSync } from '@/lib/operator/defaults';
+import { BRAIN_PROMPT_SECTION } from '@/lib/orchestrator/brain-access';
+import { buildOrchestratorSystemPrompt } from '@/lib/lane/orchestrator-system-prompt';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -341,6 +343,21 @@ export function codexOrchestratorModelFlags(model: string, reasoningEffort: stri
     return ['--oss', '--local-provider', local.provider, '--model', local.model];
   }
   return ['-c', `model=${model}`, '-c', `model_reasoning_effort=${reasoningEffort}`];
+}
+
+const CODEX_BRAIN_FIRST_SECTION = [
+  '## ENGINEERING BRAIN — USE THIS FIRST',
+  BRAIN_PROMPT_SECTION,
+  'Codex orchestrator rule: on every turn, if you need repo conventions, history, ownership, prior fixes, directives, or cross-repo context, ask the Engineering Brain first via the `cortex_ask` MCP tool (or `o8 ask` from shell) before grepping or re-reading broad files. One focused Brain question is the default context-gathering step; use direct file reads after the Brain points you at current source or when exact code is needed.',
+].join('\n\n');
+
+export function buildCodexOrchestratorPrompt(repoPath: string, message: string): string {
+  return [
+    buildOrchestratorSystemPrompt(repoPath),
+    CODEX_BRAIN_FIRST_SECTION,
+    '## USER MESSAGE',
+    message,
+  ].join('\n\n');
 }
 
 // ── Event mapping (codex JSON → OrchestratorEvent) ───────────────────────────

--- a/src/lib/lane/orchestrator-backends/codex.ts
+++ b/src/lib/lane/orchestrator-backends/codex.ts
@@ -5,7 +5,10 @@
  * File-per-backend, matching openclaw/acp.
  */
 
+import { prewarmHaiku } from '@/lib/cortex/qa/llm/haiku-adapter';
+import { prewarmSonnetCli } from '@/lib/cortex/qa/llm/sonnet-adapter';
 import {
+  buildCodexOrchestratorPrompt,
   ensureCodexOrchestratorSession,
   getCodexOrchestratorSession,
   sendToCodexOrchestrator,
@@ -24,9 +27,11 @@ export const codexBackend: OrchestratorBackend = {
     return { sessionName: session.sessionName, status: session.status };
   },
   sendTurn(repoPath, message, onEvent, options) {
+    void prewarmHaiku().catch(() => {});
+    void prewarmSonnetCli().catch(() => {});
     return sendToCodexOrchestrator(
       ensureCodexOrchestratorSession(repoPath, options?.threadId),
-      message,
+      buildCodexOrchestratorPrompt(repoPath, message),
       onEvent,
       options,
     );

--- a/src/lib/lane/orchestrator-session.ts
+++ b/src/lib/lane/orchestrator-session.ts
@@ -26,10 +26,9 @@
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
-import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join, resolve } from 'node:path';
 import { listActiveLanesWithSessions } from '@/lib/lane/registry';
 import { assertNoPrintFlag } from '@/lib/claude-code/assert-no-print-flag';
 import {
@@ -47,6 +46,7 @@ import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
 import { toClaudeJson } from '@/lib/mcp/tool-spine/emit-claude';
 import type { ToolProfile } from '@/lib/mcp/tool-spine/registry';
 import { fableEnvOverride, fableLockoutArgs } from '@/lib/lane/fable-profile';
+import { buildOrchestratorSystemPrompt } from '@/lib/lane/orchestrator-system-prompt';
 
 // ── Types ──
 
@@ -322,70 +322,6 @@ function ensureMcpConfig(repoPath: string, profile: ToolProfile = 'full'): strin
   writeFileSync(configPath, JSON.stringify(config, null, 2));
   console.log(`[orchestrator-session] MCP config written to ${configPath}`);
   return configPath;
-}
-
-/**
- * Appended to Claude Code's default system prompt on the first message only.
- *
- * Prompt body lives in `orchestrator.md` next to this file — edit the md and
- * the next orchestrator turn picks it up immediately. The file is read on
- * every call so there's no cache to bust. Placeholders:
- *
- *   {{REPO_NAME}} — primary repo name
- *   {{REPO_PATH}} — primary repo absolute path
- *   {{REPO_LIST}} — bullet list of registered repos for fleet awareness
- *
- * In dev the file resolves via `import.meta.url` to `src/lib/lane/orchestrator.md`.
- * In the Tauri-bundled prod build the md file is copied to `out/server/orchestrator.md`
- * by `scripts/tauri-export.mjs` so the same resolution strategy works.
- */
-const PROMPT_FILE_NAME = 'orchestrator.md';
-const FALLBACK_PROMPT = [
-  'You are the orchestrator for o8. The markdown prompt file could not be loaded.',
-  'Primary repo: "{{REPO_NAME}}" at {{REPO_PATH}}.',
-  'Work carefully, use cortex_* MCP tools for fleet awareness, and always end your',
-  'review turns with a VERDICT block so the user has an actionable summary.',
-].join('\n');
-
-function resolvePromptFilePath(): string {
-  const here = dirname(fileURLToPath(import.meta.url));
-  return join(here, PROMPT_FILE_NAME);
-}
-
-function buildOrchestratorSystemPrompt(repoPath: string): string {
-  const repoName = repoPath.split('/').filter(Boolean).pop() ?? repoPath;
-
-  // Load all registered repos for fleet awareness
-  let allRepos: Array<{ name: string; localPath: string }> = [];
-  try {
-    const reposFile = join(homedir(), '.o8', 'repos.json');
-    if (existsSync(reposFile)) {
-      const parsed = JSON.parse(readFileSync(reposFile, 'utf-8'));
-      allRepos = (parsed.repos ?? []).map((r: { name?: string; localPath: string }) => ({
-        name: r.name ?? r.localPath.split('/').filter(Boolean).pop() ?? r.localPath,
-        localPath: r.localPath,
-      }));
-    }
-  } catch { /* best effort */ }
-
-  const repoList = allRepos.length > 0
-    ? allRepos.map((r) => `  - ${r.name} → ${r.localPath}`).join('\n')
-    : `  - ${repoName} → ${repoPath}`;
-
-  let template: string;
-  try {
-    template = readFileSync(resolvePromptFilePath(), 'utf-8');
-  } catch (err) {
-    console.warn(
-      `[orchestrator-session] Failed to load ${PROMPT_FILE_NAME}: ${(err as Error).message}. Using minimal fallback prompt.`,
-    );
-    template = FALLBACK_PROMPT;
-  }
-
-  return template
-    .replaceAll('{{REPO_NAME}}', repoName)
-    .replaceAll('{{REPO_PATH}}', repoPath)
-    .replaceAll('{{REPO_LIST}}', repoList);
 }
 
 // ── Registry ──

--- a/src/lib/lane/orchestrator-system-prompt.ts
+++ b/src/lib/lane/orchestrator-system-prompt.ts
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Shared o8 orchestrator system prompt assembly.
+ *
+ * Claude can receive this through `--append-system-prompt`; Codex cannot, so
+ * the Codex backend prepends this same assembled prompt to each user turn.
+ */
+
+const PROMPT_FILE_NAME = 'orchestrator.md';
+const FALLBACK_PROMPT = [
+  'You are the orchestrator for o8. The markdown prompt file could not be loaded.',
+  'Primary repo: "{{REPO_NAME}}" at {{REPO_PATH}}.',
+  'Work carefully, use cortex_* MCP tools for fleet awareness, and always end your',
+  'review turns with a VERDICT block so the user has an actionable summary.',
+].join('\n');
+
+function resolvePromptFilePath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, PROMPT_FILE_NAME);
+}
+
+export function buildOrchestratorSystemPrompt(repoPath: string): string {
+  const repoName = repoPath.split('/').filter(Boolean).pop() ?? repoPath;
+
+  let allRepos: Array<{ name: string; localPath: string }> = [];
+  try {
+    const reposFile = join(homedir(), '.o8', 'repos.json');
+    if (existsSync(reposFile)) {
+      const parsed = JSON.parse(readFileSync(reposFile, 'utf-8'));
+      allRepos = (parsed.repos ?? []).map((r: { name?: string; localPath: string }) => ({
+        name: r.name ?? r.localPath.split('/').filter(Boolean).pop() ?? r.localPath,
+        localPath: r.localPath,
+      }));
+    }
+  } catch {
+    // Best effort; a missing/corrupt repo registry should not break a turn.
+  }
+
+  const repoList = allRepos.length > 0
+    ? allRepos.map((r) => `  - ${r.name} → ${r.localPath}`).join('\n')
+    : `  - ${repoName} → ${repoPath}`;
+
+  let template: string;
+  try {
+    template = readFileSync(resolvePromptFilePath(), 'utf-8');
+  } catch (err) {
+    console.warn(
+      `[orchestrator-session] Failed to load ${PROMPT_FILE_NAME}: ${(err as Error).message}. Using minimal fallback prompt.`,
+    );
+    template = FALLBACK_PROMPT;
+  }
+
+  return template
+    .replaceAll('{{REPO_NAME}}', repoName)
+    .replaceAll('{{REPO_PATH}}', repoPath)
+    .replaceAll('{{REPO_LIST}}', repoList);
+}


### PR DESCRIPTION
Codex orchestrator teaches Brain-first discipline (shared BRAIN_PROMPT_SECTION, extracted orchestrator-system-prompt.ts) and prewarms the Brain at every turn start, mirroring the fable backend.

Codex worker (wave 1, ~10 min build). Work preserved by o8 archival after a reaper false-positive; orchestrator-reviewed raw and verified (tsc clean, focused suites green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xr8Bd6vaFFPiemavF2QoW