### PR TITLE
feat: composer Mode section (Solo / Swarm / Collide) + symmetric Collide — Codex can be the aggregator (#1430)

### DIFF
--- a/src/app/api/panel/operator-defaults/route.ts
+++ b/src/app/api/panel/operator-defaults/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 
 import {
   getOperatorDefaults,
+  isCollideAggregator,
   isOrchestratorBackendSetting,
   updateOperatorDefaults,
   type OperatorDefaults,
@@ -194,6 +195,14 @@ function normalizeUpdate(body: Record<string, unknown>): Partial<OperatorDefault
       throw new Error('autoApplyUpdates must be one of "off", "when-idle".');
     }
     update.autoApplyUpdates = raw;
+  }
+
+  if (body.collideAggregator !== undefined) {
+    const raw = body.collideAggregator;
+    if (!isCollideAggregator(raw)) {
+      throw new Error('collideAggregator must be one of "auto", "claude", "codex".');
+    }
+    update.collideAggregator = raw;
   }
 
   const validateTier = (raw: unknown, name: string): OperatorDefaults['targetingTriage'] => {

--- a/src/components/desktop/settings/OperatorDefaultsTab.tsx
+++ b/src/components/desktop/settings/OperatorDefaultsTab.tsx
@@ -32,6 +32,7 @@ type ClassAComposer = 'auto' | 'haiku-cli' | 'sonnet-cli' | 'fastest';
 type WorkersUseBrain = 'off' | 'auto' | 'all';
 type OrchestratorBackendSetting = 'auto' | 'codex' | 'claude' | 'openclaw' | 'hermes' | 'collide';
 type AutoApplyUpdates = 'off' | 'when-idle';
+type CollideAggregator = 'auto' | 'claude' | 'codex';
 
 interface OperatorDefaults {
   parallelCap: number;
@@ -59,6 +60,7 @@ interface OperatorDefaults {
   targetingTriage: TargetingTierUI;
   targetingAction: TargetingTierUI;
   autoApplyUpdates: AutoApplyUpdates;
+  collideAggregator: CollideAggregator;
 }
 
 interface TargetingTierUI {
@@ -419,6 +421,7 @@ export function OperatorDefaultsTab() {
   const classAComposerEnv = sources?.classAComposer === 'env';
   const workersUseBrainEnv = sources?.workersUseBrain === 'env';
   const autoApplyUpdatesEnv = sources?.autoApplyUpdates === 'env';
+  const collideAggregatorEnv = sources?.collideAggregator === 'env';
 
   const envDisabledReason = 'Controlled by environment variable. Unset to manage from Settings.';
 
@@ -974,6 +977,28 @@ export function OperatorDefaultsTab() {
               ]}
               onChange={(next) => { void updateField('orchestratorBackend', next); }}
               disabled={sources?.orchestratorBackend === 'env' || busyField === 'orchestratorBackend'}
+            />
+          }
+        />
+        <Row
+          label="Collide aggregator"
+          description={values.collideAggregator === 'codex'
+            ? 'Codex decides: Claude and Codex propose independently, then Codex synthesizes and works on the main thread.'
+            : values.collideAggregator === 'claude'
+              ? 'Claude decides: Claude and Codex propose independently, then Claude synthesizes and works on the main thread.'
+              : 'Auto: follows the composer backend. Codex mode makes Codex decide; Claude models make Claude decide.'}
+          source={sources.collideAggregator}
+          disabledReason={collideAggregatorEnv ? envDisabledReason : undefined}
+          right={
+            <SegmentedControl<CollideAggregator>
+              value={values.collideAggregator}
+              options={[
+                { value: 'auto', label: 'Auto' },
+                { value: 'claude', label: 'Claude' },
+                { value: 'codex', label: 'Codex' },
+              ]}
+              onChange={(next) => { void updateField('collideAggregator', next); }}
+              disabled={collideAggregatorEnv || busyField === 'collideAggregator'}
             />
           }
         />

--- a/src/components/desktop/thoughts/InputButtons.tsx
+++ b/src/components/desktop/thoughts/InputButtons.tsx
@@ -530,6 +530,8 @@ export function InputButtons({
           onEffortChange={onEffortChange}
           swarmEnabled={swarmEnabled}
           onSetSwarm={onSetSwarm}
+          collideEnabled={collideEnabled}
+          onSetCollide={onSetCollide}
         />
       ) : null}
 
@@ -603,41 +605,6 @@ export function InputButtons({
         <SessionRulesChip threadId={sessionRulesThreadId} repoPath={repoPath} />
       ) : null}
 
-      {/* Collide / MoA toggle — icon-only, sibling to the permission chip.
-          Active = accent-tinted; Claude + Codex collide, Claude synthesizes. */}
-      {onSetCollide ? (
-        <button
-          type="button"
-          onClick={() => onSetCollide(!collideEnabled)}
-          aria-label={`Collide (Claude + Codex)${collideEnabled ? ' — on' : ''}`}
-          aria-pressed={collideEnabled}
-          title={`Collide — Claude and Codex each take a pass independently, then Claude fuses the best of both into one answer. Two frontier models thinking together, on your own subscriptions. Sharper when the problem's worth it, a touch slower. Toggle per message.${collideEnabled ? ' (On — click to turn off.)' : ''}`}
-          style={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            width: 24,
-            height: 24,
-            borderRadius: 6,
-            borderWidth: 0,
-            background: collideEnabled ? 'var(--t-accent-soft)' : 'transparent',
-            color: collideEnabled ? 'var(--t-accent)' : 'var(--t-text-faint)',
-            cursor: 'pointer',
-            transition: 'color 120ms, background 120ms',
-          }}
-          onMouseEnter={(event) => {
-            if (!collideEnabled) event.currentTarget.style.color = 'var(--t-text)';
-          }}
-          onMouseLeave={(event) => {
-            if (!collideEnabled) event.currentTarget.style.color = 'var(--t-text-faint)';
-          }}
-        >
-          <svg width={15} height={15} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" style={{ display: 'block', flexShrink: 0 }}>
-            <circle cx="9" cy="12" r="6" />
-            <circle cx="15" cy="12" r="6" />
-          </svg>
-        </button>
-      ) : null}
       </div>
 
       {/* Right action cluster — pinned, never shrinks or clips. */}

--- a/src/components/desktop/thoughts/ModelThinkingChip.tsx
+++ b/src/components/desktop/thoughts/ModelThinkingChip.tsx
@@ -88,6 +88,8 @@ export function ModelThinkingChip({
   onEffortChange,
   swarmEnabled = false,
   onSetSwarm,
+  collideEnabled = false,
+  onSetCollide,
   compact = false,
 }: {
   modelLabel: string;
@@ -100,6 +102,8 @@ export function ModelThinkingChip({
   onEffortChange?: (effort: ThinkingEffort) => void;
   swarmEnabled?: boolean;
   onSetSwarm?: (enabled: boolean) => void;
+  collideEnabled?: boolean;
+  onSetCollide?: (enabled: boolean) => void;
   compact?: boolean;
 }) {
   const [open, setOpen] = useState(false);
@@ -109,13 +113,16 @@ export function ModelThinkingChip({
   const options = adaptiveEnabled ? EFFORT_OPTIONS : EFFORT_OPTIONS.filter((option) => option !== 'adaptive');
   const selectedLabel = EFFORT_LABELS[effort];
   const ultraActive = Boolean(swarmEnabled);
+  const collideActive = Boolean(collideEnabled);
   const modelSwitchable = Boolean(onModelChange || onBackendChange);
-  const canOpen = Boolean(onEffortChange || onSetSwarm || onModelChange || onBackendChange);
+  const canOpen = Boolean(onEffortChange || onSetSwarm || onSetCollide || onModelChange || onBackendChange);
   const showingAffordance = canOpen && (hovered || focused || open);
   const isCodexBackend = activeBackend === 'codex';
   const effortSectionLabel = isCodexBackend ? 'Reasoning' : 'Thinking';
   const effortTitle = isCodexBackend ? 'reasoning' : 'thinking';
   const normalizedModelId = modelId?.replace(/\[[^\]]*\]$/, '');
+  const decideLabel = isCodexBackend ? 'Codex decides' : 'Claude decides';
+  const modeLabel = collideActive ? 'Collide' : ultraActive ? 'Ultracode' : 'Solo';
 
   return (
     <>
@@ -128,7 +135,7 @@ export function ModelThinkingChip({
         onFocus={() => setFocused(true)}
         onBlur={() => setFocused(false)}
         disabled={!canOpen}
-        title={ultraActive ? `${modelLabel} · Ultracode (swarm) · ${effortTitle} ${selectedLabel}` : `${modelLabel} · ${effortTitle} ${selectedLabel}`}
+        title={`${modelLabel} · ${modeLabel} · ${effortTitle} ${selectedLabel}`}
         aria-haspopup="menu"
         aria-expanded={open}
         style={{
@@ -143,10 +150,10 @@ export function ModelThinkingChip({
           paddingLeft: canOpen ? 5 : 0,
           borderWidth: 1,
           borderStyle: 'solid',
-          borderColor: ultraActive ? `color-mix(in srgb, ${SWARM_ACCENT} 32%, transparent)` : showingAffordance ? 'var(--t-border)' : 'transparent',
+          borderColor: ultraActive || collideActive ? `color-mix(in srgb, ${SWARM_ACCENT} 32%, transparent)` : showingAffordance ? 'var(--t-border)' : 'transparent',
           borderRadius: 7,
-          background: ultraActive ? `color-mix(in srgb, ${SWARM_ACCENT} 8%, transparent)` : showingAffordance ? 'var(--t-hover)' : 'transparent',
-          color: ultraActive ? 'var(--t-text)' : showingAffordance ? 'var(--t-text-muted)' : 'var(--t-text-faint)',
+          background: ultraActive || collideActive ? `color-mix(in srgb, ${SWARM_ACCENT} 8%, transparent)` : showingAffordance ? 'var(--t-hover)' : 'transparent',
+          color: ultraActive || collideActive ? 'var(--t-text)' : showingAffordance ? 'var(--t-text-muted)' : 'var(--t-text-faint)',
           cursor: canOpen ? 'pointer' : 'default',
           outline: focused && canOpen ? '2px solid var(--t-focus-ring)' : 'none',
           outlineOffset: 1,
@@ -159,7 +166,7 @@ export function ModelThinkingChip({
             {modelLabel}
           </span>
         )}
-        {ultraActive ? <SwarmGlyph size={11} /> : null}
+        {ultraActive || collideActive ? <SwarmGlyph size={11} /> : null}
         <ThinkingBars effort={effort} active={open || effort === 'max' || (isCodexBackend && effort === 'xhigh')} />
         <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" style={{ flexShrink: 0, opacity: canOpen ? 0.72 : 0 }}>
           <path d="m6 9 6 6 6-6" />
@@ -305,15 +312,63 @@ export function ModelThinkingChip({
             })}
           </div>
 
-          {onSetSwarm ? (
+          {onSetSwarm || onSetCollide ? (
             <div style={{ marginTop: 6, paddingTop: 6, borderTop: '1px solid var(--t-divider-subtle)', display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <div style={{ paddingLeft: 7, paddingRight: 7, paddingBottom: 2 }}>
+                <div style={{ fontSize: 9.5, fontWeight: 260, letterSpacing: '0', color: 'var(--t-text-faint)', lineHeight: 1.25 }}>Mode</div>
+              </div>
+              {[
+                { key: 'solo', order: 1, active: !ultraActive && !collideActive, label: 'Solo', detail: 'one orchestrator, works directly' },
+                { key: 'collide', order: 3, active: collideActive, label: 'Collide', detail: `Claude + Codex propose · ${decideLabel}` },
+              ].map((mode) => (
+                <button
+                  key={mode.key}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={mode.active}
+                  onClick={() => {
+                    onSetSwarm?.(false);
+                    onSetCollide?.(mode.key === 'collide' ? !collideActive : false);
+                    setOpen(false);
+                  }}
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'auto minmax(0, 1fr) auto',
+                    alignItems: 'center',
+                    gap: 8,
+                    minHeight: 30,
+                    paddingTop: 4,
+                    paddingRight: 6,
+                    paddingBottom: 4,
+                    paddingLeft: 7,
+                    borderWidth: 0,
+                    borderRadius: 8,
+                    background: mode.active ? `color-mix(in srgb, ${SWARM_ACCENT} 10%, transparent)` : 'transparent',
+                    color: 'var(--t-text)',
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    fontFamily: 'var(--font-sans-system)',
+                    order: mode.order,
+                  }}
+                  onMouseEnter={(event) => { if (!mode.active) event.currentTarget.style.background = 'var(--t-hover)'; }}
+                  onMouseLeave={(event) => { if (!mode.active) event.currentTarget.style.background = 'transparent'; }}
+                >
+                  <SwarmGlyph size={13} color={mode.active ? SWARM_ACCENT : 'var(--t-text-muted)'} />
+                  <span style={{ display: 'flex', flexDirection: 'column', gap: 1, minWidth: 0 }}>
+                    <span style={{ fontSize: 13.5, fontWeight: 300, letterSpacing: '0', lineHeight: 1.2, color: mode.active ? SWARM_ACCENT : 'var(--t-text)' }}>{mode.label}</span>
+                    <span style={{ fontSize: 9.5, fontWeight: 260, letterSpacing: '0', lineHeight: 1.25, color: 'var(--t-text-faint)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{mode.detail}</span>
+                  </span>
+                  <span style={{ width: 6, height: 6, borderRadius: 999, background: mode.active ? SWARM_ACCENT : 'transparent', flexShrink: 0 }} />
+                </button>
+              ))}
               <button
                 type="button"
                 role="menuitemradio"
                 aria-checked={ultraActive}
                 onClick={() => {
                   const next = !ultraActive;
-                  onSetSwarm(next);
+                  onSetSwarm?.(next);
+                  onSetCollide?.(false);
                   if (next) onEffortChange?.('xhigh');
                   setOpen(false);
                 }}
@@ -334,14 +389,15 @@ export function ModelThinkingChip({
                   cursor: 'pointer',
                   textAlign: 'left',
                   fontFamily: 'var(--font-sans-system)',
+                  order: 2,
                 }}
                 onMouseEnter={(event) => { if (!ultraActive) event.currentTarget.style.background = 'var(--t-hover)'; }}
                 onMouseLeave={(event) => { if (!ultraActive) event.currentTarget.style.background = 'transparent'; }}
               >
                 <SwarmGlyph size={13} color={ultraActive ? SWARM_ACCENT : 'var(--t-text-muted)'} />
                 <span style={{ display: 'flex', flexDirection: 'column', gap: 1, minWidth: 0 }}>
-                  <span style={{ fontSize: 13.5, fontWeight: 300, letterSpacing: '0', lineHeight: 1.2, color: ultraActive ? SWARM_ACCENT : 'var(--t-text)' }}>Ultracode</span>
-                  <span style={{ fontSize: 9.5, fontWeight: 260, letterSpacing: '0', lineHeight: 1.25, color: 'var(--t-text-faint)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>Claude + Codex swarm</span>
+                  <span style={{ fontSize: 13.5, fontWeight: 300, letterSpacing: '0', lineHeight: 1.2, color: ultraActive ? SWARM_ACCENT : 'var(--t-text)' }}>Swarm (Ultracode)</span>
+                  <span style={{ fontSize: 9.5, fontWeight: 260, letterSpacing: '0', lineHeight: 1.25, color: 'var(--t-text-faint)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>sub-agents + Codex workers in parallel</span>
                 </span>
                 <span style={{ width: 6, height: 6, borderRadius: 999, background: ultraActive ? SWARM_ACCENT : 'transparent', flexShrink: 0 }} />
               </button>

--- a/src/components/desktop/thoughts/useOrchestratorStream.ts
+++ b/src/components/desktop/thoughts/useOrchestratorStream.ts
@@ -850,6 +850,7 @@ export function useOrchestratorStream(
     const displayMessage = options?.displayMessage?.trim() || message;
     const localEntriesAfterUser = options?.localEntriesAfterUser ?? [];
     const collide = options?.collide === true;
+    const collideBaseBackend = collide ? options?.backend : undefined;
     const backend = collide ? 'collide' : options?.backend;
     // Collide is its own fusion — the swarm hint does not apply on a Collide turn.
     const swarm = options?.swarm === true && !collide;
@@ -960,6 +961,7 @@ export function useOrchestratorStream(
         // Per-turn backend override keeps the composer chip truthful even while
         // the global operator default write is still settling.
         ...(backend ? { backend } : {}),
+        ...(collideBaseBackend ? { collideBaseBackend } : {}),
         ...(options?.attachments?.length ? { attachments: options.attachments } : {}),
       });
       const delivered = await deliverOrchestratorPayload({

--- a/src/lib/lane/orchestrator-backends/collide-config.ts
+++ b/src/lib/lane/orchestrator-backends/collide-config.ts
@@ -11,6 +11,7 @@
 
 import type { OrchestratorBackendId } from './types';
 import type { MoaConfig, MoaParticipant } from './moa';
+import { resolveCollideAggregatorSync, type CollideAggregator } from '@/lib/operator/defaults';
 
 /** Default brain — Claude (opus, max) + Codex (gpt-5.5, xhigh) → Claude (opus, max). */
 export const DEFAULT_COLLIDE_CONFIG: MoaConfig = {
@@ -57,13 +58,22 @@ function parseAggregatorEnv(raw: string | undefined): MoaParticipant | null {
   }
 }
 
+function aggregatorFor(defaultSetting: CollideAggregator, activeBackend?: OrchestratorBackendId): MoaParticipant {
+  const backend = defaultSetting === 'auto'
+    ? activeBackend === 'codex' ? 'codex' : 'claude'
+    : defaultSetting;
+  const fallback = DEFAULT_COLLIDE_CONFIG.proposers.find((p) => p.backend === backend);
+  return fallback ?? { backend };
+}
+
 /**
  * Resolve the active Collide config. Pure-ish: reads env each call so an
  * override applies on the next turn. Always returns a valid config (falls back
  * to the code default piece-by-piece).
  */
-export function resolveCollideConfig(): MoaConfig {
+export function resolveCollideConfig(activeBackend?: OrchestratorBackendId): MoaConfig {
   const proposers = parseProposersEnv(process.env.O8_COLLIDE_PROPOSERS) ?? DEFAULT_COLLIDE_CONFIG.proposers;
-  const aggregator = parseAggregatorEnv(process.env.O8_COLLIDE_AGGREGATOR) ?? DEFAULT_COLLIDE_CONFIG.aggregator;
+  const aggregator = parseAggregatorEnv(process.env.O8_COLLIDE_AGGREGATOR)
+    ?? aggregatorFor(resolveCollideAggregatorSync(), activeBackend);
   return { id: 'collide', label: 'Collide', proposers, aggregator };
 }

--- a/src/lib/lane/orchestrator-backends/moa.test.ts
+++ b/src/lib/lane/orchestrator-backends/moa.test.ts
@@ -56,6 +56,8 @@ const isProposerCall = (c: MockCall) => Boolean(c.options?.threadId?.includes(':
 const isAggregatorCall = (c: MockCall) => c.options?.threadId === MAIN_THREAD;
 
 function setup(opts: {
+  config?: MoaConfig;
+  claudeEvents?: OrchestratorEvent[];
   claudeProposal?: string;
   codexEvents?: OrchestratorEvent[];
   aggregatorText?: string;
@@ -66,7 +68,9 @@ function setup(opts: {
   // Claude is BOTH a proposer (side-thread) and the aggregator (main thread) —
   // one backend, distinguished by threadId. That IS the structural independence.
   const claude = mockBackend('claude', claudeCalls, (call) =>
-    isProposerCall(call)
+    isProposerCall(call) && opts.claudeEvents
+      ? opts.claudeEvents
+      : isProposerCall(call)
       ? [{ type: 'text', text: opts.claudeProposal ?? 'CLAUDE_PROPOSAL' }, { type: 'done', sessionId: 'c1', cost: null }]
       : [{ type: 'text', text: opts.aggregatorText ?? 'SYNTHESIZED ANSWER' }, { type: 'done', sessionId: 'agg', cost: null }],
   );
@@ -75,7 +79,7 @@ function setup(opts: {
   );
 
   const deps: MoaDeps = { resolveBackend: (id) => (id === 'codex' ? codex : claude) };
-  const backend = makeMoaBackend(CONFIG, deps);
+  const backend = makeMoaBackend(opts.config ?? CONFIG, deps);
   return { backend, claudeCalls, codexCalls };
 }
 
@@ -182,6 +186,32 @@ describe('Collide fusion engine', () => {
     const agg = claudeCalls.find(isAggregatorCall)!;
     expect(agg.message).not.toContain('CODEX_WANTS_EXTERNAL'); // quarantined out of synthesis
     expect(claudeCalls.filter(isAggregatorCall)).toHaveLength(1);
+  });
+
+  it('(d4) Codex aggregation excludes a Claude proposer that attempts dispatch', async () => {
+    const events: OrchestratorEvent[] = [];
+    const codexAggregates: MoaConfig = {
+      ...CONFIG,
+      aggregator: { backend: 'codex', model: 'm-codex-agg' },
+    };
+    const { backend, codexCalls } = setup({
+      config: codexAggregates,
+      claudeEvents: [
+        { type: 'text', text: 'CLAUDE_WANTS_TO_DISPATCH' },
+        { type: 'tool_use', id: 't1', name: 'mcp__cortex__cortex_launch_agent', input: { task: 'go' } },
+      ],
+    });
+    await backend.sendTurn('/repo', 'build X', (e) => events.push(e), { threadId: MAIN_THREAD });
+
+    const breach = events.find((e) => e.type === 'collide_proposal' && e.breach) as
+      | Extract<OrchestratorEvent, { type: 'collide_proposal' }> | undefined;
+    expect(breach).toBeDefined();
+    expect(breach!.proposer).toBe('Claude');
+    expect(breach!.text).toBe('');
+    const agg = codexCalls.find(isAggregatorCall)!;
+    expect(agg.message).not.toContain('CLAUDE_WANTS_TO_DISPATCH');
+    expect(agg.message).toContain('excluded');
+    expect(codexCalls.filter(isAggregatorCall)).toHaveLength(1);
   });
 
   it('(e) proposers are independent — distinct side-thread ids (indexed by position), separate from main', async () => {

--- a/src/lib/lane/orchestrator-backends/moa.ts
+++ b/src/lib/lane/orchestrator-backends/moa.ts
@@ -291,7 +291,7 @@ async function runProposal(
  * injectable so the engine test can drive mock proposers + a mock aggregator.
  */
 export function makeMoaBackend(
-  configOrThunk: MoaConfig | (() => MoaConfig),
+  configOrThunk: MoaConfig | ((options?: OrchestratorTurnOptions) => MoaConfig),
   deps: MoaDeps = defaultDeps,
 ): OrchestratorBackend {
   const resolveConfig = typeof configOrThunk === 'function' ? configOrThunk : () => configOrThunk;
@@ -311,7 +311,7 @@ export function makeMoaBackend(
       return agg.ensureSession(repoPath, undefined, threadId);
     },
     async sendTurn(repoPath, message, onEvent, options?: OrchestratorTurnOptions): Promise<void> {
-      const config = resolveConfig();
+      const config = resolveConfig(options);
       const mainThreadId = options?.threadId ?? null;
       const signal = options?.signal;
 
@@ -381,4 +381,4 @@ export function makeMoaBackend(
 }
 
 /** The shipping Collide backend — config resolved lazily per turn from settings. */
-export const collideBackend: OrchestratorBackend = makeMoaBackend(() => resolveCollideConfig());
+export const collideBackend: OrchestratorBackend = makeMoaBackend((options) => resolveCollideConfig(options?.collideBaseBackend));

--- a/src/lib/lane/orchestrator-backends/types.ts
+++ b/src/lib/lane/orchestrator-backends/types.ts
@@ -54,6 +54,8 @@ export interface OrchestratorTurnOptions {
   toolProfile?: ToolProfile;
   thinkingEffort?: ThinkingEffort;
   model?: string;
+  /** For a Collide turn, the composer backend selected before routing to `collide`. */
+  collideBaseBackend?: OrchestratorBackendId;
   /** UI/history thread id (thoughts-*), used to isolate backend session identity. */
   threadId?: string | null;
   /**

--- a/src/lib/mcp/operator-handlers/status.ts
+++ b/src/lib/mcp/operator-handlers/status.ts
@@ -160,6 +160,11 @@ export const STATUS_TOOLS: McpTool[] = [
           enum: ['auto', 'codex', 'claude', 'openclaw', 'hermes', 'collide', 'fable'],
           description: 'Active in-app orchestrator backend. Use "codex" for Codex GPT-5.5, "claude" for Claude Code, or "auto" for legacy toggle resolution.',
         },
+        collideAggregator: {
+          type: 'string',
+          enum: ['auto', 'claude', 'codex'],
+          description: 'Collide aggregator override. "auto" follows the active composer backend; "claude" or "codex" force the synthesizer.',
+        },
         thinkingEffort: {
           type: 'string',
           enum: ['adaptive', 'low', 'medium', 'high', 'max', 'xhigh'],
@@ -199,6 +204,7 @@ export const STATUS_TOOLS: McpTool[] = [
 const OPERATOR_DEFAULTS_KEYS = [
   'orchestratorModel',
   'orchestratorBackend',
+  'collideAggregator',
   'thinkingEffort',
   'overlapGate',
   'parallelCap',

--- a/src/lib/operator/defaults.ts
+++ b/src/lib/operator/defaults.ts
@@ -121,6 +121,12 @@ export function isOrchestratorBackendSetting(value: unknown): value is Orchestra
     || value === 'hermes' || value === 'collide' || value === 'fable';
 }
 
+export type CollideAggregator = 'auto' | 'claude' | 'codex';
+
+export function isCollideAggregator(value: unknown): value is CollideAggregator {
+  return value === 'auto' || value === 'claude' || value === 'codex';
+}
+
 export interface OperatorDefaults {
   parallelCap: number;
   overlapGate: OverlapGateMode;
@@ -234,6 +240,8 @@ export interface OperatorDefaults {
   targetingAction: TargetingTier;
   /** Auto-apply downloaded desktop updates only under conservative idle gates. */
   autoApplyUpdates: AutoApplyUpdates;
+  /** Collide aggregator override. Auto follows the active composer backend. */
+  collideAggregator: CollideAggregator;
 }
 
 export interface OperatorDefaultsWithSources {
@@ -281,6 +289,7 @@ export const OPERATOR_DEFAULTS_FALLBACK: OperatorDefaults = {
   targetingTriage: { runtime: 'codex', model: '', effort: 'low' },
   targetingAction: { runtime: 'codex', model: '', effort: 'high' },
   autoApplyUpdates: 'off',
+  collideAggregator: 'auto',
 };
 
 export const CLASS_A_COMPOSER_OPTIONS: Array<{ value: ClassAComposer; label: string; detail: string }> = [
@@ -471,6 +480,12 @@ function envOrchestratorBackend(): OrchestratorBackendSetting | null {
   return null;
 }
 
+function envCollideAggregator(): CollideAggregator | null {
+  const raw = process.env.O8_COLLIDE_AGGREGATOR_DEFAULT?.trim();
+  if (raw && isCollideAggregator(raw)) return raw;
+  return null;
+}
+
 function envAutoApplyUpdates(): AutoApplyUpdates | null {
   const raw = process.env.O8_AUTO_APPLY_UPDATES?.trim();
   if (raw === 'off' || raw === 'when-idle') return raw;
@@ -505,6 +520,7 @@ interface StoredOperatorDefaults {
   targetingTriage?: TargetingTier;
   targetingAction?: TargetingTier;
   autoApplyUpdates?: AutoApplyUpdates;
+  collideAggregator?: CollideAggregator;
 }
 
 function parseStoredDefaults(raw: string): StoredOperatorDefaults {
@@ -595,6 +611,9 @@ function resolveFromFile(stored: StoredOperatorDefaults): Partial<OperatorDefaul
   if (stored.autoApplyUpdates === 'off' || stored.autoApplyUpdates === 'when-idle') {
     result.autoApplyUpdates = stored.autoApplyUpdates;
   }
+  if (isCollideAggregator(stored.collideAggregator)) {
+    result.collideAggregator = stored.collideAggregator;
+  }
   const storedTriage = coerceStoredTier(stored.targetingTriage, OPERATOR_DEFAULTS_FALLBACK.targetingTriage);
   if (storedTriage) result.targetingTriage = storedTriage;
   const storedAction = coerceStoredTier(stored.targetingAction, OPERATOR_DEFAULTS_FALLBACK.targetingAction);
@@ -628,6 +647,7 @@ function resolveDefaults(fileValues: Partial<OperatorDefaults>): OperatorDefault
   const envBrain = envWorkersUseBrain();
   const envOrchBackend = envOrchestratorBackend();
   const envApplyUpdates = envAutoApplyUpdates();
+  const envCollideAgg = envCollideAggregator();
   const envTriage = envTargetingTier('TRIAGE');
   const envAction = envTargetingTier('ACTION');
 
@@ -661,6 +681,7 @@ function resolveDefaults(fileValues: Partial<OperatorDefaults>): OperatorDefault
     targetingTriage: mergeTier(envTriage, fileValues.targetingTriage, OPERATOR_DEFAULTS_FALLBACK.targetingTriage),
     targetingAction: mergeTier(envAction, fileValues.targetingAction, OPERATOR_DEFAULTS_FALLBACK.targetingAction),
     autoApplyUpdates: envApplyUpdates ?? fileValues.autoApplyUpdates ?? OPERATOR_DEFAULTS_FALLBACK.autoApplyUpdates,
+    collideAggregator: envCollideAgg ?? fileValues.collideAggregator ?? OPERATOR_DEFAULTS_FALLBACK.collideAggregator,
   };
 
   const sources: Record<keyof OperatorDefaults, SettingSource> = {
@@ -693,6 +714,7 @@ function resolveDefaults(fileValues: Partial<OperatorDefaults>): OperatorDefault
     targetingTriage: envTriage !== null ? 'env' : fileValues.targetingTriage !== undefined ? 'file' : 'default',
     targetingAction: envAction !== null ? 'env' : fileValues.targetingAction !== undefined ? 'file' : 'default',
     autoApplyUpdates: envApplyUpdates !== null ? 'env' : fileValues.autoApplyUpdates !== undefined ? 'file' : 'default',
+    collideAggregator: envCollideAgg !== null ? 'env' : fileValues.collideAggregator !== undefined ? 'file' : 'default',
   };
 
   return { values: resolved, sources };
@@ -845,6 +867,12 @@ export async function updateOperatorDefaults(update: Partial<OperatorDefaults>):
     }
     stored.autoApplyUpdates = update.autoApplyUpdates;
   }
+  if (update.collideAggregator !== undefined) {
+    if (!isCollideAggregator(update.collideAggregator)) {
+      throw new Error('collideAggregator must be "auto", "claude", or "codex".');
+    }
+    stored.collideAggregator = update.collideAggregator;
+  }
   if (update.targetingTriage !== undefined) {
     if (!isTargetingTier(update.targetingTriage)) {
       throw new Error('targetingTriage must be { runtime: dispatch-runtime, model: string, effort: thinking-effort }.');
@@ -945,6 +973,10 @@ export function resolveWorkersUseBrainSync(): WorkersUseBrain {
  */
 export function resolveOrchestratorBackendSync(): OrchestratorBackendSetting {
   return getOperatorDefaultsSync().values.orchestratorBackend;
+}
+
+export function resolveCollideAggregatorSync(): CollideAggregator {
+  return getOperatorDefaultsSync().values.collideAggregator;
 }
 
 /** The Targeting Machine's cheap triage/rationale tier (env > file > fallback). */

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -2854,6 +2854,9 @@ async function handleOrchestratorSendMsg(client: ClientState, msg: Record<string
     : undefined;
 
   const backend = getOrchestratorBackend(resolveMsgBackendId(msg));
+  const collideBaseBackend = backend.id === 'collide' && isOrchestratorBackendId(msg.collideBaseBackend)
+    ? msg.collideBaseBackend
+    : undefined;
   const agentId = resolveMsgAgentId(msg, backend.id);
   const agentTag = agentId || undefined;
   const threadId = resolveMsgThreadId(msg);
@@ -2971,7 +2974,7 @@ async function handleOrchestratorSendMsg(client: ClientState, msg: Record<string
     const sendTurn = (
       onEvent: (event: OrchestratorEvent) => void,
       signal: AbortSignal,
-    ): Promise<void> => backend.sendTurn(repoPath, turnMessage, onEvent, { permissionMode, thinkingEffort, model, agent: agentTag, threadId, signal, ...(attachments?.length ? { attachments } : {}) });
+    ): Promise<void> => backend.sendTurn(repoPath, turnMessage, onEvent, { permissionMode, thinkingEffort, model, collideBaseBackend, agent: agentTag, threadId, signal, ...(attachments?.length ? { attachments } : {}) });
 
     // Ensure a subscription exists for the selected backend + agent.
     orchestratorSubscriptions.set(orchestratorSubKey(client.id, backend.id, agentId), {


### PR DESCRIPTION
Closes #1430. Mode section in the composer picker with truthful subtitles ('Claude decides' / 'Codex decides' follows the active backend); standalone Collide button retired; collideAggregator auto|claude|codex plumbed through defaults/route/Settings/MCP; collideBaseBackend threaded composer → ws-server (validated) → MoA resolver. Mirror-direction proposer lockout verified through the real sendTurn: a Claude proposer attempting dispatch is breached, stripped, and excluded from Codex's synthesis. 47/47 collide+authz suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj