### PR TITLE
fix: reconcile external PR merges by head ref + stamp lane prNumber (#1381)

### DIFF
--- a/src/lib/github-broker/sync.ts
+++ b/src/lib/github-broker/sync.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import {
+  getGitHubPullRequestByHead,
   getGitHubPullRequestByNumber,
   listGitHubIssues,
   listGitHubPullRequests,
@@ -255,6 +256,36 @@ async function syncPullRequest(repoFullName: string, prNumber: number) {
   return pull;
 }
 
+async function syncPullRequestByHead(repoFullName: string, headRefName: string) {
+  const owner = repoFullName.split('/')[0] ?? '';
+  const head = encodeURIComponent(`${owner}:${headRefName}`);
+  const { response, installation } = await githubInstallationFetch(
+    repoFullName,
+    `/repos/${repoFullName}/pulls?state=all&head=${head}&per_page=1&sort=updated&direction=desc`,
+  );
+
+  upsertGitHubInstallation({
+    installationId: installation.id,
+    accountLogin: installation.account?.login ?? owner,
+    accountType: installation.account?.type ?? null,
+    targetType: installation.target_type ?? null,
+    permissions: installation.permissions ?? null,
+  });
+
+  const bodyText = await response.text();
+  if (!response.ok) {
+    throw buildGitHubError(response, bodyText);
+  }
+
+  const pulls = JSON.parse(bodyText) as GitHubPullRequestPayload[];
+  const match = pulls[0];
+  if (!match) return null;
+
+  const pull = mapPullRequestSnapshot(repoFullName, match, match);
+  upsertGitHubPullRequest(pull);
+  return pull;
+}
+
 export async function ensureGitHubIssues(repoFullName: string, options?: { fresh?: boolean }) {
   const config = getGitHubAppConfig();
   const current = listGitHubIssues(repoFullName);
@@ -336,6 +367,28 @@ export async function ensureGitHubPullRequest(repoFullName: string, prNumber: nu
     return { pr, error: null, stale: false };
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unable to sync GitHub pull request';
+    markGitHubSyncError(repoFullName, 'pull_requests', message);
+    return { pr: current, error: message, stale: true };
+  }
+}
+
+export async function ensureGitHubPullRequestByHead(repoFullName: string, headRefName: string) {
+  const current = getGitHubPullRequestByHead(repoFullName, headRefName);
+  const config = getGitHubAppConfig();
+
+  if (!config) {
+    return {
+      pr: current,
+      error: current ? null : 'GitHub App is not configured.',
+      stale: true,
+    };
+  }
+
+  try {
+    const pr = await syncPullRequestByHead(repoFullName, headRefName);
+    return { pr: pr ?? current, error: null, stale: false };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to sync GitHub pull request by head branch';
     markGitHubSyncError(repoFullName, 'pull_requests', message);
     return { pr: current, error: message, stale: true };
   }

--- a/src/lib/lane/worktree-reaper.ts
+++ b/src/lib/lane/worktree-reaper.ts
@@ -22,7 +22,7 @@
 import { execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { promisify } from 'node:util';
-import { appendEvent, archiveLane, listActiveLanes } from '@/lib/lane/registry';
+import { appendEvent, archiveLane, listActiveLanes, updateLane } from '@/lib/lane/registry';
 import type { GitHubPullRequestSnapshot } from '@/lib/github-broker/store';
 import type { Lane } from '@/lib/lane/types';
 
@@ -113,6 +113,12 @@ function archiveMergedPullRequestLane(
   });
 }
 
+function stampLanePullRequestNumber(lane: Lane, pull: GitHubPullRequestSnapshot): void {
+  if (pull.number > 0 && lane.prNumber !== pull.number) {
+    updateLane(lane.id, { prNumber: pull.number }, 'system');
+  }
+}
+
 async function reconcileMergedPullRequest(
   lane: Lane,
   allowTargetedRefresh: boolean,
@@ -153,9 +159,27 @@ async function reconcileMergedPullRequest(
   }
 
   const legacyPull = getGitHubPullRequestByHead(repoFullName, lane.branch);
-  if (legacyPull?.mergedAt) {
-    archiveMergedPullRequestLane(lane, repoFullName, legacyPull, 'headRefName');
-    return { archived: true, refreshed: false };
+  if (legacyPull) {
+    stampLanePullRequestNumber(lane, legacyPull);
+    if (legacyPull.mergedAt) {
+      archiveMergedPullRequestLane(lane, repoFullName, legacyPull, 'headRefName');
+      return { archived: true, refreshed: false };
+    }
+    return { archived: false, refreshed: false };
+  }
+
+  if (allowTargetedRefresh) {
+    const { ensureGitHubPullRequestByHead } = await import('@/lib/github-broker/sync');
+    const refreshed = await ensureGitHubPullRequestByHead(repoFullName, lane.branch);
+    const pull = refreshed.pr;
+    if (pull) {
+      stampLanePullRequestNumber(lane, pull);
+      if (pull.mergedAt) {
+        archiveMergedPullRequestLane(lane, repoFullName, pull, 'headRefName');
+        return { archived: true, refreshed: true };
+      }
+    }
+    return { archived: false, refreshed: true };
   }
 
   return { archived: false, refreshed: false };

--- a/tests/worktree-reaper-pr-merge.test.ts
+++ b/tests/worktree-reaper-pr-merge.test.ts
@@ -3,17 +3,58 @@ import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 
 process.env.CORTEX_IDE_DATA_DIR = mkdtempSync(join(tmpdir(), 'o8-pr-reaper-data-'));
 process.env.O8_DATA_DIR = process.env.CORTEX_IDE_DATA_DIR;
 vi.resetModules();
+
+const targetedHeadRefreshes = new Map<string, {
+  number: number;
+  state: 'open' | 'closed';
+  closedAt?: string | null;
+  mergedAt?: string | null;
+}>();
 
 vi.doMock('@/lib/github-broker/sync', () => ({
   ensureGitHubPullRequest: vi.fn(async (repoFullName: string, prNumber: number) => {
     const { getGitHubPullRequestByNumber } = await import('@/lib/github-broker/store');
     return {
       pr: getGitHubPullRequestByNumber(repoFullName, prNumber),
+      error: null,
+      stale: false,
+    };
+  }),
+  ensureGitHubPullRequestByHead: vi.fn(async (repoFullName: string, headRefName: string) => {
+    const pull = targetedHeadRefreshes.get(`${repoFullName}:${headRefName}`);
+    if (!pull) {
+      return { pr: null, error: null, stale: false };
+    }
+
+    const { getGitHubPullRequestByNumber, upsertGitHubPullRequest } = await import('@/lib/github-broker/store');
+    upsertGitHubPullRequest({
+      pullRequestId: 910_000 + pull.number,
+      repoFullName,
+      number: pull.number,
+      title: `PR ${pull.number}`,
+      state: pull.state,
+      author: null,
+      body: '',
+      headRefName,
+      baseRefName: 'main',
+      additions: 0,
+      deletions: 0,
+      changedFiles: 0,
+      reviewDecision: null,
+      statusCheckRollup: [],
+      url: `https://github.com/${repoFullName}/pull/${pull.number}`,
+      createdAt: '2026-07-03T12:00:00.000Z',
+      updatedAt: '2026-07-03T12:05:00.000Z',
+      closedAt: pull.closedAt ?? null,
+      mergedAt: pull.mergedAt ?? null,
+    });
+    return {
+      pr: getGitHubPullRequestByNumber(repoFullName, pull.number),
       error: null,
       stale: false,
     };
@@ -32,6 +73,10 @@ afterAll(() => {
   closeDb();
   vi.doUnmock('@/lib/github-broker/sync');
   vi.resetModules();
+});
+
+afterEach(() => {
+  targetedHeadRefreshes.clear();
 });
 
 function git(cwd: string, args: string[]): string {
@@ -222,6 +267,56 @@ describe('worktree reaper PR merge reconciliation', () => {
     const event = getLaneEvents(lane.id).find((item) => item.verb === 'pr_merged_reconciled');
     expect(event?.payload.prNumber).toBe(303);
     expect(event?.payload.match).toBe('headRefName');
+    expect(getLane(lane.id)?.prNumber).toBe(303);
+  });
+
+  it('archives and stamps no-prNumber lanes by targeted GitHub head refresh when the mirror has no row', async () => {
+    const repoPath = makeRepo();
+    const lane = createLane({
+      repoPath,
+      branch: 'inline/head-refresh-pr-merged',
+      baseBranch: 'main',
+      runtime: 'codex',
+      packetId: 'pkt-head-refresh-pr-merged',
+    });
+    markReviewing(lane.id, null);
+    targetedHeadRefreshes.set(`${REPO_FULL_NAME}:${lane.branch}`, {
+      number: 305,
+      state: 'closed',
+      closedAt: '2026-07-03T12:35:00.000Z',
+      mergedAt: '2026-07-03T12:35:00.000Z',
+    });
+
+    await runWorktreeReaperTick();
+
+    expect(getLane(lane.id)?.status).toBe('archived');
+    expect(getLane(lane.id)?.prNumber).toBe(305);
+    const event = getLaneEvents(lane.id).find((item) => item.verb === 'pr_merged_reconciled');
+    expect(event?.payload.prNumber).toBe(305);
+    expect(event?.payload.match).toBe('headRefName');
+  });
+
+  it('stamps no-prNumber lanes by targeted GitHub head refresh before the PR is merged', async () => {
+    const repoPath = makeRepo();
+    const lane = createLane({
+      repoPath,
+      branch: 'inline/head-refresh-pr-open',
+      baseBranch: 'main',
+      runtime: 'codex',
+      packetId: 'pkt-head-refresh-pr-open',
+    });
+    markReviewing(lane.id, null);
+    targetedHeadRefreshes.set(`${REPO_FULL_NAME}:${lane.branch}`, {
+      number: 306,
+      state: 'open',
+    });
+
+    await runWorktreeReaperTick();
+
+    expect(getLane(lane.id)?.status).toBe('reviewing');
+    expect(getLane(lane.id)?.prNumber).toBe(306);
+    const event = getLaneEvents(lane.id).find((item) => item.verb === 'pr_merged_reconciled');
+    expect(event).toBeUndefined();
   });
 
   it('startup sweep removes terminal and unknown clone dirs while keeping active and context dirs', async () => {


### PR DESCRIPTION
Closes the two load-bearing asks of #1381 (the boot-sync audit stays open on the issue):

- `ensureGitHubPullRequestByHead` — targeted GitHub refresh by `owner:branch` when a reviewing lane has no stamped prNumber and no mirror row, so lanes whose PRs were opened outside o8 (raw `gh pr create`) converge without depending on the periodic mirror sync
- Opportunistic `lanes.pr_number` stamping whenever any path resolves a PR for the lane — subsequent ticks use the cheap by-number path, and stale mirror rows self-heal
- Real-path tests through `runWorktreeReaperTick`: merged-PR head-refresh archives + stamps; open-PR head-refresh stamps without archiving

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj