### PR TITLE
fix(dispatch): steer never kills the lane — session rebind, reaper grace, preserved uncommitted work, honest archive banner

### DIFF
--- a/src/app/api/lanes/route.ts
+++ b/src/app/api/lanes/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { requirePanelAuth } from '@/lib/panel/auth';
-import { listLanes, listActiveLanes } from '@/lib/lane/registry';
+import { getLaneEvents, listLanes, listActiveLanes } from '@/lib/lane/registry';
+import { summarizeLaneArchive } from '@/lib/lane/archive-summary';
 import { collapseArchivedLanesByTask } from '@/lib/lanes/collapse-archived-by-task';
 import { codename } from '@/lib/agents/codename';
 import { dispatch } from '@/lib/lane/commands';
@@ -44,6 +45,9 @@ export async function GET(req: NextRequest) {
   const lanes = resolvedLanes.map((lane) => ({
     ...lane,
     codename: codename(lane.id),
+    archiveSummary: lane.status === 'archived' || lane.status === 'completed'
+      ? summarizeLaneArchive(lane, getLaneEvents(lane.id, 24))
+      : null,
   }));
 
   return NextResponse.json({ lanes }, {

--- a/src/app/api/lanes/route.ts
+++ b/src/app/api/lanes/route.ts
@@ -46,7 +46,7 @@ export async function GET(req: NextRequest) {
     ...lane,
     codename: codename(lane.id),
     archiveSummary: lane.status === 'archived' || lane.status === 'completed'
-      ? summarizeLaneArchive(lane, getLaneEvents(lane.id, 24))
+      ? summarizeLaneArchive(lane, getLaneEvents(lane.id, 80))
       : null,
   }));
 

--- a/src/app/api/orchestrator/agent-task/route.ts
+++ b/src/app/api/orchestrator/agent-task/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { requirePanelAuth } from '@/lib/panel/auth';
 import { listActiveLanesWithSessions } from '@/lib/lane/registry';
+import { rebindLaneSessionIfChanged } from '@/lib/lane/session-rebind';
 import { performRuntimeAction } from '@/lib/runtime/actions';
 import { codename } from '@/lib/agents/codename';
 import { asRecord, operatorError, operatorSuccess, parseJsonBody } from '../_utils';
@@ -78,6 +79,7 @@ export async function POST(request: NextRequest) {
   if (!result.ok) {
     return operatorError('steer_failed', result.note || `Could not reach ${resolvedName}.`, 200);
   }
+  rebindLaneSessionIfChanged(lane.id, lane.sessionKey, result.sessionKey, 'orchestrator');
 
   return operatorSuccess({
     steered: resolvedName,

--- a/src/app/dashboard/hooks/useLaneArchivedSet.ts
+++ b/src/app/dashboard/hooks/useLaneArchivedSet.ts
@@ -7,6 +7,13 @@ interface LaneRecord {
   sessionKey: string | null;
   packetId: string | null;
   status: string;
+  archiveSummary?: LaneArchiveSummary | null;
+}
+
+interface LaneArchiveSummary {
+  source: string;
+  message: string;
+  preservedBranch?: string | null;
 }
 
 interface LaneLifecycleEventData {
@@ -23,6 +30,22 @@ interface LaneLifecycleEventData {
 export interface ArchivedLaneView {
   sessionKeys: Set<string>;
   packetIds: Set<string>;
+  archiveSummariesBySessionKey: Map<string, LaneArchiveSummary>;
+  archiveSummariesByPacketId: Map<string, LaneArchiveSummary>;
+}
+
+function archiveSummarySame(left: LaneArchiveSummary | undefined, right: LaneArchiveSummary | undefined): boolean {
+  return left?.source === right?.source
+    && left?.message === right?.message
+    && left?.preservedBranch === right?.preservedBranch;
+}
+
+function archiveSummaryMapsSame(
+  left: Map<string, LaneArchiveSummary>,
+  right: Map<string, LaneArchiveSummary>,
+): boolean {
+  return left.size === right.size
+    && [...right].every(([key, value]) => archiveSummarySame(left.get(key), value));
 }
 
 // Terminal lane statuses that mean "retired" — the session is done and the
@@ -66,6 +89,8 @@ export function useLaneArchivedView(): ArchivedLaneView {
   const [state, setState] = useState<ArchivedLaneView>(() => ({
     sessionKeys: new Set<string>(),
     packetIds: new Set<string>(),
+    archiveSummariesBySessionKey: new Map<string, LaneArchiveSummary>(),
+    archiveSummariesByPacketId: new Map<string, LaneArchiveSummary>(),
   }));
   const inflightRef = useRef(false);
   const laneSessionKeysRef = useRef<Map<string, Set<string>>>(new Map());
@@ -79,13 +104,22 @@ export function useLaneArchivedView(): ArchivedLaneView {
       const data = await response.json() as { lanes?: LaneRecord[] };
       const nextSessions = new Set<string>();
       const nextPackets = new Set<string>();
+      const nextSessionSummaries = new Map<string, LaneArchiveSummary>();
+      const nextPacketSummaries = new Map<string, LaneArchiveSummary>();
       for (const lane of data.lanes ?? []) {
         if (!RETIRED_LANE_STATUSES.has(lane.status)) continue;
         if (lane.sessionKey) nextSessions.add(lane.sessionKey);
         if (lane.packetId) nextPackets.add(lane.packetId);
+        if (lane.archiveSummary) {
+          if (lane.sessionKey) nextSessionSummaries.set(lane.sessionKey, lane.archiveSummary);
+          if (lane.packetId) nextPacketSummaries.set(lane.packetId, lane.archiveSummary);
+        }
         const accumulated = laneSessionKeysRef.current.get(lane.id);
         if (accumulated) {
-          for (const key of accumulated) nextSessions.add(key);
+          for (const key of accumulated) {
+            nextSessions.add(key);
+            if (lane.archiveSummary) nextSessionSummaries.set(key, lane.archiveSummary);
+          }
         }
       }
       setState((current) => {
@@ -93,9 +127,16 @@ export function useLaneArchivedView(): ArchivedLaneView {
           && [...nextSessions].every((key) => current.sessionKeys.has(key));
         const packetsSame = current.packetIds.size === nextPackets.size
           && [...nextPackets].every((id) => current.packetIds.has(id));
-        return sessionsSame && packetsSame
+        const sessionSummariesSame = archiveSummaryMapsSame(current.archiveSummariesBySessionKey, nextSessionSummaries);
+        const packetSummariesSame = archiveSummaryMapsSame(current.archiveSummariesByPacketId, nextPacketSummaries);
+        return sessionsSame && packetsSame && sessionSummariesSame && packetSummariesSame
           ? current
-          : { sessionKeys: nextSessions, packetIds: nextPackets };
+          : {
+              sessionKeys: nextSessions,
+              packetIds: nextPackets,
+              archiveSummariesBySessionKey: nextSessionSummaries,
+              archiveSummariesByPacketId: nextPacketSummaries,
+            };
       });
     } catch {
       // Lane derivation is best-effort — on fetch failure we keep the last
@@ -145,7 +186,7 @@ export function useLaneArchivedView(): ArchivedLaneView {
             packets.add(packetId);
             changed = true;
           }
-          return changed ? { sessionKeys: sessions, packetIds: packets } : current;
+          return changed ? { ...current, sessionKeys: sessions, packetIds: packets } : current;
         });
       }
       void fetchOnce();

--- a/src/components/desktop/workspace-terminal/WorkspaceChatPane.tsx
+++ b/src/components/desktop/workspace-terminal/WorkspaceChatPane.tsx
@@ -131,6 +131,20 @@ function WorkspaceChatPaneBase({
     const candidateKeys = [tab.chatSessionKey, chat.normalizedSessionKey, livePacket?.lane?.sessionKey];
     return candidateKeys.some((key) => Boolean(key) && archivedLaneView.sessionKeys.has(key as string));
   }, [tab.kind, tab.chatSessionKey, tab.orchestrationPacket?.packetId, chat.normalizedSessionKey, liveStatus, livePacket, archivedLaneView]);
+  const archiveSummary = useMemo(() => {
+    const packetId = livePacket?.id ?? tab.orchestrationPacket?.packetId ?? null;
+    if (packetId) {
+      const byPacket = archivedLaneView.archiveSummariesByPacketId.get(packetId);
+      if (byPacket) return byPacket;
+    }
+    const candidateKeys = [tab.chatSessionKey, chat.normalizedSessionKey, livePacket?.lane?.sessionKey];
+    for (const key of candidateKeys) {
+      if (!key) continue;
+      const bySession = archivedLaneView.archiveSummariesBySessionKey.get(key);
+      if (bySession) return bySession;
+    }
+    return null;
+  }, [archivedLaneView, chat.normalizedSessionKey, livePacket, tab.chatSessionKey, tab.orchestrationPacket?.packetId]);
 
   // A retired lane is NOT necessarily a merged one. The old banner said "Merged"
   // for every archived lane — including ones the operator stopped or reset, and
@@ -168,11 +182,13 @@ function WorkspaceChatPaneBase({
       tone: 'var(--t-text-muted)',
       iconBg: 'var(--t-panel)',
       heroTitle: 'Archived',
-      heroSub: `This ${chat.runtimeLabel} session’s lane was archived without merging.`,
+      heroSub: archiveSummary?.message ?? `This ${chat.runtimeLabel} session’s lane was archived without merging.`,
       bannerLabel: 'Archived · read-only',
-      bannerSub: 'This session’s lane was archived without merging. The transcript stays for review.',
+      bannerSub: archiveSummary
+        ? `${archiveSummary.message} The transcript stays for review.`
+        : 'This session’s lane was archived without merging. The transcript stays for review.',
     };
-  }, [liveStatus, livePacket?.releaseState, chat.runtimeLabel]);
+  }, [archiveSummary, liveStatus, livePacket?.releaseState, chat.runtimeLabel]);
 
   // Runtime fallback notifications: when a Gemini model quotas out, the
   // adapter picks the next model in GEMINI_FALLBACK_CASCADE before retrying.

--- a/src/components/desktop/workspace-terminal/WorkspaceChatPane.tsx
+++ b/src/components/desktop/workspace-terminal/WorkspaceChatPane.tsx
@@ -5,14 +5,9 @@ import {
   AlertCircle,
   ArrowDown,
   CheckCircle2,
-  FileText,
-  Lightbulb,
   MessageSquare,
-  Search,
 } from '../lucide-shims';
-import { useLaneArchivedView } from '@/app/dashboard/hooks/useLaneArchivedSet';
 import { useSharedDesktopWs } from '@/components/desktop/hooks/DesktopWebSocketContext';
-import { useOrchestratorData } from '@/components/desktop/orchestrator-data-context';
 import { IssueLinkPickerModal, type LinkedIssueRef } from '@/components/desktop/IssueLinkPicker';
 import type { RealtimeEventEnvelope, RealtimeMutationRecord } from '@/lib/realtime/types';
 import {
@@ -25,6 +20,7 @@ import {
 } from '@/components/desktop/workspace-terminal/constants';
 import type { TerminalTab } from '@/components/desktop/workspace-terminal/types';
 import { useWorkspaceChatPane } from '@/components/desktop/workspace-terminal/useWorkspaceChatPane';
+import { useWorkspaceChatLifecycle } from '@/components/desktop/workspace-terminal/useWorkspaceChatLifecycle';
 import { WorkspaceChatComposer } from '@/components/desktop/workspace-terminal/WorkspaceChatComposer';
 import { ChatPacketStatusBanner } from '@/components/desktop/workspace-terminal/ChatPacketStatusBanner';
 import { ChatPacketReviewDiff } from '@/components/desktop/workspace-terminal/ChatPacketReviewDiff';
@@ -33,6 +29,7 @@ import {
   WorkspaceRichChatEvents,
   stripWorkspaceRichRendererFallback,
 } from '@/components/desktop/workspace-terminal/chat-renderers/WorkspaceRichChatEvents';
+import { PromptGlyph, looksLikePacketPrompt } from '@/components/desktop/workspace-terminal/workspace-chat-prompt';
 
 const LazyMessageBubble = lazy(() => import('@/components/desktop/LLMChat').then((module) => ({ default: module.MessageBubble })));
 const LazyChainOfThought = lazy(() => import('@/components/desktop/LLMChat').then((module) => ({ default: module.ChainOfThought })));
@@ -48,26 +45,6 @@ interface WorkspaceChatPaneProps {
   onLinkedIssueChange: (tabId: string, issue: LinkedIssueRef | null) => void;
   onSaveCheckpoint: (tabId: string) => void;
   onRestoreLatestCheckpoint: (tabId: string) => void;
-}
-
-function PromptGlyph({ icon }: { icon: string }) {
-  if (icon === 'Idea') return <Lightbulb size={16} />;
-  if (icon === 'Search') return <Search size={16} />;
-  if (icon === 'Test') return <AlertCircle size={16} />;
-  return <FileText size={16} />;
-}
-
-// A dispatched-packet prompt is a large, structured brief. We collapse it into a
-// PacketHeaderCard so the transcript doesn't open with a wall of text — but the
-// gate used to require `tab.orchestrationPacket`, which is dropped when a tab is
-// reconstructed from session discovery (the packet metadata doesn't survive).
-// Detect the prompt by the markers the dispatcher always emits so the card shows
-// regardless of whether the badge metadata is present.
-function looksLikePacketPrompt(text: string): boolean {
-  if (!text || text.length < 400) return false;
-  return /##\s*Project\s+(Brief|Scope|Directives)\b/i.test(text)
-    || /(^|\n)\s*Packet:\s/i.test(text)
-    || /(^|\n)\s*STRICT SCOPE:/i.test(text);
 }
 
 function WorkspaceChatPaneBase({
@@ -94,101 +71,11 @@ function WorkspaceChatPaneBase({
     onConsumeDraftInjection,
   });
 
-  // Live packet status — the orchestrationPacket badge stored on the tab is
-  // a snapshot at openCliChatSession time. The mission state knows the
-  // current status (running → awaiting_review → released → archived);
-  // resolve it by sessionKey so the PacketHeaderCard reflects reality.
-  const orchestratorData = useOrchestratorData();
-  const livePacket = useMemo(() => {
-    if (!tab.orchestrationPacket) return null;
-    const targetSessionKey = chat.normalizedSessionKey ?? tab.id;
-    const targetPacketId = tab.orchestrationPacket.packetId ?? null;
-    return orchestratorData?.missionState?.packets.find((p) => (
-      (targetPacketId && p.id === targetPacketId)
-      || (targetSessionKey && p.lane?.sessionKey === targetSessionKey)
-    )) ?? null;
-  }, [chat.normalizedSessionKey, orchestratorData?.missionState?.packets, tab.id, tab.orchestrationPacket]);
-  const liveStatus = livePacket?.status ?? tab.orchestrationPacket?.status ?? null;
-
-  // When the lane bound to this tab's session has been archived (reviewed +
-  // merged, reaped for a missing worktree, or explicitly archived by the
-  // operator), we flip the composer into read-only mode with a dismissible
-  // banner. The transcript stays visible so the user can still scroll the
-  // history, but they can't send new turns to a retired session.
-  const archivedLaneView = useLaneArchivedView();
-  // A lane is "retired" (merged + archived → read-only) when ANY reliable
-  // signal says so. We OR several because the session-key form drifts between
-  // raw (`codex-owned:abc`), normalized (`codex:abc`), and whatever the
-  // lane-lifecycle event payload carried. The old check keyed only on the raw
-  // `tab.chatSessionKey`, so two sibling tabs from the same mission disagreed —
-  // one flipped to read-only while the other stayed stuck on "Agent working…".
-  // Packet status + the archived packetId set don't drift, so they anchor it.
-  const laneRetired = useMemo(() => {
-    if (tab.kind !== 'chat') return false;
-    if (liveStatus === 'released' || liveStatus === 'archived') return true;
-    const packetId = livePacket?.id ?? tab.orchestrationPacket?.packetId ?? null;
-    if (packetId && archivedLaneView.packetIds.has(packetId)) return true;
-    const candidateKeys = [tab.chatSessionKey, chat.normalizedSessionKey, livePacket?.lane?.sessionKey];
-    return candidateKeys.some((key) => Boolean(key) && archivedLaneView.sessionKeys.has(key as string));
-  }, [tab.kind, tab.chatSessionKey, tab.orchestrationPacket?.packetId, chat.normalizedSessionKey, liveStatus, livePacket, archivedLaneView]);
-  const archiveSummary = useMemo(() => {
-    const packetId = livePacket?.id ?? tab.orchestrationPacket?.packetId ?? null;
-    if (packetId) {
-      const byPacket = archivedLaneView.archiveSummariesByPacketId.get(packetId);
-      if (byPacket) return byPacket;
-    }
-    const candidateKeys = [tab.chatSessionKey, chat.normalizedSessionKey, livePacket?.lane?.sessionKey];
-    for (const key of candidateKeys) {
-      if (!key) continue;
-      const bySession = archivedLaneView.archiveSummariesBySessionKey.get(key);
-      if (bySession) return bySession;
-    }
-    return null;
-  }, [archivedLaneView, chat.normalizedSessionKey, livePacket, tab.chatSessionKey, tab.orchestrationPacket?.packetId]);
-
-  // A retired lane is NOT necessarily a merged one. The old banner said "Merged"
-  // for every archived lane — including ones the operator stopped or reset, and
-  // ones that failed — which is a lie (operator flagged it 2026-06-22). Derive
-  // the real outcome: `releaseState === 'released'` is the sticky merge signal
-  // (set at merge, survives archival even when status flips to 'archived'); a
-  // `failed` status is a failure; anything else retired was archived without
-  // ever merging. Only the genuine-merge branch gets the green "Merged" check.
-  const retirement = useMemo(() => {
-    const merged = liveStatus === 'released' || livePacket?.releaseState === 'released';
-    if (merged) {
-      return {
-        merged: true,
-        tone: '#22c55e',
-        iconBg: 'rgba(34, 197, 94, 0.10)',
-        heroTitle: 'Merged & archived',
-        heroSub: `This ${chat.runtimeLabel} session shipped and its lane was archived. The live transcript isn’t available here.`,
-        bannerLabel: 'Merged · read-only',
-        bannerSub: 'This session’s lane merged and was archived. The transcript stays for review.',
-      };
-    }
-    if (liveStatus === 'failed') {
-      return {
-        merged: false,
-        tone: '#f59e0b',
-        iconBg: 'rgba(245, 158, 11, 0.10)',
-        heroTitle: 'Ended without merging',
-        heroSub: `This ${chat.runtimeLabel} session ended without merging and its lane was archived.`,
-        bannerLabel: 'Ended · read-only',
-        bannerSub: 'This session ended without merging. The transcript stays for review.',
-      };
-    }
-    return {
-      merged: false,
-      tone: 'var(--t-text-muted)',
-      iconBg: 'var(--t-panel)',
-      heroTitle: 'Archived',
-      heroSub: archiveSummary?.message ?? `This ${chat.runtimeLabel} session’s lane was archived without merging.`,
-      bannerLabel: 'Archived · read-only',
-      bannerSub: archiveSummary
-        ? `${archiveSummary.message} The transcript stays for review.`
-        : 'This session’s lane was archived without merging. The transcript stays for review.',
-    };
-  }, [archiveSummary, liveStatus, livePacket?.releaseState, chat.runtimeLabel]);
+  const { orchestratorData, livePacket, liveStatus, laneRetired, retirement } = useWorkspaceChatLifecycle({
+    tab,
+    normalizedSessionKey: chat.normalizedSessionKey,
+    runtimeLabel: chat.runtimeLabel,
+  });
 
   // Runtime fallback notifications: when a Gemini model quotas out, the
   // adapter picks the next model in GEMINI_FALLBACK_CASCADE before retrying.

--- a/src/components/desktop/workspace-terminal/useWorkspaceChatLifecycle.ts
+++ b/src/components/desktop/workspace-terminal/useWorkspaceChatLifecycle.ts
@@ -1,0 +1,111 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useLaneArchivedView } from '@/app/dashboard/hooks/useLaneArchivedSet';
+import { useOrchestratorData } from '@/components/desktop/orchestrator-data-context';
+import type { TerminalTab } from '@/components/desktop/workspace-terminal/types';
+import type { OrchestratorPacket, OrchestratorPacketStatus } from '@/lib/orchestrator/types';
+
+interface UseWorkspaceChatLifecycleOptions {
+  tab: TerminalTab;
+  normalizedSessionKey?: string | null;
+  runtimeLabel: string;
+}
+
+interface RetirementCopy {
+  merged: boolean;
+  tone: string;
+  iconBg: string;
+  heroTitle: string;
+  heroSub: string;
+  bannerLabel: string;
+  bannerSub: string;
+}
+
+export function useWorkspaceChatLifecycle({
+  tab,
+  normalizedSessionKey,
+  runtimeLabel,
+}: UseWorkspaceChatLifecycleOptions): {
+  orchestratorData: ReturnType<typeof useOrchestratorData>;
+  livePacket: OrchestratorPacket | null;
+  liveStatus: OrchestratorPacketStatus | null;
+  laneRetired: boolean;
+  retirement: RetirementCopy;
+} {
+  const orchestratorData = useOrchestratorData();
+  const livePacket = useMemo(() => {
+    if (!tab.orchestrationPacket) return null;
+    const targetSessionKey = normalizedSessionKey ?? tab.id;
+    const targetPacketId = tab.orchestrationPacket.packetId ?? null;
+    return orchestratorData?.missionState?.packets.find((p) => (
+      (targetPacketId && p.id === targetPacketId)
+      || (targetSessionKey && p.lane?.sessionKey === targetSessionKey)
+    )) ?? null;
+  }, [normalizedSessionKey, orchestratorData?.missionState?.packets, tab.id, tab.orchestrationPacket]);
+  const liveStatus = livePacket?.status ?? tab.orchestrationPacket?.status ?? null;
+  const archivedLaneView = useLaneArchivedView();
+
+  const laneRetired = useMemo(() => {
+    if (tab.kind !== 'chat') return false;
+    if (liveStatus === 'released' || liveStatus === 'archived') return true;
+    const packetId = livePacket?.id ?? tab.orchestrationPacket?.packetId ?? null;
+    if (packetId && archivedLaneView.packetIds.has(packetId)) return true;
+    const candidateKeys = [tab.chatSessionKey, normalizedSessionKey, livePacket?.lane?.sessionKey];
+    return candidateKeys.some((key) => Boolean(key) && archivedLaneView.sessionKeys.has(key as string));
+  }, [tab.kind, tab.chatSessionKey, tab.orchestrationPacket?.packetId, normalizedSessionKey, liveStatus, livePacket, archivedLaneView]);
+
+  const archiveSummary = useMemo(() => {
+    const packetId = livePacket?.id ?? tab.orchestrationPacket?.packetId ?? null;
+    if (packetId) {
+      const byPacket = archivedLaneView.archiveSummariesByPacketId.get(packetId);
+      if (byPacket) return byPacket;
+    }
+    const candidateKeys = [tab.chatSessionKey, normalizedSessionKey, livePacket?.lane?.sessionKey];
+    for (const key of candidateKeys) {
+      if (!key) continue;
+      const bySession = archivedLaneView.archiveSummariesBySessionKey.get(key);
+      if (bySession) return bySession;
+    }
+    return null;
+  }, [archivedLaneView, normalizedSessionKey, livePacket, tab.chatSessionKey, tab.orchestrationPacket?.packetId]);
+
+  const retirement = useMemo<RetirementCopy>(() => {
+    const merged = liveStatus === 'released' || livePacket?.releaseState === 'released';
+    if (merged) {
+      return {
+        merged: true,
+        tone: '#22c55e',
+        iconBg: 'rgba(34, 197, 94, 0.10)',
+        heroTitle: 'Merged & archived',
+        heroSub: `This ${runtimeLabel} session shipped and its lane was archived. The live transcript isn’t available here.`,
+        bannerLabel: 'Merged · read-only',
+        bannerSub: 'This session’s lane merged and was archived. The transcript stays for review.',
+      };
+    }
+    if (liveStatus === 'failed') {
+      return {
+        merged: false,
+        tone: '#f59e0b',
+        iconBg: 'rgba(245, 158, 11, 0.10)',
+        heroTitle: 'Ended without merging',
+        heroSub: `This ${runtimeLabel} session ended without merging and its lane was archived.`,
+        bannerLabel: 'Ended · read-only',
+        bannerSub: 'This session ended without merging. The transcript stays for review.',
+      };
+    }
+    return {
+      merged: false,
+      tone: 'var(--t-text-muted)',
+      iconBg: 'var(--t-panel)',
+      heroTitle: 'Archived',
+      heroSub: archiveSummary?.message ?? `This ${runtimeLabel} session’s lane was archived without merging.`,
+      bannerLabel: 'Archived · read-only',
+      bannerSub: archiveSummary
+        ? `${archiveSummary.message} The transcript stays for review.`
+        : 'This session’s lane was archived without merging. The transcript stays for review.',
+    };
+  }, [archiveSummary, liveStatus, livePacket?.releaseState, runtimeLabel]);
+
+  return { orchestratorData, livePacket, liveStatus, laneRetired, retirement };
+}

--- a/src/components/desktop/workspace-terminal/workspace-chat-prompt.tsx
+++ b/src/components/desktop/workspace-terminal/workspace-chat-prompt.tsx
@@ -1,0 +1,22 @@
+import {
+  AlertCircle,
+  FileText,
+  Lightbulb,
+  Search,
+} from '../lucide-shims';
+
+export function PromptGlyph({ icon }: { icon: string }) {
+  if (icon === 'Idea') return <Lightbulb size={16} />;
+  if (icon === 'Search') return <Search size={16} />;
+  if (icon === 'Test') return <AlertCircle size={16} />;
+  return <FileText size={16} />;
+}
+
+// Dispatcher prompts are large structured briefs. Detect them even when
+// persisted tab metadata lost the orchestration badge.
+export function looksLikePacketPrompt(text: string): boolean {
+  if (!text || text.length < 400) return false;
+  return /##\s*Project\s+(Brief|Scope|Directives)\b/i.test(text)
+    || /(^|\n)\s*Packet:\s/i.test(text)
+    || /(^|\n)\s*STRICT SCOPE:/i.test(text);
+}

--- a/src/lib/lane/archive-summary.ts
+++ b/src/lib/lane/archive-summary.ts
@@ -1,0 +1,60 @@
+import type { Lane, LaneEvent } from './types';
+
+export interface LaneArchiveSummary {
+  source: 'zombie_reaper' | 'user' | 'orchestrator' | 'system';
+  message: string;
+  preservedBranch?: string | null;
+}
+
+function stringField(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function latestEvent(events: LaneEvent[], predicate: (event: LaneEvent) => boolean): LaneEvent | null {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (predicate(event)) return event;
+  }
+  return null;
+}
+
+export function summarizeLaneArchive(
+  lane: Pick<Lane, 'status'>,
+  events: LaneEvent[],
+): LaneArchiveSummary | null {
+  if (lane.status !== 'archived' && lane.status !== 'completed') return null;
+
+  const zombie = latestEvent(events, (event) => event.verb === 'zombie_reap');
+  if (zombie) {
+    const preservedBranch = stringField(zombie.payload.preservedBranch);
+    return {
+      source: 'zombie_reaper',
+      preservedBranch,
+      message: preservedBranch
+        ? `Archived by the zombie reaper after the session went silent - work preserved on ${preservedBranch}.`
+        : 'Archived by the zombie reaper after the session went silent.',
+    };
+  }
+
+  const archived = latestEvent(events, (event) => (
+    event.verb === 'status_change' && event.payload.status === 'archived'
+  ));
+  if (!archived) return null;
+
+  if (archived.actor === 'user') {
+    return {
+      source: 'user',
+      message: 'Archived by the operator without merging.',
+    };
+  }
+  if (archived.actor === 'orchestrator') {
+    return {
+      source: 'orchestrator',
+      message: 'Archived by the orchestrator without merging.',
+    };
+  }
+  return {
+    source: 'system',
+    message: 'Archived by the system without merging.',
+  };
+}

--- a/src/lib/lane/commands.ts
+++ b/src/lib/lane/commands.ts
@@ -26,6 +26,7 @@ import {
   archiveLane,
 } from '@/lib/lane/registry';
 import { parsePullRequestNumber } from '@/lib/lane/pr-number';
+import { rebindLaneSessionIfChanged } from '@/lib/lane/session-rebind';
 // A lane whose worker can never spawn (e.g. its worktree/cwd was cleaned up)
 // otherwise loops launching→idle forever — the scheduler re-dispatches on every
 // launch_error/launch_failed with no ceiling. Cap the attempts so it fails
@@ -476,6 +477,7 @@ export async function dispatch(command: LaneCommand): Promise<LaneCommandResult>
         });
 
         if (result.ok) {
+          rebindLaneSessionIfChanged(command.laneId, lane.sessionKey, result.sessionKey, actor);
           setLaneStatus(command.laneId, 'running', actor, 'turn_sent');
         }
 
@@ -571,6 +573,7 @@ export async function dispatch(command: LaneCommand): Promise<LaneCommandResult>
             message: command.message,
           });
           if (result.ok) {
+            rebindLaneSessionIfChanged(command.laneId, lane.sessionKey, result.sessionKey, actor);
             setLaneStatus(command.laneId, 'running', actor, 'resumed');
           }
           return { ok: result.ok, laneId: command.laneId, note: result.note, lane: getLane(command.laneId) ?? undefined };

--- a/src/lib/lane/reaper.ts
+++ b/src/lib/lane/reaper.ts
@@ -10,9 +10,11 @@ import {
   appendEvent,
   archiveLane,
   getLane,
+  getLaneEvents,
   listActiveLanes,
   updateLane,
 } from './registry';
+import { preserveLaneWorktreeHead, type LaneWorktreePreservation } from './worktree-preservation';
 
 export const LANE_ZOMBIE_REAPER_INTERVAL_MS = 5 * 60_000;
 export const LANE_HEARTBEAT_STALE_MS = 90_000;
@@ -213,6 +215,20 @@ function heartbeatStaleMs(lane: Lane, now: number): number {
   return Number.isFinite(updatedAtMs) ? now - updatedAtMs : Number.POSITIVE_INFINITY;
 }
 
+function actorStatusTransitionGraceMs(lane: Lane, now: number): number | null {
+  const events = getLaneEvents(lane.id, 12);
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event.verb !== 'status_change') continue;
+    if (event.actor !== 'orchestrator' && event.actor !== 'user') continue;
+    const eventMs = Date.parse(event.timestamp);
+    if (!Number.isFinite(eventMs)) continue;
+    const ageMs = now - eventMs;
+    return ageMs >= 0 ? ageMs : 0;
+  }
+  return null;
+}
+
 export function recordLaneHeartbeat(laneId: string, heartbeatAt: number = Date.now()): Lane | null {
   const lane = getLane(laneId);
   if (!lane) return null;
@@ -233,6 +249,8 @@ export async function listZombieLaneCandidates(now: number = Date.now()): Promis
   for (const lane of runningLanes) {
     const staleMs = heartbeatStaleMs(lane, now);
     if (staleMs <= LANE_HEARTBEAT_STALE_MS) continue;
+    const actorGraceMs = actorStatusTransitionGraceMs(lane, now);
+    if (actorGraceMs !== null && actorGraceMs <= LANE_HEARTBEAT_STALE_MS) continue;
 
     const probe = await probeLaneOwner(lane);
     if (probe.alive !== false) continue;
@@ -276,6 +294,15 @@ export async function reapZombieLane(
 ): Promise<Lane | null> {
   const before = getLane(candidate.lane.id);
   if (!before || (before.status !== 'running' && before.status !== 'merging')) return before;
+  let preservedWork: LaneWorktreePreservation | null = null;
+
+  if (before.status === 'running' && before.worktreePath) {
+    try {
+      preservedWork = await preserveLaneWorktreeHead(before);
+    } catch (error) {
+      console.warn('[lane-reaper] worktree preservation failed before zombie reap:', error);
+    }
+  }
 
   const payload = {
     source: options.source,
@@ -285,6 +312,8 @@ export async function reapZombieLane(
     previousSessionKey: before.sessionKey,
     processProbe: candidate.probe,
     recommendedAction: before.packetId ? 'retry_packet' : 'inspect_lane',
+    preservedBranch: preservedWork?.preserved ? preservedWork.branchName : undefined,
+    preservedHead: preservedWork?.preserved ? preservedWork.headSha : undefined,
   };
 
   // Salvage path (#1282 Failure B): a `running` lane whose owner died may have
@@ -299,7 +328,7 @@ export async function reapZombieLane(
       const { autoCommitCompletionWorktree, hasReviewableCompletionDiff } =
         await import('@/lib/supervisor/completion-verification');
       const baseRef = before.baseBranch?.trim() || 'main';
-      const autoCommitted = await autoCommitCompletionWorktree(before.worktreePath);
+      const autoCommitted = preservedWork?.autoCommitted ?? await autoCommitCompletionWorktree(before.worktreePath);
       const reviewable =
         autoCommitted || (await hasReviewableCompletionDiff(before.worktreePath, baseRef));
       if (reviewable) {

--- a/src/lib/lane/reaper.ts
+++ b/src/lib/lane/reaper.ts
@@ -216,7 +216,7 @@ function heartbeatStaleMs(lane: Lane, now: number): number {
 }
 
 function actorStatusTransitionGraceMs(lane: Lane, now: number): number | null {
-  const events = getLaneEvents(lane.id, 12);
+  const events = getLaneEvents(lane.id, 80);
   for (let index = events.length - 1; index >= 0; index -= 1) {
     const event = events[index];
     if (event.verb !== 'status_change') continue;

--- a/src/lib/lane/session-rebind.ts
+++ b/src/lib/lane/session-rebind.ts
@@ -1,0 +1,17 @@
+import { attachSession, getLane } from '@/lib/lane/registry';
+import type { Lane, LaneEventActor } from '@/lib/lane/types';
+
+export function rebindLaneSessionIfChanged(
+  laneId: string,
+  previousSessionKey: string | null | undefined,
+  nextSessionKey: string | null | undefined,
+  actor: LaneEventActor = 'system',
+): Lane | null {
+  const normalizedNext = nextSessionKey?.trim();
+  if (!normalizedNext) return getLane(laneId);
+
+  const normalizedPrevious = previousSessionKey?.trim() || null;
+  if (normalizedPrevious === normalizedNext) return getLane(laneId);
+
+  return attachSession(laneId, normalizedNext, actor);
+}

--- a/src/lib/lane/worktree-preservation.ts
+++ b/src/lib/lane/worktree-preservation.ts
@@ -1,0 +1,80 @@
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { autoCommitCompletionWorktree } from '@/lib/supervisor/completion-verification';
+import type { Lane } from './types';
+
+const execFileAsync = promisify(execFile);
+const COMMAND_MAX_BUFFER = 10 * 1024 * 1024;
+
+export interface LaneWorktreePreservation {
+  preserved: boolean;
+  autoCommitted: boolean;
+  branchName?: string;
+  refName?: string;
+  headSha?: string;
+}
+
+function branchSafeId(value: string): string {
+  return value.trim().replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'lane';
+}
+
+async function git(cwd: string, args: string[]) {
+  return execFileAsync('git', args, {
+    cwd,
+    timeout: 30_000,
+    maxBuffer: COMMAND_MAX_BUFFER,
+  });
+}
+
+async function headHasUnmergedWork(worktreePath: string, baseBranch: string): Promise<boolean> {
+  try {
+    await git(worktreePath, ['merge-base', '--is-ancestor', 'HEAD', baseBranch]);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+async function preserveHeadRef(
+  repoPath: string,
+  worktreePath: string,
+  refName: string,
+): Promise<void> {
+  try {
+    await git(repoPath, ['fetch', worktreePath, `+HEAD:${refName}`]);
+    return;
+  } catch {
+    await git(worktreePath, ['update-ref', refName, 'HEAD']);
+  }
+}
+
+export async function preserveLaneWorktreeHead(
+  lane: Pick<Lane, 'id' | 'repoPath' | 'worktreePath' | 'baseBranch'>,
+): Promise<LaneWorktreePreservation> {
+  const worktreePath = lane.worktreePath?.trim();
+  if (!worktreePath) {
+    return { preserved: false, autoCommitted: false };
+  }
+
+  const autoCommitted = await autoCommitCompletionWorktree(worktreePath);
+  const baseBranch = lane.baseBranch?.trim() || 'main';
+  const hasUnmergedWork = await headHasUnmergedWork(worktreePath, baseBranch);
+  if (!autoCommitted && !hasUnmergedWork) {
+    return { preserved: false, autoCommitted: false };
+  }
+
+  const id = branchSafeId(path.basename(worktreePath) || lane.id);
+  const branchName = `preserved/${id}`;
+  const refName = `refs/heads/${branchName}`;
+  await preserveHeadRef(lane.repoPath, worktreePath, refName);
+  const { stdout } = await git(worktreePath, ['rev-parse', 'HEAD']);
+
+  return {
+    preserved: true,
+    autoCommitted,
+    branchName,
+    refName,
+    headSha: stdout.trim() || undefined,
+  };
+}

--- a/src/lib/orchestrator/operator-mission-service/steer.ts
+++ b/src/lib/orchestrator/operator-mission-service/steer.ts
@@ -15,6 +15,7 @@
  */
 
 import { findLaneByPacket, setLaneStatus } from '@/lib/lane/registry';
+import { rebindLaneSessionIfChanged } from '@/lib/lane/session-rebind';
 import { performRuntimeAction } from '@/lib/runtime/actions';
 
 export interface SteerPacketInput {
@@ -41,6 +42,7 @@ export async function steerPacket({ packetId, message }: SteerPacketInput): Prom
     throw new Error(result.note || 'Runtime steer failed.');
   }
 
+  rebindLaneSessionIfChanged(lane.id, lane.sessionKey, result.sessionKey, 'orchestrator');
   const updated = setLaneStatus(lane.id, 'running', 'orchestrator', 'steered_packet');
   if (!updated || updated.status !== 'running') {
     throw new Error(NO_STEERABLE_SESSION);

--- a/src/lib/runtime/actions.ts
+++ b/src/lib/runtime/actions.ts
@@ -40,6 +40,7 @@ export interface RuntimeActionResult {
   ok: boolean;
   action: RuntimeActionKind;
   surfaceId: string;
+  sessionKey?: string;
   runtime: string;
   clientMutationId?: string;
   status: 'queued' | 'completed' | 'unavailable';
@@ -547,6 +548,7 @@ export async function performRuntimeAction(payload: RuntimeActionRequest): Promi
             ok: result.ok,
             action: payload.action,
             surfaceId: runtimeSurface.id,
+            sessionKey: result.sessionKey ?? agent.sessionKey,
             runtime: agent.runtime,
             clientMutationId: payload.clientMutationId,
             status: result.ok ? 'queued' : 'unavailable',
@@ -599,6 +601,7 @@ export async function performRuntimeAction(payload: RuntimeActionRequest): Promi
           ok: true,
           action: payload.action,
           surfaceId: runtimeSurface.id,
+          sessionKey: runtimeSurface.id,
           runtime: agent.runtime,
           clientMutationId: payload.clientMutationId,
           status: 'queued',
@@ -667,6 +670,7 @@ export async function performRuntimeAction(payload: RuntimeActionRequest): Promi
           ok: result.ok,
           action: payload.action,
           surfaceId: runtimeSurface.id,
+          sessionKey: result.sessionKey ?? agent.sessionKey,
           runtime: agent.runtime,
           clientMutationId: payload.clientMutationId,
           status: 'queued',

--- a/tests/lane-reaper-salvage.test.ts
+++ b/tests/lane-reaper-salvage.test.ts
@@ -18,7 +18,11 @@
  *     worktree is left untouched
  */
 import { execFileSync } from 'node:child_process';
+<<<<<<< HEAD
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+=======
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+>>>>>>> 82f1be27 (fix: keep steered lanes bound to live sessions)
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -33,7 +37,9 @@ import { resetOwnedSessionIndex } from '@/lib/runtimes/shared/owned-session-inde
 // dir BEFORE importing anything that touches the registry (dynamic below for
 // the same reason; static imports would hoist above this assignment).
 process.env.O8_DATA_DIR = mkdtempSync(join(tmpdir(), 'o8-reaper-salvage-'));
+process.env.CORTEX_IDE_OWNED_CODEX_ROOT = mkdtempSync(join(tmpdir(), 'o8-owned-codex-'));
 
+<<<<<<< HEAD
 const { createLane, getLane, setLaneStatus, updateLane, getLaneEvents } = await import('@/lib/lane/registry');
 const { LANE_HEARTBEAT_STALE_MS, listZombieLaneCandidates, reapZombieLane } = await import('@/lib/lane/reaper');
 
@@ -46,6 +52,12 @@ afterEach(() => {
   resetCodexProcessCwdIndexForTesting();
   resetOwnedSessionIndex();
 });
+=======
+const { createLane, getLane, setLaneStatus, getLaneEvents } = await import('@/lib/lane/registry');
+const { LANE_HEARTBEAT_STALE_MS, listZombieLaneCandidates, reapZombieLane, recordLaneHeartbeat } = await import('@/lib/lane/reaper');
+const { rebindLaneSessionIfChanged } = await import('@/lib/lane/session-rebind');
+const { resetOwnedSessionIndex } = await import('@/lib/runtimes/shared/owned-session-index');
+>>>>>>> 82f1be27 (fix: keep steered lanes bound to live sessions)
 
 function git(cwd: string, args: string[]): string {
   return execFileSync('git', args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] }).toString();
@@ -69,6 +81,17 @@ function makeWorktree(opts: { dirty: boolean }): string {
 
 function isDirty(cwd: string): boolean {
   return git(cwd, ['status', '--porcelain']).trim().length > 0;
+}
+
+function writeOwnedSession(surfaceId: string, activeRun?: { pid: number }) {
+  const id = surfaceId.replace(/^codex-owned:/, '');
+  const dir = join(process.env.CORTEX_IDE_OWNED_CODEX_ROOT!, id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'session.json'), JSON.stringify({
+    surfaceId,
+    activeRun,
+  }));
+  resetOwnedSessionIndex();
 }
 
 function deadCandidate(
@@ -151,6 +174,60 @@ describe('reapZombieLane salvage (#1282 Failure B)', () => {
     const salvageEvent = getLaneEvents(lane.id).find((e) => e.verb === 'zombie_reap');
     expect(salvageEvent?.payload.salvaged).toBe(true);
     expect(salvageEvent?.payload.autoCommitted).toBe(true);
+    const preservedBranch = salvageEvent?.payload.preservedBranch;
+    expect(typeof preservedBranch).toBe('string');
+    expect(preservedBranch).toMatch(/^preserved\//);
+    expect(git(wt, ['show', `${preservedBranch as string}:feature.ts`])).toContain('shipped = true');
+  });
+
+  it('does not reap after a steer-style rebind while the old owned key is dead', async () => {
+    const wt = makeWorktree({ dirty: false });
+    const oldSessionKey = 'codex-owned:codex-owned-test-old';
+    const liveSessionKey = 'codex-owned:codex-owned-test-live';
+    writeOwnedSession(oldSessionKey);
+    writeOwnedSession(liveSessionKey, { pid: process.pid });
+
+    const lane = createLane({
+      repoPath: wt,
+      branch: 'pkt/rebound-owned-session',
+      runtime: 'codex',
+      worktreePath: wt,
+      baseBranch: 'main',
+      packetId: 'pkt-rebind-owned-session',
+      sessionKey: oldSessionKey,
+    });
+    setLaneStatus(lane.id, 'running', 'system');
+
+    const rebound = rebindLaneSessionIfChanged(lane.id, oldSessionKey, liveSessionKey, 'orchestrator');
+    expect(rebound?.sessionKey).toBe(liveSessionKey);
+
+    const baseNow = Date.now();
+    recordLaneHeartbeat(lane.id, baseNow - (LANE_HEARTBEAT_STALE_MS * 2));
+    const candidates = await listZombieLaneCandidates(baseNow + LANE_HEARTBEAT_STALE_MS + 5_000);
+
+    expect(candidates.some((candidate) => candidate.lane.id === lane.id)).toBe(false);
+  });
+
+  it('gives actor-driven running transitions a reaper grace window', async () => {
+    const wt = makeWorktree({ dirty: false });
+    const sessionKey = 'codex-owned:codex-owned-test-dead-after-steer';
+    writeOwnedSession(sessionKey);
+    const lane = createLane({
+      repoPath: wt,
+      branch: 'pkt/recent-steer-grace',
+      runtime: 'codex',
+      worktreePath: wt,
+      baseBranch: 'main',
+      packetId: 'pkt-recent-steer-grace',
+      sessionKey,
+    });
+    setLaneStatus(lane.id, 'running', 'orchestrator', 'steered_packet');
+
+    const baseNow = Date.now();
+    recordLaneHeartbeat(lane.id, baseNow - (LANE_HEARTBEAT_STALE_MS * 2));
+    const candidates = await listZombieLaneCandidates(baseNow + LANE_HEARTBEAT_STALE_MS - 1_000);
+
+    expect(candidates.some((candidate) => candidate.lane.id === lane.id)).toBe(false);
   });
 
   it('falls through to recovering when the worktree has nothing reviewable', async () => {

--- a/tests/lane-reaper-salvage.test.ts
+++ b/tests/lane-reaper-salvage.test.ts
@@ -18,11 +18,7 @@
  *     worktree is left untouched
  */
 import { execFileSync } from 'node:child_process';
-<<<<<<< HEAD
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-=======
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
->>>>>>> 82f1be27 (fix: keep steered lanes bound to live sessions)
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -39,9 +35,9 @@ import { resetOwnedSessionIndex } from '@/lib/runtimes/shared/owned-session-inde
 process.env.O8_DATA_DIR = mkdtempSync(join(tmpdir(), 'o8-reaper-salvage-'));
 process.env.CORTEX_IDE_OWNED_CODEX_ROOT = mkdtempSync(join(tmpdir(), 'o8-owned-codex-'));
 
-<<<<<<< HEAD
 const { createLane, getLane, setLaneStatus, updateLane, getLaneEvents } = await import('@/lib/lane/registry');
-const { LANE_HEARTBEAT_STALE_MS, listZombieLaneCandidates, reapZombieLane } = await import('@/lib/lane/reaper');
+const { LANE_HEARTBEAT_STALE_MS, listZombieLaneCandidates, reapZombieLane, recordLaneHeartbeat } = await import('@/lib/lane/reaper');
+const { rebindLaneSessionIfChanged } = await import('@/lib/lane/session-rebind');
 
 let ownedRoot: string | null = null;
 
@@ -52,12 +48,6 @@ afterEach(() => {
   resetCodexProcessCwdIndexForTesting();
   resetOwnedSessionIndex();
 });
-=======
-const { createLane, getLane, setLaneStatus, getLaneEvents } = await import('@/lib/lane/registry');
-const { LANE_HEARTBEAT_STALE_MS, listZombieLaneCandidates, reapZombieLane, recordLaneHeartbeat } = await import('@/lib/lane/reaper');
-const { rebindLaneSessionIfChanged } = await import('@/lib/lane/session-rebind');
-const { resetOwnedSessionIndex } = await import('@/lib/runtimes/shared/owned-session-index');
->>>>>>> 82f1be27 (fix: keep steered lanes bound to live sessions)
 
 function git(cwd: string, args: string[]): string {
   return execFileSync('git', args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] }).toString();

--- a/tests/lane-reaper-salvage.test.ts
+++ b/tests/lane-reaper-salvage.test.ts
@@ -74,8 +74,14 @@ function isDirty(cwd: string): boolean {
 }
 
 function writeOwnedSession(surfaceId: string, activeRun?: { pid: number }) {
+  // Self-provision the owned root: the liveness suite's afterEach deletes the
+  // env var, so each test that writes a session gets a fresh isolated root.
+  if (!process.env.CORTEX_IDE_OWNED_CODEX_ROOT) {
+    ownedRoot = mkdtempSync(join(tmpdir(), 'o8-owned-codex-'));
+    process.env.CORTEX_IDE_OWNED_CODEX_ROOT = ownedRoot;
+  }
   const id = surfaceId.replace(/^codex-owned:/, '');
-  const dir = join(process.env.CORTEX_IDE_OWNED_CODEX_ROOT!, id);
+  const dir = join(process.env.CORTEX_IDE_OWNED_CODEX_ROOT, id);
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, 'session.json'), JSON.stringify({
     surfaceId,


### PR DESCRIPTION
Wave 3 / issue #1370. steer_packet resumed codex as a new process while lane.sessionKey kept the dead pre-steer key; the zombie reaper executed every steered lane ~5 min in, destroying fixes mid-work (both wave-2 steered packets died this way).

- rebindLaneSessionIfChanged: steer + resume + turn paths rebind the lane to the live resumed session (runtime actions now return the resumed sessionKey).
- Reaper grace: an orchestrator/user status transition within the 90s staleness window resets the clock — a just-steered lane can never read as stale.
- Salvage integrity: zombie reap preserves UNCOMMITTED work (auto-commit before preservation; preservedBranch + preservedHead recorded on the reap event). The wave-2 steered edits died because only committed state survived — no more.
- Operator-requested UX: the archived read-only banner now explains WHY (reads terminal lane events — e.g. zombie reap after the session went silent) and names the preserved branch when one exists.
- Real-path tests through the actual reaper tick: rebound lane not reaped; dirty-worktree reap lands the uncommitted file on preserved/.
- 906 tests green, tsc clean.

Merge AFTER #1375 (both touch reaper.ts + the salvage test; this one rebases).

Worker: Codex GPT-5.5 xhigh via o8 dispatch, packet pkt-d609b967. Reviewed at pinned HEAD 82f1be27; gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167kWJy2UsSp6x1RF3VnvjF