### PR TITLE
design(status): the beacon tells the truth — escalated · needs-review · awaiting-merge

### DIFF
--- a/src/app/dashboard/hooks/useSessionState.ts
+++ b/src/app/dashboard/hooks/useSessionState.ts
@@ -104,6 +104,7 @@ export function useSessionState() {
     () => (approvalData?.approvals ?? []).filter((a) => a.status !== 'pending').length,
     [approvalData],
   );
+  const approvals = useMemo(() => approvalData?.approvals ?? [], [approvalData]);
 
   useEffect(() => {
     approvalRefreshRef.current = () => {
@@ -150,6 +151,7 @@ export function useSessionState() {
     wsStatus,
 
     // Approvals
+    approvals,
     approvalCount,
     resolvedApprovalCount,
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -77,7 +77,7 @@ import {
   type DomainLaneSummary,
 } from '@/lib/orchestrator/store';
 import { agentDisplayLabel } from '@/lib/orchestrator/display';
-import { deriveParkedLanes } from '@/components/desktop/merge-beacon/derive';
+import { deriveParkedLanes, type ParkedLane } from '@/components/desktop/merge-beacon/derive';
 import type { WorkspaceLifecycleRecordView, WorkspaceLifecycleSummaryView } from '@/lib/workspace/lifecycle-types';
 import type {
   CanvasTileState,
@@ -650,6 +650,7 @@ function DashboardInner() {
     agentsJson, setAgentsJson,
     activeWorkspace, setActiveWorkspace,
     wsStatus,
+    approvals,
     approvalCount,
     resolvedApprovalCount,
     parsedAgents,
@@ -3422,8 +3423,9 @@ function DashboardInner() {
       .filter((l): l is typeof l & { packetId: string } => Boolean(l.packetId))
       .map((l) => ({ laneId: l.id, packetId: l.packetId, status: l.status, sessionKey: l.sessionKey, lastEventLabel: l.lastEventLabel, branch: l.branch, repoPath: l.repoPath, label: l.label }));
   }, [domainLanesRaw]);
-  // Footer merge beacon — fleet-wide "parked, needs you" lanes (review +
-  // escalation gates), derived from the same already-live lanes poll. Exclude
+  // Footer merge beacon — fleet-wide review-gate lanes split into
+  // needs-review vs approved-awaiting-merge, derived from the same already-live
+  // lanes poll plus durable approval records. Exclude
   // lanes whose PACKET has merged/released/archived — the lane summary status can
   // lag (stale-stuck at 'reviewing' after the packet closed), which left a
   // just-merged packet counting as "1 ready" in the beacon.
@@ -3436,7 +3438,23 @@ function DashboardInner() {
     }
     return closed;
   }, [thoughtsMissionState.packets]);
-  const parkedLanes = useMemo(() => deriveParkedLanes(domainLanes, closedPacketIds), [domainLanes, closedPacketIds]);
+  const parkedLanes = useMemo(() => deriveParkedLanes(domainLanes, closedPacketIds, approvals), [approvals, domainLanes, closedPacketIds]);
+
+  const handleOpenReviewLane = useCallback((lane: ParkedLane) => {
+    if (lane.repoPath) {
+      setO8RepoPathOverride(lane.repoPath);
+      setO8SelectedFile(null);
+      setO8SelectedFileRepoPath(null);
+    }
+    setRightPanelKind('review');
+    openRightPanelFromUser();
+  }, [openRightPanelFromUser]);
+
+  const handleOpenAwaitingMerge = useCallback(() => {
+    setRightPanelKind('o8');
+    openRightPanelFromUser();
+    setO8ActiveTab('inbox');
+  }, [openRightPanelFromUser]);
 
   useEffect(() => {
     if (!tileLayoutHydrated) return;
@@ -4906,6 +4924,8 @@ function DashboardInner() {
         compact={compactShell}
         glassSurface={effectiveGlassSurface}
         parkedLanes={parkedLanes}
+        onOpenReviewLane={handleOpenReviewLane}
+        onOpenAwaitingMerge={handleOpenAwaitingMerge}
         bottomPanelVisible={bottomPanelVisible}
         onToggleBottomPanel={toggleContextualPanelTile}
         onOpenBottomPanelSurface={handleOpenBottomPanelSurface}

--- a/src/components/desktop/DesktopStatusBar.tsx
+++ b/src/components/desktop/DesktopStatusBar.tsx
@@ -49,9 +49,11 @@ interface DesktopStatusBarProps {
    *  (transparent bg, no shadow/border/rounding) so the panel above floats as
    *  a self-contained Lisse card — the icons sit directly on the vibrancy. */
   glassSurface?: boolean;
-  /** Lanes parked in the review/escalation gates — drives the merge beacon
-   *  (fleet-wide "something's ready to merge / needs you" pill). */
+  /** Lanes parked in the review gate — drives the merge beacon split between
+   *  needs-review and approved-awaiting-merge. */
   parkedLanes?: ParkedLane[];
+  onOpenReviewLane?: (lane: ParkedLane) => void;
+  onOpenAwaitingMerge?: () => void;
   onOpenSettings: () => void;
   onAddRepo: () => void;
   /** Open the full-screen mobile-pairing QR view (a canvas tab). */
@@ -80,6 +82,8 @@ function DesktopStatusBarBase({
   compact = false,
   glassSurface = false,
   parkedLanes = [],
+  onOpenReviewLane,
+  onOpenAwaitingMerge,
   onOpenSettings,
   onAddRepo,
   onOpenMobilePairing,
@@ -355,7 +359,12 @@ function DesktopStatusBarBase({
         }}
       >
         <div style={{ display: 'flex', alignItems: 'center', gap: 6, pointerEvents: 'auto' }}>
-          <MergeBeacon parked={parkedLanes} compact={compact} />
+          <MergeBeacon
+            parked={parkedLanes}
+            compact={compact}
+            onOpenNeedsReviewLane={onOpenReviewLane}
+            onOpenAwaitingMerge={onOpenAwaitingMerge}
+          />
           <MergeActionCluster
             branchName={branchName}
             repoName={repoName}

--- a/src/components/desktop/merge-beacon/MergeBeacon.tsx
+++ b/src/components/desktop/merge-beacon/MergeBeacon.tsx
@@ -25,14 +25,16 @@ function MergeBeaconBase({
   onOpenNeedsReviewLane?: (lane: ParkedLane) => void;
   onOpenAwaitingMerge?: () => void;
 }) {
+  const escalated = parked.filter((lane) => lane.reviewState === 'escalated');
   const needsReview = parked.filter((lane) => lane.reviewState === 'needs-review');
   const awaitingMerge = parked.filter((lane) => lane.reviewState === 'awaiting-merge');
   if (compact || parked.length === 0) return null;
 
+  const escalatedCount = escalated.length;
   const needsReviewCount = needsReview.length;
   const awaitingMergeCount = awaitingMerge.length;
-  const urgent = needsReviewCount > 0;
-  const title = `Needs review: ${needsReviewCount}. Approved awaiting merge: ${awaitingMergeCount}.`;
+  const urgent = escalatedCount > 0 || needsReviewCount > 0;
+  const title = `Escalated: ${escalatedCount}. Needs review: ${needsReviewCount}. Approved awaiting merge: ${awaitingMergeCount}.`;
 
   const focusLane = (lane: ParkedLane) => {
     if (typeof window === 'undefined') return;
@@ -49,7 +51,7 @@ function MergeBeaconBase({
   };
 
   const handleClick = () => {
-    const lane = needsReview[0];
+    const lane = escalated[0] ?? needsReview[0];
     if (lane) {
       focusLane(lane);
       onOpenNeedsReviewLane?.(lane);
@@ -87,6 +89,12 @@ function MergeBeaconBase({
         }}
       >
         <span style={{ width: 7, height: 7, borderRadius: 999, background: urgent ? 'var(--t-brand-orange)' : 'var(--t-text-faint)', flexShrink: 0 }} />
+        {escalatedCount > 0 ? (
+          <>
+            <span>{escalatedCount} escalated</span>
+            <span style={{ color: 'var(--t-text-faint)' }}>·</span>
+          </>
+        ) : null}
         <span>{needsReviewCount} review</span>
         {awaitingMergeCount > 0 ? (
           <>

--- a/src/components/desktop/merge-beacon/MergeBeacon.tsx
+++ b/src/components/desktop/merge-beacon/MergeBeacon.tsx
@@ -1,83 +1,38 @@
 'use client';
 
 /**
- * MergeBeacon — a fleet-wide "something's ready to land / needs you" pill in
- * the bottom status bar, sitting just left of MergeActionCluster (which it
- * never touches). It surfaces lanes parked in the review/escalation gates
- * (see derive.ts) so the operator sees a worker is ready even when heads-down
- * on the orchestrator and not watching the worker tabs.
+ * MergeBeacon — a fleet-wide review gate pill in the bottom status bar,
+ * sitting just left of MergeActionCluster (which it never touches). It splits
+ * reviewing lanes into work that still needs operator review vs work already
+ * approved and waiting on merge.
  *
  * Pure signal: returns null when nothing is parked, so it only appears when
- * there's genuinely something waiting. Click → a popover list of the parked
- * lanes; clicking a row re-points the existing merge cluster + workspace
- * context at that lane's branch (reuses the o8:orchestrator-worktree-selection
- * wire the dashboard already listens for).
+ * there's genuinely something waiting. Click → the first needs-review lane's
+ * review surface, or the Inbox tab when everything left is awaiting merge.
  */
 
-import { memo, useEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
+import { memo } from 'react';
 import type { ParkedLane } from './derive';
 
-const STATUS_WORD: Record<string, string> = {
-  reviewing: 'review',
-  awaiting_orchestrator: 'escalated',
-  awaiting_human: 'needs you',
-};
-
-function statusWord(status: string): string {
-  return STATUS_WORD[status] ?? status;
-}
-
-function MergeBeaconBase({ parked, compact }: { parked: ParkedLane[]; compact?: boolean }) {
-  const [open, setOpen] = useState(false);
-  const anchorRef = useRef<HTMLDivElement | null>(null);
-  const menuRef = useRef<HTMLDivElement | null>(null);
-  // Popover opens UPWARD (the status bar is pinned to the screen bottom),
-  // positioned via the anchor rect through a portal so the thin status strip
-  // never clips it.
-  const [coords, setCoords] = useState<{ left: number; bottom: number } | null>(null);
-
-  useEffect(() => {
-    if (!open || !anchorRef.current) return;
-    const compute = () => {
-      const rect = anchorRef.current?.getBoundingClientRect();
-      if (!rect) return;
-      const left = Math.max(8, Math.min(rect.left, window.innerWidth - 332));
-      setCoords({ left, bottom: window.innerHeight - rect.top + 6 });
-    };
-    compute();
-    window.addEventListener('resize', compute);
-    window.addEventListener('scroll', compute, true);
-    return () => {
-      window.removeEventListener('resize', compute);
-      window.removeEventListener('scroll', compute, true);
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (menuRef.current?.contains(e.target as Node)) return;
-      if (anchorRef.current?.contains(e.target as Node)) return;
-      setOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
-    window.addEventListener('mousedown', onDown);
-    window.addEventListener('keydown', onKey);
-    return () => {
-      window.removeEventListener('mousedown', onDown);
-      window.removeEventListener('keydown', onKey);
-    };
-  }, [open]);
-
-  // Nothing parked anymore -> drop the popover too.
-  useEffect(() => {
-    if (parked.length === 0 && open) setOpen(false);
-  }, [parked.length, open]);
-
+function MergeBeaconBase({
+  parked,
+  compact,
+  onOpenNeedsReviewLane,
+  onOpenAwaitingMerge,
+}: {
+  parked: ParkedLane[];
+  compact?: boolean;
+  onOpenNeedsReviewLane?: (lane: ParkedLane) => void;
+  onOpenAwaitingMerge?: () => void;
+}) {
+  const needsReview = parked.filter((lane) => lane.reviewState === 'needs-review');
+  const awaitingMerge = parked.filter((lane) => lane.reviewState === 'awaiting-merge');
   if (compact || parked.length === 0) return null;
 
-  const count = parked.length;
+  const needsReviewCount = needsReview.length;
+  const awaitingMergeCount = awaitingMerge.length;
+  const urgent = needsReviewCount > 0;
+  const title = `Needs review: ${needsReviewCount}. Approved awaiting merge: ${awaitingMergeCount}.`;
 
   const focusLane = (lane: ParkedLane) => {
     if (typeof window === 'undefined') return;
@@ -91,17 +46,25 @@ function MergeBeaconBase({ parked, compact }: { parked: ParkedLane[]; compact?: 
         },
       }));
     }
-    setOpen(false);
+  };
+
+  const handleClick = () => {
+    const lane = needsReview[0];
+    if (lane) {
+      focusLane(lane);
+      onOpenNeedsReviewLane?.(lane);
+      return;
+    }
+    onOpenAwaitingMerge?.();
   };
 
   return (
-    <div ref={anchorRef} style={{ position: 'relative', display: 'inline-flex' }}>
+    <div style={{ position: 'relative', display: 'inline-flex' }}>
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-label={`${count} ready to merge`}
-        aria-haspopup="menu"
-        aria-expanded={open}
+        onClick={handleClick}
+        aria-label={title}
+        title={title}
         style={{
           display: 'inline-flex',
           alignItems: 'center',
@@ -112,104 +75,26 @@ function MergeBeaconBase({ parked, compact }: { parked: ParkedLane[]; compact?: 
           borderRadius: 7,
           borderWidth: 1,
           borderStyle: 'solid',
-          // Brand-orange (#FF5A1F) tints — the "needs you" LED. A colored
-          // accent (reads on both light + dark), not a neutral surface.
-          borderColor: 'rgba(255, 90, 31, 0.26)',
-          background: 'rgba(255, 90, 31, 0.12)',
-          color: 'var(--t-brand-orange)',
+          borderColor: urgent ? 'color-mix(in srgb, var(--t-brand-orange) 30%, var(--t-divider-subtle))' : 'var(--t-divider-subtle)',
+          background: urgent ? 'color-mix(in srgb, var(--t-brand-orange) 12%, transparent)' : 'var(--t-input-bg)',
+          color: urgent ? 'var(--t-brand-orange)' : 'var(--t-text-muted)',
           cursor: 'pointer',
           fontFamily: 'var(--font-sans-system)',
           fontSize: 11.5,
-          fontWeight: 500,
-          letterSpacing: '-0.005em',
+          fontWeight: 300,
+          letterSpacing: '-0.1px',
           whiteSpace: 'nowrap',
         }}
       >
-        <span style={{ width: 7, height: 7, borderRadius: 999, background: 'var(--t-brand-orange)', flexShrink: 0 }} />
-        {count} ready
+        <span style={{ width: 7, height: 7, borderRadius: 999, background: urgent ? 'var(--t-brand-orange)' : 'var(--t-text-faint)', flexShrink: 0 }} />
+        <span>{needsReviewCount} review</span>
+        {awaitingMergeCount > 0 ? (
+          <>
+            <span style={{ color: 'var(--t-text-faint)' }}>·</span>
+            <span style={{ color: urgent ? 'var(--t-text-muted)' : 'var(--t-text-faint)' }}>{awaitingMergeCount} merge</span>
+          </>
+        ) : null}
       </button>
-      {open && typeof document !== 'undefined' && coords ? createPortal(
-        <div
-          ref={menuRef}
-          role="menu"
-          style={{
-            position: 'fixed',
-            left: coords.left,
-            bottom: coords.bottom,
-            minWidth: 220,
-            maxWidth: 324,
-            background: 'var(--t-panel-solid, var(--t-panel))',
-            borderWidth: 1,
-            borderStyle: 'solid',
-            borderColor: 'var(--t-divider, var(--t-divider-subtle))',
-            borderRadius: 10,
-            boxShadow: '0 12px 32px rgba(15, 23, 42, 0.22)',
-            paddingTop: 4,
-            paddingBottom: 4,
-            zIndex: 1200,
-            fontFamily: 'var(--font-sans-system)',
-          }}
-        >
-          <div
-            style={{
-              paddingTop: 6,
-              paddingBottom: 4,
-              paddingLeft: 12,
-              paddingRight: 12,
-              fontSize: 10,
-              fontWeight: 600,
-              letterSpacing: '0.05em',
-              textTransform: 'uppercase',
-              color: 'var(--t-text-faint)',
-            }}
-          >
-            Ready to merge
-          </div>
-          {parked.map((lane) => (
-            <button
-              key={lane.laneId}
-              type="button"
-              onClick={() => focusLane(lane)}
-              onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--t-hover)'; }}
-              onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 8,
-                width: '100%',
-                paddingTop: 7,
-                paddingBottom: 7,
-                paddingLeft: 12,
-                paddingRight: 12,
-                background: 'transparent',
-                borderWidth: 0,
-                cursor: 'pointer',
-                textAlign: 'left',
-                fontFamily: 'inherit',
-              }}
-            >
-              <span style={{ width: 6, height: 6, borderRadius: 999, background: 'var(--t-brand-orange)', flexShrink: 0 }} />
-              <span
-                style={{
-                  flex: 1,
-                  minWidth: 0,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  fontSize: 12,
-                  color: 'var(--t-text)',
-                }}
-              >
-                {lane.label || lane.branch || 'Lane'}
-              </span>
-              <span style={{ flexShrink: 0, fontSize: 10.5, color: 'var(--t-text-faint)' }}>
-                {statusWord(lane.status)}
-              </span>
-            </button>
-          ))}
-        </div>,
-        document.body,
-      ) : null}
     </div>
   );
 }

--- a/src/components/desktop/merge-beacon/derive.test.ts
+++ b/src/components/desktop/merge-beacon/derive.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { deriveParkedLanes } from './derive';
+import { deriveParkedLaneBuckets, deriveParkedLanes, type ReviewApprovalSummary } from './derive';
 import type { DomainLaneSummary } from '@/lib/orchestrator/store';
 
 function lane(
@@ -13,12 +13,23 @@ function lane(
   };
 }
 
+function approvedReview(packetId: string, laneId?: string): ReviewApprovalSummary {
+  return {
+    status: 'approved',
+    toolName: 'orchestrator_review',
+    metadata: {
+      Packet: packetId,
+      ...(laneId ? { Lane: laneId } : {}),
+    },
+  };
+}
+
 describe('deriveParkedLanes', () => {
   it('returns empty for no lanes', () => {
     expect(deriveParkedLanes([])).toEqual([]);
   });
 
-  it('keeps only parked statuses (reviewing + awaiting_*), drops in-motion + terminal', () => {
+  it('keeps only reviewing lanes, drops in-motion + terminal + escalation states', () => {
     const lanes = [
       lane({ laneId: 'a', status: 'reviewing' }),
       lane({ laneId: 'b', status: 'running' }),
@@ -28,7 +39,7 @@ describe('deriveParkedLanes', () => {
       lane({ laneId: 'f', status: 'completed' }),
       lane({ laneId: 'g', status: 'launching' }),
     ];
-    expect(deriveParkedLanes(lanes).map((p) => p.laneId)).toEqual(['a', 'c', 'd']);
+    expect(deriveParkedLanes(lanes).map((p) => p.laneId)).toEqual(['a']);
   });
 
   it('carries branch/repoPath/label through for the popover + click', () => {
@@ -46,6 +57,27 @@ describe('deriveParkedLanes', () => {
     const closed = new Set(['pkt-merged']);
     const parked = deriveParkedLanes(lanes, closed);
     expect(parked.map((p) => p.laneId)).toEqual(['live']); // the merged one dropped
+  });
+
+  it('splits reviewing lanes into needs-review vs approved-awaiting-merge', () => {
+    const lanes = [
+      lane({ laneId: 'needs', status: 'reviewing', packetId: 'pkt-needs' }),
+      lane({ laneId: 'approved-by-packet', status: 'reviewing', packetId: 'pkt-approved' }),
+      lane({ laneId: 'approved-by-lane', status: 'reviewing', packetId: 'pkt-other' }),
+      lane({ laneId: 'running-approved', status: 'running', packetId: 'pkt-running' }),
+    ];
+    const reviews = [
+      approvedReview('pkt-approved'),
+      approvedReview('pkt-unrelated', 'approved-by-lane'),
+      approvedReview('pkt-running'),
+      { ...approvedReview('pkt-rejected'), status: 'rejected' },
+    ];
+
+    const buckets = deriveParkedLaneBuckets(lanes, reviews);
+
+    expect(buckets.needsReview.map((p) => p.laneId)).toEqual(['needs']);
+    expect(buckets.awaitingMerge.map((p) => p.laneId)).toEqual(['approved-by-packet', 'approved-by-lane']);
+    expect(buckets.all.map((p) => p.reviewState)).toEqual(['needs-review', 'awaiting-merge', 'awaiting-merge']);
   });
 
   it('with no closed set, behaves exactly as before (parity)', () => {

--- a/src/components/desktop/merge-beacon/derive.test.ts
+++ b/src/components/desktop/merge-beacon/derive.test.ts
@@ -42,7 +42,7 @@ describe('deriveParkedLanes', () => {
     expect(deriveParkedLanes(lanes).map((p) => p.laneId)).toEqual(['a']);
   });
 
-  it('carries branch/repoPath/label through for the popover + click', () => {
+  it('carries branch/repoPath/label through for click routing', () => {
     const parked = deriveParkedLanes([
       lane({ laneId: 'a', status: 'reviewing', branch: 'feat/x', repoPath: '/r', label: 'Fix x' }),
     ]);

--- a/src/components/desktop/merge-beacon/derive.test.ts
+++ b/src/components/desktop/merge-beacon/derive.test.ts
@@ -29,7 +29,7 @@ describe('deriveParkedLanes', () => {
     expect(deriveParkedLanes([])).toEqual([]);
   });
 
-  it('keeps only reviewing lanes, drops in-motion + terminal + escalation states', () => {
+  it('keeps reviewing + escalation states, drops in-motion + terminal states', () => {
     const lanes = [
       lane({ laneId: 'a', status: 'reviewing' }),
       lane({ laneId: 'b', status: 'running' }),
@@ -39,7 +39,30 @@ describe('deriveParkedLanes', () => {
       lane({ laneId: 'f', status: 'completed' }),
       lane({ laneId: 'g', status: 'launching' }),
     ];
-    expect(deriveParkedLanes(lanes).map((p) => p.laneId)).toEqual(['a']);
+    // escalated first — the strongest operator-attention signal leads the pill
+    expect(deriveParkedLanes(lanes).map((p) => p.laneId)).toEqual(['c', 'd', 'a']);
+  });
+
+  it('buckets escalation-chain lanes as escalated, regardless of review approvals', () => {
+    const lanes = [
+      lane({ laneId: 'esc-orch', status: 'awaiting_orchestrator', packetId: 'pkt-esc-1' }),
+      lane({ laneId: 'esc-human', status: 'awaiting_human', packetId: 'pkt-esc-2' }),
+      lane({ laneId: 'needs', status: 'reviewing', packetId: 'pkt-needs' }),
+      lane({ laneId: 'approved', status: 'reviewing', packetId: 'pkt-approved' }),
+    ];
+    const reviews = [approvedReview('pkt-approved'), approvedReview('pkt-esc-1')];
+
+    const buckets = deriveParkedLaneBuckets(lanes, reviews);
+
+    expect(buckets.escalated.map((p) => p.laneId)).toEqual(['esc-orch', 'esc-human']);
+    expect(buckets.needsReview.map((p) => p.laneId)).toEqual(['needs']);
+    expect(buckets.awaitingMerge.map((p) => p.laneId)).toEqual(['approved']);
+    expect(buckets.all.map((p) => p.reviewState)).toEqual(['escalated', 'escalated', 'needs-review', 'awaiting-merge']);
+  });
+
+  it('drops an escalated lane whose packet is closed', () => {
+    const lanes = [lane({ laneId: 'esc', status: 'awaiting_human', packetId: 'pkt-closed' })];
+    expect(deriveParkedLanes(lanes, new Set(['pkt-closed']))).toEqual([]);
   });
 
   it('carries branch/repoPath/label through for click routing', () => {

--- a/src/components/desktop/merge-beacon/derive.ts
+++ b/src/components/desktop/merge-beacon/derive.ts
@@ -1,29 +1,55 @@
 import type { DomainLaneSummary } from '@/lib/orchestrator/store';
 
-/**
- * The footer merge beacon's signal. A lane is "parked" — waiting on the
- * operator/orchestrator to act — when it sits in the review gate or an
- * escalation state. This is the true fleet "something's ready to land /
- * needs you" set in o8: most workers merge via worktree side-merge and
- * never open a GitHub PR, so the beacon keys on LANE STATE, not PR state.
- *
- * In-motion states (running / launching / merging) are deliberately
- * excluded so a packet that auto-reviews-and-merges in seconds never
- * lights the beacon — it only appears when something genuinely waits.
- */
-const PARKED_STATUSES = new Set<string>([
-  'reviewing', // agent finished, review gate open (the o8 approval moat)
-  'awaiting_orchestrator', // merge-failure escalation, orchestrator's call
-  'awaiting_human', // merge-failure escalation, operator's call
-]);
+const REVIEWING_STATUS = 'reviewing';
+
+export interface ReviewApprovalSummary {
+  status: string;
+  toolName?: string;
+  metadata?: Record<string, string> | null;
+}
+
+export type ParkedLaneReviewState = 'needs-review' | 'awaiting-merge';
 
 export interface ParkedLane {
   laneId: string;
   packetId: string;
   status: string;
+  reviewState: ParkedLaneReviewState;
   branch?: string;
   repoPath?: string;
   label?: string;
+}
+
+export interface ParkedLaneBuckets {
+  needsReview: ParkedLane[];
+  awaitingMerge: ParkedLane[];
+  all: ParkedLane[];
+}
+
+function approvalMatchesLane(approval: ReviewApprovalSummary, lane: DomainLaneSummary) {
+  if (approval.toolName !== 'orchestrator_review' || approval.status !== 'approved') {
+    return false;
+  }
+
+  const packetId = approval.metadata?.Packet?.trim() ?? '';
+  const laneId = approval.metadata?.Lane?.trim() ?? '';
+  return packetId === lane.packetId || laneId === lane.laneId;
+}
+
+function hasApprovedReview(lane: DomainLaneSummary, approvals: ReviewApprovalSummary[]) {
+  return approvals.some((approval) => approvalMatchesLane(approval, lane));
+}
+
+function toParkedLane(lane: DomainLaneSummary, reviewState: ParkedLaneReviewState): ParkedLane {
+  return {
+    laneId: lane.laneId,
+    packetId: lane.packetId,
+    status: lane.status,
+    reviewState,
+    branch: lane.branch,
+    repoPath: lane.repoPath,
+    label: lane.label,
+  };
 }
 
 /**
@@ -34,19 +60,36 @@ export interface ParkedLane {
  *   on the PACKET's terminal state (which IS updated on merge) drops it: a
  *   closed/merged/archived lane must never count as ready.
  */
+export function deriveParkedLaneBuckets(
+  lanes: DomainLaneSummary[],
+  approvals: ReviewApprovalSummary[] = [],
+  closedPacketIds?: ReadonlySet<string>,
+): ParkedLaneBuckets {
+  const needsReview: ParkedLane[] = [];
+  const awaitingMerge: ParkedLane[] = [];
+
+  for (const lane of lanes) {
+    if (lane.status !== REVIEWING_STATUS || closedPacketIds?.has(lane.packetId)) {
+      continue;
+    }
+    if (hasApprovedReview(lane, approvals)) {
+      awaitingMerge.push(toParkedLane(lane, 'awaiting-merge'));
+    } else {
+      needsReview.push(toParkedLane(lane, 'needs-review'));
+    }
+  }
+
+  return {
+    needsReview,
+    awaitingMerge,
+    all: [...needsReview, ...awaitingMerge],
+  };
+}
+
 export function deriveParkedLanes(
   lanes: DomainLaneSummary[],
   closedPacketIds?: ReadonlySet<string>,
+  approvals: ReviewApprovalSummary[] = [],
 ): ParkedLane[] {
-  return lanes
-    .filter((l) => PARKED_STATUSES.has(l.status))
-    .filter((l) => !closedPacketIds?.has(l.packetId))
-    .map((l) => ({
-      laneId: l.laneId,
-      packetId: l.packetId,
-      status: l.status,
-      branch: l.branch,
-      repoPath: l.repoPath,
-      label: l.label,
-    }));
+  return deriveParkedLaneBuckets(lanes, approvals, closedPacketIds).all;
 }

--- a/src/components/desktop/merge-beacon/derive.ts
+++ b/src/components/desktop/merge-beacon/derive.ts
@@ -1,6 +1,10 @@
 import type { DomainLaneSummary } from '@/lib/orchestrator/store';
 
 const REVIEWING_STATUS = 'reviewing';
+// Lanes parked in the merge-failure escalation chain (CLAUDE.md layers 2/5) —
+// the strongest operator-attention signal the beacon carries. Dropping them
+// made escalated packets invisible (wave-2 review regression, 2026-07-03).
+const ESCALATED_STATUSES = new Set(['awaiting_orchestrator', 'awaiting_human']);
 
 export interface ReviewApprovalSummary {
   status: string;
@@ -8,7 +12,7 @@ export interface ReviewApprovalSummary {
   metadata?: Record<string, string> | null;
 }
 
-export type ParkedLaneReviewState = 'needs-review' | 'awaiting-merge';
+export type ParkedLaneReviewState = 'needs-review' | 'awaiting-merge' | 'escalated';
 
 export interface ParkedLane {
   laneId: string;
@@ -21,6 +25,7 @@ export interface ParkedLane {
 }
 
 export interface ParkedLaneBuckets {
+  escalated: ParkedLane[];
   needsReview: ParkedLane[];
   awaitingMerge: ParkedLane[];
   all: ParkedLane[];
@@ -65,11 +70,19 @@ export function deriveParkedLaneBuckets(
   approvals: ReviewApprovalSummary[] = [],
   closedPacketIds?: ReadonlySet<string>,
 ): ParkedLaneBuckets {
+  const escalated: ParkedLane[] = [];
   const needsReview: ParkedLane[] = [];
   const awaitingMerge: ParkedLane[] = [];
 
   for (const lane of lanes) {
-    if (lane.status !== REVIEWING_STATUS || closedPacketIds?.has(lane.packetId)) {
+    if (closedPacketIds?.has(lane.packetId)) {
+      continue;
+    }
+    if (ESCALATED_STATUSES.has(lane.status)) {
+      escalated.push(toParkedLane(lane, 'escalated'));
+      continue;
+    }
+    if (lane.status !== REVIEWING_STATUS) {
       continue;
     }
     if (hasApprovedReview(lane, approvals)) {
@@ -80,9 +93,10 @@ export function deriveParkedLaneBuckets(
   }
 
   return {
+    escalated,
     needsReview,
     awaitingMerge,
-    all: [...needsReview, ...awaitingMerge],
+    all: [...escalated, ...needsReview, ...awaitingMerge],
   };
 }
 


### PR DESCRIPTION
Wave 2 / issue #1360, completing packet pkt-9f2cac54 after review.

The worker split the "N ready" pill into needs-review vs approved-awaiting-merge (with live lane-lifecycle re-derivation and click-to-review) — but the split dropped awaiting_orchestrator/awaiting_human lanes, making escalation-chain packets invisible; its unit test asserted the bug as intended. The layer-3 steer to fix it was killed by the zombie reaper (#1370), so the fix was applied by hand on the preserved branch:

- escalated is a first-class bucket (awaiting_orchestrator + awaiting_human), leads the pill, counts toward urgency, wins the click route; breakdown keys preserved for the Symon pill consumer.
- Tests: escalated bucketing incl. approvals interplay + closed-packet gating (8/8), full suite green on the real checkout.

Merge AFTER #1369 (shared page.tsx region); the legibility-trio PR rebases after this one.

Worker: Codex GPT-5.5 xhigh via o8 dispatch + hand-finish. Reviewed at b1b38329 + fix commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167kWJy2UsSp6x1RF3VnvjF