### PR TITLE
fix: mission state refetches on lifecycle events — MCP-created missions surface without a reload (#1396)

### DIFF
--- a/src/app/dashboard/hooks/useOrchestratorMission.ts
+++ b/src/app/dashboard/hooks/useOrchestratorMission.ts
@@ -1,12 +1,33 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { OrchestratorMissionState } from '@/lib/orchestrator/types';
+import { fetchWithLongLivedBudget } from '@/lib/connection-budget';
+import type { OrchestratorMissionState, OrchestratorStateApiResponse } from '@/lib/orchestrator/types';
 import {
+  createEmptyOrchestratorMissionState,
   loadOrchestratorMissionState,
+  normalizeOrchestratorMissionState,
+  ORCHESTRATOR_STATE_API_PATH,
   persistOrchestratorMissionState,
   readOrchestratorMissionState,
   subscribeOrchestratorMissionState,
   updateOrchestratorMissionState,
 } from '@/lib/orchestrator/store';
+
+const MISSION_STATE_LIFECYCLE_REFETCH_DEBOUNCE_MS = 350;
+
+async function refetchOrchestratorMissionState(): Promise<OrchestratorMissionState | null> {
+  try {
+    const response = await fetchWithLongLivedBudget(ORCHESTRATOR_STATE_API_PATH, {
+      cache: 'no-store',
+      headers: { 'Cache-Control': 'no-cache', Pragma: 'no-cache' },
+    });
+    if (!response.ok) return null;
+    const payload = await response.json() as Partial<OrchestratorStateApiResponse>;
+    const next = normalizeOrchestratorMissionState(payload.mission ?? createEmptyOrchestratorMissionState());
+    return updateOrchestratorMissionState(next);
+  } catch {
+    return null;
+  }
+}
 
 export function useOrchestratorMission() {
   const [thoughtsMissionState, setThoughtsMissionState] = useState<OrchestratorMissionState>(() => readOrchestratorMissionState());
@@ -23,6 +44,47 @@ export function useOrchestratorMission() {
     };
     window.addEventListener('focus', handleFocus);
     return () => window.removeEventListener('focus', handleFocus);
+  }, []);
+
+  useEffect(() => {
+    let disposed = false;
+    let inFlight = false;
+    let queued = false;
+    let timer: number | null = null;
+
+    const run = async () => {
+      if (inFlight) {
+        queued = true;
+        return;
+      }
+      inFlight = true;
+      try {
+        const next = await refetchOrchestratorMissionState();
+        if (!disposed && next) setThoughtsMissionState(next);
+      } finally {
+        inFlight = false;
+        if (queued && !disposed) {
+          queued = false;
+          schedule();
+        }
+      }
+    };
+
+    const schedule = () => {
+      if (timer !== null) window.clearTimeout(timer);
+      timer = window.setTimeout(() => {
+        timer = null;
+        void run();
+      }, MISSION_STATE_LIFECYCLE_REFETCH_DEBOUNCE_MS);
+    };
+
+    const events = ['o8:lane-lifecycle', 'o8:agent-lifecycle'];
+    for (const event of events) window.addEventListener(event, schedule);
+    return () => {
+      disposed = true;
+      if (timer !== null) window.clearTimeout(timer);
+      for (const event of events) window.removeEventListener(event, schedule);
+    };
   }, []);
 
   useEffect(() => () => {


### PR DESCRIPTION
Closes #1396. The mission hook subscribes to the o8:lane-lifecycle / o8:agent-lifecycle window events (fed by the durable WS channels) and refetches /api/orchestrator/state with a 350ms debounce + single-flight — the provider stops being a page-load snapshot. Budget-wrapped fetch per the connection-pool discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj