### PR TITLE
fix: orchestrator thread repo scope is sticky — a send can no longer rebind the titlebar repo (#1421)

### DIFF
--- a/src/app/api/v2/chat-history/route.test.ts
+++ b/src/app/api/v2/chat-history/route.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { resolveThreadRepoMetadata } from './route';
+
+describe('resolveThreadRepoMetadata', () => {
+  it('keeps existing thoughts thread repo scope when a later post sends another repo', () => {
+    expect(resolveThreadRepoMetadata({
+      tabId: 'thoughts-123',
+      existingRepoPath: '/Users/marquisehurtt/o8',
+      existingRepoName: 'o8',
+      existingRepoBranch: 'main',
+      bodyRepoPath: '/Users/marquisehurtt/o8-mobile',
+      bodyRepoName: 'o8-mobile',
+      bodyRepoBranch: 'feature/mobile',
+    })).toEqual({
+      repoPath: '/Users/marquisehurtt/o8',
+      repoName: 'o8',
+      repoBranch: 'main',
+    });
+  });
+
+  it('allows a new thoughts thread to take the posted repo scope', () => {
+    expect(resolveThreadRepoMetadata({
+      tabId: 'thoughts-456',
+      bodyRepoPath: '/Users/marquisehurtt/o8',
+      bodyRepoName: 'o8',
+      bodyRepoBranch: 'main',
+    })).toEqual({
+      repoPath: '/Users/marquisehurtt/o8',
+      repoName: 'o8',
+      repoBranch: 'main',
+    });
+  });
+
+  it('preserves non-orchestrator chat behavior', () => {
+    expect(resolveThreadRepoMetadata({
+      tabId: 'mobile-chat-1',
+      existingRepoPath: '/Users/marquisehurtt/o8',
+      existingRepoName: 'o8',
+      bodyRepoPath: '/Users/marquisehurtt/o8-mobile',
+      bodyRepoName: 'o8-mobile',
+    })).toEqual({
+      repoPath: '/Users/marquisehurtt/o8-mobile',
+      repoName: 'o8-mobile',
+      repoBranch: undefined,
+    });
+  });
+});

--- a/src/app/api/v2/chat-history/route.ts
+++ b/src/app/api/v2/chat-history/route.ts
@@ -105,6 +105,36 @@ function defaultModelForBackend(
   return undefined;
 }
 
+export function resolveThreadRepoMetadata(input: {
+  tabId: unknown;
+  existingRepoPath?: string;
+  existingRepoName?: string;
+  existingRepoBranch?: string;
+  bodyRepoPath?: unknown;
+  bodyRepoName?: unknown;
+  bodyRepoBranch?: unknown;
+}) {
+  const stickyRepoPath = isThoughtsThread(input.tabId)
+    && typeof input.existingRepoPath === 'string'
+    && input.existingRepoPath.trim()
+    ? input.existingRepoPath
+    : undefined;
+
+  if (stickyRepoPath) {
+    return {
+      repoPath: stickyRepoPath,
+      repoName: input.existingRepoName,
+      repoBranch: input.existingRepoBranch,
+    };
+  }
+
+  return {
+    repoPath: input.bodyRepoPath ?? input.existingRepoPath,
+    repoName: input.bodyRepoName ?? input.existingRepoName,
+    repoBranch: input.bodyRepoBranch ?? input.existingRepoBranch,
+  };
+}
+
 export async function GET(request: NextRequest) {
   const startedAt = performance.now();
   const tabId = request.nextUrl.searchParams.get('tabId');
@@ -232,6 +262,15 @@ export async function POST(request: NextRequest) {
     ?? model
     ?? defaultModelForBackend(nextBackend)
     ?? (isThoughtsThread(body.tabId) && nextBackend !== 'openclaw' ? 'claude-code' : undefined);
+  const repoMetadata = resolveThreadRepoMetadata({
+    tabId: body.tabId,
+    existingRepoPath: repoPath,
+    existingRepoName: repoName,
+    existingRepoBranch: repoBranch,
+    bodyRepoPath: body.repoPath,
+    bodyRepoName: body.repoName,
+    bodyRepoBranch: body.repoBranch,
+  });
 
   writeFileSync(filePath, JSON.stringify({
     messages: finalMessages,
@@ -241,9 +280,9 @@ export async function POST(request: NextRequest) {
     pinned: body.pinned ?? pinned,
     title: body.title ?? title,
     planText: normalizePlanText(body.planText) ?? planText ?? extractedPlanText,
-    repoName: body.repoName ?? repoName,
-    repoPath: body.repoPath ?? repoPath,
-    repoBranch: body.repoBranch ?? repoBranch,
+    repoName: repoMetadata.repoName,
+    repoPath: repoMetadata.repoPath,
+    repoBranch: repoMetadata.repoBranch,
     remoteUrl: body.remoteUrl ?? remoteUrl ?? null,
     backend: nextBackend,
     agent: normalizeAgent(body.agent) ?? agent ?? null,


### PR DESCRIPTION
Closes #1421. The chat-history POST let body.repoPath clobber the persisted thread scope on every save (the o8 → o8-mobile titlebar drift). resolveThreadRepoMetadata: existing thoughts-threads keep their persisted repo, new threads take the posted scope, non-orchestrator chats unchanged. Unit-tested matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj