### PR TITLE
feat: expose huddle in the mobile payloads — huddling status + plan + inbox activity (#1289)

### DIFF
--- a/src/app/api/mobile/activity/route.ts
+++ b/src/app/api/mobile/activity/route.ts
@@ -32,6 +32,7 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 import { buildErrorPayload } from '@/lib/api/error-format';
 import { listRepos } from '@/lib/repos/registry';
+import { findLaneByPacket, getLaneEvents } from '@/lib/lane/registry';
 import type { MobileActivityEvent } from '@/lib/mobile/types';
 
 const execFileAsync = promisify(execFile);
@@ -195,14 +196,22 @@ async function collectPacketEvents(previewContext: PreviewContext): Promise<Mobi
 
     return packets
       .map((packet): MobileActivityEvent | null => {
+        const lane = findLaneByPacket(packet.id);
         const eventTime = packet.lastEventAt || packet.archivedAt;
         const timestamp = eventTime ? Date.parse(eventTime) : Number.NaN;
         if (!Number.isFinite(timestamp)) return null;
 
         const released = packet.releaseState === 'released' || packet.status === 'released';
+        const huddleLabel = packet.lastEventLabel === 'huddle'
+          || packet.lastEventLabel === 'huddle_ready'
+          || packet.lane?.lastEventLabel === 'huddle'
+          || packet.lane?.lastEventLabel === 'huddle_ready'
+          || (lane?.status === 'awaiting_orchestrator' && (lane.lastEventLabel === 'huddle' || lane.lastEventLabel === 'huddle_ready'));
         let kind: MobileActivityEvent['kind'];
         if (released || packet.status === 'archived') {
           kind = 'merge';
+        } else if (huddleLabel) {
+          kind = 'huddle';
         } else if (packet.status === 'failed' || packet.status === 'blocked') {
           kind = 'alert';
         } else if (packet.status === 'awaiting_review') {
@@ -223,6 +232,11 @@ async function collectPacketEvents(previewContext: PreviewContext): Promise<Mobi
         const branch = packet.branchTarget?.trim();
         const detail = packet.lastEventLabel?.trim()
           || (branch ? `${branch} → main` : undefined);
+        const huddlePlan = lane
+          ? [...getLaneEvents(lane.id, 100)].reverse().find((event) =>
+              event.verb === 'agent_report' && event.payload.event === 'huddle'
+            )?.payload.message
+          : undefined;
 
         const repo = packet.workspaceTargetPath
           ? path.basename(packet.workspaceTargetPath)
@@ -232,7 +246,8 @@ async function collectPacketEvents(previewContext: PreviewContext): Promise<Mobi
           id: `packet:${packet.id}`,
           kind,
           title: title.slice(0, 160),
-          detail,
+          detail: kind === 'huddle' ? 'Huddling — aligned its plan, awaiting orchestrator' : detail,
+          comments: typeof huddlePlan === 'string' && huddlePlan.trim() ? [huddlePlan.trim()] : undefined,
           repo,
           previewUrl: repo ? previewUrlForRepo(repo, previewContext) : undefined,
           timestamp,

--- a/src/app/api/mobile/history/route.ts
+++ b/src/app/api/mobile/history/route.ts
@@ -6,7 +6,7 @@ import { getOwnedOpencodeRuntimeTail } from '@/lib/opencode/owned';
 import { loadMobileLlmChatHistory } from '@/lib/llm/mobile-llm-chat';
 import type { MobileHistoryResponse, MobileTranscriptEntry, MobileTranscriptToolCall } from '@/lib/mobile/types';
 import '@/lib/runtimes'; // Ensure runtimes are registered
-import { readSessionSteerTranscriptEvents } from '@/lib/orchestrator/packet-transcript';
+import { readSessionHuddleTranscriptEvents, readSessionSteerTranscriptEvents } from '@/lib/orchestrator/packet-transcript';
 import { getRuntime } from '@/lib/runtimes/registry';
 
 export const runtime = 'nodejs';
@@ -44,7 +44,20 @@ function toolCallFromEntry(name: string, text: string): MobileTranscriptToolCall
 
 function appendSteerEntries(sessionKey: string, transcript: MobileTranscriptEntry[]): MobileTranscriptEntry[] {
   const steerEvents = readSessionSteerTranscriptEvents(sessionKey);
-  if (steerEvents.length === 0) return transcript;
+  const huddleEvents = readSessionHuddleTranscriptEvents(sessionKey);
+  if (steerEvents.length === 0 && huddleEvents.length === 0) return transcript;
+  const huddleEntries = huddleEvents.map((event) => {
+    const timestamp = new Date(event.ts);
+    const timestampMs = Number.isFinite(timestamp.getTime()) ? timestamp.getTime() : Date.now();
+    const timestampLabel = new Date(timestampMs).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+    return {
+      id: `huddle-${event.seq}`,
+      role: 'assistant' as const,
+      text: `Huddling — plan posted\n\n${event.text}`,
+      timestamp: timestampMs,
+      timestampLabel,
+    };
+  });
   const steerEntries = steerEvents.map((event) => {
     const timestamp = new Date(event.ts);
     const timestampMs = Number.isFinite(timestamp.getTime()) ? timestamp.getTime() : Date.now();
@@ -57,7 +70,7 @@ function appendSteerEntries(sessionKey: string, transcript: MobileTranscriptEntr
       timestampLabel,
     };
   });
-  return [...transcript, ...steerEntries].sort((left, right) => (left.timestamp ?? 0) - (right.timestamp ?? 0));
+  return [...transcript, ...huddleEntries, ...steerEntries].sort((left, right) => (left.timestamp ?? 0) - (right.timestamp ?? 0));
 }
 
 export async function GET(request: NextRequest) {

--- a/src/app/api/mobile/orchestrator/packets/route.ts
+++ b/src/app/api/mobile/orchestrator/packets/route.ts
@@ -36,7 +36,7 @@ import { execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { promisify } from 'node:util';
 import { syncOrchestratorControlPlaneState } from '@/lib/orchestrator/control-plane';
-import { findLaneByPacket } from '@/lib/lane/registry';
+import { findLaneByPacket, getLaneEvents } from '@/lib/lane/registry';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 import type { Lane } from '@/lib/lane/types';
 import type { MobileOrchestratorAgent } from '@/lib/mobile/types';
@@ -78,8 +78,30 @@ function repoOwnsCandidate(repoPath: string, candidate: string | null | undefine
  * releaseState === 'released' wins over status (a released packet may still
  * carry a stale status), matching packetVisualState() in repo-focus/utils.ts.
  */
-function mapPacketStatus(packet: OrchestratorPacket): MobileOrchestratorAgent['status'] {
+function isHuddleLabel(value: string | null | undefined): boolean {
+  return value === 'huddle' || value === 'huddle_ready';
+}
+
+function isHuddlingPacket(packet: OrchestratorPacket, lane: Lane | null): boolean {
+  if (lane?.status === 'awaiting_orchestrator' && isHuddleLabel(lane.lastEventLabel)) return true;
+  return packet.status === 'blocked' && isHuddleLabel(packet.lastEventLabel ?? packet.lane?.lastEventLabel);
+}
+
+function latestHuddlePlan(lane: Lane | null): string | undefined {
+  if (!lane) return undefined;
+  const events = getLaneEvents(lane.id, 100);
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event?.verb !== 'agent_report' || event.payload.event !== 'huddle') continue;
+    const message = event.payload.message;
+    if (typeof message === 'string' && message.trim()) return message.trim();
+  }
+  return undefined;
+}
+
+function mapPacketStatus(packet: OrchestratorPacket, lane: Lane | null): MobileOrchestratorAgent['status'] {
   if (packet.releaseState === 'released' || packet.status === 'released') return 'merged';
+  if (isHuddlingPacket(packet, lane)) return 'huddling';
   switch (packet.status) {
     case 'archived':
       return 'merged';
@@ -218,11 +240,13 @@ export async function GET(req: NextRequest) {
           id: packet.id,
           title: packetTitle(packet),
           runtime: packetRuntime(packet, lane),
-          status: mapPacketStatus(packet),
+          status: mapPacketStatus(packet, lane),
           branch: lane?.branch ?? packet.branchTarget ?? '',
           filesChanged: diff.filesChanged,
           additions: diff.additions,
           deletions: diff.deletions,
+          huddlePlan: latestHuddlePlan(lane),
+          lastEventLabel: lane?.lastEventLabel ?? packet.lastEventLabel ?? packet.lane?.lastEventLabel ?? null,
           // Lane runtime session key only when the lane is live (findLaneByPacket
           // already excludes archived/completed/failed lanes). null otherwise.
           sessionKey: lane?.sessionKey ?? null,

--- a/src/components/desktop/AgentStatusDot.tsx
+++ b/src/components/desktop/AgentStatusDot.tsx
@@ -41,6 +41,7 @@ export function agentStatusToDotState(status?: string | null): AgentDotState {
     case 'recovering':
       return 'running';
     case 'reviewing':
+    case 'huddling':
     case 'waiting':
     case 'awaiting_input':
     case 'awaiting_human':

--- a/src/components/mobile/ActivityFeed.tsx
+++ b/src/components/mobile/ActivityFeed.tsx
@@ -117,7 +117,7 @@ function toneForAgent(agent: AgentSummary): ActivityTone {
   if (includesKeyword(taskText, ['test', 'jest', 'playwright', 'cypress', 'lint', 'typecheck', 'qa', 'spec'])) {
     return 'testing';
   }
-  if (agent.status === 'waiting' || agent.status === 'blocked' || agent.status === 'reviewing' || includesKeyword(taskText, ['think', 'plan', 'review'])) {
+  if (agent.status === 'huddling' || agent.status === 'waiting' || agent.status === 'blocked' || agent.status === 'reviewing' || includesKeyword(taskText, ['think', 'plan', 'review'])) {
     return 'thinking';
   }
 

--- a/src/lib/fleet/types.ts
+++ b/src/lib/fleet/types.ts
@@ -3,6 +3,7 @@ import type { BrowserSurfaceSummary } from '@/lib/browser/types';
 export type AgentStatus =
   | 'idle'
   | 'running'
+  | 'huddling'
   | 'blocked'
   | 'waiting'
   | 'reviewing'

--- a/src/lib/mobile/inbox.ts
+++ b/src/lib/mobile/inbox.ts
@@ -76,6 +76,7 @@ function approvalActions(approval: ApprovalRecord): MobileControlAction[] {
 }
 
 function alertSeverity(agent: AgentSummary): EventSeverity {
+  if (agent.status === 'huddling') return 'info';
   if (agent.status === 'blocked' || agent.status === 'failed') return 'critical';
   if (agent.alerts > 0 || agent.context.usedPercent >= 70) return 'warning';
   if (agent.isCurrentSession) return 'success';
@@ -94,12 +95,14 @@ function mobileSessionPriority(agent: AgentSummary) {
   const isOwnedCodex = agent.runtime === 'codex' && agent.runtimeSurface?.ownership === 'owned';
   if (agent.isCurrentSession) return 100;
   if (isOwnedCodex && agent.status === 'running') return 96;
+  if (isOwnedCodex && agent.status === 'huddling') return 93;
   if (isOwnedCodex && agent.status === 'failed') return 94;
   if (isOwnedCodex && agent.status === 'waiting') return 92;
   if (isOwnedCodex && agent.status === 'reviewing') return 90;
   if (isOwnedCodex) return 88;
   if (agent.approvalStatus === 'pending') return 82;
   if (agent.status === 'running') return 76;
+  if (agent.status === 'huddling') return 74;
   if (agent.status === 'blocked') return 72;
   if (agent.status === 'failed') return 70;
   if (agent.status === 'reviewing') return 64;
@@ -377,19 +380,22 @@ async function buildMobileInboxSnapshot(options: { fresh?: boolean } = {}): Prom
   }
 
   const reportItems = fleet.events
-    .filter((event) => event.track === 'Agent reports' && (event.subLabel === 'blocked' || event.subLabel === 'question'))
+    .filter((event) => event.track === 'Agent reports' && (event.subLabel === 'blocked' || event.subLabel === 'question' || event.subLabel === 'huddle'))
     .slice(0, 3)
     .map((event): MobileInboxItem => {
       const linkedSession = orderedSessions.find((session) => session.sessionKey === event.agentId);
       const actions: MobileControlAction[] = linkedSession
         ? sessionActions(linkedSession)
         : [{ kind: 'open_desktop', label: 'Desktop ↗', href: '/', available: true }];
+      const isHuddle = event.subLabel === 'huddle';
       return {
         id: `agent-report:${event.id}`,
         kind: 'alert',
-        severity: event.severity,
-        title: `${event.title} • ${event.subLabel === 'question' ? 'Question' : 'Blocked'}`,
+        severity: isHuddle ? 'info' : event.severity,
+        title: `${event.title} • ${isHuddle ? 'Huddling' : event.subLabel === 'question' ? 'Question' : 'Blocked'}`,
         detail: event.detail,
+        agentStatus: isHuddle ? 'huddling' : undefined,
+        metadata: isHuddle ? { status: 'huddling' } : undefined,
         sessionKey: linkedSession?.sessionKey ?? event.agentId,
         timestampLabel: relativeMobileAge(event.timestamp),
         actions,
@@ -398,7 +404,7 @@ async function buildMobileInboxSnapshot(options: { fresh?: boolean } = {}): Prom
   items.push(...reportItems);
 
   for (const agent of orderedSessions.filter((session) => session.sessionKey !== primarySession?.sessionKey)) {
-    if (!['running', 'reviewing', 'blocked', 'failed'].includes(agent.status) && agent.alerts === 0) {
+    if (!['running', 'huddling', 'reviewing', 'blocked', 'failed'].includes(agent.status) && agent.alerts === 0) {
       continue;
     }
 
@@ -408,6 +414,7 @@ async function buildMobileInboxSnapshot(options: { fresh?: boolean } = {}): Prom
       severity: alertSeverity(agent),
       title: `${agent.name} • ${agent.surfaceLabel ?? agent.status}`,
       detail: `${agent.currentTask} • ${agent.lastEventAt}`,
+      agentStatus: agent.status === 'huddling' ? 'huddling' : undefined,
       sessionKey: agent.sessionKey,
       timestampLabel: agent.lastEventAt,
       actions: sessionActions(agent),
@@ -467,7 +474,7 @@ async function buildMobileInboxSnapshot(options: { fresh?: boolean } = {}): Prom
   const alerts = items.filter((item) => item.kind === 'alert' && item.severity !== 'info').length;
   const approvalCount = pendingApprovals.length;
   const reviewItems = items.filter((item) => item.kind === 'review').length;
-  const activeRuns = orderedSessions.filter((agent) => ['running', 'reviewing', 'blocked', 'waiting', 'failed'].includes(agent.status)).length;
+  const activeRuns = orderedSessions.filter((agent) => ['running', 'huddling', 'reviewing', 'blocked', 'waiting', 'failed'].includes(agent.status)).length;
 
   return {
     generatedAt: new Date().toISOString(),

--- a/src/lib/mobile/live-activity-push.ts
+++ b/src/lib/mobile/live-activity-push.ts
@@ -484,6 +484,7 @@ function coerceStatus(status: AgentStatus, approvalStatus?: string): MobileLiveA
   if (status === 'failed' || status === 'blocked') return 'failed';
   if (status === 'completed') return 'merged';
   if (status === 'running') return 'running';
+  if (status === 'huddling') return 'queued';
   if (status === 'waiting') return 'queued';
   return 'idle';
 }

--- a/src/lib/mobile/types.ts
+++ b/src/lib/mobile/types.ts
@@ -11,6 +11,7 @@ import type { ClaudeCodeStreamJsonChatEvent } from '@/lib/claude-code/stream-jso
 import type { CompactionTrigger } from '@/lib/runtimes/compaction-detector';
 
 export type MobileInboxItemKind = 'alert' | 'approval' | 'review' | 'run_watch';
+export type MobileAgentStatus = 'queued' | 'running' | 'huddling' | 'awaiting_review' | 'merged' | 'failed';
 
 export type MobileControlActionKind =
   | 'inspect'
@@ -43,6 +44,7 @@ export interface MobileInboxItem {
   severity: EventSeverity;
   title: string;
   detail: string;
+  agentStatus?: MobileAgentStatus;
   approvalId?: string;
   metadata?: Record<string, string>;
   sessionKey?: string;
@@ -364,7 +366,11 @@ export interface MobileOrchestratorAgent {
   title: string;
   runtime: MobileOrchestratorRuntime;
   /** Collapsed packet lifecycle — see mapPacketStatus in the route. */
-  status: 'queued' | 'running' | 'awaiting_review' | 'merged' | 'failed';
+  status: MobileAgentStatus;
+  /** Worker-posted huddle plan, when status === 'huddling'. */
+  huddlePlan?: string;
+  /** Latest lane/packet event label for additive mobile rendering. */
+  lastEventLabel?: string | null;
   /** Worktree branch the agent commits to. */
   branch: string;
   /** Diff stats for the agent's worktree (zeros for queued packets). */
@@ -389,9 +395,10 @@ export interface MobileActivityEvent {
    *   - `merge`           — a git merge commit (>1 parent) or a released packet.
    *   - `dispatched`      — a packet that is launching / running.
    *   - `awaiting_review` — a packet whose work is done and awaiting review.
+   *   - `huddle`          — a worker posted its huddle plan and is awaiting alignment.
    *   - `alert`           — a failed / blocked packet.
    */
-  kind: 'dispatched' | 'awaiting_review' | 'merge' | 'commit' | 'alert';
+  kind: 'dispatched' | 'huddle' | 'awaiting_review' | 'merge' | 'commit' | 'alert';
   /** Primary line — commit subject or packet title. */
   title: string;
   /** Secondary line, e.g. `"main · 9393504"` or `"agent/x → main"`. */

--- a/src/lib/orchestrator/packet-transcript.ts
+++ b/src/lib/orchestrator/packet-transcript.ts
@@ -37,6 +37,7 @@ export interface PacketTranscriptReadback extends SessionTranscriptReadback {
 }
 
 type LaneSteerTranscriptEvent = Extract<TranscriptEvent, { type: 'steer' }>;
+type LaneHuddleTranscriptEvent = Extract<TranscriptEvent, { type: 'assistant' }>;
 
 function findPacket(packetId: string): OrchestratorPacket | null {
   try {
@@ -226,10 +227,30 @@ function laneSteerEvents(laneId: string): LaneSteerTranscriptEvent[] {
     });
 }
 
+function laneHuddleEvents(laneId: string): LaneHuddleTranscriptEvent[] {
+  return getLaneEvents(laneId, 500)
+    .filter((event) => event.verb === 'agent_report' && event.payload.event === 'huddle')
+    .map((event, index) => {
+      const message = readTextPayload(event.payload, 'message') || 'Huddle plan posted.';
+      return {
+        seq: index + 1,
+        ts: event.timestamp,
+        type: 'assistant',
+        text: message,
+      };
+    });
+}
+
 function laneSteerEventsForSession(sessionKey: string): LaneSteerTranscriptEvent[] {
   if (!sessionKey) return [];
   const lane = listLanes().find((candidate) => candidate.sessionKey === sessionKey);
   return lane ? laneSteerEvents(lane.id) : [];
+}
+
+function laneHuddleEventsForSession(sessionKey: string): LaneHuddleTranscriptEvent[] {
+  if (!sessionKey) return [];
+  const lane = listLanes().find((candidate) => candidate.sessionKey === sessionKey);
+  return lane ? laneHuddleEvents(lane.id) : [];
 }
 
 function mergeTranscriptEvents(runtimeEvents: TranscriptEvent[], extraEvents: TranscriptEvent[]): TranscriptEvent[] {
@@ -250,6 +271,10 @@ export function readSessionSteerTranscriptEvents(sessionKey: string): LaneSteerT
   return laneSteerEventsForSession(sessionKey);
 }
 
+export function readSessionHuddleTranscriptEvents(sessionKey: string): LaneHuddleTranscriptEvent[] {
+  return laneHuddleEventsForSession(sessionKey);
+}
+
 export async function readSessionTranscriptEvents(sessionKey: string): Promise<SessionTranscriptReadback> {
   const resolved = await resolveRawJsonlForSession(sessionKey);
   if (resolved.unsupportedReason) {
@@ -266,7 +291,7 @@ export async function readSessionTranscriptEvents(sessionKey: string): Promise<S
     runtime: resolved.runtime,
     events: mergeTranscriptEvents(
       normalizeForRuntime(resolved.runtime, resolved.raw),
-      laneSteerEventsForSession(sessionKey),
+      [...laneHuddleEventsForSession(sessionKey), ...laneSteerEventsForSession(sessionKey)],
     ),
   };
 }
@@ -286,7 +311,9 @@ export async function readPacketTranscriptEvents(packetId: string): Promise<Pack
 
   const readback = await readSessionTranscriptEvents(sessionKey);
   const packetLane = listLanes().find((lane) => lane.packetId === packetId);
-  const packetEvents = packetLane && packetLane.sessionKey !== sessionKey ? laneSteerEvents(packetLane.id) : [];
+  const packetEvents = packetLane && packetLane.sessionKey !== sessionKey
+    ? [...laneHuddleEvents(packetLane.id), ...laneSteerEvents(packetLane.id)]
+    : [];
   return {
     packetId,
     ...readback,

--- a/src/lib/runtime/inventory.ts
+++ b/src/lib/runtime/inventory.ts
@@ -87,6 +87,37 @@ function laneRepoLabel(lane: Lane | undefined): string | undefined {
   return repoPath.split('/').filter(Boolean).pop();
 }
 
+function isHuddleLane(lane: Lane): boolean {
+  return lane.status === 'awaiting_orchestrator'
+    && (lane.lastEventLabel === 'huddle' || lane.lastEventLabel === 'huddle_ready');
+}
+
+function applyHuddleLaneStatus(agents: AgentSummary[]): AgentSummary[] {
+  let huddleBySessionKey: Map<string, Lane>;
+  try {
+    huddleBySessionKey = new Map(
+      listLanes()
+        .filter((lane) => lane.sessionKey && isHuddleLane(lane))
+        .map((lane) => [lane.sessionKey as string, lane]),
+    );
+  } catch {
+    return agents;
+  }
+  if (huddleBySessionKey.size === 0) return agents;
+
+  return agents.map((agent) => {
+    const lane = huddleBySessionKey.get(agent.sessionKey);
+    if (!lane) return agent;
+    return {
+      ...agent,
+      status: 'huddling',
+      currentTask: agent.currentTask || 'Huddling — awaiting orchestrator alignment',
+      alerts: Math.max(0, agent.alerts - Number(agent.status === 'failed' || agent.status === 'blocked')),
+      lastEventAt: lane.lastEventAt ? relativeAge(new Date(lane.lastEventAt)) : agent.lastEventAt,
+    };
+  });
+}
+
 function readAgentReportEvents(): EventItem[] {
   try {
     const lanesById = new Map(listLanes().map((lane) => [lane.id, lane]));
@@ -372,6 +403,7 @@ async function buildCliRuntimeSnapshot(): Promise<FleetSnapshot> {
     new Set(agents.map((agent) => agent.sessionKey)),
   );
   agents.push(...fallbackAgents);
+  const visibleAgents = applyHuddleLaneStatus(agents);
 
   const liveSessionKeys = new Set(
     [...discovered, ...discoveredAll.filter(({ session }) => fallbackAgents.some((agent) => agent.sessionKey === session.sessionKey))]
@@ -393,11 +425,11 @@ async function buildCliRuntimeSnapshot(): Promise<FleetSnapshot> {
       return true;
     })
     .map(mapIdeGhostRuntimeTabToAgent);
-  agents.push(...ghostAgents);
+  visibleAgents.push(...ghostAgents);
 
   const squads: SquadSummary[] = [];
   for (const runtime of runtimes) {
-    const members = agents.filter((agent) => agent.runtime === runtime.id);
+    const members = visibleAgents.filter((agent) => agent.runtime === runtime.id);
     if (members.length === 0) continue;
     squads.push({
       id: `squad-${runtime.id}`,
@@ -418,8 +450,8 @@ async function buildCliRuntimeSnapshot(): Promise<FleetSnapshot> {
   const agentReportEvents = readAgentReportEvents();
   const events: EventItem[] = [
     ...agentReportEvents,
-    ...agents
-    .filter((agent) => ['running', 'reviewing', 'failed', 'blocked', 'waiting'].includes(agent.status))
+    ...visibleAgents
+    .filter((agent) => ['running', 'huddling', 'reviewing', 'failed', 'blocked', 'waiting'].includes(agent.status))
     .slice(0, 8)
     .map((agent): EventItem => ({
       id: `evt-${agent.id}`,
@@ -436,9 +468,9 @@ async function buildCliRuntimeSnapshot(): Promise<FleetSnapshot> {
     })),
   ];
 
-  const primarySessionKey = agents.find((agent) => agent.isCurrentSession)?.sessionKey
-    ?? agents.find((agent) => agent.status === 'running')?.sessionKey
-    ?? agents[0]?.sessionKey;
+  const primarySessionKey = visibleAgents.find((agent) => agent.isCurrentSession)?.sessionKey
+    ?? visibleAgents.find((agent) => agent.status === 'running')?.sessionKey
+    ?? visibleAgents[0]?.sessionKey;
 
   return {
     generatedAt: new Date().toISOString(),
@@ -456,7 +488,7 @@ async function buildCliRuntimeSnapshot(): Promise<FleetSnapshot> {
       primarySessionKey,
     },
     squads,
-    agents,
+    agents: visibleAgents,
     events,
     artifacts: [],
   };


### PR DESCRIPTION
Closes #1289. Mobile packets map awaiting_orchestrator/huddle_ready to 'huddling' (previously collapsed into failed), carry the latest huddle plan text, and huddle agent reports reach the mobile inbox. Additive payload shape. Salvaged from the preserved/ branch after a zombie reap; cherry-picked onto fresh main, 482 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj