### PR TITLE
fix: Symon pill never clips at the dock window — hard width cap, working tail-ellipsis, full rounding (#1419)

### DIFF
--- a/src/app/dictation-pill/page.tsx
+++ b/src/app/dictation-pill/page.tsx
@@ -832,8 +832,8 @@ export default function DictationPillPage() {
         // Keep a small internal inset so the rounded top corners are visible
         // when the dock window is floating instead of flush to a screen notch.
         paddingTop: 8,
-        paddingLeft: 20,
-        paddingRight: 20,
+        paddingLeft: 28,
+        paddingRight: 28,
         boxSizing: 'border-box',
         background: 'transparent',
         // The React layer keeps the dead-zone tight: the wrapper ignores

--- a/src/app/dictation-pill/page.tsx
+++ b/src/app/dictation-pill/page.tsx
@@ -829,10 +829,12 @@ export default function DictationPillPage() {
         display: 'flex',
         alignItems: 'flex-start',
         justifyContent: 'center',
-        // paddingTop 0 → the idle capsule's square top edge sits flush at the
-        // window top, which the Rust side anchors flush to the screen top edge
-        // (DOCK_TOP_INSET = 0). No gap above the capsule (Symon notch behavior).
-        paddingTop: 0,
+        // Keep a small internal inset so the rounded top corners are visible
+        // when the dock window is floating instead of flush to a screen notch.
+        paddingTop: 8,
+        paddingLeft: 20,
+        paddingRight: 20,
+        boxSizing: 'border-box',
         background: 'transparent',
         // The React layer keeps the dead-zone tight: the wrapper ignores
         // pointer events, only the pill itself (hideCancel = no buttons) sits

--- a/src/components/desktop/dictation/DockNotchSurface.tsx
+++ b/src/components/desktop/dictation/DockNotchSurface.tsx
@@ -50,8 +50,8 @@ const BAR_GAP = 2.5;
 const INNER_W = BAR_COUNT * BAR_WIDTH + (BAR_COUNT - 1) * BAR_GAP; // 132.5
 const INNER_H = 24;
 const DOCK_WINDOW_WIDTH = 520;
-const DOCK_WINDOW_SIDE_MARGIN = 20;
-const LISTENING_CAPSULE_MAX_WIDTH = DOCK_WINDOW_WIDTH - DOCK_WINDOW_SIDE_MARGIN * 2 - 2;
+const DOCK_WINDOW_SIDE_MARGIN = 28;
+const LISTENING_CAPSULE_MAX_WIDTH = DOCK_WINDOW_WIDTH - DOCK_WINDOW_SIDE_MARGIN * 2;
 const DOCK_WINDOW_SAFE_MAX_WIDTH = `calc(100vw - ${DOCK_WINDOW_SIDE_MARGIN * 2}px)`;
 
 const WEIGHTS = (() => {
@@ -815,9 +815,8 @@ export function DockNotchSurface({
     // listening + thinking — the darkened brand capsule. Listening with a long
     // partial transcript grows wider so the words have room (Symon listening
     // footprint grows for words); idle/short stays at the 248 capsule.
-    // Listening grows wider for a long partial, with the final rendered capsule
-    // capped below 480px inside the 520px-wide dock window (DOCK_WIDTH in
-    // dock_window.rs), preserving the 20px side gutters after border rounding.
+    // Cap the final capsule against the dock window's real usable width so the
+    // OS window never supplies the visible clip during long partials.
     const listeningWide = mode === 'listening' && trimmedPartial.length > 0;
     const width = listeningWide
       ? Math.max(248, Math.min(LISTENING_CAPSULE_MAX_WIDTH, 200 + Math.min(280, trimmedPartial.length * 6)))
@@ -1340,6 +1339,7 @@ export function DockNotchSurface({
           gap: 10,
           width: '100%',
           maxWidth: '100%',
+          minWidth: 0,
           height: '100%',
           paddingLeft: 14,
           paddingRight: 14,
@@ -1347,7 +1347,7 @@ export function DockNotchSurface({
           overflow: 'hidden',
         }}
       >
-        <div style={{ width: INNER_W, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, overflow: 'hidden' }}>
+        <div style={{ width: INNER_W, maxWidth: INNER_W, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, overflow: 'hidden' }}>
           <NotchWaveCanvas listening levelRef={levelRef} />
         </div>
         {trimmedPartial ? (
@@ -1355,9 +1355,11 @@ export function DockNotchSurface({
             style={{
               flex: 1,
               minWidth: 0,
+              maxWidth: '100%',
+              display: 'block',
               fontSize: 12.5,
               fontWeight: 300,
-              letterSpacing: '-0.1px',
+              letterSpacing: 0,
               color: '#fff',
               textShadow: '0 1px 6px rgba(0, 0, 0, 0.35)',
               whiteSpace: 'nowrap',
@@ -1371,7 +1373,7 @@ export function DockNotchSurface({
             }}
             title={trimmedPartial}
           >
-            <span style={{ direction: 'ltr', unicodeBidi: 'isolate' }}>{trimmedPartial}</span>
+            {trimmedPartial}
           </span>
         ) : null}
       </div>

--- a/src/components/desktop/dictation/DockNotchSurface.tsx
+++ b/src/components/desktop/dictation/DockNotchSurface.tsx
@@ -49,6 +49,9 @@ const BAR_WIDTH = 2;
 const BAR_GAP = 2.5;
 const INNER_W = BAR_COUNT * BAR_WIDTH + (BAR_COUNT - 1) * BAR_GAP; // 132.5
 const INNER_H = 24;
+const DOCK_WINDOW_WIDTH = 520;
+const DOCK_WINDOW_SIDE_MARGIN = 20;
+const LISTENING_CAPSULE_MAX_WIDTH = DOCK_WINDOW_WIDTH - DOCK_WINDOW_SIDE_MARGIN * 2;
 
 const WEIGHTS = (() => {
   const out = new Array<number>(BAR_COUNT);
@@ -658,7 +661,7 @@ export function DockNotchSurface({
       return {
         width: 420,
         height: 96,
-        borderRadius: '0 0 24px 24px',
+        borderRadius: 24,
         background: capsuleBg, ...capsuleBlur,
         borderColor: 'rgba(255, 255, 255, 0.4)',
         boxShadow: '0 14px 32px rgba(40, 40, 80, 0.36)',
@@ -671,7 +674,7 @@ export function DockNotchSurface({
       return {
         width: 320,
         height: 64,
-        borderRadius: '0 0 24px 24px',
+        borderRadius: 24,
         background: capsuleBg, ...capsuleBlur,
         borderColor: 'rgba(255, 255, 255, 0.45)',
         boxShadow: '0 10px 26px rgba(40, 40, 80, 0.32), inset 0 0 0 1.5px rgba(255, 90, 31, 0.45)',
@@ -681,7 +684,7 @@ export function DockNotchSurface({
       return {
         width: 420,
         height: 56,
-        borderRadius: '0 0 22px 22px',
+        borderRadius: 22,
         background: capsuleBg, ...capsuleBlur,
         borderColor: 'rgba(255, 255, 255, 0.4)',
         boxShadow: '0 8px 22px rgba(40, 40, 80, 0.3)',
@@ -691,7 +694,7 @@ export function DockNotchSurface({
       return {
         width: 248,
         height: 40,
-        borderRadius: '0 0 20px 20px',
+        borderRadius: 20,
         background: capsuleBg, ...capsuleBlur,
         borderColor: 'rgba(255, 255, 255, 0.4)',
         boxShadow: '0 8px 22px rgba(40, 40, 80, 0.3)',
@@ -701,7 +704,7 @@ export function DockNotchSurface({
       return {
         width: 320,
         height: 44,
-        borderRadius: '0 0 20px 20px',
+        borderRadius: 20,
         background: capsuleBg, ...capsuleBlur,
         borderColor: 'rgba(255, 255, 255, 0.4)',
         boxShadow: '0 8px 22px rgba(40, 40, 80, 0.3)',
@@ -713,7 +716,7 @@ export function DockNotchSurface({
         return {
           width: 248,
           height: 40,
-          borderRadius: '0 0 20px 20px',
+          borderRadius: 20,
           background: capsuleBg, ...capsuleBlur,
           borderColor: 'rgba(255, 255, 255, 0.4)',
           boxShadow: '0 8px 22px rgba(40, 40, 80, 0.3)',
@@ -725,7 +728,7 @@ export function DockNotchSurface({
       return {
         width: 420,
         height: 380,
-        borderRadius: '0 0 26px 26px',
+        borderRadius: 26,
         // Darker base (0.62 → 0.74) so the answer text stays legible even if the
         // backdrop blur momentarily drops — the warm gradient otherwise shows
         // through bright and washes the white ink out ("frost goes away, hard to
@@ -752,7 +755,7 @@ export function DockNotchSurface({
       return {
         width: 280,
         height: 40,
-        borderRadius: '0 0 20px 20px',
+        borderRadius: 20,
         background: capsuleBg, ...capsuleBlur,
         borderColor: 'rgba(255, 255, 255, 0.4)',
         boxShadow: '0 8px 22px rgba(40, 40, 80, 0.3)',
@@ -767,7 +770,7 @@ export function DockNotchSurface({
       return {
         width: withWorkers ? 348 : 268,
         height: 40,
-        borderRadius: '0 0 20px 20px',
+        borderRadius: 20,
         background: capsuleBg, ...capsuleBlur,
         borderColor: 'rgba(255, 255, 255, 0.4)',
         boxShadow: '0 8px 22px rgba(40, 40, 80, 0.3)',
@@ -785,7 +788,7 @@ export function DockNotchSurface({
       return {
         width: 128,
         height: 16,
-        borderRadius: '0 0 14px 14px',
+        borderRadius: 14,
         background: idleBg,
         borderColor: 'rgba(255, 255, 255, 0.45)',
         boxShadow: '0 6px 20px rgba(0, 0, 0, 0.28), inset 0 -2px 6px rgba(120, 110, 160, 0.22)',
@@ -798,7 +801,7 @@ export function DockNotchSurface({
         // footprint; success/error use the wide 420 done capsule.
         width: 420,
         height: 44,
-        borderRadius: '0 0 20px 20px',
+        borderRadius: 20,
         background: isError
           ? 'linear-gradient(rgba(40, 12, 12, 0.55), rgba(40, 12, 12, 0.55)), linear-gradient(100deg, #ffb4b4 0%, #f7c2c2 46%, #f7d9bf 100%)'
           : capsuleBg,
@@ -811,17 +814,17 @@ export function DockNotchSurface({
     // listening + thinking — the darkened brand capsule. Listening with a long
     // partial transcript grows wider so the words have room (Symon listening
     // footprint grows for words); idle/short stays at the 248 capsule.
-    // Listening grows wider for a long partial — capped at 480 so it stays
-    // inside the 520px-wide dock window (DOCK_WIDTH in dock_window.rs) with
-    // margin on both sides.
+    // Listening grows wider for a long partial, with the final rendered capsule
+    // capped at 480px inside the 520px-wide dock window (DOCK_WIDTH in
+    // dock_window.rs), leaving 20px on both sides.
     const listeningWide = mode === 'listening' && trimmedPartial.length > 0;
     const width = listeningWide
-      ? Math.max(248, Math.min(480, 200 + Math.min(280, trimmedPartial.length * 6)))
+      ? Math.max(248, Math.min(LISTENING_CAPSULE_MAX_WIDTH, 200 + Math.min(280, trimmedPartial.length * 6)))
       : 248;
     return {
       width,
       height: 40,
-      borderRadius: '0 0 20px 20px',
+      borderRadius: 20,
       background: capsuleBg, ...capsuleBlur,
       borderColor: 'rgba(255, 255, 255, 0.4)',
       boxShadow: '0 8px 22px rgba(40, 40, 80, 0.3)',
@@ -1066,6 +1069,7 @@ export function DockNotchSurface({
           gap: 9,
           width: '100%',
           height: '100%',
+          boxSizing: 'border-box',
           paddingLeft: 14,
           paddingRight: 14,
           overflow: 'hidden',
@@ -1156,6 +1160,7 @@ export function DockNotchSurface({
           gap: 10,
           width: '100%',
           height: '100%',
+          boxSizing: 'border-box',
           paddingLeft: 14,
           paddingRight: 14,
           overflow: 'hidden',
@@ -1357,10 +1362,11 @@ export function DockNotchSurface({
               textOverflow: 'ellipsis',
               direction: 'rtl',
               textAlign: 'left',
+              unicodeBidi: 'isolate',
             }}
             title={trimmedPartial}
           >
-            <span style={{ direction: 'ltr', unicodeBidi: 'plaintext' } as React.CSSProperties}>{trimmedPartial}</span>
+            {trimmedPartial}
           </span>
         ) : null}
       </div>
@@ -1469,7 +1475,7 @@ export function DockNotchSurface({
         WebkitFontSmoothing: 'antialiased',
         borderStyle: 'solid',
         borderWidth: 1,
-        borderTopWidth: 0,
+        boxSizing: 'border-box',
         userSelect: 'none',
         ...geometry,
         transition:

--- a/src/components/desktop/dictation/DockNotchSurface.tsx
+++ b/src/components/desktop/dictation/DockNotchSurface.tsx
@@ -20,8 +20,8 @@
  *
  * It is rendered ONLY by the always-on screen dock window (`/dictation-pill`),
  * which is top-center / level-25 / transparent. The window provides the
- * position; this surface hangs from the top (alignItems: flex-start, top edge
- * square). The in-window mic-button pill (`DictationPill`) is a separate
+ * position; this surface hangs from the top with a small route-level inset so
+ * rounded corners survive non-notch monitor layouts. The in-window mic-button pill (`DictationPill`) is a separate
  * component and is UNCHANGED.
  *
  * NOTE (operator directive): the literal color values below mirror Symon's
@@ -51,7 +51,7 @@ const INNER_W = BAR_COUNT * BAR_WIDTH + (BAR_COUNT - 1) * BAR_GAP; // 132.5
 const INNER_H = 24;
 const DOCK_WINDOW_WIDTH = 520;
 const DOCK_WINDOW_SIDE_MARGIN = 20;
-const LISTENING_CAPSULE_MAX_WIDTH = DOCK_WINDOW_WIDTH - DOCK_WINDOW_SIDE_MARGIN * 2;
+const LISTENING_CAPSULE_MAX_WIDTH = DOCK_WINDOW_WIDTH - DOCK_WINDOW_SIDE_MARGIN * 2 - 2;
 const DOCK_WINDOW_SAFE_MAX_WIDTH = `calc(100vw - ${DOCK_WINDOW_SIDE_MARGIN * 2}px)`;
 
 const WEIGHTS = (() => {
@@ -816,8 +816,8 @@ export function DockNotchSurface({
     // partial transcript grows wider so the words have room (Symon listening
     // footprint grows for words); idle/short stays at the 248 capsule.
     // Listening grows wider for a long partial, with the final rendered capsule
-    // capped at 480px inside the 520px-wide dock window (DOCK_WIDTH in
-    // dock_window.rs), leaving 20px on both sides.
+    // capped below 480px inside the 520px-wide dock window (DOCK_WIDTH in
+    // dock_window.rs), preserving the 20px side gutters after border rounding.
     const listeningWide = mode === 'listening' && trimmedPartial.length > 0;
     const width = listeningWide
       ? Math.max(248, Math.min(LISTENING_CAPSULE_MAX_WIDTH, 200 + Math.min(280, trimmedPartial.length * 6)))
@@ -1365,13 +1365,13 @@ export function DockNotchSurface({
               textOverflow: 'ellipsis',
               direction: 'rtl',
               textAlign: 'left',
-              unicodeBidi: 'isolate',
+              unicodeBidi: 'plaintext',
               WebkitMaskImage: 'linear-gradient(to right, transparent 0, #000 16px, #000 100%)',
               maskImage: 'linear-gradient(to right, transparent 0, #000 16px, #000 100%)',
             }}
             title={trimmedPartial}
           >
-            {trimmedPartial}
+            <span style={{ direction: 'ltr', unicodeBidi: 'isolate' }}>{trimmedPartial}</span>
           </span>
         ) : null}
       </div>
@@ -1481,7 +1481,7 @@ export function DockNotchSurface({
         borderStyle: 'solid',
         borderWidth: 1,
         boxSizing: 'border-box',
-        maxWidth: DOCK_WINDOW_SAFE_MAX_WIDTH,
+        maxWidth: `min(${LISTENING_CAPSULE_MAX_WIDTH}px, ${DOCK_WINDOW_SAFE_MAX_WIDTH})`,
         minWidth: 0,
         userSelect: 'none',
         ...geometry,

--- a/src/components/desktop/dictation/DockNotchSurface.tsx
+++ b/src/components/desktop/dictation/DockNotchSurface.tsx
@@ -52,6 +52,7 @@ const INNER_H = 24;
 const DOCK_WINDOW_WIDTH = 520;
 const DOCK_WINDOW_SIDE_MARGIN = 20;
 const LISTENING_CAPSULE_MAX_WIDTH = DOCK_WINDOW_WIDTH - DOCK_WINDOW_SIDE_MARGIN * 2;
+const DOCK_WINDOW_SAFE_MAX_WIDTH = `calc(100vw - ${DOCK_WINDOW_SIDE_MARGIN * 2}px)`;
 
 const WEIGHTS = (() => {
   const out = new Array<number>(BAR_COUNT);
@@ -1338,13 +1339,15 @@ export function DockNotchSurface({
           justifyContent: 'center',
           gap: 10,
           width: '100%',
+          maxWidth: '100%',
           height: '100%',
           paddingLeft: 14,
           paddingRight: 14,
+          boxSizing: 'border-box',
           overflow: 'hidden',
         }}
       >
-        <div style={{ width: INNER_W, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+        <div style={{ width: INNER_W, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, overflow: 'hidden' }}>
           <NotchWaveCanvas listening levelRef={levelRef} />
         </div>
         {trimmedPartial ? (
@@ -1363,6 +1366,8 @@ export function DockNotchSurface({
               direction: 'rtl',
               textAlign: 'left',
               unicodeBidi: 'isolate',
+              WebkitMaskImage: 'linear-gradient(to right, transparent 0, #000 16px, #000 100%)',
+              maskImage: 'linear-gradient(to right, transparent 0, #000 16px, #000 100%)',
             }}
             title={trimmedPartial}
           >
@@ -1476,6 +1481,8 @@ export function DockNotchSurface({
         borderStyle: 'solid',
         borderWidth: 1,
         boxSizing: 'border-box',
+        maxWidth: DOCK_WINDOW_SAFE_MAX_WIDTH,
+        minWidth: 0,
         userSelect: 'none',
         ...geometry,
         transition:


### PR DESCRIPTION
Closes #1419. Capsule hard-capped at 464px inside the 520px dock window; the nested ltr span that defeated the rtl tail-ellipsis is removed (leading fade mask instead); all capsule states fully rounded with an 8px top inset — the square notch-flush top retired for floating multi-monitor layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj