### PR TITLE
feat: mission registry core — dispatch/release ticks iterate all pending missions (#1389 part 1)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "o8"
-version = "0.1.519"
+version = "0.1.529"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -42,7 +42,7 @@ const DATA_DIR = process.env.O8_DATA_DIR
 // second migration step with no user-facing benefit.
 const DB_PATH = process.env.CORTEX_IDE_DB_PATH || path.join(DATA_DIR, 'cortex-ide.db');
 // Bump when ensureTables() adds new schema or backfill work.
-const DB_SCHEMA_VERSION = 30;
+const DB_SCHEMA_VERSION = 31;
 
 function migrationMarkerPath(version: number): string {
   return path.join(DATA_DIR, `.db-migrated-v${version}`);
@@ -129,6 +129,7 @@ function ensureIdempotentColumnAdds(sqlite: Database.Database): void {
   ensureMobileLiveActivityTokensTable(sqlite);
   ensureProjectsTables(sqlite);
   ensureProjectScopeColumns(sqlite);
+  ensureMissionStateColumn(sqlite);
   // #915 sub-1 — Schema v14 — Q&A retrieval foundation. FTS5 virtual tables
   // for outcomes/prs/issues/directives plus qa_eval_runs table. Skips with a
   // warning when FTS5 isn't compiled in. Always-on via the same idempotent
@@ -736,6 +737,7 @@ function ensureTables(sqlite: Database.Database): void {
       summary TEXT NOT NULL DEFAULT '',
       constraints TEXT NOT NULL DEFAULT '',
       packet_meta_json TEXT NOT NULL DEFAULT '[]',
+      mission_state_json TEXT,
       total_waves INTEGER NOT NULL DEFAULT 1,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
@@ -1085,6 +1087,12 @@ function ensureChatHistoryColumns(sqlite: Database.Database): void {
 function ensureLaneHeartbeatColumns(sqlite: Database.Database): void {
   for (const [column, type] of Object.entries({ last_heartbeat_at: 'INTEGER', pr_number: 'INTEGER' })) {
     if (!tableColumnExists(sqlite, 'lanes', column)) addColumnTolerant(sqlite, `ALTER TABLE lanes ADD COLUMN ${column} ${type}`);
+  }
+}
+
+function ensureMissionStateColumn(sqlite: Database.Database): void {
+  if (!tableColumnExists(sqlite, 'missions', 'mission_state_json')) {
+    addColumnTolerant(sqlite, 'ALTER TABLE missions ADD COLUMN mission_state_json TEXT');
   }
 }
 

--- a/src/lib/db/missions-store.ts
+++ b/src/lib/db/missions-store.ts
@@ -15,6 +15,8 @@
 
 import 'server-only';
 import { getSqlite } from '@/lib/db';
+import { normalizeOrchestratorMissionState } from '@/lib/orchestrator/store';
+import type { OrchestratorMissionState } from '@/lib/orchestrator/types';
 
 export interface MissionPacketMeta {
   id: string;
@@ -30,6 +32,7 @@ export interface MissionRecord {
   summary: string;
   constraints: string;
   packetMeta: MissionPacketMeta[];
+  missionState: OrchestratorMissionState | null;
   totalWaves: number;
   createdAt: number;
   updatedAt: number;
@@ -44,6 +47,7 @@ export interface RecordMissionInput {
   summary: string;
   constraints: string;
   packetMeta: MissionPacketMeta[];
+  missionState?: OrchestratorMissionState | null;
   totalWaves: number;
 }
 
@@ -63,6 +67,15 @@ function parsePacketMeta(json: string): MissionPacketMeta[] {
   }
 }
 
+function parseMissionState(json: string | null): OrchestratorMissionState | null {
+  if (!json) return null;
+  try {
+    return normalizeOrchestratorMissionState(JSON.parse(json));
+  } catch {
+    return null;
+  }
+}
+
 interface MissionRow {
   id: string;
   repo_path: string;
@@ -71,6 +84,7 @@ interface MissionRow {
   summary: string;
   constraints: string;
   packet_meta_json: string;
+  mission_state_json: string | null;
   total_waves: number;
   created_at: number;
   updated_at: number;
@@ -86,6 +100,7 @@ function rowToRecord(row: MissionRow): MissionRecord {
     summary: row.summary,
     constraints: row.constraints,
     packetMeta: parsePacketMeta(row.packet_meta_json),
+    missionState: parseMissionState(row.mission_state_json),
     totalWaves: row.total_waves,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -103,8 +118,8 @@ export function recordMission(input: RecordMissionInput): void {
   db.prepare(`
     INSERT INTO missions (
       id, repo_path, runtime, prompt, summary, constraints,
-      packet_meta_json, total_waves, created_at, updated_at, archived_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+      packet_meta_json, mission_state_json, total_waves, created_at, updated_at, archived_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
     ON CONFLICT(id) DO UPDATE SET
       repo_path = excluded.repo_path,
       runtime = excluded.runtime,
@@ -112,6 +127,7 @@ export function recordMission(input: RecordMissionInput): void {
       summary = excluded.summary,
       constraints = excluded.constraints,
       packet_meta_json = excluded.packet_meta_json,
+      mission_state_json = excluded.mission_state_json,
       total_waves = excluded.total_waves,
       updated_at = excluded.updated_at,
       archived_at = NULL
@@ -123,6 +139,7 @@ export function recordMission(input: RecordMissionInput): void {
     input.summary,
     input.constraints,
     JSON.stringify(input.packetMeta),
+    JSON.stringify(input.missionState ?? null),
     input.totalWaves,
     now,
     now,
@@ -130,9 +147,8 @@ export function recordMission(input: RecordMissionInput): void {
 }
 
 /**
- * Mark every mission OTHER than `currentId` as archived. Called after a fresh
- * createMission so the file-based "current" mission lines up with the only
- * row whose archived_at IS NULL.
+ * Historical rows without a packet-bearing snapshot are not dispatchable. Keep
+ * active snapshots live even when a newer mission becomes the UI focus.
  */
 export function archiveMissionsExcept(currentId: string): void {
   const db = getSqlite();
@@ -142,6 +158,7 @@ export function archiveMissionsExcept(currentId: string): void {
        SET archived_at = ?, updated_at = ?
      WHERE id != ?
        AND archived_at IS NULL
+       AND (mission_state_json IS NULL OR mission_state_json = '')
   `).run(now, now, currentId);
 }
 

--- a/src/lib/orchestrator/dispatch.ts
+++ b/src/lib/orchestrator/dispatch.ts
@@ -10,6 +10,8 @@ export {
 export {
   MAX_PARALLEL_DISPATCHES,
   MAX_RECOVERY_DISPATCHES,
+  RUNTIME_PARALLEL_CAP,
+  type DispatchLaunchBudget,
   getDispatchBlocker,
   runDispatchTick,
 } from './scheduling';

--- a/src/lib/orchestrator/headless-loop.ts
+++ b/src/lib/orchestrator/headless-loop.ts
@@ -8,9 +8,11 @@ import {
 } from '@/lib/orchestrator/control-plane';
 import { fanOutComparisonPackets } from '@/lib/orchestrator/comparison-fanout';
 import { buildDagMetadata, hasLaneBinding } from '@/lib/orchestrator/dag';
-import { runDispatchTick } from '@/lib/orchestrator/dispatch';
+import { RUNTIME_PARALLEL_CAP, runDispatchTick, type DispatchLaunchBudget } from '@/lib/orchestrator/dispatch';
+import { hasRegistryPendingHeadlessWork, listActiveMissionRegistryEntries, missionHasPendingHeadlessWork, persistMissionRegistryState } from '@/lib/orchestrator/mission-registry';
 import { normalizeOrchestratorMissionState } from '@/lib/orchestrator/store';
-import type { OrchestratorMissionState } from '@/lib/orchestrator/types';
+import type { OrchestratorMissionState, OrchestratorRuntime } from '@/lib/orchestrator/types';
+import { resolveParallelCapSync } from '@/lib/operator/defaults';
 
 const DEFAULT_INTERVAL_MS = 10_000;
 const MIN_INTERVAL_MS = 1_000;
@@ -157,6 +159,10 @@ function maybeShortCircuitIdleTick(): HeadlessSprintTickResult | null {
     silentIdleTickCount = 0;
     return null;
   }
+  if (hasRegistryPendingHeadlessWork(mission.missionId)) {
+    silentIdleTickCount = 0;
+    return null;
+  }
 
   silentIdleTickCount += 1;
   if (silentIdleTickCount >= IDLE_HEARTBEAT_TICKS) {
@@ -209,11 +215,52 @@ async function pruneWorktreesIfDue(state: OrchestratorMissionState) {
   await prunePromise;
 }
 
+function buildRemainingLaunchBudget(): DispatchLaunchBudget {
+  const parallelCap = resolveParallelCapSync();
+  const activeLanes = listLanes().filter((lane) => lane.status === 'launching' || lane.status === 'running');
+  const perRuntime: Partial<Record<OrchestratorRuntime, number>> = {};
+  for (const runtime of Object.keys(RUNTIME_PARALLEL_CAP) as OrchestratorRuntime[]) {
+    const cap = RUNTIME_PARALLEL_CAP[runtime];
+    if (cap === undefined) continue;
+    const active = activeLanes.filter((lane) => lane.runtime === runtime).length;
+    perRuntime[runtime] = Math.max(0, cap - active);
+  }
+  return {
+    maxLaunches: Math.max(0, parallelCap - activeLanes.length),
+    perRuntime,
+  };
+}
+
+async function runRegistryMissionTicks(
+  currentMissionId: string | null | undefined,
+  releasedPacketIds: string[],
+) {
+  let launched = 0;
+  for (const entry of listActiveMissionRegistryEntries(currentMissionId)) {
+    const withReleases = markReleasedPackets(entry.mission, releasedPacketIds);
+    const reconciled = reconcileOrchestratorControlPlaneState(withReleases);
+    const fanned = fanOutComparisonPackets(reconciled);
+    if (fanned !== reconciled) {
+      persistMissionRegistryState(fanned);
+    }
+    const budget = buildRemainingLaunchBudget();
+    if (!missionHasPendingHeadlessWork(fanned) || budget.maxLaunches <= 0) {
+      persistMissionRegistryState(fanned);
+      continue;
+    }
+    const dispatched = await runDispatchTick(fanned, { launchBudget: budget });
+    launched += countLaunchedPackets(fanned, dispatched);
+    persistMissionRegistryState(dispatched);
+  }
+  return launched;
+}
+
 async function executeHeadlessSprintTick(): Promise<HeadlessSprintTickResult> {
+  const releasedPacketIds = drainReleasedPackets();
   // #460 — Acquire the control-plane lock so concurrent API operations
   // (reset_packet, etc.) don't race our read-modify-write cycle.
   const { result } = await withLockedState(async (current) => {
-    const withReleases = markReleasedPackets(current, drainReleasedPackets());
+    const withReleases = markReleasedPackets(current, releasedPacketIds);
     const reconciled = reconcileOrchestratorControlPlaneState(withReleases);
     // #1293 — best-of-N fan-out: a seed packet (comparisonModels set, no
     // comparisonGroupId) is consumed by fanOutComparisonPackets — replaced by
@@ -223,7 +270,7 @@ async function executeHeadlessSprintTick(): Promise<HeadlessSprintTickResult> {
     if (fanned !== reconciled) {
       writeOrchestratorControlPlaneState(fanned);
     }
-    const dispatched = await runDispatchTick(fanned);
+    const dispatched = await runDispatchTick(fanned, { launchBudget: buildRemainingLaunchBudget() });
     // #1293 ROOT FIX — make withLockedState persist the post-dispatch state.
     // withLockedState does a FINAL reconcile+write at end-of-lock, and its basis
     // falls back to the (unmutated) pre-callback `current` when the callback
@@ -237,6 +284,7 @@ async function executeHeadlessSprintTick(): Promise<HeadlessSprintTickResult> {
     // consumed for good.
     Object.assign(current, dispatched);
     const mission = writeOrchestratorControlPlaneState(dispatched);
+    persistMissionRegistryState(mission);
     const dag = buildDagMetadata(mission.packets);
     const launched = countLaunchedPackets(reconciled, mission);
     const active = countActivePackets(mission);
@@ -251,13 +299,18 @@ async function executeHeadlessSprintTick(): Promise<HeadlessSprintTickResult> {
       mission,
     } satisfies HeadlessSprintTickResult;
   });
+  const registryLaunched = await runRegistryMissionTicks(result.mission.missionId, releasedPacketIds);
+  const tickResult = {
+    ...result,
+    launched: result.launched + registryLaunched,
+  };
 
   const archivedCompleted = archiveCompletedLanes();
   if (archivedCompleted > 0) {
     console.log(`[headless] Archived ${archivedCompleted} completed lane${archivedCompleted === 1 ? '' : 's'}`);
   }
-  const missionId = result.mission.missionId || 'current';
-  if (isMissionComplete(result.mission)) {
+  const missionId = tickResult.mission.missionId || 'current';
+  if (isMissionComplete(tickResult.mission)) {
     if (lastCompletedMissionId !== missionId) {
       lastCompletedMissionId = missionId;
       lastPruneAt = 0;
@@ -266,9 +319,9 @@ async function executeHeadlessSprintTick(): Promise<HeadlessSprintTickResult> {
   } else if (lastCompletedMissionId === missionId) {
     lastCompletedMissionId = '';
   }
-  await pruneWorktreesIfDue(result.mission);
+  await pruneWorktreesIfDue(tickResult.mission);
 
-  return result;
+  return tickResult;
 }
 
 export async function runHeadlessSprintTick(options: { releasePacketIds?: string[] } = {}) {

--- a/src/lib/orchestrator/mission-registry-headless.test.ts
+++ b/src/lib/orchestrator/mission-registry-headless.test.ts
@@ -1,0 +1,106 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+process.env.CORTEX_IDE_DATA_DIR = mkdtempSync(join(os.tmpdir(), 'o8-mission-registry-'));
+process.env.O8_DATA_DIR = process.env.CORTEX_IDE_DATA_DIR;
+
+const launchMock = vi.hoisted(() => ({
+  calls: [] as Array<{ packetId?: string; repoPath: string }>,
+}));
+const tempDirs: string[] = [];
+
+vi.mock('@/lib/runtime/actions', () => ({
+  launchRuntimeSurface: vi.fn(async (input: { packetId?: string; repoPath: string }) => {
+    launchMock.calls.push({ packetId: input.packetId, repoPath: input.repoPath });
+    return {
+      ok: true,
+      surfaceId: `codex-owned:${input.packetId ?? launchMock.calls.length}`,
+      note: 'mock runtime launched',
+      worktree: { path: input.repoPath },
+    };
+  }),
+}));
+
+function createTempRepo() {
+  const repoPath = mkdtempSync(join(os.tmpdir(), 'o8-mission-registry-repo-'));
+  tempDirs.push(repoPath);
+  const git = (...args: string[]) => execFileSync('git', args, { cwd: repoPath, stdio: 'pipe' });
+  git('init', '--initial-branch=main');
+  writeFileSync(join(repoPath, 'README.md'), 'mission registry test\n');
+  git('add', 'README.md');
+  git('-c', 'user.email=test@o8.test', '-c', 'user.name=o8-test', 'commit', '-m', 'init');
+  return repoPath;
+}
+
+function textContent(result: { content: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }> }) {
+  return result.content.find((entry) => entry.type === 'text')?.text ?? '';
+}
+
+function parseMissionResult(result: { content: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }> }) {
+  return JSON.parse(textContent(result)) as {
+    missionId: string;
+    packets: Array<{ id: string; title: string; wave: number }>;
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  launchMock.calls = [];
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('headless mission registry dispatch', () => {
+  it('dispatches a non-current mission packet after a newer mission becomes current', async () => {
+    const repoPath = createTempRepo();
+    vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const urlText = String(url);
+      if (urlText.includes('/supervisor/watch') || urlText.includes('/internal/realtime')) {
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      const body = JSON.parse(String(init?.body ?? '{}'));
+      const { createMission } = await import('@/lib/orchestrator/operator-mission-service/mission');
+      const result = await createMission(body as Parameters<typeof createMission>[0]);
+      return new Response(JSON.stringify({ ok: true, result }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }));
+
+    const { handleCreateMission } = await import('@/lib/mcp/operator-handlers/mission');
+    const first = parseMissionResult(await handleCreateMission({
+      issues_inline: [{ title: 'registry mission A', body: 'first mission must still dispatch' }],
+      repoPath,
+      runtime: 'codex',
+      dispatch: false,
+    }));
+    const second = parseMissionResult(await handleCreateMission({
+      issues_inline: [{ title: 'registry mission B', body: 'second mission becomes current focus' }],
+      repoPath,
+      runtime: 'codex',
+      dispatch: false,
+    }));
+
+    const { runHeadlessSprintTick } = await import('@/lib/orchestrator/headless-loop');
+    const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+    const { findLaneByPacket } = await import('@/lib/lane/registry');
+
+    expect(readOrchestratorControlPlaneState().missionId).toBe(second.missionId);
+    await runHeadlessSprintTick();
+
+    const firstPacketId = first.packets[0]?.id;
+    expect(firstPacketId).toBeTruthy();
+    expect(findLaneByPacket(firstPacketId!)?.id).toMatch(/^lane-/);
+    expect(readOrchestratorControlPlaneState().missionId).toBe(second.missionId);
+    expect(launchMock.calls.some((call) => call.packetId === firstPacketId)).toBe(true);
+  });
+});

--- a/src/lib/orchestrator/mission-registry.ts
+++ b/src/lib/orchestrator/mission-registry.ts
@@ -1,0 +1,114 @@
+import 'server-only';
+
+import { getSqlite } from '@/lib/db';
+import { buildDependencyGraph } from '@/lib/orchestrator/dag';
+import { normalizeOrchestratorMissionState } from '@/lib/orchestrator/store';
+import type { OrchestratorMissionState, OrchestratorPacket } from '@/lib/orchestrator/types';
+
+interface MissionStateRow {
+  id: string;
+  mission_state_json: string | null;
+  created_at: number;
+}
+
+export interface MissionRegistryEntry {
+  id: string;
+  mission: OrchestratorMissionState;
+  createdAt: number;
+}
+
+function parseMissionState(json: string | null): OrchestratorMissionState | null {
+  if (!json) return null;
+  try {
+    return normalizeOrchestratorMissionState(JSON.parse(json));
+  } catch {
+    return null;
+  }
+}
+
+function archiveRegistryRow(id: string) {
+  const now = Date.now();
+  getSqlite().prepare(`
+    UPDATE missions SET archived_at = ?, updated_at = ?
+     WHERE id = ? AND archived_at IS NULL
+  `).run(now, now, id);
+}
+
+function packetIsActive(packet: OrchestratorPacket) {
+  if (packet.archivedAt || packet.releaseState === 'released') return false;
+  if (packet.status === 'failed' || packet.status === 'released' || packet.status === 'archived') return false;
+  if (packet.queueState === 'queued' || packet.queueState === 'held') return true;
+  return packet.status === 'launching'
+    || packet.status === 'running'
+    || packet.status === 'recovering'
+    || packet.status === 'awaiting_review';
+}
+
+export function missionHasPendingHeadlessWork(state: OrchestratorMissionState) {
+  return state.packets.some((packet) => {
+    if (!packetIsActive(packet)) return false;
+    return packet.queueState === 'queued'
+      || packet.status === 'queued'
+      || packet.status === 'launching'
+      || packet.status === 'running'
+      || packet.status === 'recovering';
+  });
+}
+
+export function missionIsTerminal(state: OrchestratorMissionState) {
+  return state.packets.length > 0 && state.packets.every((packet) => !packetIsActive(packet));
+}
+
+export function listActiveMissionRegistryEntries(currentMissionId?: string | null): MissionRegistryEntry[] {
+  const rows = getSqlite().prepare(`
+    SELECT id, mission_state_json, created_at
+      FROM missions
+     WHERE archived_at IS NULL
+     ORDER BY created_at ASC
+  `).all() as MissionStateRow[];
+
+  const entries: MissionRegistryEntry[] = [];
+  for (const row of rows) {
+    if (row.id === currentMissionId) continue;
+    const mission = parseMissionState(row.mission_state_json);
+    if (!mission || missionIsTerminal(mission)) {
+      archiveRegistryRow(row.id);
+      continue;
+    }
+    entries.push({ id: row.id, mission, createdAt: row.created_at });
+  }
+  return entries;
+}
+
+export function hasRegistryPendingHeadlessWork(currentMissionId?: string | null) {
+  return listActiveMissionRegistryEntries(currentMissionId)
+    .some((entry) => missionHasPendingHeadlessWork(entry.mission));
+}
+
+export function persistMissionRegistryState(state: OrchestratorMissionState): void {
+  const missionId = state.missionId?.trim();
+  if (!missionId) return;
+  const normalized = normalizeOrchestratorMissionState(state);
+  const waves = buildDependencyGraph(normalized.packets).map((node) => node.wave);
+  const archivedAt = missionIsTerminal(normalized) ? Date.now() : null;
+  getSqlite().prepare(`
+    UPDATE missions
+       SET prompt = ?, summary = ?, constraints = ?, packet_meta_json = ?,
+           mission_state_json = ?, total_waves = ?, updated_at = ?, archived_at = ?
+     WHERE id = ?
+  `).run(
+    normalized.prompt,
+    normalized.summary,
+    normalized.constraints,
+    JSON.stringify(normalized.packets.map((packet) => ({
+      id: packet.id,
+      title: packet.title,
+      referenceLabel: packet.referenceLabel,
+    }))),
+    JSON.stringify(normalized),
+    Math.max(1, ...waves),
+    Date.now(),
+    archivedAt,
+    missionId,
+  );
+}

--- a/src/lib/orchestrator/operator-mission-service/mission.ts
+++ b/src/lib/orchestrator/operator-mission-service/mission.ts
@@ -232,6 +232,7 @@ export async function createMission(input: CreateMissionInput) {
         title: packet.title,
         referenceLabel: packet.referenceLabel,
       })),
+      missionState: persisted,
       totalWaves,
     });
     archiveMissionsExcept(missionId);

--- a/src/lib/orchestrator/scheduling.ts
+++ b/src/lib/orchestrator/scheduling.ts
@@ -19,6 +19,7 @@ import {
   type OrchestratorLaneBinding,
   type OrchestratorMissionState,
   type OrchestratorPacket,
+  type OrchestratorRuntime,
   type WorkerRouting,
 } from '@/lib/orchestrator/types';
 import { publishRealtimeMutation } from '@/lib/realtime/publisher';
@@ -30,6 +31,14 @@ import { computePredictedFiles, filterOverlappingPackets } from './preservation-
 // then the locked fallback (5). Existing imports keep working.
 export const MAX_PARALLEL_DISPATCHES = resolveParallelCapSync();
 export const MAX_RECOVERY_DISPATCHES = 2;
+export const RUNTIME_PARALLEL_CAP: Partial<Record<OrchestratorRuntime, number>> = {
+  gemini: 3,
+};
+
+export interface DispatchLaunchBudget {
+  maxLaunches: number;
+  perRuntime?: Partial<Record<OrchestratorRuntime, number>>;
+}
 
 const RECOVERY_COOLDOWN_MS = 60_000;
 const SESSION_RECOVERY_COMMIT_MESSAGE = 'auto-commit: session recovery';
@@ -324,6 +333,7 @@ export function getDispatchBlocker(
  */
 export async function runDispatchTick(
   state: OrchestratorMissionState,
+  options: { launchBudget?: DispatchLaunchBudget } = {},
 ): Promise<OrchestratorMissionState> {
   let nextState = normalizeOrchestratorMissionState(state);
   nextState = fanOutComparisonPackets(nextState);
@@ -452,23 +462,29 @@ export async function runDispatchTick(
   }
 
   const parallelCap = resolveParallelCapSync();
-  // Per-runtime parallel cap — Gemini 3.1 Pro drops concurrent calls past ~3
-  // (observed: 4-packet parallel burst lost 1 silently with no stderr). Other
-  // runtimes have no additional cap beyond the global.
-  const RUNTIME_PARALLEL_CAP: Partial<Record<typeof dispatchablePackets[number]['packet']['runtime'], number>> = {
-    gemini: 3,
-  };
+  const maxLaunches = options.launchBudget
+    ? Math.max(0, Math.floor(options.launchBudget.maxLaunches))
+    : Number.POSITIVE_INFINITY;
+  if (maxLaunches <= 0) {
+    return nextState;
+  }
   const queue = [...dispatchablePackets];
-  while (queue.length > 0) {
+  let launchedThisTick = 0;
+  const runtimeCountsInTick: Partial<Record<OrchestratorRuntime, number>> = {};
+  while (queue.length > 0 && launchedThisTick < maxLaunches) {
     const batch: typeof dispatchablePackets = [];
     const deferred: typeof dispatchablePackets = [];
-    const runtimeCountsInBatch: Record<string, number> = {};
+    const runtimeCountsInBatch: Partial<Record<OrchestratorRuntime, number>> = {};
+    const batchLimit = Math.min(parallelCap, maxLaunches - launchedThisTick);
     for (const candidate of queue) {
       const runtime = candidate.packet.runtime;
       const perRuntimeCap = RUNTIME_PARALLEL_CAP[runtime];
+      const perRuntimeBudget = options.launchBudget?.perRuntime?.[runtime];
       const hitRuntimeCap =
         perRuntimeCap !== undefined && (runtimeCountsInBatch[runtime] ?? 0) >= perRuntimeCap;
-      if (batch.length < parallelCap && !hitRuntimeCap) {
+      const hitRuntimeBudget =
+        perRuntimeBudget !== undefined && (runtimeCountsInTick[runtime] ?? 0) >= perRuntimeBudget;
+      if (batch.length < batchLimit && !hitRuntimeCap && !hitRuntimeBudget) {
         batch.push(candidate);
         runtimeCountsInBatch[runtime] = (runtimeCountsInBatch[runtime] ?? 0) + 1;
       } else {
@@ -478,6 +494,10 @@ export async function runDispatchTick(
     if (batch.length === 0) break;
     queue.length = 0;
     queue.push(...deferred);
+    launchedThisTick += batch.length;
+    for (const { packet } of batch) {
+      runtimeCountsInTick[packet.runtime] = (runtimeCountsInTick[packet.runtime] ?? 0) + 1;
+    }
     console.log(`[dag-scheduler] Dispatching ${batch.length} packets in parallel (cap ${parallelCap}): ${batch.map(({ packet }) => packet.id).join(', ')}`);
 
     const results = await Promise.allSettled(


### PR DESCRIPTION
Part 1 of #1389 (gap A). Missions persist their full packet-bearing state on the registry row (schema v31, tolerant reader); creating a new mission no longer archives active siblings (archive only when all packets are terminal or on explicit operator action); the headless tick iterates every non-current pending mission after the locked current-mission tick, dispatching under a global + per-runtime launch budget computed from active lanes across ALL missions. Non-current state writes back only to registry rows — the control-plane file remains UI focus. Real-path test: two missions created through the real MCP handler, the real headless tick dispatches the FIRST mission's packet while the second stays current.

Follow-up (part 2 of the wave): mission verbs resolve by missionId; registry-row writes get a shared mutation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj