### PR TITLE
fix: embedded browser survives panel tab switches — keep the utility shell mounted, show instead of re-open (#1384)

### DIFF
--- a/src/components/desktop/NativeBrowserSurface.tsx
+++ b/src/components/desktop/NativeBrowserSurface.tsx
@@ -221,6 +221,18 @@ export function NativeBrowserSurface({ url, agentGlow }: NativeBrowserSurfacePro
     setOccluded(occluded);
   }, [setOccluded]);
 
+  const showOrOpen = useCallback((rect: BrowserViewRect) => {
+    lastRect.current = rectKey(rect);
+    if (shownUrl.current === url) {
+      void browserViewSetRect(rect);
+      void browserViewShow();
+    } else {
+      shownUrl.current = url;
+      void browserViewOpen(url, rect, NATIVE_BROWSER_AGENT_SOURCE);
+    }
+    scheduleSnapshot();
+  }, [scheduleSnapshot, url]);
+
   /** Open/navigate the native window over the placeholder (only when visible). */
   const openHere = useCallback(() => {
     if (!visibleRef.current || !url) return;
@@ -234,17 +246,11 @@ export function NativeBrowserSurface({ url, agentGlow }: NativeBrowserSurfacePro
         if (!visibleRef.current || !url) return;
         const retry = computeRect();
         if (!retry) return;
-        lastRect.current = rectKey(retry);
-        shownUrl.current = url;
-        void browserViewOpen(url, retry, NATIVE_BROWSER_AGENT_SOURCE);
-        scheduleSnapshot();
+        showOrOpen(retry);
       });
       return;
     }
-    lastRect.current = rectKey(rect);
-    shownUrl.current = url;
-    void browserViewOpen(url, rect, NATIVE_BROWSER_AGENT_SOURCE);
-    scheduleSnapshot();
+    showOrOpen(rect);
     // Self-correct a stale open rect. The panel/window layout may not be settled
     // when the tab first opens — especially right after the operator moves the
     // o8 window between displays (mixed scale factors) — so re-measure the zoom +
@@ -258,7 +264,7 @@ export function NativeBrowserSurface({ url, agentGlow }: NativeBrowserSurfacePro
         }
       }, delay);
     });
-  }, [url, computeRect, measureZoom, scheduleSnapshot, syncRect]);
+  }, [url, computeRect, measureZoom, showOrOpen, syncRect]);
 
   // Visibility: open when the placeholder appears on screen, hide when it leaves
   // (tab switched away → display:none → not intersecting). The native window is a

--- a/src/components/desktop/O8Panel.tsx
+++ b/src/components/desktop/O8Panel.tsx
@@ -477,6 +477,12 @@ export function O8Panel({
   const renderedUtilityTabs = activeUtilityTab && !utilityTabs.includes(activeUtilityTab)
     ? [...utilityTabs, activeUtilityTab]
     : utilityTabs;
+  useEffect(() => {
+    if (!activeUtilityTab) return;
+    queueMicrotask(() => {
+      setUtilityTabs((prev) => (prev.includes(activeUtilityTab) ? prev : [...prev, activeUtilityTab]));
+    });
+  }, [activeUtilityTab]);
 
   const openRightUtilityTab = useCallback((tab: RightUtilityTab) => {
     setUtilityTabs((prev) => (prev.includes(tab) ? prev : [...prev, tab]));
@@ -690,8 +696,8 @@ export function O8Panel({
       ) : null}
 
       {/* Tab content — all tabs stay mounted to preserve state */}
-      {utilityShellActive ? (
-        <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+      {utilityShellActive || renderedUtilityTabs.length > 0 ? (
+        <div style={{ flex: 1, minHeight: 0, display: utilityShellActive ? 'flex' : 'none', flexDirection: 'column' }}>
           <RightUtilityTabStrip
             tabs={renderedUtilityTabs}
             activeTab={activeTab}


### PR DESCRIPTION
Closes #1384, implementing the approved huddle plan (option b). O8Panel keeps the utility shell mounted with display:none when a non-utility tab is active, so O8BrowserPane state (tabs, URL, the child WebviewWindow's JS heap/scroll/session) survives; NativeBrowserSurface's same-URL return path uses browserViewSetRect + browserViewShow instead of browserViewOpen (no renavigation). Hide-on-tab-away rides the existing IntersectionObserver (display:none placeholder stops intersecting), so the native view never floats over other tabs. No security-posture changes. Live smoke after ship: load o8.run in Browser, switch to o8.md, return — page intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj