### PR TITLE
fix(dispatch): reset_packet cleanup scoped to its own lane ids — closes the archive-by-branch bypass

### DIFF
--- a/src/lib/lane/worktree-cleanup.ts
+++ b/src/lib/lane/worktree-cleanup.ts
@@ -50,6 +50,7 @@ async function preserveUncommittedWork(worktreePath: string, laneId: string): Pr
 
 export async function cleanupLaneWorktree(
   lane: Pick<Lane, 'id' | 'repoPath' | 'worktreePath'>,
+  opts: { deleteBranch?: boolean } = {},
 ): Promise<boolean> {
   const worktreePath = lane.worktreePath?.trim();
   if (!worktreePath) {
@@ -73,7 +74,7 @@ export async function cleanupLaneWorktree(
     const worktree = (await manager.list()).find((candidate) => candidate.path === worktreePath);
     if (worktree) {
       // manager.cleanup already calls preserveUncommittedWork internally
-      await manager.cleanup(worktree.id, { force: true, deleteBranch: true });
+      await manager.cleanup(worktree.id, { force: true, deleteBranch: opts.deleteBranch ?? true });
       return true;
     }
   } catch (error) {

--- a/src/lib/orchestrator/operator-mission-service/reset-cleanup.ts
+++ b/src/lib/orchestrator/operator-mission-service/reset-cleanup.ts
@@ -1,0 +1,101 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { cleanupLaneWorktree } from '@/lib/lane/worktree-cleanup';
+
+const execFileAsync = promisify(execFile);
+
+export interface ResetCleanupTarget {
+  id: string;
+  repoPath: string;
+  branch: string;
+  worktreePath: string | null;
+}
+
+export interface ResetCleanupResult {
+  worktreePruned: boolean;
+  branchDeleted: boolean;
+}
+
+function normalizeRepoPath(repoPath: string) {
+  return repoPath.trim().replace(/\/+$/, '');
+}
+
+function sameRepo(left: string, right: string) {
+  return normalizeRepoPath(left) === normalizeRepoPath(right);
+}
+
+function isTerminalStatus(status: string) {
+  return status === 'archived' || status === 'completed';
+}
+
+function isDispatchBranch(branch: string) {
+  return branch.startsWith('issue/') || branch.startsWith('inline/');
+}
+
+async function localBranchExists(repoPath: string, branch: string): Promise<boolean> {
+  try {
+    await execFileAsync('git', ['rev-parse', '--verify', '--quiet', `refs/heads/${branch}`], {
+      cwd: repoPath,
+      timeout: 5_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function deleteLocalBranch(repoPath: string, branch: string): Promise<boolean> {
+  if (!isDispatchBranch(branch) || !(await localBranchExists(repoPath, branch))) {
+    return false;
+  }
+  await execFileAsync('git', ['branch', '-D', branch], { cwd: repoPath, timeout: 10_000 });
+  return true;
+}
+
+export async function cleanupResetPacketTargets(
+  targets: ResetCleanupTarget[],
+  packetId: string,
+): Promise<ResetCleanupResult> {
+  const targetIds = new Set(targets.map((target) => target.id));
+  const groups = new Map<string, ResetCleanupTarget[]>();
+  let worktreePruned = false;
+  let branchDeleted = false;
+
+  for (const target of targets) {
+    if (target.worktreePath) {
+      worktreePruned = await cleanupLaneWorktree(target, { deleteBranch: false }) || worktreePruned;
+    }
+    const key = `${normalizeRepoPath(target.repoPath)}\0${target.branch}`;
+    groups.set(key, [...(groups.get(key) ?? []), target]);
+  }
+
+  const { appendEvent, listLanes } = await import('@/lib/lane/registry');
+  for (const group of groups.values()) {
+    const first = group[0];
+    if (!first) continue;
+
+    const siblingLanes = listLanes().filter((lane) => (
+      !targetIds.has(lane.id)
+      && sameRepo(lane.repoPath, first.repoPath)
+      && lane.branch === first.branch
+      && !isTerminalStatus(lane.status)
+    ));
+
+    if (siblingLanes.length > 0) {
+      for (const target of group) {
+        appendEvent(target.id, 'update', 'system', {
+          packetId,
+          branch: first.branch,
+          branchRetained: true,
+          reason: 'sibling_lane_active',
+          siblingLaneIds: siblingLanes.map((lane) => lane.id),
+        });
+      }
+      continue;
+    }
+
+    branchDeleted = await deleteLocalBranch(first.repoPath, first.branch) || branchDeleted;
+  }
+
+  return { worktreePruned, branchDeleted };
+}

--- a/src/lib/orchestrator/operator-mission-service/reset.ts
+++ b/src/lib/orchestrator/operator-mission-service/reset.ts
@@ -1,4 +1,4 @@
-import { cleanupIssueBranch } from './branch-cleanup';
+import { cleanupResetPacketTargets, type ResetCleanupTarget } from './reset-cleanup';
 import { currentMissionState, log } from './shared';
 import type { ResetPacketInput } from './types';
 import { interruptLaneSessions, archiveLaneSessions } from '@/lib/lane/reap-sessions';
@@ -54,13 +54,14 @@ async function resetPacketViaLaneFallback(input: ResetPacketInput) {
     if (lane.sessionKey?.trim()) unregisterWatchedAgent(lane.sessionKey.trim());
   }
 
-  const cleanupTargets = new Map<string, { repoPath: string; branch: string; worktreePath: string | null }>();
+  const cleanupTargets: ResetCleanupTarget[] = [];
   let firstWorktreePath: string | null = null;
   for (const lane of bound) {
     if (!firstWorktreePath && lane.worktreePath) {
       firstWorktreePath = lane.worktreePath;
     }
-    cleanupTargets.set(`${lane.repoPath}\0${lane.branch}`, {
+    cleanupTargets.push({
+      id: lane.id,
       repoPath: lane.repoPath,
       branch: lane.branch,
       worktreePath: lane.worktreePath,
@@ -80,19 +81,16 @@ async function resetPacketViaLaneFallback(input: ResetPacketInput) {
   let worktreePruned = false;
   let branchDeleted = false;
   if (input.clearWorktree) {
-    for (const target of cleanupTargets.values()) {
-      try {
-        const cleanup = await cleanupIssueBranch(target.repoPath, target.branch);
-        worktreePruned = worktreePruned || cleanup.worktreePruned;
-        branchDeleted = branchDeleted || cleanup.branchDeleted;
-        log(`[lane-reset] Cleared branch ${target.branch} for evicted packet ${input.packetId}`, cleanup);
-      } catch (error) {
-        const targetWorktreePath = target.worktreePath ?? firstWorktreePath;
-        log(
-          `[lane-reset] Could not clear branch ${target.branch}${targetWorktreePath ? ` at ${targetWorktreePath}` : ''} — may already be gone`,
-          error instanceof Error ? error.message : String(error),
-        );
-      }
+    try {
+      const cleanup = await cleanupResetPacketTargets(cleanupTargets, input.packetId);
+      worktreePruned = worktreePruned || cleanup.worktreePruned;
+      branchDeleted = branchDeleted || cleanup.branchDeleted;
+      log(`[lane-reset] Cleared packet-owned cleanup targets for evicted packet ${input.packetId}`, cleanup);
+    } catch (error) {
+      log(
+        `[lane-reset] Could not clear packet-owned cleanup targets${firstWorktreePath ? ` at ${firstWorktreePath}` : ''} — may already be gone`,
+        error instanceof Error ? error.message : String(error),
+      );
     }
 
     // F33 fallback (#1025): mirror the in-mission reset sweep for packets
@@ -152,7 +150,7 @@ export async function resetPacket(input: ResetPacketInput) {
   // packet.lane because store.reconcileOrchestratorMissionState() can
   // null packet.lane while leaving the SQLite row in a non-terminal status.
   let worktreePath: string | null = null;
-  const branchCleanupExpected = input.clearWorktree && Boolean(packet.branchTarget && state.repoPath);
+  const cleanupTargets: ResetCleanupTarget[] = [];
   try {
     const { archiveLane, listLanes, updateLane } = await import('@/lib/lane/registry');
     const bound = listLanes().filter((lane) => lane.packetId === packet.id);
@@ -181,23 +179,24 @@ export async function resetPacket(input: ResetPacketInput) {
       if (!terminal && !worktreePath && lane.worktreePath) {
         worktreePath = lane.worktreePath;
       }
+      if (!terminal) {
+        cleanupTargets.push({
+          id: lane.id,
+          repoPath: lane.repoPath,
+          branch: lane.branch,
+          worktreePath: lane.worktreePath,
+        });
+      }
       try {
         // Clear packetId first so reconciler can't re-bind this lane.
         // #1055 — also wipe worktreePath + sessionKey so the next dispatch
-        // doesn't reuse a stale path. findLaneByRepoAndBranch returns any
-        // non-(archived/completed/failed) lane, so if branchCleanupExpected
-        // forces us to skip archive below, the lane survives reset with its
-        // old worktreePath intact — commands.ts:311 then evaluates
-        // `isolate: !lane.worktreePath` to false and Codex spawns in the
-        // main repo instead of a fresh worktree.
+        // doesn't reuse a stale path. The clearWorktree branch cleanup below
+        // uses the captured lane snapshot, so the archived row can be scrubbed
+        // here without losing the target worktree path.
         updateLane(lane.id, { packetId: '', worktreePath: null, sessionKey: null });
         console.log(`[reset-packet] cleared stale lane fields for ${lane.id}`);
         if (terminal) {
           console.log(`[reset-packet] Unbound ${lane.status} lane ${lane.id} from packet ${packet.referenceLabel}`);
-          continue;
-        }
-        if (branchCleanupExpected) {
-          console.log(`[reset-packet] Deferred lane ${lane.id} cleanup to branch cleanup for packet ${packet.referenceLabel}`);
           continue;
         }
         archiveLane(lane.id, 'user');
@@ -220,10 +219,10 @@ export async function resetPacket(input: ResetPacketInput) {
   let branchDeleted = false;
   if (input.clearWorktree && packet.branchTarget && state.repoPath) {
     try {
-      const cleanup = await cleanupIssueBranch(state.repoPath, packet.branchTarget);
+      const cleanup = await cleanupResetPacketTargets(cleanupTargets, packet.id);
       worktreePruned = cleanup.worktreePruned;
       branchDeleted = cleanup.branchDeleted;
-      log(`[lane-reset] Cleared branch ${packet.branchTarget} for packet ${packet.referenceLabel}`, cleanup);
+      log(`[lane-reset] Cleared packet-owned cleanup targets for packet ${packet.referenceLabel}`, cleanup);
     } catch (error) {
       log(
         `[lane-reset] Could not clear branch ${packet.branchTarget}${worktreePath ? ` at ${worktreePath}` : ''} — may already be gone`,

--- a/tests/reset-packet-branch-cleanup.test.ts
+++ b/tests/reset-packet-branch-cleanup.test.ts
@@ -1,0 +1,124 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+// The SQLite store resolves its data dir at module load. Force a temp o8 data
+// dir before importing reset/registry so this real-path test never touches the
+// operator's live control plane.
+const dataDir = mkdtempSync(join(tmpdir(), 'o8-reset-cleanup-data-'));
+delete process.env.O8_DATA_DIR;
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.CORTEX_IDE_DB_PATH = join(dataDir, 'cortex-ide.db');
+
+const { createLane, getLane, getLaneEvents, setLaneStatus } = await import('@/lib/lane/registry');
+const { resetPacket } = await import('@/lib/orchestrator/operator-mission-service/reset');
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+
+function initRepo(branch: string): string {
+  const repoPath = mkdtempSync(join(tmpdir(), 'o8-reset-cleanup-repo-'));
+  git(repoPath, ['init', '-q', '-b', 'main']);
+  git(repoPath, ['config', 'user.email', 'test@o8.dev']);
+  git(repoPath, ['config', 'user.name', 'o8 test']);
+  writeFileSync(join(repoPath, 'base.txt'), 'base\n');
+  git(repoPath, ['add', 'base.txt']);
+  git(repoPath, ['commit', '-q', '-m', 'base']);
+  git(repoPath, ['branch', branch]);
+  return repoPath;
+}
+
+function addPacketWorktree(repoPath: string, branch: string, packetId: string): string {
+  const worktreePath = join(repoPath, '.cortex-worktrees', `packet-${packetId}`);
+  git(repoPath, ['worktree', 'add', '-q', worktreePath, branch]);
+  return worktreePath;
+}
+
+function branchExists(repoPath: string, branch: string): boolean {
+  try {
+    git(repoPath, ['rev-parse', '--verify', '--quiet', `refs/heads/${branch}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('reset_packet clearWorktree branch cleanup', () => {
+  it('archives only the reset packet lane and retains a branch owned by a live sibling lane', async () => {
+    const branch = 'inline/reset-shared-branch';
+    const repoPath = initRepo(branch);
+    const packetA = 'pkt-reset-shared-a';
+    const packetB = 'pkt-reset-shared-b';
+    const worktreeA = addPacketWorktree(repoPath, branch, packetA);
+    const laneA = createLane({
+      repoPath,
+      branch,
+      runtime: 'codex',
+      packetId: packetA,
+      worktreePath: worktreeA,
+    });
+    setLaneStatus(laneA.id, 'running', 'system');
+    const laneB = createLane({
+      repoPath,
+      branch,
+      runtime: 'codex',
+      packetId: packetB,
+    });
+    setLaneStatus(laneB.id, 'running', 'system');
+    const siblingEventCount = getLaneEvents(laneB.id).length;
+
+    const result = await resetPacket({ packetId: packetA, clearWorktree: true });
+
+    expect(result.reset).toBe(true);
+    expect(result.worktreePruned).toBe(true);
+    expect(result.branchDeleted).toBe(false);
+    expect(existsSync(worktreeA)).toBe(false);
+    expect(branchExists(repoPath, branch)).toBe(true);
+
+    const resetLane = getLane(laneA.id);
+    expect(resetLane?.status).toBe('archived');
+    expect(resetLane?.packetId ?? '').toBe('');
+    expect(resetLane?.worktreePath).toBeNull();
+
+    const siblingLane = getLane(laneB.id);
+    expect(siblingLane?.status).toBe('running');
+    expect(siblingLane?.packetId).toBe(packetB);
+    expect(getLaneEvents(laneB.id)).toHaveLength(siblingEventCount);
+
+    const retainedEvent = getLaneEvents(laneA.id).find((event) => event.payload.branchRetained === true);
+    expect(retainedEvent?.payload.reason).toBe('sibling_lane_active');
+    expect(retainedEvent?.payload.siblingLaneIds).toEqual([laneB.id]);
+  });
+
+  it('fully prunes the worktree and branch for a single reset packet lane', async () => {
+    const branch = 'inline/reset-single-branch';
+    const repoPath = initRepo(branch);
+    const packetId = 'pkt-reset-single';
+    const worktreePath = addPacketWorktree(repoPath, branch, packetId);
+    const lane = createLane({
+      repoPath,
+      branch,
+      runtime: 'codex',
+      packetId,
+      worktreePath,
+    });
+    setLaneStatus(lane.id, 'running', 'system');
+
+    const result = await resetPacket({ packetId, clearWorktree: true });
+
+    expect(result.reset).toBe(true);
+    expect(result.worktreePruned).toBe(true);
+    expect(result.branchDeleted).toBe(true);
+    expect(existsSync(worktreePath)).toBe(false);
+    expect(branchExists(repoPath, branch)).toBe(false);
+
+    const resetLane = getLane(lane.id);
+    expect(resetLane?.status).toBe('archived');
+    expect(resetLane?.packetId ?? '').toBe('');
+    expect(resetLane?.worktreePath).toBeNull();
+  });
+});


### PR DESCRIPTION
Wave 1 / H3 of the dispatch hardening backlog (docs/research/dispatch-hardening-audit-2026-07-03.md).

The audit found reset_packet --clearWorktree called cleanupIssueBranch directly, bypassing the active-lane guard: archiveLanesForBranch archived EVERY non-terminal lane on the branch, including a different packet live lane sharing the branch via title-slug collision.

- New cleanupResetPacketTargets: prunes only the packet own worktrees (deleteBranch:false), archives only its own lane ids, deletes the branch ONLY when no live sibling references it — otherwise retains it and records a branchRetained lane event naming the sibling.
- Branch deletion is allowlisted to issue/ and inline/ prefixes — reset can never delete main or a user branch.
- The old defer-archive-to-branch-sweep path is deleted; archiveLanesForBranch is unreachable from reset.
- Real-path tests through the actual resetPacket entry point against persisted rows (temp CORTEX_IDE_DATA_DIR, real git repos + worktrees): sibling lane survives with branch retained + event recorded; single-lane reset still fully prunes worktree + branch.
- Fails safe: an unbound leftover branch now lingers (self-heals on next dispatch via the collision guard) instead of the old over-deleting sweep.

Worker: Codex GPT-5.5 xhigh via o8 dispatch, packet pkt-4b9e4e01. Reviewed + governance gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167kWJy2UsSp6x1RF3VnvjF