### PR TITLE
fix: PR-only mode review cards offer Create PR as primary, hide the doomed Merge button (#1367)

### DIFF
--- a/src/app/api/lanes/route.ts
+++ b/src/app/api/lanes/route.ts
@@ -5,6 +5,7 @@ import { summarizeLaneArchive } from '@/lib/lane/archive-summary';
 import { collapseArchivedLanesByTask } from '@/lib/lanes/collapse-archived-by-task';
 import { codename } from '@/lib/agents/codename';
 import { dispatch } from '@/lib/lane/commands';
+import { currentLaneMergePolicy } from '@/lib/lane/dogfood-guard';
 import { reconcileOrphanedWorktrees } from '@/lib/lane/reconcile';
 import type { LaneCommand } from '@/lib/lane/types';
 
@@ -42,9 +43,12 @@ export async function GET(req: NextRequest) {
   // Stamp the memorable codename (same pure fn that labels the canvas card and
   // resolves voice "[Name], [task]") so every lane consumer — the canvas, voice
   // status, mobile — sees the agent by the SAME name. Additive, deterministic.
+  const mergePolicy = currentLaneMergePolicy();
   const lanes = resolvedLanes.map((lane) => ({
     ...lane,
     codename: codename(lane.id),
+    mergeMode: mergePolicy.mode,
+    mergeModeNote: mergePolicy.note,
     archiveSummary: lane.status === 'archived' || lane.status === 'completed'
       ? summarizeLaneArchive(lane, getLaneEvents(lane.id, 80))
       : null,

--- a/src/components/desktop/thoughts/mission-panel/PacketReviewPanel.tsx
+++ b/src/components/desktop/thoughts/mission-panel/PacketReviewPanel.tsx
@@ -52,6 +52,8 @@ export function PacketReviewPanel({
   const visibleReviewFiles = reviewState?.showAllFiles ? reviewFiles : reviewFiles.slice(0, 5);
   const reviewWarningText = reviewWarnings.length > 0 ? reviewWarnings.slice(0, 2).join(' ') : null;
   const laneId = packet.lane?.laneId ?? null;
+  const prOnlyMode = packet.lane?.mergeMode === 'pr_only';
+  const prOnlyCaption = packet.lane?.mergeModeNote ?? 'PR-only mode is active. Create a PR for human merge.';
   const approvalQuery = useMemo(() => {
     if (!laneId) return null;
     const params = new URLSearchParams({ status: 'all', packetId: packet.id, laneId });
@@ -412,6 +414,12 @@ export function PacketReviewPanel({
         </div>
       ) : null}
 
+      {prOnlyMode ? (
+        <div style={{ fontSize: 11, color: 'var(--t-text-secondary)', lineHeight: 1.4 }}>
+          {prOnlyCaption}
+        </div>
+      ) : null}
+
       <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
         <button
           type="button"
@@ -436,29 +444,31 @@ export function PacketReviewPanel({
         >
           {reviewState?.action === 'create_pr' ? 'Create PR...' : 'Create PR'}
         </button>
-        <button
-          type="button"
-          onClick={() => onReviewAction('merge')}
-          disabled={reviewState?.action === 'merge' || reviewState?.loading}
-          style={{
-            minHeight: 44,
-            minWidth: 44,
-            border: '1px solid rgba(37, 99, 235, 0.2)',
-            background: 'rgba(37, 99, 235, 0.06)',
-            color: '#2563eb',
-            paddingTop: 6,
-            paddingRight: 10,
-            paddingBottom: 6,
-            paddingLeft: 10,
-            borderRadius: 8,
-            fontSize: 11,
-            fontWeight: 700,
-            cursor: reviewState?.action === 'merge' || reviewState?.loading ? 'default' : 'pointer',
-            opacity: reviewState?.action === 'merge' || reviewState?.loading ? 0.5 : 1,
-          }}
-        >
-          {reviewState?.action === 'merge' ? 'Merge...' : 'Merge'}
-        </button>
+        {!prOnlyMode ? (
+          <button
+            type="button"
+            onClick={() => onReviewAction('merge')}
+            disabled={reviewState?.action === 'merge' || reviewState?.loading}
+            style={{
+              minHeight: 44,
+              minWidth: 44,
+              border: '1px solid rgba(37, 99, 235, 0.2)',
+              background: 'rgba(37, 99, 235, 0.06)',
+              color: '#2563eb',
+              paddingTop: 6,
+              paddingRight: 10,
+              paddingBottom: 6,
+              paddingLeft: 10,
+              borderRadius: 8,
+              fontSize: 11,
+              fontWeight: 700,
+              cursor: reviewState?.action === 'merge' || reviewState?.loading ? 'default' : 'pointer',
+              opacity: reviewState?.action === 'merge' || reviewState?.loading ? 0.5 : 1,
+            }}
+          >
+            {reviewState?.action === 'merge' ? 'Merge...' : 'Merge'}
+          </button>
+        ) : null}
         {reviewState?.prUrl ? (
           <a
             href={reviewState.prUrl}

--- a/src/components/desktop/thoughts/mission-panel/review-card/ReviewPane.tsx
+++ b/src/components/desktop/thoughts/mission-panel/review-card/ReviewPane.tsx
@@ -60,8 +60,11 @@ export function ReviewPane({ packet, onActionComplete }: {
   const verdict = deriveVerdict(packet);
   const tone = verdictTone(verdict);
   const concerns = useMemo(() => buildConcerns(packet), [packet]);
+  const laneId = packet.lane?.laneId ?? null;
+  const prOnlyMode = packet.lane?.mergeMode === 'pr_only';
+  const prOnlyCaption = packet.lane?.mergeModeNote ?? 'PR-only mode is active. Create a PR for human merge.';
 
-  const [busy, setBusy] = useState<'merge' | 'respec' | 'kill' | null>(null);
+  const [busy, setBusy] = useState<'merge' | 'create_pr' | 'respec' | 'kill' | null>(null);
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   const [feedback, setFeedback] = useState('');
   const [actionError, setActionError] = useState<string | null>(null);
@@ -88,11 +91,14 @@ export function ReviewPane({ packet, onActionComplete }: {
       });
       const payload = await response.json().catch(() => null) as {
         ok?: boolean;
-        result?: { note?: string };
+        result?: { note?: string; merged?: boolean };
         error?: { message?: string };
       } | null;
       if (!response.ok || !payload?.ok) {
         throw new Error(payload?.error?.message ?? `Unable to ${kind} packet.`);
+      }
+      if (kind === 'merge' && payload.result?.merged === false) {
+        throw new Error(payload.result.note ?? 'Merge was refused.');
       }
       setActionNote(payload.result?.note ?? null);
       onActionComplete?.();
@@ -106,6 +112,38 @@ export function ReviewPane({ packet, onActionComplete }: {
   const onMerge = useCallback(() => {
     void callAction('merge', { packetId: packet.id }, '/api/orchestrator/merge');
   }, [callAction, packet.id]);
+
+  const onCreatePr = useCallback(async () => {
+    if (!laneId) {
+      setActionError('No lane is bound to this packet yet.');
+      return;
+    }
+    setBusy('create_pr');
+    setActionError(null);
+    setActionNote(null);
+    try {
+      const response = await fetch('/api/lanes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          verb: 'create_pr',
+          laneId,
+          commitMessage: 'Auto-commit from lane',
+        }),
+      });
+      const payload = await response.json().catch(() => null) as { ok?: boolean; note?: string } | null;
+      const note = payload?.note ?? 'Unable to create PR.';
+      if (!response.ok || !payload?.ok) {
+        throw new Error(note);
+      }
+      setActionNote(note);
+      onActionComplete?.();
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : 'Unable to create PR.');
+    } finally {
+      setBusy(null);
+    }
+  }, [laneId, onActionComplete]);
 
   const onKill = useCallback(() => {
     void callAction('kill', { packetId: packet.id, clearWorktree: true, reason: 'Killed via review card.' }, '/api/orchestrator/reset-packet');
@@ -376,31 +414,67 @@ export function ReviewPane({ packet, onActionComplete }: {
           </div>
         </div>
       ) : (
+        <>
+        {prOnlyMode ? (
+          <div style={{
+            fontSize: 10.5,
+            color: 'var(--t-text-secondary)',
+            fontFamily: FONT_FAMILY,
+            lineHeight: 1.4,
+          }}>
+            {prOnlyCaption}
+          </div>
+        ) : null}
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, paddingTop: 4 }}>
-          <button
-            type="button"
-            onClick={onMerge}
-            disabled={busy !== null}
-            style={{
-              paddingTop: 6,
-              paddingRight: 12,
-              paddingBottom: 6,
-              paddingLeft: 12,
-              borderRadius: 10,
-              borderWidth: 1,
-              borderStyle: 'solid',
-              borderColor: 'rgba(34, 197, 94, 0.36)',
-              background: 'rgba(34, 197, 94, 0.14)',
-              color: '#15803d',
-              fontSize: 11,
-              fontWeight: 700,
-              cursor: busy !== null ? 'not-allowed' : 'pointer',
-              opacity: busy !== null ? 0.5 : 1,
-              fontFamily: FONT_FAMILY,
-            }}
-          >
-            {busy === 'merge' ? 'Merging…' : 'Merge'}
-          </button>
+          {prOnlyMode ? (
+            <button
+              type="button"
+              onClick={onCreatePr}
+              disabled={busy !== null || !laneId}
+              style={{
+                paddingTop: 6,
+                paddingRight: 12,
+                paddingBottom: 6,
+                paddingLeft: 12,
+                borderRadius: 10,
+                borderWidth: 0,
+                background: 'var(--t-accent)',
+                color: '#fff',
+                fontSize: 11,
+                fontWeight: 700,
+                cursor: busy !== null || !laneId ? 'not-allowed' : 'pointer',
+                opacity: busy !== null || !laneId ? 0.5 : 1,
+                fontFamily: FONT_FAMILY,
+              }}
+            >
+              {busy === 'create_pr' ? 'Creating PR…' : 'Create PR'}
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={onMerge}
+              disabled={busy !== null}
+              style={{
+                paddingTop: 6,
+                paddingRight: 12,
+                paddingBottom: 6,
+                paddingLeft: 12,
+                borderRadius: 10,
+                borderWidth: 1,
+                borderStyle: 'solid',
+                borderColor: 'rgba(34, 197, 94, 0.36)',
+                background: 'rgba(34, 197, 94, 0.14)',
+                color: '#15803d',
+                fontSize: 11,
+                fontWeight: 700,
+                cursor: busy !== null ? 'not-allowed' : 'pointer',
+                opacity: busy !== null ? 0.5 : 1,
+                fontFamily: FONT_FAMILY,
+              }}
+            >
+              {busy === 'merge' ? 'Merging…' : 'Merge'}
+            </button>
+          )}
           <button
             type="button"
             onClick={() => setFeedbackOpen(true)}
@@ -450,6 +524,7 @@ export function ReviewPane({ packet, onActionComplete }: {
             {busy === 'kill' ? 'Killing…' : 'Kill packet'}
           </button>
         </div>
+        </>
       )}
     </div>
   );

--- a/src/components/desktop/workspace-terminal/ChatPacketStatusBanner.tsx
+++ b/src/components/desktop/workspace-terminal/ChatPacketStatusBanner.tsx
@@ -17,6 +17,7 @@
  */
 
 import { useCallback, useState } from 'react';
+import type { LaneMergeMode } from '@/lib/lane/merge-mode';
 import type { OrchestratorPacketStatus } from '@/lib/orchestrator/types';
 
 interface ChatPacketStatusBannerProps {
@@ -24,6 +25,8 @@ interface ChatPacketStatusBannerProps {
   laneId: string | null;
   packetId: string | null;
   packetTitle: string | null;
+  mergeMode?: LaneMergeMode | null;
+  mergeModeNote?: string | null;
   onOpenInActivity?: () => void;
 }
 
@@ -71,9 +74,13 @@ export function ChatPacketStatusBanner({
   laneId,
   packetId,
   packetTitle,
+  mergeMode,
+  mergeModeNote,
   onOpenInActivity,
 }: ChatPacketStatusBannerProps) {
   const tone = status ? TONE_BY_STATUS[status] : undefined;
+  const prOnlyMode = mergeMode === 'pr_only';
+  const prOnlyCaption = mergeModeNote ?? 'PR-only mode is active. Create a PR for human merge.';
   const [pending, setPending] = useState<'merge' | 'create_pr' | 'reject' | null>(null);
   const [actionNote, setActionNote] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -190,7 +197,9 @@ export function ChatPacketStatusBanner({
             {packetTitle ?? 'Dispatched packet'}
           </div>
           <div style={{ fontSize: 11, fontWeight: 300, color: 'var(--t-text-secondary)', marginTop: 2, lineHeight: 1.45 }}>
-            {tone.detail}
+            {status === 'awaiting_review' && prOnlyMode
+              ? 'PR-only mode is active. Create a PR so a human can merge.'
+              : tone.detail}
           </div>
         </div>
       </div>
@@ -274,8 +283,9 @@ export function ChatPacketStatusBanner({
             </div>
           </div>
         ) : (
+          <>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-            {laneId ? (
+            {laneId && !prOnlyMode ? (
               <button
                 type="button"
                 onClick={() => { void callLaneAction('merge'); }}
@@ -310,15 +320,16 @@ export function ChatPacketStatusBanner({
                   paddingBottom: 4,
                   paddingLeft: 10,
                   borderRadius: 8,
-                  borderWidth: 1,
+                  borderWidth: prOnlyMode ? 0 : 1,
                   borderStyle: 'solid',
-                  borderColor: tone.border,
-                  background: 'transparent',
-                  color: tone.color,
+                  borderColor: prOnlyMode ? 'transparent' : tone.border,
+                  background: prOnlyMode ? 'var(--t-accent)' : 'transparent',
+                  color: prOnlyMode ? '#fff' : tone.color,
                   fontSize: 11,
                   fontWeight: 400,
                   cursor: pending !== null ? 'wait' : 'pointer',
                   fontFamily: 'var(--font-sans-system)',
+                  letterSpacing: prOnlyMode ? '-0.1px' : undefined,
                 }}
               >
                 {pending === 'create_pr' ? 'Creating PR…' : 'Create PR'}
@@ -372,6 +383,12 @@ export function ChatPacketStatusBanner({
               </button>
             ) : null}
           </div>
+          {prOnlyMode ? (
+            <div style={{ fontSize: 11, color: 'var(--t-text-secondary)', lineHeight: 1.4 }}>
+              {prOnlyCaption}
+            </div>
+          ) : null}
+          </>
         )
       ) : null}
 

--- a/src/components/desktop/workspace-terminal/WorkspaceChatPane.tsx
+++ b/src/components/desktop/workspace-terminal/WorkspaceChatPane.tsx
@@ -309,6 +309,8 @@ function WorkspaceChatPaneBase({
                           laneId={livePacket.lane?.laneId ?? null}
                           packetId={livePacket.id}
                           packetTitle={livePacket.title ?? tab.orchestrationPacket.title ?? null}
+                          mergeMode={livePacket.lane?.mergeMode ?? null}
+                          mergeModeNote={livePacket.lane?.mergeModeNote ?? null}
                           onOpenInActivity={
                             orchestratorData?.onOpenO8Panel
                               ? () => orchestratorData.onOpenO8Panel?.({ tab: 'activity' })
@@ -664,6 +666,8 @@ function WorkspaceChatPaneBase({
                   laneId={livePacket.lane?.laneId ?? null}
                   packetId={livePacket.id}
                   packetTitle={livePacket.title ?? tab.orchestrationPacket.title ?? null}
+                  mergeMode={livePacket.lane?.mergeMode ?? null}
+                  mergeModeNote={livePacket.lane?.mergeModeNote ?? null}
                   onOpenInActivity={
                     orchestratorData?.onOpenO8Panel
                       ? () => orchestratorData.onOpenO8Panel?.({ tab: 'activity' })

--- a/src/lib/lane/dogfood-guard.ts
+++ b/src/lib/lane/dogfood-guard.ts
@@ -2,6 +2,7 @@ import 'server-only';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { DOGFOOD_PR_ONLY_NOTE, type LaneMergePolicy } from '@/lib/lane/merge-mode';
 
 /**
  * PR-only safety wall for the autonomous dogfood loop (#1173). While the loop is
@@ -16,5 +17,10 @@ export function dogfoodPrOnlyActive(): boolean {
   return existsSync(join(dir, '.dogfood-pr-only'));
 }
 
-export const DOGFOOD_PR_ONLY_NOTE =
-  'PR-only dogfood mode is active — merge to main is blocked. Open a PR; a human merges.';
+export { DOGFOOD_PR_ONLY_NOTE };
+
+export function currentLaneMergePolicy(): LaneMergePolicy {
+  return dogfoodPrOnlyActive()
+    ? { mode: 'pr_only', note: DOGFOOD_PR_ONLY_NOTE }
+    : { mode: 'direct', note: null };
+}

--- a/src/lib/lane/merge-mode.ts
+++ b/src/lib/lane/merge-mode.ts
@@ -1,0 +1,9 @@
+export type LaneMergeMode = 'direct' | 'pr_only';
+
+export interface LaneMergePolicy {
+  mode: LaneMergeMode;
+  note: string | null;
+}
+
+export const DOGFOOD_PR_ONLY_NOTE =
+  'PR-only dogfood mode is active — merge to main is blocked. Open a PR; a human merges.';

--- a/src/lib/orchestrator/operator-mission-service/mission.ts
+++ b/src/lib/orchestrator/operator-mission-service/mission.ts
@@ -4,6 +4,7 @@ import { withLockedState, writeOrchestratorControlPlaneState } from '@/lib/orche
 import { buildDagMetadata, buildDependencyGraph } from '@/lib/orchestrator/dag';
 import { runDispatchTick } from '@/lib/orchestrator/dispatch';
 import { findLaneByPacket } from '@/lib/lane/registry';
+import { currentLaneMergePolicy } from '@/lib/lane/dogfood-guard';
 import { listArtifacts, toArtifactRef } from '@/lib/artifacts/store';
 import { normalizeOrchestratorMissionState } from '@/lib/orchestrator/store';
 import { archiveMissionsExcept, getMissionRecord, recordMission } from '@/lib/db/missions-store';
@@ -411,6 +412,7 @@ async function readTranscriptActivityBySession(
  */
 function buildHistoricalMissionStatus(record: import('@/lib/db/missions-store').MissionRecord) {
   const lanesByPacket = new Map<string, ReturnType<typeof findLaneByPacket>>();
+  const mergePolicy = currentLaneMergePolicy();
   for (const meta of record.packetMeta) {
     lanesByPacket.set(meta.id, findLaneByPacket(meta.id));
   }
@@ -468,6 +470,8 @@ function buildHistoricalMissionStatus(record: import('@/lib/db/missions-store').
         lastActivityLabel: lane.lastEventLabel,
         transcriptUnsupportedReason: null,
         lastEventLabel: lane.lastEventLabel,
+        mergeMode: mergePolicy.mode,
+        mergeModeNote: mergePolicy.note,
       } : null,
       review: null,
     };
@@ -542,6 +546,7 @@ export async function getMissionStatus(input: MissionStatusInput) {
     return sessionKey ? [sessionKey] : [];
   });
   const transcriptActivityBySession = await readTranscriptActivityBySession(sessionKeys);
+  const mergePolicy = currentLaneMergePolicy();
 
   const agents = state.packets
     .map((packet) => {
@@ -570,6 +575,8 @@ export async function getMissionStatus(input: MissionStatusInput) {
         lastActivityLabel: activityLabel(lastActivityAt, lastTranscriptAt, lane.lastEventLabel),
         transcriptUnsupportedReason: activity?.transcriptUnsupportedReason ?? null,
         lastEventLabel: lane.lastEventLabel,
+        mergeMode: mergePolicy.mode,
+        mergeModeNote: mergePolicy.note,
       };
     })
     .filter((agent): agent is NonNullable<typeof agent> => agent !== null);
@@ -628,6 +635,8 @@ export async function getMissionStatus(input: MissionStatusInput) {
           lastActivityLabel: activityLabel(lastActivityAt, lastTranscriptAt, lane.lastEventLabel),
           transcriptUnsupportedReason: activity?.transcriptUnsupportedReason ?? null,
           lastEventLabel: lane.lastEventLabel,
+          mergeMode: mergePolicy.mode,
+          mergeModeNote: mergePolicy.note,
         } : packet.lane ? {
           ...packet.lane,
           lastEventAt: lastActivityAt ?? packet.lane.lastEventAt ?? null,
@@ -636,6 +645,8 @@ export async function getMissionStatus(input: MissionStatusInput) {
           lastActivityAt,
           lastActivityLabel: activityLabel(lastActivityAt, lastTranscriptAt, packet.lane.lastEventLabel),
           transcriptUnsupportedReason: activity?.transcriptUnsupportedReason ?? null,
+          mergeMode: mergePolicy.mode,
+          mergeModeNote: mergePolicy.note,
         } : null,
         review: packet.review ? {
           approved: packet.review.approved,

--- a/src/lib/orchestrator/store.ts
+++ b/src/lib/orchestrator/store.ts
@@ -161,6 +161,8 @@ function normalizeLaneBinding(value: unknown): OrchestratorLaneBinding | null {
     lastHeartbeatAt: typeof lane.lastHeartbeatAt === 'string' ? lane.lastHeartbeatAt : null,
     lastEventAt: typeof lane.lastEventAt === 'string' ? lane.lastEventAt : null,
     lastEventLabel: typeof lane.lastEventLabel === 'string' ? lane.lastEventLabel : null,
+    mergeMode: lane.mergeMode === 'pr_only' || lane.mergeMode === 'direct' ? lane.mergeMode : undefined,
+    mergeModeNote: typeof lane.mergeModeNote === 'string' ? lane.mergeModeNote : null,
   };
 }
 

--- a/src/lib/orchestrator/types.ts
+++ b/src/lib/orchestrator/types.ts
@@ -1,5 +1,6 @@
 // Orchestrator domain types — runtimes, packets, lanes
 import type { OrchestratorReviewFinding } from '@/lib/approvals/types';
+import type { LaneMergeMode } from '@/lib/lane/merge-mode';
 import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 
 export type OrchestratorRuntime = 'codex' | 'claude-code' | 'gemini' | 'opencode';
@@ -83,6 +84,8 @@ export interface OrchestratorLaneBinding {
   lastHeartbeatAt?: string | null;
   lastEventAt?: string | null;
   lastEventLabel?: string | null;
+  mergeMode?: LaneMergeMode;
+  mergeModeNote?: string | null;
 }
 
 export interface OrchestratorPacketReviewFinding {

--- a/tests/review-card-pr-only-mode.test.ts
+++ b/tests/review-card-pr-only-mode.test.ts
@@ -1,0 +1,51 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-review-card-pr-only-'));
+process.env.O8_DATA_DIR = dataDir;
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+
+const lanesRoute = await import('@/app/api/lanes/route');
+const { createLane } = await import('@/lib/lane/registry');
+const { DOGFOOD_PR_ONLY_NOTE } = await import('@/lib/lane/merge-mode');
+
+function lanesReq() {
+  return new NextRequest('http://localhost:3001/api/lanes?active=false', {
+    method: 'GET',
+    headers: { host: 'localhost:3001' },
+  });
+}
+
+describe('review card PR-only mode reaches the lane-list route', () => {
+  it('stamps PR-only merge policy on real /api/lanes rows before UI actions render', async () => {
+    const sentinelPath = join(dataDir, '.dogfood-pr-only');
+    rmSync(sentinelPath, { force: true });
+    const lane = createLane({
+      repoPath: '/tmp/o8-review-card-pr-only-repo',
+      branch: 'issue/pr-only-card',
+      runtime: 'codex',
+      label: 'Review card PR-only lane',
+      packetId: 'pkt-review-card-pr-only',
+    });
+
+    writeFileSync(sentinelPath, '', 'utf-8');
+    try {
+      const response = await lanesRoute.GET(lanesReq());
+      expect(response.status).toBe(200);
+      const payload = await response.json() as {
+        lanes?: Array<{ id: string; mergeMode?: string; mergeModeNote?: string | null }>;
+      };
+      const row = payload.lanes?.find((candidate) => candidate.id === lane.id);
+
+      expect(row).toBeTruthy();
+      expect(row?.mergeMode).toBe('pr_only');
+      expect(row?.mergeModeNote).toBe(DOGFOOD_PR_ONLY_NOTE);
+    } finally {
+      rmSync(sentinelPath, { force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #1367. Lanes now carry a mergeMode policy (stamped through the real /api/lanes + mission-status routes from the dogfood sentinel); in pr_only mode all three review surfaces (PacketReviewPanel, ReviewPane, ChatPacketStatusBanner) hide Merge, promote Create PR to the primary accent action, and show the mode caption. ReviewPane also surfaces merged:false as an error instead of silent success (partial #1374). Real-path test drives the actual lanes route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj