### PR TITLE
fix(review): codex auto-review verdicts create real approval cards (#1045)

### DIFF
--- a/src/lib/approvals/orchestrator-review.ts
+++ b/src/lib/approvals/orchestrator-review.ts
@@ -11,6 +11,10 @@ export interface OrchestratorReviewRecordInput {
   reviewer?: string;
   approved: boolean;
   diffSha?: string;
+  reviewedHeadSha?: string;
+  requiresSecondPass?: boolean;
+  rawText?: string;
+  parseWarning?: string;
 }
 
 function trimOptional(value?: string) {
@@ -40,20 +44,20 @@ function buildOrchestratorReviewNote(review: OrchestratorReviewRecordInput) {
     ? 'no findings'
     : `${findingCount} finding${findingCount === 1 ? '' : 's'}`;
   const diffSummary = review.diffSha ? ` Diff ${review.diffSha}.` : '';
-  return `${reviewer} ${verdict} with ${findingsSummary}.${diffSummary}`;
+  const parseSummary = review.parseWarning ? ` Parser warning: ${review.parseWarning}.` : '';
+  return `${reviewer} ${verdict} with ${findingsSummary}.${diffSummary}${parseSummary}`;
 }
 
-export function normalizeOrchestratorReview(review: {
-  findings: OrchestratorReviewFinding[];
-  reviewer?: string;
-  approved: boolean;
-  diffSha?: string;
-}): OrchestratorReviewRecordInput {
+export function normalizeOrchestratorReview(review: OrchestratorReviewRecordInput): OrchestratorReviewRecordInput {
   return {
     findings: review.findings.map(normalizeReviewFinding),
     reviewer: trimOptional(review.reviewer),
     approved: review.approved,
     diffSha: trimOptional(review.diffSha),
+    reviewedHeadSha: trimOptional(review.reviewedHeadSha),
+    requiresSecondPass: review.requiresSecondPass === true,
+    rawText: trimOptional(review.rawText),
+    parseWarning: trimOptional(review.parseWarning),
   };
 }
 
@@ -90,6 +94,9 @@ export function buildOrchestratorReviewEvent(review: OrchestratorReviewRecordInp
     reviewer: review.reviewer,
     approved: review.approved,
     diffSha: review.diffSha,
+    reviewedHeadSha: review.reviewedHeadSha,
+    parseWarning: review.parseWarning,
+    rawText: review.rawText,
   };
 }
 
@@ -111,6 +118,16 @@ export function buildOrchestratorReviewApprovalInput(
       ? `Orchestrator review: ${lane.branch} → ${lane.baseBranch}`
       : `Orchestrator review: ${packetId}`,
     toolName: 'orchestrator_review',
+    args: {
+      packetId,
+      approved: review.approved,
+      findings: review.findings,
+      ...(review.reviewedHeadSha ? { reviewedHeadSha: review.reviewedHeadSha } : {}),
+      requiresSecondPass: review.requiresSecondPass === true,
+      secondPassAgreed: false,
+      ...(review.parseWarning ? { parseWarning: review.parseWarning } : {}),
+      ...(review.rawText ? { rawText: review.rawText } : {}),
+    },
     risk: deriveOrchestratorReviewRisk(review),
     metadata: {
       Packet: packetId,
@@ -122,6 +139,8 @@ export function buildOrchestratorReviewApprovalInput(
       } : {}),
       ...(review.reviewer ? { Reviewer: review.reviewer } : {}),
       ...(review.diffSha ? { 'Diff SHA': review.diffSha } : {}),
+      ...(review.reviewedHeadSha ? { 'Reviewed HEAD': review.reviewedHeadSha } : {}),
+      ...(review.parseWarning ? { 'Parse Warning': review.parseWarning } : {}),
     },
   };
 }

--- a/src/lib/approvals/store.ts
+++ b/src/lib/approvals/store.ts
@@ -12,6 +12,7 @@ import {
   buildOrchestratorReviewEvent,
   deriveOrchestratorReviewRisk,
   normalizeOrchestratorReview,
+  type OrchestratorReviewRecordInput,
 } from '@/lib/approvals/orchestrator-review';
 import { approvals as approvalsTable, approvalEvents as approvalEventsTable, getDb, getSqlite } from '@/lib/db';
 import type { EventSeverity } from '@/lib/fleet/types';
@@ -24,7 +25,6 @@ import type {
   ApprovalRisk,
   CreateApprovalInput,
   MobileApprovalCard,
-  OrchestratorReviewFinding,
 } from '@/lib/approvals/types';
 
 type ApprovalRow = typeof approvalsTable.$inferSelect;
@@ -597,12 +597,7 @@ export function resolveApproval(id: string, action: 'approve' | 'reject', actor:
 
 export function recordOrchestratorReview(
   packetId: string,
-  review: {
-    findings: OrchestratorReviewFinding[];
-    reviewer?: string;
-    approved: boolean;
-    diffSha?: string;
-  },
+  review: OrchestratorReviewRecordInput,
 ): ApprovalAuditEvent {
   const normalizedPacketId = packetId.trim();
   const normalizedReview = normalizeOrchestratorReview(review);
@@ -642,6 +637,19 @@ export function recordOrchestratorReview(
       } : {}),
       ...(normalizedReview.reviewer ? { Reviewer: normalizedReview.reviewer } : {}),
       ...(normalizedReview.diffSha ? { 'Diff SHA': normalizedReview.diffSha } : {}),
+      ...(normalizedReview.reviewedHeadSha ? { 'Reviewed HEAD': normalizedReview.reviewedHeadSha } : {}),
+      ...(normalizedReview.parseWarning ? { 'Parse Warning': normalizedReview.parseWarning } : {}),
+    },
+    args: {
+      ...approval.args,
+      packetId: normalizedPacketId,
+      approved: normalizedReview.approved,
+      findings: normalizedReview.findings,
+      ...(normalizedReview.reviewedHeadSha ? { reviewedHeadSha: normalizedReview.reviewedHeadSha } : {}),
+      requiresSecondPass: normalizedReview.requiresSecondPass === true,
+      secondPassAgreed: approval.args?.secondPassAgreed === true ? true : false,
+      ...(normalizedReview.parseWarning ? { parseWarning: normalizedReview.parseWarning } : {}),
+      ...(normalizedReview.rawText ? { rawText: normalizedReview.rawText } : {}),
     },
     audit: [...approval.audit, reviewEvent],
   };
@@ -672,6 +680,7 @@ export function recordOrchestratorReview(
   } else {
     updateApprovalRecord(nextApproval);
   }
+  insertApprovalEvent(nextApproval.id, reviewEvent);
 
   return reviewEvent;
 }

--- a/src/lib/approvals/types.ts
+++ b/src/lib/approvals/types.ts
@@ -76,6 +76,9 @@ export interface ApprovalAuditEvent {
   reviewer?: string;
   approved?: boolean;
   diffSha?: string;
+  reviewedHeadSha?: string;
+  parseWarning?: string;
+  rawText?: string;
   patterns?: string[];
   conflictZones?: string[];
 }

--- a/src/lib/lane/auto-review.ts
+++ b/src/lib/lane/auto-review.ts
@@ -19,6 +19,7 @@ import { extractAddedLines, getLaneDiffFacts, parseDiffStat } from './lane-diff-
 import { buildAdversarialReviewProtocol, classifyReviewRisk } from './review-risk';
 import { resolveLaneReviewScreenshotReference, type LaneReviewScreenshotReference } from './review-screenshot';
 import { buildBlindSecondPassPrompt, findPendingSecondPassApproval, parseSecondPassVerdict } from './blind-second-pass-review';
+import { appendCodexAutoReviewVerdictInstructions, recordCodexAutoReviewVerdict } from './codex-auto-review-verdict';
 import type { Lane } from './types';
 
 const MAX_REVIEW_ATTEMPTS = 5;
@@ -522,6 +523,7 @@ async function performAutoReview(review: QueuedReview): Promise<void> {
   const mechanicalChecks = runMechanicalChecks(lane);
   const mergeGateResult = runMergeGate(lane, completionContext?.selfReview);
   const diffSummary = getDiffSummary(lane, depth);
+  const reviewRisk = classifyReviewRisk(diffSummary.changedFiles, diffSummary.addedLines);
   let reviewScreenshot: LaneReviewScreenshotReference | null = null;
   if (lane.runtime === 'codex') {
     try {
@@ -533,7 +535,7 @@ async function performAutoReview(review: QueuedReview): Promise<void> {
       console.warn(`[auto-review] Failed to prepare review screenshot for lane ${lane.id}:`, error);
     }
   }
-  const reviewPrompt = buildReviewPrompt(
+  let reviewPrompt = buildReviewPrompt(
     lane,
     diffSummary.summary,
     diffSummary.changedFiles,
@@ -559,6 +561,9 @@ async function performAutoReview(review: QueuedReview): Promise<void> {
   // is byte-identical to the prior dual-path branch — see registry.ts.
   const { getActiveOrchestratorBackend } = await import('./orchestrator-backends/registry');
   const backend = getActiveOrchestratorBackend();
+  if (backend.id === 'codex') {
+    reviewPrompt = appendCodexAutoReviewVerdictInstructions(reviewPrompt);
+  }
 
   console.log(`[auto-review] Routing lane ${lane.id} via ${backend.label} orchestrator`);
 
@@ -572,8 +577,10 @@ async function performAutoReview(review: QueuedReview): Promise<void> {
 
   console.log(`[auto-review] Sending review prompt to ${backend.label} orchestrator for lane ${lane.id}`);
 
+  let codexReviewText = '';
   await backend.sendTurn(lane.repoPath, reviewPrompt, (event) => {
     if (event.type === 'text') {
+      if (backend.id === 'codex') codexReviewText += event.text;
       console.log(`[auto-review] ${backend.label}: ${event.text.slice(0, 100)}`);
     } else if (event.type === 'tool_use') {
       console.log(`[auto-review] ${backend.label} called tool: ${event.name}`);
@@ -582,7 +589,17 @@ async function performAutoReview(review: QueuedReview): Promise<void> {
     }
   });
 
-  const reviewRisk = classifyReviewRisk(diffSummary.changedFiles, diffSummary.addedLines);
+  if (backend.id === 'codex') {
+    const recorded = await recordCodexAutoReviewVerdict({
+      lane,
+      rawText: codexReviewText,
+      requiresSecondPass: reviewRisk.tier === 'high',
+    });
+    if (recorded?.verdict.parseWarning) {
+      console.warn(`[auto-review] Codex verdict for lane ${lane.id} needed parser fallback: ${recorded.verdict.parseWarning}`);
+    }
+  }
+
   if (reviewRisk.tier !== 'high') {
     console.log(`[auto-review] Review complete for lane ${lane.id}`);
     return;

--- a/src/lib/lane/codex-auto-review-verdict.test.ts
+++ b/src/lib/lane/codex-auto-review-verdict.test.ts
@@ -1,0 +1,103 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { listApprovalEvents, listApprovalsForContext } from '@/lib/approvals/store';
+import { createLane } from '@/lib/lane/registry';
+import { parseCodexAutoReviewVerdict, recordCodexAutoReviewVerdict } from './codex-auto-review-verdict';
+
+function createGitRepo() {
+  const repoPath = mkdtempSync(join(tmpdir(), 'o8-codex-review-'));
+  execFileSync('git', ['init', '-b', 'main'], { cwd: repoPath });
+  writeFileSync(join(repoPath, 'README.md'), '# codex review test\n');
+  execFileSync('git', ['add', 'README.md'], { cwd: repoPath });
+  execFileSync('git', [
+    '-c',
+    'user.name=o8 test',
+    '-c',
+    'user.email=o8-test@example.com',
+    'commit',
+    '-m',
+    'init',
+  ], { cwd: repoPath });
+  const head = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repoPath, encoding: 'utf8' }).trim();
+  return { repoPath, head };
+}
+
+describe('Codex auto-review verdict fallback', () => {
+  it('records a Codex verdict as a real orchestrator_review approval row', async () => {
+    const { repoPath, head } = createGitRepo();
+    const packetId = `pkt-codex-review-${Date.now()}`;
+    const lane = createLane({
+      repoPath,
+      worktreePath: repoPath,
+      branch: 'inline/codex-review-test',
+      baseBranch: 'main',
+      runtime: 'codex',
+      label: 'Codex review test',
+      packetId,
+      sessionKey: `codex:${packetId}`,
+    });
+
+    const recorded = await recordCodexAutoReviewVerdict({
+      lane,
+      requiresSecondPass: false,
+      rawText: [
+        'Review complete.',
+        'CODEX_AUTO_REVIEW: {"approved":true,"findings":[]}',
+      ].join('\n'),
+    });
+
+    expect(recorded?.event.type).toBe('orchestrator_review');
+
+    const approval = listApprovalsForContext({
+      packetId,
+      laneId: lane.id,
+      sessionKey: lane.sessionKey ?? undefined,
+      projectId: null,
+    }).find((candidate) => candidate.toolName === 'orchestrator_review');
+
+    expect(approval).toBeTruthy();
+    expect(approval?.status).toBe('approved');
+    expect(approval?.risk).toBe('low');
+    expect(approval?.metadata).toMatchObject({
+      Packet: packetId,
+      Lane: lane.id,
+      Runtime: 'codex',
+      'Reviewed HEAD': head,
+      Reviewer: 'codex',
+    });
+    expect(approval?.args).toMatchObject({
+      packetId,
+      approved: true,
+      findings: [],
+      reviewedHeadSha: head,
+      requiresSecondPass: false,
+      secondPassAgreed: false,
+    });
+
+    const events = approval ? listApprovalEvents(approval.id) : [];
+    expect(events.some((event) => (
+      event.type === 'orchestrator_review'
+      && event.actor === 'orchestrator'
+      && event.approved === true
+      && event.reviewer === 'codex'
+      && event.reviewedHeadSha === head
+    ))).toBe(true);
+  });
+
+  it('keeps unstructured Codex verdict text for operator attention', () => {
+    const verdict = parseCodexAutoReviewVerdict('Looks fine to me, approve.');
+
+    expect(verdict.approved).toBe(false);
+    expect(verdict.parseWarning).toBe('missing CODEX_AUTO_REVIEW JSON payload');
+    expect(verdict.findings[0]).toMatchObject({
+      file: 'codex-auto-review',
+      severity: 'rule_violation',
+      resolution: 'deferred',
+    });
+    expect(verdict.findings[0]?.description).toContain('Looks fine to me');
+  });
+});

--- a/src/lib/lane/codex-auto-review-verdict.ts
+++ b/src/lib/lane/codex-auto-review-verdict.ts
@@ -1,0 +1,209 @@
+import type { ApprovalAuditEvent, OrchestratorReviewFinding } from '@/lib/approvals/types';
+import { parseReviewFindings } from '@/lib/orchestrator/review-finding-input';
+import type { Lane } from './types';
+
+const CODEX_AUTO_REVIEW_MARKER = 'CODEX_AUTO_REVIEW:';
+const RAW_TEXT_LIMIT = 2000;
+
+export interface ParsedCodexAutoReviewVerdict {
+  approved: boolean;
+  findings: OrchestratorReviewFinding[];
+  rawText: string;
+  parseWarning?: string;
+}
+
+export interface RecordedCodexAutoReviewVerdict {
+  event: ApprovalAuditEvent;
+  verdict: ParsedCodexAutoReviewVerdict;
+  reviewedHeadSha?: string;
+}
+
+function trimOptional(value: unknown): string | undefined {
+  return typeof value === 'string' ? value.trim() || undefined : undefined;
+}
+
+function truncateRawText(value: string): string {
+  const normalized = value.trim();
+  if (normalized.length <= RAW_TEXT_LIMIT) return normalized;
+  return `${normalized.slice(0, RAW_TEXT_LIMIT - 3)}...`;
+}
+
+function fallbackFinding(description: string): OrchestratorReviewFinding {
+  return {
+    file: 'codex-auto-review',
+    severity: 'rule_violation',
+    description: truncateRawText(description) || 'Codex auto-review returned no verdict text.',
+    resolution: 'deferred',
+  };
+}
+
+function takeBalancedJsonObject(input: string): string | null {
+  const start = input.indexOf('{');
+  if (start < 0) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = start; index < input.length; index += 1) {
+    const char = input[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+    } else if (char === '{') {
+      depth += 1;
+    } else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return input.slice(start, index + 1);
+    }
+  }
+
+  return null;
+}
+
+function extractJsonPayload(rawText: string): Record<string, unknown> | null {
+  const markerIndex = rawText.lastIndexOf(CODEX_AUTO_REVIEW_MARKER);
+  if (markerIndex >= 0) {
+    const markedJson = takeBalancedJsonObject(rawText.slice(markerIndex + CODEX_AUTO_REVIEW_MARKER.length));
+    if (markedJson) {
+      try {
+        return JSON.parse(markedJson) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    }
+  }
+
+  const fencedBlocks = Array.from(rawText.matchAll(/```(?:json)?\s*([\s\S]*?)```/gi)).reverse();
+  for (const block of fencedBlocks) {
+    const body = block[1]?.trim() ?? '';
+    if (!/"?(approved|verdict|findings)"?\s*:/i.test(body)) continue;
+    const json = takeBalancedJsonObject(body);
+    if (!json) continue;
+    try {
+      return JSON.parse(json) as Record<string, unknown>;
+    } catch {
+      // Try the next fenced block.
+    }
+  }
+
+  return null;
+}
+
+function readApproved(payload: Record<string, unknown>): boolean | null {
+  if (typeof payload.approved === 'boolean') return payload.approved;
+  const verdict = trimOptional(payload.verdict)?.toLowerCase().replace(/[\s-]+/g, '_');
+  if (!verdict) return null;
+  if (/^(approve|approved|pass|passed)$/.test(verdict)) return true;
+  if (/^(reject|rejected|request_changes|changes_requested|fail|failed)$/.test(verdict)) return false;
+  return null;
+}
+
+function parsePayloadFindings(payload: Record<string, unknown>): OrchestratorReviewFinding[] {
+  const findings = Array.isArray(payload.findings) ? payload.findings : [];
+  return parseReviewFindings(findings);
+}
+
+export function appendCodexAutoReviewVerdictInstructions(prompt: string): string {
+  return [
+    prompt,
+    '',
+    '## Codex auto-review fallback',
+    '',
+    'If submit_review is unavailable in this runtime, still complete the review and end with one final machine-readable line:',
+    `${CODEX_AUTO_REVIEW_MARKER} {"approved":true,"findings":[]}`,
+    'For requested changes, set approved to false and include findings with file, line when known, severity (bug|rule_violation|note), description, and status (fixed|accepted|deferred).',
+    'Do not put any text after the CODEX_AUTO_REVIEW line.',
+  ].join('\n');
+}
+
+export function parseCodexAutoReviewVerdict(rawText: string): ParsedCodexAutoReviewVerdict {
+  const raw = truncateRawText(rawText);
+  const payload = extractJsonPayload(rawText);
+  if (!payload) {
+    return {
+      approved: false,
+      findings: [fallbackFinding(`Codex auto-review verdict was not structured. Raw verdict: ${raw}`)],
+      rawText: raw,
+      parseWarning: 'missing CODEX_AUTO_REVIEW JSON payload',
+    };
+  }
+
+  const approved = readApproved(payload);
+  if (approved === null) {
+    return {
+      approved: false,
+      findings: [fallbackFinding(`Codex auto-review JSON did not include a valid approved/verdict value. Raw verdict: ${raw}`)],
+      rawText: raw,
+      parseWarning: 'invalid approved/verdict value',
+    };
+  }
+
+  try {
+    const findings = parsePayloadFindings(payload);
+    if (!approved && findings.length === 0) {
+      return {
+        approved: false,
+        findings: [fallbackFinding(`Codex requested changes without structured findings. Raw verdict: ${raw}`)],
+        rawText: raw,
+        parseWarning: 'rejected verdict had no structured findings',
+      };
+    }
+    return { approved, findings, rawText: raw };
+  } catch (error) {
+    return {
+      approved: false,
+      findings: [fallbackFinding(`Codex auto-review findings were invalid: ${error instanceof Error ? error.message : String(error)}. Raw verdict: ${raw}`)],
+      rawText: raw,
+      parseWarning: 'invalid structured findings',
+    };
+  }
+}
+
+async function captureReviewedHeadSha(lane: Lane): Promise<string | undefined> {
+  const cwd = lane.worktreePath || lane.repoPath;
+  if (!cwd) return undefined;
+  try {
+    const { normalizeHeadSha, readHeadSha } = await import('@/lib/lane/head-sha-lock');
+    return normalizeHeadSha(await readHeadSha(cwd));
+  } catch (error) {
+    console.warn(`[auto-review] Failed to capture reviewed HEAD for Codex verdict on lane ${lane.id}:`, error);
+    return undefined;
+  }
+}
+
+export async function recordCodexAutoReviewVerdict(input: {
+  lane: Lane;
+  rawText: string;
+  requiresSecondPass: boolean;
+}): Promise<RecordedCodexAutoReviewVerdict | null> {
+  if (!input.lane.packetId) {
+    console.warn(`[auto-review] Codex verdict for lane ${input.lane.id} had no packet id; skipping approval record`);
+    return null;
+  }
+
+  const verdict = parseCodexAutoReviewVerdict(input.rawText);
+  const reviewedHeadSha = await captureReviewedHeadSha(input.lane);
+  const { recordOrchestratorReview } = await import('@/lib/approvals/store');
+  const event = recordOrchestratorReview(input.lane.packetId, {
+    findings: verdict.findings,
+    reviewer: 'codex',
+    approved: verdict.approved,
+    reviewedHeadSha,
+    requiresSecondPass: verdict.approved && input.requiresSecondPass,
+    rawText: verdict.parseWarning ? verdict.rawText : undefined,
+    parseWarning: verdict.parseWarning,
+  });
+
+  return { event, verdict, reviewedHeadSha };
+}


### PR DESCRIPTION
Codex auto-review verdicts now land in the approvals store with the same shape/audit trail as Claude-path reviews; tolerant parse fallback records raw verdict text instead of dropping it. 103-line real-path test.

Codex worker (wave 1, ~10 min build). Work preserved by o8 archival after a reaper false-positive; orchestrator-reviewed raw and verified (tsc clean, focused suites green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xr8Bd6vaFFPiemavF2QoW