### PR TITLE
fix: sign-in failures surface as a visible dismissible card — never console-only again (#1437)

### DIFF
--- a/src/components/auth/DesktopAuthCallbackHandler.tsx
+++ b/src/components/auth/DesktopAuthCallbackHandler.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react';
 import { useSignIn, useClerk } from '@clerk/nextjs';
 
 import { O8_AUTH_STATE_KEY } from '@/lib/auth/start-desktop-sign-in';
+import { consumeDesktopAuthCallback } from '@/lib/auth/desktop-auth-callback';
 
 /**
  * Consumes the `o8://auth/callback?ticket=...&state=...` deep link that the Tauri
@@ -16,14 +17,6 @@ import { O8_AUTH_STATE_KEY } from '@/lib/auth/start-desktop-sign-in';
  * activates the session (which makes useUser() update; the bridge then provisions
  * the local user row). Mounted inside ClerkProvider; renders nothing.
  */
-// One-time Clerk tickets must never be exchanged twice: the Tauri shell's live
-// event and the cold-start buffer can BOTH deliver the same URL (belt-and-
-// suspenders with the Rust-side single-path fix), and a second exchange burns
-// the ticket with "sign in token has already been used" (live-hit 2026-07-05,
-// cost the operator a full sign-in attempt with zero visible feedback).
-// Module-level so remounts can't reset it.
-const consumedTickets = new Set<string>();
-
 export function DesktopAuthCallbackHandler() {
   const { signIn } = useSignIn();
   const clerk = useClerk();
@@ -44,70 +37,27 @@ export function DesktopAuthCallbackHandler() {
       const si = signInRef.current;
       if (!si) return;
 
-      let ticket: string | null = null;
-      let state: string | null = null;
-      try {
-        const u = new URL(raw);
-        if (u.protocol !== 'o8:' || u.host !== 'auth') return;
-        ticket = u.searchParams.get('ticket');
-        state = u.searchParams.get('state');
-      } catch {
-        return;
-      }
-      if (!ticket) return;
-      if (consumedTickets.has(ticket)) return;
-
-      // CSRF: the echoed state must match the nonce we stored at launch.
-      let expected: string | null = null;
-      try {
-        expected = sessionStorage.getItem(O8_AUTH_STATE_KEY);
-      } catch {
-        /* storage unavailable — skip the check rather than block sign-in */
-      }
-      if (expected && state !== expected) {
-        console.warn('[auth] callback state mismatch — ignoring');
-        return;
-      }
-
       processingRef.current = true;
-      consumedTickets.add(ticket);
       try {
-        const { error } = await si.ticket({ ticket });
-        if (error) {
-          console.error('[auth] ticket sign-in failed:', error);
-          return;
-        }
-        if (si.status === 'complete') {
-          const { error: finalizeError } = await si.finalize();
-          if (finalizeError) {
-            console.error('[auth] finalize failed:', finalizeError);
-            return;
-          }
-          // finalize() activates the session server-side, but in the desktop
-          // flow there's no post-sign-in navigation, so Clerk's React signals
-          // don't always propagate — useUser() stays null until a manual app
-          // reload, leaving the avatar + account info blank. Explicitly set the
-          // created session active (idempotent if finalize already did) and
-          // reload the user resource so useUser() — and every useO8Auth()
-          // consumer — populates live, no reload needed.
-          try {
-            if (si.createdSessionId) {
-              await clerkRef.current.setActive({ session: si.createdSessionId });
+        await consumeDesktopAuthCallback(raw, {
+          signIn: si,
+          clerk: clerkRef.current,
+          getExpectedState: () => {
+            // CSRF: the echoed state must match the nonce we stored at launch.
+            try {
+              return sessionStorage.getItem(O8_AUTH_STATE_KEY);
+            } catch {
+              return null;
             }
-            await clerkRef.current.user?.reload();
-          } catch (activateErr) {
-            console.error('[auth] post-finalize session activation failed:', activateErr);
-          }
-          try {
-            sessionStorage.removeItem(O8_AUTH_STATE_KEY);
-          } catch {
-            /* ignore */
-          }
-        } else {
-          console.warn('[auth] ticket sign-in incomplete:', si.status);
-        }
-      } catch (err) {
-        console.error('[auth] ticket exchange threw:', err);
+          },
+          clearExpectedState: () => {
+            try {
+              sessionStorage.removeItem(O8_AUTH_STATE_KEY);
+            } catch {
+              /* ignore */
+            }
+          },
+        });
       } finally {
         processingRef.current = false;
       }

--- a/src/components/desktop/SettingsQuickDrawer.tsx
+++ b/src/components/desktop/SettingsQuickDrawer.tsx
@@ -20,9 +20,15 @@ import {
   Sparkles,
 } from './lucide-shims';
 import { useO8Auth, type O8AuthState } from '@/components/auth/O8AuthProvider';
+import {
+  getDesktopAuthError,
+  subscribeDesktopAuthError,
+  type DesktopAuthError,
+} from '@/lib/auth/desktop-auth-error';
 import { useTheme } from '@/lib/theme/context';
 import { openExternalUrl } from '@/lib/desktop/open-external';
 import type { PaletteId } from '@/lib/theme/registry';
+import { SignInErrorCard } from '@/components/desktop/SignInErrorCard';
 
 const FONT = 'var(--font-sans-system)';
 const MONO = '"SF Mono", ui-monospace, "Cascadia Code", Menlo, monospace';
@@ -309,6 +315,14 @@ function separatorStyle(): CSSProperties {
  * Builds without a Clerk key keep the original local-profile header.
  */
 function AccountSection({ auth }: { auth: O8AuthState }) {
+  const [authError, setAuthError] = useState<DesktopAuthError | null>(() => getDesktopAuthError());
+
+  useEffect(() => {
+    return subscribeDesktopAuthError(() => {
+      setAuthError(getDesktopAuthError());
+    });
+  }, []);
+
   if (!auth.clerkEnabled) {
     return (
       <>
@@ -335,6 +349,7 @@ function AccountSection({ auth }: { auth: O8AuthState }) {
           <IconFrame><Github size={13} /></IconFrame>
           <span style={{ flex: 1, color: TEXT, fontSize: 13.5, fontWeight: 300, letterSpacing: '-0.1px' }}>Sign in with GitHub</span>
         </RowButton>
+        {authError ? <SignInErrorCard key={authError.id} authError={authError} /> : null}
         <div style={separatorStyle()} />
       </>
     );

--- a/src/components/desktop/SignInErrorCard.tsx
+++ b/src/components/desktop/SignInErrorCard.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState } from 'react';
+
+import { X } from './lucide-shims';
+import { clearDesktopAuthError, type DesktopAuthError } from '@/lib/auth/desktop-auth-error';
+
+const FONT = 'var(--font-sans-system)';
+const TEXT = 'var(--t-text, #0f172a)';
+const MUTED = 'var(--t-text-muted, #64748b)';
+
+export function SignInErrorCard({ authError }: { authError: DesktopAuthError }) {
+  const [detailsOpen, setDetailsOpen] = useState(false);
+
+  return (
+    <div
+      role="status"
+      style={{
+        display: 'grid',
+        gap: 7,
+        margin: '1px 0 2px',
+        padding: '9px 8px',
+        borderRadius: 12,
+        border: '1px solid var(--t-danger-border, var(--t-panel-border))',
+        background: 'var(--t-danger-bg, var(--t-bg-card))',
+        color: TEXT,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 7, minWidth: 0 }}>
+        <button
+          type="button"
+          onClick={() => setDetailsOpen((value) => !value)}
+          aria-expanded={detailsOpen}
+          style={{
+            flex: 1,
+            minHeight: 44,
+            border: 0,
+            padding: 0,
+            background: 'transparent',
+            color: TEXT,
+            cursor: 'pointer',
+            display: 'grid',
+            gap: 2,
+            textAlign: 'left',
+            fontFamily: FONT,
+          }}
+        >
+          <span style={{ fontSize: 12.5, lineHeight: 1.25, fontWeight: 420, letterSpacing: 0 }}>
+            Sign-in didn&apos;t complete — try again
+          </span>
+          <span style={{ color: MUTED, fontSize: 10.5, lineHeight: 1.25, fontWeight: 300, letterSpacing: 0 }}>
+            {detailsOpen ? 'Hide reason' : 'Show reason'}
+          </span>
+        </button>
+        <button
+          type="button"
+          aria-label="Dismiss sign-in error"
+          onClick={clearDesktopAuthError}
+          style={{
+            width: 44,
+            height: 44,
+            border: 0,
+            borderRadius: 10,
+            background: 'transparent',
+            color: MUTED,
+            cursor: 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+          }}
+        >
+          <X size={14} />
+        </button>
+      </div>
+      {detailsOpen ? (
+        <div
+          style={{
+            color: MUTED,
+            fontSize: 11,
+            lineHeight: 1.35,
+            overflowWrap: 'anywhere',
+          }}
+        >
+          {authError.message}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/auth/desktop-auth-callback.test.ts
+++ b/src/lib/auth/desktop-auth-callback.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  consumeDesktopAuthCallback,
+  resetConsumedDesktopAuthTicketsForTest,
+  type DesktopAuthClerk,
+  type DesktopAuthSignIn,
+} from '@/lib/auth/desktop-auth-callback';
+import { clearDesktopAuthError, getDesktopAuthError, reportDesktopAuthError } from '@/lib/auth/desktop-auth-error';
+
+function makeSignIn(overrides: Partial<DesktopAuthSignIn> = {}): DesktopAuthSignIn {
+  return {
+    status: 'complete',
+    createdSessionId: 'sess_123',
+    ticket: vi.fn(async () => ({})),
+    finalize: vi.fn(async () => ({})),
+    ...overrides,
+  };
+}
+
+function makeClerk(overrides: Partial<DesktopAuthClerk> = {}): DesktopAuthClerk {
+  return {
+    setActive: vi.fn(async () => undefined),
+    user: { reload: vi.fn(async () => undefined) },
+    ...overrides,
+  };
+}
+
+function callbackUrl(ticket = 'ticket_123', state = 'state_123'): string {
+  return `o8://auth/callback?ticket=${ticket}&state=${state}`;
+}
+
+describe('consumeDesktopAuthCallback', () => {
+  beforeEach(() => {
+    resetConsumedDesktopAuthTicketsForTest();
+    clearDesktopAuthError();
+    vi.restoreAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('reports state mismatch without burning the ticket', async () => {
+    const signIn = makeSignIn();
+    await consumeDesktopAuthCallback(callbackUrl(), {
+      signIn,
+      clerk: makeClerk(),
+      getExpectedState: () => 'different',
+      clearExpectedState: vi.fn(),
+    });
+
+    expect(signIn.ticket).not.toHaveBeenCalled();
+    expect(getDesktopAuthError()?.message).toContain('did not match');
+  });
+
+  it('reports Clerk ticket exchange longMessage', async () => {
+    const signIn = makeSignIn({
+      ticket: vi.fn(async () => ({ error: { longMessage: 'sign in token has already been used' } })),
+    });
+    await consumeDesktopAuthCallback(callbackUrl(), {
+      signIn,
+      clerk: makeClerk(),
+      getExpectedState: () => 'state_123',
+      clearExpectedState: vi.fn(),
+    });
+
+    expect(getDesktopAuthError()?.message).toBe('sign in token has already been used');
+  });
+
+  it('reports finalize failures', async () => {
+    const signIn = makeSignIn({
+      finalize: vi.fn(async () => ({ error: { longMessage: 'finalize failed upstream' } })),
+    });
+    await consumeDesktopAuthCallback(callbackUrl(), {
+      signIn,
+      clerk: makeClerk(),
+      getExpectedState: () => 'state_123',
+      clearExpectedState: vi.fn(),
+    });
+
+    expect(getDesktopAuthError()?.message).toBe('finalize failed upstream');
+  });
+
+  it('reports setActive failures', async () => {
+    const clerk = makeClerk({
+      setActive: vi.fn(async () => {
+        throw new Error('session activation failed');
+      }),
+    });
+    await consumeDesktopAuthCallback(callbackUrl(), {
+      signIn: makeSignIn(),
+      clerk,
+      getExpectedState: () => 'state_123',
+      clearExpectedState: vi.fn(),
+    });
+
+    expect(getDesktopAuthError()?.message).toBe('session activation failed');
+  });
+
+  it('reports incomplete sign-in status', async () => {
+    await consumeDesktopAuthCallback(callbackUrl(), {
+      signIn: makeSignIn({ status: 'needs_first_factor' }),
+      clerk: makeClerk(),
+      getExpectedState: () => 'state_123',
+      clearExpectedState: vi.fn(),
+    });
+
+    expect(getDesktopAuthError()?.message).toContain('needs_first_factor');
+  });
+
+  it('clears stale errors after a successful activation', async () => {
+    const clearExpectedState = vi.fn();
+    reportDesktopAuthError('old failure');
+    await consumeDesktopAuthCallback(callbackUrl(), {
+      signIn: makeSignIn(),
+      clerk: makeClerk(),
+      getExpectedState: () => 'state_123',
+      clearExpectedState,
+    });
+
+    expect(clearExpectedState).toHaveBeenCalledOnce();
+    expect(getDesktopAuthError()).toBeNull();
+  });
+
+  it('surfaces a used-link reason for duplicate tickets', async () => {
+    const signIn = makeSignIn();
+    const options = {
+      signIn,
+      clerk: makeClerk(),
+      getExpectedState: () => 'state_123',
+      clearExpectedState: vi.fn(),
+    };
+    await consumeDesktopAuthCallback(callbackUrl('ticket_once'), options);
+    await consumeDesktopAuthCallback(callbackUrl('ticket_once'), options);
+
+    expect(signIn.ticket).toHaveBeenCalledOnce();
+    expect(getDesktopAuthError()?.message).toContain('already used');
+  });
+});

--- a/src/lib/auth/desktop-auth-callback.ts
+++ b/src/lib/auth/desktop-auth-callback.ts
@@ -1,0 +1,115 @@
+import { clearDesktopAuthError, reportDesktopAuthError } from '@/lib/auth/desktop-auth-error';
+
+export interface DesktopAuthSignIn {
+  status?: string | null;
+  createdSessionId?: string | null;
+  ticket: (params: { ticket: string }) => Promise<{ error?: unknown }>;
+  finalize: () => Promise<{ error?: unknown }>;
+}
+
+export interface DesktopAuthClerk {
+  setActive: (params: { session: string }) => Promise<unknown>;
+  user?: { reload?: () => Promise<unknown> } | null;
+}
+
+export interface ConsumeDesktopAuthCallbackOptions {
+  signIn: DesktopAuthSignIn;
+  clerk: DesktopAuthClerk;
+  getExpectedState: () => string | null;
+  clearExpectedState: () => void;
+}
+
+// Module-level so remounts cannot reset the one-time-ticket guard.
+const consumedTickets = new Set<string>();
+
+export function resetConsumedDesktopAuthTicketsForTest(): void {
+  consumedTickets.clear();
+}
+
+function reasonFromUnknown(value: unknown, fallback: string): string {
+  if (!value) return fallback;
+  if (typeof value === 'string') return value;
+  if (value instanceof Error) return value.message || fallback;
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    for (const key of ['longMessage', 'message', 'detail', 'error']) {
+      const candidate = record[key];
+      if (typeof candidate === 'string' && candidate.trim()) return candidate;
+    }
+  }
+  return fallback;
+}
+
+export async function consumeDesktopAuthCallback(
+  raw: string,
+  options: ConsumeDesktopAuthCallbackOptions,
+): Promise<void> {
+  let ticket: string | null = null;
+  let state: string | null = null;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'o8:' || url.host !== 'auth') return;
+    ticket = url.searchParams.get('ticket');
+    state = url.searchParams.get('state');
+  } catch {
+    return;
+  }
+
+  if (!ticket) return;
+  if (consumedTickets.has(ticket)) {
+    reportDesktopAuthError('This sign-in link was already used. Try signing in again.');
+    return;
+  }
+
+  const expected = options.getExpectedState();
+  if (expected && state !== expected) {
+    console.warn('[auth] callback state mismatch — ignoring');
+    reportDesktopAuthError('The sign-in response did not match this app session. Try signing in again.');
+    return;
+  }
+
+  consumedTickets.add(ticket);
+  try {
+    const { error } = await options.signIn.ticket({ ticket });
+    if (error) {
+      const reason = reasonFromUnknown(error, 'The sign-in ticket could not be exchanged.');
+      console.error('[auth] ticket sign-in failed:', error);
+      reportDesktopAuthError(reason);
+      return;
+    }
+
+    if (options.signIn.status !== 'complete') {
+      const status = options.signIn.status || 'unknown';
+      console.warn('[auth] ticket sign-in incomplete:', status);
+      reportDesktopAuthError(`Clerk returned an incomplete sign-in status: ${status}.`);
+      return;
+    }
+
+    const { error: finalizeError } = await options.signIn.finalize();
+    if (finalizeError) {
+      const reason = reasonFromUnknown(finalizeError, 'The sign-in session could not be finalized.');
+      console.error('[auth] finalize failed:', finalizeError);
+      reportDesktopAuthError(reason);
+      return;
+    }
+
+    try {
+      if (options.signIn.createdSessionId) {
+        await options.clerk.setActive({ session: options.signIn.createdSessionId });
+      }
+      await options.clerk.user?.reload?.();
+    } catch (activateErr) {
+      const reason = reasonFromUnknown(activateErr, 'The signed-in session could not be activated.');
+      console.error('[auth] post-finalize session activation failed:', activateErr);
+      reportDesktopAuthError(reason);
+      return;
+    }
+
+    options.clearExpectedState();
+    clearDesktopAuthError();
+  } catch (err) {
+    const reason = reasonFromUnknown(err, 'The sign-in ticket exchange failed unexpectedly.');
+    console.error('[auth] ticket exchange threw:', err);
+    reportDesktopAuthError(reason);
+  }
+}

--- a/src/lib/auth/desktop-auth-error.ts
+++ b/src/lib/auth/desktop-auth-error.ts
@@ -1,0 +1,39 @@
+export interface DesktopAuthError {
+  id: number;
+  message: string;
+}
+
+let currentError: DesktopAuthError | null = null;
+let nextId = 1;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+export function getDesktopAuthError(): DesktopAuthError | null {
+  return currentError;
+}
+
+export function subscribeDesktopAuthError(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function reportDesktopAuthError(reason: string): DesktopAuthError {
+  currentError = {
+    id: nextId,
+    message: reason.trim() || 'The sign-in callback failed.',
+  };
+  nextId += 1;
+  emit();
+  return currentError;
+}
+
+export function clearDesktopAuthError(): void {
+  if (!currentError) return;
+  currentError = null;
+  emit();
+}

--- a/src/lib/auth/start-desktop-sign-in.ts
+++ b/src/lib/auth/start-desktop-sign-in.ts
@@ -10,6 +10,7 @@
  */
 
 import { openExternalUrl } from '@/lib/desktop/open-external';
+import { clearDesktopAuthError } from '@/lib/auth/desktop-auth-error';
 
 export const O8_SIGN_IN_URL =
   process.env.NEXT_PUBLIC_O8_SIGN_IN_URL || 'https://o8.run/desktop/sign-in';
@@ -29,6 +30,7 @@ function randomState(): string {
 
 export function startDesktopSignIn(): void {
   if (typeof window === 'undefined') return;
+  clearDesktopAuthError();
   const state = randomState();
   try {
     sessionStorage.setItem(O8_AUTH_STATE_KEY, state);


### PR DESCRIPTION
Closes #1437. Every DesktopAuthCallbackHandler failure branch (burned ticket, CSRF mismatch, exchange/finalize/setActive errors) reports a human-readable error rendered as a dismissible card beside the account row; cleared on the next attempt. Callback logic extracted to a testable lib with all prior invariants preserved (consumed-ticket set, state check, hydration). 7 real-path failure tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WsE6fxCGdW8rX3hX6Bzqj