### PR TITLE
feat: 'o8 app restart' + auto-apply updates when idle — the Restart button stops being a human job (#1418)

### DIFF
--- a/cli/src/commands/app.ts
+++ b/cli/src/commands/app.ts
@@ -25,6 +25,16 @@ export async function runApp(mode: OutputMode, subcommand: string | undefined, r
     );
   }
 
+  const unknown = rest.find((arg) => arg !== '--if-update-pending');
+  if (unknown) {
+    throw new CliError(
+      'unknown_app_restart_flag',
+      `Unknown app restart flag: ${unknown}`,
+      EXIT.INVALID_ARGS,
+      'Run `o8 app restart [--if-update-pending]`.',
+    );
+  }
+
   const ifUpdatePending = rest.includes('--if-update-pending');
   const cfg = resolveConfig();
   const res = await apiFetch<AppRestartResponse>(cfg, '/api/panel/app/relaunch', {

--- a/cli/src/commands/app.ts
+++ b/cli/src/commands/app.ts
@@ -1,0 +1,55 @@
+import { apiFetch, CliError, EXIT } from '../api.js';
+import { resolveConfig } from '../config.js';
+import { printHumanHeading, printJson, type OutputMode } from '../output.js';
+
+interface AppRestartResponse {
+  ok?: boolean;
+  relaunched?: boolean;
+  skipped?: boolean;
+  reason?: string;
+  message?: string;
+  state?: {
+    updatePending?: boolean;
+    version?: string | null;
+    updatedAt?: string | null;
+  };
+}
+
+export async function runApp(mode: OutputMode, subcommand: string | undefined, rest: string[]): Promise<number> {
+  if (subcommand !== 'restart') {
+    throw new CliError(
+      'unknown_app_subcommand',
+      `Unknown app subcommand: ${subcommand ?? '(none)'}`,
+      EXIT.INVALID_ARGS,
+      'Run `o8 app restart [--if-update-pending]`.',
+    );
+  }
+
+  const ifUpdatePending = rest.includes('--if-update-pending');
+  const cfg = resolveConfig();
+  const res = await apiFetch<AppRestartResponse>(cfg, '/api/panel/app/relaunch', {
+    method: 'POST',
+    body: { ifUpdatePending },
+  });
+  const data = res.data ?? {};
+  const payload = {
+    schema: 'o8/cli/app.restart/v1',
+    ok: data.ok === true,
+    requested: data.relaunched === true,
+    skipped: data.skipped === true,
+    reason: data.reason ?? null,
+    message: data.message ?? null,
+    updatePending: data.state?.updatePending === true,
+    version: data.state?.version ?? null,
+  };
+
+  if (mode.human) {
+    printHumanHeading('o8 app restart');
+    process.stdout.write(`  ${payload.message ?? (payload.requested ? 'Restart requested.' : 'No restart requested.')}\n`);
+    if (payload.version) process.stdout.write(`  update ${payload.version}\n`);
+  } else {
+    printJson(payload);
+  }
+
+  return 0;
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -17,6 +17,7 @@
  */
 
 import { runAsk } from './commands/ask.js';
+import { runApp } from './commands/app.js';
 import { runBrowser } from './commands/browser.js';
 import { runDoctor } from './commands/doctor.js';
 import { runCortexObserve } from './commands/cortex.js';
@@ -117,6 +118,7 @@ commands:
   run [--detach] <cmd> run a process in an o8-owned terminal the operator can watch
   run --list           list managed runs (running + recent, with exit codes)
   ask [--terse] "<question>"  ask the Engineering Brain about this repo (answer + cited sources)
+  app restart [--if-update-pending]  request an app restart; optionally no-op unless an update is pending
   browser open [url]   open a page — localhost rides o8's embedded browser, external URLs auto-route to headless Chrome (engine)
   browser read         page text + interactive elements (selectors)
   browser click <sel>  click an element (ghost cursor paints in the o8 UI)
@@ -202,6 +204,8 @@ async function dispatch(args: ParsedArgs): Promise<number> {
       // The question lands in `secondary` (first positional) when quoted, or
       // spreads across secondary + rest when unquoted — hand both to the parser.
       return runAsk(args.mode, secondary ? [secondary, ...args.rest] : args.rest);
+    case 'app':
+      return runApp(args.mode, secondary, args.rest);
     case 'browser':
       return runBrowser(args.mode, secondary, args.rest);
     case 'cortex': {

--- a/src/app/api/panel/app/relaunch/route.ts
+++ b/src/app/api/panel/app/relaunch/route.ts
@@ -1,0 +1,52 @@
+import { randomUUID } from 'node:crypto';
+import { NextResponse } from 'next/server';
+
+import { getAppUpdateState } from '@/lib/app-update/relaunch-state';
+import { publishRealtimeMutation } from '@/lib/realtime/publisher';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  const ifUpdatePending = isRecord(body) && body.ifUpdatePending === true;
+  const state = getAppUpdateState();
+
+  if (ifUpdatePending && !state.updatePending) {
+    return NextResponse.json({
+      ok: true,
+      relaunched: false,
+      skipped: true,
+      reason: 'no-update-pending',
+      message: 'No downloaded update is pending; restart skipped.',
+      state,
+    }, { headers: { 'Cache-Control': 'no-store, max-age=0' } });
+  }
+
+  const now = new Date().toISOString();
+  await publishRealtimeMutation({
+    mutation: {
+      mutationId: `app-relaunch-${randomUUID()}`,
+      source: 'server',
+      action: 'app-relaunch-requested',
+      status: 'queued',
+      createdAt: now,
+      timestamp: now,
+      note: ifUpdatePending
+        ? `Apply pending update${state.version ? ` ${state.version}` : ''}.`
+        : 'Restart requested from o8 CLI/API.',
+    },
+  });
+
+  return NextResponse.json({
+    ok: true,
+    relaunched: true,
+    skipped: false,
+    message: 'Restart request published to the dashboard.',
+    state,
+  }, { headers: { 'Cache-Control': 'no-store, max-age=0' } });
+}

--- a/src/app/api/panel/app/update-state/route.ts
+++ b/src/app/api/panel/app/update-state/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+
+import { setAppUpdateState } from '@/lib/app-update/relaunch-state';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  if (!isRecord(body) || typeof body.updatePending !== 'boolean') {
+    return NextResponse.json({ error: 'updatePending must be boolean.' }, { status: 400 });
+  }
+
+  const state = setAppUpdateState({
+    updatePending: body.updatePending,
+    version: typeof body.version === 'string' && body.version.trim() ? body.version.trim() : null,
+  });
+  return NextResponse.json({ ok: true, state }, { headers: { 'Cache-Control': 'no-store, max-age=0' } });
+}

--- a/src/app/api/panel/operator-defaults/route.ts
+++ b/src/app/api/panel/operator-defaults/route.ts
@@ -188,6 +188,14 @@ function normalizeUpdate(body: Record<string, unknown>): Partial<OperatorDefault
     update.orchestratorBackend = raw;
   }
 
+  if (body.autoApplyUpdates !== undefined) {
+    const raw = body.autoApplyUpdates;
+    if (raw !== 'off' && raw !== 'when-idle') {
+      throw new Error('autoApplyUpdates must be one of "off", "when-idle".');
+    }
+    update.autoApplyUpdates = raw;
+  }
+
   const validateTier = (raw: unknown, name: string): OperatorDefaults['targetingTriage'] => {
     if (!raw || typeof raw !== 'object') throw new Error(`${name} must be an object { runtime, model, effort }.`);
     const o = raw as Record<string, unknown>;

--- a/src/components/desktop/UpdateCard.tsx
+++ b/src/components/desktop/UpdateCard.tsx
@@ -119,6 +119,7 @@ export function UpdateCard() {
   const autoApplyingRef = useRef(false);
   const lastOperatorInputRef = useRef(Date.now());
   const orchestratorStreamingRef = useRef(false);
+  const orchestratorBusyTabsRef = useRef<Map<string, boolean>>(new Map());
 
   useEffect(() => {
     updateRef.current = update;
@@ -264,16 +265,18 @@ export function UpdateCard() {
 
   useEffect(() => {
     const onRealtime = (event: Event) => {
-      const detail = (event as CustomEvent<{ data?: { status?: unknown }; event?: string }>).detail;
-      const data = detail?.data;
-      if (typeof data?.status === 'string') {
-        if (data.status === 'busy' || data.status === 'streaming') orchestratorStreamingRef.current = true;
-        if (data.status === 'ready' || data.status === 'idle' || data.status === 'dead') {
-          orchestratorStreamingRef.current = false;
+      const detail = (event as CustomEvent<{ tabId?: unknown; busy?: unknown }>).detail;
+      const busy = detail?.busy === true;
+      if (typeof detail?.tabId === 'string' && detail.tabId) {
+        if (busy) {
+          orchestratorBusyTabsRef.current.set(detail.tabId, true);
+        } else {
+          orchestratorBusyTabsRef.current.delete(detail.tabId);
         }
+        orchestratorStreamingRef.current = orchestratorBusyTabsRef.current.size > 0;
+      } else {
+        orchestratorStreamingRef.current = busy;
       }
-      if (detail?.event === 'done' || detail?.event === 'error') orchestratorStreamingRef.current = false;
-      if (detail?.event === 'output' || detail?.event === 'tool-use') orchestratorStreamingRef.current = true;
     };
     window.addEventListener('o8:orchestrator', onRealtime);
     return () => window.removeEventListener('o8:orchestrator', onRealtime);
@@ -351,7 +354,7 @@ export function UpdateCard() {
     borderRadius: 10,
     border: '1px solid var(--t-divider-subtle)',
     background: 'var(--t-bg-card, var(--t-panel-solid))',
-    boxShadow: '0 4px 14px rgba(15, 23, 42, 0.06)',
+    boxShadow: '0 4px 14px var(--t-shadow-subtle, transparent)',
     fontFamily: 'var(--font-sans-system)',
     color: 'var(--t-text)',
   };
@@ -376,7 +379,7 @@ export function UpdateCard() {
     lineHeight: 1,
     borderRadius: 6,
     border: '1px solid var(--t-brand-orange, #FF5A1F)',
-    background: installing ? 'transparent' : 'rgba(255, 90, 31, 0.08)',
+    background: installing ? 'transparent' : 'color-mix(in srgb, var(--t-brand-orange, #FF5A1F) 8%, transparent)',
     color: 'var(--t-brand-orange, #FF5A1F)',
     fontSize: 11,
     fontWeight: 400,
@@ -533,7 +536,7 @@ function SummarySkeleton() {
             height: 9,
             width: `${widthPct}%`,
             borderRadius: 4,
-            background: 'var(--t-input-bg, rgba(15, 23, 42, 0.06))',
+            background: 'var(--t-input-bg, var(--t-panel))',
             animation: 'o8-update-shimmer 1.6s ease-in-out infinite',
           }}
         />

--- a/src/components/desktop/UpdateCard.tsx
+++ b/src/components/desktop/UpdateCard.tsx
@@ -19,10 +19,10 @@
  * second open is instant.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { CSSProperties } from 'react';
 import { isTauri } from '@/lib/tauri/bridge';
-import { openExternalUrl } from '@/lib/desktop/open-external';
+import { installUpdateAndRestart, RELEASE_URL } from '@/lib/app-update/client-restart';
 
 interface UpdateInfo {
   version: string;
@@ -38,7 +38,10 @@ const EXPANDED_KEY = 'o8:update-card:expanded';
 const SUMMARY_CACHE_KEY = 'o8:update-card:summary'; // per-version map
 const UPDATE_AVAILABLE_EVENT = 'o8://update-available';
 const UPDATE_CLEAR_EVENT = 'o8://update-clear';
-const RELEASE_URL = 'https://github.com/hurttlocker/o8/releases/latest';
+const AUTO_APPLY_IDLE_MS = 5 * 60 * 1000;
+const AUTO_APPLY_CHECK_MS = 60 * 1000;
+
+type AutoApplyUpdates = 'off' | 'when-idle';
 
 function readDismissedVersion() {
   if (typeof window === 'undefined') return null;
@@ -110,6 +113,20 @@ export function UpdateCard() {
   const [summary, setSummary] = useState<string | null>(null);
   const [summaryLoading, setSummaryLoading] = useState(false);
   const [summaryError, setSummaryError] = useState<string | null>(null);
+  const [autoApplyUpdates, setAutoApplyUpdates] = useState<AutoApplyUpdates>('off');
+  const updateRef = useRef<UpdateInfo | null>(null);
+  const installingRef = useRef(false);
+  const autoApplyingRef = useRef(false);
+  const lastOperatorInputRef = useRef(Date.now());
+  const orchestratorStreamingRef = useRef(false);
+
+  useEffect(() => {
+    updateRef.current = update;
+  }, [update]);
+
+  useEffect(() => {
+    installingRef.current = installing;
+  }, [installing]);
 
   const handleDismiss = useCallback(() => {
     const version = update?.version ?? '';
@@ -149,6 +166,19 @@ export function UpdateCard() {
   }, []);
 
   useEffect(() => {
+    fetch('/api/panel/operator-defaults', { cache: 'no-store' })
+      .then(async (response) => {
+        if (!response.ok) return;
+        const payload = await response.json() as {
+          values?: { autoApplyUpdates?: AutoApplyUpdates };
+        };
+        const next = payload.values?.autoApplyUpdates;
+        if (next === 'when-idle' || next === 'off') setAutoApplyUpdates(next);
+      })
+      .catch(() => { /* default off */ });
+  }, []);
+
+  useEffect(() => {
     if (!isTauri()) return;
     let cancelled = false;
     let availableUnlisten: Promise<() => void> | null = null;
@@ -176,6 +206,14 @@ export function UpdateCard() {
     const interval = window.setInterval(() => void checkForUpdate(), UPDATE_CHECK_INTERVAL);
     return () => window.clearInterval(interval);
   }, [checkForUpdate]);
+
+  useEffect(() => {
+    fetch('/api/panel/app/update-state', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ updatePending: Boolean(update), version: update?.version ?? null }),
+    }).catch(() => { /* route is best-effort state for CLI --if-update-pending */ });
+  }, [update]);
 
   // Fetch summary when the card is expanded and we have a version. Cache
   // by version in localStorage so repeated opens are instant.
@@ -214,36 +252,89 @@ export function UpdateCard() {
   }, [expanded, update?.version]);
 
   const handleInstall = useCallback(async () => {
-    if (!isTauri()) {
-      openExternalUrl(update?.releaseUrl ?? RELEASE_URL);
-      return;
-    }
     try {
       setInstalling(true);
-      const { check } = await import('@tauri-apps/plugin-updater');
-      const result = await check();
-      if (result) {
-        await result.downloadAndInstall();
-        // Restart via our own command, NOT plugin-process relaunch: the plugin
-        // exits the old process without reaping the bundled Node children, so
-        // they kept holding the API/WS ports and the new instance came up
-        // "reconnecting" (zombie observed 2026-07-03). restart_app kills the
-        // tracked children first, then restarts. Fall back to plugin relaunch
-        // if the command is unavailable (older shell).
-        try {
-          const { invoke } = await import('@tauri-apps/api/core');
-          await invoke('restart_app');
-        } catch {
-          const { relaunch } = await import('@tauri-apps/plugin-process');
-          await relaunch();
-        }
-      }
+      await installUpdateAndRestart(updateRef.current?.releaseUrl ?? RELEASE_URL);
       setInstalling(false);
     } catch (err) {
       console.error('[update-card] install failed:', err);
       setInstalling(false);
     }
-  }, [update?.releaseUrl]);
+  }, []);
+
+  useEffect(() => {
+    const onRealtime = (event: Event) => {
+      const detail = (event as CustomEvent<{ data?: { status?: unknown }; event?: string }>).detail;
+      const data = detail?.data;
+      if (typeof data?.status === 'string') {
+        if (data.status === 'busy' || data.status === 'streaming') orchestratorStreamingRef.current = true;
+        if (data.status === 'ready' || data.status === 'idle' || data.status === 'dead') {
+          orchestratorStreamingRef.current = false;
+        }
+      }
+      if (detail?.event === 'done' || detail?.event === 'error') orchestratorStreamingRef.current = false;
+      if (detail?.event === 'output' || detail?.event === 'tool-use') orchestratorStreamingRef.current = true;
+    };
+    window.addEventListener('o8:orchestrator', onRealtime);
+    return () => window.removeEventListener('o8:orchestrator', onRealtime);
+  }, []);
+
+  useEffect(() => {
+    const handler = () => { lastOperatorInputRef.current = Date.now(); };
+    const events = ['pointerdown', 'keydown', 'wheel', 'touchstart'] as const;
+    for (const event of events) window.addEventListener(event, handler, { passive: true });
+    return () => {
+      for (const event of events) window.removeEventListener(event, handler);
+    };
+  }, []);
+
+  useEffect(() => {
+    const onRealtime = (event: Event) => {
+      const detail = (event as CustomEvent<{
+        data?: {
+          events?: Array<{
+            data?: { mutation?: { action?: string; status?: string } };
+          }>;
+        };
+      }>).detail;
+      const requested = detail?.data?.events?.some((item) => {
+        const mutation = item.data?.mutation;
+        return mutation?.action === 'app-relaunch-requested' && mutation.status === 'queued';
+      });
+      if (requested) {
+        void handleInstall();
+      }
+    };
+    window.addEventListener('o8:realtime', onRealtime);
+    return () => window.removeEventListener('o8:realtime', onRealtime);
+  }, [handleInstall]);
+
+  useEffect(() => {
+    if (autoApplyUpdates !== 'when-idle') return;
+
+    async function maybeApplyWhenIdle() {
+      if (!updateRef.current || installingRef.current || autoApplyingRef.current) return;
+      if (Date.now() - lastOperatorInputRef.current < AUTO_APPLY_IDLE_MS) return;
+      if (orchestratorStreamingRef.current) return;
+
+      const response = await fetch('/api/lanes?active=true', { cache: 'no-store' }).catch(() => null);
+      if (!response?.ok) return;
+      const payload = await response.json().catch(() => null) as { lanes?: Array<{ status?: string }> } | null;
+      const lanes = Array.isArray(payload?.lanes) ? payload.lanes : [];
+      if (lanes.some((lane) => lane.status === 'running' || lane.status === 'launching')) return;
+
+      autoApplyingRef.current = true;
+      try {
+        await handleInstall();
+      } finally {
+        autoApplyingRef.current = false;
+      }
+    }
+
+    const interval = window.setInterval(() => void maybeApplyWhenIdle(), AUTO_APPLY_CHECK_MS);
+    void maybeApplyWhenIdle();
+    return () => window.clearInterval(interval);
+  }, [autoApplyUpdates, handleInstall]);
 
   if (!update) return null;
   if (dismissed && dismissed === update.version) return null;

--- a/src/components/desktop/settings/OperatorDefaultsTab.tsx
+++ b/src/components/desktop/settings/OperatorDefaultsTab.tsx
@@ -31,6 +31,7 @@ type DispatchRuntime = 'codex' | 'gemini' | 'opencode';
 type ClassAComposer = 'auto' | 'haiku-cli' | 'sonnet-cli' | 'fastest';
 type WorkersUseBrain = 'off' | 'auto' | 'all';
 type OrchestratorBackendSetting = 'auto' | 'codex' | 'claude' | 'openclaw' | 'hermes' | 'collide';
+type AutoApplyUpdates = 'off' | 'when-idle';
 
 interface OperatorDefaults {
   parallelCap: number;
@@ -57,6 +58,7 @@ interface OperatorDefaults {
   orchestratorBackend: OrchestratorBackendSetting;
   targetingTriage: TargetingTierUI;
   targetingAction: TargetingTierUI;
+  autoApplyUpdates: AutoApplyUpdates;
 }
 
 interface TargetingTierUI {
@@ -416,6 +418,7 @@ export function OperatorDefaultsTab() {
   const runtimeEnv = sources?.defaultDispatchRuntime === 'env';
   const classAComposerEnv = sources?.classAComposer === 'env';
   const workersUseBrainEnv = sources?.workersUseBrain === 'env';
+  const autoApplyUpdatesEnv = sources?.autoApplyUpdates === 'env';
 
   const envDisabledReason = 'Controlled by environment variable. Unset to manage from Settings.';
 
@@ -643,6 +646,23 @@ export function OperatorDefaultsTab() {
               checked={values.supervisorAutoEscalate}
               disabled={supervisorEnv || busyField === 'supervisorAutoEscalate'}
               onChange={(next) => { void updateField('supervisorAutoEscalate', next); }}
+            />
+          }
+        />
+        <Row
+          label="Auto-apply updates"
+          description="Apply a downloaded desktop update automatically only after all lanes are idle and the operator has been inactive for five minutes."
+          source={sources.autoApplyUpdates}
+          disabledReason={autoApplyUpdatesEnv ? envDisabledReason : undefined}
+          right={
+            <SegmentedControl<AutoApplyUpdates>
+              value={values.autoApplyUpdates}
+              options={[
+                { value: 'off', label: 'Off' },
+                { value: 'when-idle', label: 'When idle' },
+              ]}
+              onChange={(next) => { void updateField('autoApplyUpdates', next); }}
+              disabled={autoApplyUpdatesEnv || busyField === 'autoApplyUpdates'}
             />
           }
         />

--- a/src/components/desktop/workspace-terminal/OrchestratorTab.tsx
+++ b/src/components/desktop/workspace-terminal/OrchestratorTab.tsx
@@ -340,6 +340,17 @@ function OrchestratorTabInner({
 
   useEffect(() => subscribeOrchestratorRuntimePreference(setPreferredRuntime), []);
 
+  useEffect(() => {
+    window.dispatchEvent(new CustomEvent('o8:orchestrator', {
+      detail: { tabId, busy: active && chatChromeState.waitingForReply },
+    }));
+    return () => {
+      window.dispatchEvent(new CustomEvent('o8:orchestrator', {
+        detail: { tabId, busy: false },
+      }));
+    };
+  }, [active, chatChromeState.waitingForReply, tabId]);
+
   // Broadcast the chat-history thread id whenever it changes so the
   // dashboard's rename / archive / share menu can target the correct
   // file in ~/.o8/chat-history/. The workspace tab id (e.g.
@@ -1187,4 +1198,3 @@ function OrchestratorTabInner({
     </div>
   );
 }
-

--- a/src/lib/app-update/client-restart.ts
+++ b/src/lib/app-update/client-restart.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { isTauri } from '@/lib/tauri/bridge';
+import { openExternalUrl } from '@/lib/desktop/open-external';
+
+export const RELEASE_URL = 'https://github.com/hurttlocker/o8/releases/latest';
+
+export async function installUpdateAndRestart(releaseUrl?: string): Promise<boolean> {
+  if (!isTauri()) {
+    openExternalUrl(releaseUrl ?? RELEASE_URL);
+    return false;
+  }
+
+  const { check } = await import('@tauri-apps/plugin-updater');
+  const result = await check();
+  if (!result) return false;
+
+  await result.downloadAndInstall();
+  try {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('restart_app');
+  } catch {
+    const { relaunch } = await import('@tauri-apps/plugin-process');
+    await relaunch();
+  }
+  return true;
+}

--- a/src/lib/app-update/relaunch-state.ts
+++ b/src/lib/app-update/relaunch-state.ts
@@ -1,0 +1,28 @@
+import 'server-only';
+
+export type AutoApplyUpdates = 'off' | 'when-idle';
+
+export interface AppUpdateState {
+  updatePending: boolean;
+  version: string | null;
+  updatedAt: string | null;
+}
+
+let state: AppUpdateState = {
+  updatePending: false,
+  version: null,
+  updatedAt: null,
+};
+
+export function getAppUpdateState(): AppUpdateState {
+  return state;
+}
+
+export function setAppUpdateState(update: { updatePending: boolean; version?: string | null }): AppUpdateState {
+  state = {
+    updatePending: update.updatePending,
+    version: update.updatePending ? update.version ?? null : null,
+    updatedAt: new Date().toISOString(),
+  };
+  return state;
+}

--- a/src/lib/operator/defaults.ts
+++ b/src/lib/operator/defaults.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 
 import { isThinkingEffort, type ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+import type { AutoApplyUpdates } from '@/lib/app-update/relaunch-state';
 
 const DISPATCH_RUNTIMES: OrchestratorRuntime[] = ['codex', 'claude-code', 'gemini', 'opencode'];
 function isDispatchRuntime(value: unknown): value is OrchestratorRuntime {
@@ -231,6 +232,8 @@ export interface OperatorDefaults {
   targetingTriage: TargetingTier;
   /** Targeting Machine — the premium "point a real agent here" tier (default high). */
   targetingAction: TargetingTier;
+  /** Auto-apply downloaded desktop updates only under conservative idle gates. */
+  autoApplyUpdates: AutoApplyUpdates;
 }
 
 export interface OperatorDefaultsWithSources {
@@ -277,6 +280,7 @@ export const OPERATOR_DEFAULTS_FALLBACK: OperatorDefaults = {
   // operator can point triage at a cheaper runtime/model (gemini, a local model).
   targetingTriage: { runtime: 'codex', model: '', effort: 'low' },
   targetingAction: { runtime: 'codex', model: '', effort: 'high' },
+  autoApplyUpdates: 'off',
 };
 
 export const CLASS_A_COMPOSER_OPTIONS: Array<{ value: ClassAComposer; label: string; detail: string }> = [
@@ -467,6 +471,12 @@ function envOrchestratorBackend(): OrchestratorBackendSetting | null {
   return null;
 }
 
+function envAutoApplyUpdates(): AutoApplyUpdates | null {
+  const raw = process.env.O8_AUTO_APPLY_UPDATES?.trim();
+  if (raw === 'off' || raw === 'when-idle') return raw;
+  return null;
+}
+
 // ── File helpers ──
 
 interface StoredOperatorDefaults {
@@ -494,6 +504,7 @@ interface StoredOperatorDefaults {
   orchestratorBackend?: OrchestratorBackendSetting;
   targetingTriage?: TargetingTier;
   targetingAction?: TargetingTier;
+  autoApplyUpdates?: AutoApplyUpdates;
 }
 
 function parseStoredDefaults(raw: string): StoredOperatorDefaults {
@@ -581,6 +592,9 @@ function resolveFromFile(stored: StoredOperatorDefaults): Partial<OperatorDefaul
   if (isOrchestratorBackendSetting(stored.orchestratorBackend)) {
     result.orchestratorBackend = stored.orchestratorBackend;
   }
+  if (stored.autoApplyUpdates === 'off' || stored.autoApplyUpdates === 'when-idle') {
+    result.autoApplyUpdates = stored.autoApplyUpdates;
+  }
   const storedTriage = coerceStoredTier(stored.targetingTriage, OPERATOR_DEFAULTS_FALLBACK.targetingTriage);
   if (storedTriage) result.targetingTriage = storedTriage;
   const storedAction = coerceStoredTier(stored.targetingAction, OPERATOR_DEFAULTS_FALLBACK.targetingAction);
@@ -613,6 +627,7 @@ function resolveDefaults(fileValues: Partial<OperatorDefaults>): OperatorDefault
   const envBrainCli = envBrainUseClaudeCli();
   const envBrain = envWorkersUseBrain();
   const envOrchBackend = envOrchestratorBackend();
+  const envApplyUpdates = envAutoApplyUpdates();
   const envTriage = envTargetingTier('TRIAGE');
   const envAction = envTargetingTier('ACTION');
 
@@ -645,6 +660,7 @@ function resolveDefaults(fileValues: Partial<OperatorDefaults>): OperatorDefault
     orchestratorBackend: envOrchBackend ?? fileValues.orchestratorBackend ?? OPERATOR_DEFAULTS_FALLBACK.orchestratorBackend,
     targetingTriage: mergeTier(envTriage, fileValues.targetingTriage, OPERATOR_DEFAULTS_FALLBACK.targetingTriage),
     targetingAction: mergeTier(envAction, fileValues.targetingAction, OPERATOR_DEFAULTS_FALLBACK.targetingAction),
+    autoApplyUpdates: envApplyUpdates ?? fileValues.autoApplyUpdates ?? OPERATOR_DEFAULTS_FALLBACK.autoApplyUpdates,
   };
 
   const sources: Record<keyof OperatorDefaults, SettingSource> = {
@@ -676,6 +692,7 @@ function resolveDefaults(fileValues: Partial<OperatorDefaults>): OperatorDefault
     orchestratorBackend: envOrchBackend !== null ? 'env' : fileValues.orchestratorBackend !== undefined ? 'file' : 'default',
     targetingTriage: envTriage !== null ? 'env' : fileValues.targetingTriage !== undefined ? 'file' : 'default',
     targetingAction: envAction !== null ? 'env' : fileValues.targetingAction !== undefined ? 'file' : 'default',
+    autoApplyUpdates: envApplyUpdates !== null ? 'env' : fileValues.autoApplyUpdates !== undefined ? 'file' : 'default',
   };
 
   return { values: resolved, sources };
@@ -821,6 +838,12 @@ export async function updateOperatorDefaults(update: Partial<OperatorDefaults>):
       throw new Error('orchestratorBackend must be one of "auto", "codex", "claude", "openclaw", "hermes", "collide", "fable".');
     }
     stored.orchestratorBackend = update.orchestratorBackend;
+  }
+  if (update.autoApplyUpdates !== undefined) {
+    if (update.autoApplyUpdates !== 'off' && update.autoApplyUpdates !== 'when-idle') {
+      throw new Error('autoApplyUpdates must be "off" or "when-idle".');
+    }
+    stored.autoApplyUpdates = update.autoApplyUpdates;
   }
   if (update.targetingTriage !== undefined) {
     if (!isTargetingTier(update.targetingTriage)) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -238,7 +238,8 @@ export function panelGateMiddleware(req: NextRequest): NextResponse {
   }
 
   // DEFAULT-DENY. The matcher restricts this middleware to /api/*, so every
-  // remaining request is a state-touching API route. It passes ONLY from a
+  // remaining request is a state-touching API route (including app relaunch
+  // requests under /api/panel/app/*). It passes ONLY from a
   // loopback origin (socket truth — desktop app, MCP server, curl from
   // localhost) or with a valid ws/device token — never by omission. This closes
   // the fail-open + trailing-slash gate class (SECURITY_AUDIT_2026-07-02

--- a/tests/app-relaunch-route.test.ts
+++ b/tests/app-relaunch-route.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const publishRealtimeMutation = vi.fn<(request: unknown) => Promise<void>>(async () => undefined);
+
+vi.mock('@/lib/realtime/publisher', () => ({
+  publishRealtimeMutation,
+}));
+
+async function postUpdateState(body: unknown) {
+  const { POST } = await import('@/app/api/panel/app/update-state/route');
+  return POST(new Request('http://127.0.0.1/api/panel/app/update-state', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+async function postRelaunch(body: unknown) {
+  const { POST } = await import('@/app/api/panel/app/relaunch/route');
+  return POST(new Request('http://127.0.0.1/api/panel/app/relaunch', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+describe('POST /api/panel/app/relaunch', () => {
+  beforeEach(async () => {
+    publishRealtimeMutation.mockClear();
+    await postUpdateState({ updatePending: false });
+  });
+
+  it('no-ops clearly when --if-update-pending is requested with no pending update', async () => {
+    const res = await postRelaunch({ ifUpdatePending: true });
+    const data = await res.json() as { skipped?: boolean; reason?: string; message?: string };
+
+    expect(res.status).toBe(200);
+    expect(data.skipped).toBe(true);
+    expect(data.reason).toBe('no-update-pending');
+    expect(data.message).toMatch(/restart skipped/i);
+    expect(publishRealtimeMutation).not.toHaveBeenCalled();
+  });
+
+  it('publishes the realtime mutation when an update is pending', async () => {
+    await postUpdateState({ updatePending: true, version: '0.1.999' });
+    const res = await postRelaunch({ ifUpdatePending: true });
+    const data = await res.json() as { relaunched?: boolean; state?: { version?: string | null } };
+
+    expect(res.status).toBe(200);
+    expect(data.relaunched).toBe(true);
+    expect(data.state?.version).toBe('0.1.999');
+    expect(publishRealtimeMutation).toHaveBeenCalledTimes(1);
+    expect(publishRealtimeMutation.mock.calls[0]?.[0]).toMatchObject({
+      mutation: {
+        source: 'server',
+        action: 'app-relaunch-requested',
+        status: 'queued',
+      },
+    });
+  });
+});

--- a/tests/middleware-gate.test.ts
+++ b/tests/middleware-gate.test.ts
@@ -82,6 +82,16 @@ describe('panelGateMiddleware — loopback trust', () => {
     expect(res.status).toBe(401);
   });
 
+  it('gates /api/panel/app/relaunch (desktop restart request) against LAN', () => {
+    const res = panelGateMiddleware(
+      gatedRequest('http://192.168.1.50:3001/api/panel/app/relaunch', {
+        method: 'POST',
+        headers: { host: '192.168.1.50:3001' },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
   it('gates /api/browser/agent (embedded-browser verb bridge) against LAN', () => {
     const res = panelGateMiddleware(
       gatedRequest('http://192.168.1.50:3001/api/browser/agent', {


### PR DESCRIPTION
Closes #1418. CLI verb o8 app restart [--if-update-pending] → gated /api/panel/app/relaunch → realtime mutation → UpdateCard runs the same graceful restart the button uses. Optional autoApplyUpdates: when-idle (default off) applies only after 5 min operator inactivity with no streaming turns and no active lanes. Middleware + route-coverage discipline; real-path route tests. (Salvaged from the preserved/ branch after the worker died post-commit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj