### PR TITLE
fix: targeting scan shows live phased progress — no more frozen 'Scanning…' (#1343)

### DIFF
--- a/src/app/api/panel/targets/route.ts
+++ b/src/app/api/panel/targets/route.ts
@@ -1,6 +1,7 @@
 export const dynamic = 'force-dynamic';
 
 import { NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 
 import { collectSignals } from '@/lib/targeting/signals';
@@ -9,6 +10,148 @@ import { applyLlmRationales } from '@/lib/targeting/rationale';
 import { pickTier } from '@/lib/targeting/routing';
 import { replaceScores } from '@/lib/targeting/store';
 import { logTriageRun } from '@/lib/targeting/observability';
+import type { TargetScore } from '@/lib/targeting/scorer';
+
+type TargetingProgressPhase =
+  | 'starting'
+  | 'collecting-signals'
+  | 'scoring'
+  | 'rationales'
+  | 'caching'
+  | 'complete'
+  | 'error';
+
+interface TargetingProgress {
+  phase: TargetingProgressPhase;
+  label: string;
+  filesScanned: number;
+  totalFiles: number | null;
+  startedAt: string;
+  updatedAt: string;
+}
+
+interface TargetingJob {
+  id: string;
+  repoPath: string;
+  limit: number;
+  rationaleMode: 'heuristic' | 'llm';
+  progress: TargetingProgress;
+  result: Record<string, unknown> | null;
+  error: string | null;
+  startedAtMs: number;
+}
+
+const targetingJobs = new Map<string, TargetingJob>();
+const TARGETING_JOB_TTL_MS = 5 * 60 * 1000;
+
+function withTier(targets: TargetScore[]) {
+  return targets.map((t) => ({ ...t, tier: pickTier(t.signals) }));
+}
+
+function updateProgress(job: TargetingJob, update: Partial<Omit<TargetingProgress, 'startedAt' | 'updatedAt'>>) {
+  job.progress = {
+    ...job.progress,
+    ...update,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function pruneJobs() {
+  const now = Date.now();
+  for (const [id, job] of targetingJobs) {
+    if (now - job.startedAtMs > TARGETING_JOB_TTL_MS) targetingJobs.delete(id);
+  }
+}
+
+async function runTargetingJob(job: TargetingJob) {
+  try {
+    updateProgress(job, { phase: 'collecting-signals', label: 'Reading cached skeleton and git churn' });
+    const signals = collectSignals(job.repoPath);
+    updateProgress(job, {
+      phase: 'scoring',
+      label: signals.length > 0 ? 'Scoring cached files' : 'No skeleton cache found',
+      filesScanned: signals.length,
+      totalFiles: signals.length,
+    });
+
+    if (signals.length === 0) {
+      job.result = {
+        ok: true,
+        repoPath: job.repoPath,
+        count: 0,
+        targets: [],
+        reason: 'no-skeleton',
+        message: 'No skeleton cache for this repo yet — open/scan it first, then re-run the triage.',
+      };
+      updateProgress(job, { phase: 'complete', label: 'Scan complete' });
+      return;
+    }
+
+    const scored = scoreTargets(signals, job.limit);
+    job.result = {
+      ok: true,
+      repoPath: job.repoPath,
+      count: scored.length,
+      scoredAt: new Date().toISOString(),
+      partial: job.rationaleMode === 'llm',
+      targets: withTier(scored),
+    };
+
+    updateProgress(job, {
+      phase: job.rationaleMode === 'heuristic' ? 'caching' : 'rationales',
+      label: job.rationaleMode === 'heuristic' ? 'Caching ranked targets' : 'Writing rationale summaries',
+    });
+    const targets = job.rationaleMode === 'heuristic' ? scored : await applyLlmRationales(scored);
+    logTriageRun(job.repoPath, targets, job.rationaleMode);
+    updateProgress(job, { phase: 'caching', label: 'Caching ranked targets' });
+    try {
+      replaceScores(job.repoPath, targets);
+    } catch (err) {
+      console.warn('[targeting] failed to cache scores:', err instanceof Error ? err.message : err);
+    }
+
+    job.result = {
+      ok: true,
+      repoPath: job.repoPath,
+      count: targets.length,
+      scoredAt: new Date().toISOString(),
+      partial: false,
+      targets: withTier(targets),
+    };
+    updateProgress(job, { phase: 'complete', label: 'Scan complete' });
+  } catch (err) {
+    job.error = err instanceof Error ? err.message : 'targeting failed';
+    job.result = { ok: false, error: job.error };
+    updateProgress(job, { phase: 'error', label: 'Triage failed' });
+  }
+}
+
+function startTargetingJob(repoPath: string, limit: number, rationaleMode: 'heuristic' | 'llm') {
+  pruneJobs();
+  const now = new Date().toISOString();
+  const job: TargetingJob = {
+    id: randomUUID(),
+    repoPath,
+    limit,
+    rationaleMode,
+    progress: {
+      phase: 'starting',
+      label: 'Starting scan',
+      filesScanned: 0,
+      totalFiles: null,
+      startedAt: now,
+      updatedAt: now,
+    },
+    result: null,
+    error: null,
+    startedAtMs: Date.now(),
+  };
+  targetingJobs.set(job.id, job);
+  setTimeout(() => {
+    void runTargetingJob(job);
+  }, 0);
+  return job;
+}
 
 /**
  * The Targeting Machine — GET the ranked "where to point your agents" list for a
@@ -21,6 +164,27 @@ export async function GET(request: Request) {
   const raw = searchParams.get('repoPath') || searchParams.get('workspace') || process.cwd();
   const repoPath = raw.startsWith('~') ? raw.replace('~', homedir()) : raw;
   const limit = Math.max(1, Math.min(200, parseInt(searchParams.get('limit') || '', 10) || DEFAULT_TOP_N));
+  const rationaleMode = searchParams.get('rationales') === 'heuristic' ? 'heuristic' as const : 'llm' as const;
+
+  if (searchParams.get('mode') === 'start') {
+    const job = startTargetingJob(repoPath, limit, rationaleMode);
+    return NextResponse.json({ ok: true, jobId: job.id, progress: job.progress });
+  }
+
+  const jobId = searchParams.get('jobId');
+  if (jobId) {
+    pruneJobs();
+    const job = targetingJobs.get(jobId);
+    if (!job || job.repoPath !== repoPath) {
+      return NextResponse.json({ ok: false, error: 'targeting scan not found' }, { status: 404 });
+    }
+    return NextResponse.json({
+      ok: job.error ? false : true,
+      jobId: job.id,
+      progress: job.progress,
+      ...(job.result ?? {}),
+    });
+  }
 
   try {
     const signals = collectSignals(repoPath);
@@ -39,7 +203,6 @@ export async function GET(request: Request) {
     // The rationale money-shot: upgrade the top files' one-liners with the cheap
     // triage model (heuristic fallback per file). Opt out with ?rationales=heuristic
     // for an instant heuristic-only list.
-    const rationaleMode = searchParams.get('rationales') === 'heuristic' ? 'heuristic' as const : 'llm' as const;
     const targets = rationaleMode === 'heuristic' ? scored : await applyLlmRationales(scored);
     logTriageRun(repoPath, targets, rationaleMode);
     try {
@@ -56,7 +219,7 @@ export async function GET(request: Request) {
       scoredAt: new Date().toISOString(),
       // Stamp each file's dispatch tier (cheap triage vs premium action) so the
       // row can show the chip + the Dispatch button knows where it'll route.
-      targets: targets.map((t) => ({ ...t, tier: pickTier(t.signals) })),
+      targets: withTier(targets),
     });
   } catch (err) {
     return NextResponse.json(

--- a/src/components/desktop/o8-panel/TargetsPanel.tsx
+++ b/src/components/desktop/o8-panel/TargetsPanel.tsx
@@ -28,12 +28,21 @@ type DispatchState = { status: 'busy' } | { status: 'done'; runtime: string; tie
 
 interface TargetsResponse {
   ok: boolean;
+  repoPath?: string;
   count?: number;
   scoredAt?: string;
   targets?: TargetRow[];
+  partial?: boolean;
   reason?: string;
   message?: string;
   error?: string;
+}
+
+interface TargetingProgress {
+  phase: 'starting' | 'collecting-signals' | 'scoring' | 'rationales' | 'caching' | 'complete' | 'error';
+  label: string;
+  filesScanned: number;
+  totalFiles: number | null;
 }
 
 const FLOATING_ASK_O8_RIGHT = 12;
@@ -64,8 +73,11 @@ function PipBar({ label, value }: { label: string; value: number }) {
 export function TargetsPanel({ repoPath, active }: { repoPath?: string | null; active?: boolean }) {
   const [state, setState] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
   const [data, setData] = useState<TargetsResponse | null>(null);
+  const [progress, setProgress] = useState<TargetingProgress | null>(null);
   const [dispatched, setDispatched] = useState<Record<string, DispatchState>>({});
   const loadedRepoRef = useRef<string | null>(null);
+  const loadSeqRef = useRef(0);
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const dispatch = useCallback(async (path: string) => {
     if (!repoPath) return;
@@ -88,16 +100,54 @@ export function TargetsPanel({ repoPath, active }: { repoPath?: string | null; a
     }
   }, [repoPath]);
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (restart = true) => {
     if (!repoPath) return;
+    const seq = loadSeqRef.current + 1;
+    loadSeqRef.current = seq;
+    if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
     setState('loading');
+    setProgress({ phase: 'starting', label: restart ? 'Restarting scan' : 'Starting scan', filesScanned: 0, totalFiles: null });
     try {
-      const res = await fetch(`/api/panel/targets?repoPath=${encodeURIComponent(repoPath)}`);
-      const json = (await res.json()) as TargetsResponse;
-      setData(json);
-      setState(json.ok ? 'ready' : 'error');
+      const startRes = await fetch(`/api/panel/targets?repoPath=${encodeURIComponent(repoPath)}&mode=start`);
+      const startJson = (await startRes.json()) as TargetsResponse & { jobId?: string; progress?: TargetingProgress };
+      if (loadSeqRef.current !== seq) return;
+      if (!startJson.ok || !startJson.jobId) {
+        setData(startJson);
+        setProgress(null);
+        setState('error');
+        return;
+      }
+      if (startJson.progress) setProgress(startJson.progress);
+
+      const poll = async () => {
+        try {
+          const res = await fetch(`/api/panel/targets?repoPath=${encodeURIComponent(repoPath)}&jobId=${encodeURIComponent(startJson.jobId!)}`);
+          const json = (await res.json()) as TargetsResponse & { progress?: TargetingProgress };
+          if (loadSeqRef.current !== seq) return;
+          if (json.progress) setProgress(json.progress);
+          if (json.targets || json.error || json.message) setData(json);
+          if (!json.ok || json.progress?.phase === 'error') {
+            setState('error');
+            return;
+          }
+          if (json.progress?.phase === 'complete') {
+            setState('ready');
+            return;
+          }
+          setState('loading');
+          pollTimerRef.current = setTimeout(poll, 900);
+        } catch (err) {
+          if (loadSeqRef.current !== seq) return;
+          setData({ ok: false, error: err instanceof Error ? err.message : 'request failed' });
+          setState('error');
+        }
+      };
+
+      pollTimerRef.current = setTimeout(poll, 200);
     } catch (err) {
+      if (loadSeqRef.current !== seq) return;
       setData({ ok: false, error: err instanceof Error ? err.message : 'request failed' });
+      setProgress(null);
       setState('error');
     }
   }, [repoPath]);
@@ -107,11 +157,21 @@ export function TargetsPanel({ repoPath, active }: { repoPath?: string | null; a
     if (!active || !repoPath) return;
     if (loadedRepoRef.current === repoPath) return;
     loadedRepoRef.current = repoPath;
-    void load();
+    void load(false);
   }, [active, repoPath, load]);
 
-  const targets = data?.targets ?? [];
+  useEffect(() => () => {
+    if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
+  }, []);
+
+  const targets = data?.repoPath === repoPath ? data?.targets ?? [] : [];
   const scoredAt = data?.scoredAt ? new Date(data.scoredAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : null;
+  const progressFiles = progress?.totalFiles
+    ? `${progress.filesScanned}/${progress.totalFiles} files`
+    : progress && progress.filesScanned > 0 ? `${progress.filesScanned} files` : null;
+  const scanDetail = progress
+    ? `${progress.label}${progressFiles ? ` · ${progressFiles}` : ''}`
+    : 'Ranking files by impact × opportunity from the cached signals.';
 
   return (
     <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', background: 'var(--t-bg)' }}>
@@ -127,24 +187,26 @@ export function TargetsPanel({ repoPath, active }: { repoPath?: string | null; a
         <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 1 }}>
           <span style={{ fontSize: 13, fontWeight: 400, letterSpacing: '-0.1px', color: 'var(--t-text)' }}>Targeting</span>
           <span style={{ fontSize: 10.5, fontWeight: 300, letterSpacing: '-0.05px', color: 'var(--t-text-faint)' }}>
-            {state === 'ready' && targets.length > 0
+            {state === 'loading'
+              ? scanDetail
+              : state === 'ready' && targets.length > 0
               ? `${targets.length} files ranked${scoredAt ? ` · ${scoredAt}` : ''} — point your agents here`
               : 'Where to point your agents'}
           </span>
         </div>
         <button
           type="button"
-          onClick={() => void load()}
-          disabled={!repoPath || state === 'loading'}
-          title="Re-run the triage"
+          onClick={() => void load(true)}
+          disabled={!repoPath}
+          title={state === 'loading' ? 'Restart the triage scan' : 'Re-run the triage'}
           style={{
             fontSize: 11, fontWeight: 400, color: state === 'loading' ? 'var(--t-text-muted)' : 'var(--t-text)',
             background: 'var(--t-input-bg)', borderWidth: 1, borderStyle: 'solid', borderColor: 'var(--t-divider-subtle)',
             borderRadius: 7, paddingTop: 4, paddingBottom: 4, paddingLeft: 10, paddingRight: 10,
-            cursor: repoPath && state !== 'loading' ? 'pointer' : 'default', flexShrink: 0,
+            cursor: repoPath ? 'pointer' : 'default', flexShrink: 0,
           }}
         >
-          {state === 'loading' ? 'Scanning…' : 'Re-scan'}
+          {state === 'loading' ? 'Restart scan' : 'Re-scan'}
         </button>
       </div>
 
@@ -153,7 +215,7 @@ export function TargetsPanel({ repoPath, active }: { repoPath?: string | null; a
         {!repoPath ? (
           <EmptyState title="No repo selected" detail="Select a repository to triage where your agents should aim." />
         ) : state === 'loading' && targets.length === 0 ? (
-          <EmptyState title="Scanning…" detail="Ranking files by impact × opportunity from the cached signals." />
+          <EmptyState title="Scanning…" detail={scanDetail} />
         ) : state === 'error' ? (
           <EmptyState title="Triage failed" detail={data?.error || 'Something went wrong scoring this repo.'} />
         ) : targets.length === 0 ? (


### PR DESCRIPTION
Closes #1343. The scan is a progress job (starting → collecting-signals → scoring) with filesScanned + labels; the panel polls and renders the live phase; restart re-triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj