### PR TITLE
test: smokes refuse to run against the real ~/.o8 — runtime isolation guard across all 17 entrypoints (#1308)

### DIFF
--- a/tests/smoke/cortex-readonly-profile-smoke.ts
+++ b/tests/smoke/cortex-readonly-profile-smoke.ts
@@ -16,6 +16,7 @@ import { spawn } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import { join } from 'node:path';
 
+import './require-temp-data-dir';
 const SERVER = join(process.cwd(), 'src/lib/mcp/cortex-mcp-server.ts');
 const READONLY_EXPECTED = [
   'cortex_ask', 'cortex_read_packets', 'cortex_read_transcript', 'cortex_fleet_status',

--- a/tests/smoke/hermes-governed-profile-smoke.ts
+++ b/tests/smoke/hermes-governed-profile-smoke.ts
@@ -15,6 +15,7 @@ import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
+import './require-temp-data-dir';
 import { governHermesProfile, isHermesProfileGoverned, parseDisabledFromToolsList, HERMES_DENIED_TOOLSETS } from '@/lib/lane/orchestrator-backends/hermes-profile';
 
 function resolveHermes(): string | null {

--- a/tests/smoke/mobile-device-registry-smoke.ts
+++ b/tests/smoke/mobile-device-registry-smoke.ts
@@ -9,6 +9,7 @@
 
 import assert from 'node:assert';
 
+import './require-temp-data-dir';
 import { enrollDevice, resolveDeviceByToken, listDevices, revokeDevice, hashToken, isTokenRevoked } from '@/lib/mobile/device-registry';
 
 function main(): void {

--- a/tests/smoke/mobile-diff-comments-smoke.ts
+++ b/tests/smoke/mobile-diff-comments-smoke.ts
@@ -6,6 +6,7 @@
 
 import assert from 'node:assert';
 
+import './require-temp-data-dir';
 import {
   createDiffComment,
   listDiffComments,

--- a/tests/smoke/orchestrator-backend-setting-smoke.ts
+++ b/tests/smoke/orchestrator-backend-setting-smoke.ts
@@ -17,6 +17,7 @@
 
 import assert from 'node:assert';
 
+import './require-temp-data-dir';
 import { resolveOrchestratorBackendId } from '@/lib/lane/orchestrator-backends/registry';
 import { resolveInAppOrchestratorEnabledSync } from '@/lib/operator/defaults';
 

--- a/tests/smoke/proposer-profile-lockout-smoke.ts
+++ b/tests/smoke/proposer-profile-lockout-smoke.ts
@@ -13,6 +13,7 @@
 
 import assert from 'node:assert';
 
+import './require-temp-data-dir';
 import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
 import { toClaudeServersMap } from '@/lib/mcp/tool-spine/emit-claude';
 import { toCodexServersMap } from '@/lib/mcp/tool-spine/emit-codex';

--- a/tests/smoke/require-temp-data-dir.ts
+++ b/tests/smoke/require-temp-data-dir.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert';
+import { existsSync, realpathSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+
+const setup = 'CORTEX_IDE_DATA_DIR=$(mktemp -d) NODE_OPTIONS=\'--conditions=react-server\' npx tsx <smoke-file>';
+const dataDir = process.env.CORTEX_IDE_DATA_DIR;
+
+assert(
+  dataDir,
+  `CORTEX_IDE_DATA_DIR must be set to an isolated temp dir.\nRun: ${setup}`,
+);
+
+assert(
+  existsSync(dataDir),
+  `CORTEX_IDE_DATA_DIR must point at an existing isolated temp dir.\nRun: ${setup}`,
+);
+
+const actual = realpathSync(dataDir);
+const realDefault = existsSync(resolve(homedir(), '.o8'))
+  ? realpathSync(resolve(homedir(), '.o8'))
+  : resolve(homedir(), '.o8');
+
+assert.notStrictEqual(
+  actual,
+  realDefault,
+  `Refusing to run smoke against the real ~/.o8 data dir: ${actual}\nRun: ${setup}`,
+);
+
+export const smokeDataDir = dataDir;

--- a/tests/smoke/tool-spine-claude-consumer-smoke.ts
+++ b/tests/smoke/tool-spine-claude-consumer-smoke.ts
@@ -19,20 +19,19 @@
  */
 
 import assert from 'node:assert';
-import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { smokeDataDir } from './require-temp-data-dir';
 import { getMcpServersConfig } from '@/lib/lane/orchestrator-mcp-config';
 import { insertExternalMcpServer } from '@/lib/mcp/external-servers';
 import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
 import { toClaudeJson } from '@/lib/mcp/tool-spine/emit-claude';
 
 function main(): void {
-  const dataDir = process.env.CORTEX_IDE_DATA_DIR;
-  assert(dataDir && existsSync(dataDir), 'CORTEX_IDE_DATA_DIR must be set to a temp dir');
-  writeFileSync(join(dataDir, 'ws-token'), 'consumer-smoke-fixed-token\n');
-  writeFileSync(join(dataDir, 'ws-port'), '3002\n');
+  writeFileSync(join(smokeDataDir, 'ws-token'), 'consumer-smoke-fixed-token\n');
+  writeFileSync(join(smokeDataDir, 'ws-port'), '3002\n');
 
   // Externals present — the path that drifts (ordering + passthrough through the envelope).
   insertExternalMcpServer({ name: 'zeta-stdio', transport: 'stdio', command: 'zeta', args: ['--x'], env: { K: 'v' }, enabled: true });

--- a/tests/smoke/tool-spine-claude-desktop-consumer-smoke.ts
+++ b/tests/smoke/tool-spine-claude-desktop-consumer-smoke.ts
@@ -14,10 +14,11 @@
  */
 
 import assert from 'node:assert';
-import { existsSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 
+import './require-temp-data-dir';
 import { atomicWriteConfig } from '@/lib/mcp/claude-desktop-config-io';
 import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
 import { entriesForSurface } from '@/lib/mcp/tool-spine/registry';

--- a/tests/smoke/tool-spine-codex-consumer-smoke.ts
+++ b/tests/smoke/tool-spine-codex-consumer-smoke.ts
@@ -16,10 +16,11 @@
  */
 
 import assert from 'node:assert';
-import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { smokeDataDir } from './require-temp-data-dir';
 import { getMcpServersConfig } from '@/lib/lane/orchestrator-mcp-config';
 import { mergeCodexMcpConfig } from '@/lib/lane/codex-orchestrator-session';
 import { insertExternalMcpServer } from '@/lib/mcp/external-servers';
@@ -39,10 +40,8 @@ const RETAINED_FIXTURE = [
 ].join('\n');
 
 function main(): void {
-  const dataDir = process.env.CORTEX_IDE_DATA_DIR;
-  assert(dataDir && existsSync(dataDir), 'CORTEX_IDE_DATA_DIR must be set to a temp dir');
-  writeFileSync(join(dataDir, 'ws-token'), 'codex-consumer-fixed-token\n');
-  writeFileSync(join(dataDir, 'ws-port'), '3002\n');
+  writeFileSync(join(smokeDataDir, 'ws-token'), 'codex-consumer-fixed-token\n');
+  writeFileSync(join(smokeDataDir, 'ws-port'), '3002\n');
 
   insertExternalMcpServer({ name: 'zeta-stdio', transport: 'stdio', command: 'zeta', args: ['--x'], env: { K: 'v' }, enabled: true });
   insertExternalMcpServer({ name: 'alpha-http', transport: 'http', command: 'https://a/mcp', url: 'https://a/mcp', oauthToken: 'tok123', enabled: true });

--- a/tests/smoke/tool-spine-external-client-consumer-smoke.ts
+++ b/tests/smoke/tool-spine-external-client-consumer-smoke.ts
@@ -21,6 +21,7 @@ import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import './require-temp-data-dir';
 import { insertExternalMcpServer } from '@/lib/mcp/external-servers';
 import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
 import { toClaudeDesktopJson } from '@/lib/mcp/tool-spine/emit-claude-desktop';

--- a/tests/smoke/tool-spine-gemini-consumer-smoke.ts
+++ b/tests/smoke/tool-spine-gemini-consumer-smoke.ts
@@ -15,6 +15,7 @@ import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 
+import './require-temp-data-dir';
 import { atomicWriteConfig } from '@/lib/mcp/claude-desktop-config-io';
 import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
 import { entriesForSurface, type ToolRegistry } from '@/lib/mcp/tool-spine/registry';

--- a/tests/smoke/tool-spine-mcp-config-consumer-smoke.ts
+++ b/tests/smoke/tool-spine-mcp-config-consumer-smoke.ts
@@ -17,6 +17,7 @@ import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import './require-temp-data-dir';
 import { insertExternalMcpServer } from '@/lib/mcp/external-servers';
 import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
 import { toClaudeDesktopJson } from '@/lib/mcp/tool-spine/emit-claude-desktop';

--- a/tests/smoke/tool-spine-openclaw-consumer-smoke.ts
+++ b/tests/smoke/tool-spine-openclaw-consumer-smoke.ts
@@ -18,6 +18,7 @@ import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import './require-temp-data-dir';
 import { buildGovernedO8Profile } from '@/lib/lane/orchestrator-backends/openclaw';
 import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
 import { toOpenclawJson } from '@/lib/mcp/tool-spine/emit-openclaw';

--- a/tests/smoke/tool-spine-opencode-consumer-smoke.ts
+++ b/tests/smoke/tool-spine-opencode-consumer-smoke.ts
@@ -15,6 +15,7 @@ import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 
+import './require-temp-data-dir';
 import { atomicWriteConfig, type ClaudeDesktopConfig } from '@/lib/mcp/claude-desktop-config-io';
 import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
 import { entriesForSurface, type ToolRegistry } from '@/lib/mcp/tool-spine/registry';

--- a/tests/smoke/tool-spine-parity-smoke.ts
+++ b/tests/smoke/tool-spine-parity-smoke.ts
@@ -13,10 +13,11 @@
  */
 
 import assert from 'node:assert';
-import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { smokeDataDir } from './require-temp-data-dir';
 import { getMcpServersConfig } from '@/lib/lane/orchestrator-mcp-config';
 import { externalServerToMcpConfig, insertExternalMcpServer, listEnabledExternalMcpServers } from '@/lib/mcp/external-servers';
 import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
@@ -27,12 +28,9 @@ import { toOpenclawJson } from '@/lib/mcp/tool-spine/emit-openclaw';
 import { toGeminiSettings } from '@/lib/mcp/tool-spine/emit-gemini';
 
 function main(): void {
-  const dataDir = process.env.CORTEX_IDE_DATA_DIR;
-  assert(dataDir && existsSync(dataDir), 'CORTEX_IDE_DATA_DIR must be set to a temp dir');
-
   // Pin the env-derived values so the golden is deterministic.
-  writeFileSync(join(dataDir, 'ws-token'), 'test-ws-token-fixed\n');
-  writeFileSync(join(dataDir, 'ws-port'), '3002\n');
+  writeFileSync(join(smokeDataDir, 'ws-token'), 'test-ws-token-fixed\n');
+  writeFileSync(join(smokeDataDir, 'ws-port'), '3002\n');
 
   const repo = mkdtempSync(join(tmpdir(), 'tool-spine-repo-')); // non-git → slug ''
   const repoRoot = process.cwd();

--- a/tests/smoke/worker-effort-e2e-smoke.ts
+++ b/tests/smoke/worker-effort-e2e-smoke.ts
@@ -11,6 +11,7 @@
 
 import assert from 'node:assert';
 
+import './require-temp-data-dir';
 import { createMission } from '@/lib/orchestrator/operator-mission-service';
 import { currentMissionState } from '@/lib/orchestrator/operator-mission-service/shared';
 import type { WorkerRouting } from '@/lib/orchestrator/types';


### PR DESCRIPTION
Closes #1308. Shared guard asserts CORTEX_IDE_DATA_DIR is set, exists, and is not the real data dir (realpath compare) — fails with the exact setup command. Proven live: unset refuses cleanly; zero synthetic lanes reach the real DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj