### PR TITLE
fix: steer_packet resumes an exited codex session via its persisted threadId (#1387)

### DIFF
--- a/src/lib/orchestrator/operator-mission-service/steer.ts
+++ b/src/lib/orchestrator/operator-mission-service/steer.ts
@@ -19,6 +19,7 @@ import { rebindLaneSessionIfChanged } from '@/lib/lane/session-rebind';
 import { findMissionRegistryEntryByPacketId } from '@/lib/orchestrator/mission-registry';
 import { performRuntimeAction } from '@/lib/runtime/actions';
 import { currentMissionState } from './shared';
+import { continueOwnedCodexSession, getOwnedCodexTelemetrySources } from '@/lib/codex/owned';
 
 export interface SteerPacketInput {
   packetId: string;
@@ -32,6 +33,19 @@ export interface SteerPacketResult {
 }
 
 const NO_STEERABLE_SESSION = 'Packet has no steerable session — use rerun_with_feedback instead.';
+
+async function resumeExitedOwnedCodexSession(surfaceId: string, message: string) {
+  if (!surfaceId.startsWith('codex-owned:')) {
+    return null;
+  }
+
+  const sources = await getOwnedCodexTelemetrySources(surfaceId);
+  if (!sources?.threadId) {
+    return null;
+  }
+
+  return continueOwnedCodexSession(surfaceId, message);
+}
 
 export async function steerPacket({ packetId, message }: SteerPacketInput): Promise<SteerPacketResult> {
   const lane = findLaneByPacket(packetId);
@@ -50,10 +64,17 @@ export async function steerPacket({ packetId, message }: SteerPacketInput): Prom
 
   const result = await performRuntimeAction({ action: 'steer', surfaceId: lane.sessionKey, message });
   if (!result.ok || result.status === 'unavailable') {
-    throw new Error(result.note || 'Runtime steer failed.');
+    const resumed = await resumeExitedOwnedCodexSession(lane.sessionKey, message);
+    if (!resumed?.ok) {
+      if (lane.sessionKey.startsWith('codex-owned:')) {
+        throw new Error(resumed?.note || NO_STEERABLE_SESSION);
+      }
+      throw new Error(resumed?.note || result.note || NO_STEERABLE_SESSION);
+    }
+  } else {
+    rebindLaneSessionIfChanged(lane.id, lane.sessionKey, result.sessionKey, 'orchestrator');
   }
 
-  rebindLaneSessionIfChanged(lane.id, lane.sessionKey, result.sessionKey, 'orchestrator');
   const updated = setLaneStatus(lane.id, 'running', 'orchestrator', 'steered_packet');
   if (!updated || updated.status !== 'running') {
     throw new Error(NO_STEERABLE_SESSION);

--- a/tests/steer-packet-owned-resume.test.ts
+++ b/tests/steer-packet-owned-resume.test.ts
@@ -1,0 +1,129 @@
+import { spawn } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const performRuntimeActionMock = vi.hoisted(() => vi.fn());
+const ensureDispatchBackendReadyMock = vi.hoisted(() => vi.fn(async () => ({
+  ready: true,
+  reason: 'already_ready',
+  waitedMs: 0,
+  attempts: 0,
+})));
+
+vi.mock('@/lib/runtime/actions', () => ({
+  performRuntimeAction: performRuntimeActionMock,
+}));
+
+vi.mock('@/lib/runtimes/shared/dispatch-readiness', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/runtimes/shared/dispatch-readiness')>();
+  return {
+    ...actual,
+    ensureDispatchBackendReady: ensureDispatchBackendReadyMock,
+  };
+});
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: vi.fn(() => ({ pid: 424242, unref: vi.fn() })),
+  };
+});
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  performRuntimeActionMock.mockReset();
+  ensureDispatchBackendReadyMock.mockClear();
+  vi.mocked(spawn).mockClear();
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('steerPacket owned Codex resume fallback', () => {
+  it('resumes an exited owned Codex session from its persisted thread id instead of refusing', async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'o8-owned-codex-steer-'));
+    const repoPath = mkdtempSync(path.join(os.tmpdir(), 'o8-owned-codex-repo-'));
+    tempDirs.push(root, repoPath);
+    process.env.CORTEX_IDE_OWNED_CODEX_ROOT = root;
+    process.env.O8_CODEX_BIN = process.execPath;
+
+    const sessionId = 'codex-owned-steer-resume';
+    const surfaceId = `codex-owned:${sessionId}`;
+    const threadId = 'thread-steer-resume-1';
+    const sessionDir = path.join(root, sessionId);
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(path.join(sessionDir, 'session.json'), JSON.stringify({
+      surfaceId,
+      sessionDir,
+      cwd: repoPath,
+      repoPath,
+      title: 'owned resume repo',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      threadId,
+      latestPrompt: 'previous turn',
+      latestSummary: 'previous turn',
+      reviewDisposition: 'watching',
+      recentRuns: [],
+      activeRun: {
+        id: 'dead-run',
+        mode: 'launch',
+        prompt: 'previous turn',
+        startedAt: new Date(Date.now() - 60_000).toISOString(),
+        pid: 987654321,
+        stdoutPath: path.join(sessionDir, 'runs', 'dead-run.jsonl'),
+        stderrPath: path.join(sessionDir, 'runs', 'dead-run.stderr.log'),
+        outcome: 'running',
+      },
+    }, null, 2));
+
+    performRuntimeActionMock.mockResolvedValue({
+      ok: false,
+      action: 'steer',
+      surfaceId,
+      sessionKey: surfaceId,
+      runtime: 'codex',
+      status: 'unavailable',
+      note: 'Runtime surface not found.',
+    });
+
+    const { createLane, getLane } = await import('@/lib/lane/registry');
+    const { steerPacket } = await import('@/lib/orchestrator/operator-mission-service/steer');
+
+    const lane = createLane({
+      repoPath,
+      branch: 'inline/owned-resume',
+      runtime: 'codex',
+      packetId: 'pkt-owned-resume',
+      sessionKey: surfaceId,
+    });
+
+    await expect(steerPacket({
+      packetId: 'pkt-owned-resume',
+      message: 'continue from huddle approval',
+    })).resolves.toMatchObject({
+      packetId: 'pkt-owned-resume',
+      laneId: lane.id,
+      note: 'Steered packet via warm session.',
+    });
+
+    expect(performRuntimeActionMock).toHaveBeenCalledWith({
+      action: 'steer',
+      surfaceId,
+      message: 'continue from huddle approval',
+    });
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(spawn).mock.calls[0]?.[1]).toEqual(expect.arrayContaining([
+      'exec',
+      'resume',
+      threadId,
+      'continue from huddle approval',
+    ]));
+    expect(getLane(lane.id)?.status).toBe('running');
+  });
+});


### PR DESCRIPTION
When the live steer fails because the codex exec process exited (huddle stop, clean exit), steer now resumes the persisted thread (codex exec resume) through the existing owned-session primitive instead of refusing — huddle-approve becomes a warm one-turn steer. Refusal preserved when no threadId survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj