### PR TITLE
fix(dispatch): inline branch names carry the issue number — no more same-title collisions

### DIFF
--- a/src/lib/orchestrator/control-plane.ts
+++ b/src/lib/orchestrator/control-plane.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { getDataDir } from '@/lib/data-dir-migration';
 import { listLanes } from '@/lib/lane/registry';
 import type { DomainLaneSummary } from '@/lib/orchestrator/store';
 import type { OrchestratorMissionState } from '@/lib/orchestrator/types';
@@ -11,7 +11,7 @@ import {
   updateOrchestratorMissionState,
 } from '@/lib/orchestrator/store';
 
-const ORCHESTRATOR_DIR = join(homedir(), '.o8');
+const ORCHESTRATOR_DIR = getDataDir();
 const ORCHESTRATOR_PATH = join(ORCHESTRATOR_DIR, 'orchestrator-state.json');
 const ORCHESTRATOR_TMP_PATH = `${ORCHESTRATOR_PATH}.tmp`;
 

--- a/src/lib/orchestrator/operator-mission-service/inline-branch-names.test.ts
+++ b/src/lib/orchestrator/operator-mission-service/inline-branch-names.test.ts
@@ -1,0 +1,95 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const { createLane, getLane, setLaneStatus } = await import('@/lib/lane/registry');
+const { createMission } = await import('./mission');
+const { currentMissionState, slugify } = await import('./shared');
+
+function createRepo() {
+  const repoPath = mkdtempSync(join(os.tmpdir(), 'o8-inline-branch-repo-'));
+  const git = (...args: string[]) => execFileSync('git', args, { cwd: repoPath, stdio: 'pipe' });
+  git('init', '--initial-branch=main');
+  git('-c', 'user.email=test@o8.test', '-c', 'user.name=o8-test', 'commit', '--allow-empty', '-m', 'init');
+  return repoPath;
+}
+
+describe('inline packet branch names', () => {
+  it('pins inline branch format and truncates the slug to a short branch name', async () => {
+    const repoPath = createRepo();
+    const title = `Ship the collision-proof inline branch target ${'x'.repeat(120)}`;
+
+    await createMission({
+      issues: [{ number: 90001, title, body: 'do the thing', url: '' }],
+      repoPath,
+      runtime: 'codex',
+      constraints: '',
+    });
+
+    const [packet] = currentMissionState().packets;
+    expect(packet?.branchTarget).toMatch(/^inline\/90001-[a-z0-9-]+$/);
+    expect(packet?.branchTarget.startsWith('inline/90001-')).toBe(true);
+    expect(packet?.branchTarget.length).toBeLessThanOrEqual(60);
+    expect(packet?.branchTarget).not.toBe(`inline/${slugify(title)}`);
+  });
+
+  it('keeps GitHub issue branch names on the existing issue-number scheme', async () => {
+    const repoPath = createRepo();
+
+    await createMission({
+      issues: [{
+        number: 123,
+        title: 'Fix auth flow',
+        body: '',
+        url: 'https://github.com/o8/o8/issues/123',
+      }],
+      repoPath,
+      runtime: 'codex',
+      constraints: '',
+    });
+
+    const [packet] = currentMissionState().packets;
+    expect(packet?.branchTarget).toBe('issue/123-fix-auth-flow');
+  });
+
+  it('allows identical inline titles to coexist without archiving the active first lane', async () => {
+    const repoPath = createRepo();
+    const title = 'Inline branch collision task';
+
+    const firstMission = await createMission({
+      issues: [{ number: 90010, title, body: 'first body', url: '' }],
+      repoPath,
+      runtime: 'codex',
+      constraints: '',
+    });
+    const firstPacket = currentMissionState().packets[0]!;
+    const firstLane = createLane({
+      repoPath,
+      branch: firstPacket.branchTarget,
+      runtime: 'codex',
+      packetId: firstPacket.id,
+    });
+    setLaneStatus(firstLane.id, 'running', 'system');
+
+    const secondMission = await createMission({
+      issues: [{ number: 90020, title, body: 'second body', url: '' }],
+      repoPath,
+      runtime: 'codex',
+      constraints: '',
+    });
+    const secondPacket = currentMissionState().packets[0]!;
+
+    expect(firstMission.missionId).not.toBe(secondMission.missionId);
+    expect(firstPacket.branchTarget).toBe('inline/90010-inline-branch-collision-task');
+    expect(secondPacket.branchTarget).toBe('inline/90020-inline-branch-collision-task');
+    expect(firstPacket.branchTarget).not.toBe(secondPacket.branchTarget);
+    expect(secondMission.branchPreparation).toEqual([]);
+
+    const preservedLane = getLane(firstLane.id);
+    expect(preservedLane?.status).toBe('running');
+    expect(preservedLane?.packetId).toBe(firstPacket.id);
+    expect(preservedLane?.branch).toBe(firstPacket.branchTarget);
+  });
+});

--- a/src/lib/orchestrator/operator-mission-service/mission.ts
+++ b/src/lib/orchestrator/operator-mission-service/mission.ts
@@ -38,10 +38,15 @@ import type {
   MissionStatusInput,
 } from './types';
 
+const INLINE_BRANCH_MAX_LENGTH = 60;
+
 function branchTargetForIssue(issue: LoadedIssue) {
-  return isInlineIssue(issue)
-    ? `inline/${slugify(issue.title)}`
-    : `issue/${issue.number}-${slugify(issue.title)}`;
+  if (!isInlineIssue(issue)) {
+    return `issue/${issue.number}-${slugify(issue.title)}`;
+  }
+
+  const prefix = `inline/${issue.number}-`;
+  return `${prefix}${slugify(issue.title, Math.max(1, INLINE_BRANCH_MAX_LENGTH - prefix.length))}`;
 }
 
 export async function createMission(input: CreateMissionInput) {
@@ -114,7 +119,8 @@ export async function createMission(input: CreateMissionInput) {
         })
       : workerRouting;
 
-    // #453 — Inline tasks get "inline/{slug}" branches, not "issue/{number}-{slug}"
+    // #453/#inline-branch-hardening — Inline tasks carry their unique issue
+    // number in the branch to avoid same-title mission collisions.
     const branchTarget = branchTargets[index]!;
     const inlineLabel = hasInlineIssues ? referenceLabels[index] : undefined;
     const packetSummary = buildPacketSummary(issue, input.constraints, repoPath, inlineLabel);

--- a/src/lib/orchestrator/operator-mission-service/spawn-prompt.test.ts
+++ b/src/lib/orchestrator/operator-mission-service/spawn-prompt.test.ts
@@ -65,8 +65,8 @@ describe('buildInlineIssuesFromPrompt', () => {
     expect(again.some((n) => numbers.includes(n))).toBe(false);
     issues.forEach((issue) => expect(isInlineIssue(issue)).toBe(true));
 
-    // Every agent shares the body but carries a distinct (i/N) title — the
-    // mission layer derives inline/{slug(title)} branches, which must differ.
+    // Every agent shares the body but carries a distinct (i/N) title. The
+    // mission branch target also carries the unique inline issue number.
     const slugs = new Set(issues.map((i) => slugify(i.title)));
     expect(slugs.size).toBe(3);
     issues.forEach((issue) => expect(issue.body).toBe('the auth refactor'));

--- a/src/lib/orchestrator/operator-mission-service/spawn-prompt.ts
+++ b/src/lib/orchestrator/operator-mission-service/spawn-prompt.ts
@@ -30,7 +30,7 @@ export function clampSpawnCount(count: number | undefined): number {
  *
  * For count > 1 the agents race the SAME task in independent worktrees; titles
  * carry an `(i/N)` suffix so the per-agent branch slugs (and card labels) stay
- * unique — same-title inline issues would collide on `inline/{slug}`.
+ * unique — they feed the mission branch target's `inline/{number}-{slug}` prefix.
  */
 export function buildInlineIssuesFromPrompt(task: string, count = 1): LoadedIssue[] {
   const body = task.trim();


### PR DESCRIPTION
Wave 1 / H2 of the dispatch hardening backlog (docs/research/dispatch-hardening-audit-2026-07-03.md).

Inline packet branches were derived purely from the title (inline/{slug}), so two missions with the same task title collided on the branch target — under explicit reset paths that archived the other mission live lane (lane assassination). Root fix: the branch carries the packet unique issue number.

- branchTargetForIssue now emits inline/{number}-{slug}, total length capped at 60; GitHub-issue packets keep their existing issue/{number}-{slug} scheme (pinned by test).
- BONUS ROOT FIX: control-plane.ts hardcoded homedir()/.o8 for orchestrator-state.json, ignoring CORTEX_IDE_DATA_DIR — this is exactly how vitest fixture missions leaked into the real control plane (a leaked fixture once archived a real running worker). Now routed through getDataDir().
- Real-path tests through actual createMission with a real temp git repo: branch format + truncation pin, GitHub scheme unchanged, and identical-title missions coexisting while the first lane is ACTIVE and untouched.

Note: comment-only overlap with #1356 in shared.ts — whichever merges second gets a trivial rebase conflict; resolution keeps #1356 allocator implementation (I will rebase this branch after #1356 lands).

Worker: Codex GPT-5.5 xhigh via o8 dispatch, packet pkt-51f57a00. Reviewed + governance gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167kWJy2UsSp6x1RF3VnvjF