### PR TITLE
fix: one assistant-message id scheme — the socket hook adopts the server id; adjacent-duplicate collapse as belt (#1288)

### DIFF
--- a/src/components/desktop/thoughts/use-orchestrator-stream/socket.test.ts
+++ b/src/components/desktop/thoughts/use-orchestrator-stream/socket.test.ts
@@ -99,6 +99,13 @@ describe('orchestrator socket — first-turn streaming race', () => {
     expect(h.currentAssistantRef.current?.chunks).toContain('tok');
   });
 
+  it('uses the server-persisted assistant id for streamed bubbles', () => {
+    const h = makeHarness({ status: 'busy', messages: [userMsg] });
+
+    h.fire({ channel: 'orchestrator', event: 'output', data: { text: 'tok', assistantMessageId: 'assistant-123' } });
+    expect(h.currentAssistantRef.current?.id).toBe('assistant-123');
+  });
+
   it('a tool-use event also promotes to busy instead of dropping the pill', () => {
     const h = makeHarness({ status: 'ready' });
 

--- a/src/components/desktop/thoughts/use-orchestrator-stream/socket.ts
+++ b/src/components/desktop/thoughts/use-orchestrator-stream/socket.ts
@@ -46,9 +46,14 @@ interface CreateOrchestratorMessageHandlerOptions {
   wsRef: RefLike<WebSocket | null>;
 }
 
-function createAssistantState(resetEpochRef: RefLike<number>): CurrentAssistantStreamState {
+function createAssistantState(
+  resetEpochRef: RefLike<number>,
+  assistantMessageId?: unknown,
+): CurrentAssistantStreamState {
   return {
-    id: `orch-assistant-${Date.now()}`,
+    id: typeof assistantMessageId === 'string' && assistantMessageId.trim()
+      ? assistantMessageId.trim()
+      : `assistant-${Date.now()}`,
     chunks: [],
     thinkingChunks: [],
     epoch: resetEpochRef.current,
@@ -154,7 +159,7 @@ export function createOrchestratorMessageHandler(
             options.statusRef.current = 'busy';
             options.setStatus('busy');
           }
-          options.currentAssistantRef.current = createAssistantState(options.resetEpochRef);
+          options.currentAssistantRef.current = createAssistantState(options.resetEpochRef, msg.data?.assistantMessageId);
         } else if (options.currentAssistantRef.current.epoch !== options.resetEpochRef.current) {
           options.currentAssistantRef.current = null;
           break;
@@ -236,7 +241,7 @@ export function createOrchestratorMessageHandler(
             options.statusRef.current = 'busy';
             options.setStatus('busy');
           }
-          options.currentAssistantRef.current = createAssistantState(options.resetEpochRef);
+          options.currentAssistantRef.current = createAssistantState(options.resetEpochRef, msg.data?.assistantMessageId);
         }
 
         const current = options.currentAssistantRef.current;

--- a/src/lib/llm/merge-chat-messages.test.ts
+++ b/src/lib/llm/merge-chat-messages.test.ts
@@ -80,4 +80,11 @@ describe('mergeChatMessages (#1282 transcript-loss)', () => {
     expect(merged.map((m) => m.id)).toEqual(['u1', 'a1']);
     expect(merged.find((m) => m.id === 'u1')?.timestamp).toBe(100);
   });
+
+  it('collapses adjacent same-role identical-content duplicates with different ids', () => {
+    const existing = [msg('u1', 'user', 100), msg('assistant-1', 'assistant', 110, { content: 'same' })];
+    const inbound = [msg('orch-assistant-1', 'assistant', 111, { content: 'same' })];
+    const merged = mergeChatMessages(existing, inbound);
+    expect(merged.map((m) => m.id)).toEqual(['u1', 'assistant-1']);
+  });
 });

--- a/src/lib/llm/merge-chat-messages.ts
+++ b/src/lib/llm/merge-chat-messages.ts
@@ -33,10 +33,8 @@ export interface ChatMessageLike {
 function duplicateAdjacentMessage(left: ChatMessageLike, right: ChatMessageLike): boolean {
   const leftRecord = left as Record<string, unknown>;
   const rightRecord = right as Record<string, unknown>;
-  return typeof leftRecord.role === 'string'
-    && leftRecord.role === rightRecord.role
-    && typeof leftRecord.content === 'string'
-    && leftRecord.content === rightRecord.content;
+  return typeof leftRecord.role === 'string' && leftRecord.role === rightRecord.role
+    && typeof leftRecord.content === 'string' && leftRecord.content === rightRecord.content;
 }
 
 function collapseAdjacentDuplicates<T extends ChatMessageLike>(messages: T[]): T[] {

--- a/src/lib/llm/merge-chat-messages.ts
+++ b/src/lib/llm/merge-chat-messages.ts
@@ -30,6 +30,24 @@ export interface ChatMessageLike {
   timestamp?: unknown;
 }
 
+function duplicateAdjacentMessage(left: ChatMessageLike, right: ChatMessageLike): boolean {
+  const leftRecord = left as Record<string, unknown>;
+  const rightRecord = right as Record<string, unknown>;
+  return typeof leftRecord.role === 'string'
+    && leftRecord.role === rightRecord.role
+    && typeof leftRecord.content === 'string'
+    && leftRecord.content === rightRecord.content;
+}
+
+function collapseAdjacentDuplicates<T extends ChatMessageLike>(messages: T[]): T[] {
+  const next: T[] = [];
+  for (const message of messages) {
+    if (next.length > 0 && duplicateAdjacentMessage(next[next.length - 1], message)) continue;
+    next.push(message);
+  }
+  return next.length === messages.length ? messages : next;
+}
+
 function timestampOf(message: ChatMessageLike): number | null {
   const value = message?.timestamp;
   if (typeof value === 'number' && Number.isFinite(value)) return value;
@@ -88,7 +106,7 @@ export function mergeChatMessages<T extends ChatMessageLike>(existing: T[], inbo
   // to be pinned (the normal full-transcript POST) — return it untouched, no
   // reordering. If we pinned anything we must fall through to the sort so the
   // corrected timestamps actually reorder the thread.
-  if (preserved.length === 0 && !pinnedAny) return inboundList;
+  if (preserved.length === 0 && !pinnedAny) return collapseAdjacentDuplicates(inboundList);
 
   const concat: T[] = [...normalizedInbound, ...preserved];
   const decorated = concat.map((message, index) => ({ message, index, ts: timestampOf(message) }));
@@ -100,5 +118,5 @@ export function mergeChatMessages<T extends ChatMessageLike>(existing: T[], inbo
     else carry = entry.ts;
   }
   decorated.sort((a, b) => (a.ts! - b.ts!) || (a.index - b.index));
-  return decorated.map((entry) => entry.message);
+  return collapseAdjacentDuplicates(decorated.map((entry) => entry.message));
 }

--- a/src/lib/mobile/orchestrator-thread-history.test.ts
+++ b/src/lib/mobile/orchestrator-thread-history.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const tempHomes: string[] = [];
+
+async function loadHistoryModule() {
+  const home = mkdtempSync(join(tmpdir(), 'o8-orch-history-'));
+  tempHomes.push(home);
+  vi.resetModules();
+  vi.doMock('node:os', async () => ({
+    ...(await vi.importActual<typeof import('node:os')>('node:os')),
+    homedir: () => home,
+  }));
+  return import('./orchestrator-thread-history');
+}
+
+afterEach(() => {
+  vi.doUnmock('node:os');
+  vi.resetModules();
+  for (const home of tempHomes.splice(0)) {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+describe('orchestrator thread history persistence', () => {
+  it('can pair a streamed assistant message with the exact persisted user timestamp', async () => {
+    const history = await loadHistoryModule();
+    const thread = history.createMobileOrchestratorThread({ repoPath: '/tmp/repo' });
+
+    history.appendMobileOrchestratorUserMessage({
+      tabId: thread.id,
+      repoPath: '/tmp/repo',
+      message: 'hello',
+      backend: 'codex',
+      timestampMs: 1234,
+    });
+    history.upsertMobileOrchestratorAssistantMessage({
+      tabId: thread.id,
+      repoPath: '/tmp/repo',
+      messageId: 'assistant-1234',
+      content: 'hi',
+      backend: 'codex',
+      timestampMs: 1234,
+    });
+
+    const persisted = JSON.parse(readFileSync(history.safeOrchestratorHistoryPath(thread.id), 'utf-8'));
+    expect(persisted.messages.map((message: { id?: string }) => message.id)).toEqual([
+      'user-1234',
+      'assistant-1234',
+    ]);
+  });
+});

--- a/src/lib/mobile/orchestrator-thread-history.ts
+++ b/src/lib/mobile/orchestrator-thread-history.ts
@@ -398,6 +398,7 @@ export function appendMobileOrchestratorUserMessage(input: {
   repoPath: string;
   message: string;
   backend?: MobileOrchestratorBackend | null;
+  timestampMs?: number;
 }): MobileOrchestratorThread | null {
   const tabId = input.tabId;
   if (!tabId?.startsWith('thoughts-')) return null;
@@ -405,7 +406,10 @@ export function appendMobileOrchestratorUserMessage(input: {
   const content = input.message.trim();
   if (!content) return readProjectedThread(tabId);
 
-  const now = new Date();
+  const timestamp = typeof input.timestampMs === 'number' && Number.isFinite(input.timestampMs)
+    ? input.timestampMs
+    : Date.now();
+  const now = new Date(timestamp);
   const nowIso = now.toISOString();
   const existing = readHistoryRecord(tabId) ?? {
     messages: [],
@@ -434,7 +438,7 @@ export function appendMobileOrchestratorUserMessage(input: {
         id: `user-${now.getTime()}`,
         role: 'user',
         content,
-        timestamp: now.getTime(),
+        timestamp,
       },
     ];
 

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -2992,8 +2992,9 @@ async function handleOrchestratorSendMsg(client: ClientState, msg: Record<string
   // so the next list/restore sees it. Stable messageId across deltas means
   // a later client POST that replaces the array can't double-write.
   const isThreadBacked = typeof threadId === 'string' && threadId.startsWith('thoughts-');
-  const assistantMessageId = isThreadBacked ? `assistant-${Date.now()}` : null;
-  const assistantStartedAtMs = Date.now();
+  const turnStartedAtMs = Date.now();
+  const assistantMessageId = isThreadBacked ? `assistant-${turnStartedAtMs}` : null;
+  const assistantStartedAtMs = turnStartedAtMs;
   let assistantTextAccum = '';
   let lastPersistedAssistantText = '';
   // Incremental persistence (2026-06-22): persist the streamed assistant text
@@ -3044,6 +3045,7 @@ async function handleOrchestratorSendMsg(client: ClientState, msg: Record<string
       repoPath,
       message,
       backend: backend.id,
+      timestampMs: turnStartedAtMs,
     });
     if (updatedThread) {
       broadcast({

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -1019,21 +1019,21 @@ function handleReboundOrchestratorEvent(record: OrchestratorTurnRecord, event: O
       wsMsg = JSON.stringify({
         channel: 'orchestrator',
         event: 'output',
-        data: { text: event.text, repoPath, threadId, thinking: false, backend },
+        data: { text: event.text, repoPath, threadId, thinking: false, backend, assistantMessageId },
       });
       break;
     case 'thinking':
       wsMsg = JSON.stringify({
         channel: 'orchestrator',
         event: 'output',
-        data: { text: event.text, repoPath, threadId, thinking: true, backend },
+        data: { text: event.text, repoPath, threadId, thinking: true, backend, assistantMessageId },
       });
       break;
     case 'tool_use':
       wsMsg = JSON.stringify({
         channel: 'orchestrator',
         event: 'tool-use',
-        data: { name: event.name, args: event.input, toolUseId: event.id ?? null, repoPath, threadId, backend },
+        data: { name: event.name, args: event.input, toolUseId: event.id ?? null, repoPath, threadId, backend, assistantMessageId },
       });
       break;
     case 'tool_result':
@@ -3175,7 +3175,7 @@ async function handleOrchestratorSendMsg(client: ClientState, msg: Record<string
           wsMsg = JSON.stringify({
             channel: 'orchestrator',
             event: 'output',
-            data: { text: event.text, repoPath, threadId, thinking: false, backend: backend.id, agent: agentTag },
+            data: { text: event.text, repoPath, threadId, thinking: false, backend: backend.id, agent: agentTag, assistantMessageId },
           });
           break;
 
@@ -3183,7 +3183,7 @@ async function handleOrchestratorSendMsg(client: ClientState, msg: Record<string
           wsMsg = JSON.stringify({
             channel: 'orchestrator',
             event: 'output',
-            data: { text: event.text, repoPath, threadId, thinking: true, backend: backend.id, agent: agentTag },
+            data: { text: event.text, repoPath, threadId, thinking: true, backend: backend.id, agent: agentTag, assistantMessageId },
           });
           break;
 
@@ -3191,7 +3191,7 @@ async function handleOrchestratorSendMsg(client: ClientState, msg: Record<string
           wsMsg = JSON.stringify({
             channel: 'orchestrator',
             event: 'tool-use',
-            data: { name: event.name, args: event.input, toolUseId: event.id ?? null, repoPath, threadId, backend: backend.id, agent: agentTag },
+            data: { name: event.name, args: event.input, toolUseId: event.id ?? null, repoPath, threadId, backend: backend.id, agent: agentTag, assistantMessageId },
           });
           break;
 


### PR DESCRIPTION
Closes #1288. ws-server stamps assistant-<turnStartedAtMs>; the desktop stream hook adopts it instead of minting orch-assistant-<now>. merge-chat-messages collapses adjacent same-role identical-content survivors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj