### PR TITLE
fix: o8.md spec panel drops orphaned AI annotations when the operator deletes their words (#1382)

### DIFF
--- a/src/app/api/repo-spec/route.ts
+++ b/src/app/api/repo-spec/route.ts
@@ -7,6 +7,7 @@ import {
   appendRoughdraftReply,
   markRoughdraftResolved,
 } from '@/lib/o8md/rfm';
+import { cleanupOrphanedRoughdraftAnnotations } from '@/lib/o8md/cleanup';
 import { appendComment, insertSuggestion, type SuggestionKind } from '@/lib/o8md/mutate';
 
 export const runtime = 'nodejs';
@@ -84,12 +85,19 @@ export async function PUT(request: NextRequest) {
   if (content === null) {
     return NextResponse.json({ ok: false, error: 'content must be a string' }, { status: 400 });
   }
-  if (Buffer.byteLength(content, 'utf-8') > MAX_BYTES) {
+  const cleanup = cleanupOrphanedRoughdraftAnnotations(content);
+  if (Buffer.byteLength(cleanup.content, 'utf-8') > MAX_BYTES) {
     return NextResponse.json({ ok: false, error: `content exceeds ${MAX_BYTES} bytes` }, { status: 400 });
   }
   mkdirSync(dirname(specPath), { recursive: true });
-  writeFileSync(specPath, content, 'utf-8');
-  return NextResponse.json({ ok: true, path: specPath, bytes: Buffer.byteLength(content, 'utf-8') });
+  writeFileSync(specPath, cleanup.content, 'utf-8');
+  return NextResponse.json({
+    ok: true,
+    path: specPath,
+    bytes: Buffer.byteLength(cleanup.content, 'utf-8'),
+    content: cleanup.content,
+    orphanedAnnotationsRemoved: cleanup.removedAnnotations,
+  });
 }
 
 // POST ?action=reply|resolve — review mutations via the vendored RFM parser.

--- a/src/components/desktop/o8-panel/O8SpecPane.tsx
+++ b/src/components/desktop/o8-panel/O8SpecPane.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react';
 import { DoubleCheck } from 'iconoir-react';
 import { useTheme } from '@/lib/theme/context';
+import { cleanupOrphanedRoughdraftAnnotations } from '@/lib/o8md/cleanup';
 import { O8SpecEditor } from './O8SpecEditor';
 import { TitleBarButton } from '../title-bar/TitleBarButton';
 
@@ -205,8 +206,12 @@ export function O8SpecPane({ repoPath, toolbarSlot, embedded }: O8SpecPaneProps)
     })
       .then((res) => res.json())
       .then((data) => {
-        if (data?.ok) { setSavedAt(Date.now()); serverContentRef.current = next; }
-        else setError(data?.error || 'Save failed');
+        if (data?.ok) {
+          const saved = typeof data.content === 'string' ? data.content : next;
+          setSavedAt(Date.now());
+          serverContentRef.current = saved;
+          if (saved !== next) setContent(saved);
+        } else setError(data?.error || 'Save failed');
       })
       .catch((err) => {
         setError(err instanceof Error ? err.message : String(err));
@@ -217,11 +222,12 @@ export function O8SpecPane({ repoPath, toolbarSlot, embedded }: O8SpecPaneProps)
   }, [repoPath]);
 
   const handleChange = useCallback((next: string) => {
-    setContent(next);
+    const cleaned = cleanupOrphanedRoughdraftAnnotations(next).content;
+    setContent(cleaned);
     setSavePending(true);
     if (debounceRef.current) window.clearTimeout(debounceRef.current);
     debounceRef.current = window.setTimeout(() => {
-      persist(next);
+      persist(cleaned);
     }, SAVE_DEBOUNCE_MS) as unknown as number;
   }, [persist]);
 

--- a/src/lib/o8md/cleanup.ts
+++ b/src/lib/o8md/cleanup.ts
@@ -1,0 +1,86 @@
+import { extractRoughdraftReviewIndex, type RfmReviewItem } from './rfm';
+
+export interface RoughdraftAnnotationCleanupResult {
+  content: string;
+  removedAnnotations: number;
+}
+
+const EMPTY_MARKER_HINT = /\{==\s*==\}|\{~~\s*~>|\{--\s*--\}|\{\+\+\s*\+\+\}/;
+
+function empty(value: string | undefined): boolean {
+  return value !== undefined && value.trim().length === 0;
+}
+
+function findHighlightStart(markdown: string, item: RfmReviewItem): number | null {
+  if (item.anchorText === undefined) return null;
+  const from = item.offset - item.anchorText.length - 6;
+  if (from < 0) return null;
+  const closeFrom = from + 3 + item.anchorText.length;
+  if (!markdown.startsWith('{==', from)) return null;
+  if (markdown.slice(from + 3, closeFrom) !== item.anchorText) return null;
+  if (!markdown.startsWith('==}', closeFrom)) return null;
+  return closeFrom + 3 === item.offset ? from : null;
+}
+
+function rootTextGone(item: RfmReviewItem): boolean {
+  if (item.kind === 'comment') return empty(item.anchorText);
+  if (item.kind !== 'suggestion') return false;
+  if (item.suggestionKind === 'deletion') return empty(item.originalText);
+  if (item.suggestionKind === 'substitution') return empty(item.originalText);
+  if (item.suggestionKind === 'addition') return empty(item.text);
+  return false;
+}
+
+function mergeRanges(ranges: Array<{ from: number; to: number }>): Array<{ from: number; to: number }> {
+  const merged: Array<{ from: number; to: number }> = [];
+  for (const range of ranges.sort((a, b) => a.from - b.from)) {
+    const last = merged[merged.length - 1];
+    if (last && range.from <= last.to) {
+      last.to = Math.max(last.to, range.to);
+    } else {
+      merged.push({ ...range });
+    }
+  }
+  return merged;
+}
+
+export function cleanupOrphanedRoughdraftAnnotations(markdown: string): RoughdraftAnnotationCleanupResult {
+  if (!EMPTY_MARKER_HINT.test(markdown)) return { content: markdown, removedAnnotations: 0 };
+
+  const items = extractRoughdraftReviewIndex(markdown).items.slice().sort((a, b) => a.offset - b.offset);
+  const byOffset = new Map<number, RfmReviewItem>();
+  for (const item of items) {
+    if (item.kind === 'comment' || item.kind === 'reply') byOffset.set(item.offset, item);
+  }
+
+  const ranges: Array<{ from: number; to: number }> = [];
+  for (const item of items) {
+    if (!rootTextGone(item)) continue;
+    if (item.kind === 'comment') {
+      const from = findHighlightStart(markdown, item);
+      if (from === null) continue;
+      let cursor = item.offset;
+      while (true) {
+        const next = byOffset.get(cursor);
+        if (!next || (next.kind !== 'comment' && next.kind !== 'reply')) break;
+        cursor = next.endOffset;
+      }
+      ranges.push({ from, to: cursor });
+    } else if (item.kind === 'suggestion') {
+      ranges.push({ from: item.offset, to: item.endOffset });
+    }
+  }
+
+  const merged = mergeRanges(ranges).filter((range) => range.to > range.from);
+  if (merged.length === 0) return { content: markdown, removedAnnotations: 0 };
+
+  let content = markdown;
+  for (const range of merged.slice().reverse()) {
+    content = `${content.slice(0, range.from)}${content.slice(range.to)}`;
+  }
+
+  const removedAnnotations = items.filter((item) => (
+    merged.some((range) => item.offset >= range.from && item.endOffset <= range.to)
+  )).length;
+  return { content, removedAnnotations };
+}

--- a/tests/repo-spec-orphan-cleanup.test.ts
+++ b/tests/repo-spec-orphan-cleanup.test.ts
@@ -1,0 +1,77 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { NextRequest } from 'next/server';
+import { describe, expect, it } from 'vitest';
+
+import { extractRoughdraftReviewIndex } from '@/lib/o8md/rfm';
+import * as repoSpecRoute from '@/app/api/repo-spec/route';
+
+function request(repoPath: string, content: string): NextRequest {
+  return new NextRequest(`http://localhost:3001/api/repo-spec?repoPath=${encodeURIComponent(repoPath)}`, {
+    method: 'PUT',
+    headers: { host: 'localhost:3001', 'content-type': 'application/json' },
+    body: JSON.stringify({ content }),
+  });
+}
+
+describe('repo-spec PUT orphaned annotation cleanup', () => {
+  it('removes an empty-anchor comment thread through the real route write path', async () => {
+    const repoPath = mkdtempSync(join(tmpdir(), 'o8-repo-spec-cleanup-'));
+    const orphaned = [
+      'Keep ',
+      '{====}{>>stale right-rail note<<}{id="c1" by="AI" at="2026-07-03T12:00:00.000Z"}',
+      '{>>operator reply<<}{id="c2" by="user" at="2026-07-03T12:01:00.000Z" re="c1"}',
+      ' text',
+    ].join('');
+
+    const res = await repoSpecRoute.PUT(request(repoPath, orphaned));
+    const json = await res.json();
+    const written = readFileSync(join(repoPath, 'o8.md'), 'utf-8');
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.orphanedAnnotationsRemoved).toBe(2);
+    expect(json.content).toBe('Keep  text');
+    expect(written).toBe('Keep  text');
+    expect(extractRoughdraftReviewIndex(written).items).toHaveLength(0);
+  });
+
+  it('preserves live anchored and standalone notes while removing only lost anchors', async () => {
+    const repoPath = mkdtempSync(join(tmpdir(), 'o8-repo-spec-cleanup-'));
+    const content = [
+      '{==live words==}{>>keep anchored<<}{id="c1" by="AI" at="2026-07-03T12:00:00.000Z"}',
+      '\n{====}{>>drop orphan<<}{id="c2" by="AI" at="2026-07-03T12:01:00.000Z"}',
+      '\n{>>keep standalone<<}{id="c3" by="AI" at="2026-07-03T12:02:00.000Z"}',
+    ].join('');
+
+    const res = await repoSpecRoute.PUT(request(repoPath, content));
+    const written = readFileSync(join(repoPath, 'o8.md'), 'utf-8');
+    const ids = extractRoughdraftReviewIndex(written).items.map((item) => item.id);
+
+    expect(res.status).toBe(200);
+    expect(written).toContain('live words');
+    expect(written).toContain('keep anchored');
+    expect(written).not.toContain('drop orphan');
+    expect(written).toContain('keep standalone');
+    expect(ids).toEqual(['c1', 'c3']);
+  });
+
+  it('removes empty operator-side suggestions through the real route write path', async () => {
+    const repoPath = mkdtempSync(join(tmpdir(), 'o8-repo-spec-cleanup-'));
+    const content = [
+      'A {~~~>replacement~~}{id="s1" by="AI" at="2026-07-03T12:00:00.000Z"}',
+      ' B {==still here==}{>>keep note<<}{id="c1" by="AI" at="2026-07-03T12:01:00.000Z"}',
+    ].join('');
+    writeFileSync(join(repoPath, 'o8.md'), content, 'utf-8');
+
+    const res = await repoSpecRoute.PUT(request(repoPath, content));
+    const written = readFileSync(join(repoPath, 'o8.md'), 'utf-8');
+    const index = extractRoughdraftReviewIndex(written);
+
+    expect(res.status).toBe(200);
+    expect(written).not.toContain('replacement');
+    expect(index.items.map((item) => item.id)).toEqual(['c1']);
+  });
+});


### PR DESCRIPTION
Closes #1382. New cleanupOrphanedRoughdraftAnnotations removes empty-anchor highlights with their comment/reply chains and empty suggestions, preserving live-anchored and standalone notes; applied on the real repo-spec PUT write path and in the editor (server-cleaned content adopted back into state). Real-path tests drive the actual route with on-disk writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj