### PR TITLE
fix(desktop): idle surfaces hold zero sockets — connection starvation ends, and the next leak names itself

### DIFF
--- a/src/app/api/claude-code/send/streaming-spawn.ts
+++ b/src/app/api/claude-code/send/streaming-spawn.ts
@@ -66,8 +66,11 @@ export async function handleClaudeCodeSend(req: Request) {
   const stream = new ReadableStream({
     start(controller) {
       abortController = new AbortController();
-      if (req.signal.aborted) abortController.abort();
-      else req.signal.addEventListener('abort', () => abortController?.abort(), { once: true });
+      const markClientGone = () => {
+        streamClosed = true;
+      };
+      if (req.signal.aborted) markClientGone();
+      else req.signal.addEventListener('abort', markClientGone, { once: true });
       let closeText = '';
       let closeSessionId = session.sessionId ?? null;
       const enqueueEvent = (event: unknown) => {
@@ -77,6 +80,7 @@ export async function handleClaudeCodeSend(req: Request) {
       const closeStream = () => {
         if (streamClosed) return;
         streamClosed = true;
+        req.signal.removeEventListener('abort', markClientGone);
         controller.close();
       };
       void sendMessage(session, message, (event) => {
@@ -102,7 +106,6 @@ export async function handleClaudeCodeSend(req: Request) {
     },
     cancel() {
       streamClosed = true;
-      abortController?.abort();
     },
   });
 

--- a/src/app/api/codex/send/route.ts
+++ b/src/app/api/codex/send/route.ts
@@ -100,6 +100,7 @@ export async function POST(req: NextRequest) {
 
   const encoder = new TextEncoder();
 
+  let markClientGone: (() => void) | null = null;
   const stream = new ReadableStream({
     start(controller) {
       const child = spawn(CODEX_BIN, args, {
@@ -110,90 +111,89 @@ export async function POST(req: NextRequest) {
 
       let fullResponse = '';
       let capturedThreadId = '';
+      let streamClosed = false;
+      markClientGone = () => {
+        streamClosed = true;
+      };
+      const enqueue = (event: unknown) => {
+        if (streamClosed) return;
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+      };
+      const closeStream = () => {
+        if (streamClosed) return;
+        streamClosed = true;
+        controller.close();
+      };
 
-	      child.stdout.on('data', (chunk: Buffer) => {
-	        const text = chunk.toString();
+      child.stdout.on('data', (chunk: Buffer) => {
+        const text = chunk.toString();
 
-	        for (const line of text.split('\n').filter(Boolean)) {
-	          try {
-	            const event = JSON.parse(line) as Record<string, unknown>;
-	            const rawItem = (event.item ?? event.payload ?? {}) as Record<string, unknown>;
+        for (const line of text.split('\n').filter(Boolean)) {
+          try {
+            const event = JSON.parse(line) as Record<string, unknown>;
+            const rawItem = (event.item ?? event.payload ?? {}) as Record<string, unknown>;
 
-	            // Capture thread ID
-	            if (event.type === 'thread.started' && event.thread_id) {
-	              capturedThreadId = event.thread_id as string;
-              controller.enqueue(encoder.encode(
-                `data: ${JSON.stringify({ type: 'session', threadId: capturedThreadId })}\n\n`
-              ));
+            // Capture thread ID
+            if (event.type === 'thread.started' && event.thread_id) {
+              capturedThreadId = event.thread_id as string;
+              enqueue({ type: 'session', threadId: capturedThreadId });
             }
 
             // Agent message completed — the actual response text
-	            if (event.type === 'item.completed' || event.type === 'response_item') {
-	              const itemType = String(rawItem.type ?? '');
-	              const itemRole = String(rawItem.role ?? '');
-	              const messageText = extractCodexMessageText(rawItem);
-	              const reasoningText = extractCodexReasoningText(rawItem);
+            if (event.type === 'item.completed' || event.type === 'response_item') {
+              const itemType = String(rawItem.type ?? '');
+              const itemRole = String(rawItem.role ?? '');
+              const messageText = extractCodexMessageText(rawItem);
+              const reasoningText = extractCodexReasoningText(rawItem);
 
-	              if ((itemType === 'agent_message' || (itemType === 'message' && itemRole === 'assistant')) && messageText) {
-	                fullResponse += messageText;
-	                controller.enqueue(encoder.encode(
-	                  `data: ${JSON.stringify({ type: 'delta', text: messageText })}\n\n`
-	                ));
-	              }
+              if ((itemType === 'agent_message' || (itemType === 'message' && itemRole === 'assistant')) && messageText) {
+                fullResponse += messageText;
+                enqueue({ type: 'delta', text: messageText });
+              }
 
-	              if (itemType === 'reasoning' && reasoningText) {
-	                controller.enqueue(encoder.encode(
-	                  `data: ${JSON.stringify({ type: 'thinking', text: reasoningText })}\n\n`
-	                ));
-	              }
+              if (itemType === 'reasoning' && reasoningText) {
+                enqueue({ type: 'thinking', text: reasoningText });
+              }
 
-	              if (itemType === 'tool_call' || itemType === 'function_call' || itemType === 'custom_tool_call') {
-	                const toolName = typeof rawItem.name === 'string' ? rawItem.name : '';
-	                if (toolName) {
-	                  controller.enqueue(encoder.encode(
-	                    `data: ${JSON.stringify({
-	                      type: 'tool_call',
-	                      name: toolName,
-	                      status: 'running',
-	                      args: parseCodexArgs(rawItem.arguments)
-	                        ?? (typeof rawItem.input === 'string'
-	                          ? parseCodexArgs(rawItem.input)
-	                          : (rawItem.input && typeof rawItem.input === 'object' ? rawItem.input as Record<string, unknown> : undefined)),
-	                    })}\n\n`
-	                  ));
-	                }
-	              }
+              if (itemType === 'tool_call' || itemType === 'function_call' || itemType === 'custom_tool_call') {
+                const toolName = typeof rawItem.name === 'string' ? rawItem.name : '';
+                if (toolName) {
+                  enqueue({
+                    type: 'tool_call',
+                    name: toolName,
+                    status: 'running',
+                    args: parseCodexArgs(rawItem.arguments)
+                      ?? (typeof rawItem.input === 'string'
+                        ? parseCodexArgs(rawItem.input)
+                        : (rawItem.input && typeof rawItem.input === 'object' ? rawItem.input as Record<string, unknown> : undefined)),
+                  });
+                }
+              }
 
-	              if ((itemType === 'function_call_output' || itemType === 'custom_tool_call_output') && typeof rawItem.output === 'string') {
-	                controller.enqueue(encoder.encode(
-	                  `data: ${JSON.stringify({
-	                    type: 'tool_result',
-	                    name: typeof rawItem.name === 'string' ? rawItem.name : undefined,
-	                    preview: rawItem.output,
-	                  })}\n\n`
-	                ));
-	              }
-	            }
+              if ((itemType === 'function_call_output' || itemType === 'custom_tool_call_output') && typeof rawItem.output === 'string') {
+                enqueue({
+                  type: 'tool_result',
+                  name: typeof rawItem.name === 'string' ? rawItem.name : undefined,
+                  preview: rawItem.output,
+                });
+              }
+            }
 
-	            // Turn completed — usage info
-	            if (event.type === 'turn.completed') {
-	              const usage = event.usage as { input_tokens?: number; output_tokens?: number } | undefined;
-	              controller.enqueue(encoder.encode(
-	                `data: ${JSON.stringify({
-	                  type: 'usage',
-	                  inputTokens: usage?.input_tokens,
-	                  outputTokens: usage?.output_tokens,
-	                })}\n\n`
-	              ));
-	              controller.enqueue(encoder.encode(
-	                `data: ${JSON.stringify({
-	                  type: 'done',
-                  text: fullResponse,
-                  threadId: capturedThreadId || undefined,
-                  inputTokens: usage?.input_tokens,
-                  outputTokens: usage?.output_tokens,
-                })}\n\n`
-              ));
+            // Turn completed — usage info
+            if (event.type === 'turn.completed') {
+              const usage = event.usage as { input_tokens?: number; output_tokens?: number } | undefined;
+              enqueue({
+                type: 'usage',
+                inputTokens: usage?.input_tokens,
+                outputTokens: usage?.output_tokens,
+              });
+              enqueue({
+                type: 'done',
+                text: fullResponse,
+                threadId: capturedThreadId || undefined,
+                inputTokens: usage?.input_tokens,
+                outputTokens: usage?.output_tokens,
+              });
             }
           } catch {
             // Not JSON or partial — skip
@@ -205,32 +205,31 @@ export async function POST(req: NextRequest) {
         const errLines = chunk.toString().split('\n').map((line) => line.trim()).filter(Boolean);
         const visibleLines = errLines.filter((line) => !shouldSuppressCodexStderrLine(line));
         if (visibleLines.length > 0) {
-          controller.enqueue(encoder.encode(
-            `data: ${JSON.stringify({ type: 'error', text: visibleLines.join('\n') })}\n\n`
-          ));
+          enqueue({ type: 'error', text: visibleLines.join('\n') });
         }
       });
 
       child.on('close', (code) => {
-        controller.enqueue(encoder.encode(
-          `data: ${JSON.stringify({
-            type: 'close',
-            exitCode: code,
-            text: fullResponse,
-            threadId: capturedThreadId || undefined,
-          })}\n\n`
-        ));
-        controller.close();
+        enqueue({
+          type: 'close',
+          exitCode: code,
+          text: fullResponse,
+          threadId: capturedThreadId || undefined,
+        });
+        closeStream();
       });
 
       child.on('error', (err) => {
-        controller.enqueue(encoder.encode(
-          `data: ${JSON.stringify({ type: 'error', text: err.message })}\n\n`
-        ));
-        controller.close();
+        enqueue({ type: 'error', text: err.message });
+        closeStream();
       });
 
       child.stdin.end();
+    },
+    cancel() {
+      // The CLI process keeps its own transcript/session state. Client-side
+      // cancellation only releases the webview HTTP socket.
+      markClientGone?.();
     },
   });
 

--- a/src/app/api/codex/send/route.ts
+++ b/src/app/api/codex/send/route.ts
@@ -115,9 +115,9 @@ export async function POST(req: NextRequest) {
       markClientGone = () => {
         streamClosed = true;
       };
-      const enqueue = (event: unknown) => {
+      const enqueueChunk = (chunk: Uint8Array) => {
         if (streamClosed) return;
-        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+        controller.enqueue(chunk);
       };
       const closeStream = () => {
         if (streamClosed) return;
@@ -125,75 +125,89 @@ export async function POST(req: NextRequest) {
         controller.close();
       };
 
-      child.stdout.on('data', (chunk: Buffer) => {
-        const text = chunk.toString();
+	      child.stdout.on('data', (chunk: Buffer) => {
+	        const text = chunk.toString();
 
-        for (const line of text.split('\n').filter(Boolean)) {
-          try {
-            const event = JSON.parse(line) as Record<string, unknown>;
-            const rawItem = (event.item ?? event.payload ?? {}) as Record<string, unknown>;
+	        for (const line of text.split('\n').filter(Boolean)) {
+	          try {
+	            const event = JSON.parse(line) as Record<string, unknown>;
+	            const rawItem = (event.item ?? event.payload ?? {}) as Record<string, unknown>;
 
-            // Capture thread ID
-            if (event.type === 'thread.started' && event.thread_id) {
-              capturedThreadId = event.thread_id as string;
-              enqueue({ type: 'session', threadId: capturedThreadId });
+	            // Capture thread ID
+	            if (event.type === 'thread.started' && event.thread_id) {
+	              capturedThreadId = event.thread_id as string;
+              enqueueChunk(encoder.encode(
+                `data: ${JSON.stringify({ type: 'session', threadId: capturedThreadId })}\n\n`
+              ));
             }
 
             // Agent message completed — the actual response text
-            if (event.type === 'item.completed' || event.type === 'response_item') {
-              const itemType = String(rawItem.type ?? '');
-              const itemRole = String(rawItem.role ?? '');
-              const messageText = extractCodexMessageText(rawItem);
-              const reasoningText = extractCodexReasoningText(rawItem);
+	            if (event.type === 'item.completed' || event.type === 'response_item') {
+	              const itemType = String(rawItem.type ?? '');
+	              const itemRole = String(rawItem.role ?? '');
+	              const messageText = extractCodexMessageText(rawItem);
+	              const reasoningText = extractCodexReasoningText(rawItem);
 
-              if ((itemType === 'agent_message' || (itemType === 'message' && itemRole === 'assistant')) && messageText) {
-                fullResponse += messageText;
-                enqueue({ type: 'delta', text: messageText });
-              }
+	              if ((itemType === 'agent_message' || (itemType === 'message' && itemRole === 'assistant')) && messageText) {
+	                fullResponse += messageText;
+	                enqueueChunk(encoder.encode(
+	                  `data: ${JSON.stringify({ type: 'delta', text: messageText })}\n\n`
+	                ));
+	              }
 
-              if (itemType === 'reasoning' && reasoningText) {
-                enqueue({ type: 'thinking', text: reasoningText });
-              }
+	              if (itemType === 'reasoning' && reasoningText) {
+	                enqueueChunk(encoder.encode(
+	                  `data: ${JSON.stringify({ type: 'thinking', text: reasoningText })}\n\n`
+	                ));
+	              }
 
-              if (itemType === 'tool_call' || itemType === 'function_call' || itemType === 'custom_tool_call') {
-                const toolName = typeof rawItem.name === 'string' ? rawItem.name : '';
-                if (toolName) {
-                  enqueue({
-                    type: 'tool_call',
-                    name: toolName,
-                    status: 'running',
-                    args: parseCodexArgs(rawItem.arguments)
-                      ?? (typeof rawItem.input === 'string'
-                        ? parseCodexArgs(rawItem.input)
-                        : (rawItem.input && typeof rawItem.input === 'object' ? rawItem.input as Record<string, unknown> : undefined)),
-                  });
-                }
-              }
+	              if (itemType === 'tool_call' || itemType === 'function_call' || itemType === 'custom_tool_call') {
+	                const toolName = typeof rawItem.name === 'string' ? rawItem.name : '';
+	                if (toolName) {
+	                  enqueueChunk(encoder.encode(
+	                    `data: ${JSON.stringify({
+	                      type: 'tool_call',
+	                      name: toolName,
+	                      status: 'running',
+	                      args: parseCodexArgs(rawItem.arguments)
+	                        ?? (typeof rawItem.input === 'string'
+	                          ? parseCodexArgs(rawItem.input)
+	                          : (rawItem.input && typeof rawItem.input === 'object' ? rawItem.input as Record<string, unknown> : undefined)),
+	                    })}\n\n`
+	                  ));
+	                }
+	              }
 
-              if ((itemType === 'function_call_output' || itemType === 'custom_tool_call_output') && typeof rawItem.output === 'string') {
-                enqueue({
-                  type: 'tool_result',
-                  name: typeof rawItem.name === 'string' ? rawItem.name : undefined,
-                  preview: rawItem.output,
-                });
-              }
-            }
+	              if ((itemType === 'function_call_output' || itemType === 'custom_tool_call_output') && typeof rawItem.output === 'string') {
+	                enqueueChunk(encoder.encode(
+	                  `data: ${JSON.stringify({
+	                    type: 'tool_result',
+	                    name: typeof rawItem.name === 'string' ? rawItem.name : undefined,
+	                    preview: rawItem.output,
+	                  })}\n\n`
+	                ));
+	              }
+	            }
 
-            // Turn completed — usage info
-            if (event.type === 'turn.completed') {
-              const usage = event.usage as { input_tokens?: number; output_tokens?: number } | undefined;
-              enqueue({
-                type: 'usage',
-                inputTokens: usage?.input_tokens,
-                outputTokens: usage?.output_tokens,
-              });
-              enqueue({
-                type: 'done',
+	            // Turn completed — usage info
+	            if (event.type === 'turn.completed') {
+	              const usage = event.usage as { input_tokens?: number; output_tokens?: number } | undefined;
+	              enqueueChunk(encoder.encode(
+	                `data: ${JSON.stringify({
+	                  type: 'usage',
+	                  inputTokens: usage?.input_tokens,
+	                  outputTokens: usage?.output_tokens,
+	                })}\n\n`
+	              ));
+	              enqueueChunk(encoder.encode(
+	                `data: ${JSON.stringify({
+	                  type: 'done',
                 text: fullResponse,
                 threadId: capturedThreadId || undefined,
                 inputTokens: usage?.input_tokens,
                 outputTokens: usage?.output_tokens,
-              });
+                })}\n\n`
+              ));
             }
           } catch {
             // Not JSON or partial — skip
@@ -205,22 +219,28 @@ export async function POST(req: NextRequest) {
         const errLines = chunk.toString().split('\n').map((line) => line.trim()).filter(Boolean);
         const visibleLines = errLines.filter((line) => !shouldSuppressCodexStderrLine(line));
         if (visibleLines.length > 0) {
-          enqueue({ type: 'error', text: visibleLines.join('\n') });
+          enqueueChunk(encoder.encode(
+            `data: ${JSON.stringify({ type: 'error', text: visibleLines.join('\n') })}\n\n`
+          ));
         }
       });
 
       child.on('close', (code) => {
-        enqueue({
-          type: 'close',
-          exitCode: code,
-          text: fullResponse,
-          threadId: capturedThreadId || undefined,
-        });
+        enqueueChunk(encoder.encode(
+          `data: ${JSON.stringify({
+            type: 'close',
+            exitCode: code,
+            text: fullResponse,
+            threadId: capturedThreadId || undefined,
+          })}\n\n`
+        ));
         closeStream();
       });
 
       child.on('error', (err) => {
-        enqueue({ type: 'error', text: err.message });
+        enqueueChunk(encoder.encode(
+          `data: ${JSON.stringify({ type: 'error', text: err.message })}\n\n`
+        ));
         closeStream();
       });
 

--- a/src/app/dashboard/DashboardHydrationMarker.tsx
+++ b/src/app/dashboard/DashboardHydrationMarker.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { installLongLivedFetchBudgetGuard } from '@/lib/connection-budget';
 
 // The pre-ship boot gate (scripts/preship-webview-gate.mjs) treats
 // `data-o8-dashboard-hydrated` as proof the dashboard booted cleanly. We only
@@ -11,6 +12,8 @@ import { useEffect } from 'react';
 // (data-o8-mount-error) suppresses it outright.
 export function DashboardHydrationMarker() {
   useEffect(() => {
+    installLongLivedFetchBudgetGuard();
+
     const root = document.documentElement;
     root.removeAttribute('data-o8-dashboard-hydrated');
 

--- a/src/app/preview/canvas-glass/brain-card.tsx
+++ b/src/app/preview/canvas-glass/brain-card.tsx
@@ -19,6 +19,7 @@ import { Citations, InlineMarkdown, SourcesLine } from './response-blocks';
 import { CardComposer } from './card-composer';
 import { GlassCardShell } from './card-shell';
 import { useScrollBlurFade } from './use-scroll-blur-fade';
+import { fetchWithLongLivedBudget } from '@/lib/connection-budget';
 
 export interface BrainCard {
   id: number;
@@ -125,7 +126,7 @@ export function BrainConversation({
     abortRef.current = controller;
     const timeoutId = setTimeout(() => controller.abort(), 90_000);
     try {
-      const response = await fetch('/api/cortex/ask', {
+      const response = await fetchWithLongLivedBudget('/api/cortex/ask', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ question, repoPath: repoPath ?? undefined }),

--- a/src/components/desktop/llm-chat/streaming.ts
+++ b/src/components/desktop/llm-chat/streaming.ts
@@ -1,6 +1,7 @@
 import { buildLinkedIssueContext, type LinkedIssueRef } from '../IssueLinkPicker';
 
 import { buildRepoRequestHeaders, type ActiveThinkingState, type LLMMessage, MODELS, type ModelOption, type PendingApprovalState, type PreferredRepoContext, type SourceInfo, type ThinkingStep, type ToolCallInfo } from './shared';
+import { fetchWithLongLivedBudget } from '@/lib/connection-budget';
 
 function normalizeFetchFailure(error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
@@ -12,7 +13,7 @@ function normalizeFetchFailure(error: unknown) {
 
 export async function generateFollowUps(lastResponse: string, model: { id: string; label: string; provider: string }, userQuestion: string): Promise<string[]> {
   try {
-    const response = await fetch('/api/v2/proxy/llm', {
+    const response = await fetchWithLongLivedBudget('/api/v2/proxy/llm', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -111,7 +112,7 @@ export async function streamAssistantResponse({
   const retryDelays = [800, 1800];
   for (let attempt = 0; attempt < retryDelays.length + 1; attempt += 1) {
     try {
-      response = await fetch(endpoint, {
+      response = await fetchWithLongLivedBudget(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'x-tab-id': tabId, ...buildRepoRequestHeaders(preferredRepo ?? null) },
         body: requestBody,

--- a/src/components/desktop/orchestrator/send-chat-message.ts
+++ b/src/components/desktop/orchestrator/send-chat-message.ts
@@ -4,6 +4,7 @@ import type {
   ChatHistoryMessage,
 } from '@/lib/chat/types';
 import type { ChatModelOption } from './chat-models';
+import { fetchWithLongLivedBudget } from '@/lib/connection-budget';
 
 export class ChatSendError extends Error {
   status: number;
@@ -150,7 +151,7 @@ export async function sendScratchChatMessage({
   onToolResult,
   onModel,
 }: SendScratchChatInput): Promise<void> {
-  const response = await fetch('/api/panel/o8-scratch-chat', {
+  const response = await fetchWithLongLivedBudget('/api/panel/o8-scratch-chat', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({

--- a/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
+++ b/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
@@ -78,6 +78,9 @@ import { useThoughtsComposerAttachments } from './chat-panel/useThoughtsComposer
 import { ScreenshotAnnotator } from './chat-panel/ScreenshotAnnotator';
 import { interruptRuntimeSurface } from './chat-panel/runtimeInterrupt';
 import { useSteerAutoFire } from './chat-panel/useSteerAutoFire';
+import { isAbortError } from '@/lib/active-long-lived-request';
+import { fetchWithLongLivedBudget } from '@/lib/connection-budget';
+import { useActiveLongLivedRequest } from '@/lib/use-active-long-lived-request';
 import type {
   ThoughtsChatPanelChromeState,
   ThoughtsChatPanelHandle,
@@ -336,13 +339,11 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
   const thinkingPreferenceTouchedRef = useRef(false);
   const pollRef = useRef<number | null>(null);
   const pollDelayRef = useRef<number | null>(null);
-  // Aborts the in-flight transcript fetch. The 2s poll reads a JSONL transcript
-  // that grows large in long sessions; without aborting, a stalled read leaves
-  // the request open while the next tick fires another, stacking ESTABLISHED
-  // sockets until the webview's ~6-per-origin budget is exhausted (which then
-  // wedges every on-demand fetch). Abort per-tick + on teardown so at most one
-  // transcript request is ever in flight.
+  // Abort per transcript tick + on teardown so a stalled read cannot stack
+  // ESTABLISHED sockets across the webview's small per-origin budget.
   const pollAbortRef = useRef<AbortController | null>(null);
+  const openRef = useRef(open);
+  const chatStreamRequest = useActiveLongLivedRequest(open);
   const chatEndRef = useRef<HTMLDivElement>(null);
   const seenServerEntriesRef = useRef<Map<string, string>>(new Map());
   const responseSeenRef = useRef(false);
@@ -356,16 +357,8 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
   const [singleRuntimeSpawning, setSingleRuntimeSpawning] = useState(false);
   const [threadId, setThreadId] = useState<string | null>(null);
   const threadIdRef = useRef<string | null>(null);
-  // Sidebar trampoline guard. Three concurrent callers race here:
-  //   1. page.tsx handleOpenHistoryChatFromPanel dispatches o8:load-history-thread (up to 3× via the late-mount retries)
-  //   2. OrchestratorTab.tsx restoreLastThread effect calls loadThread on activation
-  //   3. OrchestratorTab.tsx initialThreadId effect calls loadThread when the prop changes
-  // Each call re-fetches the transcript and resets orchStream — duplicate
-  // fetches cause visible flicker AND lose in-flight streaming state.
-  // `inFlightLoadKeyRef` blocks ALL re-entry while a load for the same
-  // tabId is fetching. `lastLoadKeyRef` + `lastLoadAtRef` add an 800 ms
-  // post-completion cooldown so the dispatch retries hitting the listener
-  // after the load settles are also dropped.
+  // Sidebar trampoline guard: history load, restoreLastThread, and initialThreadId
+  // can race. Block re-entry for the same tab while loading and briefly after.
   const inFlightLoadKeyRef = useRef<string | null>(null);
   const lastLoadKeyRef = useRef<string | null>(null);
   const lastLoadAtRef = useRef<number>(0);
@@ -645,6 +638,10 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
   }, [isChatMode, isOrchestratorMode, orchestrationSettingsLoaded, orchestratorSpawning, resolvedRepoPath]);
 
   useEffect(() => {
+    openRef.current = open;
+  }, [open]);
+
+  useEffect(() => {
     if (!open || !draftInjection?.id) return;
     setInput((prev) => prev.trim()
       ? `${prev.trimEnd()}\n\n${draftInjection.text}\n\n`
@@ -665,17 +662,8 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
     onImageInjectionConsumed?.();
   }, [open, imageInjection?.id, imageInjection?.name, imageInjection?.dataUri, imageInjection?.mimeType, addAttachedImage, onImageInjectionConsumed]);
 
-  // Phase 4 friction fix #1: clear stale composer drafts on tab refocus.
-  // The composer state is preserved across tab switches (the parent uses
-  // display:none, not unmount), so a directive review draft sitting in
-  // the textarea before the user navigated away ends up appended to
-  // whatever they type next time they return. Snapshot the input on
-  // tab-blur (open: true→false) and clear + toast on next refocus
-  // (open: false→true) IF that snapshot was non-empty AND no fresh
-  // draft injection arrived in the interim. The newDraftArrived check
-  // prevents the clear from wiping a legitimate inject; the
-  // inject effect declared above runs first in declaration order, so
-  // we observe the post-inject input here.
+  // Clear stale composer drafts on tab refocus unless a fresh draft injection
+  // arrived while hidden. Tabs are display:none, so composer state persists.
   const previousOpenRef = useRef(open);
   const inputAtBlurRef = useRef<string>('');
   const lastSeenDraftIdRef = useRef<string | null>(draftInjection?.id ?? null);
@@ -792,7 +780,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
 
   const captureServerSnapshot = useCallback(async (sessionKey: string) => {
     try {
-      const res = await fetch(transcriptUrl(sessionKey));
+      const res = await fetchWithLongLivedBudget(transcriptUrl(sessionKey));
       if (!res.ok) return;
       const data = await res.json();
       const entries = (data.transcript ?? data.entries ?? []) as MobileTranscriptEntry[];
@@ -812,13 +800,8 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
     || sessionKey.startsWith('opencode-owned:')
   ), []);
 
-  // Owned codex/gemini/opencode sessions can't accept the next turn until
-  // their CLI emits a thread id and the lifecycle flips to ready-for-resume.
-  // The transcript poller can declare "response done" before that happens
-  // (the launch banner counts as a non-user entry), so the composer would
-  // unlock and the next steer call would 501 with "cannot accept the next
-  // input yet". Gate the composer on the inventory snapshot for these
-  // sessions to keep the user from sending into a not-yet-resumable lane.
+  // Owned CLI sessions unlock only after inventory says they can resume; a
+  // transcript tail alone can arrive before the next steer is accepted.
   const checkOwnedSessionReady = useCallback(async (sessionKey: string) => {
     try {
       const res = await fetch('/api/runtime/inventory');
@@ -849,6 +832,10 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
     };
 
     const poll = async () => {
+      if (!openRef.current) {
+        clearPolling();
+        return;
+      }
       attempts++;
       if (attempts > maxAttempts) {
         finishPolling();
@@ -862,7 +849,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
       pollAbortRef.current = controller;
 
       try {
-        const res = await fetch(transcriptUrl(sessionKey), { signal: controller.signal });
+        const res = await fetchWithLongLivedBudget(transcriptUrl(sessionKey), { signal: controller.signal });
         if (!res.ok) return;
 
         const data = await res.json();
@@ -924,6 +911,20 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
     }
     startPollingForSession(sessionKey);
   }, [isOrchestratorMode, startPollingForSession, targetSessionKey]);
+
+  const previousConnectionOpenRef = useRef(open);
+  useEffect(() => {
+    const wasOpen = previousConnectionOpenRef.current;
+    previousConnectionOpenRef.current = open;
+    if (wasOpen && !open) {
+      clearPolling();
+      chatStreamRequest.abort('inactive');
+      return;
+    }
+    if (!wasOpen && open && waitingForReply && !isChatMode) {
+      startPolling();
+    }
+  }, [chatStreamRequest, clearPolling, isChatMode, open, startPolling, waitingForReply]);
 
   const resetRemoteSession = useCallback(async () => {
     try {
@@ -1098,11 +1099,8 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
   );
 
   const handleLoadThread = useCallback(async (tabId: string) => {
-    // Sidebar trampoline guard — see refs declaration above. Three layers:
-    //   1. If a load for THIS tabId is in flight, drop the re-entry.
-    //   2. If a load for THIS tabId just settled within 800 ms, drop too
-    //      (covers the page.tsx 120/420 ms dispatch retries).
-    //   3. Otherwise proceed and claim both refs for the duration.
+    // Drop duplicate history loads for this tab while one is in flight or just
+    // settled, then claim both refs for the duration.
     const now = Date.now();
     if (inFlightLoadKeyRef.current === tabId) return;
     if (lastLoadKeyRef.current === tabId && now - lastLoadAtRef.current < 800) {
@@ -1112,12 +1110,8 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
     lastLoadKeyRef.current = tabId;
     lastLoadAtRef.current = now;
     try {
-      // In long sessions the webview's per-origin socket budget (~6) can be
-      // saturated by the dashboard poll fan-out, leaving this fetch with no
-      // free socket — a bare `await fetch` then hangs forever and the thread
-      // silently never loads (the empty state sticks). Bound it with a timeout
-      // and retry once so a transient starvation can't permanently wedge the
-      // load. (The durable fix is relieving the poll concurrency.)
+      // Bound history load with a timeout + one retry so socket starvation
+      // cannot permanently wedge the thread on an empty state.
       const fetchHistoryOnce = async (): Promise<Response | null> => {
         const controller = new AbortController();
         const timer = window.setTimeout(() => controller.abort(), 6000);
@@ -1529,19 +1523,17 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
       setChatMessages((prev) => [...prev, userEntry, assistantEntry]);
       clearAttachments();
       setWaitingForReply(true);
+      const streamController = chatStreamRequest.begin();
       try {
-        // Chat-mode always routes through the OpenRouter scratch-chat
-        // path with tools wired. The model is picked per-tab via the
-        // ChatOpenRouterPicker chip; modelOverride pins it server-side.
-        // BYOK is no longer a separate UI tier — operators with their
-        // own OpenRouter key supply it through env / Settings and the
-        // server-side resolver picks it automatically.
+        // Chat-mode streams through scratch-chat; modelOverride pins the
+        // per-tab picker choice server-side.
         await sendScratchChatMessage({
           history: chatMessages,
           message: msg,
           context: resolvedRepoPath ? { repoPath: resolvedRepoPath } : undefined,
           enableTools: true,
           modelOverride: chatOpenrouterModel ?? null,
+          signal: streamController.signal,
           onDelta: (text) => {
             assistantText += text;
             setChatMessages((prev) => prev.map((entry) => (
@@ -1560,13 +1552,16 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
           },
         });
       } catch (error) {
-        const message = error instanceof Error ? error.message : 'Chat request failed.';
+        const message = streamController.signal.aborted || isAbortError(error)
+          ? 'Stream paused because this tab became inactive. Send again when you return.'
+          : error instanceof Error ? error.message : 'Chat request failed.';
         setChatMessages((prev) => prev.map((entry) => (
           entry.id === assistantEntry.id
             ? { ...entry, text: assistantText ? `${assistantText}\n\n${message}` : message }
             : entry
         )));
       } finally {
+        chatStreamRequest.finish(streamController);
         setWaitingForReply(false);
       }
       return;
@@ -1705,7 +1700,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
       ]);
       setWaitingForReply(false);
     }
-  }, [attachedImages, captureServerSnapshot, chatMessages, chatOpenrouterModel, clearAttachments, ensureSingleRuntimeSession, input, isChatMode, isOrchestratorMode, isSingleMode, lockedMode, onSpawnChatTab, onSpawnSingleTab, orchStream, orchestratorModel, permissionMode, resolvedRepoPath, runLocalOrchestratorSlash, selectedChatModel, singleRuntime, startPolling, startPollingForSession, targetAgent, targetSessionKey, thinkingEffort, swarmEnabled, collideEnabled, waitingForReply]);
+  }, [attachedImages, captureServerSnapshot, chatMessages, chatOpenrouterModel, chatStreamRequest, clearAttachments, ensureSingleRuntimeSession, input, isChatMode, isOrchestratorMode, isSingleMode, lockedMode, onSpawnChatTab, onSpawnSingleTab, orchStream, orchestratorModel, permissionMode, resolvedRepoPath, runLocalOrchestratorSlash, selectedChatModel, singleRuntime, startPolling, startPollingForSession, targetAgent, targetSessionKey, thinkingEffort, swarmEnabled, collideEnabled, waitingForReply]);
 
   const sendNow = useCallback((text?: string) => {
     const msg = (typeof text === 'string' ? text : latestInputRef.current).trim();

--- a/src/components/desktop/thoughts/recall-card/AskAnythingRow.tsx
+++ b/src/components/desktop/thoughts/recall-card/AskAnythingRow.tsx
@@ -18,6 +18,7 @@
  */
 
 import { useCallback, useRef, useState } from 'react';
+import { fetchWithLongLivedBudget } from '@/lib/connection-budget';
 import { AnswerStream, type ContradictionNote } from './AnswerStream';
 import type { Citation, CitationKind } from './CitationPill';
 import {
@@ -141,7 +142,7 @@ export function AskAnythingRow({ open, onToggle, repoPath }: AskAnythingRowProps
     abortRef.current = controller;
 
     try {
-      const res = await fetch('/api/cortex/ask', {
+      const res = await fetchWithLongLivedBudget('/api/cortex/ask', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ question: q, repoPath, mode }),

--- a/src/components/desktop/workspace-terminal/use-packet-transcript-poll.ts
+++ b/src/components/desktop/workspace-terminal/use-packet-transcript-poll.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { useOrchestratorData } from '@/components/desktop/orchestrator-data-context';
+import { fetchWithLongLivedBudget } from '@/lib/connection-budget';
 import type { MobileTranscriptEntry, MobileTranscriptToolCall } from '@/lib/mobile/types';
 import type { TranscriptEvent } from '@/lib/orchestrator/transcript-normalizer';
 
@@ -141,17 +142,17 @@ export function usePacketTranscriptPoll({
 
   const packetId = livePacket?.id ?? packetIdHint;
   const status = livePacket?.status ?? null;
+  const visiblePacketEvents = enabled && packetId ? packetEvents : [];
 
   useEffect(() => {
     if (!enabled || !packetId) {
-      setPacketEvents([]);
       return undefined;
     }
     const controller = new AbortController();
     let cancelled = false;
     const run = async () => {
       try {
-        const response = await fetch(
+        const response = await fetchWithLongLivedBudget(
           `/api/orchestrator/packet-transcript?packetId=${encodeURIComponent(packetId)}&tail=1&limit=${TRANSCRIPT_TAIL_LIMIT}`,
           { signal: controller.signal, cache: 'no-store' },
         );
@@ -175,5 +176,5 @@ export function usePacketTranscriptPoll({
     };
   }, [enabled, packetId, status, active]);
 
-  return packetEvents;
+  return visiblePacketEvents;
 }

--- a/src/components/desktop/workspace-terminal/useWorkspaceChatPane.ts
+++ b/src/components/desktop/workspace-terminal/useWorkspaceChatPane.ts
@@ -42,6 +42,9 @@ import type {
 import { bootstrapTranscripts } from '@/lib/transcripts/bootstrap';
 import { transcriptStore } from '@/lib/transcripts/store';
 import { useTranscript } from '@/lib/transcripts/useTranscript';
+import { isAbortError } from '@/lib/active-long-lived-request';
+import { fetchWithLongLivedBudget } from '@/lib/connection-budget';
+import { useActiveLongLivedRequest } from '@/lib/use-active-long-lived-request';
 import type { ClaudeCodeStreamJsonChatEvent } from '@/lib/claude-code/stream-json-parser';
 
 interface UseWorkspaceChatPaneOptions {
@@ -90,6 +93,7 @@ export function useWorkspaceChatPane({
   const stickToBottomRef = useRef(true);
   const handledDraftInjectionRef = useRef<string | null>(null);
   const openCodeProvidersLoadedRef = useRef(openCodeProviders.length > 0);
+  const streamRequest = useActiveLongLivedRequest(active);
 
   const tabId = tab.id;
   const chatRuntime = tab.chatRuntime as 'codex' | 'claude-code' | 'gemini' | 'opencode' | undefined;
@@ -138,12 +142,7 @@ export function useWorkspaceChatPane({
   }, []);
   const disableClaudeBypassPermissions = useCallback(() => setClaudeBypassPermissions(false), []);
 
-  // Packet B: reads go through the transcript store. When the slice is still
-  // `idle` (no bootstrap yet) or we don't have a sessionKey yet, we fall back
-  // to the persisted `tab.chatMessages`. Writes mirror into the store via
-  // `commitMessages` so `useTranscript` subscribers (including this hook)
-  // round-trip the same entries. WS snapshots from `chat.done` refill the
-  // store out-of-band via the Packet A bridge wired in `page.tsx`.
+  // Reads go through the transcript store; writes mirror back via `commitMessages`.
   const transcriptSlice = useTranscript(normalizedSessionKey);
   const fallbackMessages = useMemo(() => tab.chatMessages ?? [], [tab.chatMessages]);
   const messages = useMemo(() => {
@@ -153,14 +152,7 @@ export function useWorkspaceChatPane({
     return fallbackMessages;
   }, [fallbackMessages, normalizedSessionKey, transcriptSlice]);
 
-  // #1293 FIX 1 — ADDITIVE packetId-keyed transcript poll, running ALONGSIDE the
-  // sessionKey bootstrap below. A dispatched Codex `exec --json` streams to the
-  // LANE, not the sessionKey slice, so an un-steered packet keeps an empty slice
-  // and the tab would otherwise render a static placeholder forever. Gate
-  // strictly on an EMPTY sessionKey slice so Claude-Code packets (slice filled
-  // via /api/claude-code/send) and steered Codex (slice filled via the bootstrap
-  // poll) are untouched — `packetEvents` stays empty and their render path is
-  // byte-identical.
+  // PacketId-keyed transcript poll for dispatched Codex lanes with an empty sessionKey slice.
   const packetEvents = usePacketTranscriptPoll({
     enabled: isAgentTab && messages.length === 0,
     packetIdHint: tab.orchestrationPacket?.packetId ?? null,
@@ -226,14 +218,8 @@ export function useWorkspaceChatPane({
     return status === 'running' || status === 'launched' || status === 'waiting';
   })();
 
-  // Load the transcript on mount, RE-load whenever the tab becomes active, and
-  // poll while an agent is actively working. The one-shot-on-mount bootstrap
-  // wasn't enough for DISPATCHED packets: the pane often mounts at dispatch time
-  // (transcript still empty) and the WS history push doesn't reliably cover
-  // MCP-dispatched owned-Codex sessions — so the transcript never filled in and
-  // the operator couldn't watch the agent work. A bounded pull (re-fetch on
-  // activate + 3s poll only while active AND the supervisor is running) makes
-  // the transcript load on view and stream live, then goes quiet once idle.
+  // Load on mount, re-load on activation, and poll only while this tab is active
+  // and the supervisor is running. Hidden tabs must not hold transcript polls.
   useEffect(() => {
     if (!normalizedSessionKey) return undefined;
     const controller = new AbortController();
@@ -285,6 +271,9 @@ export function useWorkspaceChatPane({
     const updated = [...baseMessages, userMsg];
     commitMessages(updated);
     scrollToBottom(true);
+
+    let streamController: AbortController | null = null;
+    let pendingAssistantId: string | null = null;
 
     try {
       const composedMessage = [buildLinkedIssueContext(linkedIssue), text].filter(Boolean).join('\n\n');
@@ -340,10 +329,7 @@ export function useWorkspaceChatPane({
           }
           return;
         }
-        // Non-owned discovered sessions fall back to the runtime-specific
-        // streaming endpoint (codex-only today; gemini/opencode discovered
-        // is a follow-up since neither CLI has a stable scratch-session UX
-        // yet).
+        // Non-owned discovered sessions fall back to the codex stream endpoint.
         if (chatRuntime !== 'codex') {
           throw new Error(`Discovered ${chatRuntime} sessions don't support send yet — dispatch a packet via the orchestrator instead.`);
         }
@@ -359,6 +345,7 @@ export function useWorkspaceChatPane({
       }
 
       const assistantId = `msg-${Date.now()}-assistant`;
+      pendingAssistantId = assistantId;
       let nextTranscript: MobileTranscriptEntry[] = [
         ...updated,
         {
@@ -373,10 +360,12 @@ export function useWorkspaceChatPane({
       setLiveAssistantId(assistantId);
       commitMessages(nextTranscript);
 
-      const res = await fetch(endpoint, {
+      streamController = streamRequest.begin();
+      const res = await fetchWithLongLivedBudget(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
+        signal: streamController.signal,
       });
 
       if (!res.ok || !res.body) {
@@ -649,6 +638,16 @@ export function useWorkspaceChatPane({
         );
       }
     } catch (err) {
+      if (streamController?.signal.aborted || isAbortError(err)) {
+        if (pendingAssistantId) {
+          commitMessages(messagesRef.current.map((entry) => (
+            entry.id === pendingAssistantId && !entry.text.trim()
+              ? { ...entry, text: 'Stream paused because this tab became inactive. Reopen it to refresh the transcript.' }
+              : entry
+          )));
+        }
+        return;
+      }
       commitMessages([
         ...updated,
         {
@@ -660,6 +659,7 @@ export function useWorkspaceChatPane({
         },
       ]);
     } finally {
+      if (streamController) streamRequest.finish(streamController);
       setSending(false);
       setAgentRunning(false);
       setLiveAssistantId(null);
@@ -671,7 +671,7 @@ export function useWorkspaceChatPane({
         transcriptStore.setStatus(normalizedSessionKey, 'loading');
       }
     }
-  }, [chatRuntime, claudeBypassPermissions, claudePlanMode, commitMessages, linkedIssue, normalizedSessionKey, onUpdateSessionKey, scrollToBottom, selectedModel, sending, tab.claudeSessionId, tab.repo?.localPath, tabId, transportSessionId]);
+  }, [chatRuntime, claudeBypassPermissions, claudePlanMode, commitMessages, linkedIssue, normalizedSessionKey, onUpdateSessionKey, scrollToBottom, selectedModel, sending, streamRequest, tab.claudeSessionId, tab.repo?.localPath, tabId, transportSessionId]);
 
   const handleSend = useCallback(async () => {
     const baseDraft = draft.trim();

--- a/src/lib/active-long-lived-request.test.ts
+++ b/src/lib/active-long-lived-request.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { createActiveLongLivedRequestController } from './active-long-lived-request';
+
+describe('active long-lived request controller', () => {
+  it('aborts the current request when a tab becomes inactive and reacquires on focus', () => {
+    const slot = createActiveLongLivedRequestController(true);
+
+    const first = slot.begin();
+    expect(first.signal.aborted).toBe(false);
+    expect(slot.getCurrent()).toBe(first);
+
+    slot.setActive(false);
+    expect(first.signal.aborted).toBe(true);
+    expect(slot.getCurrent()).toBeNull();
+
+    const hiddenAttempt = slot.begin();
+    expect(hiddenAttempt.signal.aborted).toBe(true);
+    expect(slot.getCurrent()).toBeNull();
+
+    slot.setActive(true);
+    const focused = slot.begin();
+    expect(focused.signal.aborted).toBe(false);
+    expect(slot.getCurrent()).toBe(focused);
+
+    slot.finish(focused);
+    expect(slot.getCurrent()).toBeNull();
+  });
+
+  it('replaces an older stream before starting a new one', () => {
+    const slot = createActiveLongLivedRequestController(true);
+    const first = slot.begin();
+    const second = slot.begin();
+
+    expect(first.signal.aborted).toBe(true);
+    expect(second.signal.aborted).toBe(false);
+    expect(slot.getCurrent()).toBe(second);
+  });
+});

--- a/src/lib/active-long-lived-request.ts
+++ b/src/lib/active-long-lived-request.ts
@@ -1,0 +1,50 @@
+'use client';
+
+export interface ActiveLongLivedRequestController {
+  begin: () => AbortController;
+  finish: (controller: AbortController) => void;
+  abort: (reason?: string) => void;
+  setActive: (active: boolean) => void;
+  getCurrent: () => AbortController | null;
+}
+
+export function createActiveLongLivedRequestController(initialActive = true): ActiveLongLivedRequestController {
+  let active = initialActive;
+  let current: AbortController | null = null;
+
+  const abort = (reason = 'inactive') => {
+    const controller = current;
+    current = null;
+    if (!controller || controller.signal.aborted) return;
+    controller.abort(reason);
+  };
+
+  return {
+    begin() {
+      abort('replaced');
+      const controller = new AbortController();
+      current = controller;
+      if (!active) {
+        abort('inactive');
+      }
+      return controller;
+    },
+    finish(controller) {
+      if (current === controller) {
+        current = null;
+      }
+    },
+    abort,
+    setActive(nextActive) {
+      active = nextActive;
+      if (!active) abort('inactive');
+    },
+    getCurrent() {
+      return current;
+    },
+  };
+}
+
+export function isAbortError(error: unknown): boolean {
+  return (error as { name?: string } | null)?.name === 'AbortError';
+}

--- a/src/lib/connection-budget.test.ts
+++ b/src/lib/connection-budget.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchWithLongLivedBudget,
+  installLongLivedFetchBudgetGuard,
+  resetLongLivedFetchBudgetForTests,
+  snapshotLongLivedFetchBudgetForTests,
+} from './connection-budget';
+
+function neverEndingSseResponse(): Response {
+  return new Response(new ReadableStream<Uint8Array>(), {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream; charset=utf-8' },
+  });
+}
+
+describe('long-lived fetch budget guard', () => {
+  beforeEach(() => {
+    resetLongLivedFetchBudgetForTests();
+  });
+
+  afterEach(() => {
+    resetLongLivedFetchBudgetForTests();
+    vi.restoreAllMocks();
+  });
+
+  it('logs holder labels when same-origin SSE requests exceed the budget and releases on cancel', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    window.fetch = vi.fn(async () => neverEndingSseResponse()) as unknown as typeof fetch;
+
+    installLongLivedFetchBudgetGuard();
+
+    const responses = await Promise.all([
+      window.fetch('/api/v2/chat'),
+      window.fetch('/api/v2/chat'),
+      window.fetch('/api/v2/chat'),
+      window.fetch('/api/v2/chat'),
+      window.fetch('/api/v2/chat'),
+    ]);
+
+    expect(snapshotLongLivedFetchBudgetForTests()).toEqual([
+      'GET /api/v2/chat',
+      'GET /api/v2/chat',
+      'GET /api/v2/chat',
+      'GET /api/v2/chat',
+      'GET /api/v2/chat',
+    ]);
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[conn-budget] long-lived app-origin request budget exceeded',
+      expect.objectContaining({
+        count: 5,
+        limit: 4,
+        holders: [
+          'GET /api/v2/chat',
+          'GET /api/v2/chat',
+          'GET /api/v2/chat',
+          'GET /api/v2/chat',
+          'GET /api/v2/chat',
+        ],
+      }),
+    );
+
+    await Promise.all(responses.map((response) => response.body?.cancel()));
+    expect(snapshotLongLivedFetchBudgetForTests()).toEqual([]);
+  });
+
+  it('tracks explicitly marked long-lived fetches before response headers arrive', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const resolvers: Array<(response: Response) => void> = [];
+    window.fetch = vi.fn(() => new Promise<Response>((resolve) => {
+      resolvers.push(resolve);
+    })) as unknown as typeof fetch;
+
+    const requests = Array.from({ length: 5 }, () => fetchWithLongLivedBudget('/api/runtime/transcript'));
+
+    expect(snapshotLongLivedFetchBudgetForTests()).toEqual([
+      'GET /api/runtime/transcript',
+      'GET /api/runtime/transcript',
+      'GET /api/runtime/transcript',
+      'GET /api/runtime/transcript',
+      'GET /api/runtime/transcript',
+    ]);
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[conn-budget] long-lived app-origin request budget exceeded',
+      expect.objectContaining({ count: 5, limit: 4 }),
+    );
+
+    resolvers.forEach((resolve) => resolve(new Response(null, { status: 204 })));
+    await Promise.all(requests);
+    expect(snapshotLongLivedFetchBudgetForTests()).toEqual([]);
+  });
+});

--- a/src/lib/connection-budget.ts
+++ b/src/lib/connection-budget.ts
@@ -1,0 +1,183 @@
+'use client';
+
+const INSTALL_FLAG = '__o8LongLivedFetchBudgetInstalled';
+const ORIGINAL_FETCH = '__o8OriginalFetchForLongLivedBudget';
+const MAX_LONG_LIVED_REQUESTS = 4;
+const TRACKED_INIT = Symbol.for('o8.longLivedFetchBudgetTracked');
+
+type BudgetWindow = Window & {
+  [INSTALL_FLAG]?: boolean;
+  [ORIGINAL_FETCH]?: typeof fetch;
+};
+
+type BudgetedRequestInit = RequestInit & {
+  [TRACKED_INIT]?: boolean;
+};
+
+interface ActiveHolder {
+  id: number;
+  label: string;
+  startedAt: number;
+}
+
+const activeHolders = new Map<number, ActiveHolder>();
+let nextHolderId = 1;
+
+function sameAppOrigin(input: RequestInfo | URL): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    const url = typeof Request !== 'undefined' && input instanceof Request
+      ? new URL(input.url)
+      : new URL(String(input), window.location.href);
+    return url.origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+function requestLabel(input: RequestInfo | URL, init?: RequestInit): string {
+  const method = init?.method ?? (typeof Request !== 'undefined' && input instanceof Request ? input.method : 'GET');
+  try {
+    const url = typeof Request !== 'undefined' && input instanceof Request
+      ? new URL(input.url)
+      : new URL(String(input), window.location.href);
+    return `${method.toUpperCase()} ${url.pathname}`;
+  } catch {
+    return `${method.toUpperCase()} ${String(input)}`;
+  }
+}
+
+function acquireHolder(label: string): () => void {
+  const id = nextHolderId;
+  nextHolderId += 1;
+  activeHolders.set(id, { id, label, startedAt: Date.now() });
+
+  if (activeHolders.size > MAX_LONG_LIVED_REQUESTS) {
+    console.error('[conn-budget] long-lived app-origin request budget exceeded', {
+      count: activeHolders.size,
+      limit: MAX_LONG_LIVED_REQUESTS,
+      holders: Array.from(activeHolders.values()).map((holder) => holder.label),
+    });
+  }
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    activeHolders.delete(id);
+  };
+}
+
+function noopRelease(): void {}
+
+function wrapsLongLivedBody(response: Response): boolean {
+  return response.headers.get('content-type')?.toLowerCase().includes('text/event-stream') === true;
+}
+
+function wrapResponseBody(response: Response, release: () => void): Response {
+  if (!response.body) {
+    release();
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  let released = false;
+  const releaseOnce = () => {
+    if (released) return;
+    released = true;
+    release();
+  };
+
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          releaseOnce();
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        releaseOnce();
+        controller.error(error);
+      }
+    },
+    async cancel(reason) {
+      releaseOnce();
+      await reader.cancel(reason).catch(() => undefined);
+    },
+  });
+
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
+export function beginLongLivedFetchBudget(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  label?: string,
+): () => void {
+  if (typeof window === 'undefined' || !sameAppOrigin(input)) return noopRelease;
+  return acquireHolder(label ?? requestLabel(input, init));
+}
+
+export async function fetchWithLongLivedBudget(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  if (typeof window === 'undefined' || !sameAppOrigin(input)) {
+    return fetch(input, init);
+  }
+
+  const release = beginLongLivedFetchBudget(input, init);
+  try {
+    const budgetedInit = {
+      ...(init ?? {}),
+      [TRACKED_INIT]: true,
+    } as BudgetedRequestInit;
+    const response = await fetch(input, budgetedInit);
+    return wrapResponseBody(response, release);
+  } catch (error) {
+    release();
+    throw error;
+  }
+}
+
+export function installLongLivedFetchBudgetGuard(): void {
+  if (typeof window === 'undefined') return;
+  const budgetWindow = window as BudgetWindow;
+  if (budgetWindow[INSTALL_FLAG]) return;
+
+  const nativeFetch = budgetWindow.fetch.bind(window);
+  budgetWindow[ORIGINAL_FETCH] = budgetWindow.fetch;
+  budgetWindow.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const budgetedInit = init as BudgetedRequestInit | undefined;
+    const response = await nativeFetch(input, init);
+    if (budgetedInit?.[TRACKED_INIT] || !sameAppOrigin(input) || !wrapsLongLivedBody(response)) {
+      return response;
+    }
+    const release = acquireHolder(requestLabel(input, init));
+    return wrapResponseBody(response, release);
+  };
+  budgetWindow[INSTALL_FLAG] = true;
+}
+
+export function snapshotLongLivedFetchBudgetForTests(): string[] {
+  return Array.from(activeHolders.values()).map((holder) => holder.label);
+}
+
+export function resetLongLivedFetchBudgetForTests(): void {
+  activeHolders.clear();
+  nextHolderId = 1;
+  if (typeof window === 'undefined') return;
+  const budgetWindow = window as BudgetWindow;
+  if (budgetWindow[ORIGINAL_FETCH]) {
+    budgetWindow.fetch = budgetWindow[ORIGINAL_FETCH]!;
+    delete budgetWindow[ORIGINAL_FETCH];
+  }
+  delete budgetWindow[INSTALL_FLAG];
+}

--- a/src/lib/use-active-long-lived-request.ts
+++ b/src/lib/use-active-long-lived-request.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  createActiveLongLivedRequestController,
+  type ActiveLongLivedRequestController,
+} from '@/lib/active-long-lived-request';
+
+export function useActiveLongLivedRequest(active: boolean): ActiveLongLivedRequestController {
+  const [controller] = useState(() => createActiveLongLivedRequestController(active));
+
+  useEffect(() => {
+    controller.setActive(active);
+  }, [active, controller]);
+
+  useEffect(() => () => controller.abort('unmount'), [controller]);
+
+  return controller;
+}


### PR DESCRIPTION
Wave 3 / issue #1359 (P0). Three starvations in one day: WebKit 6-per-origin cap exhausted by streams held by idle tabs — panels skeletoned, then the operator merge click silently died (and the UI showed success, #1374).

- Full inventory of long-lived holds (in the packet report): workspace chat streams (claude-code/codex send), scratch-chat SSE, transcript polls, mobile history.
- Release-on-idle everywhere: streams abort when their tab goes inactive/hidden/unmounts, reacquire on focus. The #1293 packet-transcript poll keeps its exact gating.
- src/lib/connection-budget.ts: shared long-lived fetch tracking + a dashboard fetch guard — more than 4 concurrent long-lived same-origin requests logs [conn-budget] with holder labels, so the next regression reports itself instead of eating operator clicks.
- Tests: active-tab request controller + budget counter. 908 green, tsc clean.
- Deferred (recorded in review): live multi-hour dogfood verification post-ship.

Worker: Codex GPT-5.5 xhigh via o8 dispatch, packet pkt-10b7f4e0. Reviewed at pinned HEAD c4416813; gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167kWJy2UsSp6x1RF3VnvjF