### PR TITLE
Beta-exit rocks 2+4: telemetry + updater safety, ws-server decomposition

### DIFF
--- a/docs/beta-exit-roadmap.md
+++ b/docs/beta-exit-roadmap.md
@@ -32,6 +32,20 @@ real use. Beta exit = five rocks (four engineering, one proof) + three explicit 
   contract. Dupes folded: #1499→#1486 (ship-over-existing-release, hit independently twice in
   24h), #1510→#1485 (flaky steering test).
 
+**RE-AUDIT 2026-07-08 (code-level, clause by clause): DECOMPOSED — no longer one rock.**
+Scaffolding largely exists: stop verb end-to-end (#1286: `orchestrator/stop-packet.ts`, routes,
+CLI), restart reconcile refuses to archive live lanes (lost session→paused, missing
+worktree→awaiting_orchestrator + card), reaper preserves worktree HEAD, cleanup checks
+uncommitted work. Remaining core = ONE STONE (~2–3 days): a lane-lifecycle invariant module that
+(a) unifies the two divergent terminal-state definitions (`lane/terminal-states.ts` vs
+`lane/types.ts` disagree on `reviewing`) and adds wedge-timeouts for `awaiting_*`/paused/
+recovering so nothing parks forever, and (b) routes every worktree-prune path through one guarded
+gate (uncommitted OR recent-mtime → refuse + emit lane event; the force path currently has no
+dirty check). Separable follow-ups, each PEBBLE–STONE: persisted idempotency key on steer/rerun
+(#1497 — cache is in-memory and only guards merge verbs), confirmed-kill escalation
+SIGINT→SIGTERM→SIGKILL (#1471 S1), headless transcript binding (#1502), huddle-exit steer
+reclassification (#1496).
+
 ### Rock 2 — Telemetry + updater safety, one program (M-L) — THIS PR
 - [x] Process-level crash capture (uncaughtException/unhandledRejection) in Next server + ws-server,
       persisted locally under `~/.o8/telemetry/` (ring-buffered)
@@ -48,10 +62,17 @@ real use. Beta exit = five rocks (four engineering, one proof) + three explicit 
   no staged rollout. A bad release currently hits the whole fleet invisibly and irrecoverably.
 - Related: #1454 (opt-in fleet telemetry console — the console UI is follow-up, not this PR).
 
-### Rock 3 — Symon Agent Mode desktop half (L) — LANDED 0.1.565/566
+### Rock 3 — Symon Agent Mode desktop half (L) — LANDED, now a PEBBLE
 Desktop half (phone-hosted realtime voice, Mac-executed tools) landed on main 2026-07-08
-(8edbfe16) after the audit snapshot. Remaining: live verification + governance review of the
-phone-initiated tool-call approval path.
+(8edbfe16). Code-level re-audit: COMPLETE, zero stubs — symon WS channel with full handler set +
+stale/preemption sweeps, ephemeral mint with the contract's exact error table, strict
+callId-correlated execution through the same SafetyClass gate as desk, symmetric last-start-wins,
+and a real-path verifier (`scripts/verify-symon-agent-mode.ts`) that drives an actual ws-server
+over a real WS client. Phone-side approval is excluded from v1 BY CONTRACT (confirm-gated tools
+honestly return needs_confirmation; approval stays on the Mac dock).
+Remaining (PEBBLE — one dogfood session, no code): real iPhone against the installed app with a
+BYOK key — mint through the real webview bridge, one real tool round-trip, desk↔phone preemption
+both directions within ~3s, confirm-gated tool pops the Mac dock card.
 
 ### Rock 4 — ws-server decomposition (L) — THIS PR
 - [x] Event-loop lag watchdog with `[ws-health]` logging + counters on `/health` (caught real
@@ -66,14 +87,20 @@ phone-initiated tool-call approval path.
 - Evidence: #1498 (event loop wedged minutes on a sync FS walk; every mobile client shares that
   one thread). The specific walk was fixed; the structural exposure was not.
 
-### Rock 5 — Native mobile app to the App Store (L)
-- [ ] Parity audit vs web `/mobile`
-- [ ] Native-module EAS builds green
-- [ ] App Store submission
-- [ ] Retire the parallel web surface
-- Evidence: full Expo SDK 55 app exists at `~/o8-mobile` (daily commits, EAS configured) — #1074
-  reads "not started" but is stale. Phase-4 gate (resolve a real approval from the phone) is the
-  stated pre-launch bar.
+### Rock 5 — Native mobile app to the App Store (L) — DECOMPOSED
+- [x] Parity audit vs web `/mobile` — the 07-07 handoff is FULLY RESOLVED (review-units authority
+      e214e6c3, canonical fleet session identity 6a5fe067, agent-visible identity d78ba854)
+- [ ] TestFlight (2 stones + pebble): first EAS production build with the full current native set
+      (WebRTC + widgets + relay — wired but never cloud-built; quota blocked 06-27, reset 07-01,
+      nobody re-ran); relay E2E green (in flight now); rename fork-residue package name "chat"
+- [ ] App Store submission (stone + external rock): listing copy + full screenshot set + hosted
+      privacy policy; then Apple review itself (camera/mic/local-network/background-audio +
+      companion-app dependency = week+ of calendar, not engineering)
+- [ ] Retire the parallel web surface (after TestFlight proves out)
+- Evidence: `~/o8-mobile` near feature-parity native (chat/fleet/approvals/diffs/activity/
+  terminal/symon-voice/pairing), 10 commits today on Relay v1. Desktop relay connector
+  (`src/lib/mobile/relay-connector.ts`, db39127f) already wired into ws-server bootstrap;
+  standalone `services/relay/` Railway service + cross-repo E2E matrix in flight 2026-07-08.
 
 ## The proof gate (parallel, non-engineering)
 - [ ] Fresh-machine walkdown: DMG → sign-in → badge → first merge on the clean Intel MacBook
@@ -96,3 +123,18 @@ Status update 2026-07-08 (post-cleanup): the canvas↔Symon cluster (#1503–#15
 7 resolved on 0.1.566 (#1503, #1507, #1509 fixed; two closed as dupes), #1508 kept open honestly
 (landed fix is hygiene, live probe stays armed), epic #1505 in progress (1 of 7 items done). The
 lifecycle cluster (#1463–#1502) is intact and is THE beta-exit rock.
+
+## Merge-to-ship plan (2026-07-08 re-audit)
+
+Rocks-to-pebbles scoreboard: rock 2 DONE (this PR) · rock 4 DONE (this PR) · rock 3 code-complete
+(pebble: live dogfood) · rock 1 decomposed (one stone core + 4 small follow-ups) · rock 5
+decomposed (TestFlight = 2 stones; Apple review = external calendar).
+
+1. Relay E2E agent + mobile parity/connection agent finish and land on main.
+2. Merge latest main into this PR — expect a real `src/ws-server.ts` merge (relay connector
+   bootstrap wiring vs the rock-4 restructure); re-verify (tsc, targeted suites, :3999 boot).
+3. Merge this PR to main; ship next version (Q-gated).
+4. One post-ship dogfood session covers three pebbles: Symon agent mode live (iPhone), terminal
+   host child mode in the packaged build (then flip the default), UI parity eyeball.
+5. Next build effort: the rock-1 stone core (lifecycle invariant module + guarded prune gate),
+   then the EAS TestFlight build stone.

--- a/docs/beta-exit-roadmap.md
+++ b/docs/beta-exit-roadmap.md
@@ -1,0 +1,77 @@
+# Beta-Exit Roadmap (executive audit 2026-07-08)
+
+Synthesized from five parallel audits: product docs vs built, 6 weeks of git history (1,751 commits),
+the open issue backlog (125 issues), an architect-level structural audit, and the vault readiness
+scorecard (80/100, 2026-07-05). This doc is the tracking artifact for the work; the PR that
+introduced it carries rocks 2 and 4.
+
+## The read
+
+Engineering (architecture + capability) grades ~90; the weak legs are **distribution & proof (52)**
+and **first-stranger readiness (68)**. But the last 48 hours of dogfooding filed 25 issues in two
+clusters that sit directly on the product's core promise — the loop is not yet trustworthy under
+real use. Beta exit = five rocks (four engineering, one proof) + three explicit scope declarations.
+
+## The five rocks
+
+### Rock 1 — Dispatch/lane lifecycle contract (M-L) — BLOCKS EVERYTHING
+- [ ] Defined terminal-state contract for the packet/lane state machine (no silent wedges)
+- [ ] Real cancel/kill verb, reachable from every surface
+- [ ] Idempotency persisted across restarts (rerun/steer double-fire class, #1497)
+- [ ] Restart sweep must never archive running packets (#1500–#1502 class)
+- Evidence: 18 issues (#1463–#1502) from one dogfood session; orchestrator = only churn hotspot
+  in 6 weeks of history (29 fixes).
+
+### Rock 2 — Telemetry + updater safety, one program (M-L) — THIS PR
+- [ ] Process-level crash capture (uncaughtException/unhandledRejection) in Next server + ws-server,
+      persisted locally under `~/.o8/telemetry/` (ring-buffered)
+- [ ] Renderer error capture routed to the same store
+- [ ] Opt-in (default OFF) batched upload, ingest URL env-configured (`O8_TELEMETRY_INGEST_URL`);
+      Settings toggle with plain-language "what's collected"
+- [ ] Updater kill-switch: release-health manifest checked before applying an update; a pulled
+      version is skipped (fail-open on network errors)
+- [ ] Rollback path: operator can reinstall the previous signed release
+- Evidence: zero crash reporting in the codebase; local `npm run ship` bypasses CI; no rollback,
+  no staged rollout. A bad release currently hits the whole fleet invisibly and irrecoverably.
+- Related: #1454 (opt-in fleet telemetry console — the console UI is follow-up, not this PR).
+
+### Rock 3 — Symon Agent Mode desktop half (L) — LANDED 0.1.565/566
+Desktop half (phone-hosted realtime voice, Mac-executed tools) landed on main 2026-07-08
+(8edbfe16) after the audit snapshot. Remaining: live verification + governance review of the
+phone-initiated tool-call approval path.
+
+### Rock 4 — ws-server decomposition (L) — THIS PR
+- [ ] Event-loop lag watchdog with `[ws-health]` logging + health surface
+- [ ] Eliminate the 41 sync FS calls from the WS event loop's hot paths
+- [ ] PTY/terminal handling isolated off the main WS event loop (child-process terminal host)
+- [ ] Decompose the 6,307-line `ws-server.ts` into modules without changing channel semantics
+      (LOSSY vs DURABLE preserved)
+- Evidence: #1498 (event loop wedged minutes on a sync FS walk; every mobile client shares that
+  one thread). The specific walk was fixed; the structural exposure was not.
+
+### Rock 5 — Native mobile app to the App Store (L)
+- [ ] Parity audit vs web `/mobile`
+- [ ] Native-module EAS builds green
+- [ ] App Store submission
+- [ ] Retire the parallel web surface
+- Evidence: full Expo SDK 55 app exists at `~/o8-mobile` (daily commits, EAS configured) — #1074
+  reads "not started" but is stale. Phase-4 gate (resolve a real approval from the phone) is the
+  stated pre-launch bar.
+
+## The proof gate (parallel, non-engineering)
+- [ ] Fresh-machine walkdown: DMG → sign-in → badge → first merge on the clean Intel MacBook
+- [ ] Five recorded golden-path demos (record AFTER rock 1 stabilizes)
+- [ ] One real live purchase through the founder ladder
+- [ ] First external operator session
+- Fold #1013/#1014 (external-engineer / non-engineer readiness epics — oldest untouched) into
+  this track.
+
+## Scope declarations needed (in or out of beta-exit)
+- **Team Governance tier** ($25/seat; schema-only today) — recommend post-beta, first post-beta rock
+- **Windows/Linux port** (144 macOS cfg blocks; a port, not a flag) — recommend post-beta
+- **Cloud sync / managed orchestrator runtime** (zero code) — recommend post-beta
+
+## Sequence
+Weeks 1–2: rock 1 + canvas↔Symon wiring burst (#1503–#1510) with telemetry foundation (rock 2)
+in parallel. Weeks 2–5: rock 4 hardening, rock 3 verification, rock 5 submission track. Proof gate
+opens as soon as rock 1 stabilizes.

--- a/docs/beta-exit-roadmap.md
+++ b/docs/beta-exit-roadmap.md
@@ -16,11 +16,21 @@ real use. Beta exit = five rocks (four engineering, one proof) + three explicit 
 
 ### Rock 1 — Dispatch/lane lifecycle contract (M-L) — BLOCKS EVERYTHING
 - [ ] Defined terminal-state contract for the packet/lane state machine (no silent wedges)
-- [ ] Real cancel/kill verb, reachable from every surface
-- [ ] Idempotency persisted across restarts (rerun/steer double-fire class, #1497)
+- [ ] Real cancel/kill verb, reachable from every surface (#1471)
+- [ ] Idempotency persisted across restarts (rerun/steer double-fire class, #1497 — live-hit
+      2026-07-08: rerun double-dispatched into two parallel clones after a restart)
 - [ ] Restart sweep must never archive running packets (#1500–#1502 class)
-- Evidence: 18 issues (#1463–#1502) from one dogfood session; orchestrator = only churn hotspot
-  in 6 weeks of history (29 fixes).
+- [ ] Prune-safety: never delete a worktree with uncommitted work or recent mtime without
+      emitting an event (sweep pruned a worktree under an active orchestrator, 2026-07-08)
+- [ ] Durable transcript/session binding: #1502's zero-transcript headless workers and the
+      no_session_binding failures are the same hole — a packet must never lose its session
+- [ ] Steer must be reachable from every non-terminal state (structurally dead after
+      huddle-exits, #1496)
+- Evidence: 18 issues (#1463–#1502) from one dogfood session, re-confirmed live 2026-07-08 by a
+  second orchestrator (co-signed with receipts); orchestrator = only churn hotspot in 6 weeks of
+  history (29 fixes). Salvage-ref banking is currently a coping strategy standing in for this
+  contract. Dupes folded: #1499→#1486 (ship-over-existing-release, hit independently twice in
+  24h), #1510→#1485 (flaky steering test).
 
 ### Rock 2 — Telemetry + updater safety, one program (M-L) — THIS PR
 - [ ] Process-level crash capture (uncaughtException/unhandledRejection) in Next server + ws-server,
@@ -72,6 +82,10 @@ phone-initiated tool-call approval path.
 - **Cloud sync / managed orchestrator runtime** (zero code) — recommend post-beta
 
 ## Sequence
-Weeks 1–2: rock 1 + canvas↔Symon wiring burst (#1503–#1510) with telemetry foundation (rock 2)
-in parallel. Weeks 2–5: rock 4 hardening, rock 3 verification, rock 5 submission track. Proof gate
-opens as soon as rock 1 stabilizes.
+Weeks 1–2: rock 1 with telemetry foundation (rock 2) in parallel. Weeks 2–5: rock 4 hardening,
+rock 3 verification, rock 5 submission track. Proof gate opens as soon as rock 1 stabilizes.
+
+Status update 2026-07-08 (post-cleanup): the canvas↔Symon cluster (#1503–#1510) is beaten — 5 of
+7 resolved on 0.1.566 (#1503, #1507, #1509 fixed; two closed as dupes), #1508 kept open honestly
+(landed fix is hygiene, live probe stays armed), epic #1505 in progress (1 of 7 items done). The
+lifecycle cluster (#1463–#1502) is intact and is THE beta-exit rock.

--- a/docs/beta-exit-roadmap.md
+++ b/docs/beta-exit-roadmap.md
@@ -33,14 +33,17 @@ real use. Beta exit = five rocks (four engineering, one proof) + three explicit 
   24h), #1510→#1485 (flaky steering test).
 
 ### Rock 2 — Telemetry + updater safety, one program (M-L) — THIS PR
-- [ ] Process-level crash capture (uncaughtException/unhandledRejection) in Next server + ws-server,
+- [x] Process-level crash capture (uncaughtException/unhandledRejection) in Next server + ws-server,
       persisted locally under `~/.o8/telemetry/` (ring-buffered)
-- [ ] Renderer error capture routed to the same store
-- [ ] Opt-in (default OFF) batched upload, ingest URL env-configured (`O8_TELEMETRY_INGEST_URL`);
+- [x] Renderer error capture routed to the same store
+- [x] Opt-in (default OFF) batched upload, ingest URL env-configured (`O8_TELEMETRY_INGEST_URL`);
       Settings toggle with plain-language "what's collected"
-- [ ] Updater kill-switch: release-health manifest checked before applying an update; a pulled
+- [x] Updater kill-switch: release-health manifest checked before applying an update; a pulled
       version is skipped (fail-open on network errors)
-- [ ] Rollback path: operator can reinstall the previous signed release
+- [x] Rollback path: operator can reinstall the previous signed release (`scripts/rollback-release.mjs`,
+      minisign-verified; dry-run proven against v0.1.565)
+- Follow-ups: in-app text field for the ingest URL; an ingest endpoint (license-server) before
+  public launch; telemetry console UI (#1454).
 - Evidence: zero crash reporting in the codebase; local `npm run ship` bypasses CI; no rollback,
   no staged rollout. A bad release currently hits the whole fleet invisibly and irrecoverably.
 - Related: #1454 (opt-in fleet telemetry console — the console UI is follow-up, not this PR).
@@ -51,11 +54,15 @@ Desktop half (phone-hosted realtime voice, Mac-executed tools) landed on main 20
 phone-initiated tool-call approval path.
 
 ### Rock 4 — ws-server decomposition (L) — THIS PR
-- [ ] Event-loop lag watchdog with `[ws-health]` logging + health surface
-- [ ] Eliminate the 41 sync FS calls from the WS event loop's hot paths
-- [ ] PTY/terminal handling isolated off the main WS event loop (child-process terminal host)
-- [ ] Decompose the 6,307-line `ws-server.ts` into modules without changing channel semantics
-      (LOSSY vs DURABLE preserved)
+- [x] Event-loop lag watchdog with `[ws-health]` logging + counters on `/health` (caught real
+      2.8s/6s boot spikes during verification)
+- [x] Hot-path sync FS calls converted to async (startup-only sync probes documented inline)
+- [x] PTY/terminal-host seam built + real-fork tested; ships OPT-IN (`O8_TERMINAL_HOST=child`,
+      default `inline`) — flip the default only after a packaged-build dogfood
+- [x] Helper clusters decomposed into `src/lib/ws-server/` (channels/backpressure moved
+      byte-for-byte; LOSSY vs DURABLE semantics unchanged); entry stays the waived multiplexer
+- Follow-ups: packaged dogfood of child mode, then default flip; deeper split of the singleton
+  core if wedges recur despite the watchdog data.
 - Evidence: #1498 (event loop wedged minutes on a sync FS walk; every mobile client shares that
   one thread). The specific walk was fixed; the structural exposure was not.
 

--- a/release-health.example.json
+++ b/release-health.example.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Updater kill-switch manifest. The REAL file lives at the root of the hurttlocker/o8-releases repo (raw.githubusercontent.com/hurttlocker/o8-releases/main/release-health.json) and is operator-edited AFTER a bad release ships. Before applying an auto-update, o8 fetches it and skips any version listed in `pulled`. Fail-open: if this file is missing, unreachable, or malformed, updates proceed normally.",
+  "pulled": [
+    "0.1.567"
+  ],
+  "note": "0.1.567 crashes on launch for some installs — auto-update paused while a fixed build ships. You can still update manually from GitHub releases."
+}

--- a/scripts/rollback-release.mjs
+++ b/scripts/rollback-release.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Rollback the installed o8.app to the PREVIOUS signed release.
+ *
+ * When a bad version ships and the release-health kill-switch has stopped the
+ * fleet from auto-updating INTO it, this brings a machine that already updated
+ * back down to the prior good build. It:
+ *
+ *   1. Lists the two most recent GitHub releases (gh CLI).
+ *   2. Downloads the PREVIOUS release's signed o8.app.tar.gz + .sig.
+ *   3. Verifies the minisign signature against the updater pubkey embedded in
+ *      src-tauri/tauri.conf.json (pure Node — Ed25519 over a Blake2b-512
+ *      prehash, the exact scheme Tauri's updater uses). REFUSES to swap if the
+ *      signature does not validate.
+ *   4. Extracts + swaps /Applications/o8.app (the current app is moved aside to
+ *      a timestamped backup, never deleted).
+ *
+ * Usage:
+ *   node scripts/rollback-release.mjs            # do it
+ *   node scripts/rollback-release.mjs --dry-run  # download + verify only
+ *   node scripts/rollback-release.mjs --repo hurttlocker/o8-releases
+ *   node scripts/rollback-release.mjs --app "/Applications/o8.app"
+ *
+ * Requires: gh (authenticated), tar, ditto (macOS).
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, renameSync } from 'node:fs';
+import { createHash, createPublicKey, verify as edVerify } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// ── Args ──
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+function argValue(flag, fallback) {
+  const i = args.indexOf(flag);
+  return i >= 0 && args[i + 1] ? args[i + 1] : fallback;
+}
+// Default to the public mirror — that's where updater artifacts (the signed
+// .app.tar.gz + .sig) are published for anonymous download.
+const REPO = argValue('--repo', 'hurttlocker/o8-releases');
+const APP_PATH = argValue('--app', '/Applications/o8.app');
+const root = process.cwd();
+
+function log(msg) { console.log(`[rollback] ${msg}`); }
+function fail(msg) { console.error(`[rollback] ERROR: ${msg}`); process.exit(1); }
+
+// ── 1. Discover the two most recent releases ──
+let tags;
+try {
+  const out = execFileSync(
+    'gh',
+    ['api', `repos/${REPO}/releases?per_page=10`, '--jq', '[.[] | select(.draft==false) | .tag_name]'],
+    { encoding: 'utf8' },
+  );
+  tags = JSON.parse(out);
+} catch (err) {
+  fail(`could not list releases for ${REPO} via gh (${err?.message ?? err}). Is gh installed + authenticated?`);
+}
+if (!Array.isArray(tags) || tags.length < 2) {
+  fail(`need at least two published releases on ${REPO} to roll back; found ${tags?.length ?? 0}.`);
+}
+const [currentTag, previousTag] = tags;
+log(`current release:  ${currentTag}`);
+log(`rolling back to:  ${previousTag}`);
+
+// ── 2. Download the previous release's signed artifact + signature ──
+const workDir = mkdtempSync(join(tmpdir(), 'o8-rollback-'));
+log(`work dir: ${workDir}`);
+try {
+  execFileSync(
+    'gh',
+    ['release', 'download', previousTag, '-R', REPO,
+      '-p', 'o8.app.tar.gz', '-p', 'o8.app.tar.gz.sig', '-D', workDir],
+    { stdio: 'inherit' },
+  );
+} catch (err) {
+  fail(`failed to download artifacts for ${previousTag} (${err?.message ?? err}).`);
+}
+const tarPath = join(workDir, 'o8.app.tar.gz');
+const sigPath = join(workDir, 'o8.app.tar.gz.sig');
+if (!existsSync(tarPath) || !existsSync(sigPath)) {
+  fail(`downloaded artifacts missing (expected o8.app.tar.gz + .sig in ${workDir}).`);
+}
+
+// ── 3. Verify the minisign signature against the updater pubkey ──
+function loadUpdaterPubkey() {
+  const conf = JSON.parse(readFileSync(join(root, 'src-tauri', 'tauri.conf.json'), 'utf8'));
+  const wrapped = conf?.plugins?.updater?.pubkey;
+  if (typeof wrapped !== 'string' || !wrapped) fail('no plugins.updater.pubkey in src-tauri/tauri.conf.json.');
+  // Tauri stores the pubkey base64-wrapped around the standard minisign text.
+  const std = Buffer.from(wrapped, 'base64').toString('utf8');
+  const b64 = std.trim().split('\n')[1];
+  const raw = Buffer.from(b64, 'base64'); // [2 alg][8 keyid][32 ed25519 key]
+  return raw.subarray(10, 42);
+}
+
+function verifyMinisign(filePath, minisignSigPath, edPubRaw) {
+  // Tauri's .sig is base64 of the standard minisign signature file.
+  const std = Buffer.from(readFileSync(minisignSigPath, 'utf8').trim(), 'base64').toString('utf8');
+  const sigB64 = std.trim().split('\n')[1];
+  const sigRaw = Buffer.from(sigB64, 'base64'); // [2 alg][8 keyid][64 sig]
+  const alg = sigRaw.subarray(0, 2).toString('latin1');
+  const edSig = sigRaw.subarray(10, 74);
+
+  // Ed25519 raw pubkey -> SPKI DER so Node's crypto can consume it.
+  const der = Buffer.concat([Buffer.from('302a300506032b6570032100', 'hex'), edPubRaw]);
+  const keyObj = createPublicKey({ key: der, format: 'der', type: 'spki' });
+
+  const file = readFileSync(filePath);
+  // 'ED' = prehashed (Blake2b-512 of the file); 'Ed' = legacy (raw file).
+  const message = alg === 'ED' ? createHash('blake2b512').update(file).digest() : file;
+  return edVerify(null, message, keyObj, edSig);
+}
+
+let verified = false;
+try {
+  verified = verifyMinisign(tarPath, sigPath, loadUpdaterPubkey());
+} catch (err) {
+  fail(`signature verification threw (${err?.message ?? err}). Refusing to swap.`);
+}
+if (!verified) {
+  fail(`signature verification FAILED for ${previousTag}. Refusing to swap the app.`);
+}
+log(`signature verified OK for ${previousTag} against the updater pubkey.`);
+
+if (dryRun) {
+  log('DRY RUN — download + verification succeeded. No files were swapped.');
+  log(`Verified artifact: ${tarPath}`);
+  process.exit(0);
+}
+
+// ── 4. Extract + swap /Applications/o8.app ──
+const extractDir = join(workDir, 'extracted');
+try {
+  execFileSync('mkdir', ['-p', extractDir]);
+  // COPYFILE_DISABLE=1 keeps macOS tar from materializing AppleDouble ._ files.
+  execFileSync('tar', ['-xzf', tarPath, '-C', extractDir], {
+    stdio: 'inherit',
+    env: { ...process.env, COPYFILE_DISABLE: '1' },
+  });
+} catch (err) {
+  fail(`failed to extract ${tarPath} (${err?.message ?? err}).`);
+}
+const extractedApp = join(extractDir, 'o8.app');
+if (!existsSync(extractedApp)) {
+  fail(`extracted bundle missing o8.app (looked in ${extractDir}).`);
+}
+
+// Move the current app aside (never delete) so a bad rollback is recoverable.
+if (existsSync(APP_PATH)) {
+  const backup = `${APP_PATH}.rollback-backup-${Date.now()}`;
+  try {
+    renameSync(APP_PATH, backup);
+    log(`moved current app aside → ${backup}`);
+  } catch (err) {
+    fail(`could not move ${APP_PATH} aside (${err?.message ?? err}). Do you have permission?`);
+  }
+}
+
+try {
+  // ditto is the macOS-blessed bundle copy (preserves resource forks + perms).
+  execFileSync('ditto', [extractedApp, APP_PATH], { stdio: 'inherit' });
+} catch (err) {
+  fail(`failed to install rolled-back app to ${APP_PATH} (${err?.message ?? err}).`);
+}
+
+log(`DONE — ${APP_PATH} is now ${previousTag}. Quit + relaunch o8 if it is running.`);
+log('The previous app bundle is kept as a .rollback-backup-* sibling; delete it once you are happy.');

--- a/scripts/tauri-export.mjs
+++ b/scripts/tauri-export.mjs
@@ -270,6 +270,45 @@ if (releaseConfig.githubOAuthClientId) {
   console.log('📦 No GITHUB_OAUTH_CLIENT_ID configured — device flow stays disabled in this build');
 }
 
+// Bake the app version so both the boot crash guard below AND the server's
+// resolveAppVersion() (src/lib/telemetry/crash-store.ts) stamp the real version
+// even when cwd's package.json is the minimal Next standalone one.
+let bakedAppVersion = 'unknown';
+try {
+  bakedAppVersion = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version || 'unknown';
+} catch { /* keep 'unknown' */ }
+const APP_VERSION_STANZA =
+  `\nif (!process.env.O8_APP_VERSION) process.env.O8_APP_VERSION = ${JSON.stringify(bakedAppVersion)};\n`;
+
+// Early-boot crash guard (Rock 2): observe crashes that happen BEFORE Next's
+// instrumentation hook installs the full crash capture. Self-contained (no
+// imports of app code), best-effort, never throws. Appends the same JSONL shape
+// src/lib/telemetry/crash-store.ts uses, honouring the same data-dir env vars,
+// with a coarse 1MB ceiling so a boot-loop can't grow the file unbounded.
+const BOOT_CAPTURE_STANZA = `
+(function installBootCrashCapture() {
+  try {
+    const bfs = require('node:fs');
+    const bos = require('node:os');
+    const bpath = require('node:path');
+    const dir = bpath.join(process.env.O8_DATA_DIR || process.env.CORTEX_IDE_DATA_DIR || bpath.join(bos.homedir(), '.o8'), 'telemetry');
+    const file = bpath.join(dir, 'crashes.jsonl');
+    const write = (kind, err) => {
+      try {
+        bfs.mkdirSync(dir, { recursive: true });
+        try { if (bfs.existsSync(file) && bfs.statSync(file).size > 1000000) return; } catch (e) {}
+        const msg = err && err.message ? err.message : String(err);
+        const rec = { ts: Date.now(), source: 'boot', appVersion: process.env.O8_APP_VERSION || 'unknown', kind: kind, message: String(msg).slice(0, 2000) };
+        if (err && err.stack) rec.stack = String(err.stack).slice(0, 8000);
+        bfs.appendFileSync(file, JSON.stringify(rec) + '\\n', 'utf8');
+      } catch (e) { /* swallow */ }
+    };
+    process.on('uncaughtExceptionMonitor', (err) => write('uncaughtException', err));
+    process.on('unhandledRejection', (reason) => write('unhandledRejection', reason));
+  } catch (e) { /* telemetry must never block boot */ }
+})();
+`;
+
 // ── Server bundle ──
 // Next's stock standalone entry ships as server-impl.js; server.js becomes a
 // thin wrapper that stamps the REAL TCP peer address into x-o8-client-addr on
@@ -310,7 +349,7 @@ const origHttpsCreate = https.createServer;
 https.createServer = function (...args) {
   return stampClientAddr(origHttpsCreate.apply(this, args));
 };
-${RELEASE_ENV_STANZA}
+${RELEASE_ENV_STANZA}${APP_VERSION_STANZA}${BOOT_CAPTURE_STANZA}
 process.env.O8_PACKAGED_APP = '1';
 require('./server-impl.js');
 `);

--- a/scripts/tauri-export.mjs
+++ b/scripts/tauri-export.mjs
@@ -420,6 +420,14 @@ const NATIVE_EXTERNALS = '--external:node-pty --external:better-sqlite3 --extern
 
 compileServerBundle('ws-server', 'src/ws-server.ts', NATIVE_EXTERNALS);
 
+// terminal-host fork target (#1498 follow-up). ws-server forks this when
+// O8_TERMINAL_HOST=child so node-pty spawn + data pump run in a separate
+// process. Sits next to ws-server.mjs in out/server/ — the child resolver
+// (terminal-host-client.ts) finds it via import.meta.url adjacency. Bundled
+// unconditionally so flipping the env in a packaged install just works; inline
+// (default) never forks it.
+compileServerBundle('terminal-host', 'src/lib/ws-server/terminal-host-entry.ts', NATIVE_EXTERNALS);
+
 // ── Compile MCP servers ──
 // Ships alongside the bundled Next.js backend so the packaged Tauri app
 // can expose MCP tools to Claude Desktop/Code without requiring `tsx` or
@@ -512,7 +520,7 @@ exec "$NODE_BIN" "$DIR/o8.mjs" "$@"
 
 // ── Sanity check: every expected standalone bundle must exist ──
 // Belt-and-braces guard against future compile failures slipping through.
-const REQUIRED_BUNDLES = ['ws-server.mjs', 'operator-mcp-server.mjs', 'operator-mcp-server-main.mjs', 'cortex-mcp-server.mjs'];
+const REQUIRED_BUNDLES = ['ws-server.mjs', 'terminal-host.mjs', 'operator-mcp-server.mjs', 'operator-mcp-server-main.mjs', 'cortex-mcp-server.mjs'];
 for (const bundle of REQUIRED_BUNDLES) {
   const bundlePath = join(server, bundle);
   if (!existsSync(bundlePath)) {

--- a/src/app/api/panel/operator-defaults/route.ts
+++ b/src/app/api/panel/operator-defaults/route.ts
@@ -258,6 +258,20 @@ function normalizeUpdate(body: Record<string, unknown>): Partial<OperatorDefault
     update.collideAggregator = raw;
   }
 
+  if (body.telemetryOptIn !== undefined) {
+    if (typeof body.telemetryOptIn !== 'boolean') {
+      throw new Error('telemetryOptIn must be boolean.');
+    }
+    update.telemetryOptIn = body.telemetryOptIn;
+  }
+
+  if (body.telemetryIngestUrl !== undefined) {
+    if (typeof body.telemetryIngestUrl !== 'string') {
+      throw new Error('telemetryIngestUrl must be a string.');
+    }
+    update.telemetryIngestUrl = body.telemetryIngestUrl.trim();
+  }
+
   const validateTier = (raw: unknown, name: string): OperatorDefaults['targetingTriage'] => {
     if (!raw || typeof raw !== 'object') throw new Error(`${name} must be an object { runtime, model, effort }.`);
     const o = raw as Record<string, unknown>;

--- a/src/app/api/panel/release-health/route.ts
+++ b/src/app/api/panel/release-health/route.ts
@@ -1,0 +1,33 @@
+/**
+ * GET /api/panel/release-health?version=X — updater kill-switch check.
+ *
+ * The desktop webview CSP forbids connecting to raw.githubusercontent.com, so
+ * the UpdateCard asks the (loopback-gated) server to fetch the release-health
+ * manifest and decide whether the target version is pulled. FAIL-OPEN: any
+ * error returns `{ pulled: false }` so the update proceeds. Never throws.
+ */
+
+import { NextResponse } from 'next/server';
+
+import { evaluateReleaseHealth } from '@/lib/app-update/release-health';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const NO_STORE = { 'Cache-Control': 'no-store, max-age=0' };
+
+export async function GET(request: Request) {
+  try {
+    const version = new URL(request.url).searchParams.get('version')?.trim();
+    if (!version) {
+      // No version to evaluate — fail open.
+      return NextResponse.json({ pulled: false }, { headers: NO_STORE });
+    }
+    const decision = await evaluateReleaseHealth(version);
+    return NextResponse.json(decision, { headers: NO_STORE });
+  } catch (error) {
+    console.error('[app-update] release-health route error:', error instanceof Error ? error.message : error);
+    // Fail open on any unexpected error.
+    return NextResponse.json({ pulled: false }, { headers: NO_STORE });
+  }
+}

--- a/src/app/api/telemetry/crash/route.ts
+++ b/src/app/api/telemetry/crash/route.ts
@@ -1,0 +1,50 @@
+/**
+ * POST /api/telemetry/crash — renderer crash sink.
+ *
+ * The desktop renderer (TelemetryCrashCapture) POSTs window 'error' /
+ * 'unhandledrejection' events here; the server sanitizes them and appends to the
+ * same crash store the process-level capture writes to. Gated by the default-deny
+ * middleware (loopback / ws-token) like every other /api route — no allowlist
+ * entry. NEVER throws: always returns a structured JSON body.
+ */
+
+import { NextResponse } from 'next/server';
+
+import { appendCrashLine, buildCrashRecord, type CrashKind } from '@/lib/telemetry/crash-store';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const NO_STORE = { 'Cache-Control': 'no-store, max-age=0' };
+
+function json(payload: unknown, status = 200) {
+  return NextResponse.json(payload, { status, headers: NO_STORE });
+}
+
+function resolveKind(raw: unknown): CrashKind {
+  return raw === 'window.unhandledrejection' ? 'window.unhandledrejection' : 'window.error';
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => null);
+    if (!body || typeof body !== 'object') {
+      return json({ ok: false, error: 'Invalid request body.' }, 400);
+    }
+    const record = body as Record<string, unknown>;
+    // The server stamps appVersion + ts; the client only supplies message/stack.
+    await appendCrashLine(
+      buildCrashRecord({
+        source: typeof record.source === 'string' ? record.source : 'renderer',
+        kind: resolveKind(record.kind),
+        message: record.message,
+        stack: record.stack,
+      }),
+    );
+    return json({ ok: true });
+  } catch (error) {
+    // Structured error — never throw out of an API route.
+    console.error('[telemetry] crash route error:', error instanceof Error ? error.message : error);
+    return json({ ok: false, error: 'Failed to record crash.' }, 200);
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -35,6 +35,7 @@ import { DictationHost } from '@/components/desktop/dictation/DictationHost';
 import { RealtimeVoiceHost } from '@/components/desktop/dictation/RealtimeVoiceHost';
 import { FileOpenBridge } from '@/components/desktop/FileOpenBridge';
 import { AttendanceHeartbeat } from '@/components/desktop/AttendanceHeartbeat';
+import { TelemetryCrashCapture } from '@/components/desktop/TelemetryCrashCapture';
 import { UiZoomLayer } from '@/components/desktop/UiZoomLayer';
 import { ReportIssueHost } from '@/components/desktop/ReportIssueHost';
 import {
@@ -4201,6 +4202,7 @@ function DashboardInner() {
       <UiZoomLayer />
       <RealtimeVoiceHost />
       <ReportIssueHost />
+      <TelemetryCrashCapture />
     <div data-vibrancy-passthrough="" data-mcp-scope="dashboard" style={{
       // Divided by --ui-zoom: WebKit CSS zoom scales output but vh keeps
       // computing against the unscaled window, so a plain 100vh shell shrinks

--- a/src/components/desktop/TelemetryCrashCapture.tsx
+++ b/src/components/desktop/TelemetryCrashCapture.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Renderer crash capture. Listens for window 'error' + 'unhandledrejection' and
+ * POSTs a sanitized payload to /api/telemetry/crash, where the server stamps the
+ * app version and appends it to the shared crash store. Renders nothing.
+ *
+ * Sends only the error message + stack — never DOM/user content. Best-effort:
+ * every failure is swallowed so a telemetry hiccup can't disturb the app. Pairs
+ * with src/lib/telemetry/crash-store.ts (process-level capture writes the same
+ * store).
+ */
+
+const MAX_MESSAGE = 2_000;
+const MAX_STACK = 8_000;
+
+function clip(value: string | undefined, max: number): string | undefined {
+  if (!value) return undefined;
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+function report(kind: 'window.error' | 'window.unhandledrejection', message: string, stack?: string) {
+  try {
+    fetch('/api/telemetry/crash', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        source: 'renderer',
+        kind,
+        message: clip(message, MAX_MESSAGE) ?? '(no message)',
+        stack: clip(stack, MAX_STACK),
+      }),
+      keepalive: true,
+    }).catch(() => {});
+  } catch {
+    /* swallow */
+  }
+}
+
+export function TelemetryCrashCapture() {
+  useEffect(() => {
+    const onError = (event: ErrorEvent) => {
+      const message = event.message || (event.error instanceof Error ? event.error.message : 'Uncaught error');
+      const stack = event.error instanceof Error ? event.error.stack : undefined;
+      report('window.error', message, stack);
+    };
+    const onRejection = (event: PromiseRejectionEvent) => {
+      const reason = event.reason;
+      const message = reason instanceof Error ? reason.message : String(reason ?? 'Unhandled rejection');
+      const stack = reason instanceof Error ? reason.stack : undefined;
+      report('window.unhandledrejection', message, stack);
+    };
+    window.addEventListener('error', onError);
+    window.addEventListener('unhandledrejection', onRejection);
+    return () => {
+      window.removeEventListener('error', onError);
+      window.removeEventListener('unhandledrejection', onRejection);
+    };
+  }, []);
+  return null;
+}

--- a/src/components/desktop/UpdateCard.tsx
+++ b/src/components/desktop/UpdateCard.tsx
@@ -114,6 +114,7 @@ export function UpdateCard() {
   const [summaryLoading, setSummaryLoading] = useState(false);
   const [summaryError, setSummaryError] = useState<string | null>(null);
   const [autoApplyUpdates, setAutoApplyUpdates] = useState<AutoApplyUpdates>('off');
+  const [blockedNote, setBlockedNote] = useState<string | null>(null);
   const updateRef = useRef<UpdateInfo | null>(null);
   const installingRef = useRef(false);
   const autoApplyingRef = useRef(false);
@@ -255,7 +256,16 @@ export function UpdateCard() {
   const handleInstall = useCallback(async () => {
     try {
       setInstalling(true);
-      await installUpdateAndRestart(updateRef.current?.releaseUrl ?? RELEASE_URL);
+      setBlockedNote(null);
+      const outcome = await installUpdateAndRestart(updateRef.current?.releaseUrl ?? RELEASE_URL);
+      if (outcome.blocked) {
+        // Kill-switch: this version was pulled post-release. Surface a quiet
+        // note instead of restarting; the operator waits for the next build.
+        setBlockedNote(
+          outcome.blocked.note?.trim()
+            || `Update to v${outcome.blocked.version} was paused by the o8 team — waiting for a fixed build.`,
+        );
+      }
       setInstalling(false);
     } catch (err) {
       console.error('[update-card] install failed:', err);
@@ -487,6 +497,24 @@ export function UpdateCard() {
           ×
         </button>
       </div>
+
+      {blockedNote ? (
+        <div
+          role="note"
+          style={{
+            marginTop: 8,
+            paddingTop: 8,
+            borderTop: '1px solid var(--t-divider-subtle)',
+            fontSize: 10.5,
+            fontWeight: 320,
+            lineHeight: 1.5,
+            color: 'var(--t-text-faint)',
+            wordBreak: 'break-word',
+          }}
+        >
+          {blockedNote}
+        </div>
+      ) : null}
 
       {expanded ? (
         <div

--- a/src/components/desktop/settings/OperatorDefaultsTab.tsx
+++ b/src/components/desktop/settings/OperatorDefaultsTab.tsx
@@ -120,6 +120,14 @@ function UpdateIcon() {
   );
 }
 
+function ShieldIcon() {
+  return (
+    <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+    </svg>
+  );
+}
+
 function CpuIcon() {
   return (
     <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
@@ -556,6 +564,22 @@ export function OperatorDefaultsTab() {
               />
             }
             disabled={envLocked('claudeWorkerEffort') || busyField === 'claudeWorkerEffort'}
+          />
+        </SettingsGroup>
+      </section>
+
+      <section style={{ marginTop: 28 }}>
+        <SettingsGroup
+          header="Privacy"
+          footnote="Crash reports contain only the error stack trace and the app version — never your code, prompts, files, or environment. They are always written locally to ~/.o8/telemetry; this only controls whether they are also sent to the o8 team to help fix crashes. Off by default."
+        >
+          <SettingsRow
+            icon={<ShieldIcon />}
+            label="Send crash reports"
+            subtitle={lockedSub('telemetryOptIn', 'Share crash stack traces + app version — nothing else')}
+            checked={values.telemetryOptIn}
+            disabled={envLocked('telemetryOptIn') || busyField === 'telemetryOptIn'}
+            onToggle={(next) => { updateField('telemetryOptIn', next); }}
           />
         </SettingsGroup>
       </section>

--- a/src/components/desktop/settings/dispatch-shared.tsx
+++ b/src/components/desktop/settings/dispatch-shared.tsx
@@ -72,6 +72,8 @@ export interface OperatorDefaults {
   targetingAction: TargetingTierUI;
   autoApplyUpdates: AutoApplyUpdates;
   collideAggregator: CollideAggregator;
+  telemetryOptIn: boolean;
+  telemetryIngestUrl: string;
 }
 
 export interface OperatorDefaultsResponse {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -16,6 +16,19 @@
 export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME !== 'nodejs') return;
 
+  // Crash telemetry (Rock 2): observe uncaught exceptions + unhandled
+  // rejections in the Next server process and persist them to the local crash
+  // store. Never throws; runs before any of the warm-up work below. The opt-in
+  // uploader loop is a cheap no-op unless the operator enabled telemetry.
+  try {
+    const { installProcessCrashCapture } = await import('@/lib/telemetry/crash-capture');
+    installProcessCrashCapture('next-server');
+    const { startTelemetryUploadLoop } = await import('@/lib/telemetry/uploader');
+    startTelemetryUploadLoop();
+  } catch {
+    // never block boot on telemetry
+  }
+
   // Dynamic import so the warm-up module isn't pulled into Edge bundles.
   const { warmupOpenRouter } = await import('@/lib/cortex/qa/llm/openrouter-adapter');
 

--- a/src/lib/app-update/client-restart.ts
+++ b/src/lib/app-update/client-restart.ts
@@ -5,15 +5,57 @@ import { openExternalUrl } from '@/lib/desktop/open-external';
 
 export const RELEASE_URL = 'https://github.com/hurttlocker/o8/releases/latest';
 
-export async function installUpdateAndRestart(releaseUrl?: string): Promise<boolean> {
+export interface InstallUpdateOutcome {
+  /** True when the update downloaded + a restart was initiated. */
+  installed: boolean;
+  /** Set when the update was skipped because the version is pulled (kill-switch). */
+  blocked?: { version: string; note?: string };
+}
+
+/**
+ * Ask the (loopback-gated) server whether `version` is pulled. FAIL-OPEN: any
+ * error resolves to not-pulled so the update proceeds. The server does the
+ * actual raw.githubusercontent.com fetch because the webview CSP forbids it.
+ */
+async function isVersionPulled(version: string): Promise<{ pulled: boolean; note?: string }> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 4000);
+    try {
+      const res = await fetch(`/api/panel/release-health?version=${encodeURIComponent(version)}`, {
+        cache: 'no-store',
+        signal: controller.signal,
+      });
+      if (!res.ok) return { pulled: false };
+      const payload = await res.json().catch(() => null) as { pulled?: unknown; note?: unknown } | null;
+      if (payload && payload.pulled === true) {
+        return { pulled: true, note: typeof payload.note === 'string' ? payload.note : undefined };
+      }
+      return { pulled: false };
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    return { pulled: false }; // fail open
+  }
+}
+
+export async function installUpdateAndRestart(releaseUrl?: string): Promise<InstallUpdateOutcome> {
   if (!isTauri()) {
     openExternalUrl(releaseUrl ?? RELEASE_URL);
-    return false;
+    return { installed: false };
   }
 
   const { check } = await import('@tauri-apps/plugin-updater');
   const result = await check();
-  if (!result) return false;
+  if (!result) return { installed: false };
+
+  // Kill-switch: skip a version the operator has pulled post-release.
+  const health = await isVersionPulled(result.version);
+  if (health.pulled) {
+    console.warn(`[app-update] update to ${result.version} blocked by release-health kill-switch`);
+    return { installed: false, blocked: { version: result.version, note: health.note } };
+  }
 
   await result.downloadAndInstall();
   try {
@@ -23,5 +65,5 @@ export async function installUpdateAndRestart(releaseUrl?: string): Promise<bool
     const { relaunch } = await import('@tauri-apps/plugin-process');
     await relaunch();
   }
-  return true;
+  return { installed: true };
 }

--- a/src/lib/app-update/release-health.test.ts
+++ b/src/lib/app-update/release-health.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  evaluateReleaseHealth,
+  isVersionPulled,
+  normalizeVersion,
+  parseReleaseHealth,
+} from './release-health';
+
+describe('release-health — pure decision', () => {
+  it('normalizeVersion strips a leading v and trims', () => {
+    expect(normalizeVersion('v0.1.567')).toBe('0.1.567');
+    expect(normalizeVersion(' 0.1.567 ')).toBe('0.1.567');
+  });
+
+  it('isVersionPulled matches with and without a leading v', () => {
+    const health = { pulled: ['0.1.567'] };
+    expect(isVersionPulled('0.1.567', health)).toBe(true);
+    expect(isVersionPulled('v0.1.567', health)).toBe(true);
+    expect(isVersionPulled('0.1.568', health)).toBe(false);
+  });
+
+  it('isVersionPulled returns false for an empty manifest (fail-open)', () => {
+    expect(isVersionPulled('0.1.567', { pulled: [] })).toBe(false);
+  });
+
+  it('isVersionPulled returns false for a null manifest (fail-open)', () => {
+    expect(isVersionPulled('0.1.567', null)).toBe(false);
+  });
+
+  it('parseReleaseHealth accepts a valid manifest and captures the note', () => {
+    const parsed = parseReleaseHealth({ pulled: ['0.1.567'], note: 'bad build' });
+    expect(parsed).toEqual({ pulled: ['0.1.567'], note: 'bad build' });
+  });
+
+  it('parseReleaseHealth rejects malformed payloads → null', () => {
+    expect(parseReleaseHealth(null)).toBeNull();
+    expect(parseReleaseHealth('nope')).toBeNull();
+    expect(parseReleaseHealth({ pulled: 'not-an-array' })).toBeNull();
+    expect(parseReleaseHealth([])).toBeNull();
+  });
+
+  it('parseReleaseHealth drops non-string entries from pulled', () => {
+    expect(parseReleaseHealth({ pulled: ['0.1.1', 42, null] })).toEqual({ pulled: ['0.1.1'] });
+  });
+});
+
+describe('release-health — evaluate (fetch seam, fail-open)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('a fetch failure → proceed with the update (pulled: false)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+    const decision = await evaluateReleaseHealth('0.1.567');
+    expect(decision.pulled).toBe(false);
+  });
+
+  it('a non-2xx response → proceed (pulled: false)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+    const decision = await evaluateReleaseHealth('0.1.567');
+    expect(decision.pulled).toBe(false);
+  });
+
+  it('a manifest listing the version → blocked (pulled: true) with the note', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ pulled: ['0.1.567'], note: 'crashes on launch' }),
+    }));
+    const decision = await evaluateReleaseHealth('0.1.567');
+    expect(decision.pulled).toBe(true);
+    expect(decision.note).toBe('crashes on launch');
+  });
+
+  it('a manifest NOT listing the version → proceed (pulled: false)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ pulled: ['0.1.999'] }),
+    }));
+    const decision = await evaluateReleaseHealth('0.1.567');
+    expect(decision.pulled).toBe(false);
+  });
+
+  it('malformed JSON → proceed (pulled: false)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => { throw new Error('bad json'); },
+    }));
+    const decision = await evaluateReleaseHealth('0.1.567');
+    expect(decision.pulled).toBe(false);
+  });
+});

--- a/src/lib/app-update/release-health.ts
+++ b/src/lib/app-update/release-health.ts
@@ -1,0 +1,103 @@
+/**
+ * Updater kill-switch. Before applying an auto-update, o8 consults a small
+ * release-health manifest published alongside releases. If the target version
+ * is listed as `pulled`, the update is skipped and a quiet note is surfaced.
+ *
+ * FAIL-OPEN by design: any fetch error, timeout, or malformed JSON means we
+ * PROCEED with the update normally. The kill-switch can only ever STOP a known-
+ * bad version — it must never block a healthy update because the manifest was
+ * briefly unreachable.
+ *
+ * The manifest lives in the public releases repo and is operator-edited after a
+ * bad release ships. Schema (see release-health.example.json):
+ *   { "pulled": ["0.1.567"], "note": "0.1.567 crashes on launch — skipped." }
+ *
+ * NOTE ON THE FETCH SEAM: the desktop webview CSP does not allow connecting to
+ * raw.githubusercontent.com, so `evaluateReleaseHealth` runs SERVER-SIDE (the
+ * gated /api/panel/release-health route). The pure decision helpers below are
+ * environment-agnostic and unit-tested directly.
+ */
+
+export const RELEASE_HEALTH_URL =
+  'https://raw.githubusercontent.com/hurttlocker/o8-releases/main/release-health.json';
+
+export interface ReleaseHealth {
+  /** Versions that must NOT be auto-applied (with or without a leading 'v'). */
+  pulled: string[];
+  /** Optional human note shown when a version is skipped. */
+  note?: string;
+}
+
+export interface ReleaseHealthDecision {
+  pulled: boolean;
+  note?: string;
+}
+
+/** Normalize a version string for comparison — strip a leading 'v', trim. */
+export function normalizeVersion(version: string): string {
+  return version.trim().replace(/^v/i, '');
+}
+
+/**
+ * Parse an untrusted JSON payload into a ReleaseHealth, or null if it doesn't
+ * match the schema. Pure — never throws.
+ */
+export function parseReleaseHealth(raw: unknown): ReleaseHealth | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const record = raw as Record<string, unknown>;
+  if (!Array.isArray(record.pulled)) return null;
+  const pulled = record.pulled.filter((v): v is string => typeof v === 'string');
+  const health: ReleaseHealth = { pulled };
+  if (typeof record.note === 'string' && record.note.trim()) health.note = record.note.trim();
+  return health;
+}
+
+/**
+ * Pure decision: is `version` present in the manifest's pulled list? A null
+ * manifest (unreachable / malformed) yields false — fail-open.
+ */
+export function isVersionPulled(version: string, health: ReleaseHealth | null): boolean {
+  if (!health || !Array.isArray(health.pulled)) return false;
+  const target = normalizeVersion(version);
+  return health.pulled.some((entry) => normalizeVersion(entry) === target);
+}
+
+/**
+ * Fetch + parse the manifest. Returns null on ANY error (network, timeout,
+ * non-2xx, malformed JSON) — the caller then fails open. Runs server-side.
+ */
+export async function fetchReleaseHealth(
+  opts: { url?: string; timeoutMs?: number } = {},
+): Promise<ReleaseHealth | null> {
+  const url = opts.url ?? RELEASE_HEALTH_URL;
+  const timeoutMs = opts.timeoutMs ?? 3500;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { signal: controller.signal, cache: 'no-store' });
+    if (!res.ok) return null;
+    const json = await res.json();
+    return parseReleaseHealth(json);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * The full decision for a target version. Fetches the manifest and returns
+ * whether the version is pulled (+ an optional note). Fails open: on any error
+ * the result is `{ pulled: false }` and the update proceeds.
+ */
+export async function evaluateReleaseHealth(
+  version: string,
+  opts: { url?: string; timeoutMs?: number } = {},
+): Promise<ReleaseHealthDecision> {
+  const health = await fetchReleaseHealth(opts);
+  if (isVersionPulled(version, health)) {
+    console.warn(`[app-update] version ${version} is marked pulled — skipping auto-update`);
+    return { pulled: true, note: health?.note };
+  }
+  return { pulled: false };
+}

--- a/src/lib/operator/defaults-env.ts
+++ b/src/lib/operator/defaults-env.ts
@@ -274,3 +274,14 @@ export function envAutoApplyUpdates(): AutoApplyUpdates | null {
   if (raw === 'off' || raw === 'when-idle') return raw;
   return null;
 }
+
+export function envTelemetryOptIn(): boolean | null {
+  const raw = process.env.O8_TELEMETRY_OPT_IN;
+  if (raw === '1') return true;
+  if (raw === '0') return false;
+  return null;
+}
+
+export function envTelemetryIngestUrl(): string | null {
+  return process.env.O8_TELEMETRY_INGEST_URL?.trim() || null;
+}

--- a/src/lib/operator/defaults-roundtrip.test.ts
+++ b/src/lib/operator/defaults-roundtrip.test.ts
@@ -44,6 +44,8 @@ const NON_DEFAULT_UPDATE = {
   buyinDocEnabled: true,
   autoApplyUpdates: 'off',
   collideAggregator: 'claude',
+  telemetryOptIn: true,
+  telemetryIngestUrl: 'https://telemetry.example/ingest',
 } as const;
 
 describe('updateOperatorDefaults round-trip', () => {

--- a/src/lib/operator/defaults.ts
+++ b/src/lib/operator/defaults.ts
@@ -55,6 +55,8 @@ import {
   envReviewerBackend,
   envSubscriptionProfile,
   envSupervisorAutoEscalate,
+  envTelemetryIngestUrl,
+  envTelemetryOptIn,
   envThinkingEffort,
   envWorkersUseBrain,
   type OverlapGateMode,
@@ -285,6 +287,21 @@ export interface OperatorDefaults {
   autoApplyUpdates: AutoApplyUpdates;
   /** Collide aggregator override. Auto follows the active composer backend. */
   collideAggregator: CollideAggregator;
+  /**
+   * Crash-telemetry opt-in (Rock 2). **Off by default.** When on AND an ingest
+   * endpoint is configured (`O8_TELEMETRY_INGEST_URL` env or
+   * {@link telemetryIngestUrl}), the uploader batch-POSTs captured crash lines
+   * (stack traces + app version — no user content). Off = crashes are still
+   * captured locally to `~/.o8/telemetry/crashes.jsonl` but never leave the
+   * machine. Env: `O8_TELEMETRY_OPT_IN` (1/0).
+   */
+  telemetryOptIn: boolean;
+  /**
+   * Crash-telemetry ingest endpoint. Empty = no upload (local capture only).
+   * `O8_TELEMETRY_INGEST_URL` env overrides this. Only consulted when
+   * {@link telemetryOptIn} is on.
+   */
+  telemetryIngestUrl: string;
 }
 
 export interface OperatorDefaultsWithSources {
@@ -343,6 +360,9 @@ export const OPERATOR_DEFAULTS_FALLBACK: OperatorDefaults = {
   targetingAction: { runtime: 'codex', model: '', effort: 'high' },
   autoApplyUpdates: 'off',
   collideAggregator: 'auto',
+  // Crash telemetry OFF by default — local capture only, nothing uploaded.
+  telemetryOptIn: false,
+  telemetryIngestUrl: '',
 };
 
 export const CLASS_A_COMPOSER_OPTIONS: Array<{ value: ClassAComposer; label: string; detail: string }> = [
@@ -431,6 +451,8 @@ interface StoredOperatorDefaults {
   targetingAction?: TargetingTier;
   autoApplyUpdates?: AutoApplyUpdates;
   collideAggregator?: CollideAggregator;
+  telemetryOptIn?: boolean;
+  telemetryIngestUrl?: string;
 }
 
 type FileOperatorDefaults = Partial<OperatorDefaults> & {
@@ -550,6 +572,12 @@ function resolveFromFile(stored: StoredOperatorDefaults): FileOperatorDefaults {
   if (isCollideAggregator(stored.collideAggregator)) {
     result.collideAggregator = stored.collideAggregator;
   }
+  if (typeof stored.telemetryOptIn === 'boolean') {
+    result.telemetryOptIn = stored.telemetryOptIn;
+  }
+  if (typeof stored.telemetryIngestUrl === 'string') {
+    result.telemetryIngestUrl = stored.telemetryIngestUrl.trim();
+  }
   const storedTriage = coerceStoredTier(stored.targetingTriage, OPERATOR_DEFAULTS_FALLBACK.targetingTriage);
   if (storedTriage) result.targetingTriage = storedTriage;
   const storedAction = coerceStoredTier(stored.targetingAction, OPERATOR_DEFAULTS_FALLBACK.targetingAction);
@@ -591,6 +619,8 @@ function resolveDefaults(fileValues: FileOperatorDefaults): OperatorDefaultsWith
   const envBuyinDoc = envBuyinDocEnabled();
   const envApplyUpdates = envAutoApplyUpdates();
   const envCollideAgg = envCollideAggregator();
+  const envTelemetry = envTelemetryOptIn();
+  const envTelemetryUrl = envTelemetryIngestUrl();
   const envTriage = envTargetingTier('TRIAGE');
   const envAction = envTargetingTier('ACTION');
   const subscriptionProfile =
@@ -650,6 +680,8 @@ function resolveDefaults(fileValues: FileOperatorDefaults): OperatorDefaultsWith
     targetingAction: mergeTier(envAction, fileValues.targetingAction, OPERATOR_DEFAULTS_FALLBACK.targetingAction),
     autoApplyUpdates: envApplyUpdates ?? fileValues.autoApplyUpdates ?? OPERATOR_DEFAULTS_FALLBACK.autoApplyUpdates,
     collideAggregator: envCollideAgg ?? fileValues.collideAggregator ?? OPERATOR_DEFAULTS_FALLBACK.collideAggregator,
+    telemetryOptIn: envTelemetry ?? fileValues.telemetryOptIn ?? OPERATOR_DEFAULTS_FALLBACK.telemetryOptIn,
+    telemetryIngestUrl: envTelemetryUrl ?? fileValues.telemetryIngestUrl ?? OPERATOR_DEFAULTS_FALLBACK.telemetryIngestUrl,
   };
 
   const sources: Record<keyof OperatorDefaults, SettingSource> = {
@@ -692,6 +724,8 @@ function resolveDefaults(fileValues: FileOperatorDefaults): OperatorDefaultsWith
     targetingAction: envAction !== null ? 'env' : fileValues.targetingAction !== undefined ? 'file' : 'default',
     autoApplyUpdates: envApplyUpdates !== null ? 'env' : fileValues.autoApplyUpdates !== undefined ? 'file' : 'default',
     collideAggregator: envCollideAgg !== null ? 'env' : fileValues.collideAggregator !== undefined ? 'file' : 'default',
+    telemetryOptIn: envTelemetry !== null ? 'env' : fileValues.telemetryOptIn !== undefined ? 'file' : 'default',
+    telemetryIngestUrl: envTelemetryUrl !== null ? 'env' : fileValues.telemetryIngestUrl !== undefined ? 'file' : 'default',
   };
 
   return { values: resolved, sources };
@@ -884,6 +918,15 @@ export async function updateOperatorDefaults(update: Partial<OperatorDefaults>):
     }
     stored.collideAggregator = update.collideAggregator;
   }
+  if (update.telemetryOptIn !== undefined) {
+    stored.telemetryOptIn = Boolean(update.telemetryOptIn);
+  }
+  if (update.telemetryIngestUrl !== undefined) {
+    if (typeof update.telemetryIngestUrl !== 'string') {
+      throw new Error('telemetryIngestUrl must be a string.');
+    }
+    stored.telemetryIngestUrl = update.telemetryIngestUrl.trim();
+  }
   if (update.targetingTriage !== undefined) {
     if (!isTargetingTier(update.targetingTriage)) {
       throw new Error('targetingTriage must be { runtime: dispatch-runtime, model: string, effort: thinking-effort }.');
@@ -1021,6 +1064,16 @@ export function resolveBuyinDocEnabledSync(): boolean {
 
 export function resolveCollideAggregatorSync(): CollideAggregator {
   return getOperatorDefaultsSync().values.collideAggregator;
+}
+
+/** Whether crash-telemetry upload is opted in (Rock 2, default off). */
+export function resolveTelemetryOptInSync(): boolean {
+  return getOperatorDefaultsSync().values.telemetryOptIn;
+}
+
+/** Crash-telemetry ingest endpoint ('' = no upload). Env overrides file. */
+export function resolveTelemetryIngestUrlSync(): string {
+  return getOperatorDefaultsSync().values.telemetryIngestUrl;
 }
 
 /** The Targeting Machine's cheap triage/rationale tier (env > file > fallback). */

--- a/src/lib/telemetry/crash-capture.ts
+++ b/src/lib/telemetry/crash-capture.ts
@@ -1,0 +1,102 @@
+/**
+ * Process-level crash capture. Registers observers for uncaught exceptions and
+ * unhandled promise rejections that persist a sanitized JSON line to the crash
+ * store (src/lib/telemetry/crash-store.ts).
+ *
+ * Wiring:
+ *   - Next server process — installed from src/instrumentation.ts register().
+ *   - ws-server process   — the ws-server owner adds ONE line at its entry:
+ *       import { installProcessCrashCapture } from '@/lib/telemetry/crash-capture';
+ *       installProcessCrashCapture('ws-server');
+ *   - Packaged early boot  — the generated out/server/server.js wrapper installs
+ *       a minimal inline guard before Next boots (scripts/tauri-export.mjs).
+ *
+ * We use `uncaughtExceptionMonitor` (not a plain `uncaughtException` listener)
+ * so we OBSERVE the crash without suppressing Node's default action — the
+ * process still prints + exits exactly as it would have. The monitor runs
+ * synchronously before teardown, so we write synchronously there (an async
+ * write would never flush before the process dies). Unhandled rejections do not
+ * kill the process the same way, so those are written on the async hot path.
+ */
+
+import {
+  appendCrashLine,
+  appendCrashLineSync,
+  buildCrashRecord,
+  type CrashSource,
+} from './crash-store';
+
+interface CaptureGlobal {
+  __o8TelemetryCaptureSources?: Set<string>;
+}
+
+function installedSources(): Set<string> {
+  const g = globalThis as unknown as CaptureGlobal;
+  if (!g.__o8TelemetryCaptureSources) g.__o8TelemetryCaptureSources = new Set<string>();
+  return g.__o8TelemetryCaptureSources;
+}
+
+function messageOf(err: unknown): string {
+  if (err instanceof Error) return err.message || err.name || 'Error';
+  if (typeof err === 'string') return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+function stackOf(err: unknown): string | undefined {
+  return err instanceof Error && typeof err.stack === 'string' ? err.stack : undefined;
+}
+
+/**
+ * Idempotently install crash observers for `source`. Safe to call more than once
+ * (dev HMR, double registration) — a per-source guard on globalThis prevents
+ * duplicate listeners. Never throws.
+ */
+export function installProcessCrashCapture(source: CrashSource): void {
+  try {
+    const sources = installedSources();
+    if (sources.has(source)) return;
+    sources.add(source);
+
+    process.on('uncaughtExceptionMonitor', (err) => {
+      try {
+        appendCrashLineSync(
+          buildCrashRecord({
+            source,
+            kind: 'uncaughtException',
+            message: messageOf(err),
+            stack: stackOf(err),
+          }),
+        );
+      } catch {
+        /* observer must never interfere with the crash */
+      }
+    });
+
+    process.on('unhandledRejection', (reason) => {
+      try {
+        void appendCrashLine(
+          buildCrashRecord({
+            source,
+            kind: 'unhandledRejection',
+            message: messageOf(reason),
+            stack: stackOf(reason),
+          }),
+        );
+      } catch {
+        /* fire-and-forget */
+      }
+    });
+
+    try {
+      console.log(`[telemetry] crash capture installed for "${source}"`);
+    } catch {
+      /* swallow */
+    }
+  } catch {
+    // Installing telemetry must never throw into the caller's boot path.
+  }
+}

--- a/src/lib/telemetry/crash-store.test.ts
+++ b/src/lib/telemetry/crash-store.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const dataDir = mkdtempSync(join(tmpdir(), 'o8-telemetry-'));
+process.env.O8_DATA_DIR = dataDir;
+process.env.O8_APP_VERSION = '9.9.9-test';
+
+const {
+  appendCrashLine,
+  appendCrashLineSync,
+  buildCrashRecord,
+  computeRetainedTail,
+  crashLogPath,
+  readCrashRecords,
+} = await import('./crash-store');
+
+describe('crash-store — sanitize', () => {
+  it('truncates message + stack and never carries extra fields', () => {
+    const record = buildCrashRecord({
+      source: 'next-server',
+      kind: 'uncaughtException',
+      message: 'x'.repeat(5000),
+      stack: 'y'.repeat(20000),
+    });
+    expect(record.message.length).toBeLessThan(2100);
+    expect(record.message.endsWith('…[truncated]')).toBe(true);
+    expect((record.stack ?? '').length).toBeLessThan(8100);
+    expect(record.appVersion).toBe('9.9.9-test');
+    // Only the known keys — no leaked input.
+    expect(Object.keys(record).sort()).toEqual(['appVersion', 'kind', 'message', 'source', 'stack', 'ts']);
+  });
+
+  it('serializes newlines inside a message as a single JSONL line', async () => {
+    await appendCrashLine(buildCrashRecord({
+      source: 'renderer',
+      kind: 'window.error',
+      message: 'line one\nline two',
+    }));
+    const raw = readFileSync(crashLogPath(), 'utf8').trimEnd();
+    const lastLine = raw.split('\n').pop() ?? '';
+    // The record must round-trip as ONE JSON object despite the embedded newline.
+    expect(() => JSON.parse(lastLine)).not.toThrow();
+    expect(JSON.parse(lastLine).message).toBe('line one\nline two');
+  });
+});
+
+describe('crash-store — ring buffer', () => {
+  it('computeRetainedTail drops oldest lines to fit the budget', () => {
+    const lines = Array.from({ length: 100 }, (_, i) => `line-${i}`).join('\n');
+    const tail = computeRetainedTail(lines, 40);
+    expect(Buffer.byteLength(tail, 'utf8')).toBeLessThanOrEqual(40);
+    // Keeps the NEWEST content.
+    expect(tail).toContain('line-99');
+    expect(tail).not.toContain('line-0\n');
+  });
+
+  it('sync + async appends both persist and read back', async () => {
+    appendCrashLineSync(buildCrashRecord({ source: 'boot', kind: 'uncaughtException', message: 'sync crash' }));
+    await appendCrashLine(buildCrashRecord({ source: 'ws-server', kind: 'unhandledRejection', message: 'async crash' }));
+    const records = readCrashRecords();
+    const messages = records.map((r) => r.message);
+    expect(messages).toContain('sync crash');
+    expect(messages).toContain('async crash');
+  });
+});
+
+beforeAll(() => {
+  // Marker so a failed import surfaces clearly rather than as a silent skip.
+  expect(typeof buildCrashRecord).toBe('function');
+});

--- a/src/lib/telemetry/crash-store.ts
+++ b/src/lib/telemetry/crash-store.ts
@@ -1,0 +1,278 @@
+/**
+ * Crash telemetry store — the append-only JSONL sink shared by every crash
+ * source (Next server process, ws-server process, renderer window).
+ *
+ * Design constraints (Rock 2):
+ *   - NEVER throws. Every public function swallows its own errors — a broken
+ *     telemetry write must never take down the process it is observing.
+ *   - NEVER blocks the event loop on the hot path. Normal appends are async and
+ *     serialized through an internal promise chain. The ONE sync path is the
+ *     dying-process crash handler (uncaughtException), where an async write
+ *     would not flush before the process tears down.
+ *   - Bounded on disk. A size-based ring buffer keeps crashes.jsonl under ~1MB;
+ *     when it would overflow we drop the OLDEST lines and keep the tail.
+ *   - Contains NO user content and NO environment variables — only the app
+ *     version, a source tag, the error message, and the stack.
+ *
+ * File: DATA_DIR/telemetry/crashes.jsonl (DATA_DIR honours O8_DATA_DIR /
+ * CORTEX_IDE_DATA_DIR exactly like src/lib/db/).
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { appendFile, mkdir, readFile, rename, stat, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+export type CrashSource = string;
+
+export type CrashKind =
+  | 'uncaughtException'
+  | 'unhandledRejection'
+  | 'window.error'
+  | 'window.unhandledrejection';
+
+export interface CrashRecord {
+  /** Epoch millis when the crash was captured. */
+  ts: number;
+  /** Where it happened: 'next-server' | 'ws-server' | 'renderer' | 'boot' | … */
+  source: CrashSource;
+  /** App version at crash time (best-effort; 'unknown' if unresolved). */
+  appVersion: string;
+  kind: CrashKind;
+  /** Sanitized error message (truncated, no user content). */
+  message: string;
+  /** Sanitized stack trace (truncated). */
+  stack?: string;
+}
+
+const MAX_FILE_BYTES = 1_000_000; // ~1MB ring-buffer ceiling.
+const KEEP_TAIL_BYTES = 500_000; // On overflow, retain roughly the last half.
+const MAX_MESSAGE_CHARS = 2_000;
+const MAX_STACK_CHARS = 8_000;
+
+function dataDir(): string {
+  return (
+    process.env.O8_DATA_DIR
+    || process.env.CORTEX_IDE_DATA_DIR
+    || path.join(os.homedir(), '.o8')
+  );
+}
+
+export function telemetryDir(): string {
+  return path.join(dataDir(), 'telemetry');
+}
+
+export function crashLogPath(): string {
+  return path.join(telemetryDir(), 'crashes.jsonl');
+}
+
+// ── App version (best-effort, cached) ──
+
+let cachedVersion: string | null = null;
+
+export function resolveAppVersion(): string {
+  if (cachedVersion) return cachedVersion;
+  const fromEnv = process.env.O8_APP_VERSION?.trim();
+  if (fromEnv) {
+    cachedVersion = fromEnv;
+    return cachedVersion;
+  }
+  // Walk up from cwd looking for a package.json with a version. In dev the cwd
+  // is the repo root; in the packaged standalone build a package.json is copied
+  // alongside the server entry (scripts/tauri-export.mjs), so this resolves in
+  // both worlds without hardcoding a path.
+  let dir = process.cwd();
+  for (let i = 0; i < 6; i += 1) {
+    try {
+      const pkgPath = path.join(dir, 'package.json');
+      if (existsSync(pkgPath)) {
+        const parsed = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: unknown };
+        if (typeof parsed.version === 'string' && parsed.version.trim()) {
+          cachedVersion = parsed.version.trim();
+          return cachedVersion;
+        }
+      }
+    } catch {
+      // keep walking
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  cachedVersion = 'unknown';
+  return cachedVersion;
+}
+
+// ── Sanitize ──
+
+function truncate(value: unknown, max: number): string {
+  if (typeof value !== 'string') {
+    if (value == null) return '';
+    try {
+      value = String(value);
+    } catch {
+      return '';
+    }
+  }
+  const str = value as string;
+  return str.length > max ? `${str.slice(0, max)}…[truncated]` : str;
+}
+
+/**
+ * Build a fully-sanitized record. Message + stack are truncated; nothing else
+ * from the caller is trusted onto disk. JSON.stringify escapes any embedded
+ * newlines so each record stays a single JSONL line.
+ */
+export function buildCrashRecord(input: {
+  source: CrashSource;
+  kind: CrashKind;
+  message?: unknown;
+  stack?: unknown;
+  ts?: number;
+  appVersion?: string;
+}): CrashRecord {
+  const record: CrashRecord = {
+    ts: typeof input.ts === 'number' && Number.isFinite(input.ts) ? input.ts : Date.now(),
+    source: truncate(input.source || 'unknown', 64),
+    appVersion: input.appVersion?.trim() || resolveAppVersion(),
+    kind: input.kind,
+    message: truncate(input.message, MAX_MESSAGE_CHARS) || '(no message)',
+  };
+  const stack = truncate(input.stack, MAX_STACK_CHARS);
+  if (stack) record.stack = stack;
+  return record;
+}
+
+function serialize(record: CrashRecord): string {
+  return `${JSON.stringify(record)}\n`;
+}
+
+/**
+ * Given the existing file contents and a target byte budget, drop whole lines
+ * from the FRONT (oldest) until the retained tail fits. Pure — unit-testable.
+ */
+export function computeRetainedTail(existing: string, keepBytes: number): string {
+  if (Buffer.byteLength(existing, 'utf8') <= keepBytes) return existing;
+  const lines = existing.split('\n');
+  // Drop from the front until the joined tail is under budget.
+  while (lines.length > 1 && Buffer.byteLength(lines.join('\n'), 'utf8') > keepBytes) {
+    lines.shift();
+  }
+  return lines.join('\n');
+}
+
+// ── Async append (hot path, serialized) ──
+
+let writeChain: Promise<void> = Promise.resolve();
+
+async function doAsyncAppend(line: string): Promise<void> {
+  const dir = telemetryDir();
+  const file = crashLogPath();
+  await mkdir(dir, { recursive: true });
+  try {
+    const info = await stat(file);
+    if (info.size + Buffer.byteLength(line, 'utf8') > MAX_FILE_BYTES) {
+      const existing = await readFile(file, 'utf8');
+      const tail = computeRetainedTail(existing, KEEP_TAIL_BYTES);
+      const tmp = `${file}.tmp`;
+      await writeFile(tmp, tail, 'utf8');
+      await rename(tmp, file);
+    }
+  } catch {
+    // ENOENT (first write) or any stat/rotate failure — just append below.
+  }
+  await appendFile(file, line, 'utf8');
+}
+
+/**
+ * Append a crash record without blocking the caller. Fire-and-forget: the
+ * returned promise resolves when the write lands but callers may ignore it.
+ * Appends are serialized so concurrent writers cannot interleave or corrupt a
+ * rotation. Never rejects.
+ */
+export function appendCrashLine(record: CrashRecord): Promise<void> {
+  const line = serialize(record);
+  writeChain = writeChain.then(() => doAsyncAppend(line)).catch((err) => {
+    try {
+      console.error('[telemetry] async crash append failed:', err instanceof Error ? err.message : err);
+    } catch {
+      /* swallow */
+    }
+  });
+  return writeChain;
+}
+
+// ── Sync append (dying-process path only) ──
+
+/**
+ * Synchronous best-effort append. Used ONLY from the uncaughtException path,
+ * where the process is about to exit and an async write would never flush.
+ * Never throws.
+ */
+export function appendCrashLineSync(record: CrashRecord): void {
+  try {
+    const dir = telemetryDir();
+    const file = crashLogPath();
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const line = serialize(record);
+    try {
+      if (existsSync(file)) {
+        const info = statSync(file);
+        if (info.size + Buffer.byteLength(line, 'utf8') > MAX_FILE_BYTES) {
+          const existing = readFileSync(file, 'utf8');
+          const tail = computeRetainedTail(existing, KEEP_TAIL_BYTES);
+          const tmp = `${file}.tmp`;
+          writeFileSync(tmp, tail, 'utf8');
+          renameSync(tmp, file);
+        }
+      }
+    } catch {
+      // rotation is best-effort; still append below.
+    }
+    appendFileSync(file, line, 'utf8');
+  } catch (err) {
+    try {
+      console.error('[telemetry] sync crash append failed:', err instanceof Error ? err.message : err);
+    } catch {
+      /* swallow */
+    }
+  }
+}
+
+// ── Read (uploader) ──
+
+/**
+ * Read all persisted crash records. Malformed lines are skipped. Never throws;
+ * returns [] when the file is absent or unreadable.
+ */
+export function readCrashRecords(): CrashRecord[] {
+  try {
+    const file = crashLogPath();
+    if (!existsSync(file)) return [];
+    const raw = readFileSync(file, 'utf8');
+    const out: CrashRecord[] = [];
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const parsed = JSON.parse(trimmed) as CrashRecord;
+        if (parsed && typeof parsed.ts === 'number' && typeof parsed.message === 'string') {
+          out.push(parsed);
+        }
+      } catch {
+        // skip malformed line
+      }
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/telemetry/uploader.ts
+++ b/src/lib/telemetry/uploader.ts
@@ -1,0 +1,143 @@
+/**
+ * Opt-in crash uploader. Default OFF: uploads happen ONLY when the operator has
+ * enabled `telemetryOptIn` AND an ingest endpoint is configured
+ * (O8_TELEMETRY_INGEST_URL env, or the `telemetryIngestUrl` operator setting).
+ * When either is missing this is a pure no-op.
+ *
+ * No retry storm: a single POST attempt per interval with a bounded timeout. A
+ * failed attempt simply leaves the cursor untouched and retries next interval.
+ * Never throws.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import {
+  resolveTelemetryIngestUrlSync,
+  resolveTelemetryOptInSync,
+} from '@/lib/operator/defaults';
+import { readCrashRecords, telemetryDir, type CrashRecord } from './crash-store';
+
+const UPLOAD_INTERVAL_MS = 5 * 60 * 1000;
+const INITIAL_DELAY_MS = 30 * 1000;
+const UPLOAD_TIMEOUT_MS = 10 * 1000;
+const MAX_BATCH = 200;
+
+export type UploadStatus = 'disabled' | 'empty' | 'uploaded' | 'failed' | 'error';
+
+interface UploadCursor {
+  lastUploadedTs: number;
+}
+
+function cursorPath(): string {
+  return path.join(telemetryDir(), 'upload-cursor.json');
+}
+
+function resolveIngestUrl(): string {
+  const fromEnv = process.env.O8_TELEMETRY_INGEST_URL?.trim();
+  if (fromEnv) return fromEnv;
+  try {
+    return resolveTelemetryIngestUrlSync();
+  } catch {
+    return '';
+  }
+}
+
+function readCursor(): UploadCursor {
+  try {
+    const file = cursorPath();
+    if (!existsSync(file)) return { lastUploadedTs: 0 };
+    const parsed = JSON.parse(readFileSync(file, 'utf8')) as Partial<UploadCursor>;
+    const ts = typeof parsed.lastUploadedTs === 'number' && Number.isFinite(parsed.lastUploadedTs)
+      ? parsed.lastUploadedTs
+      : 0;
+    return { lastUploadedTs: ts };
+  } catch {
+    return { lastUploadedTs: 0 };
+  }
+}
+
+async function writeCursor(cursor: UploadCursor): Promise<void> {
+  try {
+    await mkdir(telemetryDir(), { recursive: true });
+    await writeFile(cursorPath(), `${JSON.stringify(cursor, null, 2)}\n`, 'utf8');
+  } catch {
+    // best-effort — a lost cursor at worst re-uploads a bounded batch.
+  }
+}
+
+/**
+ * Run one upload pass. Returns a status describing what happened. Never throws.
+ */
+export async function runTelemetryUpload(): Promise<UploadStatus> {
+  try {
+    if (!resolveTelemetryOptInSync()) return 'disabled';
+    const ingestUrl = resolveIngestUrl();
+    if (!ingestUrl) return 'disabled';
+
+    const cursor = readCursor();
+    const pending = readCrashRecords()
+      .filter((r) => r.ts > cursor.lastUploadedTs)
+      .slice(0, MAX_BATCH);
+    if (pending.length === 0) return 'empty';
+
+    const maxTs = pending.reduce((max: number, r: CrashRecord) => (r.ts > max ? r.ts : max), cursor.lastUploadedTs);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), UPLOAD_TIMEOUT_MS);
+    let ok = false;
+    try {
+      const res = await fetch(ingestUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ source: 'o8', count: pending.length, records: pending }),
+        signal: controller.signal,
+      });
+      ok = res.ok;
+    } catch {
+      ok = false;
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!ok) {
+      console.warn('[telemetry] crash upload attempt failed — will retry next interval');
+      return 'failed';
+    }
+
+    await writeCursor({ lastUploadedTs: maxTs });
+    console.log(`[telemetry] uploaded ${pending.length} crash record(s)`);
+    return 'uploaded';
+  } catch (err) {
+    try {
+      console.error('[telemetry] upload pass error:', err instanceof Error ? err.message : err);
+    } catch {
+      /* swallow */
+    }
+    return 'error';
+  }
+}
+
+interface UploaderGlobal {
+  __o8TelemetryUploadLoopStarted?: boolean;
+}
+
+/**
+ * Start the periodic upload loop (idempotent). Each tick is a cheap no-op when
+ * telemetry is off. Timers are unref'd so they never keep the process alive.
+ */
+export function startTelemetryUploadLoop(): void {
+  try {
+    const g = globalThis as unknown as UploaderGlobal;
+    if (g.__o8TelemetryUploadLoopStarted) return;
+    g.__o8TelemetryUploadLoopStarted = true;
+
+    const initial = setTimeout(() => { void runTelemetryUpload(); }, INITIAL_DELAY_MS);
+    const interval = setInterval(() => { void runTelemetryUpload(); }, UPLOAD_INTERVAL_MS);
+    if (typeof initial.unref === 'function') initial.unref();
+    if (typeof interval.unref === 'function') interval.unref();
+  } catch {
+    // never block boot
+  }
+}

--- a/src/lib/ws-server/channels.ts
+++ b/src/lib/ws-server/channels.ts
@@ -1,0 +1,52 @@
+/**
+ * Channel backpressure semantics for the ws-server multiplexer.
+ *
+ * These are LOAD-BEARING and must not change: LOSSY channels (chat deltas,
+ * terminal data, pong, orchestrator output) may be dropped under backpressure;
+ * DURABLE channels (inbox, history, review, conflicts, lane/agent-lifecycle,
+ * cortex-changes, artifacts, chat done/error) are queued and flushed. Buffer
+ * limit 64KB, max 32 queued messages per client, 50ms flush interval.
+ *
+ * Pure classification extracted from the ws-server monolith — no shared state.
+ * Faithful move; do not "improve" the fast-path matching.
+ */
+
+/** 64KB — queue durable messages once a client's socket buffer exceeds this. */
+export const BACKPRESSURE_LIMIT = 64 * 1024;
+/** Max queued messages per client before the oldest are dropped. */
+export const BACKPRESSURE_QUEUE_LIMIT = 32;
+/** Check interval (ms) to flush queued messages. */
+export const BACKPRESSURE_FLUSH_MS = 50;
+
+/**
+ * Determine whether a message is "lossy" (safe to drop under backpressure)
+ * or "durable" (must be queued and flushed later).
+ *
+ * Lossy channels: chat deltas, terminal data, pong, orchestrator output — all
+ * are either inherently lossy or recovered by higher-level mechanisms.
+ */
+export function isLossyMessage(json: string): boolean {
+  // Fast path: avoid parsing — check for known lossy patterns
+  const maybeLossy =
+    json.includes('"channel":"pong"') ||
+    // Chat deltas (not done/error) are lossy
+    (json.includes('"channel":"chat"') && json.includes('"event":"delta"')) ||
+    // Terminal data frames are lossy (PTY output is best-effort)
+    (json.includes('"channel":"terminal"') && json.includes('"event":"data"')) ||
+    // Orchestrator output chunks are lossy (intermediate deltas can be dropped)
+    (json.includes('"channel":"orchestrator"') && json.includes('"event":"output"'));
+  if (!maybeLossy) return false;
+  // Confirm with a real parse: payload text that merely *contains* one of the
+  // marker substrings (e.g. an agent quoting protocol frames) must not cause
+  // a durable message to be silently dropped. Only runs under backpressure.
+  try {
+    const msg = JSON.parse(json) as { channel?: unknown; event?: unknown };
+    if (msg.channel === 'pong') return true;
+    if (msg.channel === 'chat' && msg.event === 'delta') return true;
+    if (msg.channel === 'terminal' && msg.event === 'data') return true;
+    if (msg.channel === 'orchestrator' && msg.event === 'output') return true;
+    return false;
+  } catch {
+    return false; // unparseable → treat as durable (safer)
+  }
+}

--- a/src/lib/ws-server/git-worktrees.ts
+++ b/src/lib/ws-server/git-worktrees.ts
@@ -1,0 +1,39 @@
+/**
+ * Git worktree parsing helpers for the ws-server review watcher.
+ *
+ * Pure string/path helpers extracted from the ws-server monolith. No shared
+ * state. Faithful move — no behavior change.
+ */
+
+import { homedir } from 'node:os';
+
+export type GitWorktreeRecord = {
+  path: string;
+  branch: string | null;
+};
+
+/** Collapse an absolute path under $HOME to a leading `~/`. */
+export function shortHome(filePath: string): string {
+  const home = process.env.HOME ?? homedir();
+  return filePath.startsWith(`${home}/`) ? filePath.replace(`${home}/`, '~/') : filePath;
+}
+
+/** Parse `git worktree list --porcelain` output into path/branch records. */
+export function parseGitWorktreeList(raw: string): GitWorktreeRecord[] {
+  const worktrees: GitWorktreeRecord[] = [];
+  let current: GitWorktreeRecord | null = null;
+
+  for (const line of raw.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      current = { path: line.slice('worktree '.length), branch: null };
+      worktrees.push(current);
+      continue;
+    }
+    if (!current) continue;
+    if (line.startsWith('branch refs/heads/')) {
+      current.branch = line.slice('branch refs/heads/'.length);
+    }
+  }
+
+  return worktrees;
+}

--- a/src/lib/ws-server/health-watchdog.test.ts
+++ b/src/lib/ws-server/health-watchdog.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { WsWatchdog } from './health-watchdog';
+
+/**
+ * Deterministic driver: an injected monotonic clock + a captured scheduler
+ * callback so the test advances "loop time" and fires samples by hand. This is
+ * the fake-timer discipline — no wall-clock sleeps, fully reproducible.
+ */
+function makeDriver(overrides: Partial<{
+  intervalMs: number;
+  thresholdMs: number;
+  sustainedSamples: number;
+}> = {}) {
+  let clock = 1_000_000; // monotonic ms
+  let wall = 1_700_000_000_000; // epoch ms
+  const logs: string[] = [];
+  let scheduled: (() => void) | null = null;
+  let cleared = false;
+
+  const watchdog = new WsWatchdog({
+    intervalMs: overrides.intervalMs ?? 1000,
+    thresholdMs: overrides.thresholdMs ?? 250,
+    sustainedSamples: overrides.sustainedSamples ?? 3,
+    nowMs: () => clock,
+    wallClock: () => wall,
+    scheduler: (cb) => {
+      scheduled = cb;
+      return { unref: () => {} };
+    },
+    cancelScheduler: () => {
+      cleared = true;
+    },
+    log: (m) => logs.push(m),
+  });
+
+  return {
+    watchdog,
+    logs,
+    isScheduled: () => scheduled !== null,
+    wasCleared: () => cleared,
+    /** Advance monotonic clock by `ms`, then fire one sample. */
+    advanceAndSample(ms: number) {
+      clock += ms;
+      scheduled?.();
+    },
+    setWall(v: number) {
+      wall = v;
+    },
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('WsWatchdog', () => {
+  it('registers an interval on start and clears it on stop', () => {
+    const d = makeDriver();
+    expect(d.isScheduled()).toBe(false);
+    d.watchdog.start();
+    expect(d.isScheduled()).toBe(true);
+    d.watchdog.stop();
+    expect(d.wasCleared()).toBe(true);
+  });
+
+  it('stays healthy (no wedge, no log) when samples fire on cadence', () => {
+    const d = makeDriver({ intervalMs: 1000, thresholdMs: 250 });
+    d.watchdog.start();
+    // Each gap is exactly the interval → lag 0.
+    for (let i = 0; i < 10; i += 1) d.advanceAndSample(1000);
+    const s = d.watchdog.getStats();
+    expect(s.samples).toBe(10);
+    expect(s.maxLagMs).toBe(0);
+    expect(s.wedgeCount).toBe(0);
+    expect(s.wedged).toBe(false);
+    expect(s.lastWedgeAt).toBeNull();
+    expect(d.logs).toHaveLength(0);
+  });
+
+  it('detects a wedge only after N consecutive high samples and logs once', () => {
+    const d = makeDriver({ intervalMs: 1000, thresholdMs: 250, sustainedSamples: 3 });
+    d.watchdog.start();
+
+    // Sample 1: 300ms over → high (1 consecutive), not yet a wedge.
+    d.advanceAndSample(1300);
+    expect(d.watchdog.getStats().wedgeCount).toBe(0);
+    expect(d.watchdog.getStats().consecutiveHighSamples).toBe(1);
+    expect(d.logs).toHaveLength(0);
+
+    // Sample 2: still high (2 consecutive), not yet a wedge.
+    d.advanceAndSample(1400);
+    expect(d.watchdog.getStats().wedgeCount).toBe(0);
+    expect(d.logs).toHaveLength(0);
+
+    // Sample 3: crosses the sustained threshold → wedge onset, one log.
+    d.setWall(1_700_000_055_555);
+    d.advanceAndSample(1500);
+    const s = d.watchdog.getStats();
+    expect(s.wedgeCount).toBe(1);
+    expect(s.wedged).toBe(true);
+    expect(s.lastWedgeAt).toBe(1_700_000_055_555);
+    expect(s.lastWedgeLagMs).toBe(500);
+    expect(s.maxLagMs).toBe(500);
+    expect(d.logs).toHaveLength(1);
+    expect(d.logs[0]).toContain('[ws-health]');
+    expect(d.logs[0]).toContain('wedge detected');
+
+    // Sample 4: still wedged — must NOT log again (once per episode).
+    d.advanceAndSample(1300);
+    expect(d.watchdog.getStats().wedgeCount).toBe(1);
+    expect(d.logs).toHaveLength(1);
+  });
+
+  it('logs recovery and resets the counter when the loop comes back healthy', () => {
+    const d = makeDriver({ intervalMs: 1000, thresholdMs: 250, sustainedSamples: 3 });
+    d.watchdog.start();
+    d.advanceAndSample(1300);
+    d.advanceAndSample(1300);
+    d.advanceAndSample(1300); // wedge onset
+    expect(d.watchdog.getStats().wedged).toBe(true);
+
+    d.advanceAndSample(1000); // healthy sample → recovery
+    const s = d.watchdog.getStats();
+    expect(s.wedged).toBe(false);
+    expect(s.consecutiveHighSamples).toBe(0);
+    expect(s.wedgeCount).toBe(1); // count of episodes is retained
+    expect(d.logs.some((l) => l.includes('recovered'))).toBe(true);
+
+    // A second wedge is a distinct episode → count increments.
+    d.advanceAndSample(1300);
+    d.advanceAndSample(1300);
+    d.advanceAndSample(1300);
+    expect(d.watchdog.getStats().wedgeCount).toBe(2);
+  });
+
+  it('works end-to-end with vitest fake timers driving the real interval', () => {
+    vi.useFakeTimers();
+    const logs: string[] = [];
+    // Real setInterval (faked) + Date-based clocks. Fake time is exact, so no
+    // lag is produced — this asserts the wiring: interval fires, stays healthy.
+    const watchdog = new WsWatchdog({
+      intervalMs: 1000,
+      thresholdMs: 250,
+      nowMs: () => Date.now(),
+      wallClock: () => Date.now(),
+      log: (m) => logs.push(m),
+    });
+    watchdog.start();
+    vi.advanceTimersByTime(5000);
+    const s = watchdog.getStats();
+    expect(s.samples).toBeGreaterThanOrEqual(4);
+    expect(s.wedgeCount).toBe(0);
+    expect(logs).toHaveLength(0);
+    watchdog.stop();
+    const after = watchdog.getStats().samples;
+    vi.advanceTimersByTime(5000);
+    expect(watchdog.getStats().samples).toBe(after); // stop() really cleared it
+  });
+});

--- a/src/lib/ws-server/health-watchdog.ts
+++ b/src/lib/ws-server/health-watchdog.ts
@@ -1,0 +1,163 @@
+/**
+ * Event-loop lag watchdog for the ws-server process.
+ *
+ * ws-server multiplexes every mobile realtime client, PTY data pump, and
+ * orchestrator stream on a single event loop (port 3002). Incident #1498: a
+ * sync FS walk wedged the loop for minutes and every client froze silently.
+ * This watchdog measures loop lag with the classic timer-drift method — a
+ * fixed-cadence timer whose callback should fire every `intervalMs`; the amount
+ * it fires *late* is the time the loop spent blocked. On sustained lag it logs
+ * `[ws-health]` and keeps rolling counters queryable in-process (exposed on the
+ * existing `/health` HTTP endpoint).
+ *
+ * Cost: one unref'd interval + a couple of arithmetic ops per sample. Zero
+ * allocation, zero overhead when the loop is healthy.
+ */
+
+import { performance } from 'node:perf_hooks';
+
+export interface WsHealthStats {
+  /** Wall-clock time the watchdog started sampling (epoch ms). */
+  startedAt: number;
+  /** Total samples taken since start. */
+  samples: number;
+  /** Lag of the most recent sample (ms, floored at 0). */
+  lastSampleLagMs: number;
+  /** Worst single-sample lag observed since start (ms). */
+  maxLagMs: number;
+  /** Consecutive samples currently over threshold (resets on a healthy one). */
+  consecutiveHighSamples: number;
+  /** Number of distinct wedge episodes detected (one per onset). */
+  wedgeCount: number;
+  /** Epoch ms of the last wedge onset, or null if never wedged. */
+  lastWedgeAt: number | null;
+  /** Lag (ms) recorded at the last wedge onset. */
+  lastWedgeLagMs: number | null;
+  /** Whether the loop is currently inside a wedge episode. */
+  wedged: boolean;
+  intervalMs: number;
+  thresholdMs: number;
+  sustainedSamples: number;
+}
+
+export interface WsWatchdogOptions {
+  /** Sampling cadence in ms. Default 1000. */
+  intervalMs?: number;
+  /** A single sample above this lag (ms) counts as "high". Default 250. */
+  thresholdMs?: number;
+  /** Consecutive high samples that constitute a wedge. Default 3. */
+  sustainedSamples?: number;
+  /** Monotonic clock (ms). Default `performance.now`. Injectable for tests. */
+  nowMs?: () => number;
+  /** Wall clock (epoch ms). Default `Date.now`. Injectable for tests. */
+  wallClock?: () => number;
+  /** setInterval-like scheduler. Default global setInterval. Injectable for tests. */
+  scheduler?: (cb: () => void, ms: number) => { unref?: () => void };
+  /** clearInterval-like canceller. Default global clearInterval. */
+  cancelScheduler?: (handle: unknown) => void;
+  /** Log sink. Default console.log. */
+  log?: (msg: string) => void;
+}
+
+export class WsWatchdog {
+  private readonly intervalMs: number;
+  private readonly thresholdMs: number;
+  private readonly sustainedSamples: number;
+  private readonly nowMs: () => number;
+  private readonly wallClock: () => number;
+  private readonly scheduler: (cb: () => void, ms: number) => { unref?: () => void };
+  private readonly cancelScheduler: (handle: unknown) => void;
+  private readonly log: (msg: string) => void;
+
+  private timer: { unref?: () => void } | null = null;
+  private expected = 0;
+
+  private stats: WsHealthStats;
+
+  constructor(opts: WsWatchdogOptions = {}) {
+    this.intervalMs = opts.intervalMs ?? 1000;
+    this.thresholdMs = opts.thresholdMs ?? 250;
+    this.sustainedSamples = opts.sustainedSamples ?? 3;
+    this.nowMs = opts.nowMs ?? (() => performance.now());
+    this.wallClock = opts.wallClock ?? (() => Date.now());
+    this.scheduler = opts.scheduler ?? ((cb, ms) => setInterval(cb, ms));
+    this.cancelScheduler = opts.cancelScheduler ?? ((h) => clearInterval(h as ReturnType<typeof setInterval>));
+    this.log = opts.log ?? ((m) => console.log(m));
+
+    this.stats = {
+      startedAt: this.wallClock(),
+      samples: 0,
+      lastSampleLagMs: 0,
+      maxLagMs: 0,
+      consecutiveHighSamples: 0,
+      wedgeCount: 0,
+      lastWedgeAt: null,
+      lastWedgeLagMs: null,
+      wedged: false,
+      intervalMs: this.intervalMs,
+      thresholdMs: this.thresholdMs,
+      sustainedSamples: this.sustainedSamples,
+    };
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.stats.startedAt = this.wallClock();
+    this.expected = this.nowMs() + this.intervalMs;
+    this.timer = this.scheduler(() => this.tick(), this.intervalMs);
+    // Never keep the process alive on the watchdog alone.
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (!this.timer) return;
+    this.cancelScheduler(this.timer);
+    this.timer = null;
+  }
+
+  getStats(): WsHealthStats {
+    return { ...this.stats };
+  }
+
+  /**
+   * One sample. Public so tests can drive it deterministically without a real
+   * timer, but production only invokes it via the scheduled interval.
+   */
+  tick(): void {
+    const now = this.nowMs();
+    const lag = Math.max(0, now - this.expected);
+    // Reset the baseline from the actual fire time so lag is measured per-gap
+    // and does not accumulate drift across samples.
+    this.expected = now + this.intervalMs;
+
+    const s = this.stats;
+    s.samples += 1;
+    s.lastSampleLagMs = lag;
+    if (lag > s.maxLagMs) s.maxLagMs = lag;
+
+    if (lag > this.thresholdMs) {
+      s.consecutiveHighSamples += 1;
+      if (s.consecutiveHighSamples >= this.sustainedSamples && !s.wedged) {
+        // Wedge onset — log once per episode, not per sample.
+        s.wedged = true;
+        s.wedgeCount += 1;
+        s.lastWedgeAt = this.wallClock();
+        s.lastWedgeLagMs = lag;
+        this.log(
+          `[ws-health] event-loop wedge detected — lag=${Math.round(lag)}ms ` +
+          `(${s.consecutiveHighSamples} consecutive samples >${this.thresholdMs}ms), ` +
+          `maxLag=${Math.round(s.maxLagMs)}ms, wedgeCount=${s.wedgeCount}`,
+        );
+      }
+    } else {
+      if (s.wedged) {
+        this.log(
+          `[ws-health] event-loop recovered — lastLag=${Math.round(lag)}ms, ` +
+          `maxLag=${Math.round(s.maxLagMs)}ms, wedgeCount=${s.wedgeCount}`,
+        );
+      }
+      s.consecutiveHighSamples = 0;
+      s.wedged = false;
+    }
+  }
+}

--- a/src/lib/ws-server/next-fetch.ts
+++ b/src/lib/ws-server/next-fetch.ts
@@ -1,0 +1,113 @@
+/**
+ * Next.js HTTP fetch helpers for the ws-server → Next API hop.
+ *
+ * ws-server reads sync state from the Next.js backend over loopback HTTP. This
+ * module owns the origin resolution, retry/backoff, and JSON envelope handling.
+ * Extracted faithfully from the ws-server monolith — no behavior change.
+ *
+ * The ws auth token is sourced from the same `getOrCreateWsToken()` the entry
+ * uses and cached on first call (getOrCreateWsToken does a file read each time).
+ */
+
+import { getApiBase } from '@/lib/panel/api-port';
+import { getOrCreateWsToken } from '@/lib/ws-auth';
+
+/** Default per-request timeout (ms). Also used by the entry's fetchSync probe. */
+export const FETCH_TIMEOUT_MS = 8_000;
+const NEXT_FETCH_MAX_ATTEMPTS = 5;
+const NEXT_FETCH_INITIAL_BACKOFF_MS = 100;
+
+const RETRYABLE_NEXT_FETCH_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENOTFOUND',
+  'UND_ERR_SOCKET',
+]);
+
+let cachedWsToken: string | null = null;
+function wsToken(): string {
+  return (cachedWsToken ??= getOrCreateWsToken());
+}
+
+function getNextOrigin(): string {
+  return process.env.NEXT_ORIGIN ?? getApiBase();
+}
+
+export function buildNextUrl(pathname: string, searchParams?: URLSearchParams): string {
+  const query = searchParams && searchParams.size > 0 ? `?${searchParams.toString()}` : '';
+  return `${getNextOrigin()}${pathname}${query}`;
+}
+
+function getNextFetchErrorCode(error: Error): string | null {
+  const cause = (error as Error & { cause?: unknown }).cause;
+  if (!cause || typeof cause !== 'object') return null;
+  const code = (cause as { code?: unknown }).code;
+  return typeof code === 'string' ? code : null;
+}
+
+function isRetryableNextFetchError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.name === 'AbortError' || error.name === 'TimeoutError') return false;
+  const code = getNextFetchErrorCode(error);
+  return error.message === 'fetch failed' || (code !== null && RETRYABLE_NEXT_FETCH_CODES.has(code));
+}
+
+function delayNextFetchRetry(delayMs: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+export async function fetchWithRetry(input: string, init: RequestInit): Promise<Response> {
+  let backoffMs = NEXT_FETCH_INITIAL_BACKOFF_MS;
+
+  for (let attempt = 1; attempt <= NEXT_FETCH_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      return await fetch(input, init);
+    } catch (error) {
+      if (attempt === NEXT_FETCH_MAX_ATTEMPTS || !isRetryableNextFetchError(error)) {
+        throw error;
+      }
+
+      await delayNextFetchRetry(backoffMs);
+      backoffMs *= 2;
+    }
+  }
+
+  throw new Error('[ws-server] internal fetch retry loop exited unexpectedly');
+}
+
+export async function fetchNextJson<T>(
+  pathname: string,
+  options: {
+    method?: 'GET' | 'POST';
+    searchParams?: URLSearchParams;
+    body?: unknown;
+    timeoutMs?: number;
+  } = {},
+): Promise<T> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${wsToken()}`,
+  };
+  if (options.body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  const response = await fetchWithRetry(buildNextUrl(pathname, options.searchParams), {
+    method: options.method ?? 'GET',
+    headers,
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+    signal: AbortSignal.timeout(options.timeoutMs ?? FETCH_TIMEOUT_MS),
+  });
+
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const error = payload && typeof payload === 'object' && 'error' in payload
+      ? String((payload as { error?: string }).error ?? '')
+      : '';
+    throw new Error(error || `${pathname} failed (${response.status})`);
+  }
+
+  return payload as T;
+}

--- a/src/lib/ws-server/pty-support.ts
+++ b/src/lib/ws-server/pty-support.ts
@@ -1,0 +1,85 @@
+/**
+ * PTY / tmux / shell support helpers for the ws-server terminal subsystem.
+ *
+ * Pure helpers (process.env + node builtins only — no shared ws-server state)
+ * extracted from the ws-server monolith so both the entry process and the
+ * forked terminal-host (O8_TERMINAL_HOST=child) share one implementation of
+ * shell/tmux resolution. Faithful move — no behavior change.
+ */
+
+import { existsSync } from 'node:fs';
+import { execSync, execFileSync } from 'node:child_process';
+
+/** A clean env for spawned PTYs — inherits process.env, pins TERM/locale/PATH. */
+export function sanitizePtyEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (typeof value === 'string') {
+      env[key] = value;
+    }
+  }
+  env.TERM = 'xterm-256color';
+  env.LANG = env.LANG || 'en_US.UTF-8';
+  env.LC_ALL = env.LC_ALL || 'en_US.UTF-8';
+  env.PATH = env.PATH || '/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin';
+  return env;
+}
+
+export function resolvePreferredShell(): string {
+  const candidates = [
+    process.env.SHELL,
+    '/bin/zsh',
+    '/bin/bash',
+    '/bin/sh',
+  ].filter((value): value is string => Boolean(value));
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+
+  return '/bin/sh';
+}
+
+export function resolveTmuxBinary(): string {
+  const candidates = [
+    process.env.TMUX_BIN,
+    '/opt/homebrew/bin/tmux',
+    '/usr/local/bin/tmux',
+    '/usr/bin/tmux',
+    '/bin/tmux',
+  ].filter((value): value is string => Boolean(value));
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+
+  try {
+    return execSync('command -v tmux', {
+      encoding: 'utf-8',
+      timeout: 3000,
+      env: sanitizePtyEnv() as NodeJS.ProcessEnv,
+    }).trim() || 'tmux';
+  } catch {
+    return 'tmux';
+  }
+}
+
+export function tmuxSessionExists(sessionName: string): boolean {
+  const target = sessionName.trim();
+  if (!target) return false;
+
+  try {
+    execFileSync(resolveTmuxBinary(), ['has-session', '-t', target], {
+      timeout: 2000,
+      stdio: 'ignore',
+      env: sanitizePtyEnv() as NodeJS.ProcessEnv,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isDashTerminalSession(sessionName: string): boolean {
+  return sessionName.startsWith('cortex-dash-');
+}

--- a/src/lib/ws-server/terminal-host-child.ts
+++ b/src/lib/ws-server/terminal-host-child.ts
@@ -1,0 +1,102 @@
+/**
+ * Child-side terminal-host logic.
+ *
+ * Owns a Map<id, pty> and translates parent requests into node-pty calls,
+ * streaming data/exit back. Pure + injectable (spawn/send/log are passed in)
+ * so it can be unit-tested with a fake pty and driven by a real fork in the
+ * seam test — no node-pty import here.
+ */
+
+import type {
+  PtySpawnSpec,
+  TerminalHostRequest,
+  TerminalHostEvent,
+} from './terminal-host-protocol';
+
+/** The minimal node-pty IPty surface the child drives. */
+export interface ChildPty {
+  readonly pid: number | undefined;
+  onData(cb: (data: string) => void): void;
+  onExit(cb: (e: { exitCode: number; signal?: number }) => void): void;
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+  kill(signal?: string): void;
+}
+
+export interface TerminalHostChildDeps {
+  /** Spawn a real PTY. Throws if node-pty is unavailable. */
+  spawn: (spec: PtySpawnSpec) => ChildPty;
+  /** Emit an event back to the parent. */
+  send: (evt: TerminalHostEvent) => void;
+  log?: (msg: string) => void;
+}
+
+export interface TerminalHostChild {
+  handle(req: TerminalHostRequest): void;
+  /** Kill every live pty (used on disconnect / shutdown). */
+  killAll(): void;
+  /** Live pty count — for tests/introspection. */
+  size(): number;
+}
+
+export function createTerminalHostChild(deps: TerminalHostChildDeps): TerminalHostChild {
+  const ptys = new Map<string, ChildPty>();
+  const log = deps.log ?? (() => {});
+
+  function handle(req: TerminalHostRequest): void {
+    switch (req.type) {
+      case 'spawn': {
+        try {
+          const p = deps.spawn(req.spec);
+          ptys.set(req.id, p);
+          p.onData((data) => deps.send({ type: 'data', id: req.id, data }));
+          p.onExit((e) => {
+            ptys.delete(req.id);
+            deps.send({ type: 'exit', id: req.id, exitCode: e.exitCode, signal: e.signal });
+          });
+          deps.send({ type: 'spawned', id: req.id, pid: p.pid });
+          log(`spawned ${req.id} (${req.spec.file}) pid=${p.pid ?? '?'}`);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          deps.send({ type: 'spawn-error', id: req.id, message });
+          log(`spawn-error ${req.id}: ${message}`);
+        }
+        break;
+      }
+      case 'write': {
+        const p = ptys.get(req.id);
+        if (p) {
+          try { p.write(req.data); } catch { /* pty already gone */ }
+        }
+        break;
+      }
+      case 'resize': {
+        const p = ptys.get(req.id);
+        if (p) {
+          try { p.resize(req.cols, req.rows); } catch { /* pty already gone */ }
+        }
+        break;
+      }
+      case 'kill': {
+        const p = ptys.get(req.id);
+        if (p) {
+          try { p.kill(req.signal); } catch { /* pty already gone */ }
+        }
+        break;
+      }
+      default: {
+        // Exhaustiveness: unknown request types are ignored (forward-compat).
+        break;
+      }
+    }
+  }
+
+  function killAll(): void {
+    for (const p of ptys.values()) {
+      try { p.kill(); } catch { /* already gone */ }
+    }
+    ptys.clear();
+  }
+
+  return { handle, killAll, size: () => ptys.size };
+}

--- a/src/lib/ws-server/terminal-host-client.ts
+++ b/src/lib/ws-server/terminal-host-client.ts
@@ -1,0 +1,190 @@
+/**
+ * Parent-side terminal-host: the seam ws-server spawns PTYs through.
+ *
+ *   - InlineTerminalHost: node-pty in-process (the historical behavior).
+ *   - ChildTerminalHost:  forks terminal-host-entry and proxies each PTY over
+ *     IPC, so a PTY wedge in either process can't freeze the other (#1498).
+ *
+ * Both present the identical `TerminalHandle` surface, so ws-server's terminal
+ * handlers (batch buffer, scrollback, client fan-out) are untouched and the
+ * client-facing WS protocol stays byte-identical. Selected by O8_TERMINAL_HOST
+ * (inline | child); default resolved by the caller.
+ */
+
+import { fork, type ChildProcess } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import type {
+  PtySpawnSpec,
+  TerminalHandle,
+  TerminalHost,
+  TerminalHostEvent,
+} from './terminal-host-protocol';
+import type { ChildPty } from './terminal-host-child';
+
+export type { TerminalHandle, TerminalHost } from './terminal-host-protocol';
+
+// ── Inline host (node-pty in this process) ──────────────────────────────────
+
+/** The node-pty module surface the inline host needs. */
+export interface InlinePtyModule {
+  spawn(
+    file: string,
+    args: string[],
+    opts: { name: string; cols: number; rows: number; cwd: string; env: Record<string, string> },
+  ): ChildPty;
+}
+
+export function createInlineTerminalHost(ptyModule: InlinePtyModule): TerminalHost {
+  return {
+    mode: 'inline',
+    spawn(spec: PtySpawnSpec): TerminalHandle {
+      const p = ptyModule.spawn(spec.file, spec.args, {
+        name: spec.name ?? 'xterm-256color',
+        cols: spec.cols,
+        rows: spec.rows,
+        cwd: spec.cwd,
+        env: spec.env,
+      });
+      return {
+        get pid() { return p.pid; },
+        onData: (cb) => p.onData(cb),
+        onExit: (cb) => p.onExit((e) => cb({ exitCode: e.exitCode, signal: e.signal })),
+        write: (d) => p.write(d),
+        resize: (c, r) => p.resize(c, r),
+        kill: (s) => p.kill(s),
+      };
+    },
+    dispose() { /* PTYs are killed by ws-server per-attachment */ },
+  };
+}
+
+// ── Child host (forked terminal-host) ───────────────────────────────────────
+
+class ChildHandle implements TerminalHandle {
+  pid: number | undefined = undefined;
+  private dataCb: ((data: string) => void) | null = null;
+  private exitCb: ((e: { exitCode: number; signal?: number }) => void) | null = null;
+  private exited = false;
+
+  constructor(
+    private readonly id: string,
+    private readonly child: ChildProcess,
+  ) {}
+
+  onData(cb: (data: string) => void): void { this.dataCb = cb; }
+  onExit(cb: (e: { exitCode: number; signal?: number }) => void): void { this.exitCb = cb; }
+
+  write(data: string): void {
+    this.child.send?.({ type: 'write', id: this.id, data });
+  }
+  resize(cols: number, rows: number): void {
+    this.child.send?.({ type: 'resize', id: this.id, cols, rows });
+  }
+  kill(signal?: string): void {
+    this.child.send?.({ type: 'kill', id: this.id, signal });
+  }
+
+  /** @internal — fed by the host from IPC frames. */
+  _emitData(data: string): void { this.dataCb?.(data); }
+  /** @internal */
+  _emitExit(e: { exitCode: number; signal?: number }): void {
+    if (this.exited) return;
+    this.exited = true;
+    this.exitCb?.(e);
+  }
+}
+
+export interface ChildTerminalHostOptions {
+  /** Absolute path to the fork entry. Defaults resolved from import.meta.url. */
+  forkEntry?: string;
+  /** execArgv for the fork (e.g. ['--import','tsx'] in dev). */
+  execArgv?: string[];
+  log?: (msg: string) => void;
+}
+
+/** Resolve the fork entry + execArgv for dev (tsx .ts) vs packaged (.mjs). */
+export function resolveTerminalHostForkTarget(): { forkEntry: string; execArgv: string[] } {
+  // A sidecar may point us straight at the bundled artifact.
+  const bundled = process.env.O8_BUNDLED_TERMINAL_HOST;
+  if (bundled) return { forkEntry: bundled, execArgv: [] };
+
+  const here = dirname(fileURLToPath(import.meta.url));
+  const isDev = import.meta.url.endsWith('.ts');
+  return isDev
+    ? { forkEntry: join(here, 'terminal-host-entry.ts'), execArgv: ['--import', 'tsx'] }
+    : { forkEntry: join(here, 'terminal-host.mjs'), execArgv: [] };
+}
+
+export function createChildTerminalHost(options: ChildTerminalHostOptions = {}): TerminalHost {
+  const resolved = resolveTerminalHostForkTarget();
+  const forkEntry = options.forkEntry ?? resolved.forkEntry;
+  const execArgv = options.execArgv ?? resolved.execArgv;
+  const log = options.log ?? (() => {});
+
+  const child = fork(forkEntry, [], {
+    execArgv,
+    stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+  });
+
+  const handles = new Map<string, ChildHandle>();
+  let seq = 0;
+  let disposed = false;
+
+  child.on('message', (msg: TerminalHostEvent) => {
+    const h = handles.get(msg.id);
+    if (!h) return;
+    switch (msg.type) {
+      case 'spawned':
+        h.pid = msg.pid;
+        break;
+      case 'spawn-error':
+        log(`spawn-error for ${msg.id}: ${msg.message}`);
+        handles.delete(msg.id);
+        h._emitExit({ exitCode: 1 });
+        break;
+      case 'data':
+        h._emitData(msg.data);
+        break;
+      case 'exit':
+        handles.delete(msg.id);
+        h._emitExit({ exitCode: msg.exitCode, signal: msg.signal });
+        break;
+      default:
+        break;
+    }
+  });
+
+  child.on('exit', (code, signal) => {
+    log(`terminal-host child exited (code=${code ?? '?'} signal=${signal ?? '?'})`);
+    // Surface an exit to every live handle so ws-server tears the attachment
+    // down (broadcasts 'exited', cleans clients). No auto-respawn — child mode
+    // is opt-in; a crash falls back visibly rather than silently reconnecting.
+    for (const h of handles.values()) {
+      h._emitExit({ exitCode: code ?? 1, signal: signal ? 1 : undefined });
+    }
+    handles.clear();
+  });
+
+  child.on('error', (err) => {
+    log(`terminal-host child error: ${err instanceof Error ? err.message : String(err)}`);
+  });
+
+  return {
+    mode: 'child',
+    spawn(spec: PtySpawnSpec): TerminalHandle {
+      const id = `t${(seq += 1)}`;
+      const handle = new ChildHandle(id, child);
+      handles.set(id, handle);
+      // IPC preserves order: the child processes this spawn (creating the pty)
+      // before any subsequent write/resize/kill on the same id.
+      child.send?.({ type: 'spawn', id, spec });
+      return handle;
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      try { child.kill(); } catch { /* already gone */ }
+    },
+  };
+}

--- a/src/lib/ws-server/terminal-host-entry.ts
+++ b/src/lib/ws-server/terminal-host-entry.ts
@@ -1,0 +1,71 @@
+/**
+ * terminal-host fork entry point.
+ *
+ * ws-server forks this file (dev: `node --import tsx …entry.ts`; packaged:
+ * `node …/terminal-host.mjs` bundled by scripts/tauri-export.mjs). It loads
+ * node-pty here — in the child — so a native-module wedge or a runaway PTY
+ * data pump can never freeze the parent's event loop (#1498 follow-up), and
+ * runs the pure child logic over Node's fork IPC channel.
+ *
+ * node-pty is loaded defensively: if it's missing/broken, spawns report a
+ * `spawn-error` instead of crashing the fork (parent then surfaces it).
+ */
+
+import { createRequire } from 'node:module';
+import { createTerminalHostChild, type ChildPty } from './terminal-host-child';
+import type { PtySpawnSpec, TerminalHostRequest } from './terminal-host-protocol';
+
+const require = createRequire(import.meta.url);
+
+type NodePtyModule = {
+  spawn(
+    file: string,
+    args: string[],
+    opts: { name: string; cols: number; rows: number; cwd: string; env: Record<string, string> },
+  ): ChildPty;
+};
+
+let ptyMod: NodePtyModule | null = null;
+try {
+  ptyMod = require('node-pty') as NodePtyModule;
+} catch (err) {
+  console.error(`[terminal-host] node-pty unavailable: ${err instanceof Error ? err.message : String(err)}`);
+}
+
+function spawnPty(spec: PtySpawnSpec): ChildPty {
+  if (!ptyMod) throw new Error('node-pty not available in terminal-host');
+  return ptyMod.spawn(spec.file, spec.args, {
+    name: spec.name ?? 'xterm-256color',
+    cols: spec.cols,
+    rows: spec.rows,
+    cwd: spec.cwd,
+    env: spec.env,
+  });
+}
+
+const child = createTerminalHostChild({
+  spawn: spawnPty,
+  send: (evt) => {
+    // process.send exists because the parent forked us with an IPC channel.
+    process.send?.(evt);
+  },
+  log: (msg) => console.log(`[terminal-host] ${msg}`),
+});
+
+process.on('message', (msg) => {
+  child.handle(msg as TerminalHostRequest);
+});
+
+// Parent closed the IPC channel (shutdown / crash) — kill our PTYs and exit so
+// no orphaned shells survive the parent.
+process.on('disconnect', () => {
+  child.killAll();
+  process.exit(0);
+});
+
+process.on('SIGTERM', () => {
+  child.killAll();
+  process.exit(0);
+});
+
+console.log('[terminal-host] child started');

--- a/src/lib/ws-server/terminal-host-protocol.ts
+++ b/src/lib/ws-server/terminal-host-protocol.ts
@@ -1,0 +1,59 @@
+/**
+ * IPC protocol between ws-server (parent) and the forked terminal-host child.
+ *
+ * The child owns every node-pty process; the parent keeps the batch buffer,
+ * scrollback, client fan-out, and tmux control. Only these small JSON frames
+ * cross the process boundary (over Node's fork IPC channel). node-pty already
+ * delivers/accepts PTY bytes as UTF-8 strings, so `data` is a string here —
+ * faithful to what the inline path passed around.
+ *
+ * See docs/o8 CLAUDE.md "#1498 follow-up" — a PTY wedge in the child can no
+ * longer freeze the parent's event loop (every mobile client), and vice-versa.
+ */
+
+export interface PtySpawnSpec {
+  file: string;
+  args: string[];
+  cols: number;
+  rows: number;
+  cwd: string;
+  env: Record<string, string>;
+  /** terminal name; defaults to xterm-256color. */
+  name?: string;
+}
+
+/** Parent → child. */
+export type TerminalHostRequest =
+  | { type: 'spawn'; id: string; spec: PtySpawnSpec }
+  | { type: 'write'; id: string; data: string }
+  | { type: 'resize'; id: string; cols: number; rows: number }
+  | { type: 'kill'; id: string; signal?: string };
+
+/** Child → parent. */
+export type TerminalHostEvent =
+  | { type: 'spawned'; id: string; pid: number | undefined }
+  | { type: 'spawn-error'; id: string; message: string }
+  | { type: 'data'; id: string; data: string }
+  | { type: 'exit'; id: string; exitCode: number; signal?: number };
+
+/**
+ * The subset of node-pty's IPty the terminal subsystem actually touches.
+ * Both the inline adapter and the child proxy present exactly this surface.
+ */
+export interface TerminalHandle {
+  /** May be undefined in child mode until the `spawned` frame returns. */
+  readonly pid: number | undefined;
+  onData(cb: (data: string) => void): void;
+  onExit(cb: (e: { exitCode: number; signal?: number }) => void): void;
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+  kill(signal?: string): void;
+}
+
+/** A spawner for PTYs — inline (in-process) or child (forked host). */
+export interface TerminalHost {
+  readonly mode: 'inline' | 'child';
+  spawn(spec: PtySpawnSpec): TerminalHandle;
+  /** Tear down (kills the fork in child mode; no-op inline). */
+  dispose(): void;
+}

--- a/src/lib/ws-server/terminal-host.test.ts
+++ b/src/lib/ws-server/terminal-host.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { createTerminalHostChild, type ChildPty } from './terminal-host-child';
+import { createChildTerminalHost } from './terminal-host-client';
+import type { TerminalHostEvent, TerminalHostRequest } from './terminal-host-protocol';
+
+/**
+ * Real-path seam coverage (repo reachability rule): the child logic is unit-
+ * tested with a fake pty AND the whole seam is driven through a REAL fork of
+ * terminal-host-entry.ts, round-tripping spawn → data → exit and write over the
+ * actual IPC framing with a real node-pty in the child.
+ */
+
+// ── Unit: child logic with a fake pty ───────────────────────────────────────
+
+function fakePty(): ChildPty & { emitData: (d: string) => void; emitExit: (c: number) => void; writes: string[]; killed: boolean } {
+  let dataCb: ((d: string) => void) | null = null;
+  let exitCb: ((e: { exitCode: number; signal?: number }) => void) | null = null;
+  const writes: string[] = [];
+  return {
+    pid: 4242,
+    onData: (cb) => { dataCb = cb; },
+    onExit: (cb) => { exitCb = cb; },
+    write: (d) => { writes.push(d); },
+    resize: () => {},
+    kill: function (this: { killed: boolean }) { this.killed = true; },
+    killed: false,
+    writes,
+    emitData: (d) => dataCb?.(d),
+    emitExit: (c) => exitCb?.({ exitCode: c }),
+  };
+}
+
+describe('createTerminalHostChild (unit, fake pty)', () => {
+  it('spawns, forwards data/exit, and routes write/kill by id', () => {
+    const sent: TerminalHostEvent[] = [];
+    const pty = fakePty();
+    const child = createTerminalHostChild({ spawn: () => pty, send: (e) => sent.push(e) });
+
+    const spawnReq: TerminalHostRequest = {
+      type: 'spawn',
+      id: 'a',
+      spec: { file: '/bin/sh', args: [], cols: 80, rows: 24, cwd: '/tmp', env: {} },
+    };
+    child.handle(spawnReq);
+    expect(sent).toContainEqual({ type: 'spawned', id: 'a', pid: 4242 });
+    expect(child.size()).toBe(1);
+
+    pty.emitData('hello');
+    expect(sent).toContainEqual({ type: 'data', id: 'a', data: 'hello' });
+
+    child.handle({ type: 'write', id: 'a', data: 'ls\n' });
+    expect(pty.writes).toEqual(['ls\n']);
+
+    // write/kill to an unknown id must be a no-op (not throw)
+    expect(() => child.handle({ type: 'write', id: 'nope', data: 'x' })).not.toThrow();
+
+    pty.emitExit(0);
+    expect(sent).toContainEqual({ type: 'exit', id: 'a', exitCode: 0, signal: undefined });
+    expect(child.size()).toBe(0);
+  });
+
+  it('reports spawn-error when the pty throws', () => {
+    const sent: TerminalHostEvent[] = [];
+    const child = createTerminalHostChild({
+      spawn: () => { throw new Error('node-pty not available'); },
+      send: (e) => sent.push(e),
+    });
+    child.handle({ type: 'spawn', id: 'z', spec: { file: 'x', args: [], cols: 1, rows: 1, cwd: '/', env: {} } });
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ type: 'spawn-error', id: 'z' });
+    expect(child.size()).toBe(0);
+  });
+});
+
+// ── Real fork: full IPC round-trip through terminal-host-entry.ts ────────────
+
+describe('ChildTerminalHost (real fork over IPC)', () => {
+  it('round-trips spawn → data → exit with a real node-pty child', async () => {
+    const host = createChildTerminalHost();
+    try {
+      expect(host.mode).toBe('child');
+      const handle = host.spawn({
+        file: '/bin/sh',
+        args: ['-c', 'printf hello-terminal-host; exit 7'],
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp',
+        env: { PATH: process.env.PATH ?? '/usr/bin:/bin' },
+      });
+
+      let buffer = '';
+      const exit = await new Promise<{ exitCode: number }>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`no exit; buffer=${JSON.stringify(buffer)}`)), 15000);
+        handle.onData((d) => { buffer += d; });
+        handle.onExit((e) => { clearTimeout(timer); resolve(e); });
+      });
+
+      expect(buffer).toContain('hello-terminal-host');
+      expect(exit.exitCode).toBe(7);
+    } finally {
+      host.dispose();
+    }
+  }, 20000);
+
+  it('delivers write() to the child pty and echoes it back', async () => {
+    const host = createChildTerminalHost();
+    try {
+      // `cat` echoes stdin back through the PTY.
+      const handle = host.spawn({
+        file: '/bin/cat',
+        args: [],
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp',
+        env: { PATH: process.env.PATH ?? '/usr/bin:/bin' },
+      });
+
+      let buffer = '';
+      const got = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`no echo; buffer=${JSON.stringify(buffer)}`)), 15000);
+        handle.onData((d) => {
+          buffer += d;
+          if (buffer.includes('ping-1498')) { clearTimeout(timer); resolve(); }
+        });
+      });
+
+      // Give the fork a beat to spawn before writing.
+      await new Promise((r) => setTimeout(r, 400));
+      handle.write('ping-1498\n');
+      await got;
+      expect(buffer).toContain('ping-1498');
+    } finally {
+      host.dispose();
+    }
+  }, 20000);
+});

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -190,6 +190,11 @@ import {
   fetchWithRetry,
   fetchNextJson,
 } from './lib/ws-server/next-fetch';
+import {
+  createInlineTerminalHost,
+  createChildTerminalHost,
+  type TerminalHost,
+} from './lib/ws-server/terminal-host-client';
 
 const execFileAsync = promisify(execFile);
 
@@ -217,11 +222,33 @@ async function listRepoPaths(): Promise<string[]> {
   }
 }
 
-// ── node-pty (optional — terminal feature) ──
-let pty: typeof import('node-pty') | null = null;
+// ── node-pty + terminal-host (#1498 follow-up) ──
+// PTYs are spawned through a TerminalHost seam. Default 'inline' (node-pty in
+// this process — historical behavior). O8_TERMINAL_HOST=child forks a separate
+// terminal-host process so a PTY wedge or runaway data pump in either process
+// can't freeze the other's event loop. WS protocol is byte-identical either
+// way. Default is inline: the child path is built + fork-tested in dev but not
+// yet proven in a packaged build, so it's opt-in.
+let terminalHost: TerminalHost | null = null;
+const TERMINAL_HOST_MODE: 'inline' | 'child' =
+  (process.env.O8_TERMINAL_HOST ?? '').trim().toLowerCase() === 'child' ? 'child' : 'inline';
+
+if (TERMINAL_HOST_MODE === 'child') {
+  try {
+    terminalHost = createChildTerminalHost({ log: (m) => console.log(`[terminal-host] ${m}`) });
+    console.log('[ws-server] terminal-host: child mode (forked terminal-host process)');
+  } catch (err) {
+    console.warn(`[ws-server] terminal-host child failed to start — falling back to inline: ${err instanceof Error ? err.message : String(err)}`);
+    terminalHost = null; // inline path below picks up when node-pty loads
+  }
+}
+
 void import('node-pty')
   .then((mod) => {
-    pty = mod;
+    // Inline mode (or child fallback): back the host with in-process node-pty.
+    if (!terminalHost) {
+      terminalHost = createInlineTerminalHost(mod);
+    }
     console.log('[ws-server] node-pty loaded — terminal feature available');
   })
   .catch(() => {
@@ -1184,7 +1211,7 @@ function spawnDashShellPty(
   rows: number,
   requestedCwd?: string,
 ) {
-  if (!pty) {
+  if (!terminalHost) {
     throw new Error('node-pty not available');
   }
 
@@ -1195,7 +1222,9 @@ function spawnDashShellPty(
     ?? process.env.HOME ?? homedir() ?? '/tmp';
 
   console.log(`[ws-server] Spawning dashboard PTY shell: ${shell} -l (${sessionName})`);
-  return pty.spawn(shell, ['-l'], {
+  return terminalHost.spawn({
+    file: shell,
+    args: ['-l'],
     name: 'xterm-256color',
     cols,
     rows,
@@ -1390,7 +1419,7 @@ function spawnManagedCommandPty(
   rows: number,
   envOverrides?: Record<string, string>,
 ) {
-  if (!pty) {
+  if (!terminalHost) {
     throw new Error('node-pty not available');
   }
 
@@ -1402,7 +1431,9 @@ function spawnManagedCommandPty(
   };
 
   console.log(`[ws-server] Spawning managed PTY session: ${shell} -lc <command> (${sessionName})`);
-  return pty.spawn(shell, ['-l', '-c', shellCommand], {
+  return terminalHost.spawn({
+    file: shell,
+    args: ['-l', '-c', shellCommand],
     name: 'xterm-256color',
     cols,
     rows,
@@ -1515,7 +1546,7 @@ function spawnTmuxAttachPty(
   cols: number,
   rows: number,
 ) {
-  if (!pty) {
+  if (!terminalHost) {
     throw new Error('node-pty not available');
   }
 
@@ -1525,7 +1556,9 @@ function spawnTmuxAttachPty(
 
   try {
     console.log(`[ws-server] Spawning terminal directly: ${tmuxBin} attach-session -t ${sessionName}`);
-    return pty.spawn(tmuxBin, ['attach-session', '-t', sessionName], {
+    return terminalHost.spawn({
+      file: tmuxBin,
+      args: ['attach-session', '-t', sessionName],
       name: 'xterm-256color',
       cols,
       rows,
@@ -1537,7 +1570,9 @@ function spawnTmuxAttachPty(
     const shellCmd = `exec "${tmuxBin}" attach-session -t ${sessionName}`;
     console.warn(`[ws-server] Direct tmux PTY spawn failed, falling back to shell wrapper: ${directError instanceof Error ? directError.message : String(directError)}`);
     console.log(`[ws-server] Spawning terminal via shell: ${shellCmd}`);
-    return pty.spawn(shell, ['-l', '-c', shellCmd], {
+    return terminalHost.spawn({
+      file: shell,
+      args: ['-l', '-c', shellCmd],
       name: 'xterm-256color',
       cols,
       rows,
@@ -4011,7 +4046,7 @@ function materializePendingDashSession(
 }
 
 function handleTerminalCreate(client: ClientState, msg: Record<string, unknown>) {
-  if (!pty) {
+  if (!terminalHost) {
     sendTerminal(client, 'error', { sessionName: '', error: 'Terminal not available (node-pty not installed)' });
     return;
   }
@@ -4048,7 +4083,7 @@ function handleTerminalAttach(client: ClientState, msg: Record<string, unknown>)
     return;
   }
 
-  if (!pty) {
+  if (!terminalHost) {
     sendTerminal(client, 'error', { sessionName, error: 'Terminal not available (node-pty not installed)' });
     return;
   }
@@ -4558,7 +4593,7 @@ const httpServer = createServer((req, res) => {
         res.end('invalid session name');
         return;
       }
-      if (!pty) {
+      if (!terminalHost) {
         res.writeHead(503);
         res.end('node-pty unavailable');
         return;
@@ -6348,6 +6383,8 @@ function shutdown(signal: string) {
     try { att.ptyProcess.kill(); } catch { /* already gone */ }
   }
   terminalAttachments.clear();
+  // Tear down the forked terminal-host (child mode); no-op inline.
+  try { terminalHost?.dispose(); } catch { /* already gone */ }
 
   // Send close frame to every client so they reconnect cleanly
   for (const client of clients.values()) {

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -168,6 +168,7 @@ import {
   recordRealtimeBridgeFailure,
   recordRealtimeBridgeSuccess,
 } from './lib/realtime/bridge-backoff';
+import { WsWatchdog } from './lib/ws-server/health-watchdog';
 
 const execFileAsync = promisify(execFile);
 
@@ -204,6 +205,12 @@ const NEXT_FETCH_INITIAL_BACKOFF_MS = 100;
 const BACKPRESSURE_LIMIT = 64 * 1024; // 64KB — queue durable messages if client buffer exceeds this
 const BACKPRESSURE_QUEUE_LIMIT = 32; // max queued messages per client before oldest are dropped
 const BACKPRESSURE_FLUSH_MS = 50; // check interval to flush queued messages
+
+// Event-loop lag watchdog (#1498 structural follow-up). ws-server pumps every
+// mobile client, PTY, and orchestrator stream on this one loop; a sync wedge
+// freezes them all. Sample loop lag; log + count sustained wedges. Cheap when
+// healthy, queryable via /health.
+const wsWatchdog = new WsWatchdog();
 
 const RETRYABLE_NEXT_FETCH_CODES = new Set([
   'ECONNREFUSED',
@@ -5323,6 +5330,7 @@ const httpServer = createServer((req, res) => {
       status: 'ok',
       clients: clients.size,
       gateway: 'disabled',
+      eventLoop: wsWatchdog.getStats(),
     }));
     return;
   }
@@ -5834,6 +5842,7 @@ httpServer.on('error', (err: NodeJS.ErrnoException) => {
       setTimeout(() => {
         httpServer.listen(WS_PORT, '0.0.0.0', () => {
           console.log(`[ws-server] o8 WebSocket server listening on ws://0.0.0.0:${WS_PORT}/ws`);
+          wsWatchdog.start(); // idempotent — covers the port-reclaim retry path
         });
       }, 500);
     } catch {
@@ -5980,6 +5989,9 @@ async function bootstrapWsServer() {
 
   httpServer.listen(WS_PORT, '0.0.0.0', () => {
     console.log(`[ws-server] o8 WebSocket server listening on ws://0.0.0.0:${WS_PORT}/ws`);
+
+    // Begin event-loop lag sampling (#1498 follow-up).
+    wsWatchdog.start();
 
     // ── Start Agent Supervisor ──
     const supervisorCallbacks: SupervisorCallbacks = {
@@ -6504,6 +6516,7 @@ function shutdown(signal: string) {
   stopWorktreeReaper();
   stopLaneZombieReaper();
   stopDashSessionGc();
+  wsWatchdog.stop();
   clearInterval(stallCheckTimer);
   if (runtimeRefreshTimer) clearTimeout(runtimeRefreshTimer);
   if (mobileRefreshTimer) clearTimeout(mobileRefreshTimer);

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -56,7 +56,7 @@ migrateDataDirOnce();
 
 import { expireStaleApprovals } from '@/lib/approvals/store';
 import { getDb } from '@/lib/db';
-import { getApiBase, resolvePortInfo } from '@/lib/panel/api-port';
+import { resolvePortInfo } from '@/lib/panel/api-port';
 import {
   startAgentSession,
   updateAgentStatus,
@@ -170,6 +170,26 @@ import {
   recordRealtimeBridgeSuccess,
 } from './lib/realtime/bridge-backoff';
 import { WsWatchdog } from './lib/ws-server/health-watchdog';
+import {
+  sanitizePtyEnv,
+  resolvePreferredShell,
+  resolveTmuxBinary,
+  tmuxSessionExists,
+  isDashTerminalSession,
+} from './lib/ws-server/pty-support';
+import { parseGitWorktreeList, shortHome } from './lib/ws-server/git-worktrees';
+import {
+  BACKPRESSURE_LIMIT,
+  BACKPRESSURE_QUEUE_LIMIT,
+  BACKPRESSURE_FLUSH_MS,
+  isLossyMessage,
+} from './lib/ws-server/channels';
+import {
+  FETCH_TIMEOUT_MS,
+  buildNextUrl,
+  fetchWithRetry,
+  fetchNextJson,
+} from './lib/ws-server/next-fetch';
 
 const execFileAsync = promisify(execFile);
 
@@ -212,26 +232,11 @@ void import('node-pty')
 
 const { wsPort: WS_PORT } = resolvePortInfo();
 const PING_INTERVAL_MS = 25_000;
-const FETCH_TIMEOUT_MS = 8_000;
-const NEXT_FETCH_MAX_ATTEMPTS = 5;
-const NEXT_FETCH_INITIAL_BACKOFF_MS = 100;
-const BACKPRESSURE_LIMIT = 64 * 1024; // 64KB — queue durable messages if client buffer exceeds this
-const BACKPRESSURE_QUEUE_LIMIT = 32; // max queued messages per client before oldest are dropped
-const BACKPRESSURE_FLUSH_MS = 50; // check interval to flush queued messages
-
 // Event-loop lag watchdog (#1498 structural follow-up). ws-server pumps every
 // mobile client, PTY, and orchestrator stream on this one loop; a sync wedge
 // freezes them all. Sample loop lag; log + count sustained wedges. Cheap when
 // healthy, queryable via /health.
 const wsWatchdog = new WsWatchdog();
-
-const RETRYABLE_NEXT_FETCH_CODES = new Set([
-  'ECONNREFUSED',
-  'ECONNRESET',
-  'EHOSTUNREACH',
-  'ENOTFOUND',
-  'UND_ERR_SOCKET',
-]);
 
 interface RuntimeTranscriptApiEntry {
   id: string;
@@ -242,88 +247,6 @@ interface RuntimeTranscriptApiEntry {
   timestampLabel: string;
   toolName?: string;
   filePath?: string;
-}
-
-function getNextOrigin() {
-  return process.env.NEXT_ORIGIN ?? getApiBase();
-}
-
-function buildNextUrl(pathname: string, searchParams?: URLSearchParams) {
-  const query = searchParams && searchParams.size > 0 ? `?${searchParams.toString()}` : '';
-  return `${getNextOrigin()}${pathname}${query}`;
-}
-
-function getNextFetchErrorCode(error: Error): string | null {
-  const cause = (error as Error & { cause?: unknown }).cause;
-  if (!cause || typeof cause !== 'object') return null;
-  const code = (cause as { code?: unknown }).code;
-  return typeof code === 'string' ? code : null;
-}
-
-function isRetryableNextFetchError(error: unknown) {
-  if (!(error instanceof Error)) return false;
-  if (error.name === 'AbortError' || error.name === 'TimeoutError') return false;
-  const code = getNextFetchErrorCode(error);
-  return error.message === 'fetch failed' || (code !== null && RETRYABLE_NEXT_FETCH_CODES.has(code));
-}
-
-function delayNextFetchRetry(delayMs: number) {
-  return new Promise<void>((resolve) => {
-    setTimeout(resolve, delayMs);
-  });
-}
-
-async function fetchWithRetry(input: string, init: RequestInit): Promise<Response> {
-  let backoffMs = NEXT_FETCH_INITIAL_BACKOFF_MS;
-
-  for (let attempt = 1; attempt <= NEXT_FETCH_MAX_ATTEMPTS; attempt += 1) {
-    try {
-      return await fetch(input, init);
-    } catch (error) {
-      if (attempt === NEXT_FETCH_MAX_ATTEMPTS || !isRetryableNextFetchError(error)) {
-        throw error;
-      }
-
-      await delayNextFetchRetry(backoffMs);
-      backoffMs *= 2;
-    }
-  }
-
-  throw new Error('[ws-server] internal fetch retry loop exited unexpectedly');
-}
-
-async function fetchNextJson<T>(
-  pathname: string,
-  options: {
-    method?: 'GET' | 'POST';
-    searchParams?: URLSearchParams;
-    body?: unknown;
-    timeoutMs?: number;
-  } = {},
-): Promise<T> {
-  const headers: Record<string, string> = {
-    Authorization: `Bearer ${WS_TOKEN}`,
-  };
-  if (options.body !== undefined) {
-    headers['Content-Type'] = 'application/json';
-  }
-
-  const response = await fetchWithRetry(buildNextUrl(pathname, options.searchParams), {
-    method: options.method ?? 'GET',
-    headers,
-    body: options.body === undefined ? undefined : JSON.stringify(options.body),
-    signal: AbortSignal.timeout(options.timeoutMs ?? FETCH_TIMEOUT_MS),
-  });
-
-  const payload = await response.json().catch(() => null);
-  if (!response.ok) {
-    const error = payload && typeof payload === 'object' && 'error' in payload
-      ? String((payload as { error?: string }).error ?? '')
-      : '';
-    throw new Error(error || `${pathname} failed (${response.status})`);
-  }
-
-  return payload as T;
 }
 
 // ── Boot readiness probe ──
@@ -1255,79 +1178,6 @@ async function drainOrchestratorAutoQueue(): Promise<void> {
 // handleTerminalImage, getReviewWatchTargets/listRepoPaths — ARE async now.
 // Remaining sync FS is startup/module-init only (git-watcher setup, port
 // reclaim, bootstrap worktree prune) or the deferred terminal chain above.
-function sanitizePtyEnv() {
-  const env: Record<string, string> = {};
-  for (const [key, value] of Object.entries(process.env)) {
-    if (typeof value === 'string') {
-      env[key] = value;
-    }
-  }
-  env.TERM = 'xterm-256color';
-  env.LANG = env.LANG || 'en_US.UTF-8';
-  env.LC_ALL = env.LC_ALL || 'en_US.UTF-8';
-  env.PATH = env.PATH || '/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin';
-  return env;
-}
-
-function resolvePreferredShell() {
-  const candidates = [
-    process.env.SHELL,
-    '/bin/zsh',
-    '/bin/bash',
-    '/bin/sh',
-  ].filter((value): value is string => Boolean(value));
-
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) return candidate;
-  }
-
-  return '/bin/sh';
-}
-
-function resolveTmuxBinary() {
-  const candidates = [
-    process.env.TMUX_BIN,
-    '/opt/homebrew/bin/tmux',
-    '/usr/local/bin/tmux',
-    '/usr/bin/tmux',
-    '/bin/tmux',
-  ].filter((value): value is string => Boolean(value));
-
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) return candidate;
-  }
-
-  try {
-    return execSync('command -v tmux', {
-      encoding: 'utf-8',
-      timeout: 3000,
-      env: sanitizePtyEnv() as NodeJS.ProcessEnv,
-    }).trim() || 'tmux';
-  } catch {
-    return 'tmux';
-  }
-}
-
-function tmuxSessionExists(sessionName: string) {
-  const target = sessionName.trim();
-  if (!target) return false;
-
-  try {
-    execFileSync(resolveTmuxBinary(), ['has-session', '-t', target], {
-      timeout: 2000,
-      stdio: 'ignore',
-      env: sanitizePtyEnv() as NodeJS.ProcessEnv,
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function isDashTerminalSession(sessionName: string) {
-  return sessionName.startsWith('cortex-dash-');
-}
-
 function spawnDashShellPty(
   sessionName: string,
   cols: number,
@@ -1724,38 +1574,6 @@ function extractText(delta: ChatDelta): string {
     .join('');
 }
 
-/**
- * Determine whether a message is "lossy" (safe to drop under backpressure)
- * or "durable" (must be queued and flushed later).
- *
- * Lossy channels: chat deltas, terminal data, pong — all are either
- * inherently lossy or recovered by higher-level mechanisms.
- */
-function isLossyMessage(json: string): boolean {
-  // Fast path: avoid parsing — check for known lossy patterns
-  const maybeLossy =
-    json.includes('"channel":"pong"') ||
-    // Chat deltas (not done/error) are lossy
-    (json.includes('"channel":"chat"') && json.includes('"event":"delta"')) ||
-    // Terminal data frames are lossy (PTY output is best-effort)
-    (json.includes('"channel":"terminal"') && json.includes('"event":"data"')) ||
-    // Orchestrator output chunks are lossy (intermediate deltas can be dropped)
-    (json.includes('"channel":"orchestrator"') && json.includes('"event":"output"'));
-  if (!maybeLossy) return false;
-  // Confirm with a real parse: payload text that merely *contains* one of the
-  // marker substrings (e.g. an agent quoting protocol frames) must not cause
-  // a durable message to be silently dropped. Only runs under backpressure.
-  try {
-    const msg = JSON.parse(json) as { channel?: unknown; event?: unknown };
-    if (msg.channel === 'pong') return true;
-    if (msg.channel === 'chat' && msg.event === 'delta') return true;
-    if (msg.channel === 'terminal' && msg.event === 'data') return true;
-    if (msg.channel === 'orchestrator' && msg.event === 'output') return true;
-    return false;
-  } catch {
-    return false; // unparseable → treat as durable (safer)
-  }
-}
 
 /** Flush any queued durable messages once backpressure clears. */
 function flushBackpressureQueue(client: ClientState) {
@@ -5539,35 +5357,6 @@ const REVIEW_POLL_INTERVAL_MS = 10_000;
 const REVIEW_SCAN_CONCURRENCY = 3;
 let reviewRefreshInFlight = false;
 let reviewRefreshRerequest = false;
-
-type GitWorktreeRecord = {
-  path: string;
-  branch: string | null;
-};
-
-function shortHome(filePath: string) {
-  const home = process.env.HOME ?? homedir();
-  return filePath.startsWith(`${home}/`) ? filePath.replace(`${home}/`, '~/') : filePath;
-}
-
-function parseGitWorktreeList(raw: string): GitWorktreeRecord[] {
-  const worktrees: GitWorktreeRecord[] = [];
-  let current: GitWorktreeRecord | null = null;
-
-  for (const line of raw.split('\n')) {
-    if (line.startsWith('worktree ')) {
-      current = { path: line.slice('worktree '.length), branch: null };
-      worktrees.push(current);
-      continue;
-    }
-    if (!current) continue;
-    if (line.startsWith('branch refs/heads/')) {
-      current.branch = line.slice('branch refs/heads/'.length);
-    }
-  }
-
-  return worktrees;
-}
 
 async function pruneOrphanedCodexWorktreeBranches(repoPath: string): Promise<number> {
   // `git worktree prune` only removes admin entries for deleted git-worktree

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -42,7 +42,8 @@
  *   pong              — LOSSY: keepalive response, loss is harmless.
  */
 
-import { readFileSync, statSync, watch, existsSync } from 'node:fs';
+import { watch, existsSync } from 'node:fs';
+import { readFile, stat, access } from 'node:fs/promises';
 import { basename, extname, join, resolve } from 'node:path';
 import { execSync, execFile, execFileSync } from 'node:child_process';
 import { createServer } from 'node:http';
@@ -172,11 +173,23 @@ import { WsWatchdog } from './lib/ws-server/health-watchdog';
 
 const execFileAsync = promisify(execFile);
 
+// Async existence check — never blocks the shared event loop for FS calls on
+// per-message / per-poll hot paths (the #1498 exposure class). Startup-only
+// probes may still use existsSync.
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // Read repo registry directly (avoid importing registry.ts which uses 'server-only')
-function listRepoPathsSync(): string[] {
+async function listRepoPaths(): Promise<string[]> {
   try {
     const registryPath = join(homedir(), '.o8', 'repos.json');
-    const raw = readFileSync(registryPath, 'utf-8');
+    const raw = await readFile(registryPath, 'utf-8');
     const store = JSON.parse(raw) as { repos?: Array<{ localPath?: string }> };
     return (store.repos ?? []).map(r => r.localPath).filter(Boolean) as string[];
   } catch {
@@ -901,9 +914,9 @@ const METERED_WINDOW_VALVE_STEP_TOKENS = 60_000;
 const meteredWindowValveWarnedStep = new Map<string, number>();
 
 /** Approximate persisted-thread tokens from the chat-history file (chars/4). */
-function estimateThreadTokens(threadId: string): number {
+async function estimateThreadTokens(threadId: string): Promise<number> {
   try {
-    const raw = readFileSync(join(homedir(), '.o8', 'chat-history', `${threadId}.json`), 'utf-8');
+    const raw = await readFile(join(homedir(), '.o8', 'chat-history', `${threadId}.json`), 'utf-8');
     const payload = JSON.parse(raw) as { messages?: Array<{ text?: string; content?: string }> };
     const chars = (payload.messages ?? []).reduce((sum, m) => sum + (m.text ?? m.content ?? '').length, 0);
     return Math.ceil(chars / 4);
@@ -1229,6 +1242,19 @@ async function drainOrchestratorAutoQueue(): Promise<void> {
 // Orchestrator now uses structured JSON output (stream-json) instead of PTY.
 // See orchestrator-session.ts for the new approach.
 
+// ── Sync-FS note (#1498 sweep) ──────────────────────────────────────────────
+// The tmux helpers below still use execFileSync (has-session / new-session /
+// capture-pane / kill-session) and a couple of existsSync probes. These are
+// intentionally NOT converted to async in this sweep: they are wired into a
+// synchronous terminal create/attach call chain (materializePendingDashSession
+// → createDashTmuxSessionSync → spawn*Pty → registerTerminalAttachment) and
+// threading async through it piecemeal would (a) be invasive and (b) be redone
+// by the terminal-host extraction, which moves ALL PTY/tmux work off this event
+// loop into a forked child process (the real structural fix). The pure-FS hot
+// paths that touch the loop per-message/per-poll — estimateThreadTokens,
+// handleTerminalImage, getReviewWatchTargets/listRepoPaths — ARE async now.
+// Remaining sync FS is startup/module-init only (git-watcher setup, port
+// reclaim, bootstrap worktree prune) or the deferred terminal chain above.
 function sanitizePtyEnv() {
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
@@ -2961,7 +2987,7 @@ function handleClientMessage(client: ClientState, raw: string) {
       handleTerminalDetach(client, msg);
       break;
     case 'terminal-image':
-      handleTerminalImage(client, msg);
+      void handleTerminalImage(client, msg);
       break;
     case 'agent-kill':
       handleAgentKill(client, msg);
@@ -3461,7 +3487,7 @@ async function handleOrchestratorSendMsg(client: ClientState, msg: Record<string
     // notice banner each time the persisted thread crosses another 60K-token
     // step past the metered target.
     if (threadId && isMeteredOrchestratorBackend(activeBackend.id)) {
-      const approxThreadTokens = estimateThreadTokens(threadId);
+      const approxThreadTokens = await estimateThreadTokens(threadId);
       const step = Math.floor(approxThreadTokens / METERED_WINDOW_VALVE_STEP_TOKENS);
       if (step >= 1 && (meteredWindowValveWarnedStep.get(threadId) ?? 0) < step) {
         meteredWindowValveWarnedStep.set(threadId, step);
@@ -4392,7 +4418,7 @@ const TERMINAL_IMAGE_EXTENSIONS = new Set([
 ]);
 const TERMINAL_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
 
-function handleTerminalImage(_client: ClientState, msg: Record<string, unknown>) {
+async function handleTerminalImage(_client: ClientState, msg: Record<string, unknown>) {
   const sessionName = typeof msg.sessionName === 'string' ? msg.sessionName : '';
   const filePath = typeof msg.filePath === 'string' ? msg.filePath : '';
   if (!sessionName || !filePath) return;
@@ -4407,12 +4433,12 @@ function handleTerminalImage(_client: ClientState, msg: Record<string, unknown>)
       console.log(`[ws-server] terminal-image: refused non-image path ${resolved}`);
       return;
     }
-    const stat = statSync(resolved);
-    if (!stat.isFile() || stat.size > TERMINAL_IMAGE_MAX_BYTES) {
+    const fileStat = await stat(resolved);
+    if (!fileStat.isFile() || fileStat.size > TERMINAL_IMAGE_MAX_BYTES) {
       console.log(`[ws-server] terminal-image: refused ${resolved} (not a regular file or too large)`);
       return;
     }
-    const data = readFileSync(resolved);
+    const data = await readFile(resolved);
     const b64 = data.toString('base64');
     const filename = basename(resolved);
     // Send raw components — client builds the IIP escape sequence
@@ -5619,7 +5645,7 @@ async function pruneOrphanedCodexWorktreeBranches(repoPath: string): Promise<num
 
 async function getReviewWatchTargets() {
   const repoPaths = new Set<string>([REPO_ROOT]);
-  for (const p of listRepoPathsSync()) {
+  for (const p of await listRepoPaths()) {
     repoPaths.add(resolve(p));
   }
 
@@ -5630,8 +5656,8 @@ async function getReviewWatchTargets() {
 
     try {
       const metaPath = resolve(repoPath, '.cortex-worktrees', '.meta.json');
-      if (!existsSync(metaPath)) continue;
-      const raw = readFileSync(metaPath, 'utf-8');
+      if (!(await pathExists(metaPath))) continue;
+      const raw = await readFile(metaPath, 'utf-8');
       const meta = JSON.parse(raw) as {
         worktrees?: Record<string, { id: string; sessionKey?: string; claudeManaged?: boolean }>;
       };
@@ -5639,7 +5665,7 @@ async function getReviewWatchTargets() {
         const workspacePath = worktree.claudeManaged
           ? resolve(repoPath, '.claude', 'worktrees', worktree.id)
           : resolve(repoPath, '.cortex-worktrees', worktree.id);
-        if (!existsSync(workspacePath)) continue;
+        if (!(await pathExists(workspacePath))) continue;
         targets.push({
           repoPath,
           workspacePath,

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -195,6 +195,9 @@ import {
   createChildTerminalHost,
   type TerminalHost,
 } from './lib/ws-server/terminal-host-client';
+import { installProcessCrashCapture } from './lib/telemetry/crash-capture';
+
+installProcessCrashCapture('ws-server');
 
 const execFileAsync = promisify(execFile);
 
@@ -5266,6 +5269,13 @@ const wss = new WebSocketServer({
     }
     done(false, 401, 'Unauthorized');
   },
+});
+
+// The httpServer has its own 'error' handler (stale-port recovery below), but the
+// WebSocketServer can emit 'error' independently (e.g. during upgrade handling).
+// Without a listener that's an uncaughtException that kills every connected client.
+wss.on('error', (err) => {
+  console.error('[ws-server] WebSocketServer error (non-fatal):', err);
 });
 
 wss.on('connection', (ws, req) => {

--- a/tests/middleware-gate.test.ts
+++ b/tests/middleware-gate.test.ts
@@ -183,6 +183,26 @@ describe('panelGateMiddleware — loopback trust', () => {
     expect(res.status).toBe(200);
   });
 
+  it('gates /api/telemetry/crash (renderer crash sink) against LAN', () => {
+    const res = panelGateMiddleware(
+      gatedRequest('http://192.168.1.50:3001/api/telemetry/crash', {
+        method: 'POST',
+        headers: { host: '192.168.1.50:3001' },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('passes /api/telemetry/crash from loopback (the webview origin)', () => {
+    const res = panelGateMiddleware(
+      gatedRequest('http://localhost:3001/api/telemetry/crash', {
+        method: 'POST',
+        headers: { host: 'localhost:3001' },
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
   it('gates /api/invites (beta founding-invite codes) against LAN', () => {
     const res = panelGateMiddleware(
       gatedRequest('http://192.168.1.50:3001/api/invites', {


### PR DESCRIPTION
Executive-audit follow-through (see docs/beta-exit-roadmap.md in this PR for the full five-rock roadmap). This PR builds **rock 2** and **rock 4** against 0.1.566.

## Rock 2 — Telemetry + updater safety (one program)
- Process-level crash capture (Next server + ws-server), local ring-buffered store under `~/.o8/telemetry/`
- Renderer error capture into the same store
- Opt-in (default OFF) batched upload, `O8_TELEMETRY_INGEST_URL`-configured; Settings toggle
- Updater kill-switch via release-health manifest (fail-open)
- Operator rollback path to the previous signed release

## Rock 4 — ws-server decomposition
- Event-loop lag watchdog + health surface
- Sync FS calls off the WS event loop hot paths (41 today)
- PTY/terminal host isolated off the main event loop (child process)
- `ws-server.ts` (6,307 lines) decomposed into modules; LOSSY/DURABLE channel semantics unchanged

Draft until both rocks land verified (tsc + vitest green, real-path tests for new seams).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NP8SdT614MD5biFQotaPqr