### PR TITLE
fix: render steers in the packet transcript (#1432)

### DIFF
--- a/src/app/api/mobile/history/route.ts
+++ b/src/app/api/mobile/history/route.ts
@@ -6,6 +6,7 @@ import { getOwnedOpencodeRuntimeTail } from '@/lib/opencode/owned';
 import { loadMobileLlmChatHistory } from '@/lib/llm/mobile-llm-chat';
 import type { MobileHistoryResponse, MobileTranscriptEntry, MobileTranscriptToolCall } from '@/lib/mobile/types';
 import '@/lib/runtimes'; // Ensure runtimes are registered
+import { readSessionSteerTranscriptEvents } from '@/lib/orchestrator/packet-transcript';
 import { getRuntime } from '@/lib/runtimes/registry';
 
 export const runtime = 'nodejs';
@@ -39,6 +40,24 @@ function toolCallFromEntry(name: string, text: string): MobileTranscriptToolCall
     args: parseToolArgs(text),
     status: 'done',
   };
+}
+
+function appendSteerEntries(sessionKey: string, transcript: MobileTranscriptEntry[]): MobileTranscriptEntry[] {
+  const steerEvents = readSessionSteerTranscriptEvents(sessionKey);
+  if (steerEvents.length === 0) return transcript;
+  const steerEntries = steerEvents.map((event) => {
+    const timestamp = new Date(event.ts);
+    const timestampMs = Number.isFinite(timestamp.getTime()) ? timestamp.getTime() : Date.now();
+    const timestampLabel = new Date(timestampMs).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+    return {
+      id: `steer-${event.seq}`,
+      role: 'user' as const,
+      text: `${event.failed ? 'Steer failed to start' : event.source} · ${timestampLabel}\n\n${event.text}${event.note && event.note !== event.text ? `\n\n${event.note}` : ''}`,
+      timestamp: timestampMs,
+      timestampLabel,
+    };
+  });
+  return [...transcript, ...steerEntries].sort((left, right) => (left.timestamp ?? 0) - (right.timestamp ?? 0));
 }
 
 export async function GET(request: NextRequest) {
@@ -124,7 +143,7 @@ export async function GET(request: NextRequest) {
         }
       }
 
-      const payload: MobileHistoryResponse = { sessionKey, transcript: chatTranscript };
+      const payload: MobileHistoryResponse = { sessionKey, transcript: appendSteerEntries(sessionKey, chatTranscript) };
       return NextResponse.json(payload, { headers: { 'Cache-Control': 'no-store, max-age=0' } });
     }
 
@@ -173,7 +192,7 @@ export async function GET(request: NextRequest) {
         seen.add(key);
         deduped.push(entry);
       }
-      const payload: MobileHistoryResponse = { sessionKey, transcript: deduped };
+      const payload: MobileHistoryResponse = { sessionKey, transcript: appendSteerEntries(sessionKey, deduped) };
       return NextResponse.json(payload, {
         headers: { 'Cache-Control': 'no-store, max-age=0' },
       });
@@ -212,7 +231,7 @@ export async function GET(request: NextRequest) {
           } : undefined,
         }));
         return NextResponse.json(
-          { sessionKey, transcript } satisfies MobileHistoryResponse,
+          { sessionKey, transcript: appendSteerEntries(sessionKey, transcript) } satisfies MobileHistoryResponse,
           { headers: { 'Cache-Control': 'no-store, max-age=0' } },
         );
       }

--- a/src/app/api/orchestrator/steer-packet/route.ts
+++ b/src/app/api/orchestrator/steer-packet/route.ts
@@ -35,6 +35,7 @@ export async function POST(request: NextRequest) {
 
   const packetId = typeof record.packetId === 'string' ? record.packetId.trim() : '';
   const message = typeof record.message === 'string' ? record.message.trim() : '';
+  const source = typeof record.source === 'string' ? record.source.trim() : undefined;
   if (!packetId) {
     return operatorError('invalid_request', 'packetId is required.', 400);
   }
@@ -43,7 +44,7 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const result = await steerPacket({ packetId, message });
+    const result = await steerPacket({ packetId, message, source });
     return operatorSuccess(result);
   } catch (error) {
     const messageText = error instanceof Error ? error.message : 'Unable to steer packet.';

--- a/src/app/api/runtime/transcript/route.ts
+++ b/src/app/api/runtime/transcript/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { performance } from 'node:perf_hooks';
+import { readSessionSteerTranscriptEvents } from '@/lib/orchestrator/packet-transcript';
 import { readRuntimeTranscript } from '@/lib/runtime/transcript';
 
 export const runtime = 'nodejs';
@@ -35,6 +36,23 @@ export async function GET(request: NextRequest) {
         summary: entry.compaction.summary,
       } : undefined,
     }));
+    for (const event of readSessionSteerTranscriptEvents(sessionKey)) {
+      const timestamp = new Date(event.ts);
+      const timestampMs = Number.isFinite(timestamp.getTime()) ? timestamp.getTime() : Date.now();
+      const timestampLabel = new Date(timestampMs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      transcript.push({
+        id: `steer-${event.seq}`,
+        role: 'user',
+        text: `${event.failed ? 'Steer failed to start' : event.source} · ${timestampLabel}\n\n${event.text}${event.note && event.note !== event.text ? `\n\n${event.note}` : ''}`,
+        type: 'message',
+        timestamp: timestampMs,
+        timestampLabel,
+        toolName: undefined,
+        filePath: undefined,
+        compaction: undefined,
+      });
+    }
+    transcript.sort((left, right) => (left.timestamp ?? 0) - (right.timestamp ?? 0));
     return NextResponse.json({ transcript }, {
       headers: { 'Cache-Control': 'no-store, max-age=0', 'Server-Timing': `total;dur=${Math.max(0, performance.now() - startedAt).toFixed(1)}` },
     });

--- a/src/components/desktop/workspace-terminal/use-packet-transcript-poll.ts
+++ b/src/components/desktop/workspace-terminal/use-packet-transcript-poll.ts
@@ -101,6 +101,15 @@ export function mapPacketTranscriptEntries(events: TranscriptEvent[]): MobileTra
       case 'assistant':
         flush(`pkt-${event.seq}`, event.text, event.ts);
         break;
+      case 'steer':
+        entries.push({
+          id: `pkt-steer-${event.seq}`,
+          role: 'user',
+          text: `${event.failed ? 'Steer failed to start' : event.source} · ${tsLabel(event.ts) ?? 'now'}\n\n${event.text}${event.note && event.note !== event.text ? `\n\n${event.note}` : ''}`,
+          timestamp: tsMs(event.ts),
+          timestampLabel: tsLabel(event.ts),
+        });
+        break;
       case 'error':
         flush(`pkt-${event.seq}`, `Error: ${event.message}`, event.ts);
         break;

--- a/src/lib/lane/types.ts
+++ b/src/lib/lane/types.ts
@@ -216,7 +216,11 @@ export type LaneEventVerb =
   // Session rules governed this packet at dispatch (#1329). Snapshot of the
   // exact operator session rules injected into the worker prompt, so review is
   // "what changed, under which constraints." Payload: { threadId, ruleCount, rules }
-  | 'rules_applied';
+  | 'rules_applied'
+  // Packet steer injected into an existing warm session. Payload: { packetId, source, message }
+  | 'steered_packet'
+  // Packet steer failed before a worker turn could start. Payload: { packetId, source, message, note, stderrHead? }
+  | 'steer_failed';
 
 export type AgentReportReason =
   | 'needs_clarification'

--- a/src/lib/mcp/operator-handlers/status.ts
+++ b/src/lib/mcp/operator-handlers/status.ts
@@ -295,7 +295,7 @@ export async function handleSteerPacket(args: Record<string, unknown>): Promise<
     // warm-session pool), not this MCP process's stale registry instance.
     const res = await apiFetch('/api/orchestrator/steer-packet', {
       method: 'POST',
-      body: JSON.stringify({ packetId, message }),
+      body: JSON.stringify({ packetId, message, source: 'orchestrator' }),
     }) as { ok?: boolean; result?: Record<string, unknown> };
     return jsonResult({ ok: true, ...(res.result ?? {}) });
   } catch (err) {

--- a/src/lib/orchestrator/operator-mission-service/steer.ts
+++ b/src/lib/orchestrator/operator-mission-service/steer.ts
@@ -51,7 +51,7 @@ function stderrPathForStdout(stdoutPath: string): string {
     : `${stdoutPath}.stderr.log`;
 }
 
-async function readStartupFailureHead(surfaceId: string): Promise<string | null> {
+async function readStartupFailureHead(surfaceId: string, sinceMs: number): Promise<string | null> {
   if (!surfaceId.startsWith('codex-owned:')) return null;
   await new Promise((resolve) => setTimeout(resolve, STARTUP_FAILURE_PROBE_MS));
   const sources = await getOwnedCodexTelemetrySources(surfaceId);
@@ -61,7 +61,11 @@ async function readStartupFailureHead(surfaceId: string): Promise<string | null>
   const stderr = await readFile(stderrPathForStdout(stdoutPath), 'utf8').catch(() => '');
   const tail = await getOwnedCodexRuntimeTail(surfaceId).catch(() => null);
   const lifecycle = tail?.surface.lifecycle;
-  if (lifecycle?.lastRunMode === 'resume' && lifecycle.lastOutcome === 'failed') {
+  // Only a run STARTED BY THIS STEER counts — a previous resume's failure must
+  // not flag a fresh, healthy steer (caught by the #1415 regression test).
+  const lastRunStartedMs = lifecycle?.lastRunStartedAt ? Date.parse(lifecycle.lastRunStartedAt) : NaN;
+  const startedByThisSteer = Number.isFinite(lastRunStartedMs) && lastRunStartedMs >= sinceMs - 1_000;
+  if (startedByThisSteer && lifecycle?.lastRunMode === 'resume' && lifecycle.lastOutcome === 'failed') {
     return (stderr.trim() || lifecycle.summary || 'owned Codex resume exited non-zero')
       .replace(/\s+/g, ' ')
       .slice(0, 500);
@@ -98,6 +102,7 @@ export async function steerPacket({ packetId, message, source }: SteerPacketInpu
   }
 
   const steerSource = normalizeSource(source);
+  const steerStartedMs = Date.now();
   recordLaneEvent(lane.id, 'steered_packet', 'orchestrator', {
     packetId,
     source: steerSource,
@@ -124,7 +129,7 @@ export async function steerPacket({ packetId, message, source }: SteerPacketInpu
     rebindLaneSessionIfChanged(lane.id, lane.sessionKey, result.sessionKey, 'orchestrator');
   }
 
-  const startupFailure = await readStartupFailureHead(lane.sessionKey);
+  const startupFailure = await readStartupFailureHead(lane.sessionKey, steerStartedMs);
   if (startupFailure) {
     recordLaneEvent(lane.id, 'steer_failed', 'orchestrator', {
       packetId,

--- a/src/lib/orchestrator/operator-mission-service/steer.ts
+++ b/src/lib/orchestrator/operator-mission-service/steer.ts
@@ -15,15 +15,17 @@
  */
 
 import { findLaneByPacket, setLaneStatus } from '@/lib/lane/registry';
+import { recordLaneEvent } from '@/lib/lane/events';
 import { rebindLaneSessionIfChanged } from '@/lib/lane/session-rebind';
 import { findMissionRegistryEntryByPacketId } from '@/lib/orchestrator/mission-registry';
 import { performRuntimeAction } from '@/lib/runtime/actions';
 import { currentMissionState } from './shared';
-import { continueOwnedCodexSession, getOwnedCodexTelemetrySources } from '@/lib/codex/owned';
+import { continueOwnedCodexSession, getOwnedCodexRuntimeTail, getOwnedCodexTelemetrySources } from '@/lib/codex/owned';
 
 export interface SteerPacketInput {
   packetId: string;
   message: string;
+  source?: string;
 }
 
 export interface SteerPacketResult {
@@ -33,6 +35,39 @@ export interface SteerPacketResult {
 }
 
 const NO_STEERABLE_SESSION = 'Packet has no steerable session — use rerun_with_feedback instead.';
+const STARTUP_FAILURE_PROBE_MS = 2_000;
+
+function normalizeSource(source: string | undefined): string {
+  const normalized = source?.trim().toLowerCase();
+  if (normalized === 'operator' || normalized === 'heal-bot' || normalized === 'orchestrator') {
+    return normalized;
+  }
+  return 'orchestrator';
+}
+
+function stderrPathForStdout(stdoutPath: string): string {
+  return stdoutPath.endsWith('.jsonl')
+    ? stdoutPath.replace(/\.jsonl$/, '.stderr.log')
+    : `${stdoutPath}.stderr.log`;
+}
+
+async function readStartupFailureHead(surfaceId: string): Promise<string | null> {
+  if (!surfaceId.startsWith('codex-owned:')) return null;
+  await new Promise((resolve) => setTimeout(resolve, STARTUP_FAILURE_PROBE_MS));
+  const sources = await getOwnedCodexTelemetrySources(surfaceId);
+  const stdoutPath = sources?.stdoutPaths[sources.stdoutPaths.length - 1];
+  if (!stdoutPath) return null;
+  const { readFile } = await import('node:fs/promises');
+  const stderr = await readFile(stderrPathForStdout(stdoutPath), 'utf8').catch(() => '');
+  const tail = await getOwnedCodexRuntimeTail(surfaceId).catch(() => null);
+  const lifecycle = tail?.surface.lifecycle;
+  if (lifecycle?.lastRunMode === 'resume' && lifecycle.lastOutcome === 'failed') {
+    return (stderr.trim() || lifecycle.summary || 'owned Codex resume exited non-zero')
+      .replace(/\s+/g, ' ')
+      .slice(0, 500);
+  }
+  return null;
+}
 
 async function resumeExitedOwnedCodexSession(surfaceId: string, message: string) {
   if (!surfaceId.startsWith('codex-owned:')) {
@@ -47,7 +82,7 @@ async function resumeExitedOwnedCodexSession(surfaceId: string, message: string)
   return continueOwnedCodexSession(surfaceId, message);
 }
 
-export async function steerPacket({ packetId, message }: SteerPacketInput): Promise<SteerPacketResult> {
+export async function steerPacket({ packetId, message, source }: SteerPacketInput): Promise<SteerPacketResult> {
   const lane = findLaneByPacket(packetId);
   if (!lane?.sessionKey) {
     const current = currentMissionState();
@@ -62,17 +97,43 @@ export async function steerPacket({ packetId, message }: SteerPacketInput): Prom
     throw new Error(NO_STEERABLE_SESSION);
   }
 
-  const result = await performRuntimeAction({ action: 'steer', surfaceId: lane.sessionKey, message });
+  const steerSource = normalizeSource(source);
+  recordLaneEvent(lane.id, 'steered_packet', 'orchestrator', {
+    packetId,
+    source: steerSource,
+    message,
+  });
+
+  const result = await performRuntimeAction({ action: 'steer', surfaceId: lane.sessionKey, message, auditSteer: false });
   if (!result.ok || result.status === 'unavailable') {
-    const resumed = await resumeExitedOwnedCodexSession(lane.sessionKey, message);
+    const canTryOwnedResumeFallback = lane.sessionKey.startsWith('codex-owned:')
+      && /cannot accept|not found|surface/i.test(result.note);
+    const resumed = canTryOwnedResumeFallback
+      ? await resumeExitedOwnedCodexSession(lane.sessionKey, message)
+      : null;
     if (!resumed?.ok) {
-      if (lane.sessionKey.startsWith('codex-owned:')) {
-        throw new Error(resumed?.note || NO_STEERABLE_SESSION);
-      }
+      recordLaneEvent(lane.id, 'steer_failed', 'orchestrator', {
+        packetId,
+        source: steerSource,
+        message,
+        note: resumed?.note || result.note || NO_STEERABLE_SESSION,
+      });
       throw new Error(resumed?.note || result.note || NO_STEERABLE_SESSION);
     }
   } else {
     rebindLaneSessionIfChanged(lane.id, lane.sessionKey, result.sessionKey, 'orchestrator');
+  }
+
+  const startupFailure = await readStartupFailureHead(lane.sessionKey);
+  if (startupFailure) {
+    recordLaneEvent(lane.id, 'steer_failed', 'orchestrator', {
+      packetId,
+      source: steerSource,
+      message,
+      note: 'Steer failed to start',
+      stderrHead: startupFailure,
+    });
+    throw new Error(`Steer failed to start: ${startupFailure}`);
   }
 
   const updated = setLaneStatus(lane.id, 'running', 'orchestrator', 'steered_packet');

--- a/src/lib/orchestrator/packet-transcript-steer.test.ts
+++ b/src/lib/orchestrator/packet-transcript-steer.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const registryMock = vi.hoisted(() => ({
+  lanes: [{ id: 'lane-1', sessionKey: 'codex-owned:abc', packetId: 'pkt-1' }],
+  events: [
+    {
+      id: 'evt-1',
+      laneId: 'lane-1',
+      verb: 'steered_packet',
+      actor: 'orchestrator',
+      payload: { packetId: 'pkt-1', source: 'orchestrator', message: 'Use the new plan.' },
+      timestamp: '2026-07-05T12:00:00.000Z',
+    },
+    {
+      id: 'evt-2',
+      laneId: 'lane-1',
+      verb: 'steer_failed',
+      actor: 'orchestrator',
+      payload: {
+        packetId: 'pkt-1',
+        source: 'heal-bot',
+        message: 'Retry startup.',
+        note: 'Steer failed to start',
+        stderrHead: 'codex exited 1',
+      },
+      timestamp: '2026-07-05T12:00:02.000Z',
+    },
+  ],
+}));
+
+vi.mock('@/lib/lane/registry', () => ({
+  getLaneEvents: vi.fn(() => registryMock.events),
+  listLanes: vi.fn(() => registryMock.lanes),
+}));
+
+describe('packet transcript steer events', () => {
+  it('projects steer lane events into renderable transcript events', async () => {
+    const { readSessionSteerTranscriptEvents } = await import('./packet-transcript');
+
+    expect(readSessionSteerTranscriptEvents('codex-owned:abc')).toEqual([
+      {
+        seq: 1,
+        ts: '2026-07-05T12:00:00.000Z',
+        type: 'steer',
+        source: 'orchestrator',
+        text: 'Use the new plan.',
+        failed: false,
+      },
+      {
+        seq: 2,
+        ts: '2026-07-05T12:00:02.000Z',
+        type: 'steer',
+        source: 'heal-bot',
+        text: 'Retry startup.',
+        failed: true,
+        note: 'Steer failed to start\ncodex exited 1',
+      },
+    ]);
+  });
+});

--- a/src/lib/orchestrator/packet-transcript.ts
+++ b/src/lib/orchestrator/packet-transcript.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { getCodexRolloutPath } from '@/lib/codex/sessions';
 import { getOwnedCodexTelemetrySources } from '@/lib/codex/owned';
 import { getOwnedGeminiTelemetrySources } from '@/lib/gemini/owned';
-import { listLanes } from '@/lib/lane/registry';
+import { getLaneEvents, listLanes } from '@/lib/lane/registry';
 import { getOwnedOpencodeTelemetrySources } from '@/lib/opencode/owned';
 import { readOrchestratorControlPlaneState } from '@/lib/orchestrator/control-plane';
 import { normalizeCodexEvents, type TranscriptEvent } from '@/lib/orchestrator/transcript-normalizer';
@@ -35,6 +35,8 @@ export interface PacketTranscriptReadback extends SessionTranscriptReadback {
   packetId: string;
   note?: string;
 }
+
+type LaneSteerTranscriptEvent = Extract<TranscriptEvent, { type: 'steer' }>;
 
 function findPacket(packetId: string): OrchestratorPacket | null {
   try {
@@ -195,6 +197,59 @@ function normalizeForRuntime(runtime: TranscriptRuntime, raw: string): Transcrip
   }
 }
 
+function readTextPayload(payload: Record<string, unknown>, ...keys: string[]): string {
+  for (const key of keys) {
+    const value = payload[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return '';
+}
+
+function laneSteerEvents(laneId: string): LaneSteerTranscriptEvent[] {
+  return getLaneEvents(laneId, 500)
+    .filter((event) => event.verb === 'steered_packet' || event.verb === 'steer_failed')
+    .map((event, index) => {
+      const source = readTextPayload(event.payload, 'source', 'actor') || event.actor || 'orchestrator';
+      const text = readTextPayload(event.payload, 'message', 'text');
+      const noteText = readTextPayload(event.payload, 'note', 'error');
+      const stderrHead = readTextPayload(event.payload, 'stderrHead');
+      const note = [noteText, stderrHead].filter(Boolean).join('\n');
+      return {
+        seq: index + 1,
+        ts: event.timestamp,
+        type: 'steer',
+        source,
+        text: text || note || 'Steer requested.',
+        failed: event.verb === 'steer_failed',
+        ...(note ? { note } : {}),
+      };
+    });
+}
+
+function laneSteerEventsForSession(sessionKey: string): LaneSteerTranscriptEvent[] {
+  if (!sessionKey) return [];
+  const lane = listLanes().find((candidate) => candidate.sessionKey === sessionKey);
+  return lane ? laneSteerEvents(lane.id) : [];
+}
+
+function mergeTranscriptEvents(runtimeEvents: TranscriptEvent[], extraEvents: TranscriptEvent[]): TranscriptEvent[] {
+  if (extraEvents.length === 0) return runtimeEvents;
+  const stamped = [...runtimeEvents, ...extraEvents]
+    .map((event, index) => ({ event, index }))
+    .sort((left, right) => {
+      const leftMs = new Date(left.event.ts).getTime();
+      const rightMs = new Date(right.event.ts).getTime();
+      const leftSafe = Number.isFinite(leftMs) ? leftMs : 0;
+      const rightSafe = Number.isFinite(rightMs) ? rightMs : 0;
+      return leftSafe - rightSafe || left.index - right.index;
+    });
+  return stamped.map(({ event }, index) => ({ ...event, seq: index + 1 }) as TranscriptEvent);
+}
+
+export function readSessionSteerTranscriptEvents(sessionKey: string): LaneSteerTranscriptEvent[] {
+  return laneSteerEventsForSession(sessionKey);
+}
+
 export async function readSessionTranscriptEvents(sessionKey: string): Promise<SessionTranscriptReadback> {
   const resolved = await resolveRawJsonlForSession(sessionKey);
   if (resolved.unsupportedReason) {
@@ -209,7 +264,10 @@ export async function readSessionTranscriptEvents(sessionKey: string): Promise<S
   return {
     sessionKey,
     runtime: resolved.runtime,
-    events: normalizeForRuntime(resolved.runtime, resolved.raw),
+    events: mergeTranscriptEvents(
+      normalizeForRuntime(resolved.runtime, resolved.raw),
+      laneSteerEventsForSession(sessionKey),
+    ),
   };
 }
 
@@ -227,7 +285,13 @@ export async function readPacketTranscriptEvents(packetId: string): Promise<Pack
   }
 
   const readback = await readSessionTranscriptEvents(sessionKey);
-  return { packetId, ...readback };
+  const packetLane = listLanes().find((lane) => lane.packetId === packetId);
+  const packetEvents = packetLane && packetLane.sessionKey !== sessionKey ? laneSteerEvents(packetLane.id) : [];
+  return {
+    packetId,
+    ...readback,
+    events: mergeTranscriptEvents(readback.events, packetEvents),
+  };
 }
 
 export function latestTranscriptEventAt(events: TranscriptEvent[]): string | null {

--- a/src/lib/orchestrator/transcript-normalizer.ts
+++ b/src/lib/orchestrator/transcript-normalizer.ts
@@ -18,6 +18,7 @@ export type TranscriptEvent =
   | { seq: number; ts: string; type: 'tool_call'; tool: string; args: string; summary: string }
   | { seq: number; ts: string; type: 'tool_result'; tool: string; ok: boolean; summary: string }
   | { seq: number; ts: string; type: 'assistant'; text: string }
+  | { seq: number; ts: string; type: 'steer'; source: string; text: string; failed?: boolean; note?: string }
   | { seq: number; ts: string; type: 'error'; message: string }
   | { seq: number; ts: string; type: 'done'; exitCode: number };
 

--- a/src/lib/runtime/actions.ts
+++ b/src/lib/runtime/actions.ts
@@ -1,4 +1,6 @@
 import type { AgentSummary } from '@/lib/fleet/types';
+import { recordLaneEvent } from '@/lib/lane/events';
+import { listLanes } from '@/lib/lane/registry';
 import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import { continueOwnedCodexSession, interruptOwnedCodexSession, setOwnedCodexReviewDisposition } from '@/lib/codex/owned';
 import { markRepoOriginConfigured, markRepoOriginMissing } from '@/lib/repos/origin-readiness';
@@ -34,6 +36,8 @@ export interface RuntimeActionRequest {
     fileName: string;
     content: string;
   }>;
+  auditSteer?: boolean;
+  steerSource?: 'operator' | 'orchestrator' | 'heal-bot';
 }
 
 export interface RuntimeActionResult {
@@ -116,6 +120,23 @@ function fetchCooldownRetrySeconds(repoPath: string): number | null {
 
 function recordFetchUnreachable(repoPath: string): void {
   fetchUnreachableFailures.set(repoPath, Date.now());
+}
+
+function auditRuntimeSteer(payload: RuntimeActionRequest, sessionKey: string): void {
+  if (payload.auditSteer === false || (payload.action !== 'steer' && payload.action !== 'send_input')) return;
+  const message = payload.message?.trim();
+  if (!message) return;
+  try {
+    const lane = listLanes().find((candidate) => candidate.sessionKey === sessionKey && candidate.packetId);
+    if (!lane?.packetId) return;
+    recordLaneEvent(lane.id, 'steered_packet', 'orchestrator', {
+      packetId: lane.packetId,
+      source: payload.steerSource ?? 'operator',
+      message,
+    });
+  } catch {
+    // Runtime action delivery should not fail because lane audit storage is temporarily unavailable.
+  }
 }
 
 function clearFetchUnreachable(repoPath: string): void {
@@ -529,6 +550,7 @@ export async function performRuntimeAction(payload: RuntimeActionRequest): Promi
   if (!runtimeSurface) {
     return actionUnavailable(payload, agent.sessionKey, agent.runtime, 'Runtime surface metadata is unavailable.');
   }
+  auditRuntimeSteer(payload, agent.sessionKey);
 
   switch (agent.runtime) {
     case 'codex': {
@@ -598,13 +620,13 @@ export async function performRuntimeAction(payload: RuntimeActionRequest): Promi
         }
         const result = await continueOwnedCodexSession(runtimeSurface.id, message);
         return {
-          ok: true,
+          ok: result.ok,
           action: payload.action,
           surfaceId: runtimeSurface.id,
           sessionKey: runtimeSurface.id,
           runtime: agent.runtime,
           clientMutationId: payload.clientMutationId,
-          status: 'queued',
+          status: result.ok ? 'queued' : 'unavailable',
           note: result.note,
         };
       }

--- a/tests/steer-packet-owned-resume.test.ts
+++ b/tests/steer-packet-owned-resume.test.ts
@@ -29,7 +29,10 @@ vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:child_process')>();
   return {
     ...actual,
-    spawn: vi.fn(() => ({ pid: 424242, unref: vi.fn() })),
+    // A LIVE pid — the steer startup-failure probe (#1432) checks whether the
+    // resume run it spawned actually came alive; a fake dead pid reads as
+    // 'Steer failed to start'. The test process itself is the liveness stand-in.
+    spawn: vi.fn(() => ({ pid: process.pid, unref: vi.fn() })),
   };
 });
 
@@ -116,6 +119,7 @@ describe('steerPacket owned Codex resume fallback', () => {
       action: 'steer',
       surfaceId,
       message: 'continue from huddle approval',
+      auditSteer: false,
     });
     expect(spawn).toHaveBeenCalledTimes(1);
     expect(vi.mocked(spawn).mock.calls[0]?.[1]).toEqual(expect.arrayContaining([


### PR DESCRIPTION
Closes #1432.

## What changed
Orchestrator/CLI/heal-bot/operator steers were invisible — a worker would visibly pivot with no shown cause. This surfaces them:

- New `steer` variant on `TranscriptEvent`.
- `steerPacket()` records a `steered_packet` lane event before dispatching, and `steer_failed` (with stderr head) when a resume fails or exits at startup. A new startup-failure probe catches a resume that launches but exits non-zero.
- `performRuntimeAction` audits direct operator steers (source `operator`) unless `auditSteer:false` (which `steerPacket` passes to avoid a double-record).
- `packet-transcript.ts` projects `steered_packet`/`steer_failed` lane events into `type:'steer'` transcript events and merge-sorts them by timestamp into the runtime stream.
- Rendered on all three surfaces: desktop packet poll (`use-packet-transcript-poll` `case 'steer'`), runtime transcript route, and mobile history route. Source-attributed (operator/orchestrator/heal-bot) with timestamps.

## Verification
- `npx tsc --noEmit` clean.
- New test `packet-transcript-steer.test.ts` passes (projects both success + failed steer events).
- Writes partitioned to the lane; de-duped via `auditSteer:false` and a `sessionKey !== sessionKey` merge guard.

## Reviewer notes (operator awareness)
- **Merge-gate BUDGET block** on `steer.ts` (+68 vs budget 17) is a size heuristic, not a correctness defect — the extra lines are source normalization, the failure audit, and the startup-failure probe (all in-scope).
- **~2s latency** added to every successful Codex-worker steer: the startup-failure probe waits to catch a resume that exits at startup. Deliberate correctness-over-latency tradeoff.
- Owned-Codex resume-fallback narrowed to notes matching `cannot accept|not found|surface` (more precise recovery).

🤖 Orchestrator-reviewed (approved on correctness) at b6102c2.