### PR TITLE
fix: huddle-armed lanes park for the orchestrator instead of failing the zero-diff gate (#1387)

### DIFF
--- a/src/lib/lane/commands.ts
+++ b/src/lib/lane/commands.ts
@@ -677,6 +677,17 @@ export async function dispatch(command: LaneCommand): Promise<LaneCommandResult>
         const baseBranch = lane.baseBranch || 'main';
         const probe = await probeNoChangesProduced(reviewCwd, baseBranch);
         if (probe.noChangesProduced) {
+          const { parkHuddleReadyZeroDiffLane } = await import('@/lib/orchestrator/huddle-zero-diff');
+          const huddlePark = await parkHuddleReadyZeroDiffLane(lane);
+          if (huddlePark.parked) {
+            console.warn(`[lane] request_review: ${command.laneId} produced no diff after huddle report — parking for orchestrator.`);
+            return {
+              ok: false,
+              laneId: command.laneId,
+              note: 'huddle_ready',
+              lane: huddlePark.lane ?? undefined,
+            };
+          }
           console.warn(`[lane] request_review: ${command.laneId} has 0 commits ahead of ${baseBranch} — runtime reported success but produced no diff. Marking failed.`);
           const failed = setLaneStatus(command.laneId, 'failed', 'system', 'zero_diff_failed');
           return {

--- a/src/lib/orchestrator/huddle-zero-diff.ts
+++ b/src/lib/orchestrator/huddle-zero-diff.ts
@@ -1,0 +1,68 @@
+import { getLaneEvents, setLaneStatus } from '@/lib/lane/registry';
+import type { Lane } from '@/lib/lane/types';
+import { readOrchestratorControlPlaneState, withLockedState } from '@/lib/orchestrator/control-plane';
+
+export const HUDDLE_READY_EVENT_LABEL = 'huddle_ready';
+
+function hasPersistedHuddleReport(laneId: string): boolean {
+  return getLaneEvents(laneId, 500).some((event) =>
+    event.verb === 'agent_report' && event.payload.event === 'huddle'
+  );
+}
+
+function looksLikeFinalPlan(text: string): boolean {
+  const normalized = text.trim().toLowerCase();
+  if (!normalized) return false;
+  return /\b(implementation plan|plan:|here'?s (my )?plan|i'?ll|i will)\b/.test(normalized);
+}
+
+async function transcriptEndsWithPlan(lane: Lane): Promise<boolean> {
+  const sessionKey = lane.sessionKey?.trim();
+  if (!sessionKey) return false;
+
+  try {
+    const { readRuntimeTranscript } = await import('@/lib/runtime/transcript');
+    const transcript = await readRuntimeTranscript(sessionKey, { limit: 12 });
+    const finalAssistant = [...transcript].reverse().find((entry) =>
+      entry.role === 'assistant' && entry.text.trim().length > 0
+    );
+    return finalAssistant ? looksLikeFinalPlan(finalAssistant.text) : false;
+  } catch {
+    return false;
+  }
+}
+
+export async function parkHuddleReadyZeroDiffLane(lane: Lane): Promise<{ parked: boolean; lane?: Lane }> {
+  const packetId = lane.packetId?.trim();
+  if (!packetId) return { parked: false };
+
+  const state = readOrchestratorControlPlaneState();
+  const packet = state.packets.find((candidate) => candidate.id === packetId);
+  if (packet?.huddle !== true) return { parked: false };
+
+  const huddleReady = hasPersistedHuddleReport(lane.id) || await transcriptEndsWithPlan(lane);
+  if (!huddleReady) return { parked: false };
+
+  const now = new Date().toISOString();
+  const parkedLane = setLaneStatus(lane.id, 'awaiting_orchestrator', 'system', HUDDLE_READY_EVENT_LABEL) ?? lane;
+
+  await withLockedState((current) => {
+    const currentPacket = current.packets.find((candidate) => candidate.id === packetId);
+    if (!currentPacket) return;
+    currentPacket.status = 'blocked';
+    currentPacket.blockedReason = HUDDLE_READY_EVENT_LABEL;
+    currentPacket.lastEventAt = now;
+    currentPacket.lastEventLabel = HUDDLE_READY_EVENT_LABEL;
+    if (currentPacket.lane) {
+      currentPacket.lane = {
+        ...currentPacket.lane,
+        laneId: parkedLane.id,
+        sessionKey: parkedLane.sessionKey ?? lane.sessionKey ?? null,
+        lastEventAt: now,
+        lastEventLabel: HUDDLE_READY_EVENT_LABEL,
+      };
+    }
+  });
+
+  return { parked: true, lane: parkedLane };
+}

--- a/src/lib/supervisor/silent-exit-detector.ts
+++ b/src/lib/supervisor/silent-exit-detector.ts
@@ -388,6 +388,12 @@ async function triageSilentExit(lane: Lane): Promise<boolean> {
 
   // Clean worktree branch.
   if (state.commitsAhead === 0) {
+    const { parkHuddleReadyZeroDiffLane } = await import('@/lib/orchestrator/huddle-zero-diff');
+    const huddlePark = await parkHuddleReadyZeroDiffLane(lane);
+    if (huddlePark.parked) {
+      console.log(`[silent-exit] Lane ${lane.id} completed its huddle turn with no changes; parked for orchestrator.`);
+      return true;
+    }
     setLaneStatus(lane.id, 'awaiting_input', 'system', 'silent_exit_no_work');
     enqueueSilentExitInbox(
       lane,

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -5354,6 +5354,17 @@ async function bootstrapWsServer() {
               if (probe.noChangesProduced) {
                 const packetId = lane.packetId?.trim();
                 const now = new Date().toISOString();
+                const { parkHuddleReadyZeroDiffLane } = await import('@/lib/orchestrator/huddle-zero-diff');
+                const huddlePark = await parkHuddleReadyZeroDiffLane(lane);
+                if (huddlePark.parked) {
+                  const label = packetId ? `Packet ${packetId}` : `Lane ${lane.id}`;
+                  const detail = `${label} completed its huddle turn with no changes; awaiting orchestrator alignment.`;
+                  console.warn(`[supervisor] ${detail}`);
+                  return {
+                    block: true,
+                    detail,
+                  };
+                }
                 const failedLane = setLaneStatus(lane.id, 'failed', 'system', 'zero_diff_failed');
 
                 if (packetId) {

--- a/tests/huddle-zero-diff-classification.test.ts
+++ b/tests/huddle-zero-diff-classification.test.ts
@@ -1,0 +1,124 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+process.env.CORTEX_IDE_DATA_DIR = mkdtempSync(join(tmpdir(), 'o8-huddle-zero-diff-data-'));
+process.env.O8_DATA_DIR = process.env.CORTEX_IDE_DATA_DIR;
+
+const { dispatch } = await import('@/lib/lane/commands');
+const { reportAgentEvent } = await import('@/lib/lane/agent-report');
+const { createLane, getLane, listLanes } = await import('@/lib/lane/registry');
+const { readOrchestratorControlPlaneState, writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+const { HUDDLE_READY_EVENT_LABEL } = await import('@/lib/orchestrator/huddle-zero-diff');
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+
+afterAll(() => {
+  rmSync(process.env.CORTEX_IDE_DATA_DIR as string, { recursive: true, force: true });
+});
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] }).toString();
+}
+
+function makeCleanWorktree(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'o8-huddle-zero-diff-wt-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@o8.dev']);
+  git(dir, ['config', 'user.name', 'o8 test']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+  writeFileSync(join(dir, 'base.txt'), 'base\n');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '--no-verify', '-m', 'base']);
+  return dir;
+}
+
+function packetFor(worktreePath: string, laneId: string): OrchestratorPacket {
+  return {
+    id: 'pkt-huddle-zero-diff',
+    referenceLabel: 'P1',
+    title: 'Plan before editing',
+    summary: 'Huddle turn should not produce a diff.',
+    workspaceTargetPath: worktreePath,
+    branchTarget: 'pkt/huddle-zero-diff',
+    runtime: 'codex',
+    dependencyLabels: [],
+    dependencyPacketIds: [],
+    queueState: 'queued',
+    releaseState: 'pending',
+    status: 'running',
+    blockedReason: null,
+    lastEventAt: null,
+    lastEventLabel: null,
+    archivedAt: null,
+    review: null,
+    lane: {
+      tileId: laneId,
+      tabId: laneId,
+      repoPath: worktreePath,
+      worktreePath,
+      runtime: 'codex',
+      sessionKey: 'codex-owned:huddle-zero-diff',
+      laneId,
+      lastHeartbeatAt: null,
+      lastEventAt: null,
+      lastEventLabel: null,
+    },
+    huddle: true,
+  };
+}
+
+describe('huddle zero-diff classification', () => {
+  it('parks a huddle-armed lane with a persisted huddle report instead of failing zero-diff', async () => {
+    const worktreePath = makeCleanWorktree();
+    const lane = createLane({
+      repoPath: worktreePath,
+      worktreePath,
+      branch: 'pkt/huddle-zero-diff',
+      baseBranch: 'main',
+      runtime: 'codex',
+      sessionKey: 'codex-owned:huddle-zero-diff',
+      packetId: 'pkt-huddle-zero-diff',
+    });
+
+    writeOrchestratorControlPlaneState({
+      ...createEmptyOrchestratorMissionState(),
+      missionId: 'mission-huddle-zero-diff',
+      repoPath: worktreePath,
+      runtime: 'codex',
+      packets: [packetFor(worktreePath, lane.id)],
+      updatedAt: new Date().toISOString(),
+    });
+
+    const report = reportAgentEvent({
+      laneId: lane.id,
+      actor: 'system',
+      event: 'huddle',
+      message: 'Implementation plan: inspect the classifier, patch the chokepoint, add regression coverage.',
+    });
+    expect(report?.statusChanged).toBe(true);
+
+    const result = await dispatch({
+      verb: 'request_review',
+      laneId: lane.id,
+      actor: 'system',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.note).toBe(HUDDLE_READY_EVENT_LABEL);
+
+    const parkedLane = getLane(lane.id);
+    expect(parkedLane?.status).toBe('awaiting_orchestrator');
+    expect(parkedLane?.lastEventLabel).toBe(HUDDLE_READY_EVENT_LABEL);
+
+    const packet = readOrchestratorControlPlaneState().packets.find((candidate) => candidate.id === 'pkt-huddle-zero-diff');
+    expect(packet?.status).toBe('blocked');
+    expect(packet?.blockedReason).toBe(HUDDLE_READY_EVENT_LABEL);
+    expect(packet?.lastEventLabel).toBe(HUDDLE_READY_EVENT_LABEL);
+    expect(packet?.status).not.toBe('failed');
+    expect(listLanes()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
A huddled worker stops with zero diff BY DESIGN. All three zero-diff classification chokepoints (request_review, silent-exit triage, supervisor probe) now route through parkHuddleReadyZeroDiffLane: huddle-armed packet + persisted huddle report (or plan-shaped final message) → lane awaiting_orchestrator with huddle_ready, packet blocked — never zero_diff_failed. Real-path test through the actual request_review dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj