### PR TITLE
feat(canvas): quick-docs rows show the resolved absolute path

### DIFF
--- a/src/components/desktop/o8-panel/workspace-rail/QuickDocs.tsx
+++ b/src/components/desktop/o8-panel/workspace-rail/QuickDocs.tsx
@@ -28,6 +28,12 @@ function ChevronIcon({ size = 13 }: { size?: number }) {
   );
 }
 
+function displayPathForEntry(entryPath: string, repoPath?: string | null) {
+  if (entryPath.startsWith('/')) return entryPath;
+  if (!repoPath?.startsWith('/')) return entryPath;
+  return `${repoPath.replace(/\/$/, '')}/${entryPath.replace(/^\//, '')}`;
+}
+
 export function QuickDocs({
   repoPath,
   selectedFile,
@@ -81,11 +87,13 @@ export function QuickDocs({
           </div>
           {group.entries.map((entry) => {
             const selected = selectedFile === entry.path;
+            const displayPath = displayPathForEntry(entry.path, repoPath);
             return (
               <button
                 key={entry.path}
                 type="button"
                 onClick={() => onSelectFile(entry.path)}
+                title={displayPath}
                 style={{
                   minHeight: 44,
                   width: '100%',
@@ -113,6 +121,9 @@ export function QuickDocs({
                   </span>
                   <span style={{ color: 'var(--t-text-faint)', fontFamily: MONO_FONT, fontSize: 10, fontWeight: 500, letterSpacing: 0, lineHeight: 1.15, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                     {entry.value}
+                  </span>
+                  <span style={{ color: 'var(--t-text-secondary)', fontFamily: MONO_FONT, fontSize: 9, fontWeight: 450, letterSpacing: 0, lineHeight: 1.1, opacity: 0.74, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {displayPath}
                   </span>
                 </span>
                 <ChevronIcon />


### PR DESCRIPTION
Each Quick Docs row now shows the resolved absolute path (dimmed secondary line + hover title) so the operator sees exactly which file a click opens. Presentation-only — no allowlist/API/resolution change. Inline styles, theme tokens, 44px target preserved.

Acceptance test for the pipeline root-fix release (v0.1.521): first dispatch through the fixed pipeline — completed and HELD at reviewing instead of being buried. Codex worker ~4 min, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xr8Bd6vaFFPiemavF2QoW