### PR TITLE
fix(dispatch): unify inline issue numbering through one collision-proof allocator

### DIFF
--- a/src/app/api/panel/targets/dispatch/route.ts
+++ b/src/app/api/panel/targets/dispatch/route.ts
@@ -7,6 +7,7 @@ import { getScores } from '@/lib/targeting/store';
 import { resolveTargetingRouting } from '@/lib/targeting/routing';
 import { logDispatchChoice } from '@/lib/targeting/observability';
 import { createMission, dispatchMission } from '@/lib/orchestrator/operator-mission-service';
+import { nextInlineIssueNumbers } from '@/lib/orchestrator/operator-mission-service/shared';
 
 /**
  * Point an agent at a targeted file. Resolves the file's dispatch routing (cheap
@@ -41,6 +42,7 @@ export async function POST(request: Request) {
   const routing = resolveTargetingRouting(score.signals);
 
   try {
+    const [issueNumber] = nextInlineIssueNumbers(1);
     const brief = [
       `Operator-directed target from the Targeting Machine (impact ${score.impact}/5, opportunity ${score.opportunity}/5).`,
       `Why here: ${score.rationale}`,
@@ -49,9 +51,7 @@ export async function POST(request: Request) {
     ].join('\n');
 
     const mission = await createMission({
-      // Inline issues require a positive synthetic number (normalizeLoadedIssue
-      // rejects 0); mirror the create_mission MCP convention (90001+).
-      issues: [{ number: 90001, title: `Targeting: ${filePath}`, body: brief, url: '' }],
+      issues: [{ number: issueNumber!, title: `Targeting: ${filePath}`, body: brief, url: '' }],
       repoPath,
       runtime: routing.runtime,
       requestedRuntime: routing.runtime,

--- a/src/lib/mcp/operator-handlers/mission-inline-issues.test.ts
+++ b/src/lib/mcp/operator-handlers/mission-inline-issues.test.ts
@@ -1,0 +1,74 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+process.env.CORTEX_IDE_DATA_DIR = mkdtempSync(join(os.tmpdir(), 'o8-mcp-inline-'));
+process.env.O8_DATA_DIR = process.env.CORTEX_IDE_DATA_DIR;
+
+function createTempRepo() {
+  const repoPath = mkdtempSync(join(os.tmpdir(), 'o8-mcp-inline-repo-'));
+  const git = (...args: string[]) => execFileSync('git', args, { cwd: repoPath, stdio: 'pipe' });
+  git('init', '--initial-branch=main');
+  git('-c', 'user.email=test@o8.test', '-c', 'user.name=o8-test', 'commit', '--allow-empty', '-m', 'init');
+  return repoPath;
+}
+
+function textContent(result: { content: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }> }) {
+  return result.content.find((entry) => entry.type === 'text')?.text ?? '';
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('handleCreateMission inline issue numbering', () => {
+  it('creates same-ms inline missions with non-colliding issue numbers', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-07-03T12:00:00.000Z').getTime());
+    const repoPath = createTempRepo();
+    const createBodies: Array<{ issues?: Array<{ number: number }> }> = [];
+
+    vi.stubGlobal('fetch', vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as { issues?: Array<{ number: number }> };
+      createBodies.push(body);
+
+      const { createMission } = await import('@/lib/orchestrator/operator-mission-service/mission');
+      const result = await createMission(body as Parameters<typeof createMission>[0]);
+      return new Response(JSON.stringify({ ok: true, result }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }));
+
+    const { handleCreateMission } = await import('./mission');
+
+    const first = await handleCreateMission({
+      issues_inline: [{ title: 'same millisecond task one', body: 'first body' }],
+      repoPath,
+      runtime: 'codex',
+      dispatch: false,
+    });
+    const second = await handleCreateMission({
+      issues_inline: [{ title: 'same millisecond task two', body: 'second body' }],
+      repoPath,
+      runtime: 'codex',
+      dispatch: false,
+    });
+
+    expect(first.isError).not.toBe(true);
+    expect(second.isError).not.toBe(true);
+    expect(textContent(first)).toContain('missionId');
+    expect(textContent(second)).toContain('missionId');
+    expect(createBodies).toHaveLength(2);
+
+    const numbers = createBodies.map((body) => body.issues?.[0]?.number);
+    expect(numbers.every((number): number is number => typeof number === 'number')).toBe(true);
+    expect(new Set(numbers).size).toBe(2);
+    for (const number of numbers) {
+      expect(Number.isSafeInteger(number)).toBe(true);
+      expect(number).toBeGreaterThanOrEqual(90001);
+    }
+  });
+});

--- a/src/lib/mcp/operator-handlers/mission.ts
+++ b/src/lib/mcp/operator-handlers/mission.ts
@@ -25,6 +25,7 @@ import {
 } from '@/lib/tasks/actions';
 import { getTaskPool, getTaskPoolTask } from '@/lib/tasks/pool';
 import type { ExistingBranchPolicy } from '@/lib/orchestrator/operator-mission-service';
+import { nextInlineIssueNumbers } from '@/lib/orchestrator/operator-mission-service/shared';
 import {
   apiFetch,
   type McpTool,
@@ -822,17 +823,15 @@ export async function handleCreateMission(args: Record<string, unknown>): Promis
     const comparisonModels = comparisonModelsRaw.length > 0 ? comparisonModelsRaw : undefined;
 
     if (inlineIssues) {
-      // #453 — Auto-assign synthetic numbers when not provided. UNIQUE per
-      // creation (pipeline root fix 2026-07-03): fixed 90001+index numbers made
-      // every inline mission collide with every prior one, and branch cleanup
-      // archived the older mission's live lanes on the collision.
-      const syntheticBase = 90_000_000_000 + Date.now() * 10;
+      // #453 — Auto-assign synthetic numbers when not provided. Centralized so
+      // every inline creator uses the same collision-resistant allocator.
+      const syntheticNumbers = nextInlineIssueNumbers(inlineIssues.length);
       const parsed = inlineIssues.map((entry, index) => {
         if (typeof entry !== 'object' || entry === null) throw new Error('Each inline issue must be an object.');
         const e = entry as Record<string, unknown>;
         const title = typeof e.title === 'string' ? e.title.trim() : '';
         if (!title) throw new Error('Each inline issue must have a title.');
-        const syntheticNumber = syntheticBase + index * 10;
+        const syntheticNumber = syntheticNumbers[index]!;
         return { number: syntheticNumber, title, body: typeof e.body === 'string' ? e.body : '' };
       });
       const createResult = await createMissionInline({

--- a/src/lib/orchestrator/operator-mission-service/shared-inline-issues.test.ts
+++ b/src/lib/orchestrator/operator-mission-service/shared-inline-issues.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { isInlineIssue, nextInlineIssueNumbers } from './shared';
+
+function expectInlineIssueNumber(number: number) {
+  expect(Number.isSafeInteger(number)).toBe(true);
+  expect(isInlineIssue({ number, title: 'inline task', body: '', url: '' })).toBe(true);
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('nextInlineIssueNumbers', () => {
+  it('allocates unique numbers across same-ms batches', () => {
+    vi.useFakeTimers({ now: new Date('2026-07-03T12:00:00.000Z') });
+
+    const first = nextInlineIssueNumbers(25);
+    const second = nextInlineIssueNumbers(25);
+    const numbers = [...first, ...second];
+
+    expect(new Set(numbers).size).toBe(numbers.length);
+    numbers.forEach(expectInlineIssueNumber);
+  });
+
+  it('keeps a 1000-iteration allocation loop collision-free', () => {
+    const numbers = Array.from({ length: 1000 }, () => nextInlineIssueNumbers(1)[0]!);
+
+    expect(new Set(numbers).size).toBe(numbers.length);
+    numbers.forEach(expectInlineIssueNumber);
+  });
+});

--- a/src/lib/orchestrator/operator-mission-service/shared.ts
+++ b/src/lib/orchestrator/operator-mission-service/shared.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { randomInt, randomUUID } from 'node:crypto';
 import { existsSync, statSync } from 'node:fs';
 import { basename } from 'node:path';
 import { listLanes } from '@/lib/lane/registry';
@@ -45,22 +45,27 @@ export function isInlineIssue(issue: LoadedIssue) {
   return !issue.url && issue.number >= 90001;
 }
 
-let inlineIssueSequence = 0;
+const INLINE_ISSUE_BASE = 90_000_000_000;
+const INLINE_ISSUE_RANDOM_SPACE = 2 ** 47;
+const issuedInlineIssueNumbers = new Set<number>();
 
 /**
  * Pipeline root fix (2026-07-03): UNIQUE synthetic numbers for inline issues.
- * Every creator used to hand out `90001 + index`, so every inline mission
- * collided with every prior inline mission on issue number — and the branch
- * preparation collision handler (`archiveLanesForBranch`) then archived the
- * OLDER mission's in-flight lanes, worktrees and branches. Observed live: a
- * leaked test-fixture mission with number 90002 archived a real running
- * worker. Time-based numbers keep `isInlineIssue` true (>= 90001) while
- * making cross-mission number collisions impossible; same-task re-dispatch
- * dedupe still works because it keys on the title-derived branch slug.
+ * Early creators reused fixed low numbers, then a time-based variant still
+ * allowed same-ms collisions across processes. Crypto-backed values keep
+ * `isInlineIssue` true while making cross-process collisions practically
+ * impossible; the issued set also prevents same-process repeats.
  */
 export function nextInlineIssueNumbers(count: number): number[] {
-  const base = 90_000_000_000 + Date.now() * 10 + (inlineIssueSequence++ % 10);
-  return Array.from({ length: Math.max(1, count) }, (_unused, index) => base + index * 10);
+  const normalizedCount = Number.isFinite(count) ? Math.max(1, Math.trunc(count)) : 1;
+  return Array.from({ length: normalizedCount }, () => {
+    let candidate = INLINE_ISSUE_BASE + randomInt(INLINE_ISSUE_RANDOM_SPACE);
+    while (issuedInlineIssueNumbers.has(candidate)) {
+      candidate = INLINE_ISSUE_BASE + randomInt(INLINE_ISSUE_RANDOM_SPACE);
+    }
+    issuedInlineIssueNumbers.add(candidate);
+    return candidate;
+  });
 }
 
 export function ensureRepoPath(repoPath: string) {


### PR DESCRIPTION
Wave 1 / H1 of the dispatch hardening backlog (docs/research/dispatch-hardening-audit-2026-07-03.md).

The adversarial audit found fix 2 incomplete: the MCP create_mission handler reimplemented inline issue numbering without the disambiguator (same-ms collisions), and the targeting dispatch route still hardcoded 90001. Colliding numbers historically let a new mission archive a prior mission live lanes.

- Both remaining creators (operator-handlers/mission.ts, panel/targets/dispatch/route.ts) now route through nextInlineIssueNumbers().
- The allocator is crypto-backed: randomInt over a 2^47 space + per-process issued-set. Outputs stay safe integers, >= 90001, isInlineIssue-true.
- Contract tests: same-ms batch uniqueness (fake timers) + 1000-iteration loop.
- Deferred (recorded in review): real-path test through handleCreateMission — needs the control-plane getDataDir fix from the sibling branch-names PR first.

Worker: Codex GPT-5.5 xhigh via o8 dispatch, packet pkt-17c5282f. Reviewed + governance gates green (security/diff-budget/untracked-imports/self-review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167kWJy2UsSp6x1RF3VnvjF