### PR TITLE
fix: browser pane survives closing/reopening the right side panel

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4763,6 +4763,7 @@ function DashboardInner() {
                           prRepo={o8PrRepo}
                           repoSlug={o8CommitRepoSlug ?? repoSlugFromRemote(globalRepoEntry?.remoteUrl)}
                           browserUrl={o8BrowserUrl}
+                          browserStateKey={o8AllRepos ? 'right-panel:all-repos' : `right-panel:${currentO8RepoPath ?? 'default'}`}
                           onBrowserActiveUrlChange={setO8BrowserHoverUrl}
                           commitSha={o8CommitSha}
                           onClearCommit={handleClearCommit}

--- a/src/components/desktop/NativeBrowserSurface.tsx
+++ b/src/components/desktop/NativeBrowserSurface.tsx
@@ -42,13 +42,15 @@ function rectKey(r: BrowserViewRect): string {
   return `${Math.round(r.x)},${Math.round(r.y)},${Math.round(r.w)},${Math.round(r.h)}`;
 }
 
+let lastShownNativeBrowserUrl = '';
+
 export function NativeBrowserSurface({ url, agentGlow }: NativeBrowserSurfaceProps) {
   const ref = useRef<HTMLDivElement>(null);
   const lastRect = useRef<string>('');
   /** Whether the placeholder is currently on screen (driven by the observer). */
   const visibleRef = useRef<boolean>(false);
   /** The URL currently shown by the native window (so we navigate on change). */
-  const shownUrl = useRef<string>('');
+  const shownUrl = useRef<string>(lastShownNativeBrowserUrl);
   /** Page-zoom factor: visual-viewport px ÷ layout (CSS) px. 1 at 100%. */
   const zoomRef = useRef<number>(1);
   /** Occlusion state (Stage 5): the native window composites ABOVE o8's web
@@ -223,6 +225,7 @@ export function NativeBrowserSurface({ url, agentGlow }: NativeBrowserSurfacePro
 
   const showOrOpen = useCallback((rect: BrowserViewRect) => {
     lastRect.current = rectKey(rect);
+    lastShownNativeBrowserUrl = url;
     if (shownUrl.current === url) {
       void browserViewSetRect(rect);
       void browserViewShow();

--- a/src/components/desktop/O8BrowserPane.tsx
+++ b/src/components/desktop/O8BrowserPane.tsx
@@ -64,9 +64,16 @@ interface BrowserTab {
   title: string;
 }
 
+interface BrowserPaneStateSnapshot {
+  tabs: BrowserTab[];
+  activeTabId: string | null;
+  activeUrl: string | null;
+}
+
 interface O8BrowserPaneProps {
   previews?: DetectedLocalhostPreview[];
   navigateToUrl?: string | null;
+  stateScopeKey?: string;
   // Bubbles the currently-loaded URL up to the dashboard so the TitleBar
   // Browser button can render a hover-preview iframe pointed at it.
   onActiveUrlChange?: (url: string | null) => void;
@@ -100,16 +107,60 @@ function newTabId(): string {
   return `btab-${tabCounter}-${Date.now()}`;
 }
 
+const DEFAULT_STATE_SCOPE_KEY = 'right-panel';
+const browserPaneStateStore = new Map<string, BrowserPaneStateSnapshot>();
+
+function normalizeStateScopeKey(key?: string): string {
+  const trimmed = key?.trim();
+  return trimmed || DEFAULT_STATE_SCOPE_KEY;
+}
+
+function cloneTabs(tabs: BrowserTab[]): BrowserTab[] {
+  return tabs.map((tab) => ({ ...tab }));
+}
+
+function readBrowserPaneState(scopeKey: string): BrowserPaneStateSnapshot | null {
+  const stored = browserPaneStateStore.get(scopeKey);
+  if (!stored) return null;
+  const tabs = cloneTabs(stored.tabs);
+  const activeFromId = tabs.find((tab) => tab.id === stored.activeTabId) ?? null;
+  const activeFromUrl = stored.activeUrl ? tabs.find((tab) => tab.url === stored.activeUrl) ?? null : null;
+  const activeTab = activeFromId ?? activeFromUrl ?? tabs[0] ?? null;
+  return {
+    tabs,
+    activeTabId: activeTab?.id ?? null,
+    activeUrl: activeTab?.url ?? null,
+  };
+}
+
+function writeBrowserPaneState(scopeKey: string, tabs: BrowserTab[], activeTabId: string | null): void {
+  const cloned = cloneTabs(tabs);
+  const activeTab = cloned.find((tab) => tab.id === activeTabId) ?? cloned[0] ?? null;
+  browserPaneStateStore.set(scopeKey, {
+    tabs: cloned,
+    activeTabId: activeTab?.id ?? null,
+    activeUrl: activeTab?.url ?? null,
+  });
+}
+
+function activeUrlFromSnapshot(snapshot: BrowserPaneStateSnapshot | null): string {
+  if (!snapshot) return '';
+  return snapshot.tabs.find((tab) => tab.id === snapshot.activeTabId)?.url ?? snapshot.activeUrl ?? '';
+}
+
 // ── Component ──
 
-export function O8BrowserPane({ previews = [], navigateToUrl, onActiveUrlChange }: O8BrowserPaneProps) {
-  const [tabs, setTabs] = useState<BrowserTab[]>([]);
-  const [activeTabId, setActiveTabId] = useState<string | null>(null);
-  const [urlInput, setUrlInput] = useState('');
+export function O8BrowserPane({ previews = [], navigateToUrl, stateScopeKey, onActiveUrlChange }: O8BrowserPaneProps) {
+  const normalizedStateScopeKey = normalizeStateScopeKey(stateScopeKey);
+  const [initialBrowserState] = useState<BrowserPaneStateSnapshot | null>(() => readBrowserPaneState(normalizedStateScopeKey));
+  const [tabs, setTabs] = useState<BrowserTab[]>(() => initialBrowserState?.tabs ?? []);
+  const [activeTabId, setActiveTabId] = useState<string | null>(() => initialBrowserState?.activeTabId ?? null);
+  const [urlInput, setUrlInput] = useState(() => activeUrlFromSnapshot(initialBrowserState));
   const [hoveredTabId, setHoveredTabId] = useState<string | null>(null);
   const urlRef = useRef<HTMLInputElement>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  const seeded = useRef(false);
+  const seeded = useRef(initialBrowserState !== null);
+  const hasStoredState = useRef(initialBrowserState !== null);
   /** Agent-driving glow — pulses when an agent verb lands on this surface. */
   const [agentGlow, setAgentGlow] = useState(false);
   /** URLs that blank out when proxied (auth-gated SPAs) — drive them in the
@@ -150,6 +201,7 @@ export function O8BrowserPane({ previews = [], navigateToUrl, onActiveUrlChange 
   useEffect(() => {
     if (seeded.current || previews.length === 0) return;
     seeded.current = true;
+    hasStoredState.current = true;
     const initial: BrowserTab[] = previews.map(p => ({
       id: newTabId(),
       url: p.url || `http://localhost:${p.port}`,
@@ -164,6 +216,12 @@ export function O8BrowserPane({ previews = [], navigateToUrl, onActiveUrlChange 
     });
     return () => { cancelled = true; };
   }, [previews]);
+
+  useEffect(() => {
+    if (!hasStoredState.current && tabs.length === 0 && activeTabId === null) return;
+    hasStoredState.current = true;
+    writeBrowserPaneState(normalizedStateScopeKey, tabs, activeTabId);
+  }, [activeTabId, normalizedStateScopeKey, tabs]);
 
   // Navigate to externally-provided URL (e.g. from port popover)
   const lastNavigatedUrl = useRef<string | null>(null);

--- a/src/components/desktop/O8BrowserPane.tsx
+++ b/src/components/desktop/O8BrowserPane.tsx
@@ -201,7 +201,6 @@ export function O8BrowserPane({ previews = [], navigateToUrl, stateScopeKey, onA
   useEffect(() => {
     if (seeded.current || previews.length === 0) return;
     seeded.current = true;
-    hasStoredState.current = true;
     const initial: BrowserTab[] = previews.map(p => ({
       id: newTabId(),
       url: p.url || `http://localhost:${p.port}`,
@@ -210,6 +209,7 @@ export function O8BrowserPane({ previews = [], navigateToUrl, stateScopeKey, onA
     let cancelled = false;
     queueMicrotask(() => {
       if (cancelled) return;
+      hasStoredState.current = true;
       setTabs(initial);
       setActiveTabId(initial[0].id);
       setUrlInput(initial[0].url);

--- a/src/components/desktop/O8Panel.tsx
+++ b/src/components/desktop/O8Panel.tsx
@@ -57,6 +57,7 @@ interface O8PanelProps {
   onActiveTabChange?: (tab: O8Tab) => void;
   selectedFile?: string | null;
   browserUrl?: string | null;
+  browserStateKey?: string;
   // Bubbles the browser pane's active URL up so the TitleBar Browser
   // button can render a hover preview iframe pointed at it.
   onBrowserActiveUrlChange?: (url: string | null) => void;
@@ -432,6 +433,7 @@ export function O8Panel({
   onActiveTabChange,
   selectedFile,
   browserUrl,
+  browserStateKey = 'right-panel',
   onBrowserActiveUrlChange,
   onSelectedFileChange,
   onSelectCommit,
@@ -598,8 +600,10 @@ export function O8Panel({
     if (tab === 'browser') {
       return (
         <O8BrowserPane
+          key={browserStateKey}
           previews={previews}
           navigateToUrl={pendingBrowserUrl ?? browserUrl}
+          stateScopeKey={browserStateKey}
           onActiveUrlChange={onBrowserActiveUrlChange}
         />
       );
@@ -744,7 +748,7 @@ export function O8Panel({
         )}
       </div>
       <div style={{ flex: 1, minHeight: 0, display: activeTab === 'browser' && !utilityShellActive ? 'flex' : 'none', flexDirection: 'column' }}>
-        <O8BrowserPane previews={previews} navigateToUrl={pendingBrowserUrl ?? browserUrl} onActiveUrlChange={onBrowserActiveUrlChange} />
+        <O8BrowserPane key={browserStateKey} previews={previews} navigateToUrl={pendingBrowserUrl ?? browserUrl} stateScopeKey={browserStateKey} onActiveUrlChange={onBrowserActiveUrlChange} />
       </div>
       <div style={{ flex: 1, minHeight: 0, display: activeTab === 'activity' || activeTab === 'prs' ? 'flex' : 'none', flexDirection: 'column' }}>
         <O8ActivityPane


### PR DESCRIPTION
Operator repro: load a site in the Browser tab, close the right panel entirely, reopen — page gone. The #1397 fix only covered tab switches; closing the panel unmounts O8BrowserPane and its local state. The native child WebviewWindow is never closed (only hidden), so this persists the pane's tabs + active URL in a module-level store keyed per panel scope and seeds NativeBrowserSurface's shownUrl from the last-shown URL — a remount takes the setRect+show path and re-adopts the living window without renavigation. Empty-snapshot guard prevents clobbering stored state. Security posture untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj