### PR TITLE
fix: stamp merged_clean at PR reconcile — head-tree-first comparison (#1386)

### DIFF
--- a/src/lib/lane/worktree-reaper.ts
+++ b/src/lib/lane/worktree-reaper.ts
@@ -35,6 +35,15 @@ const MAX_TARGETED_PR_REFRESHES_PER_TICK = 5;
 
 let reaperTimer: ReturnType<typeof setInterval> | null = null;
 
+interface MergedCleanResolution {
+  mergedClean: boolean | null;
+  reason: string;
+  reviewedHeadSha?: string;
+  reviewedTree?: string;
+  comparisonRef?: string;
+  comparisonTree?: string;
+}
+
 async function branchIsMergedIntoBase(
   repoPath: string,
   branch: string,
@@ -75,6 +84,116 @@ async function worktreeHasNoDiffAgainstBase(
   }
 }
 
+async function readTreeHash(repoPath: string, ref: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['rev-parse', `${ref}^{tree}`],
+      { cwd: repoPath, timeout: 5_000 },
+    );
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function firstReadableTree(
+  repoPath: string,
+  refs: Array<string | null | undefined>,
+): Promise<{ ref: string; tree: string } | null> {
+  const seen = new Set<string>();
+  for (const ref of refs) {
+    const trimmed = ref?.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    const tree = await readTreeHash(repoPath, trimmed);
+    if (tree) return { ref: trimmed, tree };
+  }
+  return null;
+}
+
+async function resolvePrMergedClean(
+  lane: Lane,
+  pull: GitHubPullRequestSnapshot,
+): Promise<MergedCleanResolution> {
+  const { latestRecordedReviewedHeadSha } = await import('@/lib/lane/review-head-integrity');
+  const reviewedHeadSha = latestRecordedReviewedHeadSha(lane);
+  if (!reviewedHeadSha) {
+    return { mergedClean: null, reason: 'missing-reviewed-head' };
+  }
+
+  const reviewedTree = await readTreeHash(lane.repoPath, reviewedHeadSha);
+  if (!reviewedTree) {
+    return { mergedClean: null, reason: 'missing-reviewed-tree', reviewedHeadSha };
+  }
+
+  const baseTree = await firstReadableTree(lane.repoPath, [
+    pull.baseRefName,
+    lane.baseBranch,
+    pull.baseRefName ? `origin/${pull.baseRefName}` : null,
+    lane.baseBranch ? `origin/${lane.baseBranch}` : null,
+  ]);
+  if (baseTree?.tree === reviewedTree) {
+    return {
+      mergedClean: true,
+      reason: 'merged-tree-matches-reviewed-head',
+      reviewedHeadSha,
+      reviewedTree,
+      comparisonRef: baseTree.ref,
+      comparisonTree: baseTree.tree,
+    };
+  }
+
+  if (baseTree) {
+    return {
+      mergedClean: false,
+      reason: 'merged-tree-differs-from-reviewed-head',
+      reviewedHeadSha,
+      reviewedTree,
+      comparisonRef: baseTree.ref,
+      comparisonTree: baseTree.tree,
+    };
+  }
+
+  const headTree = await firstReadableTree(lane.repoPath, [
+    pull.headRefName,
+    lane.branch,
+    pull.headRefName ? `origin/${pull.headRefName}` : null,
+    lane.branch ? `origin/${lane.branch}` : null,
+  ]);
+  if (headTree) {
+    return {
+      mergedClean: headTree.tree === reviewedTree,
+      reason: headTree.tree === reviewedTree
+        ? 'pr-head-tree-matches-reviewed-head'
+        : 'pr-head-tree-differs-from-reviewed-head',
+      reviewedHeadSha,
+      reviewedTree,
+      comparisonRef: headTree.ref,
+      comparisonTree: headTree.tree,
+    };
+  }
+
+  return { mergedClean: null, reason: 'missing-merged-tree', reviewedHeadSha, reviewedTree };
+}
+
+async function stampPrMergedClean(
+  lane: Lane,
+  pull: GitHubPullRequestSnapshot,
+): Promise<MergedCleanResolution> {
+  const resolution = await resolvePrMergedClean(lane, pull);
+  if (resolution.mergedClean === null) {
+    return resolution;
+  }
+  const { markOutcomeMerged } = await import('@/lib/orchestrator/context-relay');
+  await markOutcomeMerged({
+    laneId: lane.id,
+    packetId: lane.packetId,
+    mergedClean: resolution.mergedClean,
+  });
+  return resolution;
+}
+
 function repoSlugFromRemoteUrl(remoteUrl: string): string | null {
   const normalized = remoteUrl
     .trim()
@@ -97,19 +216,24 @@ async function resolveRepoFullName(repoPath: string): Promise<string | null> {
   }
 }
 
-function archiveMergedPullRequestLane(
+async function archiveMergedPullRequestLane(
   lane: Lane,
   repoFullName: string,
   pull: GitHubPullRequestSnapshot,
   match: 'prNumber' | 'headRefName',
-): void {
+): Promise<void> {
   console.log(`[worktree-reaper] ${lane.id} PR #${pull.number} merged at ${pull.mergedAt} — archiving`);
+  const mergedClean = await stampPrMergedClean(lane, pull);
   archiveLane(lane.id, 'system');
   appendEvent(lane.id, 'pr_merged_reconciled', 'system', {
     repoFullName,
     prNumber: pull.number,
     mergedAt: pull.mergedAt,
     match,
+    mergedClean: mergedClean.mergedClean,
+    mergedCleanReason: mergedClean.reason,
+    reviewedHeadSha: mergedClean.reviewedHeadSha ?? null,
+    comparisonRef: mergedClean.comparisonRef ?? null,
   });
 }
 
@@ -140,7 +264,7 @@ async function reconcileMergedPullRequest(
   if (prNumber !== null) {
     let pull = getGitHubPullRequestByNumber(repoFullName, prNumber);
     if (pull?.mergedAt) {
-      archiveMergedPullRequestLane(lane, repoFullName, pull, 'prNumber');
+      await archiveMergedPullRequestLane(lane, repoFullName, pull, 'prNumber');
       return { archived: true, refreshed: false };
     }
 
@@ -149,7 +273,7 @@ async function reconcileMergedPullRequest(
       const refreshed = await ensureGitHubPullRequest(repoFullName, prNumber);
       pull = refreshed.pr;
       if (pull?.mergedAt) {
-        archiveMergedPullRequestLane(lane, repoFullName, pull, 'prNumber');
+        await archiveMergedPullRequestLane(lane, repoFullName, pull, 'prNumber');
         return { archived: true, refreshed: true };
       }
       return { archived: false, refreshed: true };
@@ -162,7 +286,7 @@ async function reconcileMergedPullRequest(
   if (legacyPull) {
     stampLanePullRequestNumber(lane, legacyPull);
     if (legacyPull.mergedAt) {
-      archiveMergedPullRequestLane(lane, repoFullName, legacyPull, 'headRefName');
+      await archiveMergedPullRequestLane(lane, repoFullName, legacyPull, 'headRefName');
       return { archived: true, refreshed: false };
     }
     return { archived: false, refreshed: false };
@@ -175,7 +299,7 @@ async function reconcileMergedPullRequest(
     if (pull) {
       stampLanePullRequestNumber(lane, pull);
       if (pull.mergedAt) {
-        archiveMergedPullRequestLane(lane, repoFullName, pull, 'headRefName');
+        await archiveMergedPullRequestLane(lane, repoFullName, pull, 'headRefName');
         return { archived: true, refreshed: true };
       }
     }

--- a/src/lib/lane/worktree-reaper.ts
+++ b/src/lib/lane/worktree-reaper.ts
@@ -127,6 +127,35 @@ async function resolvePrMergedClean(
     return { mergedClean: null, reason: 'missing-reviewed-tree', reviewedHeadSha };
   }
 
+  // The exact semantic of "merged clean" is: the PR HEAD tree at merge equals
+  // the reviewed tree. Compare the head tree FIRST — it is usually still
+  // readable right after merge, before branch pruning. Comparing against the
+  // base branch first produced systematic FALSE NEGATIVES: any other PR landing
+  // on main between the merge and the reaper tick moves the base tree even
+  // though the operator merged the agent's diff untouched.
+  const headTree = await firstReadableTree(lane.repoPath, [
+    pull.headRefName,
+    lane.branch,
+    pull.headRefName ? `origin/${pull.headRefName}` : null,
+    lane.branch ? `origin/${lane.branch}` : null,
+  ]);
+  if (headTree) {
+    return {
+      mergedClean: headTree.tree === reviewedTree,
+      reason: headTree.tree === reviewedTree
+        ? 'pr-head-tree-matches-reviewed-head'
+        : 'pr-head-tree-differs-from-reviewed-head',
+      reviewedHeadSha,
+      reviewedTree,
+      comparisonRef: headTree.ref,
+      comparisonTree: headTree.tree,
+    };
+  }
+
+  // Head refs pruned — fall back to the base tree. A MATCH is still conclusive
+  // (the squash landed exactly the reviewed tree and nothing else moved), but a
+  // MISMATCH is indeterminate, not "touched": base drift after merge is the
+  // expected state of a busy repo.
   const baseTree = await firstReadableTree(lane.repoPath, [
     pull.baseRefName,
     lane.baseBranch,
@@ -146,31 +175,12 @@ async function resolvePrMergedClean(
 
   if (baseTree) {
     return {
-      mergedClean: false,
-      reason: 'merged-tree-differs-from-reviewed-head',
+      mergedClean: null,
+      reason: 'base-tree-moved-head-unreadable',
       reviewedHeadSha,
       reviewedTree,
       comparisonRef: baseTree.ref,
       comparisonTree: baseTree.tree,
-    };
-  }
-
-  const headTree = await firstReadableTree(lane.repoPath, [
-    pull.headRefName,
-    lane.branch,
-    pull.headRefName ? `origin/${pull.headRefName}` : null,
-    lane.branch ? `origin/${lane.branch}` : null,
-  ]);
-  if (headTree) {
-    return {
-      mergedClean: headTree.tree === reviewedTree,
-      reason: headTree.tree === reviewedTree
-        ? 'pr-head-tree-matches-reviewed-head'
-        : 'pr-head-tree-differs-from-reviewed-head',
-      reviewedHeadSha,
-      reviewedTree,
-      comparisonRef: headTree.ref,
-      comparisonTree: headTree.tree,
     };
   }
 

--- a/src/lib/orchestrator/context-relay.ts
+++ b/src/lib/orchestrator/context-relay.ts
@@ -634,20 +634,22 @@ async function persistSessionOutcome(
 }
 
 /**
- * Stamp `merged_clean = 1` on the session_outcomes row(s) for a successfully-
- * merged packet/lane. Best-effort + fire-and-forget by the caller — never
+ * Stamp `merged_clean` on the session_outcomes row(s) for a successfully-
+ * reconciled packet/lane. Best-effort + fire-and-forget by the caller — never
  * block a merge over a ledger write.
  *
- * Looks up by laneId first (most specific), falls back to packetId. Updates
- * every matching row in case a retry produced two captures for the same
+ * Looks up by laneId and packetId when available. Updates every matching row
+ * in case a retry produced two captures for the same
  * packet (deterministic id collapses most cases, but be defensive).
  */
 export async function markOutcomeMerged({
   laneId,
   packetId,
+  mergedClean = true,
 }: {
   laneId?: string | null;
   packetId?: string | null;
+  mergedClean?: boolean;
 }): Promise<void> {
   const db = getDb();
   if (!db) return;
@@ -658,11 +660,12 @@ export async function markOutcomeMerged({
   try {
     if (trimmedLane) {
       await db.update(sessionOutcomes)
-        .set({ mergedClean: true })
+        .set({ mergedClean })
         .where(eq(sessionOutcomes.laneId, trimmedLane));
-    } else if (trimmedPacket) {
+    }
+    if (trimmedPacket) {
       await db.update(sessionOutcomes)
-        .set({ mergedClean: true })
+        .set({ mergedClean })
         .where(eq(sessionOutcomes.packetId, trimmedPacket));
     }
   } catch (err) {

--- a/tests/worktree-reaper-pr-merge.test.ts
+++ b/tests/worktree-reaper-pr-merge.test.ts
@@ -66,6 +66,7 @@ const { createLane, getLane, getLaneEvents } = await import('@/lib/lane/registry
 const { runWorktreeReaperTick } = await import('@/lib/lane/worktree-reaper');
 const { sweepTerminalCortexWorktrees } = await import('@/lib/lane/terminal-worktree-sweep');
 const { upsertGitHubPullRequest } = await import('@/lib/github-broker/store');
+const { recordOrchestratorReview } = await import('@/lib/approvals/store');
 
 const REPO_FULL_NAME = 'hurttlocker/o8-reaper-pr-test';
 
@@ -103,6 +104,60 @@ function makePacketWorktree(repoPath: string, branch: string, dirName: string): 
   git(repoPath, ['branch', branch]);
   git(repoPath, ['worktree', 'add', '-q', worktreePath, branch]);
   return worktreePath;
+}
+
+function commitFile(cwd: string, fileName: string, body: string, message: string): string {
+  writeFileSync(join(cwd, fileName), body);
+  git(cwd, ['add', fileName]);
+  git(cwd, ['commit', '-q', '--no-verify', '-m', message]);
+  return git(cwd, ['rev-parse', 'HEAD']).trim();
+}
+
+function squashBranchToMain(repoPath: string, branch: string, message: string): string {
+  git(repoPath, ['merge', '--squash', branch]);
+  git(repoPath, ['commit', '-q', '--no-verify', '-m', message]);
+  return git(repoPath, ['rev-parse', 'HEAD']).trim();
+}
+
+function insertSucceededOutcome(input: {
+  laneId: string;
+  packetId: string;
+  repoPath: string;
+  branch: string;
+}): void {
+  const now = new Date().toISOString();
+  getSqlite().prepare(`
+    INSERT INTO session_outcomes (
+      id, repo_path, branch, runtime, lane_id, packet_id, outcome, summary,
+      review_approved, started_at, completed_at
+    ) VALUES (?, ?, ?, 'codex', ?, ?, 'succeeded', ?, 1, ?, ?)
+  `).run(
+    `outcome-${input.packetId}`,
+    input.repoPath,
+    input.branch,
+    input.laneId,
+    input.packetId,
+    `completed ${input.packetId}`,
+    now,
+    now,
+  );
+}
+
+function readMergedClean(packetId: string): number | null {
+  const row = getSqlite().prepare(`
+    SELECT merged_clean as mergedClean
+    FROM session_outcomes
+    WHERE packet_id = ?
+  `).get(packetId) as { mergedClean: number | null } | undefined;
+  return row?.mergedClean ?? null;
+}
+
+function recordApprovedReview(packetId: string, reviewedHeadSha: string): void {
+  recordOrchestratorReview(packetId, {
+    approved: true,
+    findings: [],
+    reviewedHeadSha,
+  });
 }
 
 async function waitForPathGone(targetPath: string): Promise<void> {
@@ -187,6 +242,79 @@ describe('worktree reaper PR merge reconciliation', () => {
     const event = getLaneEvents(lane.id).find((item) => item.verb === 'pr_merged_reconciled');
     expect(event?.payload.prNumber).toBe(301);
     expect(event?.payload.match).toBe('prNumber');
+  });
+
+  it('stamps merged_clean when the PR squash tree matches the reviewed packet head', async () => {
+    const repoPath = makeRepo();
+    const packetId = 'pkt-pr-merged-clean';
+    const branch = 'inline/pr-merged-clean';
+    const worktreePath = makePacketWorktree(repoPath, branch, 'packet-pkt-pr-merged-clean');
+    const lane = createLane({
+      repoPath,
+      branch,
+      baseBranch: 'main',
+      runtime: 'codex',
+      packetId,
+      worktreePath,
+    });
+    const reviewedHeadSha = commitFile(worktreePath, 'clean.txt', 'reviewed\n', 'feat: reviewed change [via-o8]');
+    recordApprovedReview(packetId, reviewedHeadSha);
+    insertSucceededOutcome({ laneId: lane.id, packetId, repoPath, branch });
+    squashBranchToMain(repoPath, branch, 'squash reviewed change');
+    markReviewing(lane.id, 307);
+    mirrorPullRequest({
+      number: 307,
+      headRefName: lane.branch,
+      state: 'closed',
+      closedAt: '2026-07-03T12:40:00.000Z',
+      mergedAt: '2026-07-03T12:40:00.000Z',
+    });
+
+    await runWorktreeReaperTick();
+
+    expect(getLane(lane.id)?.status).toBe('archived');
+    await waitForPathGone(worktreePath);
+    expect(readMergedClean(packetId)).toBe(1);
+    const event = getLaneEvents(lane.id).find((item) => item.verb === 'pr_merged_reconciled');
+    expect(event?.payload.mergedClean).toBe(true);
+    expect(event?.payload.reviewedHeadSha).toBe(reviewedHeadSha);
+  });
+
+  it('stamps merged_clean false when the merged PR tree moved after review', async () => {
+    const repoPath = makeRepo();
+    const packetId = 'pkt-pr-merged-touched';
+    const branch = 'inline/pr-merged-touched';
+    const worktreePath = makePacketWorktree(repoPath, branch, 'packet-pkt-pr-merged-touched');
+    const lane = createLane({
+      repoPath,
+      branch,
+      baseBranch: 'main',
+      runtime: 'codex',
+      packetId,
+      worktreePath,
+    });
+    const reviewedHeadSha = commitFile(worktreePath, 'touched.txt', 'reviewed\n', 'feat: reviewed change [via-o8]');
+    recordApprovedReview(packetId, reviewedHeadSha);
+    commitFile(worktreePath, 'touched.txt', 'reviewed\noperator touch\n', 'fix: operator touch-up');
+    insertSucceededOutcome({ laneId: lane.id, packetId, repoPath, branch });
+    squashBranchToMain(repoPath, branch, 'squash touched change');
+    markReviewing(lane.id, 308);
+    mirrorPullRequest({
+      number: 308,
+      headRefName: lane.branch,
+      state: 'closed',
+      closedAt: '2026-07-03T12:45:00.000Z',
+      mergedAt: '2026-07-03T12:45:00.000Z',
+    });
+
+    await runWorktreeReaperTick();
+
+    expect(getLane(lane.id)?.status).toBe('archived');
+    await waitForPathGone(worktreePath);
+    expect(readMergedClean(packetId)).toBe(0);
+    const event = getLaneEvents(lane.id).find((item) => item.verb === 'pr_merged_reconciled');
+    expect(event?.payload.mergedClean).toBe(false);
+    expect(event?.payload.mergedCleanReason).toBe('merged-tree-differs-from-reviewed-head');
   });
 
   it('preserves dirty terminal work before deleting a PR-merged packet clone', async () => {

--- a/tests/worktree-reaper-pr-merge.test.ts
+++ b/tests/worktree-reaper-pr-merge.test.ts
@@ -314,7 +314,47 @@ describe('worktree reaper PR merge reconciliation', () => {
     expect(readMergedClean(packetId)).toBe(0);
     const event = getLaneEvents(lane.id).find((item) => item.verb === 'pr_merged_reconciled');
     expect(event?.payload.mergedClean).toBe(false);
-    expect(event?.payload.mergedCleanReason).toBe('merged-tree-differs-from-reviewed-head');
+    expect(event?.payload.mergedCleanReason).toBe('pr-head-tree-differs-from-reviewed-head');
+  });
+
+  it('stamps merged_clean true when other commits land on main after a clean squash merge', async () => {
+    const repoPath = makeRepo();
+    const packetId = 'pkt-pr-merged-clean-busy-main';
+    const branch = 'inline/pr-merged-clean-busy-main';
+    const worktreePath = makePacketWorktree(repoPath, branch, 'packet-pkt-pr-merged-clean-busy-main');
+    const lane = createLane({
+      repoPath,
+      branch,
+      baseBranch: 'main',
+      runtime: 'codex',
+      packetId,
+      worktreePath,
+    });
+    const reviewedHeadSha = commitFile(worktreePath, 'busy.txt', 'reviewed\n', 'feat: reviewed change [via-o8]');
+    recordApprovedReview(packetId, reviewedHeadSha);
+    insertSucceededOutcome({ laneId: lane.id, packetId, repoPath, branch });
+    squashBranchToMain(repoPath, branch, 'squash reviewed change');
+    // Another PR lands on main between the merge and the reaper tick — the
+    // base tree moves, but the packet's diff was merged untouched. This is the
+    // false-negative case the head-tree-first ordering exists for.
+    commitFile(repoPath, 'unrelated.txt', 'someone else\n', 'feat: unrelated change');
+    markReviewing(lane.id, 309);
+    mirrorPullRequest({
+      number: 309,
+      headRefName: lane.branch,
+      state: 'closed',
+      closedAt: '2026-07-03T12:50:00.000Z',
+      mergedAt: '2026-07-03T12:50:00.000Z',
+    });
+
+    await runWorktreeReaperTick();
+
+    expect(getLane(lane.id)?.status).toBe('archived');
+    await waitForPathGone(worktreePath);
+    expect(readMergedClean(packetId)).toBe(1);
+    const event = getLaneEvents(lane.id).find((item) => item.verb === 'pr_merged_reconciled');
+    expect(event?.payload.mergedClean).toBe(true);
+    expect(event?.payload.mergedCleanReason).toBe('pr-head-tree-matches-reviewed-head');
   });
 
   it('preserves dirty terminal work before deleting a PR-merged packet clone', async () => {


### PR DESCRIPTION
Closes #1386. In PR-only mode, mergedClean was only stamped inside approve_and_merge (which never runs), leaving every outcome NULL and the Autonomy panel at 0% merged-clean.

- `resolvePrMergedClean` compares the reviewed HEAD's tree against the merged result at reconcile time, three-valued (true/false/null) with an audit `reason` carried on the `pr_merged_reconciled` event
- **Head-tree-first ordering**: the exact semantic is "PR head tree at merge == reviewed tree"; comparing the base branch first produced false negatives whenever another PR landed on main between merge and the reaper tick. Base-tree fallback: match is conclusive-true, mismatch is indeterminate (null, `base-tree-moved-head-unreadable`)
- `markOutcomeMerged` takes an explicit boolean and updates both lane- and packet-matched ledger rows
- Real-path tests through `runWorktreeReaperTick`: clean squash → 1, operator touch-up → 0, clean squash + busy main → 1 (the false-negative case)

Worker note: the base implementation is the codex worker's; the ordering fix was applied by the orchestrator after the steered session died silently (4th identical codex death tonight — same rmcp session-delete signature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj