### PR TITLE
fix: session-rules GET binds workers to their dispatching thread (#1331)

### DIFF
--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -179,6 +179,7 @@ export async function apiFetch<T = unknown>(
     Accept: 'application/json',
   };
   if (cfg.token) headers.Authorization = `Bearer ${cfg.token}`;
+  if (cfg.source.token === 'worker' && cfg.workerPacketId) headers['x-o8-worker-packet-id'] = cfg.workerPacketId;
   if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
 
   let res: Response;

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -15,12 +15,13 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 
 export interface ResolvedConfig {
   apiPort: number;
   apiBase: string;
   token: string | null;
+  workerPacketId: string | null;
   source: {
     port: 'env' | 'o8-dir' | 'cortex-ide-dir' | 'default';
     token: 'worker' | 'env' | 'o8-dir' | 'cortex-ide-dir' | 'none';
@@ -54,6 +55,20 @@ function readTokenFile(dir: string): string | null {
   }
 }
 
+function detectPacketIdFromCwd(cwd: string): string | null {
+  const parts = cwd.split(sep);
+  for (let i = parts.length - 1; i >= 1; i--) {
+    const prev = parts[i - 1];
+    const cur = parts[i];
+    if (!cur?.startsWith('packet-')) continue;
+    if (prev === '.cortex-worktrees' || (prev === 'worktrees' && parts[i - 2] === '.claude')) {
+      const packetId = cur.slice('packet-'.length).trim();
+      return packetId || null;
+    }
+  }
+  return null;
+}
+
 export function resolveConfig(): ResolvedConfig {
   const envPort = process.env.O8_API_PORT && Number.parseInt(process.env.O8_API_PORT, 10);
   // A dispatched worker carries O8_WORKER_TOKEN (stamped at spawn). Sending it as
@@ -63,6 +78,9 @@ export function resolveConfig(): ResolvedConfig {
   // (SECURITY_AUDIT_2026-07-02 §CRIT-1.) A human running `o8` manually has no
   // O8_WORKER_TOKEN, so they fall through to the ws-token and act as operator.
   const workerToken = process.env.O8_WORKER_TOKEN?.trim() || null;
+  const workerPacketId = workerToken
+    ? process.env.O8_WORKER_PACKET_ID?.trim() || detectPacketIdFromCwd(process.cwd())
+    : null;
   const envToken = process.env.O8_API_TOKEN?.trim() || null;
 
   let apiPort: number | null = null;
@@ -117,6 +135,7 @@ export function resolveConfig(): ResolvedConfig {
     apiPort,
     apiBase: `http://127.0.0.1:${apiPort}`,
     token,
+    workerPacketId,
     source: { port: portSource, token: tokenSource },
     dataDir,
   };

--- a/src/app/api/orchestrator/session-rules/route.ts
+++ b/src/app/api/orchestrator/session-rules/route.ts
@@ -6,6 +6,9 @@ import {
   listSessionRules,
   removeSessionRule,
 } from '@/lib/db/session-rules-store';
+import { readOrchestratorControlPlaneState } from '@/lib/orchestrator/control-plane';
+import { findMissionRegistryEntryByPacketId } from '@/lib/orchestrator/mission-registry';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 import { asRecord, operatorError, operatorSuccess, parseJsonBody } from '../_utils';
 
 export const runtime = 'nodejs';
@@ -23,8 +26,23 @@ function requireThreadId(value: unknown): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
 }
 
+function findPacketForWorker(packetId: string): OrchestratorPacket | null {
+  const current = readOrchestratorControlPlaneState().packets.find((packet) => packet.id === packetId);
+  if (current) return current;
+  const registry = findMissionRegistryEntryByPacketId(packetId, { includeArchived: true });
+  return registry?.mission.packets.find((packet) => packet.id === packetId) ?? null;
+}
+
+function workerMayReadThread(request: NextRequest, threadId: string): boolean {
+  const packetId = request.headers.get('x-o8-worker-packet-id')?.trim() ?? '';
+  if (!packetId) return false;
+  const packet = findPacketForWorker(packetId);
+  return packet?.orchestratorThreadId === threadId;
+}
+
 // GET /api/orchestrator/session-rules?threadId=<id> — list active rules.
-// Read is allowed for any authenticated principal (workers included).
+// Operators may read any thread; workers may read only the thread that
+// dispatched their packet.
 export async function GET(request: NextRequest) {
   const denied = requirePanelAuth(request);
   if (denied) return denied;
@@ -32,6 +50,9 @@ export async function GET(request: NextRequest) {
   const threadId = requireThreadId(request.nextUrl.searchParams.get('threadId'));
   if (!threadId) {
     return operatorError('invalid_request', 'threadId query param is required.', 400);
+  }
+  if (resolveRequestPrincipal(request) === 'worker' && !workerMayReadThread(request, threadId)) {
+    return operatorError('forbidden', 'A dispatched worker can only read session rules for the thread that dispatched its packet.', 403);
   }
   try {
     return operatorSuccess({ rules: listSessionRules(threadId) });

--- a/tests/principal-authz.test.ts
+++ b/tests/principal-authz.test.ts
@@ -24,6 +24,7 @@ import { join } from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
+import type { OrchestratorMissionState, OrchestratorPacket } from '@/lib/orchestrator/types';
 
 // Realtime publisher fans out over WS + touches the network; stub it so the
 // approvals handler runs its GOVERNANCE logic without side effects.
@@ -50,6 +51,8 @@ const fileIo = await import('@/app/api/panel/file-io/route');
 const laneEvents = await import('@/app/api/lanes/[id]/events/route');
 const { createTestApproval, getApproval } = await import('@/lib/approvals/store');
 const { panelGateMiddleware } = await import('@/middleware');
+const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+const { writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
 
 type Principal = 'operator' | 'worker';
 
@@ -58,14 +61,50 @@ type Principal = 'operator' | 'worker';
  *  CLI actually calls the loopback API. */
 function req(
   url: string,
-  { principal, method = 'POST', body }: { principal: Principal; method?: string; body?: unknown },
+  { principal, method = 'POST', body, workerPacketId }: { principal: Principal; method?: string; body?: unknown; workerPacketId?: string },
 ): NextRequest {
   const headers: Record<string, string> = { host: 'localhost:3001' };
-  if (principal === 'worker') headers.authorization = `Bearer ${WORKER_TOKEN}`;
+  if (principal === 'worker') {
+    headers.authorization = `Bearer ${WORKER_TOKEN}`;
+    if (workerPacketId) headers['x-o8-worker-packet-id'] = workerPacketId;
+  }
   return new NextRequest(url, {
     method,
     headers,
     body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function packetFixture(overrides: Partial<OrchestratorPacket> = {}): OrchestratorPacket {
+  return {
+    id: 'pkt-authz-session-rules',
+    referenceLabel: 'PKT-AUTHZ',
+    title: 'authz packet',
+    summary: 'test packet',
+    workspaceTargetPath: null,
+    branchTarget: 'issue/authz',
+    runtime: 'codex',
+    dependencyLabels: [],
+    dependencyPacketIds: [],
+    queueState: 'queued',
+    releaseState: 'pending',
+    status: 'running',
+    blockedReason: null,
+    lastEventAt: null,
+    lastEventLabel: null,
+    archivedAt: null,
+    review: null,
+    lane: null,
+    orchestratorThreadId: null,
+    ...overrides,
+  };
+}
+
+function writeMissionWithPackets(packets: OrchestratorPacket[]): OrchestratorMissionState {
+  return writeOrchestratorControlPlaneState({
+    ...createEmptyOrchestratorMissionState(),
+    missionId: 'mission-principal-authz',
+    packets,
   });
 }
 
@@ -151,9 +190,33 @@ describe('principal-authz — session rules writes are operator-only (#1329 HIGH
     expect(res.status).toBe(403);
   });
 
-  it('GET (read) is allowed for a worker — inheritance requires reading the rules', async () => {
-    const res = await sessionRules.GET(req(`${url}?threadId=t-1`, { principal: 'worker', method: 'GET' }));
+  it('GET: WORKER → 200 only for the thread that dispatched its packet', async () => {
+    writeMissionWithPackets([
+      packetFixture({ id: 'pkt-authz-owned-thread', orchestratorThreadId: 't-owned' }),
+    ]);
+    const res = await sessionRules.GET(req(`${url}?threadId=t-owned`, {
+      principal: 'worker',
+      method: 'GET',
+      workerPacketId: 'pkt-authz-owned-thread',
+    }));
     expect(res.status).toBe(200);
+  });
+
+  it('GET: WORKER naming another thread → 403', async () => {
+    writeMissionWithPackets([
+      packetFixture({ id: 'pkt-authz-other-thread', orchestratorThreadId: 't-owned' }),
+    ]);
+    const res = await sessionRules.GET(req(`${url}?threadId=t-stolen`, {
+      principal: 'worker',
+      method: 'GET',
+      workerPacketId: 'pkt-authz-other-thread',
+    }));
+    expect(res.status).toBe(403);
+  });
+
+  it('GET: WORKER without packet binding → 403', async () => {
+    const res = await sessionRules.GET(req(`${url}?threadId=t-1`, { principal: 'worker', method: 'GET' }));
+    expect(res.status).toBe(403);
   });
 });
 


### PR DESCRIPTION
Closes hurttlocker/o8#1331. Workers may read session rules only for the thread that dispatched their packet — fail-closed on missing/unknown packet binding; operators unchanged. CLI stamps x-o8-worker-packet-id (env override or worktree-cwd detection). Real-path principal tests through the actual route. Documented limitation: header is client-supplied — cryptographic per-packet identity is hurttlocker/o8-security#17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj