### PR TITLE
fix: first-run from DMG offers Move to Applications + DMG gains the drag-install affordance (#1337)

### DIFF
--- a/scripts/sign-and-notarize.mjs
+++ b/scripts/sign-and-notarize.mjs
@@ -19,7 +19,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, readdirSync, statSync, rmSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, statSync, rmSync, readFileSync, mkdirSync, symlinkSync, cpSync } from 'node:fs';
 import { join } from 'node:path';
 
 const REQUIRED = ['APPLE_SIGNING_IDENTITY', 'APPLE_ID', 'APPLE_PASSWORD', 'APPLE_TEAM_ID'];
@@ -39,6 +39,7 @@ const APP = join(BUNDLE, 'macos/o8.app');
 const TAR = join(BUNDLE, 'macos/o8.app.tar.gz');
 const TAR_SIG = join(BUNDLE, 'macos/o8.app.tar.gz.sig');
 const DMG = join(BUNDLE, `dmg/o8_${version}_x64.dmg`);
+const DMG_STAGING = join(BUNDLE, 'dmg-staging');
 const ENTITLEMENTS = join(root, 'src-tauri/entitlements.plist');
 // Voice STT sidecar (lifted from aqua/Symon) ships as a Tauri externalBin in
 // Contents/MacOS/speech_recognizer. It needs its own entitlements (audio-input
@@ -209,14 +210,19 @@ execFileSync('cargo', ['tauri', 'signer', 'sign', TAR], {
 
 console.log('[sign-and-notarize] rebuilding DMG with stapled app');
 if (existsSync(DMG)) rmSync(DMG);
+if (existsSync(DMG_STAGING)) rmSync(DMG_STAGING, { recursive: true, force: true });
+mkdirSync(DMG_STAGING, { recursive: true });
+cpSync(APP, join(DMG_STAGING, 'o8.app'), { recursive: true, preserveTimestamps: true });
+symlinkSync('/Applications', join(DMG_STAGING, 'Applications'));
 execFileSync('hdiutil', [
   'create',
   '-volname', `o8 ${version}`,
-  '-srcfolder', APP,
+  '-srcfolder', DMG_STAGING,
   '-ov',
   '-format', 'UDZO',
   DMG,
 ], { stdio: 'inherit' });
+rmSync(DMG_STAGING, { recursive: true, force: true });
 
 console.log('[sign-and-notarize] signing DMG');
 execFileSync('codesign', [

--- a/src-tauri/src/first_run_install.rs
+++ b/src-tauri/src/first_run_install.rs
@@ -1,0 +1,89 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const DEST_APP: &str = "/Applications/o8.app";
+
+fn escape_applescript(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn enclosing_app_bundle(exe: &Path) -> Option<PathBuf> {
+    exe.ancestors()
+        .find(|path| path.extension().is_some_and(|extension| extension == "app"))
+        .map(Path::to_path_buf)
+}
+
+fn is_dmg_or_translocated(path: &Path) -> bool {
+    let path = path.to_string_lossy();
+    path.starts_with("/Volumes/") || path.contains("/AppTranslocation/")
+}
+
+fn user_wants_move(source_app: &Path) -> bool {
+    let body = format!(
+        "o8 is running from a disk image or temporary macOS copy. Move it to Applications now so permissions and automatic updates work correctly?\n\nSource: {}",
+        source_app.display()
+    );
+    let script = format!(
+        r#"display dialog "{}" with title "Move o8 to Applications" buttons {{"Quit", "Move to Applications"}} default button "Move to Applications" cancel button "Quit" with icon caution"#,
+        escape_applescript(&body)
+    );
+    Command::new("osascript")
+        .args(["-e", &script])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .is_some_and(|stdout| stdout.contains("Move to Applications"))
+}
+
+fn spawn_move_and_relaunch(source_app: &Path) -> std::io::Result<()> {
+    let script = r#"
+set -eu
+sleep 0.5
+rm -rf "$O8_DEST_APP"
+/usr/bin/ditto "$O8_SOURCE_APP" "$O8_DEST_APP"
+/usr/bin/xattr -dr com.apple.quarantine "$O8_DEST_APP" 2>/dev/null || true
+/usr/bin/open "$O8_DEST_APP"
+"#;
+    Command::new("/bin/sh")
+        .arg("-c")
+        .arg(script)
+        .env("O8_SOURCE_APP", source_app)
+        .env("O8_DEST_APP", DEST_APP)
+        .spawn()
+        .map(|_| ())
+}
+
+pub fn offer_move_to_applications_if_needed() {
+    let exe = match std::env::current_exe() {
+        Ok(path) => path,
+        Err(_) => return,
+    };
+    if !is_dmg_or_translocated(&exe) {
+        return;
+    }
+
+    let Some(source_app) = enclosing_app_bundle(&exe) else {
+        log::warn!(
+            "[first-run-install] could not resolve .app bundle for {}",
+            exe.display()
+        );
+        return;
+    };
+    log::warn!(
+        "[first-run-install] o8 is running from {} — offering move to {}",
+        source_app.display(),
+        DEST_APP
+    );
+
+    if !user_wants_move(&source_app) {
+        return;
+    }
+
+    match spawn_move_and_relaunch(&source_app) {
+        Ok(()) => std::process::exit(0),
+        Err(err) => {
+            log::warn!("[first-run-install] move helper failed to launch: {}", err);
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,8 @@ mod dev_frontend;
 mod dictation_history;
 mod dock_window;
 mod fn_hotkey;
+#[cfg(target_os = "macos")]
+mod first_run_install;
 mod point_overlay;
 mod launch_updater;
 mod mac_perms;
@@ -1078,34 +1080,6 @@ fn load_ai_keys_from_login_shell() -> Vec<(String, String)> {
         }
     }
     Vec::new()
-}
-
-/// Warn (non-fatal) when o8 is running translocated / from a disk image instead
-/// of /Applications. macOS App Translocation runs quarantined apps from a
-/// randomized read-only path, which (a) keeps o8 out of the Accessibility list
-/// so dictation paste silently fails, and (b) blocks the auto-updater from
-/// replacing the app. The remedy is always "move o8 to /Applications".
-#[cfg(target_os = "macos")]
-fn warn_if_translocated() {
-    let exe = match std::env::current_exe() {
-        Ok(p) => p,
-        Err(_) => return,
-    };
-    let path = exe.to_string_lossy().to_string();
-    let translocated = path.contains("/AppTranslocation/");
-    let from_dmg = path.starts_with("/Volumes/");
-    if !translocated && !from_dmg {
-        return;
-    }
-    log::warn!(
-        "[translocation] o8 is running from a non-Applications location ({path}) — dictation paste, \
-         Accessibility, and auto-update will not work until o8 is moved to /Applications"
-    );
-    let msg = "o8 is running from a temporary copy, so dictation, permissions, and automatic updates won't work yet.\\n\\nQuit o8, drag it into your Applications folder, eject the disk image, then reopen o8 from Applications.";
-    let script = format!(
-        r#"display dialog "{msg}" with title "Move o8 to Applications" buttons {{"OK"}} default button "OK" with icon caution"#
-    );
-    let _ = Command::new("osascript").args(["-e", &script]).output();
 }
 
 /// Returns Some((major, raw_version)) on success, None on failure.
@@ -3943,7 +3917,7 @@ pub fn run() {
             // and auto-update silently break (#fresh-user). Off-thread so the
             // blocking osascript dialog doesn't delay window creation.
             #[cfg(target_os = "macos")]
-            std::thread::spawn(warn_if_translocated);
+            std::thread::spawn(first_run_install::offer_move_to_applications_if_needed);
             // ── System Tray (issue #731) ──
             // Menu items: Show / Quit.
             let show = MenuItem::with_id(app, "show", "Show o8", true, None::<&str>)?;


### PR DESCRIPTION
Closes #1337. The DMG now stages o8.app beside an /Applications symlink (the standard drag-install layout), and running from a disk image or translocated path triggers an actionable dialog: Move to Applications → ditto copy, quarantine strip (signed+notarized bundle — kills the double Gatekeeper prompt), relaunch from /Applications. Replaces the old warn-only dialog. cargo check + node --check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj