### PR TITLE
fix(dispatch): gate worker launch on backend readiness (no cold-start doomed launches)

### DIFF
--- a/src/app/api/setup/status/route.ts
+++ b/src/app/api/setup/status/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  return NextResponse.json(
+    {
+      ok: true,
+      ready: true,
+      service: 'o8',
+    },
+    { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+  );
+}

--- a/src/lib/runtimes/shared/dispatch-readiness.test.ts
+++ b/src/lib/runtimes/shared/dispatch-readiness.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  isDispatchBackendReady,
+  waitForDispatchBackendReady,
+  type DispatchBackendReadiness,
+} from './dispatch-readiness';
+
+describe('dispatch backend readiness', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reports ready when the setup status probe returns 200', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await isDispatchBackendReady();
+
+    expect(result.ready).toBe(true);
+    expect(result.reason).toBe('http_200');
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/setup\/status$/),
+      expect.objectContaining({ cache: 'no-store' }),
+    );
+  });
+
+  it('reports not ready for non-200 and timeout probe results', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('{}', { status: 500 }))
+      .mockRejectedValueOnce(Object.assign(new Error('signal timed out'), { name: 'TimeoutError' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(isDispatchBackendReady()).resolves.toMatchObject({
+      ready: false,
+      reason: 'http_500',
+      status: 500,
+    });
+    await expect(isDispatchBackendReady()).resolves.toMatchObject({
+      ready: false,
+      reason: 'timeout',
+    });
+  });
+
+  it('retries cold probes until the backend becomes ready', async () => {
+    let now = 0;
+    const sleeps: number[] = [];
+    const checks: DispatchBackendReadiness[] = [
+      coldCheck('http_500'),
+      coldCheck('timeout'),
+      { ...coldCheck('http_200'), ready: true, status: 200 },
+    ];
+
+    const result = await waitForDispatchBackendReady({
+      maxWaitMs: 50,
+      stepMs: 10,
+      check: async () => checks.shift() ?? coldCheck('unexpected'),
+      sleep: async (ms) => {
+        sleeps.push(ms);
+        now += ms;
+      },
+      now: () => now,
+    });
+
+    expect(result).toMatchObject({
+      ready: true,
+      waitedMs: 20,
+      attempts: 3,
+      reason: 'http_200',
+    });
+    expect(sleeps).toEqual([10, 10]);
+  });
+});
+
+function coldCheck(reason: string): DispatchBackendReadiness {
+  return {
+    ready: false,
+    reason,
+    apiBase: 'http://o8.test',
+    portSource: 'default',
+    apiPortFilePresent: false,
+  };
+}

--- a/src/lib/runtimes/shared/dispatch-readiness.ts
+++ b/src/lib/runtimes/shared/dispatch-readiness.ts
@@ -1,0 +1,158 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { getApiBase, resolvePortInfo } from '@/lib/panel/api-port';
+
+const DEFAULT_PROBE_TIMEOUT_MS = 1_500;
+const DEFAULT_MAX_WAIT_MS = 20_000;
+const DEFAULT_STEP_MS = 2_000;
+const READINESS_PATH = '/api/setup/status';
+
+export interface DispatchBackendReadiness {
+  ready: boolean;
+  reason: string;
+  apiBase: string;
+  status?: number;
+  portSource: 'env' | 'file' | 'default';
+  apiPortFilePresent: boolean;
+}
+
+export interface DispatchBackendWaitResult {
+  ready: boolean;
+  reason: string;
+  waitedMs: number;
+  attempts: number;
+  lastCheck: DispatchBackendReadiness;
+}
+
+interface WaitForDispatchBackendReadyOptions {
+  maxWaitMs?: number;
+  stepMs?: number;
+  probeTimeoutMs?: number;
+  check?: () => Promise<DispatchBackendReadiness>;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+}
+
+function dataDir(): string {
+  return process.env.CORTEX_IDE_DATA_DIR || join(process.env.HOME || '', '.o8');
+}
+
+function apiPortFilePresent(): boolean {
+  return existsSync(join(dataDir(), 'api-port'));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function readinessUrl(apiBase: string): string {
+  return new URL(READINESS_PATH, apiBase).toString();
+}
+
+export async function isDispatchBackendReady(
+  timeoutMs = DEFAULT_PROBE_TIMEOUT_MS,
+): Promise<DispatchBackendReadiness> {
+  const portInfo = resolvePortInfo();
+  const apiBase = getApiBase();
+  const base = {
+    apiBase,
+    portSource: portInfo.source,
+    apiPortFilePresent: apiPortFilePresent(),
+  };
+
+  try {
+    const response = await fetch(readinessUrl(apiBase), {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (response.ok) {
+      return { ...base, ready: true, reason: 'http_200', status: response.status };
+    }
+    return {
+      ...base,
+      ready: false,
+      reason: `http_${response.status}`,
+      status: response.status,
+    };
+  } catch (error) {
+    const name = error instanceof Error ? error.name : '';
+    const reason = name === 'TimeoutError' || name === 'AbortError'
+      ? 'timeout'
+      : 'fetch_failed';
+    return { ...base, ready: false, reason };
+  }
+}
+
+export async function waitForDispatchBackendReady(
+  options: WaitForDispatchBackendReadyOptions = {},
+): Promise<DispatchBackendWaitResult> {
+  const maxWaitMs = options.maxWaitMs ?? DEFAULT_MAX_WAIT_MS;
+  const stepMs = options.stepMs ?? DEFAULT_STEP_MS;
+  const probeTimeoutMs = options.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+  const check = options.check ?? (() => isDispatchBackendReady(probeTimeoutMs));
+  const wait = options.sleep ?? sleep;
+  const now = options.now ?? Date.now;
+  const startedAt = now();
+  let attempts = 0;
+  let lastCheck = await check();
+  attempts += 1;
+
+  while (!lastCheck.ready) {
+    const elapsedMs = Math.max(0, now() - startedAt);
+    if (elapsedMs >= maxWaitMs) {
+      return {
+        ready: false,
+        reason: lastCheck.reason,
+        waitedMs: elapsedMs,
+        attempts,
+        lastCheck,
+      };
+    }
+
+    await wait(Math.min(stepMs, maxWaitMs - elapsedMs));
+    lastCheck = await check();
+    attempts += 1;
+  }
+
+  return {
+    ready: true,
+    reason: lastCheck.reason,
+    waitedMs: Math.max(0, now() - startedAt),
+    attempts,
+    lastCheck,
+  };
+}
+
+export async function ensureDispatchBackendReady(
+  runtimeId: string,
+  mode: string,
+): Promise<DispatchBackendWaitResult> {
+  const readiness = await waitForDispatchBackendReady();
+  if (!readiness.ready) {
+    throw new DispatchBackendNotReadyError(readiness);
+  }
+  if (readiness.waitedMs > 0 || readiness.attempts > 1) {
+    console.log(
+      `[dispatch] waited ${readiness.waitedMs}ms for backend readiness before ${runtimeId} ${mode} (${readiness.reason})`,
+    );
+  }
+  return readiness;
+}
+
+export class DispatchBackendNotReadyError extends Error {
+  readonly code = 'dispatch_backend_not_ready';
+  readonly reason: string;
+  readonly waitedMs: number;
+  readonly attempts: number;
+
+  constructor(result: DispatchBackendWaitResult) {
+    super(
+      `Dispatch backend is still warming after ${result.waitedMs}ms (${result.reason}); retry the launch once the o8 server is ready.`,
+    );
+    this.name = 'DispatchBackendNotReadyError';
+    this.reason = result.reason;
+    this.waitedMs = result.waitedMs;
+    this.attempts = result.attempts;
+  }
+}

--- a/src/lib/runtimes/shared/owned-session/store.test.ts
+++ b/src/lib/runtimes/shared/owned-session/store.test.ts
@@ -1,0 +1,117 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { DispatchBackendWaitResult } from '@/lib/runtimes/shared/dispatch-readiness';
+import type { OwnedRuntimeAdapter, ParsedRunLog } from './types';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+const ensureDispatchBackendReadyMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
+
+vi.mock('@/lib/runtimes/shared/dispatch-readiness', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/runtimes/shared/dispatch-readiness')>();
+  return {
+    ...actual,
+    ensureDispatchBackendReady: ensureDispatchBackendReadyMock,
+  };
+});
+
+describe('createOwnedSessionStore launch readiness gate', () => {
+  let tempRoot: string;
+  let repoPath: string;
+  let priorRoot: string | undefined;
+  let priorBin: string | undefined;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(path.join(process.cwd(), '.tmp-owned-store-'));
+    repoPath = path.join(tempRoot, 'repo');
+    execFileSync('git', ['init', '-q', repoPath]);
+    priorRoot = process.env.O8_TEST_OWNED_ROOT;
+    priorBin = process.env.O8_TEST_BIN;
+    process.env.O8_TEST_OWNED_ROOT = path.join(tempRoot, 'sessions');
+    process.env.O8_TEST_BIN = process.execPath;
+    spawnMock.mockReturnValue({ pid: 42, unref: vi.fn() });
+    ensureDispatchBackendReadyMock.mockReset();
+  });
+
+  afterEach(() => {
+    spawnMock.mockReset();
+    if (priorRoot === undefined) delete process.env.O8_TEST_OWNED_ROOT;
+    else process.env.O8_TEST_OWNED_ROOT = priorRoot;
+    if (priorBin === undefined) delete process.env.O8_TEST_BIN;
+    else process.env.O8_TEST_BIN = priorBin;
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('does not spawn the worker until the readiness wait completes warm', async () => {
+    const { createOwnedSessionStore } = await import('./store');
+    let releaseReady: ((result: DispatchBackendWaitResult) => void) | undefined;
+    ensureDispatchBackendReadyMock.mockReturnValue(new Promise((resolve) => {
+      releaseReady = resolve;
+    }));
+
+    const store = createOwnedSessionStore(testAdapter());
+    const launched = store.launch({ cwd: repoPath, prompt: 'do work' });
+
+    await waitUntil(() => ensureDispatchBackendReadyMock.mock.calls.length === 1);
+    expect(spawnMock).not.toHaveBeenCalled();
+
+    releaseReady?.({
+      ready: true,
+      reason: 'http_200',
+      waitedMs: 4_000,
+      attempts: 3,
+      lastCheck: {
+        ready: true,
+        reason: 'http_200',
+        apiBase: 'http://o8.test',
+        status: 200,
+        portSource: 'file',
+        apiPortFilePresent: true,
+      },
+    });
+
+    await expect(launched).resolves.toMatchObject({ ok: true, runtime: 'test-runtime' });
+    expect(ensureDispatchBackendReadyMock).toHaveBeenCalledWith('test-runtime', 'launch');
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+function testAdapter(): OwnedRuntimeAdapter {
+  return {
+    runtimeId: 'test-runtime',
+    surfaceIdPrefix: 'test-owned:',
+    rootEnvVar: 'O8_TEST_OWNED_ROOT',
+    rootDefault: path.join(os.tmpdir(), 'o8-test-owned-store'),
+    binaryName: 'node',
+    binaryEnvOverride: 'O8_TEST_BIN',
+    humanLabel: 'Owned Test',
+    squadShortName: 'Test',
+    launchArgs: ({ prompt }) => ['-e', `console.log(${JSON.stringify(prompt)})`],
+    resumeArgs: ({ prompt }) => ['-e', `console.log(${JSON.stringify(prompt)})`],
+    parseRunLog: (): ParsedRunLog => ({
+      entries: [],
+      outcome: 'running',
+      completedTurn: false,
+    }),
+  };
+}
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  for (let i = 0; i < 100; i += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error('timed out waiting for predicate');
+}

--- a/src/lib/runtimes/shared/owned-session/store.ts
+++ b/src/lib/runtimes/shared/owned-session/store.ts
@@ -18,7 +18,6 @@ import { closeSync, openSync } from 'node:fs';
 import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
-
 import { CliNotFoundError, resolveCli } from '@/lib/runtimes/shared/cli-resolver';
 import { getRuntimeRepoReview } from '@/lib/git/runtime-review';
 import { chainOnKey } from '@/lib/util/keyed-promise-chain';
@@ -41,7 +40,6 @@ import type {
   RuntimeSurfaceSummary,
   SquadSummary,
 } from '@/lib/fleet/types';
-
 import {
   ACTIVE_WINDOW_MS,
   AUTO_RETRY_FRESHNESS_MS,
@@ -86,6 +84,7 @@ import type {
 import { stageMissingCliRun } from './missing-cli';
 import { crashSurvivableWorkersEnabled } from './crash-survival';
 import { getOrCreateLocalWorkerToken } from '@/lib/auth/worker-token';
+import { ensureDispatchBackendReady } from '@/lib/runtimes/shared/dispatch-readiness';
 
 export function createOwnedSessionStore(adapter: OwnedRuntimeAdapter): OwnedSessionStore {
   const runtimeId = adapter.runtimeId;
@@ -104,7 +103,6 @@ export function createOwnedSessionStore(adapter: OwnedRuntimeAdapter): OwnedSess
   let fleetCache: { value: OwnedFleetAdditions; cachedAt: number } | null = null;
   let fleetInflight: Promise<OwnedFleetAdditions> | null = null;
   let fleetGeneration = 0;
-
   function invalidateFleetCache() {
     fleetGeneration += 1;
     fleetCache = null;
@@ -582,6 +580,8 @@ export function createOwnedSessionStore(adapter: OwnedRuntimeAdapter): OwnedSess
       // + orchestrator MCP never carry it. (SECURITY_AUDIT_2026-07-02 §CRIT-1.)
       O8_WORKER_TOKEN: getOrCreateLocalWorkerToken(),
     };
+
+    await ensureDispatchBackendReady(runtimeId, mode);
 
     // #4 — crash-survivable workers (default ON since the 0.1.512 kill-test). When
     // enabled we skip the ws-server PTY bridge and spawn the worker detached


### PR DESCRIPTION
A codex worker dispatched ~30s after a server restart launched into not-yet-warm MCP endpoints, opened a thread+turn, then quit with zero work. The pipeline surfaced it correctly (awaiting_input, not buried), but the worker should never have launched cold.

ensureDispatchBackendReady() now gates the owned-session spawn: probes /api/setup/status (fast, side-effect-free) with a 1.5s timeout, retries with short backoff up to a cap, logs the wait, and raises a clear error only if still cold. Runtime-agnostic (all owned workers benefit), no hardcoded ports, no new deps. 4 tests.

Codex worker, orchestrator-reviewed raw + verified (tsc 0, tests green). Second surface through the now-fixed pipeline — completed and HELD at reviewing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xr8Bd6vaFFPiemavF2QoW