### PR TITLE
fix: harden first-connect access points — homebrew path, o8 doctor --repair, o8 mcp install, visible diagnostics (#1273)

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -8,6 +8,7 @@
 import { apiFetch, CliError, EXIT } from '../api.js';
 import { resolveConfig } from '../config.js';
 import { printHumanHeading, printHumanKv, printJson, type OutputMode } from '../output.js';
+import { repairCliInstall, type CliInstallResult } from './install.js';
 
 interface ReapCandidate {
   lane: {
@@ -39,9 +40,11 @@ interface ReapResponse {
 function parseDoctorArgs(rest: string[]) {
   let reap = false;
   let force = false;
+  let repair = false;
   for (const tok of rest) {
     if (tok === '--reap') reap = true;
     else if (tok === '--force') force = true;
+    else if (tok === '--repair') repair = true;
     else {
       throw new CliError('invalid_args', `Unknown doctor flag: ${tok}`, EXIT.INVALID_ARGS);
     }
@@ -49,7 +52,7 @@ function parseDoctorArgs(rest: string[]) {
   if (force && !reap) {
     throw new CliError('invalid_args', '`o8 doctor --force` requires --reap.', EXIT.INVALID_ARGS);
   }
-  return { reap, force };
+  return { reap, force, repair };
 }
 
 export async function runDoctor(mode: OutputMode, rest: string[] = []): Promise<number> {
@@ -57,6 +60,31 @@ export async function runDoctor(mode: OutputMode, rest: string[] = []): Promise<
   const cfg = resolveConfig();
   const findings: Array<{ level: 'info' | 'warn' | 'error'; code: string; message: string }> = [];
   let reapPayload: ReapResponse | null = null;
+  let repairPayload: CliInstallResult | null = null;
+
+  if (args.repair) {
+    repairPayload = repairCliInstall(process.argv[1] ?? '');
+    if (!repairPayload.installedAt) {
+      findings.push({
+        level: 'error',
+        code: 'cli_install_failed',
+        message: 'Could not install the o8 CLI symlink. See repair.candidates for details.',
+      });
+    } else if (!repairPayload.onPath) {
+      findings.push({
+        level: 'warn',
+        code: 'cli_not_on_path',
+        message: `o8 is installed at ${repairPayload.installedAt}, but that directory is not on PATH.`,
+      });
+    }
+    if (!repairPayload.nodeResolvable) {
+      findings.push({
+        level: 'error',
+        code: 'node_not_resolvable',
+        message: 'Node.js is not resolvable from this shell. Install Node 22 or relaunch o8 so O8_NODE_BIN can be injected.',
+      });
+    }
+  }
 
   let serverReachable = false;
   let serverPayload: Record<string, unknown> | null = null;
@@ -146,6 +174,7 @@ export async function runDoctor(mode: OutputMode, rest: string[] = []): Promise<
       candidates: reapPayload.candidates,
       reaped: reapPayload.reaped ?? [],
     } : null,
+    repair: repairPayload,
     runtimes: runtimes.map((rt) => ({
       id: rt.id,
       name: rt.name,
@@ -165,6 +194,18 @@ export async function runDoctor(mode: OutputMode, rest: string[] = []): Promise<
       ['data dir', cfg.dataDir ?? '(none)'],
       ['reachable', serverReachable ? 'yes' : 'no'],
     ]);
+    if (repairPayload) {
+      printHumanHeading('cli repair');
+      printHumanKv([
+        ['source', repairPayload.source],
+        ['installed at', repairPayload.installedAt ?? '(not installed)'],
+        ['on PATH', repairPayload.onPath ? 'yes' : 'no'],
+        ['node', repairPayload.nodeBin ?? 'missing'],
+      ]);
+      for (const candidate of repairPayload.candidates) {
+        process.stdout.write(`  ${candidate.path}: ${candidate.status} — ${candidate.detail}\n`);
+      }
+    }
     if (runtimes.length > 0) {
       printHumanHeading('runtimes');
       for (const rt of runtimes) {

--- a/cli/src/commands/install.ts
+++ b/cli/src/commands/install.ts
@@ -1,0 +1,122 @@
+import { existsSync, lstatSync, mkdirSync, readlinkSync, rmSync, symlinkSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+export interface CliInstallCandidate {
+  path: string;
+  directoryOnPath: boolean;
+  status: 'linked' | 'already-linked' | 'blocked' | 'failed' | 'skipped';
+  detail: string;
+}
+
+export interface CliInstallResult {
+  source: string;
+  installedAt: string | null;
+  onPath: boolean;
+  nodeResolvable: boolean;
+  nodeBin: string | null;
+  candidates: CliInstallCandidate[];
+}
+
+function cliCandidates(): string[] {
+  const home = homedir();
+  const candidates: string[] = [];
+  if (process.platform === 'darwin' && process.arch === 'arm64') {
+    candidates.push('/opt/homebrew/bin/o8');
+  }
+  if (process.platform === 'darwin' || process.platform === 'linux') {
+    candidates.push('/usr/local/bin/o8');
+  }
+  candidates.push(`${home}/.local/bin/o8`);
+  return [...new Set(candidates)];
+}
+
+function directoryOnPath(target: string): boolean {
+  const dir = dirname(target);
+  return (process.env.PATH ?? '').split(':').includes(dir);
+}
+
+function findNode(): { ok: boolean; path: string | null } {
+  if (process.env.O8_NODE_BIN && existsSync(process.env.O8_NODE_BIN)) {
+    return { ok: true, path: process.env.O8_NODE_BIN };
+  }
+  try {
+    const out = execFileSync('sh', ['-lc', 'command -v node'], { encoding: 'utf8' }).trim();
+    return out ? { ok: true, path: out } : { ok: false, path: null };
+  } catch {
+    return { ok: false, path: null };
+  }
+}
+
+export function repairCliInstall(source: string): CliInstallResult {
+  const candidates: CliInstallCandidate[] = [];
+  let installedAt: string | null = null;
+
+  for (const target of cliCandidates()) {
+    const candidate: CliInstallCandidate = {
+      path: target,
+      directoryOnPath: directoryOnPath(target),
+      status: 'skipped',
+      detail: '',
+    };
+
+    try {
+      mkdirSync(dirname(target), { recursive: true });
+      if (existsSync(target)) {
+        const meta = lstatSync(target);
+        if (meta.isSymbolicLink()) {
+          const existing = readlinkSync(target);
+          if (existing === source) {
+            candidate.status = 'already-linked';
+            candidate.detail = `already points to ${source}`;
+            installedAt = target;
+            candidates.push(candidate);
+            break;
+          }
+          if (
+            existing.includes('/Applications/o8.app/')
+            || existing.includes('/server/bin/o8')
+            || existing.includes('/server/bin/o8.mjs')
+          ) {
+            rmSync(target);
+          } else {
+            candidate.status = 'blocked';
+            candidate.detail = `existing symlink points to ${existing}`;
+            candidates.push(candidate);
+            continue;
+          }
+        } else {
+          candidate.status = 'blocked';
+          candidate.detail = 'existing path is not a symlink';
+          candidates.push(candidate);
+          continue;
+        }
+      }
+
+      symlinkSync(source, target);
+      candidate.status = 'linked';
+      candidate.detail = `linked to ${source}`;
+      installedAt = target;
+      candidates.push(candidate);
+      break;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      candidate.status = 'failed';
+      candidate.detail = target.startsWith('/usr/local/bin/')
+        ? `${message}; retry with: sudo ln -sf "${source}" "${target}"`
+        : message;
+      candidates.push(candidate);
+    }
+  }
+
+  const node = findNode();
+  return {
+    source,
+    installedAt,
+    onPath: installedAt ? directoryOnPath(installedAt) : false,
+    nodeResolvable: node.ok,
+    nodeBin: node.path,
+    candidates,
+  };
+}

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -1,0 +1,93 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { apiFetch, CliError, EXIT } from '../api.js';
+import { resolveConfig } from '../config.js';
+import { printHumanHeading, printHumanKv, printJson, type OutputMode } from '../output.js';
+
+type McpTarget = 'print' | 'claude-code' | 'cursor';
+
+function parseMcpArgs(sub: string | undefined, rest: string[]): { target: McpTarget } {
+  if (sub !== 'install') {
+    throw new CliError(
+      'unknown_mcp_subcommand',
+      `Unknown mcp subcommand: ${sub ?? '(none)'}`,
+      EXIT.INVALID_ARGS,
+      'Run `o8 mcp install --print` to emit a generic MCP config.',
+    );
+  }
+
+  let target: McpTarget = 'print';
+  for (const token of rest) {
+    if (token === '--print') target = 'print';
+    else if (token === '--claude-code') target = 'claude-code';
+    else if (token === '--cursor') target = 'cursor';
+    else {
+      throw new CliError('invalid_args', `Unknown mcp install flag: ${token}`, EXIT.INVALID_ARGS);
+    }
+  }
+  return { target };
+}
+
+export async function runMcp(mode: OutputMode, sub: string | undefined, rest: string[]): Promise<number> {
+  const args = parseMcpArgs(sub, rest);
+  const cfg = resolveConfig();
+
+  if (args.target === 'claude-code') {
+    const res = await apiFetch<Record<string, unknown>>(cfg, '/api/setup/claude-desktop', {
+      method: 'POST',
+      body: { target: 'claude-code' },
+    });
+    const payload = {
+      schema: 'o8/cli/mcp-install/v1',
+      target: args.target,
+      result: res.data,
+    };
+    if (mode.human) {
+      printHumanHeading('mcp install');
+      printHumanKv([
+        ['target', 'Claude Code'],
+        ['status', res.status < 400 ? 'installed' : 'failed'],
+      ]);
+    } else {
+      printJson(payload);
+    }
+    return res.status < 400 ? 0 : 1;
+  }
+
+  const res = await apiFetch<{
+    setupReady?: boolean;
+    setupBlockedDetail?: string | null;
+    fullConfig: Record<string, unknown>;
+  }>(cfg, '/api/setup/mcp-config');
+  const data = res.data;
+  if (!data) {
+    throw new CliError('mcp_config_empty', 'The o8 server returned an empty MCP config response.', EXIT.CONFLICT);
+  }
+  if (data.setupReady === false) {
+    throw new CliError(
+      'mcp_setup_not_ready',
+      data.setupBlockedDetail ?? 'MCP setup is not ready.',
+      EXIT.CONFLICT,
+      'Finish first launch, then retry `o8 mcp install --print`.',
+    );
+  }
+
+  const cursorPath = join(homedir(), '.cursor', 'mcp.json');
+  const payload = {
+    schema: 'o8/cli/mcp-install/v1',
+    target: args.target,
+    config: data.fullConfig,
+    destination: args.target === 'cursor' ? cursorPath : null,
+    note: args.target === 'cursor'
+    ? `Write this JSON to ${cursorPath}, then restart Cursor.`
+    : 'Use this JSON with any MCP client that accepts a Claude-style mcpServers object.',
+  };
+  if (mode.human) {
+    printHumanHeading(args.target === 'cursor' ? 'cursor mcp config' : 'mcp config');
+    process.stdout.write(`${JSON.stringify(data.fullConfig, null, 2)}\n`);
+    if (payload.note) process.stdout.write(`\n${payload.note}\n`);
+  } else {
+    printJson(payload);
+  }
+  return 0;
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -24,6 +24,7 @@ import { runCortexObserve } from './commands/cortex.js';
 import { runInbox } from './commands/inbox.js';
 import { runLaneTouches } from './commands/lane.js';
 import { runMission } from './commands/mission.js';
+import { runMcp } from './commands/mcp.js';
 import { runStatus } from './commands/status.js';
 import { runRun } from './commands/run.js';
 import { runVersion } from './commands/version.js';
@@ -113,7 +114,7 @@ usage: o8 <command> [subcommand] [flags]
 
 commands:
   version              CLI version + connected server version
-  doctor               verify port + token resolution, ping server
+  doctor               verify port + token resolution, ping server; --repair reinstalls the o8 CLI symlink
   status               snapshot: running packets, lanes, merges, approvals
   run [--detach] <cmd> run a process in an o8-owned terminal the operator can watch
   run --list           list managed runs (running + recent, with exit codes)
@@ -132,6 +133,7 @@ commands:
   mission status       mission + packet state [--mission <id>] [--cost]
   mission wait         block until a packet hits a review/terminal state [--timeout --poll]
   mission tail         stream packet status transitions until terminal [--timeout --poll]
+  mcp install          install/print the o8 MCP config (--claude-code | --cursor | --print)
   inbox list           pending governance approvals (--all includes resolved)
   inbox approve <id>   approve a card → runs the deferred action (e.g. a held merge)
   inbox reject <id>    reject a pending approval
@@ -218,6 +220,8 @@ async function dispatch(args: ParsedArgs): Promise<number> {
     }
     case 'mission':
       return runMission(args.mode, secondary, args.rest);
+    case 'mcp':
+      return runMcp(args.mode, secondary, args.rest);
     case 'inbox':
       return runInbox(args.mode, secondary, args.rest);
     case 'task': {

--- a/scripts/tauri-export.mjs
+++ b/scripts/tauri-export.mjs
@@ -311,6 +311,7 @@ https.createServer = function (...args) {
   return stampClientAddr(origHttpsCreate.apply(this, args));
 };
 ${RELEASE_ENV_STANZA}
+process.env.O8_PACKAGED_APP = '1';
 require('./server-impl.js');
 `);
 console.log('📦 Wrote server.js wrapper (socket-addr stamping) + server-impl.js');
@@ -459,13 +460,15 @@ if (existsSync(DECOMPOSE_PROMPT_SRC)) {
 }
 
 // ── Build + bundle the agent-facing CLI ──
-// Builds cli/dist/o8.mjs via the package's own esbuild config, then copies it
-// into out/server/bin/o8. The Tauri sidecar symlinks /usr/local/bin/o8 → that
-// path on first launch so the user (and dispatched workers) have `o8` on PATH.
+// Builds cli/dist/o8.mjs via the package's own esbuild config, then writes a
+// shell wrapper at out/server/bin/o8. The wrapper uses O8_NODE_BIN when the app
+// injected it, then falls back to a login-shell lookup so Finder/minimal-PATH
+// sessions do not fail at `#!/usr/bin/env node`.
 const CLI_BUILD = join(root, 'cli', 'esbuild.config.mjs');
 const CLI_OUTPUT = join(root, 'cli', 'dist', 'o8.mjs');
 const CLI_BIN_DIR = join(server, 'bin');
 const CLI_BIN_DST = join(CLI_BIN_DIR, 'o8');
+const CLI_BUNDLE_DST = join(CLI_BIN_DIR, 'o8.mjs');
 if (existsSync(CLI_BUILD)) {
   console.log('   building cli bundle…');
   execSync(`node "${CLI_BUILD}"`, { stdio: 'inherit', cwd: join(root, 'cli') });
@@ -474,8 +477,22 @@ if (existsSync(CLI_BUILD)) {
     process.exit(1);
   }
   mkdirSync(CLI_BIN_DIR, { recursive: true });
-  cpSync(CLI_OUTPUT, CLI_BIN_DST);
+  cpSync(CLI_OUTPUT, CLI_BUNDLE_DST);
+  writeFileSync(CLI_BIN_DST, `#!/bin/sh
+set -eu
+DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+NODE_BIN="\${O8_NODE_BIN:-}"
+if [ -z "$NODE_BIN" ] || [ ! -x "$NODE_BIN" ]; then
+  NODE_BIN="$(zsh -l -c 'command -v node' 2>/dev/null || bash -l -c 'command -v node' 2>/dev/null || sh -lc 'command -v node' 2>/dev/null || true)"
+fi
+if [ -z "$NODE_BIN" ]; then
+  echo "o8: Node.js 22+ is required. Relaunch o8.app or install Node from https://nodejs.org." >&2
+  exit 127
+fi
+exec "$NODE_BIN" "$DIR/o8.mjs" "$@"
+`);
   execSync(`chmod +x "${CLI_BIN_DST}"`);
+  execSync(`chmod +x "${CLI_BUNDLE_DST}"`);
 } else {
   console.warn('⚠️  CLI build config missing — skipping `o8` cli bundle');
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2253,7 +2253,7 @@ fn sanitize_window_state() {
 /// well-known bin directory. Best-effort — logs and returns on any error so a
 /// permission failure never blocks app startup.
 ///
-/// Priority: /usr/local/bin (Homebrew-style, most common) → ~/.local/bin.
+/// Priority: /opt/homebrew/bin on Apple Silicon → /usr/local/bin → ~/.local/bin.
 /// We refuse to clobber a non-symlink at the target. If an existing symlink
 /// points at any /Applications/o8.app path, we replace it (assume stale o8
 /// from a previous install).
@@ -2272,15 +2272,19 @@ fn ensure_cli_on_path(cli_source: &Path) {
         }
     };
 
-    let candidates: [std::path::PathBuf; 2] = [
-        std::path::PathBuf::from("/usr/local/bin/o8"),
-        home.join(".local").join("bin").join("o8"),
-    ];
+    let mut candidates: Vec<std::path::PathBuf> = Vec::new();
+    if cfg!(target_arch = "aarch64") {
+        candidates.push(std::path::PathBuf::from("/opt/homebrew/bin/o8"));
+    }
+    candidates.push(std::path::PathBuf::from("/usr/local/bin/o8"));
+    candidates.push(home.join(".local").join("bin").join("o8"));
 
+    let mut failures: Vec<String> = Vec::new();
     for target in &candidates {
         if let Some(parent) = target.parent() {
             if !parent.exists() {
-                if std::fs::create_dir_all(parent).is_err() {
+                if let Err(err) = std::fs::create_dir_all(parent) {
+                    failures.push(format!("mkdir {} failed: {}", parent.display(), err));
                     continue;
                 }
             }
@@ -2292,6 +2296,8 @@ fn ensure_cli_on_path(cli_source: &Path) {
                     match std::fs::read_link(target) {
                         Ok(existing) if existing == cli_source => {
                             // Already pointing where we want — nothing to do.
+                            std::env::set_var("O8_CLI_INSTALL_PATH", target.to_string_lossy().to_string());
+                            std::env::set_var("O8_CLI_INSTALL_STATUS", "already-linked");
                             return;
                         }
                         Ok(existing) if existing.to_string_lossy().contains("/Applications/o8.app/") => {
@@ -2309,7 +2315,8 @@ fn ensure_cli_on_path(cli_source: &Path) {
                         }
                         Ok(_) => {
                             // User-owned symlink to something else — leave alone.
-                            return;
+                            failures.push(format!("{} points to a user-owned symlink", target.display()));
+                            continue;
                         }
                         Err(_) => {
                             let _ = std::fs::remove_file(target);
@@ -2317,8 +2324,10 @@ fn ensure_cli_on_path(cli_source: &Path) {
                     }
                 } else {
                     // Regular file or directory — never clobber.
-                    eprintln!("[cli-symlink] {} exists and is not a symlink — leaving alone", target.display());
-                    return;
+                    let message = format!("{} exists and is not a symlink", target.display());
+                    failures.push(message.clone());
+                    eprintln!("[cli-symlink] {} — leaving alone", message);
+                    continue;
                 }
             }
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
@@ -2326,6 +2335,7 @@ fn ensure_cli_on_path(cli_source: &Path) {
             }
             Err(err) => {
                 eprintln!("[cli-symlink] stat {} failed: {}", target.display(), err);
+                failures.push(format!("stat {} failed: {}", target.display(), err));
                 continue;
             }
         }
@@ -2333,13 +2343,18 @@ fn ensure_cli_on_path(cli_source: &Path) {
         match std::os::unix::fs::symlink(cli_source, target) {
             Ok(()) => {
                 eprintln!("[cli-symlink] linked {} -> {}", target.display(), cli_source.display());
+                std::env::set_var("O8_CLI_INSTALL_PATH", target.to_string_lossy().to_string());
+                std::env::set_var("O8_CLI_INSTALL_STATUS", "linked");
                 return;
             }
             Err(err) => {
                 eprintln!("[cli-symlink] {} failed: {}", target.display(), err);
+                failures.push(format!("{} failed: {}", target.display(), err));
             }
         }
     }
+    let detail = failures.join("; ");
+    std::env::set_var("O8_CLI_INSTALL_STATUS", format!("failed: {}", detail));
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -4501,6 +4516,7 @@ pub fn run() {
                     .env("PORT", api_port.to_string())
                     .env("HOSTNAME", "0.0.0.0")
                     .env("NODE_ENV", "production")
+                    .env("O8_PACKAGED_APP", "1")
                     .env("O8_NODE_BIN", &node_bin)
                     .env("O8_API_PORT", api_port.to_string())
                     .env("O8_WS_PORT", ws_port.to_string())

--- a/src/app/api/setup/claude-desktop/route.ts
+++ b/src/app/api/setup/claude-desktop/route.ts
@@ -24,6 +24,7 @@ import { NextResponse } from 'next/server';
 import { existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { readClaudeConfig, atomicWriteConfig } from '@/lib/mcp/claude-desktop-config-io';
+import { getMcpSetupReadiness } from '@/lib/mcp/setup-readiness';
 import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
 import { entriesForSurface } from '@/lib/mcp/tool-spine/registry';
 import { toClaudeDesktopJson } from '@/lib/mcp/tool-spine/emit-claude-desktop';
@@ -79,7 +80,10 @@ export async function GET(request: Request) {
     const existingEntry = existingServers['o8'];
     const existingCodebaseMemoryEntry = existingServers['codebase-memory'];
 
-    const projected = toClaudeDesktopJson(buildToolRegistry(process.cwd()), {}).mcpServers as Record<string, unknown>;
+    const mcpReady = getMcpSetupReadiness();
+    const projected = mcpReady.ready
+      ? toClaudeDesktopJson(buildToolRegistry(process.cwd()), {}).mcpServers as Record<string, unknown>
+      : {};
     const proposed = projected['o8'];
     const proposedCodebaseMemory = projected['codebase-memory'] ?? null;
 
@@ -105,7 +109,10 @@ export async function GET(request: Request) {
       path,
       fileExists,
       alreadyRegistered: Boolean(existingEntry),
-      alreadyUpToDate,
+      alreadyUpToDate: mcpReady.ready ? alreadyUpToDate : false,
+      setupReady: mcpReady.ready,
+      setupBlockedReason: mcpReady.reason,
+      setupBlockedDetail: mcpReady.detail,
       proposed,
       existingEntry: existingEntry ?? null,
       proposedCodebaseMemory,
@@ -131,6 +138,18 @@ export async function POST(request: Request) {
     const target = normalizeTarget(body.target);
     const remove = body.remove === true;
     const path = getTargetConfigPath(target);
+    const mcpReady = getMcpSetupReadiness();
+    if (!remove && !mcpReady.ready) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: 'MCP setup is not ready',
+          detail: mcpReady.detail,
+          setupBlockedReason: mcpReady.reason,
+        },
+        { status: 409 },
+      );
+    }
 
     const config = readClaudeConfig(path);
     if (!config.mcpServers || typeof config.mcpServers !== 'object') {

--- a/src/app/api/setup/mcp-config/route.ts
+++ b/src/app/api/setup/mcp-config/route.ts
@@ -36,6 +36,8 @@ import { userInfo } from 'node:os';
 import { join } from 'node:path';
 import { execSync } from 'node:child_process';
 import { getApiBase, resolvePortInfo } from '@/lib/panel/api-port';
+import { getCliAccessStatus } from '@/lib/access-points/cli-status';
+import { getMcpSetupReadiness } from '@/lib/mcp/setup-readiness';
 import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
 import { toClaudeDesktopJson } from '@/lib/mcp/tool-spine/emit-claude-desktop';
 
@@ -78,11 +80,6 @@ function buildInstructions(): { claudeDesktop: string; claudeCode: string } {
 
 export async function GET() {
   try {
-    const mcpServers = toClaudeDesktopJson(buildToolRegistry(process.cwd()), {}).mcpServers as Record<string, unknown>;
-    const server = mcpServers['o8'];
-    const codebaseMemory = mcpServers['codebase-memory'] ?? null;
-    const fullConfig = { mcpServers };
-
     const nodeBin = findCommand('node');
     const codexBin = findCommand('codex');
     const ghBin = findCommand('gh');
@@ -94,8 +91,18 @@ export async function GET() {
     const dbPath = join(dataDir, 'cortex-ide.db');
     const dbExists = existsSync(dbPath);
     const dbSize = dbExists ? statSync(dbPath).size : 0;
+    const mcpReady = getMcpSetupReadiness();
+    const mcpServers = mcpReady.ready
+      ? toClaudeDesktopJson(buildToolRegistry(process.cwd()), {}).mcpServers as Record<string, unknown>
+      : {};
+    const server = mcpServers['o8'] ?? null;
+    const codebaseMemory = mcpServers['codebase-memory'] ?? null;
+    const fullConfig = { mcpServers };
 
     return NextResponse.json({
+      setupReady: mcpReady.ready,
+      setupBlockedReason: mcpReady.reason,
+      setupBlockedDetail: mcpReady.detail,
       server,
       codebaseMemory,
       fullConfig,
@@ -119,6 +126,7 @@ export async function GET() {
         webviewSocketPath,
         webviewToolsAvailable: existsSync(webviewSocketPath),
         codebaseMemoryAvailable: Boolean(codebaseMemory),
+        cli: getCliAccessStatus(),
       },
     });
   } catch (error) {

--- a/src/components/desktop/settings/MCPTab.tsx
+++ b/src/components/desktop/settings/MCPTab.tsx
@@ -17,13 +17,12 @@ import {
   APP_FONT_STACK,
   MONO_FONT_STACK,
   RAMS_ACCENT,
-  RAMS_CONTROL_BG,
-  RAMS_CONTROL_BORDER,
   RAMS_CONTROL_ACTIVE_BG,
   RAMS_CONTROL_ACTIVE_BORDER,
+  RAMS_CONTROL_BG,
+  RAMS_CONTROL_BORDER,
   RAMS_HAIRLINE_SOFT,
   RAMS_INK_QUIET,
-  BracketLabel,
   HairlineRule,
   SectionLabel,
   TabBreadcrumb,
@@ -32,6 +31,16 @@ import {
 } from './shared';
 import { ChevronDown, ChevronRight } from '../lucide-shims';
 import { ExternalMcpServersSection } from './mcp/ExternalMcpServersSection';
+import { AccessPointDiagnostics, type AccessPointDiagnosticsData } from './mcp/AccessPointDiagnostics';
+import {
+  ClaudeTargetRow,
+  ExternalClientRow,
+  type AnyTarget,
+  type ClaudeTargetStatus,
+  type ExternalTarget,
+  type ExternalTargetStatus,
+  type Target,
+} from './mcp/ClientRows';
 import { MONO_FONT } from './mcp/shared';
 
 interface McpServerConfig {
@@ -41,50 +50,17 @@ interface McpServerConfig {
 }
 
 interface McpConfigResponse {
-  server: McpServerConfig;
+  setupReady?: boolean;
+  setupBlockedDetail?: string | null;
+  server: McpServerConfig | null;
   fullConfig: { mcpServers: Record<string, McpServerConfig> };
   instructions: { claudeDesktop: string; claudeCode: string };
-  diagnostics: {
-    apiBase: string;
+  diagnostics: AccessPointDiagnosticsData & {
     apiPort?: number;
     wsPort?: number;
-    portSource?: 'env' | 'file' | 'default';
-    bundled: boolean;
     platform: string;
-    nodeInstalled: boolean;
-    nodeBin: string | null;
-    codexInstalled: boolean;
-    codexBin: string | null;
-    ghInstalled: boolean;
-    ghBin: string | null;
     dataDir: string;
-    dbExists: boolean;
-    dbSize: number;
-    webviewSocketPath: string;
-    webviewToolsAvailable: boolean;
   };
-}
-
-type Target = 'claude-desktop' | 'claude-code';
-type ExternalTarget = 'hermes' | 'openclaw';
-type AnyTarget = Target | ExternalTarget;
-
-interface ClaudeTargetStatus {
-  target: Target;
-  path: string;
-  fileExists: boolean;
-  alreadyRegistered: boolean;
-  alreadyUpToDate: boolean;
-  otherServers: string[];
-  size: number;
-}
-
-interface ExternalTargetStatus {
-  target: ExternalTarget;
-  installed: boolean;
-  cliPath: string | null;
-  registered: boolean;
-  hint?: string;
 }
 
 export function MCPTab() {
@@ -251,7 +227,7 @@ export function MCPTab() {
   }, [loadClaudeStatus]);
 
   const copyToClipboard = useCallback(async () => {
-    if (!data) return;
+    if (!data || data.setupReady === false) return;
     const text = JSON.stringify(data.fullConfig, null, 2);
     try {
       await navigator.clipboard.writeText(text);
@@ -299,7 +275,8 @@ export function MCPTab() {
 
   const configJson = JSON.stringify(data.fullConfig, null, 2);
   const d = data.diagnostics;
-  const ready = d.nodeInstalled;
+  const ready = d.cli.nodeResolvable;
+  const setupReady = data.setupReady !== false;
 
   return (
     <div style={{
@@ -361,6 +338,38 @@ export function MCPTab() {
         </div>
       ) : null}
 
+      {!setupReady ? (
+        <div style={{
+          marginBottom: 28,
+          paddingTop: 2,
+          paddingBottom: 2,
+        }}>
+          <div style={{
+            fontSize: 13,
+            fontWeight: 300,
+            color: 'var(--t-text)',
+            marginBottom: 4,
+            letterSpacing: '-0.005em',
+          }}>
+            <span style={{
+              fontFamily: MONO_FONT_STACK,
+              fontSize: 11,
+              fontWeight: 300,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: '#f59e0b',
+              marginRight: 8,
+            }}>
+              [wait]
+            </span>
+            MCP setup is still finishing
+          </div>
+          <div style={{ color: 'var(--t-text-secondary)', fontSize: 12, lineHeight: 1.55 }}>
+            {data.setupBlockedDetail ?? 'Finish first launch, then reconnect your MCP client.'}
+          </div>
+        </div>
+      ) : null}
+
       {/* 01 — CLAUDE DESKTOP */}
       <section style={{ marginBottom: 28 }}>
         <SectionLabel number="01">CLAUDE DESKTOP</SectionLabel>
@@ -368,7 +377,7 @@ export function MCPTab() {
           target="claude-desktop"
           status={desktopStatus}
           installing={installing === 'claude-desktop'}
-          disabled={!ready}
+          disabled={!ready || !setupReady}
           note={installNote?.target === 'claude-desktop' ? installNote : null}
           onInstall={() => { void installToClaude('claude-desktop'); }}
           onRemove={() => { void removeFromClaude('claude-desktop'); }}
@@ -383,7 +392,7 @@ export function MCPTab() {
           target="claude-code"
           status={codeStatus}
           installing={installing === 'claude-code'}
-          disabled={!ready}
+          disabled={!ready || !setupReady}
           note={installNote?.target === 'claude-code' ? installNote : null}
           onInstall={() => { void installToClaude('claude-code'); }}
           onRemove={() => { void removeFromClaude('claude-code'); }}
@@ -431,24 +440,7 @@ export function MCPTab() {
       <section style={{ marginBottom: 24 }}>
         <SectionLabel number="06">DIAGNOSTICS</SectionLabel>
         <Disclosure title="System details" subtitle="Show the runtime environment o8 is using.">
-          <div style={{
-            paddingTop: 8,
-            borderTop: `1px solid ${RAMS_HAIRLINE_SOFT}`,
-          }}>
-            <DiagnosticRow label="Backend" ok detail={`${d.apiBase}${d.portSource ? ` (${d.portSource === 'env' ? 'env var' : d.portSource === 'file' ? 'port file' : 'default'})` : ''}`} />
-            <DiagnosticRow label="Install mode" ok detail={d.bundled ? 'Packaged Tauri app' : 'Dev checkout'} />
-            <DiagnosticRow label="Node.js" ok={d.nodeInstalled} detail={d.nodeBin} />
-            <DiagnosticRow label="Codex CLI" ok={d.codexInstalled} detail={d.codexBin} />
-            <DiagnosticRow label="GitHub CLI" ok={d.ghInstalled} detail={d.ghBin} />
-            <DiagnosticRow label="Database" ok={d.dbExists} detail={d.dbExists ? `${(d.dbSize / 1024 / 1024).toFixed(1)} MB` : 'not initialized'} />
-            <DiagnosticRow
-              label="Webview tools"
-              ok={d.webviewToolsAvailable}
-              detail={d.webviewToolsAvailable
-                ? `Connected to ${d.webviewSocketPath}`
-                : 'Off — launch with --features dev-mcp-plugin'}
-            />
-          </div>
+          <AccessPointDiagnostics diagnostics={d} />
           {d.nodeInstalled && !d.codexInstalled ? (
             <div style={{
               marginTop: 14,
@@ -506,7 +498,7 @@ export function MCPTab() {
         </Disclosure>
 
         <div style={{ marginTop: 8 }}>
-          <Disclosure title="Manual config" subtitle="Prefer to edit the file yourself?">
+          <Disclosure title="Manual config" subtitle={setupReady ? 'Prefer to edit the file yourself?' : 'Config appears after first launch finishes.'}>
             <div style={{
               position: 'relative',
               border: `1px solid ${RAMS_HAIRLINE_SOFT}`,
@@ -517,6 +509,7 @@ export function MCPTab() {
               <button
                 type="button"
                 onClick={() => { void copyToClipboard(); }}
+                disabled={!setupReady}
                 style={{
                   position: 'absolute',
                   top: 8,
@@ -538,7 +531,8 @@ export function MCPTab() {
                   fontWeight: 400,
                   letterSpacing: '-0.01em',
                   textTransform: 'capitalize',
-                  cursor: 'pointer',
+                  cursor: setupReady ? 'pointer' : 'default',
+                  opacity: setupReady ? 1 : 0.55,
                   zIndex: 1,
                 }}
               >
@@ -620,332 +614,4 @@ function Disclosure({
       {open ? <div style={{ marginTop: 4 }}>{children}</div> : null}
     </div>
   );
-}
-
-// ── Claude target row ──
-
-function ClaudeTargetRow({
-  status,
-  installing,
-  disabled = false,
-  note,
-  onInstall,
-  onRemove,
-  restartHint,
-}: {
-  target: Target;
-  status: ClaudeTargetStatus | null;
-  installing: boolean;
-  disabled?: boolean;
-  note: { target: AnyTarget; message: string; ok: boolean } | null;
-  onInstall: () => void;
-  onRemove: () => void;
-  restartHint: string;
-}) {
-  const connected = Boolean(status?.alreadyUpToDate);
-  const needsUpdate = Boolean(status?.alreadyRegistered && !status?.alreadyUpToDate);
-
-  const statusLine = !status
-    ? 'Checking...'
-    : connected
-      ? 'Connected. o8 tools available in this client.'
-      : needsUpdate
-        ? 'Older o8 entry found. Update to the current config.'
-        : status.fileExists
-          ? `Ready to connect${status.otherServers.length > 0 ? ` (${status.otherServers.length} other server${status.otherServers.length === 1 ? '' : 's'} preserved)` : ''}.`
-          : 'Not connected yet.';
-
-  const primaryLabel = connected ? 'connected' : needsUpdate ? 'update' : 'install';
-  const primaryDisabled = disabled || installing || connected;
-
-  return (
-    <div style={{
-      paddingTop: 10,
-      paddingBottom: 16,
-      borderBottom: `1px solid ${RAMS_HAIRLINE_SOFT}`,
-      opacity: disabled ? 0.55 : 1,
-    }}>
-      <div style={{
-        display: 'flex',
-        alignItems: 'flex-start',
-        justifyContent: 'space-between',
-        gap: 20,
-        flexWrap: 'wrap',
-      }}>
-        <div style={{ flex: 1, minWidth: 0, maxWidth: 520 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4, flexWrap: 'wrap' }}>
-            <BracketLabel tone={connected ? 'quiet' : 'accent'}>
-              {connected ? 'connected' : needsUpdate ? 'needs update' : 'not connected'}
-            </BracketLabel>
-          </div>
-          <div style={{
-            fontSize: 13,
-            color: 'var(--t-text-secondary)',
-            lineHeight: 1.55,
-          }}>
-            {statusLine}
-          </div>
-          {status?.path ? (
-            <div style={{
-              marginTop: 6,
-              fontFamily: MONO_FONT_STACK,
-              fontSize: 11,
-              letterSpacing: '0.02em',
-              color: RAMS_INK_QUIET,
-              wordBreak: 'break-all',
-            }}>
-              {status.path}
-            </div>
-          ) : null}
-          {note ? (
-            <div style={{
-              marginTop: 8,
-              fontSize: 12,
-              lineHeight: 1.55,
-              color: note.ok ? '#15803d' : '#dc2626',
-            }}>
-              {note.ok ? `${note.message} ${restartHint}` : note.message}
-            </div>
-          ) : null}
-        </div>
-
-        <div style={{ display: 'flex', gap: 16, alignItems: 'center', flexWrap: 'wrap' }}>
-          {status?.alreadyRegistered ? (
-            <button
-              type="button"
-              onClick={onRemove}
-              disabled={installing || disabled}
-              style={quietActionStyle(installing || disabled)}
-            >
-              remove
-            </button>
-          ) : null}
-          <button
-            type="button"
-            onClick={onInstall}
-            disabled={primaryDisabled}
-            style={accentActionStyle(primaryDisabled)}
-          >
-            {installing ? 'working...' : primaryLabel}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ExternalClientRow({
-  target,
-  status,
-  installing,
-  disabled = false,
-  note,
-  onInstall,
-  onRemove,
-  restartHint,
-}: {
-  target: ExternalTarget;
-  status: ExternalTargetStatus | null;
-  installing: boolean;
-  disabled?: boolean;
-  note: { target: AnyTarget; message: string; ok: boolean } | null;
-  onInstall: () => void;
-  onRemove: () => void;
-  restartHint: string;
-}) {
-  const cliInstalled = Boolean(status?.installed);
-  const registered = Boolean(status?.registered);
-
-  const labelText = target === 'hermes' ? 'Hermes Agent' : 'OpenClaw';
-
-  const statusLine = !status
-    ? 'Checking...'
-    : !cliInstalled
-      ? `${labelText} CLI not found.`
-      : registered
-        ? `Connected. The o8 tools are wired into ${labelText}.`
-        : `Ready to connect. ${labelText} CLI detected.`;
-
-  const primaryLabel = registered ? 'connected' : 'install';
-  const primaryDisabled = disabled || installing || !cliInstalled || registered;
-
-  return (
-    <div style={{
-      paddingTop: 10,
-      paddingBottom: 16,
-      borderBottom: `1px solid ${RAMS_HAIRLINE_SOFT}`,
-      opacity: disabled ? 0.55 : 1,
-    }}>
-      <div style={{
-        display: 'flex',
-        alignItems: 'flex-start',
-        justifyContent: 'space-between',
-        gap: 20,
-        flexWrap: 'wrap',
-      }}>
-        <div style={{ flex: 1, minWidth: 0, maxWidth: 520 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4, flexWrap: 'wrap' }}>
-            <BracketLabel tone={registered ? 'quiet' : cliInstalled ? 'accent' : 'quiet'}>
-              {!cliInstalled ? 'not installed' : registered ? 'connected' : 'not connected'}
-            </BracketLabel>
-          </div>
-          <div style={{
-            fontSize: 13,
-            color: 'var(--t-text-secondary)',
-            lineHeight: 1.55,
-          }}>
-            {statusLine}
-          </div>
-          {status?.cliPath ? (
-            <div style={{
-              marginTop: 6,
-              fontFamily: MONO_FONT_STACK,
-              fontSize: 11,
-              letterSpacing: '0.02em',
-              color: RAMS_INK_QUIET,
-              wordBreak: 'break-all',
-            }}>
-              {status.cliPath}
-            </div>
-          ) : null}
-          {!cliInstalled && status?.hint ? (
-            <div style={{
-              marginTop: 8,
-              fontFamily: MONO_FONT_STACK,
-              fontSize: 11,
-              color: 'var(--t-text-muted)',
-              lineHeight: 1.5,
-              wordBreak: 'break-all',
-            }}>
-              {status.hint}
-            </div>
-          ) : null}
-          {note ? (
-            <div style={{
-              marginTop: 8,
-              fontSize: 12,
-              lineHeight: 1.55,
-              color: note.ok ? '#15803d' : '#dc2626',
-            }}>
-              {note.ok ? `${note.message} ${restartHint}` : note.message}
-            </div>
-          ) : null}
-        </div>
-
-        <div style={{ display: 'flex', gap: 16, alignItems: 'center', flexWrap: 'wrap' }}>
-          {registered ? (
-            <button
-              type="button"
-              onClick={onRemove}
-              disabled={installing || disabled}
-              style={quietActionStyle(installing || disabled)}
-            >
-              remove
-            </button>
-          ) : null}
-          <button
-            type="button"
-            onClick={onInstall}
-            disabled={primaryDisabled}
-            style={accentActionStyle(primaryDisabled)}
-          >
-            {installing ? 'working...' : primaryLabel}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function DiagnosticRow({ label, ok, detail }: { label: string; ok: boolean; detail?: string | null }) {
-  return (
-    <div style={{
-      display: 'flex',
-      alignItems: 'center',
-      gap: 14,
-      paddingTop: 10,
-      paddingBottom: 10,
-      borderBottom: `1px solid ${RAMS_HAIRLINE_SOFT}`,
-    }}>
-      <span style={{
-        width: 6,
-        height: 6,
-        borderRadius: 3,
-        background: ok ? '#22c55e' : '#ef4444',
-        flexShrink: 0,
-      }} />
-      <span style={{
-        fontFamily: APP_FONT_STACK,
-        fontSize: 11,
-        fontWeight: 400,
-        color: RAMS_INK_QUIET,
-        textTransform: 'uppercase',
-        letterSpacing: '0.14em',
-        minWidth: 130,
-      }}>
-        {label}
-      </span>
-      <span style={{
-        fontFamily: MONO_FONT_STACK,
-        fontSize: 12,
-        color: 'var(--t-text-secondary)',
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
-        flex: 1,
-      }}>
-        {detail || (ok ? 'installed' : 'missing')}
-      </span>
-    </div>
-  );
-}
-
-function accentActionStyle(disabled: boolean): React.CSSProperties {
-  return {
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    minHeight: 32,
-    paddingLeft: 14,
-    paddingRight: 14,
-    borderRadius: 9,
-    borderWidth: 1,
-    borderStyle: 'solid',
-    borderColor: disabled ? RAMS_CONTROL_BORDER : RAMS_CONTROL_ACTIVE_BORDER,
-    background: disabled ? 'transparent' : RAMS_CONTROL_ACTIVE_BG,
-    fontFamily: APP_FONT_STACK,
-    fontSize: 12,
-    fontWeight: 400,
-    letterSpacing: '-0.01em',
-    textTransform: 'capitalize',
-    color: disabled ? RAMS_INK_QUIET : RAMS_ACCENT,
-    cursor: disabled ? 'default' : 'pointer',
-    opacity: disabled ? 0.6 : 1,
-    transition: 'background 150ms cubic-bezier(0.22, 1, 0.36, 1), border-color 150ms cubic-bezier(0.22, 1, 0.36, 1), color 150ms cubic-bezier(0.22, 1, 0.36, 1)',
-  };
-}
-
-function quietActionStyle(disabled: boolean): React.CSSProperties {
-  return {
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    minHeight: 32,
-    paddingLeft: 14,
-    paddingRight: 14,
-    borderRadius: 9,
-    borderWidth: 1,
-    borderStyle: 'solid',
-    borderColor: RAMS_CONTROL_BORDER,
-    background: disabled ? 'transparent' : RAMS_CONTROL_BG,
-    fontFamily: APP_FONT_STACK,
-    fontSize: 12,
-    fontWeight: 400,
-    letterSpacing: '-0.01em',
-    textTransform: 'capitalize',
-    color: 'var(--t-text-muted)',
-    cursor: disabled ? 'default' : 'pointer',
-    opacity: disabled ? 0.6 : 1,
-    transition: 'background 150ms cubic-bezier(0.22, 1, 0.36, 1), border-color 150ms cubic-bezier(0.22, 1, 0.36, 1), color 150ms cubic-bezier(0.22, 1, 0.36, 1)',
-  };
 }

--- a/src/components/desktop/settings/mcp/AccessPointDiagnostics.tsx
+++ b/src/components/desktop/settings/mcp/AccessPointDiagnostics.tsx
@@ -1,0 +1,101 @@
+import {
+  APP_FONT_STACK,
+  MONO_FONT_STACK,
+  RAMS_HAIRLINE_SOFT,
+  RAMS_INK_QUIET,
+} from '../shared';
+
+export interface CliAccessStatus {
+  installedAt: string | null;
+  installStatus: string | null;
+  onPath: boolean;
+  nodeResolvable: boolean;
+  nodeBin: string | null;
+}
+
+export interface AccessPointDiagnosticsData {
+  apiBase: string;
+  portSource?: 'env' | 'file' | 'default';
+  bundled: boolean;
+  nodeInstalled: boolean;
+  nodeBin: string | null;
+  codexInstalled: boolean;
+  codexBin: string | null;
+  ghInstalled: boolean;
+  ghBin: string | null;
+  dbExists: boolean;
+  dbSize: number;
+  webviewSocketPath: string;
+  webviewToolsAvailable: boolean;
+  cli: CliAccessStatus;
+}
+
+export function AccessPointDiagnostics({ diagnostics }: { diagnostics: AccessPointDiagnosticsData }) {
+  const d = diagnostics;
+  return (
+    <div style={{
+      paddingTop: 8,
+      borderTop: `1px solid ${RAMS_HAIRLINE_SOFT}`,
+    }}>
+      <DiagnosticRow label="Backend" ok detail={`${d.apiBase}${d.portSource ? ` (${d.portSource === 'env' ? 'env var' : d.portSource === 'file' ? 'port file' : 'default'})` : ''}`} />
+      <DiagnosticRow label="Install mode" ok detail={d.bundled ? 'Packaged Tauri app' : 'Dev checkout'} />
+      <DiagnosticRow label="CLI installed" ok={Boolean(d.cli.installedAt)} detail={d.cli.installedAt ?? d.cli.installStatus ?? 'missing'} />
+      <DiagnosticRow label="CLI on PATH" ok={d.cli.onPath} detail={d.cli.onPath ? 'available as o8' : 'run o8 doctor --repair, then add the install directory to PATH'} />
+      <DiagnosticRow label="CLI Node" ok={d.cli.nodeResolvable} detail={d.cli.nodeBin ?? 'Node.js 22+ not resolvable'} />
+      <DiagnosticRow label="Node.js" ok={d.nodeInstalled || d.cli.nodeResolvable} detail={d.nodeBin ?? d.cli.nodeBin} />
+      <DiagnosticRow label="Codex CLI" ok={d.codexInstalled} detail={d.codexBin} />
+      <DiagnosticRow label="GitHub CLI" ok={d.ghInstalled} detail={d.ghBin} />
+      <DiagnosticRow label="Database" ok={d.dbExists} detail={d.dbExists ? `${(d.dbSize / 1024 / 1024).toFixed(1)} MB` : 'not initialized'} />
+      <DiagnosticRow
+        label="Webview tools"
+        ok={d.webviewToolsAvailable}
+        detail={d.webviewToolsAvailable
+          ? `Connected to ${d.webviewSocketPath}`
+          : 'Off - launch with --features dev-mcp-plugin'}
+      />
+    </div>
+  );
+}
+
+function DiagnosticRow({ label, ok, detail }: { label: string; ok: boolean; detail?: string | null }) {
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 14,
+      paddingTop: 10,
+      paddingBottom: 10,
+      borderBottom: `1px solid ${RAMS_HAIRLINE_SOFT}`,
+    }}>
+      <span style={{
+        width: 6,
+        height: 6,
+        borderRadius: 3,
+        background: ok ? '#22c55e' : '#ef4444',
+        flexShrink: 0,
+      }} />
+      <span style={{
+        fontFamily: APP_FONT_STACK,
+        fontSize: 11,
+        fontWeight: 400,
+        color: RAMS_INK_QUIET,
+        textTransform: 'uppercase',
+        letterSpacing: '0.14em',
+        minWidth: 130,
+      }}>
+        {label}
+      </span>
+      <span style={{
+        fontFamily: MONO_FONT_STACK,
+        fontSize: 12,
+        color: 'var(--t-text-secondary)',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        flex: 1,
+      }}>
+        {detail || (ok ? 'installed' : 'missing')}
+      </span>
+    </div>
+  );
+}

--- a/src/components/desktop/settings/mcp/ClientRows.tsx
+++ b/src/components/desktop/settings/mcp/ClientRows.tsx
@@ -1,0 +1,286 @@
+import type React from 'react';
+import {
+  APP_FONT_STACK,
+  MONO_FONT_STACK,
+  RAMS_ACCENT,
+  RAMS_CONTROL_ACTIVE_BG,
+  RAMS_CONTROL_ACTIVE_BORDER,
+  RAMS_CONTROL_BG,
+  RAMS_CONTROL_BORDER,
+  RAMS_HAIRLINE_SOFT,
+  RAMS_INK_QUIET,
+  BracketLabel,
+} from '../shared';
+
+export type Target = 'claude-desktop' | 'claude-code';
+export type ExternalTarget = 'hermes' | 'openclaw';
+export type AnyTarget = Target | ExternalTarget;
+
+export interface ClaudeTargetStatus {
+  target: Target;
+  path: string;
+  fileExists: boolean;
+  alreadyRegistered: boolean;
+  alreadyUpToDate: boolean;
+  setupReady?: boolean;
+  setupBlockedDetail?: string | null;
+  otherServers: string[];
+  size: number;
+}
+
+export interface ExternalTargetStatus {
+  target: ExternalTarget;
+  installed: boolean;
+  cliPath: string | null;
+  registered: boolean;
+  hint?: string;
+}
+
+export function ClaudeTargetRow({
+  status,
+  installing,
+  disabled = false,
+  note,
+  onInstall,
+  onRemove,
+  restartHint,
+}: {
+  target: Target;
+  status: ClaudeTargetStatus | null;
+  installing: boolean;
+  disabled?: boolean;
+  note: { target: AnyTarget; message: string; ok: boolean } | null;
+  onInstall: () => void;
+  onRemove: () => void;
+  restartHint: string;
+}) {
+  const connected = Boolean(status?.alreadyUpToDate);
+  const needsUpdate = Boolean(status?.alreadyRegistered && !status?.alreadyUpToDate);
+  const setupBlocked = status?.setupReady === false;
+
+  const statusLine = !status
+    ? 'Checking...'
+    : setupBlocked
+      ? status.setupBlockedDetail ?? 'Finish first launch, then connect again.'
+      : connected
+        ? 'Connected. o8 tools available in this client.'
+        : needsUpdate
+          ? 'Older o8 entry found. Update to the current config.'
+          : status.fileExists
+            ? `Ready to connect${status.otherServers.length > 0 ? ` (${status.otherServers.length} other server${status.otherServers.length === 1 ? '' : 's'} preserved)` : ''}.`
+            : 'Not connected yet.';
+
+  const primaryLabel = connected ? 'connected' : needsUpdate ? 'update' : 'install';
+  const primaryDisabled = disabled || installing || connected || setupBlocked;
+
+  return (
+    <ClientRowShell disabled={disabled}>
+      <div style={{ flex: 1, minWidth: 0, maxWidth: 520 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4, flexWrap: 'wrap' }}>
+          <BracketLabel tone={connected ? 'quiet' : 'accent'}>
+            {setupBlocked ? 'not ready' : connected ? 'connected' : needsUpdate ? 'needs update' : 'not connected'}
+          </BracketLabel>
+        </div>
+        <RowBody statusLine={statusLine} path={status?.path ?? null} note={note} restartHint={restartHint} />
+      </div>
+      <div style={{ display: 'flex', gap: 16, alignItems: 'center', flexWrap: 'wrap' }}>
+        {status?.alreadyRegistered ? (
+          <button type="button" onClick={onRemove} disabled={installing || disabled} style={quietActionStyle(installing || disabled)}>
+            remove
+          </button>
+        ) : null}
+        <button type="button" onClick={onInstall} disabled={primaryDisabled} style={accentActionStyle(primaryDisabled)}>
+          {installing ? 'working...' : primaryLabel}
+        </button>
+      </div>
+    </ClientRowShell>
+  );
+}
+
+export function ExternalClientRow({
+  target,
+  status,
+  installing,
+  disabled = false,
+  note,
+  onInstall,
+  onRemove,
+  restartHint,
+}: {
+  target: ExternalTarget;
+  status: ExternalTargetStatus | null;
+  installing: boolean;
+  disabled?: boolean;
+  note: { target: AnyTarget; message: string; ok: boolean } | null;
+  onInstall: () => void;
+  onRemove: () => void;
+  restartHint: string;
+}) {
+  const cliInstalled = Boolean(status?.installed);
+  const registered = Boolean(status?.registered);
+  const labelText = target === 'hermes' ? 'Hermes Agent' : 'OpenClaw';
+  const statusLine = !status
+    ? 'Checking...'
+    : !cliInstalled
+      ? `${labelText} CLI not found.`
+      : registered
+        ? `Connected. The o8 tools are wired into ${labelText}.`
+        : `Ready to connect. ${labelText} CLI detected.`;
+  const primaryDisabled = disabled || installing || !cliInstalled || registered;
+
+  return (
+    <ClientRowShell disabled={disabled}>
+      <div style={{ flex: 1, minWidth: 0, maxWidth: 520 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4, flexWrap: 'wrap' }}>
+          <BracketLabel tone={registered ? 'quiet' : cliInstalled ? 'accent' : 'quiet'}>
+            {!cliInstalled ? 'not installed' : registered ? 'connected' : 'not connected'}
+          </BracketLabel>
+        </div>
+        <RowBody
+          statusLine={statusLine}
+          path={status?.cliPath ?? null}
+          note={note}
+          restartHint={restartHint}
+          hint={!cliInstalled ? status?.hint : null}
+        />
+      </div>
+      <div style={{ display: 'flex', gap: 16, alignItems: 'center', flexWrap: 'wrap' }}>
+        {registered ? (
+          <button type="button" onClick={onRemove} disabled={installing || disabled} style={quietActionStyle(installing || disabled)}>
+            remove
+          </button>
+        ) : null}
+        <button type="button" onClick={onInstall} disabled={primaryDisabled} style={accentActionStyle(primaryDisabled)}>
+          {installing ? 'working...' : registered ? 'connected' : 'install'}
+        </button>
+      </div>
+    </ClientRowShell>
+  );
+}
+
+function ClientRowShell({ disabled, children }: { disabled: boolean; children: React.ReactNode }) {
+  return (
+    <div style={{
+      paddingTop: 10,
+      paddingBottom: 16,
+      borderBottom: `1px solid ${RAMS_HAIRLINE_SOFT}`,
+      opacity: disabled ? 0.55 : 1,
+    }}>
+      <div style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'space-between',
+        gap: 20,
+        flexWrap: 'wrap',
+      }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function RowBody({
+  statusLine,
+  path,
+  note,
+  restartHint,
+  hint,
+}: {
+  statusLine: string;
+  path: string | null;
+  note: { target: AnyTarget; message: string; ok: boolean } | null;
+  restartHint: string;
+  hint?: string | null;
+}) {
+  return (
+    <>
+      <div style={{ fontSize: 13, color: 'var(--t-text-secondary)', lineHeight: 1.55 }}>
+        {statusLine}
+      </div>
+      {path ? (
+        <div style={{
+          marginTop: 6,
+          fontFamily: MONO_FONT_STACK,
+          fontSize: 11,
+          letterSpacing: '0.02em',
+          color: RAMS_INK_QUIET,
+          wordBreak: 'break-all',
+        }}>
+          {path}
+        </div>
+      ) : null}
+      {hint ? (
+        <div style={{
+          marginTop: 8,
+          fontFamily: MONO_FONT_STACK,
+          fontSize: 11,
+          color: 'var(--t-text-muted)',
+          lineHeight: 1.5,
+          wordBreak: 'break-all',
+        }}>
+          {hint}
+        </div>
+      ) : null}
+      {note ? (
+        <div style={{
+          marginTop: 8,
+          fontSize: 12,
+          lineHeight: 1.55,
+          color: note.ok ? '#15803d' : '#dc2626',
+        }}>
+          {note.ok ? `${note.message} ${restartHint}` : note.message}
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function accentActionStyle(disabled: boolean): React.CSSProperties {
+  return {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 32,
+    paddingLeft: 14,
+    paddingRight: 14,
+    borderRadius: 9,
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: disabled ? RAMS_CONTROL_BORDER : RAMS_CONTROL_ACTIVE_BORDER,
+    background: disabled ? 'transparent' : RAMS_CONTROL_ACTIVE_BG,
+    fontFamily: APP_FONT_STACK,
+    fontSize: 12,
+    fontWeight: 400,
+    letterSpacing: '-0.01em',
+    textTransform: 'capitalize',
+    color: disabled ? RAMS_INK_QUIET : RAMS_ACCENT,
+    cursor: disabled ? 'default' : 'pointer',
+    opacity: disabled ? 0.6 : 1,
+    transition: 'background 150ms cubic-bezier(0.22, 1, 0.36, 1), border-color 150ms cubic-bezier(0.22, 1, 0.36, 1), color 150ms cubic-bezier(0.22, 1, 0.36, 1)',
+  };
+}
+
+function quietActionStyle(disabled: boolean): React.CSSProperties {
+  return {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 32,
+    paddingLeft: 14,
+    paddingRight: 14,
+    borderRadius: 9,
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: RAMS_CONTROL_BORDER,
+    background: disabled ? 'transparent' : RAMS_CONTROL_BG,
+    fontFamily: APP_FONT_STACK,
+    fontSize: 12,
+    fontWeight: 400,
+    letterSpacing: '-0.01em',
+    textTransform: 'capitalize',
+    color: 'var(--t-text-muted)',
+    cursor: disabled ? 'default' : 'pointer',
+    opacity: disabled ? 0.6 : 1,
+    transition: 'background 150ms cubic-bezier(0.22, 1, 0.36, 1), border-color 150ms cubic-bezier(0.22, 1, 0.36, 1), color 150ms cubic-bezier(0.22, 1, 0.36, 1)',
+  };
+}

--- a/src/lib/access-points/cli-status.ts
+++ b/src/lib/access-points/cli-status.ts
@@ -1,0 +1,81 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, lstatSync, readlinkSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname } from 'node:path';
+
+export interface CliAccessStatus {
+  installedAt: string | null;
+  installStatus: string | null;
+  onPath: boolean;
+  nodeResolvable: boolean;
+  nodeBin: string | null;
+  candidates: Array<{
+    path: string;
+    exists: boolean;
+    isSymlink: boolean;
+    target: string | null;
+    directoryOnPath: boolean;
+  }>;
+}
+
+export function cliInstallCandidates(): string[] {
+  const candidates: string[] = [];
+  if (process.platform === 'darwin' && process.arch === 'arm64') {
+    candidates.push('/opt/homebrew/bin/o8');
+  }
+  if (process.platform === 'darwin' || process.platform === 'linux') {
+    candidates.push('/usr/local/bin/o8');
+  }
+  candidates.push(`${homedir()}/.local/bin/o8`);
+  return [...new Set(candidates)];
+}
+
+function directoryOnPath(path: string): boolean {
+  return (process.env.PATH ?? '').split(':').includes(dirname(path));
+}
+
+function resolveNode(): { path: string | null; ok: boolean } {
+  if (process.env.O8_NODE_BIN && existsSync(process.env.O8_NODE_BIN)) {
+    return { path: process.env.O8_NODE_BIN, ok: true };
+  }
+  try {
+    const out = execFileSync('sh', ['-lc', 'command -v node'], { encoding: 'utf8' }).trim();
+    return out ? { path: out, ok: true } : { path: null, ok: false };
+  } catch {
+    return { path: null, ok: false };
+  }
+}
+
+export function getCliAccessStatus(): CliAccessStatus {
+  const candidates = cliInstallCandidates().map((path) => {
+    try {
+      const stat = lstatSync(path);
+      const isSymlink = stat.isSymbolicLink();
+      return {
+        path,
+        exists: true,
+        isSymlink,
+        target: isSymlink ? readlinkSync(path) : null,
+        directoryOnPath: directoryOnPath(path),
+      };
+    } catch {
+      return {
+        path,
+        exists: false,
+        isSymlink: false,
+        target: null,
+        directoryOnPath: directoryOnPath(path),
+      };
+    }
+  });
+  const installed = candidates.find((candidate) => candidate.isSymlink) ?? null;
+  const node = resolveNode();
+  return {
+    installedAt: process.env.O8_CLI_INSTALL_PATH || installed?.path || null,
+    installStatus: process.env.O8_CLI_INSTALL_STATUS || null,
+    onPath: installed ? installed.directoryOnPath : false,
+    nodeResolvable: node.ok,
+    nodeBin: node.path,
+    candidates,
+  };
+}

--- a/src/lib/mcp/setup-readiness.ts
+++ b/src/lib/mcp/setup-readiness.ts
@@ -1,0 +1,34 @@
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export interface McpSetupReadiness {
+  ready: boolean;
+  reason: string | null;
+  detail: string | null;
+}
+
+export function getMcpSetupReadiness(): McpSetupReadiness {
+  const packaged = process.env.O8_PACKAGED_APP === '1';
+  const bundledPath = process.env.O8_BUNDLED_MCP_PATH;
+  if (!packaged) {
+    return { ready: true, reason: null, detail: null };
+  }
+  if (bundledPath && existsSync(bundledPath)) {
+    const codebaseMemoryBin = process.env.O8_CODEBASE_MEMORY_BIN
+      || join(homedir(), '.o8', 'bin', process.platform === 'win32' ? 'codebase-memory-mcp.exe' : 'codebase-memory-mcp');
+    if (existsSync(codebaseMemoryBin)) {
+      return { ready: true, reason: null, detail: null };
+    }
+    return {
+      ready: false,
+      reason: 'codebase_memory_not_ready',
+      detail: 'o8 is still downloading codebase-memory for first launch. Wait for startup to finish, then run Connect again.',
+    };
+  }
+  return {
+    ready: false,
+    reason: 'bundled_mcp_not_ready',
+    detail: 'o8 is still finishing first launch. Wait for startup to finish, then run Connect again.',
+  };
+}


### PR DESCRIPTION
Closes #1273. Apple-Silicon /opt/homebrew/bin symlink target; o8 doctor --repair recreates the CLI symlink + verifies node; o8 mcp install writes client config; Settings → MCP gains AccessPointDiagnostics so first-connect failures surface to the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj