### PR TITLE
fix: lazy chunks retry with backoff and render a reload fallback — no more permanently stuck Suspense (#1394)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars -- dashboard shell is mid-refactor and keeps dormant wiring for upcoming panels */
 
-import { lazy, Suspense, useState, useCallback, useEffect, useRef, useMemo } from 'react';
+import { Suspense, useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import { isTauri } from '@/lib/tauri/bridge';
 import { track } from '@/lib/analytics/track';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -126,6 +126,7 @@ import { createTileRegistry } from './tileRegistry';
 import { SettingsOverlay } from './SettingsOverlay';
 import type { TerminalTabHandle } from '@/components/desktop/workspace-terminal/types';
 import type { SavedChatRepoContext } from '@/lib/llm/chat-history';
+import { retryingLazy } from '@/lib/react/retrying-lazy';
 
 // Mark the dashboard module load as early as possible. Runs once when the
 // bundle is first parsed, before the React component is even invoked, so
@@ -138,16 +139,16 @@ markDashboardScriptStart();
    open a panel, hit Cmd+K, or trigger design mode before its chunk needs to
    load. Keeping these out of the main dashboard chunk shaves real ms off
    first-render on cold launch. */
-const LazySettingsPage = lazy(() => import('@/components/desktop/SettingsPage').then(m => ({ default: m.SettingsPage })));
+const LazySettingsPage = retryingLazy(() => import('@/components/desktop/SettingsPage').then(m => ({ default: m.SettingsPage })), { label: 'Settings' });
 // LazyAnalyticsPage full-page mount retired — Settings → Analytics tab is
 // the live entry point. AnalyticsPage is still consumed via that tab.
-const LazyAutomationsPage = lazy(() => import('@/components/desktop/AutomationsPage').then(m => ({ default: m.AutomationsPage })));
-const LazyOnboarding = lazy(() => import('@/components/desktop/Onboarding').then(m => ({ default: m.Onboarding })));
-const LazyCommandPalette = lazy(() => import('@/components/desktop/CommandPalette').then(m => ({ default: m.CommandPalette })));
-const LazyKeyboardShortcutsOverlay = lazy(() => import('@/components/desktop/KeyboardShortcutsOverlay').then(m => ({ default: m.KeyboardShortcutsOverlay })));
-const LazyDesignModeOverlay = lazy(() => import('@/components/desktop/DesignModeOverlay').then(m => ({ default: m.DesignModeOverlay })));
-const LazyO8ElementPanel = lazy(() => import('@/components/desktop/O8ElementPanel').then(m => ({ default: m.O8ElementPanel })));
-const LazyO8Panel = lazy(() => import('@/components/desktop/O8Panel').then(m => ({ default: m.O8Panel })));
+const LazyAutomationsPage = retryingLazy(() => import('@/components/desktop/AutomationsPage').then(m => ({ default: m.AutomationsPage })), { label: 'Automations' });
+const LazyOnboarding = retryingLazy(() => import('@/components/desktop/Onboarding').then(m => ({ default: m.Onboarding })), { label: 'Onboarding' });
+const LazyCommandPalette = retryingLazy(() => import('@/components/desktop/CommandPalette').then(m => ({ default: m.CommandPalette })), { label: 'Command palette' });
+const LazyKeyboardShortcutsOverlay = retryingLazy(() => import('@/components/desktop/KeyboardShortcutsOverlay').then(m => ({ default: m.KeyboardShortcutsOverlay })), { label: 'Keyboard shortcuts' });
+const LazyDesignModeOverlay = retryingLazy(() => import('@/components/desktop/DesignModeOverlay').then(m => ({ default: m.DesignModeOverlay })), { label: 'Design mode' });
+const LazyO8ElementPanel = retryingLazy(() => import('@/components/desktop/O8ElementPanel').then(m => ({ default: m.O8ElementPanel })), { label: 'Element panel' });
+const LazyO8Panel = retryingLazy(() => import('@/components/desktop/O8Panel').then(m => ({ default: m.O8Panel })), { label: 'o8 panel' });
 // #888/#895 — packet-mode right panel (Spec / Agent Overview / Changes).
 import { OrchestratorDataProvider } from '@/components/desktop/orchestrator-data-context';
 import { useMissionCompleteDetector } from '@/components/desktop/thoughts/mission-complete-detector';

--- a/src/app/dashboard/tileRegistry.tsx
+++ b/src/app/dashboard/tileRegistry.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, lazy, type Dispatch, type SetStateAction } from 'react';
+import { Suspense, type Dispatch, type SetStateAction } from 'react';
 import { toast } from '@/components/shared/ConfirmToastHost';
 import type { CanvasRepoTaskLaunchRequest } from '@/components/desktop/Canvas';
 import { ContextualPanel, type ContextualPanelHandle, type ContextualPanelProps } from '@/components/desktop/ContextualPanel';
@@ -25,6 +25,7 @@ import {
   getFirstLeaf,
 } from '@/lib/tiles/operations';
 import type { TileLayout } from '@/lib/tiles/types';
+import { retryingLazy } from '@/lib/react/retrying-lazy';
 import type {
   CanvasTileState,
   PaletteAgentSummary,
@@ -36,8 +37,8 @@ import {
   sameWorkspaceLaneState,
 } from './utils';
 
-const LazyWorkspaceTerminal = lazy(() => import('@/components/desktop/WorkspaceTerminal').then(m => ({ default: m.WorkspaceTerminal })));
-const LazyCanvas = lazy(() => import('@/components/desktop/Canvas').then(m => ({ default: m.Canvas })));
+const LazyWorkspaceTerminal = retryingLazy(() => import('@/components/desktop/WorkspaceTerminal').then(m => ({ default: m.WorkspaceTerminal })), { label: 'Workspace terminal' });
+const LazyCanvas = retryingLazy(() => import('@/components/desktop/Canvas').then(m => ({ default: m.Canvas })), { label: 'Canvas' });
 
 const TILE_LAYOUT_STORAGE_KEY = 'o8:dashboard-tiles:v1';
 

--- a/src/components/desktop/Canvas.tsx
+++ b/src/components/desktop/Canvas.tsx
@@ -15,8 +15,9 @@
  * Q's spec: bottom half of center, tabbed, replaces modals for primary content.
  */
 
-import { lazy, memo, Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
+import { retryingLazy } from '@/lib/react/retrying-lazy';
 import {
   AlertCircle,
   BookOpen,
@@ -31,15 +32,15 @@ import {
   Terminal,
   X,
 } from './lucide-shims';
-const AuditLogPanel = lazy(() => import('@/components/desktop/AuditLogPanel').then(m => ({ default: m.AuditLogPanel })));
-const CommitViewer = lazy(() => import('@/components/desktop/CommitViewer').then(m => ({ default: m.CommitViewer })));
-const FileViewer = lazy(() => import('@/components/desktop/FileViewer').then(m => ({ default: m.FileViewer })));
-const HtmlPreview = lazy(() => import('@/components/desktop/canvas/HtmlPreview').then(m => ({ default: m.HtmlPreview })));
-const InlineDiffViewer = lazy(() => import('@/components/desktop/InlineDiffViewer').then(m => ({ default: m.InlineDiffViewer })));
-const IssueCreator = lazy(() => import('@/components/desktop/IssueCreator').then(m => ({ default: m.IssueCreator })));
-const IssueViewer = lazy(() => import('@/components/desktop/IssueViewer').then(m => ({ default: m.IssueViewer })));
-const MobilePairingView = lazy(() => import('@/components/desktop/canvas/MobilePairingView').then(m => ({ default: m.MobilePairingView })));
-const PRViewer = lazy(() => import('@/components/desktop/PRViewer').then(m => ({ default: m.PRViewer })));
+const AuditLogPanel = retryingLazy(() => import('@/components/desktop/AuditLogPanel').then(m => ({ default: m.AuditLogPanel })), { label: 'Audit log' });
+const CommitViewer = retryingLazy(() => import('@/components/desktop/CommitViewer').then(m => ({ default: m.CommitViewer })), { label: 'Commit viewer' });
+const FileViewer = retryingLazy(() => import('@/components/desktop/FileViewer').then(m => ({ default: m.FileViewer })), { label: 'File viewer' });
+const HtmlPreview = retryingLazy(() => import('@/components/desktop/canvas/HtmlPreview').then(m => ({ default: m.HtmlPreview })), { label: 'HTML preview' });
+const InlineDiffViewer = retryingLazy(() => import('@/components/desktop/InlineDiffViewer').then(m => ({ default: m.InlineDiffViewer })), { label: 'Diff viewer' });
+const IssueCreator = retryingLazy(() => import('@/components/desktop/IssueCreator').then(m => ({ default: m.IssueCreator })), { label: 'Issue creator' });
+const IssueViewer = retryingLazy(() => import('@/components/desktop/IssueViewer').then(m => ({ default: m.IssueViewer })), { label: 'Issue viewer' });
+const MobilePairingView = retryingLazy(() => import('@/components/desktop/canvas/MobilePairingView').then(m => ({ default: m.MobilePairingView })), { label: 'Mobile pairing' });
+const PRViewer = retryingLazy(() => import('@/components/desktop/PRViewer').then(m => ({ default: m.PRViewer })), { label: 'PR viewer' });
 import {
   CanvasEmpty,
   CIViewer,

--- a/src/components/desktop/ContextualPanel.tsx
+++ b/src/components/desktop/ContextualPanel.tsx
@@ -11,7 +11,7 @@
  * Repo-owned inspectors and task surfaces belong in repo-scoped workspace panes.
  */
 
-import { Suspense, forwardRef, lazy, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import { Suspense, forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import type React from 'react';
 import { BottomXtermPanel, type XtermPanelHandle } from '@/components/desktop/BottomXtermPanel';
 import { ClaudeIcon, CodexIcon, GeminiIcon, OpenCodeIcon } from '@/components/desktop/repo-registry/shared';
@@ -23,8 +23,9 @@ import { FileViewer } from '@/components/desktop/o8-panel/workspace-rail/FileVie
 import { ReviewPanel } from '@/components/desktop/review/ReviewPanel';
 import type { DetectedLocalhostPreview } from '@/lib/panel/preview';
 import type { RepoRegistryEntry } from '@/lib/repos/types';
+import { retryingLazy } from '@/lib/react/retrying-lazy';
 
-const LazyOrchestratorTab = lazy(() => import('@/components/desktop/workspace-terminal/OrchestratorTab').then((module) => ({ default: module.OrchestratorTab })));
+const LazyOrchestratorTab = retryingLazy(() => import('@/components/desktop/workspace-terminal/OrchestratorTab').then((module) => ({ default: module.OrchestratorTab })), { label: 'Orchestrator tab' });
 
 // ── CLI Agents (terminal only, no chat modes) ──
 

--- a/src/components/desktop/O8Panel.tsx
+++ b/src/components/desktop/O8Panel.tsx
@@ -7,7 +7,7 @@
  * Modeled after Cursor 3's right panel, adapted for governance.
  */
 
-import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import type React from 'react';
 import { CircleSpark, DoubleCheck, Folder, Internet } from 'iconoir-react';
 import { Terminal as TablerTerminal } from '@/components/desktop/tabler-shims';
@@ -29,9 +29,10 @@ import { ContextualPanel, type ContextualPanelHandle, type ContextualPanelProps 
 import type { O8Tab } from './o8-panel/types';
 import type { DetectedLocalhostPreview } from '@/lib/panel/preview';
 import type { RepoRegistryEntry } from '@/lib/repos/types';
+import { retryingLazy } from '@/lib/react/retrying-lazy';
 // O8 panel uses the native dark theme — no LIGHT_CANVAS_VARS override needed
 
-const LazyOrchestratorTab = lazy(() => import('@/components/desktop/workspace-terminal/OrchestratorTab').then((module) => ({ default: module.OrchestratorTab })));
+const LazyOrchestratorTab = retryingLazy(() => import('@/components/desktop/workspace-terminal/OrchestratorTab').then((module) => ({ default: module.OrchestratorTab })), { label: 'Orchestrator tab' });
 
 type RightUtilityTab = Extract<O8Tab, 'files' | 'side-chat' | 'browser' | 'review' | 'terminal'>;
 

--- a/src/components/desktop/workspace-terminal/WorkspaceChatPane.tsx
+++ b/src/components/desktop/workspace-terminal/WorkspaceChatPane.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, lazy, memo, useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { Suspense, memo, useEffect, useMemo, useState, type CSSProperties } from 'react';
 import {
   AlertCircle,
   ArrowDown,
@@ -30,9 +30,10 @@ import {
   stripWorkspaceRichRendererFallback,
 } from '@/components/desktop/workspace-terminal/chat-renderers/WorkspaceRichChatEvents';
 import { PromptGlyph, looksLikePacketPrompt } from '@/components/desktop/workspace-terminal/workspace-chat-prompt';
+import { retryingLazy } from '@/lib/react/retrying-lazy';
 
-const LazyMessageBubble = lazy(() => import('@/components/desktop/LLMChat').then((module) => ({ default: module.MessageBubble })));
-const LazyChainOfThought = lazy(() => import('@/components/desktop/LLMChat').then((module) => ({ default: module.ChainOfThought })));
+const LazyMessageBubble = retryingLazy(() => import('@/components/desktop/LLMChat').then((module) => ({ default: module.MessageBubble })), { label: 'Message bubble' });
+const LazyChainOfThought = retryingLazy(() => import('@/components/desktop/LLMChat').then((module) => ({ default: module.ChainOfThought })), { label: 'Chain of thought' });
 
 interface WorkspaceChatPaneProps {
   tab: TerminalTab;

--- a/src/components/desktop/workspace-terminal/WorkspaceTerminalPanels.tsx
+++ b/src/components/desktop/workspace-terminal/WorkspaceTerminalPanels.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MutableRefObject, Suspense, lazy, memo, useEffect, useRef, useState } from 'react';
+import { MutableRefObject, Suspense, memo, useEffect, useRef, useState } from 'react';
 import { Terminal as TerminalIcon } from '../lucide-shims';
 import type { CanvasTab } from '@/components/desktop/Canvas';
 import { WorkspaceChatPane } from '@/components/desktop/workspace-terminal/WorkspaceChatPane';
@@ -8,14 +8,15 @@ import type { RegisteredRepo, TerminalTab } from '@/components/desktop/workspace
 import { repoSlugFromRemote, shortenPath } from '@/components/desktop/workspace-terminal/utils';
 import { XtermPanel, type XtermPanelHandle } from '@/components/desktop/workspace-terminal/XtermPanel';
 import { WorkspaceBootLoader } from '@/components/desktop/workspace-terminal/WorkspaceBootLoader';
+import { retryingLazy } from '@/lib/react/retrying-lazy';
 
 // LazyLLMChat used to render the Assistant tab (kind='llm-chat'). The
 // chooser-spawn rewrite routes both orchestrator and llm-chat tabs
 // through OrchestratorTab now (chat tabs run with lockedMode='chat'),
 // so the standalone LLMChat surface is no longer mounted from here.
-const LazyCanvas = lazy(() => import('@/components/desktop/Canvas').then((module) => ({ default: module.Canvas })));
-const LazyOrchestratorTab = lazy(() => import('@/components/desktop/workspace-terminal/OrchestratorTab').then((module) => ({ default: module.OrchestratorTab })));
-const LazyFleetCanvasTab = lazy(() => import('@/components/desktop/workspace-terminal/FleetCanvasTab').then((module) => ({ default: module.FleetCanvasTab })));
+const LazyCanvas = retryingLazy(() => import('@/components/desktop/Canvas').then((module) => ({ default: module.Canvas })), { label: 'Canvas' });
+const LazyOrchestratorTab = retryingLazy(() => import('@/components/desktop/workspace-terminal/OrchestratorTab').then((module) => ({ default: module.OrchestratorTab })), { label: 'Orchestrator tab' });
+const LazyFleetCanvasTab = retryingLazy(() => import('@/components/desktop/workspace-terminal/FleetCanvasTab').then((module) => ({ default: module.FleetCanvasTab })), { label: 'Fleet canvas' });
 
 interface WorkspaceTerminalPanelsProps {
   visibleTabs: TerminalTab[];

--- a/src/lib/react/retrying-lazy.test.ts
+++ b/src/lib/react/retrying-lazy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { loadWithRetries } from './retrying-lazy';
+
+describe('loadWithRetries', () => {
+  it('resolves when a failing import factory succeeds on a retry', async () => {
+    let attempts = 0;
+
+    const result = await loadWithRetries(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error('transient chunk fetch failure');
+      }
+      return { default: 'loaded' };
+    }, { retries: 2, delayMs: 0 });
+
+    expect(result).toEqual({ default: 'loaded' });
+    expect(attempts).toBe(2);
+  });
+
+  it('rejects after exhausting retries for an always-failing import factory', async () => {
+    let attempts = 0;
+    const failure = new Error('chunk unavailable');
+
+    await expect(loadWithRetries(async () => {
+      attempts += 1;
+      throw failure;
+    }, { retries: 2, delayMs: 0 })).rejects.toBe(failure);
+
+    expect(attempts).toBe(3);
+  });
+});

--- a/src/lib/react/retrying-lazy.tsx
+++ b/src/lib/react/retrying-lazy.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { lazy, type ComponentType, type CSSProperties, type LazyExoticComponent } from 'react';
+
+// React.lazy uses ComponentType<any> so ref-bearing and memoized components keep their exact prop type.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type LazyModule<TComponent extends ComponentType<any>> = { default: TComponent };
+
+interface RetryingLazyOptions {
+  label: string;
+  retries?: number;
+  delayMs?: number;
+}
+
+const fallbackShellStyle: CSSProperties = {
+  display: 'flex',
+  flex: 1,
+  minHeight: 160,
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: 18,
+  color: 'var(--t-text)',
+};
+
+const fallbackCardStyle: CSSProperties = {
+  display: 'flex',
+  maxWidth: 360,
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 10,
+  padding: 16,
+  borderRadius: 18,
+  border: '1px solid var(--t-divider-subtle)',
+  background: 'var(--t-bg-card)',
+  boxShadow: 'var(--t-shadow-soft)',
+  textAlign: 'center',
+};
+
+const fallbackTitleStyle: CSSProperties = {
+  margin: 0,
+  color: 'var(--t-text)',
+  fontSize: 14,
+  fontWeight: 650,
+};
+
+const fallbackDetailStyle: CSSProperties = {
+  margin: 0,
+  color: 'var(--t-text-muted)',
+  fontSize: 12,
+  lineHeight: 1.45,
+};
+
+const fallbackButtonStyle: CSSProperties = {
+  border: '1px solid var(--t-divider-subtle)',
+  borderRadius: 999,
+  background: 'var(--t-input-bg)',
+  color: 'var(--t-text)',
+  cursor: 'pointer',
+  fontSize: 12,
+  fontWeight: 650,
+  padding: '7px 12px',
+};
+
+function wait(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function loadWithRetries<T>(
+  loader: () => Promise<T>,
+  options: { retries?: number; delayMs?: number } = {},
+): Promise<T> {
+  const retries = Math.max(0, options.retries ?? 2);
+  const delayMs = Math.max(0, options.delayMs ?? 250);
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      return await loader();
+    } catch (error) {
+      lastError = error;
+      if (attempt < retries) {
+        await wait(delayMs * (attempt + 1));
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+function LazyChunkReloadFallback({ label }: { label: string }) {
+  return (
+    <div role="alert" style={fallbackShellStyle}>
+      <div style={fallbackCardStyle}>
+        <p style={fallbackTitleStyle}>{label} needs a reload</p>
+        <p style={fallbackDetailStyle}>A fresh app bundle is available. Reload to continue.</p>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          style={fallbackButtonStyle}
+        >
+          Reload to continue
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function retryingLazy<TComponent extends ComponentType<any>>(
+  loader: () => Promise<LazyModule<TComponent>>,
+  options: RetryingLazyOptions,
+): LazyExoticComponent<TComponent> {
+  return lazy(async () => {
+    try {
+      return await loadWithRetries(loader, options);
+    } catch {
+      const FailedLazyChunk = () => <LazyChunkReloadFallback label={options.label} />;
+      return { default: FailedLazyChunk as unknown as TComponent };
+    }
+  });
+}

--- a/src/lib/react/retrying-lazy.tsx
+++ b/src/lib/react/retrying-lazy.tsx
@@ -30,7 +30,9 @@ const fallbackCardStyle: CSSProperties = {
   gap: 10,
   padding: 16,
   borderRadius: 18,
-  border: '1px solid var(--t-divider-subtle)',
+  borderWidth: 1,
+  borderStyle: 'solid',
+  borderColor: 'var(--t-divider-subtle)',
   background: 'var(--t-bg-card)',
   boxShadow: 'var(--t-shadow-soft)',
   textAlign: 'center',
@@ -51,14 +53,19 @@ const fallbackDetailStyle: CSSProperties = {
 };
 
 const fallbackButtonStyle: CSSProperties = {
-  border: '1px solid var(--t-divider-subtle)',
+  borderWidth: 1,
+  borderStyle: 'solid',
+  borderColor: 'var(--t-divider-subtle)',
   borderRadius: 999,
   background: 'var(--t-input-bg)',
   color: 'var(--t-text)',
   cursor: 'pointer',
   fontSize: 12,
   fontWeight: 650,
-  padding: '7px 12px',
+  paddingTop: 7,
+  paddingBottom: 7,
+  paddingLeft: 12,
+  paddingRight: 12,
 };
 
 function wait(ms: number): Promise<void> {


### PR DESCRIPTION
Ref #1394. React caches a rejected lazy() import forever; one failed chunk fetch during an update-relaunch bricked Settings/panels until a manual reload. retryingLazy retries the import (backoff) and on final failure renders a tokened 'Reload to continue' card. Adopted across dashboard/panel lazy sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj