### PR TITLE
feat: mission verbs resolve by missionId across the registry (#1389 part 2)

### DIFF
--- a/src/lib/orchestrator/headless-loop.ts
+++ b/src/lib/orchestrator/headless-loop.ts
@@ -9,7 +9,7 @@ import {
 import { fanOutComparisonPackets } from '@/lib/orchestrator/comparison-fanout';
 import { buildDagMetadata, hasLaneBinding } from '@/lib/orchestrator/dag';
 import { RUNTIME_PARALLEL_CAP, runDispatchTick, type DispatchLaunchBudget } from '@/lib/orchestrator/dispatch';
-import { hasRegistryPendingHeadlessWork, listActiveMissionRegistryEntries, missionHasPendingHeadlessWork, persistMissionRegistryState } from '@/lib/orchestrator/mission-registry';
+import { hasRegistryPendingHeadlessWork, listActiveMissionRegistryEntries, missionHasPendingHeadlessWork, persistMissionRegistryState, withMissionRegistryState } from '@/lib/orchestrator/mission-registry';
 import { normalizeOrchestratorMissionState } from '@/lib/orchestrator/store';
 import type { OrchestratorMissionState, OrchestratorRuntime } from '@/lib/orchestrator/types';
 import { resolveParallelCapSync } from '@/lib/operator/defaults';
@@ -250,20 +250,18 @@ async function runRegistryMissionTicks(
 ) {
   let launched = 0;
   for (const entry of listActiveMissionRegistryEntries(currentMissionId)) {
-    const withReleases = markReleasedPackets(entry.mission, releasedPacketIds);
-    const reconciled = reconcileOrchestratorControlPlaneState(withReleases);
-    const fanned = fanOutComparisonPackets(reconciled);
-    if (fanned !== reconciled) {
-      persistMissionRegistryState(fanned);
-    }
-    const budget = buildRemainingLaunchBudget();
-    if (!missionHasPendingHeadlessWork(fanned) || budget.maxLaunches <= 0) {
-      persistMissionRegistryState(fanned);
-      continue;
-    }
-    const dispatched = await runDispatchTick(fanned, { launchBudget: budget });
-    launched += countLaunchedPackets(fanned, dispatched);
-    persistMissionRegistryState(dispatched);
+    const { result: entryLaunched } = await withMissionRegistryState(entry.id, async (fresh) => {
+      const withReleases = markReleasedPackets(fresh, releasedPacketIds);
+      const reconciled = reconcileOrchestratorControlPlaneState(withReleases);
+      const fanned = fanOutComparisonPackets(reconciled);
+      const budget = buildRemainingLaunchBudget();
+      if (!missionHasPendingHeadlessWork(fanned) || budget.maxLaunches <= 0) {
+        return { state: fanned, result: 0 };
+      }
+      const dispatched = await runDispatchTick(fanned, { launchBudget: budget });
+      return { state: dispatched, result: countLaunchedPackets(fanned, dispatched) };
+    });
+    launched += entryLaunched;
   }
   return launched;
 }
@@ -297,7 +295,7 @@ async function executeHeadlessSprintTick(): Promise<HeadlessSprintTickResult> {
     // consumed for good.
     Object.assign(current, dispatched);
     const mission = writeOrchestratorControlPlaneState(dispatched);
-    persistMissionRegistryState(mission);
+    await persistMissionRegistryState(mission);
     const dag = buildDagMetadata(mission.packets);
     const launched = countLaunchedPackets(reconciled, mission);
     const active = countActivePackets(mission);

--- a/src/lib/orchestrator/mission-registry-headless.test.ts
+++ b/src/lib/orchestrator/mission-registry-headless.test.ts
@@ -46,6 +46,78 @@ function parseMissionResult(result: { content: Array<{ type: 'text'; text: strin
   };
 }
 
+function parseJsonResult<T>(result: { content: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }> }) {
+  return JSON.parse(textContent(result)) as T;
+}
+
+function apiResponse(factory: () => Promise<unknown>) {
+  return factory()
+    .then((result) => new Response(JSON.stringify({ ok: true, result }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+    .catch((error) => new Response(JSON.stringify({
+      ok: false,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+}
+
+function stubMissionApiFetch() {
+  vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const urlText = String(url);
+    if (urlText.includes('/supervisor/watch') || urlText.includes('/internal/realtime')) {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const body = JSON.parse(String(init?.body ?? '{}'));
+    if (urlText.includes('/api/orchestrator/create-mission')) {
+      return apiResponse(async () => {
+        const { createMission } = await import('@/lib/orchestrator/operator-mission-service/mission');
+        return createMission(body as Parameters<typeof createMission>[0]);
+      });
+    }
+    if (urlText.includes('/api/orchestrator/dispatch')) {
+      return apiResponse(async () => {
+        const { dispatchMission } = await import('@/lib/orchestrator/operator-mission-service/mission');
+        return dispatchMission(body as Parameters<typeof dispatchMission>[0]);
+      });
+    }
+    if (urlText.includes('/api/orchestrator/reset-packet')) {
+      return apiResponse(async () => {
+        const { resetPacket } = await import('@/lib/orchestrator/operator-mission-service/reset');
+        return resetPacket(body as Parameters<typeof resetPacket>[0]);
+      });
+    }
+    if (urlText.includes('/api/orchestrator/rerun-with-feedback')) {
+      return apiResponse(async () => {
+        const { rerunWithFeedback } = await import('@/lib/orchestrator/operator-mission-service/rerun-with-feedback');
+        return rerunWithFeedback(body as Parameters<typeof rerunWithFeedback>[0]);
+      });
+    }
+
+    return new Response(JSON.stringify({ ok: false, error: { message: `Unhandled test URL: ${urlText}` } }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }));
+}
+
+async function createInlineMission(title: string, repoPath: string) {
+  const { handleCreateMission } = await import('@/lib/mcp/operator-handlers/mission');
+  return parseMissionResult(await handleCreateMission({
+    issues_inline: [{ title, body: `${title} body` }],
+    repoPath,
+    runtime: 'codex',
+    dispatch: false,
+  }));
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
@@ -58,37 +130,10 @@ afterEach(() => {
 describe('headless mission registry dispatch', () => {
   it('dispatches a non-current mission packet after a newer mission becomes current', async () => {
     const repoPath = createTempRepo();
-    vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
-      const urlText = String(url);
-      if (urlText.includes('/supervisor/watch') || urlText.includes('/internal/realtime')) {
-        return new Response(JSON.stringify({ ok: true }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        });
-      }
+    stubMissionApiFetch();
 
-      const body = JSON.parse(String(init?.body ?? '{}'));
-      const { createMission } = await import('@/lib/orchestrator/operator-mission-service/mission');
-      const result = await createMission(body as Parameters<typeof createMission>[0]);
-      return new Response(JSON.stringify({ ok: true, result }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      });
-    }));
-
-    const { handleCreateMission } = await import('@/lib/mcp/operator-handlers/mission');
-    const first = parseMissionResult(await handleCreateMission({
-      issues_inline: [{ title: 'registry mission A', body: 'first mission must still dispatch' }],
-      repoPath,
-      runtime: 'codex',
-      dispatch: false,
-    }));
-    const second = parseMissionResult(await handleCreateMission({
-      issues_inline: [{ title: 'registry mission B', body: 'second mission becomes current focus' }],
-      repoPath,
-      runtime: 'codex',
-      dispatch: false,
-    }));
+    const first = await createInlineMission('registry mission A', repoPath);
+    const second = await createInlineMission('registry mission B', repoPath);
 
     const { runHeadlessSprintTick } = await import('@/lib/orchestrator/headless-loop');
     const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
@@ -103,4 +148,106 @@ describe('headless mission registry dispatch', () => {
     expect(readOrchestratorControlPlaneState().missionId).toBe(second.missionId);
     expect(launchMock.calls.some((call) => call.packetId === firstPacketId)).toBe(true);
   }, 20_000);
+
+  it('dispatch_mission addresses a non-current missionId through the real MCP handler', async () => {
+    const repoPath = createTempRepo();
+    stubMissionApiFetch();
+    const first = await createInlineMission('registry mcp dispatch A', repoPath);
+    const second = await createInlineMission('registry mcp dispatch B', repoPath);
+
+    const { handleDispatchMission } = await import('@/lib/mcp/operator-handlers/mission');
+    const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+    const { findLaneByPacket } = await import('@/lib/lane/registry');
+
+    expect(readOrchestratorControlPlaneState().missionId).toBe(second.missionId);
+    const result = parseJsonResult<{ dispatched?: number }>(await handleDispatchMission({ missionId: first.missionId }));
+
+    const firstPacketId = first.packets[0]?.id;
+    expect(firstPacketId).toBeTruthy();
+    expect(result.dispatched).toBe(1);
+    expect(findLaneByPacket(firstPacketId!)?.id).toMatch(/^lane-/);
+    expect(readOrchestratorControlPlaneState().missionId).toBe(second.missionId);
+  }, 20_000);
+
+  it('retry_packet mutates a non-current registry packet through the real MCP handler', async () => {
+    const repoPath = createTempRepo();
+    stubMissionApiFetch();
+    const first = await createInlineMission('registry mcp retry A', repoPath);
+    const second = await createInlineMission('registry mcp retry B', repoPath);
+
+    const packetId = first.packets[0]?.id;
+    expect(packetId).toBeTruthy();
+    const { handleRetryPacket } = await import('@/lib/mcp/operator-handlers/mission');
+    const retryResult = parseJsonResult<{ reset?: boolean; referenceLabel?: string }>(await handleRetryPacket({
+      packetId: packetId!,
+      reason: 'retry non-current packet',
+    }));
+
+    const { readMissionRegistryEntry } = await import('@/lib/orchestrator/mission-registry');
+    const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+    const packet = readMissionRegistryEntry(first.missionId, { includeArchived: true })?.mission.packets
+      .find((candidate) => candidate.id === packetId);
+
+    expect(retryResult.reset).toBe(true);
+    expect(retryResult.referenceLabel).toBe('inline-1');
+    expect(packet?.status).toBe('draft');
+    expect(packet?.queueState).toBe('held');
+    expect(readOrchestratorControlPlaneState().missionId).toBe(second.missionId);
+  });
+
+  it('rerun_with_feedback relaunches a non-current registry packet through the real MCP handler', async () => {
+    const repoPath = createTempRepo();
+    stubMissionApiFetch();
+    const first = await createInlineMission('registry mcp rerun A', repoPath);
+    const second = await createInlineMission('registry mcp rerun B', repoPath);
+
+    const packetId = first.packets[0]?.id;
+    expect(packetId).toBeTruthy();
+    const { handleRerunWithFeedback } = await import('@/lib/mcp/operator-handlers/mission');
+    const result = parseJsonResult<{ dispatched?: boolean; referenceLabel?: string }>(await handleRerunWithFeedback({
+      packetId: packetId!,
+      feedback: 'tighten the implementation',
+    }));
+
+    const { findLaneByPacket } = await import('@/lib/lane/registry');
+    const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+    expect(result.dispatched).toBe(true);
+    expect(result.referenceLabel).toBe('inline-1');
+    expect(findLaneByPacket(packetId!)?.id).toMatch(/^lane-/);
+    expect(readOrchestratorControlPlaneState().missionId).toBe(second.missionId);
+  }, 20_000);
+
+  it('returns a clean unknown-packet error through the retry MCP handler', async () => {
+    stubMissionApiFetch();
+    const { handleRetryPacket } = await import('@/lib/mcp/operator-handlers/mission');
+    const result = parseJsonResult<{ error?: string }>(await handleRetryPacket({
+      packetId: 'pkt-missing-from-registry',
+      reason: 'negative case',
+    }));
+    expect(result.error).toContain('Packet pkt-missing-from-registry not found');
+  });
+
+  it('serializes registry-row mutations per mission', async () => {
+    const repoPath = createTempRepo();
+    stubMissionApiFetch();
+    const mission = await createInlineMission('registry mutation serialization', repoPath);
+    const { readMissionRegistryEntry, withMissionRegistryState } = await import('@/lib/orchestrator/mission-registry');
+    const observed: string[] = [];
+
+    await Promise.all([
+      withMissionRegistryState(mission.missionId, async (state) => {
+        observed.push(`first:${state.constraints}`);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return { state: { ...state, constraints: 'first-write' }, result: null };
+      }),
+      withMissionRegistryState(mission.missionId, (state) => {
+        observed.push(`second:${state.constraints}`);
+        return { state: { ...state, summary: `second saw ${state.constraints}` }, result: null };
+      }),
+    ]);
+
+    const persisted = readMissionRegistryEntry(mission.missionId, { includeArchived: true })?.mission;
+    expect(observed).toEqual(['first:', 'second:first-write']);
+    expect(persisted?.summary).toBe('second saw first-write');
+  });
 });

--- a/src/lib/orchestrator/mission-registry.ts
+++ b/src/lib/orchestrator/mission-registry.ts
@@ -9,13 +9,17 @@ interface MissionStateRow {
   id: string;
   mission_state_json: string | null;
   created_at: number;
+  archived_at: number | null;
 }
 
 export interface MissionRegistryEntry {
   id: string;
   mission: OrchestratorMissionState;
   createdAt: number;
+  archivedAt: number | null;
 }
+
+const registryMutationLocks = new Map<string, Promise<void>>();
 
 function parseMissionState(json: string | null): OrchestratorMissionState | null {
   if (!json) return null;
@@ -26,12 +30,22 @@ function parseMissionState(json: string | null): OrchestratorMissionState | null
   }
 }
 
-function archiveRegistryRow(id: string) {
+function archiveRegistryRowUnlocked(id: string) {
   const now = Date.now();
   getSqlite().prepare(`
     UPDATE missions SET archived_at = ?, updated_at = ?
      WHERE id = ? AND archived_at IS NULL
   `).run(now, now, id);
+}
+
+function queueArchiveRegistryRow(id: string) {
+  const missionId = id.trim();
+  if (!missionId) return;
+  void withRegistryMutationLock(missionId, async () => {
+    archiveRegistryRowUnlocked(missionId);
+  }).catch((error) => {
+    console.warn(`[mission-registry] Failed to archive ${missionId}: ${error instanceof Error ? error.message : String(error)}`);
+  });
 }
 
 function packetIsActive(packet: OrchestratorPacket) {
@@ -59,25 +73,77 @@ export function missionIsTerminal(state: OrchestratorMissionState) {
   return state.packets.length > 0 && state.packets.every((packet) => !packetIsActive(packet));
 }
 
+function missionRegistryEntryFromRow(row: MissionStateRow): MissionRegistryEntry | null {
+  const mission = parseMissionState(row.mission_state_json);
+  return mission ? { id: row.id, mission, createdAt: row.created_at, archivedAt: row.archived_at } : null;
+}
+
+export function readMissionRegistryEntry(
+  missionId: string,
+  options: { includeArchived?: boolean } = {},
+): MissionRegistryEntry | null {
+  const normalizedId = missionId.trim();
+  if (!normalizedId) return null;
+  const row = getSqlite().prepare(`
+    SELECT id, mission_state_json, created_at, archived_at
+      FROM missions
+     WHERE id = ?
+       ${options.includeArchived ? '' : 'AND archived_at IS NULL'}
+  `).get(normalizedId) as MissionStateRow | undefined;
+  return row ? missionRegistryEntryFromRow(row) : null;
+}
+
+export function listMissionRegistryEntries(
+  options: { includeArchived?: boolean; excludeMissionId?: string | null } = {},
+): MissionRegistryEntry[] {
+  const rows = getSqlite().prepare(`
+    SELECT id, mission_state_json, created_at, archived_at
+      FROM missions
+     WHERE ${options.includeArchived ? '1 = 1' : 'archived_at IS NULL'}
+     ORDER BY created_at ASC
+  `).all() as MissionStateRow[];
+
+  const entries: MissionRegistryEntry[] = [];
+  const excludeMissionId = options.excludeMissionId?.trim() ?? '';
+  for (const row of rows) {
+    if (excludeMissionId && row.id === excludeMissionId) continue;
+    const entry = missionRegistryEntryFromRow(row);
+    if (!entry) continue;
+    entries.push(entry);
+  }
+  return entries;
+}
+
 export function listActiveMissionRegistryEntries(currentMissionId?: string | null): MissionRegistryEntry[] {
   const rows = getSqlite().prepare(`
-    SELECT id, mission_state_json, created_at
+    SELECT id, mission_state_json, created_at, archived_at
       FROM missions
      WHERE archived_at IS NULL
      ORDER BY created_at ASC
   `).all() as MissionStateRow[];
 
   const entries: MissionRegistryEntry[] = [];
+  const excludeMissionId = currentMissionId?.trim() ?? '';
   for (const row of rows) {
-    if (row.id === currentMissionId) continue;
-    const mission = parseMissionState(row.mission_state_json);
-    if (!mission || missionIsTerminal(mission)) {
-      archiveRegistryRow(row.id);
+    if (excludeMissionId && row.id === excludeMissionId) continue;
+    const entry = missionRegistryEntryFromRow(row);
+    if (!entry || missionIsTerminal(entry.mission)) {
+      queueArchiveRegistryRow(row.id);
       continue;
     }
-    entries.push({ id: row.id, mission, createdAt: row.created_at });
+    entries.push(entry);
   }
   return entries;
+}
+
+export function findMissionRegistryEntryByPacketId(
+  packetId: string,
+  options: { includeArchived?: boolean; excludeMissionId?: string | null } = {},
+): MissionRegistryEntry | null {
+  const normalizedPacketId = packetId.trim();
+  if (!normalizedPacketId) return null;
+  return listMissionRegistryEntries(options)
+    .find((entry) => entry.mission.packets.some((packet) => packet.id === normalizedPacketId)) ?? null;
 }
 
 export function hasRegistryPendingHeadlessWork(currentMissionId?: string | null) {
@@ -85,30 +151,87 @@ export function hasRegistryPendingHeadlessWork(currentMissionId?: string | null)
     .some((entry) => missionHasPendingHeadlessWork(entry.mission));
 }
 
-export function persistMissionRegistryState(state: OrchestratorMissionState): void {
+function writeMissionRegistryStateUnlocked(state: OrchestratorMissionState): OrchestratorMissionState | null {
   const missionId = state.missionId?.trim();
-  if (!missionId) return;
+  if (!missionId) return null;
   const normalized = normalizeOrchestratorMissionState(state);
   const waves = buildDependencyGraph(normalized.packets).map((node) => node.wave);
   const archivedAt = missionIsTerminal(normalized) ? Date.now() : null;
-  getSqlite().prepare(`
-    UPDATE missions
-       SET prompt = ?, summary = ?, constraints = ?, packet_meta_json = ?,
-           mission_state_json = ?, total_waves = ?, updated_at = ?, archived_at = ?
-     WHERE id = ?
-  `).run(
-    normalized.prompt,
-    normalized.summary,
-    normalized.constraints,
-    JSON.stringify(normalized.packets.map((packet) => ({
-      id: packet.id,
-      title: packet.title,
-      referenceLabel: packet.referenceLabel,
-    }))),
-    JSON.stringify(normalized),
-    Math.max(1, ...waves),
-    Date.now(),
-    archivedAt,
-    missionId,
-  );
+  const now = Date.now();
+  const write = getSqlite().transaction(() => {
+    getSqlite().prepare(`
+      UPDATE missions
+         SET prompt = ?, summary = ?, constraints = ?, packet_meta_json = ?,
+             mission_state_json = ?, total_waves = ?, updated_at = ?, archived_at = ?
+       WHERE id = ?
+    `).run(
+      normalized.prompt,
+      normalized.summary,
+      normalized.constraints,
+      JSON.stringify(normalized.packets.map((packet) => ({
+        id: packet.id,
+        title: packet.title,
+        referenceLabel: packet.referenceLabel,
+      }))),
+      JSON.stringify(normalized),
+      Math.max(1, ...waves),
+      now,
+      archivedAt,
+      missionId,
+    );
+  });
+  write();
+  return normalized;
+}
+
+async function withRegistryMutationLock<T>(missionId: string, fn: () => Promise<T>): Promise<T> {
+  const key = missionId.trim();
+  const previous = registryMutationLocks.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const lock = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const chained = previous.catch(() => {}).then(() => lock);
+  registryMutationLocks.set(key, chained);
+  await previous.catch(() => {});
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (registryMutationLocks.get(key) === chained) {
+      registryMutationLocks.delete(key);
+    }
+  }
+}
+
+export async function withMissionRegistryState<T>(
+  missionId: string,
+  updater: (state: OrchestratorMissionState) => Promise<{ state: OrchestratorMissionState; result: T }> | { state: OrchestratorMissionState; result: T },
+): Promise<{ state: OrchestratorMissionState; result: T }> {
+  const normalizedId = missionId.trim();
+  if (!normalizedId) {
+    throw new Error('missionId is required.');
+  }
+
+  return withRegistryMutationLock(normalizedId, async () => {
+    const entry = readMissionRegistryEntry(normalizedId, { includeArchived: true });
+    if (!entry) {
+      throw new Error(`Mission ${normalizedId} not found.`);
+    }
+    const next = await updater(entry.mission);
+    const persisted = writeMissionRegistryStateUnlocked({
+      ...next.state,
+      missionId: normalizedId,
+    });
+    if (!persisted) {
+      throw new Error(`Mission ${normalizedId} could not be persisted.`);
+    }
+    return { result: next.result, state: persisted };
+  });
+}
+
+export async function persistMissionRegistryState(state: OrchestratorMissionState): Promise<OrchestratorMissionState | null> {
+  const missionId = state.missionId?.trim();
+  if (!missionId) return null;
+  return withRegistryMutationLock(missionId, async () => writeMissionRegistryStateUnlocked(state));
 }

--- a/src/lib/orchestrator/operator-mission-service/mission.ts
+++ b/src/lib/orchestrator/operator-mission-service/mission.ts
@@ -1,6 +1,6 @@
 import { aggregateMissionCost } from '@/lib/orchestrator/cost-aggregator';
 import { resolveWorkerRouting } from '@/lib/agents/routing';
-import { withLockedState, writeOrchestratorControlPlaneState } from '@/lib/orchestrator/control-plane';
+import { reconcileOrchestratorControlPlaneState, withLockedState, writeOrchestratorControlPlaneState } from '@/lib/orchestrator/control-plane';
 import { buildDagMetadata, buildDependencyGraph } from '@/lib/orchestrator/dag';
 import { runDispatchTick } from '@/lib/orchestrator/dispatch';
 import { findLaneByPacket } from '@/lib/lane/registry';
@@ -8,6 +8,7 @@ import { currentLaneMergePolicy } from '@/lib/lane/dogfood-guard';
 import { listArtifacts, toArtifactRef } from '@/lib/artifacts/store';
 import { normalizeOrchestratorMissionState } from '@/lib/orchestrator/store';
 import { archiveMissionsExcept, getMissionRecord, recordMission } from '@/lib/db/missions-store';
+import { readMissionRegistryEntry, withMissionRegistryState } from '@/lib/orchestrator/mission-registry';
 import {
   latestTranscriptEventAt,
   readSessionTranscriptEvents,
@@ -29,7 +30,6 @@ import {
   log,
   missionAgentKeys,
   normalizeLoadedIssue,
-  normalizeMissionSelection,
   slugify,
 } from './shared';
 import type {
@@ -308,7 +308,36 @@ async function logDispatchRoutingRecommendations(
 
 export async function dispatchMission(input: DispatchMissionInput) {
   const before = currentMissionState();
-  normalizeMissionSelection(before, input.missionId);
+  const requestedMissionId = input.missionId?.trim();
+  const currentMissionId = before.missionId?.trim() ?? '';
+
+  if (requestedMissionId && requestedMissionId !== currentMissionId) {
+    const { result, state: finalState } = await withMissionRegistryState(requestedMissionId, async (stored) => {
+      const registryBefore = reconcileOrchestratorControlPlaneState(stored);
+      for (const packet of registryBefore.packets) {
+        if (packet.queueState === 'held') packet.queueState = 'queued';
+      }
+      const afterDispatch = await runDispatchTick(registryBefore);
+      const beforeByPacketId = new Map(registryBefore.packets.map((packet) => [packet.id, packet] as const));
+      const dispatched = afterDispatch.packets.filter((packet) => {
+        const previous = beforeByPacketId.get(packet.id);
+        const hadLane = Boolean(previous?.lane?.laneId || previous?.lane?.sessionKey);
+        const hasLane = Boolean(packet.lane?.laneId || packet.lane?.sessionKey);
+        return !hadLane && hasLane;
+      }).length;
+      return { state: afterDispatch, result: dispatched };
+    });
+
+    const packetIds = new Set(finalState.packets.map((packet) => packet.id));
+    const dag = buildDagMetadata(finalState.packets);
+    log(`Dispatched mission ${finalState.missionId || requestedMissionId} with ${result} packet launches.`);
+
+    return {
+      dispatched: result,
+      waves: dag.totalWaves,
+      activeAgents: missionAgentKeys(packetIds),
+    };
+  }
 
   // Use locked state to prevent race with headless loop tick
   const { result, state: finalState } = await withLockedState(async (current) => {
@@ -519,22 +548,23 @@ function buildHistoricalMissionStatus(record: import('@/lib/db/missions-store').
 }
 
 export async function getMissionStatus(input: MissionStatusInput) {
-  const state = currentMissionState();
+  const currentState = currentMissionState();
   const requestedMissionId = input.missionId?.trim();
-  const currentMissionId = (state.missionId ?? '').trim();
+  const currentMissionId = (currentState.missionId ?? '').trim();
   const isCurrent = !requestedMissionId || requestedMissionId === currentMissionId;
+  let state = currentState;
 
-  // Historical mission path — the requested mission isn't the current one,
-  // but it may still be in the SQLite archive. Rebuild a lite snapshot from
-  // the mission record + live lanes table.
   if (!isCurrent) {
-    const record = getMissionRecord(requestedMissionId);
-    if (!record) {
-      // Preserve the legacy error so callers that depended on the throw
-      // still get a clear "no such mission" signal.
-      throw new Error(`Mission mismatch. Current mission is ${currentMissionId || '(none)'}, requested ${requestedMissionId}.`);
+    const registryEntry = readMissionRegistryEntry(requestedMissionId, { includeArchived: true });
+    if (registryEntry) {
+      state = reconcileOrchestratorControlPlaneState(registryEntry.mission);
+    } else {
+      const record = getMissionRecord(requestedMissionId);
+      if (!record) {
+        throw new Error(`Mission ${requestedMissionId} not found.`);
+      }
+      return buildHistoricalMissionStatus(record);
     }
-    return buildHistoricalMissionStatus(record);
   }
 
   const graph = buildDependencyGraph(state.packets);

--- a/src/lib/orchestrator/operator-mission-service/rerun-with-feedback.ts
+++ b/src/lib/orchestrator/operator-mission-service/rerun-with-feedback.ts
@@ -3,7 +3,8 @@ import { runDispatchTick } from '@/lib/orchestrator/dispatch';
 import { archiveLane, listLanes, updateLane } from '@/lib/lane/registry';
 import { getWorktreeManager } from '@/lib/worktree/launch';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
-import { log } from './shared';
+import { findMissionRegistryEntryByPacketId, withMissionRegistryState } from '@/lib/orchestrator/mission-registry';
+import { currentMissionState, log } from './shared';
 
 /**
  * #662 — One-click rerun-with-feedback.
@@ -123,6 +124,54 @@ export function resetPacketFields(packet: OrchestratorPacket) {
   // operator reset_packet refreshes it.
 }
 
+async function rerunRegistryPacketWithFeedback(
+  missionId: string,
+  packetId: string,
+  feedback: string,
+) {
+  let worktreePruned = false;
+  let referenceLabel = packetId;
+
+  const { state: finalState } = await withMissionRegistryState(missionId, async (current) => {
+    const packet = current.packets.find((candidate) => candidate.id === packetId);
+    if (!packet) {
+      throw new Error(`Packet ${packetId} not found.`);
+    }
+    referenceLabel = packet.referenceLabel;
+
+    const originalSummary = packet.summary;
+    const originalPrompt = packet.prompt?.trim()
+      || [packet.title, originalSummary].map((part) => part.trim()).filter(Boolean).join('\n\n');
+
+    const worktreePath = archiveLanesForPacket(packetId, packet.referenceLabel);
+    if (worktreePath) {
+      worktreePruned = await pruneWorktree(current.repoPath, worktreePath);
+    }
+
+    resetPacketFields(packet);
+    packet.summary = appendFeedback(originalSummary, feedback);
+    packet.prompt = appendFeedback(originalPrompt, feedback);
+
+    const afterDispatch = await runDispatchTick(current);
+    return { state: afterDispatch, result: null };
+  });
+
+  const dispatchedPacket = finalState.packets.find((candidate) => candidate.id === packetId) ?? null;
+  const dispatched = Boolean(dispatchedPacket?.lane?.laneId || dispatchedPacket?.lane?.sessionKey);
+
+  log(`Rerun-with-feedback for registry packet ${referenceLabel} (${packetId}). dispatched=${dispatched}`);
+
+  return {
+    packetId,
+    referenceLabel,
+    dispatched,
+    worktreePruned,
+    note: dispatched
+      ? `Packet ${referenceLabel} relaunched with operator feedback.`
+      : `Packet ${referenceLabel} reset and queued. Awaiting next dispatch tick.`,
+  };
+}
+
 export async function rerunWithFeedback(input: RerunWithFeedbackInput) {
   const packetId = input.packetId.trim();
   if (!packetId) {
@@ -131,6 +180,18 @@ export async function rerunWithFeedback(input: RerunWithFeedbackInput) {
   const feedback = input.feedback.trim();
   if (!feedback) {
     throw new Error('feedback is required.');
+  }
+
+  const current = currentMissionState();
+  if (!current.packets.some((candidate) => candidate.id === packetId)) {
+    const registryEntry = findMissionRegistryEntryByPacketId(packetId, {
+      includeArchived: true,
+      excludeMissionId: current.missionId,
+    });
+    if (!registryEntry) {
+      throw new Error(`Packet ${packetId} not found.`);
+    }
+    return rerunRegistryPacketWithFeedback(registryEntry.id, packetId, feedback);
   }
 
   let worktreePruned = false;

--- a/src/lib/orchestrator/operator-mission-service/reset.ts
+++ b/src/lib/orchestrator/operator-mission-service/reset.ts
@@ -3,6 +3,8 @@ import { currentMissionState, log } from './shared';
 import type { ResetPacketInput } from './types';
 import { interruptLaneSessions, archiveLaneSessions } from '@/lib/lane/reap-sessions';
 import { unregisterWatchedAgent } from '@/lib/supervisor/agent-supervisor';
+import { findMissionRegistryEntryByPacketId, withMissionRegistryState } from '@/lib/orchestrator/mission-registry';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 
 async function resetPacketViaLaneFallback(input: ResetPacketInput) {
   const { archiveLane, listLanes, updateLane } = await import('@/lib/lane/registry');
@@ -132,10 +134,83 @@ async function resetPacketViaLaneFallback(input: ResetPacketInput) {
   };
 }
 
+function markPacketResetHeld(packet: OrchestratorPacket) {
+  // Reset packet to a CLEAN, NON-auto-dispatchable state.
+  // #23 — queueState is 'held' (NOT 'queued') so the supervisor's headless
+  // dispatch tick does NOT relaunch it on its own. reset is a CLEANUP, not a
+  // relaunch — the old reset->queued->supervisor-auto-dispatch "boomerang" spawned
+  // surprise agents (even surviving an app restart). An explicit dispatch_mission()
+  // promotes held->queued when the operator actually wants to re-launch.
+  // #455 — lane MUST be null, not a blank object. A truthy lane with empty laneId
+  // causes the reconciler to see "has lane but no domain match" → 'recovering',
+  // which races the next dispatch tick and traps the packet in a recovery loop.
+  packet.status = 'draft';
+  packet.queueState = 'held';
+  packet.releaseState = 'pending';
+  packet.blockedReason = null;
+  packet.lane = null;
+  packet.review = null;
+  packet.lastEventAt = null;
+  packet.lastEventLabel = null;
+  // #455 — Clear recovery counter so a manual reset gives fresh retry budget
+  packet.recoveryCount = 0;
+  packet.lastRecoveryAt = null;
+  // Operator reset also refreshes the typecheck auto-rerun budget (#1108) —
+  // this is the ONLY place it resets; rerun_with_feedback preserves it.
+  packet.typecheckAutoRetries = 0;
+  // Same for the self-review stall budget + the operator-Stop flag (2026-06-22):
+  // a reset gives a fresh stall budget and re-enables dispatch.
+  packet.stallRetries = 0;
+  packet.operatorStopped = false;
+}
+
+async function resetRegistryPacket(input: ResetPacketInput, missionId: string) {
+  let worktreePruned = false;
+  let branchDeleted = false;
+  try {
+    const laneReset = await resetPacketViaLaneFallback(input);
+    worktreePruned = laneReset.worktreePruned;
+    branchDeleted = laneReset.branchDeleted;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes('no mission packet and no lane')) {
+      throw error;
+    }
+  }
+
+  const { result } = await withMissionRegistryState(missionId, (state) => {
+    const packet = state.packets.find((candidate) => candidate.id === input.packetId);
+    if (!packet) {
+      throw new Error(`Packet ${input.packetId} not found.`);
+    }
+    markPacketResetHeld(packet);
+    log(`Reset registry packet ${packet.referenceLabel} (${input.packetId}). Reason: ${input.reason ?? 'operator reset'}`);
+    return {
+      state,
+      result: {
+        reset: true,
+        packetId: input.packetId,
+        referenceLabel: packet.referenceLabel,
+        worktreePruned,
+        branchDeleted,
+        note: `Packet ${packet.referenceLabel} reset + held (will NOT auto-redispatch). Old lane archived.${worktreePruned ? ' Worktree pruned.' : ''}${branchDeleted ? ' Branch deleted.' : ''} Call dispatch_mission to re-launch.`,
+      },
+    };
+  });
+  return result;
+}
+
 export async function resetPacket(input: ResetPacketInput) {
   const state = currentMissionState();
   const packet = state.packets.find((candidate) => candidate.id === input.packetId);
   if (!packet) {
+    const registryEntry = findMissionRegistryEntryByPacketId(input.packetId, {
+      includeArchived: true,
+      excludeMissionId: state.missionId,
+    });
+    if (registryEntry) {
+      return resetRegistryPacket(input, registryEntry.id);
+    }
     return resetPacketViaLaneFallback(input);
   }
 
@@ -257,33 +332,7 @@ export async function resetPacket(input: ResetPacketInput) {
     }
   }
 
-  // Reset packet to a CLEAN, NON-auto-dispatchable state.
-  // #23 — queueState is 'held' (NOT 'queued') so the supervisor's headless
-  // dispatch tick does NOT relaunch it on its own. reset is a CLEANUP, not a
-  // relaunch — the old reset->queued->supervisor-auto-dispatch "boomerang" spawned
-  // surprise agents (even surviving an app restart). An explicit dispatch_mission()
-  // promotes held->queued when the operator actually wants to re-launch.
-  // #455 — lane MUST be null, not a blank object. A truthy lane with empty laneId
-  // causes the reconciler to see "has lane but no domain match" → 'recovering',
-  // which races the next dispatch tick and traps the packet in a recovery loop.
-  packet.status = 'draft';
-  packet.queueState = 'held';
-  packet.releaseState = 'pending';
-  packet.blockedReason = null;
-  packet.lane = null;
-  packet.review = null;
-  packet.lastEventAt = null;
-  packet.lastEventLabel = null;
-  // #455 — Clear recovery counter so a manual reset gives fresh retry budget
-  packet.recoveryCount = 0;
-  packet.lastRecoveryAt = null;
-  // Operator reset also refreshes the typecheck auto-rerun budget (#1108) —
-  // this is the ONLY place it resets; rerun_with_feedback preserves it.
-  packet.typecheckAutoRetries = 0;
-  // Same for the self-review stall budget + the operator-Stop flag (2026-06-22):
-  // a reset gives a fresh stall budget and re-enables dispatch.
-  packet.stallRetries = 0;
-  packet.operatorStopped = false;
+  markPacketResetHeld(packet);
 
   // Persist
   const { updateOrchestratorMissionState } = await import('@/lib/orchestrator/store');

--- a/src/lib/orchestrator/operator-mission-service/shared.ts
+++ b/src/lib/orchestrator/operator-mission-service/shared.ts
@@ -168,9 +168,6 @@ export function normalizeMissionSelection(state: OrchestratorMissionState, missi
   if (!currentMissionId) {
     throw new Error(`No active mission is stored. Requested ${requestedMissionId}.`);
   }
-  if (currentMissionId !== requestedMissionId) {
-    throw new Error(`Mission mismatch. Current mission is ${currentMissionId}, requested ${requestedMissionId}.`);
-  }
 }
 
 export function currentMissionState() {

--- a/src/lib/orchestrator/operator-mission-service/steer.ts
+++ b/src/lib/orchestrator/operator-mission-service/steer.ts
@@ -16,7 +16,9 @@
 
 import { findLaneByPacket, setLaneStatus } from '@/lib/lane/registry';
 import { rebindLaneSessionIfChanged } from '@/lib/lane/session-rebind';
+import { findMissionRegistryEntryByPacketId } from '@/lib/orchestrator/mission-registry';
 import { performRuntimeAction } from '@/lib/runtime/actions';
+import { currentMissionState } from './shared';
 
 export interface SteerPacketInput {
   packetId: string;
@@ -34,6 +36,15 @@ const NO_STEERABLE_SESSION = 'Packet has no steerable session — use rerun_with
 export async function steerPacket({ packetId, message }: SteerPacketInput): Promise<SteerPacketResult> {
   const lane = findLaneByPacket(packetId);
   if (!lane?.sessionKey) {
+    const current = currentMissionState();
+    const packetExists = current.packets.some((packet) => packet.id === packetId)
+      || Boolean(findMissionRegistryEntryByPacketId(packetId, {
+        includeArchived: true,
+        excludeMissionId: current.missionId,
+      }));
+    if (!packetExists) {
+      throw new Error(`Packet ${packetId} not found.`);
+    }
     throw new Error(NO_STEERABLE_SESSION);
   }
 


### PR DESCRIPTION
Part 2 of #1389, on part 1's registry. dispatch_mission / get_mission_status / retry_packet / reset_packet / rerun_with_feedback / steer_packet resolve missions and packets registry-wide — the 'Mission mismatch' refusal is gone, non-current missions dispatch from their registry snapshot (held→queued promotion preserved), and status returns full reconciled state for any registered mission. All registry-row mutations (verbs AND the headless tick) now serialize through a per-mission keyed lock with fresh-read-inside-lock, closing part 1's deferred last-write-wins race. Governance semantics byte-identical — only addressing changed; steer now distinguishes unknown-packet from no-steerable-session. Six real-path tests through the actual MCP handlers (non-current dispatch/retry/rerun, unknown-packet negative, mutation serialization). Full suite 945/945.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj