### PR TITLE
fix: keep packet transcript working footer live (#1431)

### DIFF
--- a/src/components/desktop/workspace-terminal/PacketWorkingFooter.tsx
+++ b/src/components/desktop/workspace-terminal/PacketWorkingFooter.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { memo, useEffect, useMemo, useState } from 'react';
+import { AgentStatusDot } from '@/components/desktop/AgentStatusDot';
+import type { PacketTranscriptActivity } from '@/components/desktop/workspace-terminal/use-packet-transcript-poll';
+import type { OrchestratorPacketStatus } from '@/lib/orchestrator/types';
+
+interface PacketWorkingFooterProps {
+  status: OrchestratorPacketStatus | null;
+  runtimeLabel: string;
+  activity: PacketTranscriptActivity | null;
+  fallbackStartedAt?: string | number | null;
+}
+
+function isWorkingStatus(status: OrchestratorPacketStatus | null): boolean {
+  return status === 'running' || status === 'launching' || status === 'recovering';
+}
+
+function toMs(value: string | number | null | undefined): number | null {
+  if (value == null) return null;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes <= 0) return `${seconds}s`;
+  if (minutes < 60) return `${minutes}m ${seconds}s`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+function PacketWorkingFooterBase({
+  status,
+  runtimeLabel,
+  activity,
+  fallbackStartedAt,
+}: PacketWorkingFooterProps) {
+  const working = isWorkingStatus(status);
+  const startedAtMs = useMemo(
+    () => toMs(activity?.startedAt ?? fallbackStartedAt),
+    [activity?.startedAt, fallbackStartedAt],
+  );
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!working) return undefined;
+    const interval = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(interval);
+  }, [working, startedAtMs]);
+
+  if (!working) return null;
+
+  const label = activity?.label ?? 'Working';
+  const elapsed = startedAtMs == null ? null : formatElapsed(now - startedAtMs);
+  const text = activity
+    ? `${label} ${elapsed ?? ''}`.trim()
+    : `${label}${elapsed ? ` — ${elapsed}` : ''}`;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 7,
+        paddingTop: 12,
+        paddingRight: 16,
+        paddingBottom: 12,
+        paddingLeft: 16,
+      }}
+    >
+      <AgentStatusDot state="running" startedAt={startedAtMs} label={`${runtimeLabel} working`} />
+      <span
+        style={{
+          fontSize: 11,
+          color: 'var(--t-text-faint)',
+          fontFamily: 'var(--font-sans-system)',
+          fontWeight: 500,
+        }}
+      >
+        {text}
+      </span>
+    </div>
+  );
+}
+
+export const PacketWorkingFooter = memo(PacketWorkingFooterBase);

--- a/src/components/desktop/workspace-terminal/WorkspaceChatPane.tsx
+++ b/src/components/desktop/workspace-terminal/WorkspaceChatPane.tsx
@@ -25,6 +25,7 @@ import { WorkspaceChatComposer } from '@/components/desktop/workspace-terminal/W
 import { ChatPacketStatusBanner } from '@/components/desktop/workspace-terminal/ChatPacketStatusBanner';
 import { ChatPacketReviewDiff } from '@/components/desktop/workspace-terminal/ChatPacketReviewDiff';
 import { PacketHeaderCard } from '@/components/desktop/workspace-terminal/PacketHeaderCard';
+import { PacketWorkingFooter } from '@/components/desktop/workspace-terminal/PacketWorkingFooter';
 import {
   WorkspaceRichChatEvents,
   stripWorkspaceRichRendererFallback,
@@ -373,27 +374,12 @@ function WorkspaceChatPaneBase({
                           );
                         })}
                         {stillWorking && !awaitingReview ? (
-                          <div style={{ display: 'flex', alignItems: 'center', gap: 6, paddingTop: 8, paddingBottom: 4 }}>
-                            <div style={{ display: 'flex', gap: 3, alignItems: 'center' }}>
-                              {[0, 1, 2].map((dot) => (
-                                <span
-                                  key={dot}
-                                  style={{
-                                    width: 5,
-                                    height: 5,
-                                    borderRadius: '50%',
-                                    background: '#22c55e',
-                                    opacity: 0.4,
-                                    animation: `o8ThinkPulse 1.4s ease-in-out ${dot * 0.2}s infinite`,
-                                  }}
-                                />
-                              ))}
-                            </div>
-                            <span style={{ fontSize: 11, color: 'var(--t-text-faint)', fontFamily: 'var(--font-sans-system)', fontWeight: 500 }}>
-                              {chat.runtimeLabel} working…
-                            </span>
-                            <style>{'@keyframes o8ThinkPulse { 0%, 80%, 100% { opacity: 0.25; transform: scale(0.8); } 40% { opacity: 1; transform: scale(1.1); } }'}</style>
-                          </div>
+                          <PacketWorkingFooter
+                            status={liveStatus}
+                            runtimeLabel={chat.runtimeLabel}
+                            activity={chat.packetTranscriptActivity}
+                            fallbackStartedAt={livePacket?.lane?.lastEventAt ?? livePacket?.lastEventAt ?? null}
+                          />
                         ) : null}
                         <div style={{ display: 'flex', flexDirection: 'column', gap: 12, alignItems: 'flex-start', paddingTop: 4 }}>
                           {reviewAffordances}
@@ -629,37 +615,12 @@ function WorkspaceChatPaneBase({
                 </div>
               ) : null}
               {!chat.agentRunning && chat.isRuntimeBound && chat.supervisorActive && chat.messages.length > 0 && !laneRetired ? (
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 6,
-                    paddingTop: 12,
-                    paddingRight: 16,
-                    paddingBottom: 12,
-                    paddingLeft: 16,
-                  }}
-                >
-                  <div style={{ display: 'flex', gap: 3, alignItems: 'center' }}>
-                    {[0, 1, 2].map((index) => (
-                      <span
-                        key={index}
-                        style={{
-                          width: 5,
-                          height: 5,
-                          borderRadius: '50%',
-                          background: '#22c55e',
-                          opacity: 0.4,
-                          animation: `o8ThinkPulse 1.4s ease-in-out ${index * 0.2}s infinite`,
-                        }}
-                      />
-                    ))}
-                  </div>
-                  <span style={{ fontSize: 11, color: 'var(--t-text-faint)', fontFamily: 'var(--font-sans-system)', fontWeight: 500 }}>
-                    Agent working...
-                  </span>
-                  <style>{'@keyframes o8ThinkPulse { 0%, 80%, 100% { opacity: 0.25; transform: scale(0.8); } 40% { opacity: 1; transform: scale(1.1); } }'}</style>
-                </div>
+                <PacketWorkingFooter
+                  status={liveStatus}
+                  runtimeLabel={chat.runtimeLabel}
+                  activity={chat.packetTranscriptActivity}
+                  fallbackStartedAt={livePacket?.lane?.lastEventAt ?? livePacket?.lastEventAt ?? null}
+                />
               ) : null}
               {tab.orchestrationPacket && livePacket ? (
                 <ChatPacketStatusBanner

--- a/src/components/desktop/workspace-terminal/use-packet-transcript-poll.ts
+++ b/src/components/desktop/workspace-terminal/use-packet-transcript-poll.ts
@@ -36,6 +36,16 @@ function releaseTranscriptFetchSlot(): void {
 }
 const TRANSCRIPT_TAIL_LIMIT = 200;
 
+export interface PacketTranscriptActivity {
+  label: string;
+  startedAt: string | number | null;
+}
+
+export interface PacketTranscriptPollResult {
+  entries: MobileTranscriptEntry[];
+  activity: PacketTranscriptActivity | null;
+}
+
 /**
  * #1293 — Pure map from the normalized packet transcript (`TranscriptEvent[]`,
  * produced server-side by the SAME `normalizeCodexEvents` the AgentsTab uses)
@@ -124,6 +134,25 @@ export function mapPacketTranscriptEntries(events: TranscriptEvent[]): MobileTra
   return entries;
 }
 
+function packetToolActivityLabel(event: Extract<TranscriptEvent, { type: 'tool_call' }>): string {
+  if (event.tool === 'exec_command') return 'Running terminal command…';
+  if (event.tool === 'read_file' || event.tool === 'Read') return 'Reading files…';
+  if (event.tool === 'list_files' || event.tool === 'Glob') return 'Listing files…';
+  if (event.tool === 'search_code' || event.tool === 'Grep') return 'Searching code…';
+  if (event.tool === 'search_web' || event.tool === 'WebSearch') return 'Searching web…';
+  if (event.tool === 'Edit' || event.tool === 'Write' || event.tool === 'NotebookEdit') return 'Editing files…';
+  return `Running ${event.tool}…`;
+}
+
+export function derivePacketTranscriptActivity(events: TranscriptEvent[]): PacketTranscriptActivity | null {
+  const latest = [...events].reverse().find((event) => event.type !== 'done');
+  if (!latest) return null;
+  if (latest.type === 'tool_call') return { label: packetToolActivityLabel(latest), startedAt: latest.ts };
+  if (latest.type === 'assistant' || latest.type === 'tool_result') return { label: 'Thinking…', startedAt: latest.ts };
+  if (latest.type === 'error') return { label: 'Recovering…', startedAt: latest.ts };
+  return null;
+}
+
 interface UsePacketTranscriptPollArgs {
   /**
    * ADDITIVE gate. Must be `true` ONLY when the sessionKey-keyed transcript
@@ -152,8 +181,9 @@ export function usePacketTranscriptPoll({
   packetIdHint,
   sessionKey,
   active,
-}: UsePacketTranscriptPollArgs): MobileTranscriptEntry[] {
+}: UsePacketTranscriptPollArgs): PacketTranscriptPollResult {
   const [packetEvents, setPacketEvents] = useState<MobileTranscriptEntry[]>([]);
+  const [packetActivity, setPacketActivity] = useState<PacketTranscriptActivity | null>(null);
   const hasEventsRef = useRef(false);
   const orchestratorData = useOrchestratorData();
 
@@ -171,6 +201,7 @@ export function usePacketTranscriptPoll({
   const packetId = livePacket?.id ?? packetIdHint;
   const status = livePacket?.status ?? null;
   const visiblePacketEvents = enabled && (packetId || sessionKey) ? packetEvents : [];
+  const visiblePacketActivity = enabled && (packetId || sessionKey) ? packetActivity : null;
 
   useEffect(() => {
     // sessionKey fallback — the tab always carries its lane sessionKey, but
@@ -213,6 +244,7 @@ export function usePacketTranscriptPoll({
         const mapped = mapPacketTranscriptEntries(payload.events);
         hasEventsRef.current = mapped.length > 0;
         setPacketEvents(mapped);
+        setPacketActivity(derivePacketTranscriptActivity(payload.events));
       } catch {
         /* best-effort — transient network error or abort */
       } finally {
@@ -237,5 +269,5 @@ export function usePacketTranscriptPoll({
     };
   }, [enabled, packetId, sessionKey, status, active]);
 
-  return visiblePacketEvents;
+  return { entries: visiblePacketEvents, activity: visiblePacketActivity };
 }

--- a/src/components/desktop/workspace-terminal/useWorkspaceChatModelOptions.ts
+++ b/src/components/desktop/workspace-terminal/useWorkspaceChatModelOptions.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  CLAUDE_CLI_MODELS,
+  CODEX_CLI_MODELS,
+  GEMINI_CLI_MODELS,
+  getOpenCodeModels,
+} from '@/components/desktop/workspace-terminal/constants';
+import type {
+  WorkspaceChatRuntime,
+  WorkspaceCliModelOption,
+} from '@/components/desktop/workspace-terminal/types';
+import { getCachedOpenCodeProviders, loadOpenCodeProviders } from '@/lib/setup/detection-cache';
+
+export function useWorkspaceChatModelOptions(
+  chatRuntime: WorkspaceChatRuntime | undefined,
+  selectedModelId: string | undefined,
+): {
+  availableModels: WorkspaceCliModelOption[];
+  selectedModel: WorkspaceCliModelOption;
+  selectedModelLabel: string | undefined;
+} {
+  const [openCodeProviders, setOpenCodeProviders] = useState<string[]>(() => getCachedOpenCodeProviders());
+  const openCodeProvidersLoadedRef = useRef(openCodeProviders.length > 0);
+
+  useEffect(() => {
+    if (chatRuntime !== 'opencode' || openCodeProvidersLoadedRef.current) return;
+    openCodeProvidersLoadedRef.current = true;
+    let cancelled = false;
+    void loadOpenCodeProviders().then((providers) => {
+      if (!cancelled) setOpenCodeProviders(providers);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [chatRuntime]);
+
+  const availableModels = useMemo<WorkspaceCliModelOption[]>(
+    () => {
+      if (chatRuntime === 'claude-code') return CLAUDE_CLI_MODELS;
+      if (chatRuntime === 'gemini') return GEMINI_CLI_MODELS;
+      if (chatRuntime === 'opencode') return getOpenCodeModels(openCodeProviders);
+      return CODEX_CLI_MODELS;
+    },
+    [chatRuntime, openCodeProviders],
+  );
+  const selectedModel = useMemo(
+    () => availableModels.find((model) => model.id === selectedModelId) ?? availableModels[0] ?? CODEX_CLI_MODELS[0],
+    [availableModels, selectedModelId],
+  );
+
+  return {
+    availableModels,
+    selectedModel,
+    selectedModelLabel: selectedModel?.label,
+  };
+}

--- a/src/components/desktop/workspace-terminal/useWorkspaceChatPane.ts
+++ b/src/components/desktop/workspace-terminal/useWorkspaceChatPane.ts
@@ -2,18 +2,10 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { buildLinkedIssueContext } from '@/components/desktop/IssueLinkPicker';
-import {
-  CLAUDE_CLI_MODELS,
-  CODEX_CLI_MODELS,
-  GEMINI_CLI_MODELS,
-  getOpenCodeModels,
-} from '@/components/desktop/workspace-terminal/constants';
-import type {
-  TerminalTab,
-  WorkspaceCliModelOption,
-} from '@/components/desktop/workspace-terminal/types';
+import type { TerminalTab } from '@/components/desktop/workspace-terminal/types';
 import { mapWorkspaceTranscriptMessages } from '@/components/desktop/workspace-terminal/workspace-chat-message-mapper';
 import { usePacketTranscriptPoll } from '@/components/desktop/workspace-terminal/use-packet-transcript-poll';
+import { useWorkspaceChatModelOptions } from '@/components/desktop/workspace-terminal/useWorkspaceChatModelOptions';
 import {
   buildClaudePermissionDecisionMessage,
   coerceClaudeCodeChatEvent,
@@ -21,7 +13,6 @@ import {
   type ClaudePermissionDecision,
   type WorkspaceStreamEvent,
 } from '@/components/desktop/workspace-terminal/workspace-stream-events';
-import { getCachedOpenCodeProviders, loadOpenCodeProviders } from '@/lib/setup/detection-cache';
 import { getRuntimeCapability } from '@/lib/orchestrator/runtime-capabilities';
 import {
   buildQueuedContextCard,
@@ -67,7 +58,6 @@ export function useWorkspaceChatPane({
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
   const [agentRunning, setAgentRunning] = useState(false);
-  const [openCodeProviders, setOpenCodeProviders] = useState<string[]>(() => getCachedOpenCodeProviders());
   const [queuedContextCards, setQueuedContextCards] = useState<ReturnType<typeof buildQueuedContextCard>[]>([]);
   const [liveAssistantId, setLiveAssistantId] = useState<string | null>(null);
   const [streamingText, setStreamingText] = useState('');
@@ -92,7 +82,6 @@ export function useWorkspaceChatPane({
   const messagesRef = useRef<MobileTranscriptEntry[]>([]);
   const stickToBottomRef = useRef(true);
   const handledDraftInjectionRef = useRef<string | null>(null);
-  const openCodeProvidersLoadedRef = useRef(openCodeProviders.length > 0);
   const streamRequest = useActiveLongLivedRequest(active);
 
   const tabId = tab.id;
@@ -111,20 +100,7 @@ export function useWorkspaceChatPane({
     () => getRuntimeCapability(chatRuntime ?? 'codex').label,
     [chatRuntime],
   );
-  const availableModels = useMemo<WorkspaceCliModelOption[]>(
-    () => {
-      if (chatRuntime === 'claude-code') return CLAUDE_CLI_MODELS;
-      if (chatRuntime === 'gemini') return GEMINI_CLI_MODELS;
-      if (chatRuntime === 'opencode') return getOpenCodeModels(openCodeProviders);
-      return CODEX_CLI_MODELS;
-    },
-    [chatRuntime, openCodeProviders],
-  );
-  const selectedModel = useMemo(
-    () => availableModels.find((model) => model.id === tab.chatModel) ?? availableModels[0],
-    [availableModels, tab.chatModel],
-  );
-  const selectedModelLabel = selectedModel?.label;
+  const { availableModels, selectedModel, selectedModelLabel } = useWorkspaceChatModelOptions(chatRuntime, tab.chatModel);
   const isAgentTab = isAgentRuntimeTab(tab);
   const isRuntimeBound = Boolean(normalizedSessionKey && isAgentTab);
 
@@ -160,8 +136,8 @@ export function useWorkspaceChatPane({
     active,
   });
   const packetLlmMessages = useMemo(
-    () => mapWorkspaceTranscriptMessages(packetEvents, selectedModelLabel),
-    [packetEvents, selectedModelLabel],
+    () => mapWorkspaceTranscriptMessages(packetEvents.entries, selectedModelLabel),
+    [packetEvents.entries, selectedModelLabel],
   );
 
   const commitMessages = useCallback(
@@ -177,18 +153,6 @@ export function useWorkspaceChatPane({
     },
     [normalizedSessionKey, onUpdateMessages, tabId],
   );
-
-  useEffect(() => {
-    if (chatRuntime !== 'opencode' || openCodeProvidersLoadedRef.current) return;
-    openCodeProvidersLoadedRef.current = true;
-    let cancelled = false;
-    void loadOpenCodeProviders().then((providers) => {
-      if (!cancelled) setOpenCodeProviders(providers);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [chatRuntime]);
 
   useEffect(() => {
     messagesRef.current = messages;
@@ -809,6 +773,7 @@ export function useWorkspaceChatPane({
     llmMessages,
     messages,
     packetLlmMessages,
+    packetTranscriptActivity: packetEvents.activity,
     normalizedSessionKey,
     queuedContextCards,
     runtimeLabel,


### PR DESCRIPTION
Closes #1431.

## What changed
Replaces two bespoke pulsing-dot "working…" indicators in `WorkspaceChatPane` with a single shared `PacketWorkingFooter` that:
- **Follows lane status** (`status={liveStatus}`) so it stays visible during long tool executions instead of vanishing when the streaming/agentRunning flag flickers between tool calls.
- **Shows a real activity label** derived from the latest transcript event (`derivePacketTranscriptActivity`): "Running terminal command…", "Reading files…", "Searching code…", "Editing files…", "Thinking…", "Recovering…".
- **Shows ticking elapsed time** for the current activity (1s interval).
- **Shares the sidebar's dot** via the canonical `AgentStatusDot` (removes the prior hardcoded `#22c55e` green).

A `useWorkspaceChatModelOptions` hook was extracted from `useWorkspaceChatPane` to keep it under the 800-line ceiling while threading the new activity field.

## Verification
- `npx tsc --noEmit` clean.
- Merge gate: clean-worktree / security-patterns / diff-budget / untracked-imports / self-review-integrity all pass.
- Directives honored: inline styles only, palette CSS vars (no hardcoded rgba), 800-line ceiling, surgical.

## Reviewer note
Minor non-blocking nit: outer gate includes the transient `queued` status but `isWorkingStatus()` omits it, so the footer briefly renders nothing pre-launch.

🤖 Orchestrator-reviewed (approved) at ee9432c.