### PR TITLE
fix: suppress stale review cards while the codex run is still active + read-time clean-worktree gate (#1366)

### DIFF
--- a/src/app/api/orchestrator/review-state/route.ts
+++ b/src/app/api/orchestrator/review-state/route.ts
@@ -14,7 +14,7 @@
  */
 import { NextResponse, type NextRequest } from 'next/server';
 import { findLatestLaneByPacket } from '@/lib/lane/registry';
-import { runMergeGate, type MergeGateResult } from '@/lib/lane/merge-gate';
+import { buildPreviewForLane, type MergePreviewResult } from '@/lib/lane/preview-merge';
 import {
   derivePacketReviewState,
   type DeriveReviewStateMergeGate,
@@ -29,15 +29,6 @@ export const dynamic = 'force-dynamic';
 
 const LOG_PREFIX = '[review-state]';
 const JSON_HEADERS = { 'Cache-Control': 'no-store, max-age=0' };
-
-// Labels surfaced in the response `mergeGate.checks` field. Mirrors the
-// enforcement categories in `runMergeGate` so agents can reason about which
-// check class flagged them.
-const MERGE_GATE_CHECK_LABELS: Record<'security' | 'budget' | 'integrity', string> = {
-  security: 'security-patterns',
-  budget: 'diff-budget',
-  integrity: 'self-review-integrity',
-};
 
 function errorResponse(code: string, message: string, status = 500) {
   return NextResponse.json({ error: { code, message } }, { status, headers: JSON_HEADERS });
@@ -56,26 +47,12 @@ function toOrchestratorReview(review: {
   };
 }
 
-function toMergeGate(gate: MergeGateResult | null): DeriveReviewStateMergeGate | null {
-  if (!gate) return null;
-
-  // Build the check list from the categories that had findings, plus an
-  // "untracked-imports" pseudo-check that's always relevant.
-  const categories = new Set<string>();
-  for (const violation of gate.violations) {
-    const label = MERGE_GATE_CHECK_LABELS[violation.category];
-    if (label) categories.add(label);
-  }
-  // Always surface these as "ran" — even clean runs executed them.
-  categories.add('security-patterns');
-  categories.add('diff-budget');
-  categories.add('untracked-imports');
-  categories.add('self-review-integrity');
-
+function toMergeGate(preview: MergePreviewResult | null): DeriveReviewStateMergeGate | null {
+  if (!preview) return null;
   return {
-    verdict: gate.passed ? 'passing' : 'failing',
+    verdict: preview.wouldMerge ? 'passing' : 'failing',
     ts: new Date().toISOString(),
-    checks: [...categories].sort(),
+    checks: preview.checks.map((check) => check.name),
   };
 }
 
@@ -104,21 +81,25 @@ export async function GET(request: NextRequest) {
     }
     const packet = missionPacket ?? synthesizePacketFromLane(packetId, lane!);
 
-    // Merge gate is computed on-demand from the lane's diff. If the lane is
+    // Merge preview is computed on-demand from the lane's diff. If the lane is
     // gone (archived / never spawned) we can't run the gate — fall back to
-    // null and let the derivation treat it as unwired.
-    let gateResult: MergeGateResult | null = null;
+    // null and let the derivation treat it as unwired. This uses the same
+    // preview shape as the review card/CLI so dirty worktrees are re-checked at
+    // read time, not only when the review transition first fired.
+    let mergePreview: MergePreviewResult | null = null;
     if (lane) {
       try {
-        gateResult = runMergeGate(lane);
+        mergePreview = buildPreviewForLane(lane, packetId, {
+          orchestratorApproved: packet.review?.approved === true,
+        });
       } catch (error) {
-        console.warn(`${LOG_PREFIX} runMergeGate failed for packet ${packetId}:`, error);
-        gateResult = null;
+        console.warn(`${LOG_PREFIX} buildPreviewForLane failed for packet ${packetId}:`, error);
+        mergePreview = null;
       }
     }
 
     const orchestratorReview = toOrchestratorReview(packet.review ?? null);
-    const mergeGate = toMergeGate(gateResult);
+    const mergeGate = toMergeGate(mergePreview);
 
     const { state, stateChangedAt } = derivePacketReviewState({
       packet,

--- a/src/app/dashboard/hooks/useSessionState.ts
+++ b/src/app/dashboard/hooks/useSessionState.ts
@@ -44,6 +44,14 @@ function reviewPayloadTouchesApprovals(data: Record<string, unknown>): boolean {
     || typeof data.policyRuleId === 'string';
 }
 
+function normalizeRuntimeAvailability(
+  value: string | null | undefined,
+): OrchestratorRuntimeTruth['runtimeAvailability'] {
+  return value === 'awaiting-thread' || value === 'running' || value === 'ready-for-resume'
+    ? value
+    : null;
+}
+
 export function useSessionState() {
   // ── Core session state ──
   const [activeSessionKey, setActiveSessionKey] = useState<string | undefined>();
@@ -132,6 +140,10 @@ export function useSessionState() {
         currentTask: agent.currentTask ?? null,
         lastEventAt: agent.lastEventAt ?? null,
         workflowStageLabel: null,
+        canSendInput: agent.runtimeSurface?.capabilities?.sendInput ?? null,
+        canInterrupt: agent.runtimeSurface?.capabilities?.interrupt ?? null,
+        runtimeAvailability: normalizeRuntimeAvailability(agent.runtimeSurface?.lifecycle?.availability),
+        ownership: agent.runtimeSurface?.ownership ?? null,
       })),
     [parsedAgents],
   );

--- a/src/app/dashboard/types.ts
+++ b/src/app/dashboard/types.ts
@@ -73,6 +73,11 @@ export interface PaletteAgentSummary {
   };
   runtimeSurface?: {
     cwd?: string | null;
+    ownership?: 'provider' | 'discovered' | 'owned';
+    capabilities?: {
+      sendInput?: boolean;
+      interrupt?: boolean;
+    };
     lifecycle?: {
       availability?: string;
       summary?: string;

--- a/src/lib/lane/preview-merge.ts
+++ b/src/lib/lane/preview-merge.ts
@@ -12,6 +12,8 @@
  * "gate could not run".
  */
 
+import { execFileSync } from 'node:child_process';
+
 import { findLatestLaneByPacket } from '@/lib/lane/registry';
 import type { Lane } from '@/lib/lane/types';
 import { readOrchestratorControlPlaneState } from '@/lib/orchestrator/control-plane';
@@ -21,6 +23,7 @@ import { runMergeGate, type MergeGateResult, type MergeViolation } from './merge
 
 /** One row per enforcement check that ran, in the order listed below. */
 export type MergeCheckName =
+  | 'clean-worktree'
   | 'security-patterns'
   | 'diff-budget'
   | 'untracked-imports'
@@ -61,6 +64,7 @@ const CATEGORY_TO_CHECK: Record<MergeViolation['category'], MergeCheckName> = {
 };
 
 const ALL_CHECKS: MergeCheckName[] = [
+  'clean-worktree',
   'security-patterns',
   'diff-budget',
   'untracked-imports',
@@ -125,6 +129,23 @@ function hasApprovedOrchestratorReview(packetId: string): boolean {
   return mission.packets.find((packet) => packet.id === packetId)?.review?.approved === true;
 }
 
+function readDirtyWorktreeDetail(cwd: string): string | null {
+  try {
+    const output = execFileSync('git', ['status', '--porcelain'], {
+      cwd,
+      timeout: 5000,
+      encoding: 'utf-8',
+      maxBuffer: 1024 * 1024,
+    }).trim();
+    if (!output) return null;
+    const lines = output.split('\n').slice(0, 5);
+    const suffix = output.split('\n').length > lines.length ? '\n...' : '';
+    return `Uncommitted worktree changes are still present:\n${lines.join('\n')}${suffix}`;
+  } catch {
+    return 'Unable to verify that the worktree is clean.';
+  }
+}
+
 /**
  * Run the merge gate against a lane and return the structured preview shape.
  * Callers already holding a `Lane` reference should use this path — it
@@ -139,9 +160,18 @@ export function buildPreviewForLane(
   const gateResult = runMergeGate(lane, undefined, orchestratorApproved);
   const checks = buildCheckList(gateResult);
   const blockers = buildBlockerList(gateResult);
+  const dirtyDetail = readDirtyWorktreeDetail(lane.worktreePath ?? lane.repoPath);
+  if (dirtyDetail) {
+    const cleanCheck = checks.find((check) => check.name === 'clean-worktree');
+    if (cleanCheck) {
+      cleanCheck.verdict = 'fail';
+      cleanCheck.detail = dirtyDetail;
+    }
+    blockers.unshift('clean-worktree');
+  }
   return {
     packetId,
-    wouldMerge: gateResult.passed,
+    wouldMerge: gateResult.passed && !dirtyDetail,
     checks,
     blockers,
     branch: lane.branch ?? null,

--- a/src/lib/orchestrator/control-plane.ts
+++ b/src/lib/orchestrator/control-plane.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { getDataDir } from '@/lib/data-dir-migration';
 import { listLanes } from '@/lib/lane/registry';
 import type { DomainLaneSummary } from '@/lib/orchestrator/store';
-import type { OrchestratorMissionState } from '@/lib/orchestrator/types';
+import type { OrchestratorMissionState, OrchestratorRuntimeTruth } from '@/lib/orchestrator/types';
 import {
   createEmptyOrchestratorMissionState,
   normalizeOrchestratorMissionState,
@@ -84,19 +84,51 @@ export function buildDomainLaneSummaries(): DomainLaneSummary[] {
     }));
 }
 
-export function reconcileOrchestratorControlPlaneState(state?: OrchestratorMissionState) {
+function needsRuntimeTruth(domainLanes: DomainLaneSummary[]): boolean {
+  return domainLanes.some((lane) =>
+    lane.status === 'reviewing' && lane.sessionKey?.startsWith('codex-owned:')
+  );
+}
+
+async function buildRuntimeTruthSummaries(domainLanes: DomainLaneSummary[]): Promise<OrchestratorRuntimeTruth[]> {
+  if (!needsRuntimeTruth(domainLanes)) return [];
+  const { getRuntimeInventorySnapshot } = await import('@/lib/runtime/inventory');
+  const snapshot = await getRuntimeInventorySnapshot({ fresh: true });
+  return snapshot.agents
+    .filter((agent) => agent.sessionKey && (agent.runtime === 'codex' || agent.runtime === 'claude-code'))
+    .map((agent) => ({
+      sessionKey: agent.sessionKey,
+      runtime: agent.runtime === 'claude-code' ? 'claude-code' as const : 'codex' as const,
+      status: agent.status ?? 'idle',
+      currentTask: agent.currentTask ?? null,
+      lastEventAt: agent.lastEventAt ?? null,
+      workflowStageLabel: null,
+      canSendInput: agent.runtimeSurface?.capabilities.sendInput ?? null,
+      canInterrupt: agent.runtimeSurface?.capabilities.interrupt ?? null,
+      runtimeAvailability: agent.runtimeSurface?.lifecycle?.availability ?? null,
+      ownership: agent.runtimeSurface?.ownership ?? null,
+    }));
+}
+
+export function reconcileOrchestratorControlPlaneState(
+  state?: OrchestratorMissionState,
+  runtimeTruth: OrchestratorRuntimeTruth[] = [],
+  domainLanes: DomainLaneSummary[] = buildDomainLaneSummaries(),
+) {
   const current = normalizeOrchestratorMissionState(state ?? readOrchestratorControlPlaneState());
   return reconcileOrchestratorMissionState(current, {
     laneSnapshots: [],
-    runtimeTruth: [],
-    domainLanes: buildDomainLaneSummaries(),
+    runtimeTruth,
+    domainLanes,
   });
 }
 
 export async function syncOrchestratorControlPlaneState(state?: OrchestratorMissionState) {
   await acquireLock();
   try {
-    const reconciled = reconcileOrchestratorControlPlaneState(state);
+    const domainLanes = buildDomainLaneSummaries();
+    const runtimeTruth = await buildRuntimeTruthSummaries(domainLanes).catch(() => []);
+    const reconciled = reconcileOrchestratorControlPlaneState(state, runtimeTruth, domainLanes);
     return writeOrchestratorControlPlaneState(reconciled);
   } finally {
     releaseLock();
@@ -128,7 +160,9 @@ export async function withLockedState<T>(
       && 'lanes' in (result as object)
         ? (result as unknown as OrchestratorMissionState)
         : current;
-    const reconciled = reconcileOrchestratorControlPlaneState(basisForReconcile);
+    const domainLanes = buildDomainLaneSummaries();
+    const runtimeTruth = await buildRuntimeTruthSummaries(domainLanes).catch(() => []);
+    const reconciled = reconcileOrchestratorControlPlaneState(basisForReconcile, runtimeTruth, domainLanes);
     const state = writeOrchestratorControlPlaneState(reconciled);
     return { result, state };
   } finally {

--- a/src/lib/orchestrator/runtime-truth.ts
+++ b/src/lib/orchestrator/runtime-truth.ts
@@ -1,0 +1,12 @@
+import { normalizeRuntimeStatusToOrchestratorStatus } from '@/lib/orchestrator/runtime-status';
+import type { OrchestratorRuntimeTruth } from '@/lib/orchestrator/types';
+
+export function runtimeTruthHasActiveWriter(runtime: OrchestratorRuntimeTruth | undefined): boolean {
+  if (!runtime) return false;
+  if (runtime.runtime !== 'codex' || runtime.ownership === 'discovered') return false;
+  if (runtime.runtimeAvailability === 'running' || runtime.canInterrupt === true) return true;
+  return normalizeRuntimeStatusToOrchestratorStatus(runtime.status, {
+    waitingAsRunning: true,
+    fallbackStatus: null,
+  }) === 'running';
+}

--- a/src/lib/orchestrator/store.ts
+++ b/src/lib/orchestrator/store.ts
@@ -1,5 +1,6 @@
 import { normalizeDecompositionMetadata, normalizePacketType } from '@/lib/orchestrator/normalize/decomposition';
 import { normalizeRuntimeStatusToOrchestratorStatus } from '@/lib/orchestrator/runtime-status';
+import { runtimeTruthHasActiveWriter } from '@/lib/orchestrator/runtime-truth';
 import { hydrateOrchestratorTurnPinEntry, installOrchestratorTurnPinFetchPatch, persistOrchestratorTurnPin, readCachedOrchestratorTurnPin, stageOrchestratorTurnPin } from '@/lib/orchestrator/turn-pins';
 import {
   normalizeRequestedRuntime,
@@ -799,8 +800,9 @@ export function reconcileOrchestratorMissionState(
         ?? (packet.lane.sessionKey ? laneBySession.get(packet.lane.sessionKey) : undefined)
         ?? laneByPacketId.get(packet.id)
       : laneByPacketId.get(packet.id);
-    const runtime = laneMatch?.sessionKey ? runtimeTruthBySession.get(laneMatch.sessionKey) : undefined;
     const domainLane = domainLaneByPacketId?.get(packet.id) ?? null;
+    const runtimeSessionKey = laneMatch?.sessionKey ?? domainLane?.sessionKey ?? packet.lane?.sessionKey ?? null;
+    const runtime = runtimeSessionKey ? runtimeTruthBySession.get(runtimeSessionKey) : undefined;
     const laneId = domainLane?.laneId ?? packet.lane?.laneId ?? null;
     const next: OrchestratorPacket = {
       ...packet,
@@ -860,6 +862,7 @@ export function reconcileOrchestratorMissionState(
     // ── Lane domain model status takes priority when available ──
     if (domainLane) {
       const ds = domainLane.status;
+      if (ds === 'reviewing' && runtimeTruthHasActiveWriter(runtime)) { next.status = 'running'; return next; }
       if (ds === 'reviewing') { next.status = 'awaiting_review'; return next; }
       if (ds === 'merging') { next.status = 'awaiting_review'; next.blockedReason = 'Merge in progress'; return next; }
       if (ds === 'completed') { next.status = 'released'; next.releaseState = 'released'; return next; }

--- a/src/lib/orchestrator/types.ts
+++ b/src/lib/orchestrator/types.ts
@@ -399,6 +399,10 @@ export interface OrchestratorRuntimeTruth {
   currentTask?: string | null;
   lastEventAt?: string | null;
   workflowStageLabel?: string | null;
+  canSendInput?: boolean | null;
+  canInterrupt?: boolean | null;
+  runtimeAvailability?: 'awaiting-thread' | 'running' | 'ready-for-resume' | null;
+  ownership?: 'provider' | 'discovered' | 'owned' | null;
 }
 
 export type WorkspaceLaneTranscriptState =

--- a/tests/real-path-seams.test.ts
+++ b/tests/real-path-seams.test.ts
@@ -32,20 +32,41 @@
  *      (fable) even for a frontier worker (codex) — through the real
  *      operator-defaults resolution, not resolveBrainEnabledWith in isolation.
  */
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import { join } from 'node:path';
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
 import type { OrchestratorMissionState, OrchestratorPacket } from '@/lib/orchestrator/types';
+
+const runtimeInventoryMock = vi.hoisted(() => ({
+  agents: [] as Array<{
+    sessionKey: string;
+    runtime: 'codex' | 'claude-code';
+    status: string;
+    currentTask?: string | null;
+    lastEventAt?: string | null;
+    runtimeSurface?: {
+      ownership?: 'provider' | 'discovered' | 'owned';
+      capabilities?: { sendInput?: boolean; interrupt?: boolean };
+      lifecycle?: { availability?: 'awaiting-thread' | 'running' | 'ready-for-resume' };
+    };
+  }>,
+}));
 
 vi.mock('@/lib/realtime/publisher', () => ({
   publishRealtimeMutation: vi.fn(async () => {}),
 }));
 
+vi.mock('@/lib/runtime/inventory', () => ({
+  getRuntimeInventorySnapshot: vi.fn(async () => ({ agents: runtimeInventoryMock.agents })),
+}));
+
 const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-real-path-seams-'));
+const tempDirs: string[] = [];
 const WORKER_TOKEN = 'local-worker-token-seambeef0123456789abcd';
 const WS_TOKEN = 'operator-ws-token-seam-0123456789abcdef';
 writeFileSync(join(dataDir, 'worker-token'), `${WORKER_TOKEN}\n`, 'utf-8');
@@ -56,10 +77,18 @@ process.env.CORTEX_IDE_DATA_DIR = dataDir;
 const { buildPacketPrompt } = await import('@/lib/orchestrator/packet-prompt');
 const { addSessionRule } = await import('@/lib/db/session-rules-store');
 const mergeRoute = await import('@/app/api/orchestrator/merge/route');
+const mergePreviewRoute = await import('@/app/api/orchestrator/merge-preview/route');
 const stateRoute = await import('@/app/api/orchestrator/state/route');
-const { createLane, findLaneByPacket } = await import('@/lib/lane/registry');
+const { createLane, findLaneByPacket, setLaneStatus } = await import('@/lib/lane/registry');
 const { listApprovalsForContext } = await import('@/lib/approvals/store');
 const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+
+afterEach(() => {
+  runtimeInventoryMock.agents = [];
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 function packetFixture(overrides: Partial<OrchestratorPacket> = {}): OrchestratorPacket {
   return {
@@ -129,6 +158,9 @@ function operatorReq(url: string, body: unknown): NextRequest {
     headers: { host: 'localhost:3001' },
     body: JSON.stringify(body),
   });
+}
+function operatorGet(url: string): NextRequest {
+  return new NextRequest(url, { method: 'GET', headers: { host: 'localhost:3001' } });
 }
 
 describe('seam B — a dispatched worker approve_and_merge raises an operator card (CRIT-1/HIGH-4)', () => {
@@ -244,5 +276,106 @@ describe('seam D — a metered orchestrator (fable) puts the Brain in a frontier
       );
       expect(prompt).not.toContain('Engineering Brain available');
     });
+  });
+});
+
+// ── Seam E — reviewing projection consumes active-run liveness (#1366) ──────
+
+describe('seam E — review-ready projection is suppressed while owned Codex is still active', () => {
+  const url = 'http://localhost:3001/api/orchestrator/state';
+
+  it('real state GET maps a reviewing lane back to running when runtime truth says active owned run', async () => {
+    const packetId = 'pkt-seam-E-active-reviewing';
+    const surfaceId = 'codex-owned:seam-E-active';
+    const repoPath = mkdtempSync(join(os.tmpdir(), 'o8-seam-E-repo-'));
+    tempDirs.push(repoPath);
+
+    const lane = createLane({
+      repoPath,
+      worktreePath: repoPath,
+      branch: 'inline/seam-e',
+      runtime: 'codex',
+      packetId,
+      sessionKey: surfaceId,
+    });
+    setLaneStatus(lane.id, 'reviewing', 'system', 'review_ready');
+
+    runtimeInventoryMock.agents = [{
+      sessionKey: surfaceId,
+      runtime: 'codex',
+      status: 'running',
+      currentTask: 'Editing files',
+      lastEventAt: new Date().toISOString(),
+      runtimeSurface: {
+        ownership: 'owned',
+        capabilities: { sendInput: false, interrupt: true },
+        lifecycle: { availability: 'running' },
+      },
+    }];
+
+    const seed = await (await stateRoute.GET(operatorGet(url))).json();
+    const current: OrchestratorMissionState = seed.mission ?? createEmptyOrchestratorMissionState();
+    const mission: OrchestratorMissionState = {
+      ...current,
+      packets: [
+        ...current.packets,
+        packetFixture({ id: packetId, status: 'awaiting_review', lane: null }),
+      ],
+    };
+    const postRes = await stateRoute.POST(operatorReq(url, { mission }));
+    expect(postRes.status).toBe(200);
+
+    const getRes = await stateRoute.GET(operatorGet(url));
+    expect(getRes.status).toBe(200);
+    const json = await getRes.json();
+    const packet = json.mission.packets.find((p: OrchestratorPacket) => p.id === packetId);
+
+    expect(packet).toBeTruthy();
+    expect(packet.status).toBe('running');
+    expect(packet.status).not.toBe('awaiting_review');
+  });
+});
+
+// ── Seam F — merge preview re-checks clean tree at read time (#1366/#1363) ───
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+function makeDirtyGitRepo(): string {
+  const repoPath = mkdtempSync(join(os.tmpdir(), 'o8-seam-F-repo-'));
+  tempDirs.push(repoPath);
+  git(repoPath, ['init', '-b', 'main']);
+  writeFileSync(join(repoPath, 'tracked.txt'), 'base\n');
+  git(repoPath, ['add', 'tracked.txt']);
+  git(repoPath, ['-c', 'user.name=o8-test', '-c', 'user.email=o8@example.test', 'commit', '-m', 'base']);
+  writeFileSync(join(repoPath, 'tracked.txt'), 'moving target\n');
+  return repoPath;
+}
+
+describe('seam F — merge preview blocks dirty review worktrees', () => {
+  it('real merge-preview route returns clean-worktree blocker for uncommitted writes after review', async () => {
+    const packetId = 'pkt-seam-F-dirty-preview';
+    const repoPath = makeDirtyGitRepo();
+    const lane = createLane({
+      repoPath,
+      worktreePath: repoPath,
+      branch: 'inline/seam-f',
+      baseBranch: 'main',
+      runtime: 'codex',
+      packetId,
+      sessionKey: 'codex-owned:seam-F-dirty',
+    });
+    setLaneStatus(lane.id, 'reviewing', 'system', 'review_ready');
+
+    const res = await mergePreviewRoute.GET(operatorGet(`http://localhost:3001/api/orchestrator/merge-preview?packetId=${packetId}`));
+    expect(res.status).toBe(200);
+    const preview = await res.json();
+
+    expect(preview.wouldMerge).toBe(false);
+    expect(preview.blockers).toContain('clean-worktree');
+    expect(preview.checks.some((check: { name: string; verdict: string }) =>
+      check.name === 'clean-worktree' && check.verdict === 'fail'
+    )).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #1366 — the premature READY FOR REVIEW class (hit 4× across two days).

Two prongs:

- **Projection-level liveness**: when a lane says `reviewing` but the owned Codex session's lifecycle says the run is still active (`availability === 'running'` / interruptible), the mission projection maps the packet back to `running` — the review card never renders against a still-writing worker. This consumes the same owned-session lifecycle signal the steer path uses (the guard that said "wait for the active run to settle" while the lane sat in reviewing). Parked sessions report `ready-for-resume` (interrupt=false), so genuinely-done and salvaged-dead lanes still surface their cards.
- **Read-time clean-tree gate**: merge preview (and the review-state route, now sharing the same preview) adds a `clean-worktree` check that re-runs `git status` at read time — post-review drift blocks `wouldMerge` with a visible blocker instead of being silently mergeable.

Real-path tests (seams E/F in tests/real-path-seams.test.ts): the actual state route projects a reviewing lane back to running under active runtime truth; the actual merge-preview route returns the clean-worktree blocker for a dirty tree.

Full suite 921/922 — only the known mission-inline-issues 5s load flake (passes isolated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj