### PR TITLE
fix(supervisor): a live codex worker in its worktree is never declared dead — no more premature review cards

### DIFF
--- a/src/lib/lane/reaper.ts
+++ b/src/lib/lane/reaper.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm';
 import { getDb, lanes } from '@/lib/db';
 import { isBridgeSessionAlive } from '@/lib/runtime/pty-bridge';
 import { getRuntimeTerminalSession } from '@/lib/runtime/terminal-session-registry';
+import { findLiveCodexProcessByCwd } from '@/lib/runtimes/shared/codex-process-cwd';
 import { lookupOwnedActiveRun } from '@/lib/runtimes/shared/owned-session-index';
 import type { Lane } from './types';
 import {
@@ -61,18 +62,43 @@ function parseLivePidSessionKey(sessionKey: string): number | null {
   return Number.isFinite(pid) && pid > 0 ? pid : null;
 }
 
+async function probeCodexWorktreeContinuity(
+  sessionKey: string,
+  lane: Lane,
+): Promise<LaneOwnerProbe | null> {
+  if (!sessionKey.startsWith('codex-owned:')) return null;
+  const match = await findLiveCodexProcessByCwd(lane.worktreePath);
+  if (!match) return null;
+  return {
+    alive: true,
+    source: 'codex-process-cwd',
+    pid: match.pid,
+    note: 'live codex process cwd matches lane worktree',
+  };
+}
+
 async function probeOwnedSession(
   sessionKey: string,
+  lane: Lane,
 ): Promise<LaneOwnerProbe> {
   // Shared, TTL-memoized owned-session index (perf 2026-07-03) — one readdir
   // per root per tick, shared with the silent-exit detector, instead of a
   // per-lane scan. Semantics unchanged: null=gone, {}=cleared.
   const run = await lookupOwnedActiveRun(sessionKey);
   if (!run) {
-    return { alive: false, source: 'owned-session-registry', note: 'owned session metadata not found' };
+    return (await probeCodexWorktreeContinuity(sessionKey, lane))
+      ?? { alive: false, source: 'owned-session-registry', note: 'owned session metadata not found' };
+  }
+  if (run.tmuxSession === undefined && run.pid === undefined) {
+    return (await probeCodexWorktreeContinuity(sessionKey, lane))
+      ?? { alive: false, source: 'owned-session-registry', note: 'owned session activeRun cleared' };
   }
   if (run.tmuxSession) {
     const alive = await isBridgeSessionAlive(run.tmuxSession);
+    if (!alive) {
+      const continuity = await probeCodexWorktreeContinuity(sessionKey, lane);
+      if (continuity) return continuity;
+    }
     return {
       alive,
       source: 'owned-session-registry',
@@ -80,8 +106,13 @@ async function probeOwnedSession(
       pid: run.pid,
     };
   }
+  const pidAlive = isPidAlive(run.pid);
+  if (!pidAlive) {
+    const continuity = await probeCodexWorktreeContinuity(sessionKey, lane);
+    if (continuity) return continuity;
+  }
   return {
-    alive: isPidAlive(run.pid),
+    alive: pidAlive,
     source: 'owned-session-registry',
     pid: run.pid,
   };
@@ -149,13 +180,13 @@ async function probeLaneOwner(lane: Lane): Promise<LaneOwnerProbe> {
   }
 
   if (sessionKey.startsWith('codex-owned:')) {
-    return probeOwnedSession(sessionKey);
+    return probeOwnedSession(sessionKey, lane);
   }
   if (sessionKey.startsWith('gemini-owned:')) {
-    return probeOwnedSession(sessionKey);
+    return probeOwnedSession(sessionKey, lane);
   }
   if (sessionKey.startsWith('opencode-owned:')) {
-    return probeOwnedSession(sessionKey);
+    return probeOwnedSession(sessionKey, lane);
   }
 
   const terminalSession = getRuntimeTerminalSession(sessionKey);

--- a/src/lib/lane/types.ts
+++ b/src/lib/lane/types.ts
@@ -209,6 +209,9 @@ export type LaneEventVerb =
   // Operator picked a best-of-N comparison winner (item 3). Recorded on the
   // winner's lane. Payload: { groupId, winnerPacketId, archivedPacketIds }
   | 'comparison_resolved'
+  // Review card invalidated because the worker resumed activity after review.
+  // Payload: { reason, source, surfaceId, packetId, worktreePath }
+  | 'review_invalidated'
   // Session rules governed this packet at dispatch (#1329). Snapshot of the
   // exact operator session rules injected into the worker prompt, so review is
   // "what changed, under which constraints." Payload: { threadId, ruleCount, rules }

--- a/src/lib/runtimes/shared/codex-process-cwd.ts
+++ b/src/lib/runtimes/shared/codex-process-cwd.ts
@@ -1,0 +1,120 @@
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const INDEX_TTL_MS = 2_000;
+
+export interface LiveCodexProcess {
+  pid: number;
+  parentPid?: number;
+  command?: string;
+  cwd?: string;
+}
+
+type ProcessReader = () => Promise<LiveCodexProcess[]>;
+
+let processReader: ProcessReader | null = null;
+let cachedIndex: { builtAt: number; byCwd: Map<string, LiveCodexProcess> } | null = null;
+
+function normalizeCwd(cwd: string | null | undefined): string | null {
+  const trimmed = cwd?.trim();
+  if (!trimmed) return null;
+  return path.resolve(trimmed).replace(/\/+$/, '');
+}
+
+function commandLooksLikeCodex(command: string): boolean {
+  const [first, second] = command.trim().split(/\s+/, 2);
+  const firstBase = first ? path.basename(first) : '';
+  const secondBase = second ? path.basename(second) : '';
+  const isCodexToken = (value: string) => value === 'codex' || value.startsWith('codex.');
+  return isCodexToken(firstBase) || (firstBase === 'node' && isCodexToken(secondBase));
+}
+
+async function readCodexProcessRows(): Promise<LiveCodexProcess[]> {
+  let psOut = '';
+  try {
+    const { stdout } = await execFileAsync(
+      'ps',
+      ['-eo', 'pid=', '-o', 'ppid=', '-o', 'command='],
+      { maxBuffer: 512 * 1024, timeout: 3000 },
+    );
+    psOut = stdout;
+  } catch {
+    return [];
+  }
+
+  const rows: LiveCodexProcess[] = [];
+  for (const line of psOut.split('\n').map((value) => value.trim()).filter(Boolean)) {
+    const match = line.match(/^(\d+)\s+(\d+)\s+(.*)$/);
+    if (!match?.[1] || !match[3]) continue;
+    const pid = Number(match[1]);
+    const parentPid = Number(match[2]);
+    if (!Number.isFinite(pid) || !commandLooksLikeCodex(match[3])) continue;
+    rows.push({
+      pid,
+      parentPid: Number.isFinite(parentPid) ? parentPid : undefined,
+      command: match[3],
+    });
+  }
+  if (rows.length === 0) return [];
+
+  try {
+    const { stdout } = await execFileAsync(
+      'lsof',
+      ['-a', '-p', rows.map((row) => row.pid).join(','), '-d', 'cwd', '-Fn'],
+      { maxBuffer: 512 * 1024, timeout: 4000 },
+    );
+    let currentPid: number | null = null;
+    for (const line of stdout.split('\n')) {
+      if (line.startsWith('p')) {
+        currentPid = Number(line.slice(1));
+      } else if (line.startsWith('n/') && currentPid !== null) {
+        const row = rows.find((candidate) => candidate.pid === currentPid);
+        if (row) row.cwd = line.slice(1);
+      }
+    }
+  } catch {
+    // CWD lookup is best-effort; callers only treat a positive CWD match as live.
+  }
+
+  return rows;
+}
+
+async function buildIndex(now: number): Promise<Map<string, LiveCodexProcess>> {
+  if (cachedIndex && now - cachedIndex.builtAt < INDEX_TTL_MS) {
+    return cachedIndex.byCwd;
+  }
+
+  const reader = processReader ?? readCodexProcessRows;
+  const byCwd = new Map<string, LiveCodexProcess>();
+  const processes = await reader();
+  for (const proc of processes) {
+    const cwd = normalizeCwd(proc.cwd);
+    if (!cwd || byCwd.has(cwd)) continue;
+    byCwd.set(cwd, proc);
+  }
+
+  cachedIndex = { builtAt: now, byCwd };
+  return byCwd;
+}
+
+export async function findLiveCodexProcessByCwd(
+  cwd: string | null | undefined,
+  now: number = Date.now(),
+): Promise<LiveCodexProcess | null> {
+  const normalized = normalizeCwd(cwd);
+  if (!normalized) return null;
+  const index = await buildIndex(now);
+  return index.get(normalized) ?? null;
+}
+
+export function resetCodexProcessCwdIndexForTesting(): void {
+  cachedIndex = null;
+  processReader = null;
+}
+
+export function setCodexProcessReaderForTesting(reader: ProcessReader): void {
+  cachedIndex = null;
+  processReader = reader;
+}

--- a/src/lib/supervisor/review-invalidation.test.ts
+++ b/src/lib/supervisor/review-invalidation.test.ts
@@ -1,0 +1,47 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createLane, getLane, getLaneEvents, setLaneStatus } from '@/lib/lane/registry';
+import { invalidateReviewingLaneForWorkerActivity } from './review-invalidation';
+
+let tempWorktree: string | null = null;
+
+afterEach(() => {
+  if (tempWorktree) rmSync(tempWorktree, { recursive: true, force: true });
+  tempWorktree = null;
+});
+
+describe('review invalidation on resumed worker activity', () => {
+  it('moves a reviewing Codex lane back to running when transcript progress arrives', async () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), 'o8-review-invalidated-'));
+    tempWorktree = worktreePath;
+    const surfaceId = 'codex-owned:review-invalidated';
+    const lane = createLane({
+      repoPath: worktreePath,
+      worktreePath,
+      branch: 'pkt/review-invalidated',
+      runtime: 'codex',
+      sessionKey: surfaceId,
+      packetId: 'pkt-review-invalidated',
+    });
+    setLaneStatus(lane.id, 'reviewing', 'system', 'silent_exit_work_present');
+
+    const changed = await invalidateReviewingLaneForWorkerActivity({
+      surfaceId,
+      source: 'transcript_progress',
+      lastMessage: 'still working',
+    });
+
+    expect(changed).toBe(true);
+    const after = getLane(lane.id);
+    expect(after?.status).toBe('running');
+    expect(after?.lastEventLabel).toBe('review_invalidated');
+    const event = getLaneEvents(lane.id).find((candidate) => candidate.verb === 'review_invalidated');
+    expect(event?.payload.reason).toBe('worker_activity_after_review');
+    expect(event?.payload.source).toBe('transcript_progress');
+    expect(event?.payload.lastMessageLength).toBe('still working'.length);
+  });
+});

--- a/src/lib/supervisor/review-invalidation.ts
+++ b/src/lib/supervisor/review-invalidation.ts
@@ -1,0 +1,30 @@
+export type WorkerActivitySource = 'transcript_progress' | 'worktree_write';
+
+export async function invalidateReviewingLaneForWorkerActivity(input: {
+  surfaceId: string;
+  source: WorkerActivitySource;
+  lastMessage?: string;
+}): Promise<boolean> {
+  const { appendEvent, findLaneBySession, updateLane } = await import('@/lib/lane/registry');
+  const lane = findLaneBySession(input.surfaceId);
+  if (!lane || lane.runtime !== 'codex' || lane.status !== 'reviewing') {
+    return false;
+  }
+
+  const event = appendEvent(lane.id, 'review_invalidated', 'system', {
+    reason: 'worker_activity_after_review',
+    source: input.source,
+    surfaceId: input.surfaceId,
+    packetId: lane.packetId,
+    worktreePath: lane.worktreePath,
+    lastMessageLength: input.lastMessage?.length ?? 0,
+  });
+
+  const updated = updateLane(lane.id, {
+    status: 'running',
+    lastEventAt: event.timestamp,
+    lastEventLabel: 'review_invalidated',
+  }, 'system');
+
+  return updated?.status === 'running';
+}

--- a/src/lib/supervisor/silent-exit-detector.test.ts
+++ b/src/lib/supervisor/silent-exit-detector.test.ts
@@ -4,9 +4,41 @@
  * that re-adds `reviewing` to the probe set or `silent_exit_work_present` to
  * the terminally-dead set fails loudly with this incident's context.
  */
-import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
-import { DEAD_LANE_EVENT_LABELS, INTERESTING_LANE_STATUSES } from './silent-exit-detector';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { resetCodexProcessCwdIndexForTesting, setCodexProcessReaderForTesting } from '@/lib/runtimes/shared/codex-process-cwd';
+import { resetOwnedSessionIndex } from '@/lib/runtimes/shared/owned-session-index';
+import {
+  DEAD_LANE_EVENT_LABELS,
+  INTERESTING_LANE_STATUSES,
+  runSilentExitTickForTesting,
+} from './silent-exit-detector';
+
+const { createLane, getLane, updateLane } = await import('@/lib/lane/registry');
+
+let ownedRoot: string | null = null;
+let tempWorktree: string | null = null;
+
+function writeOwnedSession(surfaceId: string, activeRun: unknown): void {
+  if (!ownedRoot) throw new Error('ownedRoot not initialized');
+  const dir = join(ownedRoot, surfaceId.replace(/^codex-owned:/, ''));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'session.json'), JSON.stringify({ surfaceId, activeRun }));
+}
+
+afterEach(() => {
+  if (ownedRoot) rmSync(ownedRoot, { recursive: true, force: true });
+  if (tempWorktree) rmSync(tempWorktree, { recursive: true, force: true });
+  ownedRoot = null;
+  tempWorktree = null;
+  delete process.env.CORTEX_IDE_OWNED_CODEX_ROOT;
+  resetOwnedSessionIndex();
+  resetCodexProcessCwdIndexForTesting();
+});
 
 describe('silent-exit detector policy (wave-1B burial incident)', () => {
   it('never probes reviewing lanes — a dead process after completion is normal, not a silent exit', () => {
@@ -19,5 +51,41 @@ describe('silent-exit detector policy (wave-1B burial incident)', () => {
     expect(DEAD_LANE_EVENT_LABELS.has('silent_exit_work_present')).toBe(false);
     expect(DEAD_LANE_EVENT_LABELS.has('silent_exit_no_work')).toBe(true);
     expect(DEAD_LANE_EVENT_LABELS.has('zombie_reap')).toBe(true);
+  });
+
+  it('does not salvage a quiet owned Codex lane when a live codex process is still in its worktree', async () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), 'o8-live-codex-wt-'));
+    tempWorktree = worktreePath;
+    ownedRoot = mkdtempSync(join(tmpdir(), 'o8-owned-codex-'));
+    process.env.CORTEX_IDE_OWNED_CODEX_ROOT = ownedRoot;
+    resetOwnedSessionIndex();
+
+    const surfaceId = 'codex-owned:test-live-cwd';
+    writeOwnedSession(surfaceId, { pid: 2_147_483_647 });
+    setCodexProcessReaderForTesting(async () => [{
+      pid: 12345,
+      command: '/usr/local/bin/codex exec --resume abc',
+      cwd: worktreePath,
+    }]);
+
+    const lane = createLane({
+      repoPath: worktreePath,
+      worktreePath,
+      branch: 'pkt/live-cwd',
+      runtime: 'codex',
+      sessionKey: surfaceId,
+      packetId: 'pkt-live-cwd',
+    });
+    updateLane(lane.id, {
+      status: 'running',
+      lastEventAt: new Date(Date.now() - 120_000).toISOString(),
+      lastEventLabel: 'session_launched',
+    });
+
+    await runSilentExitTickForTesting();
+
+    const after = getLane(lane.id);
+    expect(after?.status).toBe('running');
+    expect(after?.lastEventLabel).toBe('session_launched');
   });
 });

--- a/src/lib/supervisor/silent-exit-detector.ts
+++ b/src/lib/supervisor/silent-exit-detector.ts
@@ -44,6 +44,7 @@ import {
   setLaneStatus,
 } from '@/lib/lane/registry';
 import type { Lane } from '@/lib/lane/types';
+import { findLiveCodexProcessByCwd } from '@/lib/runtimes/shared/codex-process-cwd';
 import { lookupOwnedActiveRun } from '@/lib/runtimes/shared/owned-session-index';
 import {
   autoCommitCompletionWorktree,
@@ -99,13 +100,22 @@ function isPidAlive(pid: number | undefined): boolean {
 }
 
 
+async function hasCodexWorktreeContinuity(
+  surfaceId: string,
+  worktreePath: string | null | undefined,
+): Promise<boolean> {
+  if (!surfaceId.startsWith('codex-owned:')) return false;
+  return Boolean(await findLiveCodexProcessByCwd(worktreePath));
+}
+
 async function isOwnedSessionAlive(
   surfaceId: string,
+  worktreePath?: string | null,
 ): Promise<boolean | undefined> {
   // Shared, TTL-memoized index (perf 2026-07-03): one readdir per root per tick
   // instead of one per-lane. Semantics unchanged — null=gone, {}=cleared.
   const run = await lookupOwnedActiveRun(surfaceId);
-  if (!run) return false;
+  if (!run) return await hasCodexWorktreeContinuity(surfaceId, worktreePath) ? true : false;
   // F44 — when session.json exists but `activeRun` is cleared (the runtime
   // store does this when the recorded pid dies, see owned-session/store.ts
   // line 253), readOwnedActiveRun returns `{}`. That's not "I can't tell" —
@@ -114,17 +124,20 @@ async function isOwnedSessionAlive(
   // `reviewing`. Without this, F44 lanes stayed `running` for 45+ min after
   // Codex finished.
   if (run.tmuxSession === undefined && run.pid === undefined) {
-    return false;
+    return await hasCodexWorktreeContinuity(surfaceId, worktreePath) ? true : false;
   }
   // Trust the tmux/bridge session first — it survives `zsh -l -c CMD` exec-ing
   // into the CLI, where the wrapper pid is replaced by the child pid and our
   // stored pid goes stale. If tmux exists AND is dead, we know the session is
   // gone. If tmux exists AND is alive, the session is alive regardless of pid.
   if (run.tmuxSession) {
-    return isBridgeSessionAlive(run.tmuxSession);
+    const bridgeAlive = await isBridgeSessionAlive(run.tmuxSession);
+    if (bridgeAlive) return true;
+    return await hasCodexWorktreeContinuity(surfaceId, worktreePath) ? true : false;
   }
   // No tmux session recorded (e.g. bridge failed to spawn) — fall back to pid.
   if (isPidAlive(run.pid)) return true;
+  if (await hasCodexWorktreeContinuity(surfaceId, worktreePath)) return true;
   // pid was set but is now dead, with no tmux to confirm — bail rather than
   // miscategorize. The store will clear activeRun on its next pass and the
   // case above will then trigger the silent-exit triage.
@@ -158,7 +171,7 @@ async function probeSessionAlive(lane: Lane): Promise<boolean | undefined> {
     || sessionKey.startsWith('opencode-owned:')
   ) {
     try {
-      return await isOwnedSessionAlive(sessionKey);
+      return await isOwnedSessionAlive(sessionKey, lane.worktreePath);
     } catch (error) {
       console.warn(`[silent-exit] Owned session probe failed for ${sessionKey}:`, error);
       return undefined;

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -103,6 +103,7 @@ import {
   resetSelfReviewStallGuard,
   type SelfReviewStallDecision,
 } from './lib/supervisor/self-review-stall-guard';
+import { invalidateReviewingLaneForWorkerActivity } from './lib/supervisor/review-invalidation';
 import {
   enqueueSupervisorInboxItem,
   startHealBot,
@@ -481,6 +482,15 @@ async function enqueueVerificationFailureInboxItem(input: {
 }
 
 async function handleCodexSelfReviewProgress(surfaceId: string, lastMessage: string): Promise<void> {
+  if (await invalidateReviewingLaneForWorkerActivity({
+    surfaceId,
+    source: 'transcript_progress',
+    lastMessage,
+  })) {
+    resetSelfReviewStallGuard(surfaceId);
+    return;
+  }
+
   const watched = getWatchedAgents().find((agent) => agent.surfaceId === surfaceId);
   const { findLaneBySession, updateLane } = await import('@/lib/lane/registry');
   const lane = findLaneBySession(surfaceId);

--- a/tests/lane-reaper-salvage.test.ts
+++ b/tests/lane-reaper-salvage.test.ts
@@ -18,22 +18,34 @@
  *     worktree is left untouched
  */
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import type { ZombieLaneCandidate } from '@/lib/lane/reaper';
 import type { Lane } from '@/lib/lane/types';
+import { resetCodexProcessCwdIndexForTesting, setCodexProcessReaderForTesting } from '@/lib/runtimes/shared/codex-process-cwd';
+import { resetOwnedSessionIndex } from '@/lib/runtimes/shared/owned-session-index';
 
 // The SQLite store resolves its data dir at module load — point it at a temp
 // dir BEFORE importing anything that touches the registry (dynamic below for
 // the same reason; static imports would hoist above this assignment).
 process.env.O8_DATA_DIR = mkdtempSync(join(tmpdir(), 'o8-reaper-salvage-'));
 
-const { createLane, getLane, setLaneStatus, getLaneEvents } = await import('@/lib/lane/registry');
-const { reapZombieLane } = await import('@/lib/lane/reaper');
+const { createLane, getLane, setLaneStatus, updateLane, getLaneEvents } = await import('@/lib/lane/registry');
+const { LANE_HEARTBEAT_STALE_MS, listZombieLaneCandidates, reapZombieLane } = await import('@/lib/lane/reaper');
+
+let ownedRoot: string | null = null;
+
+afterEach(() => {
+  if (ownedRoot) rmSync(ownedRoot, { recursive: true, force: true });
+  ownedRoot = null;
+  delete process.env.CORTEX_IDE_OWNED_CODEX_ROOT;
+  resetCodexProcessCwdIndexForTesting();
+  resetOwnedSessionIndex();
+});
 
 function git(cwd: string, args: string[]): string {
   return execFileSync('git', args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] }).toString();
@@ -73,6 +85,48 @@ function deadCandidate(
 }
 
 describe('reapZombieLane salvage (#1282 Failure B)', () => {
+  it('does not classify an owned Codex lane dead when a live codex process cwd matches the worktree', async () => {
+    const wt = makeWorktree({ dirty: false });
+    ownedRoot = mkdtempSync(join(tmpdir(), 'o8-reaper-owned-codex-'));
+    process.env.CORTEX_IDE_OWNED_CODEX_ROOT = ownedRoot;
+    resetOwnedSessionIndex();
+
+    const surfaceId = 'codex-owned:reaper-live-cwd';
+    const sessionDir = join(ownedRoot, 'reaper-live-cwd');
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, 'session.json'), JSON.stringify({
+      surfaceId,
+      activeRun: { pid: 2_147_483_647 },
+    }));
+    setCodexProcessReaderForTesting(async () => [{
+      pid: 23456,
+      command: '/opt/homebrew/bin/codex exec --resume reaper',
+      cwd: wt,
+    }]);
+
+    const lane = createLane({
+      repoPath: wt,
+      branch: 'pkt/reaper-live-cwd',
+      runtime: 'codex',
+      worktreePath: wt,
+      baseBranch: 'main',
+      sessionKey: surfaceId,
+      packetId: 'pkt-reaper-live-cwd',
+    });
+    setLaneStatus(lane.id, 'running', 'system');
+    const now = Date.now();
+    updateLane(lane.id, {
+      lastHeartbeatAt: now - LANE_HEARTBEAT_STALE_MS - 5_000,
+      lastEventAt: new Date(now - LANE_HEARTBEAT_STALE_MS - 5_000).toISOString(),
+      lastEventLabel: 'session_launched',
+    });
+
+    const candidates = await listZombieLaneCandidates(now);
+
+    expect(candidates.some((candidate) => candidate.lane.id === lane.id)).toBe(false);
+    expect(getLane(lane.id)?.status).toBe('running');
+  });
+
   it('commits a running lane\'s uncommitted work and routes it to reviewing', async () => {
     const wt = makeWorktree({ dirty: true });
     const lane = createLane({


### PR DESCRIPTION
Wave 3 / issue #1366. Codex multi-turn drive rotates processes between turns; the owned-session registry held the old pid, so a >45s thinking gap got live workers salvaged to reviewing mid-work — premature READY FOR REVIEW cards with half-done auto-commits on multiple wave-2 packets.

- New TTL-memoized codex process-cwd index (one ps+lsof per 2s shared across every lane and both sweepers — same pattern as the owned-session index): before any dead verdict, silent-exit and the zombie reaper check for a live codex process whose cwd is the lane worktree.
- Review invalidation: transcript progress on a reviewing codex lane flips it back to running + records review_invalidated (ws-server progress chokepoint) — a review card never shows for a lane with an active writer.
- Real-path tests: continuity probe through both sweepers (injectable process reader) + the reviewing-to-running flip.
- 907 tests green, tsc clean. Worker self-narrowed the process matcher during its own self-review.

Worker: Codex GPT-5.5 xhigh via o8 dispatch, packet pkt-181d8998. Reviewed at pinned HEAD 0068da2d; gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167kWJy2UsSp6x1RF3VnvjF