### PR TITLE
fix: app traffic can never be lost to the Clerk fetch interceptor again — non-Clerk fetches bypass the plugin wrapper (#1436)

### DIFF
--- a/src/components/auth/O8AuthProvider.tsx
+++ b/src/components/auth/O8AuthProvider.tsx
@@ -5,6 +5,7 @@ import { ClerkProvider, useUser, useClerk } from '@clerk/nextjs';
 import { startDesktopSignIn } from '@/lib/auth/start-desktop-sign-in';
 import { DesktopAuthCallbackHandler } from '@/components/auth/DesktopAuthCallbackHandler';
 import { highResolutionAvatarUrl } from '@/lib/auth/avatar-url';
+import { installTauriClerkFetchGuard } from '@/lib/auth/clerk-fetch-guard';
 
 // The Clerk publishable key is app-wide and public, baked into the build at ship
 // time. When it's absent (fresh build with no Clerk app yet), Clerk is disabled
@@ -185,11 +186,13 @@ function ClerkSessionHost({ children }: { children: ReactNode }) {
       return;
     }
     let active = true;
+    const nativeFetch = globalThis.fetch;
     // Client-only dynamic import — the plugin touches Tauri globals, so it must
     // never load during Next's SSR/static export.
     import('tauri-plugin-clerk')
       .then((m) => m.initClerk())
       .then((clerk) => {
+        installTauriClerkFetchGuard(nativeFetch);
         if (active) setEngine(clerk);
       })
       .catch((err) => {

--- a/src/lib/auth/clerk-fetch-guard.test.ts
+++ b/src/lib/auth/clerk-fetch-guard.test.ts
@@ -4,21 +4,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   installTauriClerkFetchGuard,
   isClerkBoundFetch,
-  resetTauriClerkFetchGuardForTests,
 } from './clerk-fetch-guard';
 
 describe('tauri Clerk fetch guard', () => {
   const originalFetch = globalThis.fetch;
 
   beforeEach(() => {
-    resetTauriClerkFetchGuardForTests();
     window.history.replaceState(null, '', '/dashboard');
   });
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
-    resetTauriClerkFetchGuardForTests();
   });
 
   it('bypasses a throwing plugin interceptor for app API traffic', async () => {

--- a/src/lib/auth/clerk-fetch-guard.test.ts
+++ b/src/lib/auth/clerk-fetch-guard.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  installTauriClerkFetchGuard,
+  isClerkBoundFetch,
+  resetTauriClerkFetchGuardForTests,
+} from './clerk-fetch-guard';
+
+describe('tauri Clerk fetch guard', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    resetTauriClerkFetchGuardForTests();
+    window.history.replaceState(null, '', '/dashboard');
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    resetTauriClerkFetchGuardForTests();
+  });
+
+  it('bypasses a throwing plugin interceptor for app API traffic', async () => {
+    const nativeFetch = vi.fn(async () => new Response('ok', { status: 200 })) as unknown as typeof fetch;
+    const pluginFetch = vi.fn(() => {
+      throw new Error('URL@[native code]');
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = pluginFetch;
+    installTauriClerkFetchGuard(nativeFetch);
+
+    const response = await fetch('/api/panel/repos');
+
+    expect(await response.text()).toBe('ok');
+    expect(nativeFetch).toHaveBeenCalledWith('/api/panel/repos', undefined);
+    expect(pluginFetch).not.toHaveBeenCalled();
+  });
+
+  it('delegates Clerk and plugin-http traffic to the plugin fetch wrapper', async () => {
+    const nativeFetch = vi.fn(async () => new Response('native', { status: 200 })) as unknown as typeof fetch;
+    const pluginFetch = vi.fn(async () => new Response('plugin', { status: 200 })) as unknown as typeof fetch;
+
+    globalThis.fetch = pluginFetch;
+    installTauriClerkFetchGuard(nativeFetch);
+
+    await fetch('https://clerk.o8.run/v1/client');
+    await fetch('http://ipc.localhost/plugin:http|fetch');
+    await fetch('/api/panel/entitlement/sync', {
+      headers: { 'x-tauri-fetch': '1' },
+    });
+
+    expect(pluginFetch).toHaveBeenCalledTimes(3);
+    expect(nativeFetch).not.toHaveBeenCalled();
+  });
+
+  it('identifies the Clerk Frontend API domains without treating app routes as Clerk-bound', () => {
+    expect(isClerkBoundFetch('https://clerk.o8.run/v1/client')).toBe(true);
+    expect(isClerkBoundFetch('https://steady-mallard-12.clerk.accounts.dev/v1/client')).toBe(true);
+    expect(isClerkBoundFetch('/api/panel/repos')).toBe(false);
+  });
+});

--- a/src/lib/auth/clerk-fetch-guard.ts
+++ b/src/lib/auth/clerk-fetch-guard.ts
@@ -1,0 +1,89 @@
+'use client';
+
+type FetchFn = typeof fetch;
+type FetchInput = Parameters<FetchFn>[0];
+type FetchInit = Parameters<FetchFn>[1];
+
+let warnedFallback = false;
+
+function resolveFetchUrl(input: FetchInput): URL | null {
+  try {
+    if (typeof input === 'string') {
+      if (input.startsWith('plugin:http')) return new URL(input);
+      return new URL(input, window.location.origin);
+    }
+    if (input instanceof URL) return input;
+    return new URL(input.url, window.location.origin);
+  } catch {
+    return null;
+  }
+}
+
+function hasTauriFetchHeader(input: FetchInput, init?: FetchInit): boolean {
+  const initHeaders = init?.headers;
+  if (initHeaders instanceof Headers) return initHeaders.has('x-tauri-fetch');
+  if (Array.isArray(initHeaders)) return initHeaders.some(([key]) => key.toLowerCase() === 'x-tauri-fetch');
+  if (initHeaders) {
+    return Object.keys(initHeaders).some((key) => key.toLowerCase() === 'x-tauri-fetch');
+  }
+  return input instanceof Request && input.headers.has('x-tauri-fetch');
+}
+
+export function isClerkBoundFetch(input: FetchInput, init?: FetchInit): boolean {
+  if (hasTauriFetchHeader(input, init)) return true;
+
+  const url = resolveFetchUrl(input);
+  if (!url) return false;
+
+  if (url.protocol === 'plugin:' && url.href.startsWith('plugin:http')) return true;
+  if (decodeURIComponent(url.pathname) === '/plugin:http|fetch') return true;
+
+  const hostname = url.hostname.toLowerCase();
+  return (
+    hostname === 'clerk.o8.run' ||
+    hostname === 'api.clerk.com' ||
+    hostname.endsWith('.accounts.dev') ||
+    hostname.endsWith('.clerk.accounts.dev')
+  );
+}
+
+function isLikelyNetworkError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.name === 'AbortError') return true;
+  if (error instanceof TypeError && /fetch|network|load failed|cancel/i.test(error.message)) return true;
+  return false;
+}
+
+function warnNativeFallbackOnce(error: unknown) {
+  if (warnedFallback) return;
+  warnedFallback = true;
+  console.warn('[auth] native Clerk fetch wrapper failed for app traffic; falling back to native fetch', error);
+}
+
+export function installTauriClerkFetchGuard(nativeFetch: FetchFn): void {
+  const pluginFetch = globalThis.fetch;
+  if (pluginFetch === nativeFetch) return;
+
+  const boundNativeFetch = nativeFetch.bind(globalThis);
+  const boundPluginFetch = pluginFetch.bind(globalThis);
+
+  globalThis.fetch = (async (input: FetchInput, init?: FetchInit) => {
+    if (!isClerkBoundFetch(input, init)) {
+      return boundNativeFetch(input, init);
+    }
+
+    try {
+      return await boundPluginFetch(input, init);
+    } catch (error) {
+      if (!isLikelyNetworkError(error) && !isClerkBoundFetch(input, init)) {
+        warnNativeFallbackOnce(error);
+        return boundNativeFetch(input, init);
+      }
+      throw error;
+    }
+  }) as FetchFn;
+}
+
+export function resetTauriClerkFetchGuardForTests(): void {
+  warnedFallback = false;
+}

--- a/src/lib/auth/clerk-fetch-guard.ts
+++ b/src/lib/auth/clerk-fetch-guard.ts
@@ -4,8 +4,6 @@ type FetchFn = typeof fetch;
 type FetchInput = Parameters<FetchFn>[0];
 type FetchInit = Parameters<FetchFn>[1];
 
-let warnedFallback = false;
-
 function resolveFetchUrl(input: FetchInput): URL | null {
   try {
     if (typeof input === 'string') {
@@ -47,19 +45,6 @@ export function isClerkBoundFetch(input: FetchInput, init?: FetchInit): boolean 
   );
 }
 
-function isLikelyNetworkError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  if (error.name === 'AbortError') return true;
-  if (error instanceof TypeError && /fetch|network|load failed|cancel/i.test(error.message)) return true;
-  return false;
-}
-
-function warnNativeFallbackOnce(error: unknown) {
-  if (warnedFallback) return;
-  warnedFallback = true;
-  console.warn('[auth] native Clerk fetch wrapper failed for app traffic; falling back to native fetch', error);
-}
-
 export function installTauriClerkFetchGuard(nativeFetch: FetchFn): void {
   const pluginFetch = globalThis.fetch;
   if (pluginFetch === nativeFetch) return;
@@ -68,22 +53,14 @@ export function installTauriClerkFetchGuard(nativeFetch: FetchFn): void {
   const boundPluginFetch = pluginFetch.bind(globalThis);
 
   globalThis.fetch = (async (input: FetchInput, init?: FetchInit) => {
+    // Non-Clerk traffic NEVER touches the plugin wrapper — this is the whole
+    // guard. Clerk-bound traffic goes to the plugin and its errors propagate
+    // to clerk-js untouched; falling back to native fetch for Clerk traffic
+    // would silently reintroduce the WKWebView cookie problem native mode
+    // exists to solve.
     if (!isClerkBoundFetch(input, init)) {
       return boundNativeFetch(input, init);
     }
-
-    try {
-      return await boundPluginFetch(input, init);
-    } catch (error) {
-      if (!isLikelyNetworkError(error) && !isClerkBoundFetch(input, init)) {
-        warnNativeFallbackOnce(error);
-        return boundNativeFetch(input, init);
-      }
-      throw error;
-    }
+    return boundPluginFetch(input, init);
   }) as FetchFn;
-}
-
-export function resetTauriClerkFetchGuardForTests(): void {
-  warnedFallback = false;
 }


### PR DESCRIPTION
Ref #1436 (hardening half). Native fetch captured before the plugin's dynamic import; after initClerk, a guard routes non-Clerk traffic straight to native fetch — the 0.1.538 blank-dashboard class is structurally dead. Clerk/plugin-http traffic still owns the plugin path with errors propagating to clerk-js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj