### PR TITLE
feat: add composer undo-send buffer

### DIFF
--- a/src/app/preview/canvas-glass/use-send-buffer.tsx
+++ b/src/app/preview/canvas-glass/use-send-buffer.tsx
@@ -21,14 +21,19 @@
  * value lives in the composer).
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
+import {
+  SEND_UNDO_GRACE_MS,
+  useComposerSendBuffer,
+  type ComposerSendBuffer,
+  type ComposerSendImage,
+  type QueuedComposerSend,
+} from '@/lib/hooks/use-composer-send-buffer';
 import { FONT } from './ui';
 
-export const SEND_UNDO_GRACE_MS = 4500;
-
-export interface ComposerImage { name: string; dataUri: string }
-export interface QueuedSend { id: number; text: string; images: ComposerImage[] }
+export { SEND_UNDO_GRACE_MS };
+export type ComposerImage = ComposerSendImage;
+export type QueuedSend = QueuedComposerSend;
 
 /** Where an undo would truncate the transcript back to. Returned by a
  *  successful dispatch; null means the send never went out (don't arm undo). */
@@ -49,101 +54,17 @@ export interface SendBufferConfig {
   truncate: (lane: string, fromEntryId: number) => void;
 }
 
-export interface SendBuffer {
-  /** Queue when busy, else dispatch + arm the undo window. Returns true when
-   *  the message was accepted (so the composer can clear). */
-  send: (text: string, images?: ComposerImage[]) => boolean;
-  /** Always stops the run; within the grace window also restores + erases. */
-  stopOrUndo: () => void;
-  /** A just-sent message is still take-back-able. */
-  undoArmed: boolean;
-  queued: QueuedSend[];
-  cancelQueued: (id: number) => void;
-}
+export type SendBuffer = ComposerSendBuffer;
 
 export function useSendBuffer(config: SendBufferConfig): SendBuffer {
-  // Host callbacks change identity every render; mirror them so the edge
-  // effect and stable callbacks below always see the latest without re-running.
-  const cfgRef = useRef(config);
-  cfgRef.current = config;
-  const graceMs = config.graceMs ?? SEND_UNDO_GRACE_MS;
-
-  const [queued, setQueued] = useState<QueuedSend[]>([]);
-  const queuedRef = useRef(queued);
-  queuedRef.current = queued;
-  const idRef = useRef(1);
-
-  const [undoArmed, setUndoArmed] = useState(false);
-  const undoRef = useRef<{ text: string; images: ComposerImage[]; lane: string; fromEntryId: number } | null>(null);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const prevBusyRef = useRef(config.busy);
-
-  const disarm = useCallback(() => {
-    if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
-    undoRef.current = null;
-    setUndoArmed(false);
-  }, []);
-
-  const arm = useCallback((handle: DispatchHandle, text: string, images: ComposerImage[]) => {
-    if (timerRef.current) clearTimeout(timerRef.current);
-    undoRef.current = { text, images, lane: handle.lane, fromEntryId: handle.fromEntryId };
-    setUndoArmed(true);
-    timerRef.current = setTimeout(() => {
-      timerRef.current = null;
-      undoRef.current = null;
-      setUndoArmed(false);
-    }, graceMs);
-  }, [graceMs]);
-
-  const send = useCallback((text: string, images: ComposerImage[] = []) => {
-    const trimmed = text.trim();
-    if (!trimmed) return false;
-    if (cfgRef.current.busy) {
-      const id = idRef.current;
-      idRef.current += 1;
-      setQueued((previous) => [...previous, { id, text: trimmed, images }]);
-      return true;
-    }
-    const handle = cfgRef.current.dispatch(trimmed, images);
-    if (!handle) return false;
-    arm(handle, trimmed, images);
-    return true;
-  }, [arm]);
-
-  const stopOrUndo = useCallback(() => {
-    cfgRef.current.interrupt(); // the run always stops
-    const buf = undoRef.current;
-    if (!buf) return; // past the window — just a stop
-    disarm();
-    cfgRef.current.truncate(buf.lane, buf.fromEntryId);
-    cfgRef.current.restore(buf.text, buf.images);
-  }, [disarm]);
-
-  const cancelQueued = useCallback((id: number) => {
-    setQueued((previous) => previous.filter((item) => item.id !== id));
-  }, []);
-
-  // Busy → idle edge: the finished turn's undo window closes, and the next
-  // queued message fires. Edge-detection serializes the queue — the dispatched
-  // message flips busy back on, so the next one waits for the following edge.
-  useEffect(() => {
-    const was = prevBusyRef.current;
-    prevBusyRef.current = config.busy;
-    if (was && !config.busy) {
-      disarm();
-      const q = queuedRef.current;
-      if (q.length > 0) {
-        const [head, ...rest] = q;
-        setQueued(rest);
-        const handle = cfgRef.current.dispatch(head.text, head.images);
-        if (handle) arm(handle, head.text, head.images);
-      }
-    }
-  }, [config.busy, disarm, arm]);
-
-  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current); }, []);
-
-  return { send, stopOrUndo, undoArmed, queued, cancelQueued };
+  return useComposerSendBuffer({
+    busy: config.busy,
+    graceMs: config.graceMs,
+    dispatch: config.dispatch,
+    interrupt: config.interrupt,
+    restore: config.restore,
+    truncate: (handle) => config.truncate(handle.lane, handle.fromEntryId),
+  });
 }
 
 /** The take-it-back affordance — a quiet pill that surfaces for the grace

--- a/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
+++ b/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
@@ -28,7 +28,6 @@ import type {
 } from '@/lib/orchestrator/types';
 import type { OrchestratorBackendId } from '@/lib/lane/orchestrator-backends/types';
 import type { MobileTranscriptEntry } from '@/lib/mobile/types';
-import type { PendingSteer } from './chat-panel/PendingSteerCard';
 import { serializeThreadToMarkdown } from '@/lib/llm/export-thread';
 import {
   executeOrchestratorSlashCommand,
@@ -57,6 +56,8 @@ import { track } from '@/lib/analytics/track';
 import type { TurnSummary } from './chat-panel/TurnSummaryCard';
 import { ChatToastStack } from './chat-panel/ChatToastStack';
 import { ComposerArea } from './chat-panel/ComposerArea';
+import { ComposerSendBufferStatus } from './chat-panel/ComposerSendBufferStatus';
+import { useDefaultComposerSendBuffer } from './chat-panel/useDefaultComposerSendBuffer';
 import { shouldApplyAutoRestoreAfterFetch } from './chat-panel/autoRestoreGuard';
 import { loadOrchestrationMode, persistOrchestrationMode, type ChatModelId, type OrchestrationMode } from '@/components/desktop/orchestrator/ModePicker';
 import { useReadyRuntimeCount } from './use-ready-runtimes';
@@ -84,8 +85,6 @@ import { useSuggestedReplies } from './chat-panel/useSuggestedReplies';
 import { useThoughtsComposerAttachments } from './chat-panel/useThoughtsComposerAttachments';
 import { useThreadHistoryBackfill, type ThreadHistoryPage } from './chat-panel/useThreadHistoryBackfill';
 import { ScreenshotAnnotator } from './chat-panel/ScreenshotAnnotator';
-import { interruptRuntimeSurface } from './chat-panel/runtimeInterrupt';
-import { useSteerAutoFire } from './chat-panel/useSteerAutoFire';
 import { isAbortError } from '@/lib/active-long-lived-request';
 import { fetchWithLongLivedBudget } from '@/lib/connection-budget';
 import { useActiveLongLivedRequest } from '@/lib/use-active-long-lived-request';
@@ -412,12 +411,6 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
   const [planText, setPlanText] = useState<string | null>(null);
   const [waitingForReply, setWaitingForReply] = useState(false);
   const [targetAgentKey, setTargetAgentKey] = useState<string>('__claude__');
-  // ⌘⏎ steer queue. Held locally; not persisted across reloads (ephemeral
-  // intent). Head fires automatically when the agent goes idle (auto-fire
-  // useEffect below sendNow). editingSteerId pauses the auto-fire while the
-  // head row is being edited inline ([[borrow_conductor_steer_queue]]).
-  const [pendingSteers, setPendingSteers] = useState<PendingSteer[]>([]);
-  const [editingSteerId, setEditingSteerId] = useState<string | null>(null);
   const thinkingPreferenceTouchedRef = useRef(false);
   const pollRef = useRef<number | null>(null);
   const pollDelayRef = useRef<number | null>(null);
@@ -432,7 +425,6 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
   const responseSeenRef = useRef(false);
   const idlePollsRef = useRef(0);
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  const queuedSteerSendNowRef = useRef<(text?: string) => void>(() => {});
   const orchestratorSessionRef = useRef<string | null>(null);
   const singleRuntimeSessionRef = useRef<string | null>(null);
   const singleRuntimeLaunchPromiseRef = useRef<Promise<string | null> | null>(null);
@@ -1478,10 +1470,6 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
   // the empty-state check matches the empty-state-override condition.
   const composerRepoLabel = displayMessages.length === 0 ? null : composerRepoLabelBase;
   const displayWaiting = isChatMode ? false : isOrchestratorMode ? orchStream.status === 'busy' : (waitingForReply || (isSingleMode && singleRuntimeSpawning));
-  const { clearFiringSteerLatch } = useSteerAutoFire({
-    displayWaiting, isOrchestratorMode, pendingSteers, editingSteerId, setPendingSteers,
-    sendNowRef: queuedSteerSendNowRef,
-  });
   const displayPlanText = isOrchestratorMode && !isChatMode && planText?.trim() ? planText.trim() : null;
   const hasAssistantActivity = displayMessages.some((message) => message.role !== 'user');
   const activeBackendIdentity = isOrchestratorMode
@@ -1593,7 +1581,6 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
 
     if (prev !== 'busy' && next === 'busy') {
       // New turn started — clear stale summary and snapshot the baseline.
-      clearFiringSteerLatch();
       setTurnSummary(null);
       turnStartRef.current = {
         startedAt: Date.now(),
@@ -1682,7 +1669,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
         })();
       }
     }
-  }, [clearFiringSteerLatch, displayMessages, isChatMode, isOrchestratorMode, orchStream.runningTotal, orchStream.status, resolvedRepoPath]);
+  }, [displayMessages, isChatMode, isOrchestratorMode, orchStream.runningTotal, orchStream.status, resolvedRepoPath]);
 
   // Clear the summary when the thread changes — stale cards from a prior
   // thread should not bleed into the new one.
@@ -2106,64 +2093,44 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
     setTimeout(() => { void handleTaskSend(msg); }, 0);
     return true;
   }, [attachedImages, clearAttachments, handleTaskSend, isChatMode, isOrchestratorMode, orchStream, orchestratorBackend, orchestratorModel, permissionMode, runLocalOrchestratorSlash, thinkingEffort, swarmEnabled, soloOrchestrator, collideEnabled, waitingForReply]);
-  queuedSteerSendNowRef.current = sendNow;
 
-  // ⌘⏎ steer handlers. enqueueSteer routes the typed input through the queue:
-  // idle → fire immediately via sendNow; busy → push onto pendingSteers and let
-  // the auto-fire effect drain it when displayWaiting falls. handleSteerNow
-  // preempts the running turn by interrupting it; the steered row stays in the
-  // queue and gets picked up by the same auto-fire path on the next idle tick.
-  // Edit/Delete operate on the queue without touching the runtime.
-  const enqueueSteer = useCallback(() => {
-    const msg = latestInputRef.current.trim();
-    if (!msg) return;
-    setInput('');
-    latestInputRef.current = '';
-    if (displayWaiting) {
-      const id = `steer-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
-      setPendingSteers((prev) => [...prev, { id, text: msg }]);
-      return;
-    }
-    sendNow(msg);
-  }, [displayWaiting, sendNow]);
-
-  const handleSteerNow = useCallback((id: string) => {
-    // Move the target steer to head so the auto-fire effect picks it up first.
-    setPendingSteers((prev) => {
-      const idx = prev.findIndex((s) => s.id === id);
-      if (idx < 0) return prev;
-      if (idx === 0) return prev;
-      const target = prev[idx];
-      return [target, ...prev.slice(0, idx), ...prev.slice(idx + 1)];
+  const dispatchBufferedOrchestratorSend = useCallback((text: string, images: Array<{ name: string; dataUri: string }>) => {
+    if (!isOrchestratorMode) return null;
+    const turnOrchestrationMode = resolveComposerExecutionMode(composerModeRef.current, swarmEnabled, soloOrchestrator);
+    const promptMode = turnOrchestrationMode === 'fusion' && composerModeRef.current === 'solo'
+      ? 'multitask'
+      : composerModeRef.current;
+    const { displayMessage, wireMessage } = composeComposerModeMessage(text, promptMode);
+    track('orchestrator.message');
+    return orchStream.send(wireMessage, {
+      permissionMode,
+      backend: composerBackendTurnOverride(orchestratorBackend),
+      thinkingEffort,
+      model: orchestratorModel,
+      displayMessage,
+      orchestrationMode: turnOrchestrationMode,
+      collide: collideEnabled,
+      ...(images.length > 0 ? { attachments: images } : {}),
     });
-    // Interrupt the running turn so displayWaiting flips false. The effect
-    // below will then dequeue + sendNow on the next render.
-    if (isOrchestratorMode) {
-      orchStream.interrupt?.();
-    } else {
-      const sessionKey = isSingleMode ? singleRuntimeSessionRef.current : targetSessionKey;
-      void interruptRuntimeSurface(sessionKey)
-        .finally(() => {
-          clearPolling();
-          setWaitingForReply(false);
-        });
-    }
-  }, [clearPolling, isOrchestratorMode, isSingleMode, orchStream, targetSessionKey]);
+  }, [collideEnabled, isOrchestratorMode, orchStream, orchestratorBackend, orchestratorModel, permissionMode, soloOrchestrator, swarmEnabled, thinkingEffort]);
 
-  const handleDeleteSteer = useCallback((id: string) => {
-    setPendingSteers((prev) => prev.filter((s) => s.id !== id));
-    setEditingSteerId((curr) => (curr === id ? null : curr));
-  }, []);
-
-  const handleEditSteer = useCallback((id: string, text: string) => {
-    const next = text.trim();
-    if (!next) {
-      // Empty edit = delete (Conductor matches this).
-      setPendingSteers((prev) => prev.filter((s) => s.id !== id));
-      return;
-    }
-    setPendingSteers((prev) => prev.map((s) => (s.id === id ? { ...s, text: next } : s)));
-  }, []);
+  const { sendBuffer, handleSend: handleComposerSend } = useDefaultComposerSendBuffer({
+    active: isOrchestratorMode,
+    busy: displayWaiting,
+    threadId,
+    repoPath: resolvedRepoPath,
+    attachedImages,
+    latestInputRef,
+    inputRef,
+    setInput,
+    addAttachedImage,
+    clearAttachments,
+    dispatch: dispatchBufferedOrchestratorSend,
+    interrupt: orchStream.interrupt,
+    undoSend: orchStream.undoSend,
+    shouldBypass: (text) => Boolean(parseOrchestratorSlashCommand(text) || parseModeRoutingPrefix(text)),
+    sendUnbuffered: (text) => { void handleTaskSend(text); },
+  });
 
   const handleCopyMarkdownRef = useRef<() => Promise<boolean>>(async () => false);
 
@@ -2486,14 +2453,18 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
         preEnhanceInput={preEnhanceInput}
         onEnhance={handleEnhance}
         onUndoEnhance={handleUndoEnhance}
-        onSubmit={() => { void handleTaskSend(); }}
-        onStop={orchStream.interrupt}
-        onSteer={enqueueSteer}
-        pendingSteers={pendingSteers}
-        onSteerNow={handleSteerNow}
-        onDeleteSteer={handleDeleteSteer}
-        onEditSteer={handleEditSteer}
-        onEditingSteerChange={setEditingSteerId}
+        onSubmit={handleComposerSend}
+        onStop={sendBuffer.stopOrUndo}
+        onSteer={handleComposerSend}
+        sendBufferStatus={isOrchestratorMode ? (
+          <ComposerSendBufferStatus
+            undoArmed={sendBuffer.undoArmed}
+            undoSequence={sendBuffer.undoSequence}
+            queued={sendBuffer.queued}
+            onUndo={sendBuffer.stopOrUndo}
+            onCancelQueued={sendBuffer.cancelQueued}
+          />
+        ) : null}
         onSlashCommand={handleSlashCommand}
         modelLabel={isChatMode ? selectedChatModel.label : isSingleMode ? activeTargetLabel : isOrchestratorMode ? activeBackendLabel ?? formatComposerBackendLabel(orchestratorBackend, orchestratorModel) : activeTargetLabel}
         modelId={isOrchestratorMode ? orchestratorModel : undefined}

--- a/src/components/desktop/thoughts/chat-panel/ComposerArea.tsx
+++ b/src/components/desktop/thoughts/chat-panel/ComposerArea.tsx
@@ -5,7 +5,6 @@ import { InputButtons, type ThinkingEffort } from '../InputButtons';
 import { composerModeSpec, type ComposerMode } from '../composer-mode';
 import type { OrchestratorBackendSetting } from '../operator-defaults';
 import { SlashCommandPicker } from './SlashCommandPicker';
-import { PendingSteerCard, type PendingSteer } from './PendingSteerCard';
 import { ComposerStatusBar } from './ComposerStatusBar';
 import type { MobileTranscriptEntry, MobileTranscriptToolCall } from '@/lib/mobile/types';
 import type { OrchestratorWorkspaceTarget } from '@/lib/orchestrator/types';
@@ -71,18 +70,9 @@ interface ComposerAreaProps {
   selectedRepoPath?: string | null;
   onSelectRepoPath?: (next: string) => void;
   composerLeadingExtras?: React.ReactNode;
-  /** ⌘⏎ in the composer fires this. Consumer enqueues when busy, sends when idle. */
+  /** ⌘⏎ or Return while busy routes through the host send buffer. */
   onSteer?: () => void;
-  /** Queued steers waiting for an idle agent. Rendered as a card above the composer. */
-  pendingSteers?: PendingSteer[];
-  /** Preempt: abort the running turn + bump this steer to fire next. */
-  onSteerNow?: (id: string) => void;
-  /** Discard a queued steer without firing. */
-  onDeleteSteer?: (id: string) => void;
-  /** Commit an inline-edit on a queued steer. */
-  onEditSteer?: (id: string, text: string) => void;
-  /** Notify the consumer when a row enters/leaves inline-edit. Used to pause auto-fire of the head while it's being edited. */
-  onEditingSteerChange?: (id: string | null) => void;
+  sendBufferStatus?: React.ReactNode;
 }
 
 export const ComposerArea = forwardRef<HTMLTextAreaElement, ComposerAreaProps>(function ComposerArea({
@@ -136,27 +126,11 @@ export const ComposerArea = forwardRef<HTMLTextAreaElement, ComposerAreaProps>(f
   onSelectRepoPath,
   composerLeadingExtras,
   onSteer,
-  pendingSteers,
-  onSteerNow,
-  onDeleteSteer,
-  onEditSteer,
-  onEditingSteerChange,
+  sendBufferStatus,
 }, inputRef) {
   const composerCenterRef = useRef<HTMLDivElement>(null);
   const [activeSlashIndex, setActiveSlashIndex] = useState(0);
   const [dismissedSlashInput, setDismissedSlashInput] = useState<string | null>(null);
-  // Conductor-style keyboard queue (borrow: @mattyp tweet). queueNavIndex !== null
-  // means keyboard focus is "in" the steer queue (the index is the focused steer);
-  // null means the composer has focus. autoEditSteerId asks PendingSteerCard to
-  // begin an inline edit on that steer (the E key).
-  const [queueNavIndex, setQueueNavIndex] = useState<number | null>(null);
-  const [autoEditSteerId, setAutoEditSteerId] = useState<string | null>(null);
-  useEffect(() => {
-    if (!pendingSteers || pendingSteers.length === 0) {
-      setQueueNavIndex(null);
-      setAutoEditSteerId(null);
-    }
-  }, [pendingSteers]);
   const runningTools = useMemo<MobileTranscriptToolCall[]>(() => {
     if (!isOrchestratorMode) return [];
     // Scan the latest assistant message for any tool calls still marked as
@@ -351,6 +325,7 @@ export const ComposerArea = forwardRef<HTMLTextAreaElement, ComposerAreaProps>(f
           awaitingReply={awaitingReply}
         />
       ) : null}
+      {sendBufferStatus}
       <div style={{ position: 'relative' }}>
         <SlashCommandPicker
           suggestions={slashSuggestions}
@@ -541,30 +516,6 @@ export const ComposerArea = forwardRef<HTMLTextAreaElement, ComposerAreaProps>(f
             </div>
           ) : null}
 
-          {pendingSteers && pendingSteers.length > 0 && onSteerNow && onDeleteSteer && onEditSteer ? (
-            <PendingSteerCard
-              steers={pendingSteers}
-              focusedIndex={queueNavIndex}
-              autoEditId={autoEditSteerId}
-              onSteerNow={onSteerNow}
-              onDelete={onDeleteSteer}
-              onEdit={onEditSteer}
-              onEditingChange={(id) => {
-                onEditingSteerChange?.(id);
-                if (id === null) {
-                  // Inline edit finished — drop the E-trigger, exit queue nav, and
-                  // return focus to the composer so ↑ can re-enter the queue.
-                  setAutoEditSteerId(null);
-                  setQueueNavIndex(null);
-                  requestAnimationFrame(() => {
-                    const node = inputRef && typeof inputRef !== 'function' && 'current' in inputRef ? inputRef.current : null;
-                    node?.focus();
-                  });
-                }
-              }}
-            />
-          ) : null}
-
           <textarea
             ref={inputRef}
             data-o8-active-composer={activeComposer ? 'true' : undefined}
@@ -576,25 +527,6 @@ export const ComposerArea = forwardRef<HTMLTextAreaElement, ComposerAreaProps>(f
               el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
             }}
             onKeyDown={(event) => {
-              // Conductor-style keyboard queue: when focus is "in" the steer queue,
-              // ↑/↓ navigate, E edits, Return steers-now, Delete removes, Esc/any
-              // other key returns to the composer. The textarea keeps DOM focus
-              // (the queue is navigated virtually) until E moves focus into the
-              // inline editor.
-              if (queueNavIndex !== null && pendingSteers && pendingSteers.length > 0) {
-                const count = pendingSteers.length;
-                const idx = Math.min(queueNavIndex, count - 1);
-                if (event.key === 'ArrowUp') { event.preventDefault(); setQueueNavIndex(Math.max(0, idx - 1)); return; }
-                if (event.key === 'ArrowDown') { event.preventDefault(); setQueueNavIndex(idx >= count - 1 ? null : idx + 1); return; }
-                if (event.key === 'Enter' && !event.shiftKey) { event.preventDefault(); onSteerNow?.(pendingSteers[idx].id); setQueueNavIndex(null); return; }
-                if (event.key === 'Delete' || event.key === 'Backspace') { event.preventDefault(); onDeleteSteer?.(pendingSteers[idx].id); setQueueNavIndex(count - 1 <= 0 ? null : Math.min(idx, count - 2)); return; }
-                if (event.key === 'e' || event.key === 'E') { event.preventDefault(); setAutoEditSteerId(pendingSteers[idx].id); return; }
-                if (event.key === 'Escape') { event.preventDefault(); setQueueNavIndex(null); return; }
-                if (event.key === 'Shift' || event.key === 'Meta' || event.key === 'Control' || event.key === 'Alt') { return; }
-                // Any other key (typing) exits queue nav and falls through so the
-                // keystroke lands in the composer.
-                setQueueNavIndex(null);
-              }
               if (slashSuggestions.length > 0) {
                 if (event.key === 'ArrowDown') {
                   event.preventDefault();
@@ -615,12 +547,6 @@ export const ComposerArea = forwardRef<HTMLTextAreaElement, ComposerAreaProps>(f
               }
               if (event.key === 'ArrowUp' && !input.trim()) {
                 event.preventDefault();
-                // ↑ on an empty composer enters the steer queue if one exists
-                // (Conductor borrow); otherwise recall the last sent message.
-                if (pendingSteers && pendingSteers.length > 0) {
-                  setQueueNavIndex(pendingSteers.length - 1);
-                  return;
-                }
                 const lastUserMsg = [...chatMessages].reverse().find((message) => message.role === 'user');
                 if (lastUserMsg) updateInput(lastUserMsg.text);
                 return;

--- a/src/components/desktop/thoughts/chat-panel/ComposerSendBufferStatus.tsx
+++ b/src/components/desktop/thoughts/chat-panel/ComposerSendBufferStatus.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import {
+  SEND_UNDO_GRACE_MS,
+  type QueuedComposerSend,
+} from '@/lib/hooks/use-composer-send-buffer';
+
+interface ComposerSendBufferStatusProps {
+  undoArmed: boolean;
+  undoSequence: number;
+  queued: QueuedComposerSend[];
+  onUndo: () => void;
+  onCancelQueued: (id: number) => void;
+}
+
+export function ComposerSendBufferStatus({
+  undoArmed,
+  undoSequence,
+  queued,
+  onUndo,
+  onCancelQueued,
+}: ComposerSendBufferStatusProps) {
+  if (!undoArmed && queued.length === 0) return null;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        gap: 6,
+        paddingRight: 2,
+        paddingBottom: 8,
+        paddingLeft: 2,
+      }}
+    >
+      {undoArmed ? (
+        <UndoSendButton key={undoSequence} onUndo={onUndo} />
+      ) : null}
+      {queued.length > 0 ? (
+        <div
+          role="list"
+          aria-label={`${queued.length} queued message${queued.length === 1 ? '' : 's'}`}
+          style={{ display: 'flex', flexWrap: 'wrap', gap: 5, width: '100%' }}
+        >
+          {queued.map((item) => (
+            <div
+              key={item.id}
+              role="listitem"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 7,
+                minWidth: 0,
+                maxWidth: '100%',
+                paddingTop: 5,
+                paddingRight: 5,
+                paddingBottom: 5,
+                paddingLeft: 10,
+                borderRadius: 999,
+                borderWidth: 1,
+                borderStyle: 'solid',
+                borderColor: 'var(--t-divider)',
+                background: 'var(--t-input-bg)',
+                color: 'var(--t-text)',
+                boxShadow: 'var(--t-panel-shadow)',
+              }}
+            >
+              <span
+                style={{
+                  maxWidth: 280,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  fontFamily: 'var(--font-sans-system)',
+                  fontSize: 11,
+                }}
+              >
+                {item.text}
+                {item.images.length > 0 ? (
+                  <span style={{ color: 'var(--t-text-muted)' }}>
+                    {` · ${item.images.length} image${item.images.length === 1 ? '' : 's'}`}
+                  </span>
+                ) : null}
+              </span>
+              <button
+                type="button"
+                aria-label={`Cancel queued message: ${item.text}`}
+                title="Cancel queued message"
+                onPointerDown={(event) => event.stopPropagation()}
+                onClick={() => onCancelQueued(item.id)}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 20,
+                  height: 20,
+                  paddingTop: 0,
+                  paddingRight: 0,
+                  paddingBottom: 0,
+                  paddingLeft: 0,
+                  borderWidth: 0,
+                  borderRadius: 999,
+                  background: 'transparent',
+                  color: 'var(--t-text-muted)',
+                  cursor: 'pointer',
+                  flexShrink: 0,
+                }}
+              >
+                <svg width={11} height={11} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" aria-hidden>
+                  <path d="M4 4l8 8M12 4l-8 8" />
+                </svg>
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function UndoSendButton({ onUndo }: { onUndo: () => void }) {
+  const progressRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    const progress = progressRef.current;
+    if (!progress) return;
+    const animation = progress.animate(
+      [{ transform: 'scaleX(1)' }, { transform: 'scaleX(0)' }],
+      { duration: SEND_UNDO_GRACE_MS, easing: 'linear', fill: 'forwards' },
+    );
+    return () => animation.cancel();
+  }, []);
+
+  return (
+    <button
+      type="button"
+      aria-label="Undo send and restore the message"
+      onPointerDown={(event) => event.stopPropagation()}
+      onClick={onUndo}
+      style={{
+        position: 'relative',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        overflow: 'hidden',
+        paddingTop: 6,
+        paddingRight: 11,
+        paddingBottom: 6,
+        paddingLeft: 10,
+        borderWidth: 1,
+        borderStyle: 'solid',
+        borderColor: 'var(--t-divider)',
+        borderRadius: 999,
+        background: 'var(--t-input-bg)',
+        color: 'var(--t-text)',
+        boxShadow: 'var(--t-panel-shadow)',
+        cursor: 'pointer',
+        fontFamily: 'var(--font-sans-system)',
+        fontSize: 11,
+      }}
+    >
+      <svg width={12} height={12} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+        <path d="M9 14 4 9l5-5" />
+        <path d="M4 9h11a5 5 0 0 1 0 10h-1" />
+      </svg>
+      Undo send
+      <span
+        ref={progressRef}
+        aria-hidden
+        style={{
+          position: 'absolute',
+          right: 0,
+          bottom: 0,
+          left: 0,
+          height: 2,
+          background: 'var(--t-accent)',
+          opacity: 0.55,
+          transformOrigin: 'left center',
+        }}
+      />
+    </button>
+  );
+}

--- a/src/components/desktop/thoughts/chat-panel/useDefaultComposerSendBuffer.ts
+++ b/src/components/desktop/thoughts/chat-panel/useDefaultComposerSendBuffer.ts
@@ -1,0 +1,94 @@
+'use client';
+
+import { useCallback, useEffect, useRef, type MutableRefObject, type RefObject } from 'react';
+import {
+  useComposerSendBuffer,
+  type ComposerSendBuffer,
+  type ComposerSendImage,
+} from '@/lib/hooks/use-composer-send-buffer';
+import type { OrchestratorSendHandle } from '../useOrchestratorStream';
+import type { ThoughtsAttachedImage } from './useThoughtsComposerAttachments';
+
+interface UseDefaultComposerSendBufferOptions {
+  active: boolean;
+  busy: boolean;
+  threadId: string | null;
+  repoPath: string | null;
+  attachedImages: ThoughtsAttachedImage[];
+  latestInputRef: MutableRefObject<string>;
+  inputRef: RefObject<HTMLTextAreaElement | null>;
+  setInput: (text: string) => void;
+  addAttachedImage: (image: ThoughtsAttachedImage) => void;
+  clearAttachments: () => void;
+  dispatch: (text: string, images: ComposerSendImage[]) => OrchestratorSendHandle | null;
+  interrupt: () => void;
+  undoSend: (handle: OrchestratorSendHandle) => void;
+  shouldBypass: (text: string) => boolean;
+  sendUnbuffered: (text: string) => void;
+}
+
+export function useDefaultComposerSendBuffer({
+  active,
+  busy,
+  threadId,
+  repoPath,
+  attachedImages,
+  latestInputRef,
+  inputRef,
+  setInput,
+  addAttachedImage,
+  clearAttachments,
+  dispatch,
+  interrupt,
+  undoSend,
+  shouldBypass,
+  sendUnbuffered,
+}: UseDefaultComposerSendBufferOptions): {
+  sendBuffer: ComposerSendBuffer;
+  handleSend: () => void;
+} {
+  const restoreDraft = useCallback((text: string, images: ComposerSendImage[]) => {
+    setInput(text);
+    latestInputRef.current = text;
+    clearAttachments();
+    for (const image of images) {
+      const mimeType = image.dataUri.match(/^data:([^;]+);/)?.[1] ?? 'image/png';
+      addAttachedImage({ ...image, mimeType });
+    }
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, [addAttachedImage, clearAttachments, inputRef, latestInputRef, setInput]);
+
+  const sendBuffer = useComposerSendBuffer<OrchestratorSendHandle>({
+    busy: active && busy,
+    dispatch,
+    interrupt,
+    restore: restoreDraft,
+    truncate: undoSend,
+  });
+  const clearSendBuffer = sendBuffer.clear;
+  const scopeRef = useRef({ threadId, repoPath });
+  useEffect(() => {
+    const previous = scopeRef.current;
+    const repoChanged = previous.repoPath !== repoPath;
+    const switchedExistingThread = previous.threadId !== null && previous.threadId !== threadId;
+    if (repoChanged || switchedExistingThread) clearSendBuffer();
+    scopeRef.current = { threadId, repoPath };
+  }, [clearSendBuffer, repoPath, threadId]);
+
+  const handleSend = useCallback(() => {
+    const text = latestInputRef.current.trim();
+    if (!text) return;
+    if (!active || shouldBypass(text)) {
+      sendUnbuffered(text);
+      return;
+    }
+
+    const images = attachedImages.map((image) => ({ name: image.name, dataUri: image.dataUri }));
+    if (!sendBuffer.send(text, images)) return;
+    setInput('');
+    latestInputRef.current = '';
+    clearAttachments();
+  }, [active, attachedImages, clearAttachments, latestInputRef, sendBuffer, sendUnbuffered, setInput, shouldBypass]);
+
+  return { sendBuffer, handleSend };
+}

--- a/src/components/desktop/thoughts/use-orchestrator-stream/durable-pending-send.ts
+++ b/src/components/desktop/thoughts/use-orchestrator-stream/durable-pending-send.ts
@@ -116,6 +116,20 @@ export function useDurablePendingSend(options: DurablePendingSendOptions) {
     persistOrchestratorPendingSend(record);
   }, []);
 
+  const cancelPending = useCallback((clientMessageId: string) => {
+    const activeRecord = activeRecordRef.current;
+    const record = activeRecord?.clientMessageId === clientMessageId
+      ? activeRecord
+      : threadId ? readPersistedOrchestratorPendingSend(threadId, clientMessageId) : null;
+    if (record) settlePersistedOrchestratorPendingSend(record.threadId, record.clientMessageId);
+    if (pendingRef.current?.clientMessageId === clientMessageId) {
+      clearTimeout(pendingRef.current.timeoutId);
+      pendingRef.current = null;
+    }
+    if (activeRecord?.clientMessageId === clientMessageId) activeRecordRef.current = null;
+    removeFailureEntry(clientMessageId);
+  }, [pendingRef, removeFailureEntry, threadId]);
+
   const failPending = useCallback((record: PersistedOrchestratorPendingSend) => {
     setStatusReady();
     appendOrchestratorDeliveryFailureEntry(setMessages, messagesRef, {
@@ -190,5 +204,5 @@ export function useDurablePendingSend(options: DurablePendingSendOptions) {
     armRecord(newest, newest.sentAtMs);
   }, [armRecord, ensureUserBubble, failPending, pendingRef, setStatusBusy, threadId]);
 
-  return { armRecord, failPending, observeActivity, recordPending, retryPending };
+  return { armRecord, cancelPending, failPending, observeActivity, recordPending, retryPending };
 }

--- a/src/components/desktop/thoughts/use-orchestrator-stream/socket.test.ts
+++ b/src/components/desktop/thoughts/use-orchestrator-stream/socket.test.ts
@@ -25,6 +25,7 @@ function makeHarness(initial: {
   lastEventAt?: number;
   /** Thread this view is bound to (thread-scope ingest guard). */
   threadId?: string | null;
+  suppressTurnEvents?: boolean;
 }) {
   const ws = {} as WebSocket;
   const statusRef = { current: initial.status };
@@ -41,6 +42,7 @@ function makeHarness(initial: {
   const snapshotSeenRef = { current: false };
   const onSnapshotTurnTerminal = vi.fn();
   const onSettledAssistantMissing = vi.fn();
+  const suppressTurnEventsRef = { current: initial.suppressTurnEvents ?? false };
 
   const handler = createOrchestratorMessageHandler({
     captureFirstTurnPlanRef: { current: false },
@@ -63,6 +65,7 @@ function makeHarness(initial: {
     setMessages,
     setStatus,
     statusRef,
+    suppressTurnEventsRef,
     threadIdRef: { current: initial.threadId ?? null },
     wsRef: { current: ws },
   });
@@ -86,6 +89,7 @@ function makeHarness(initial: {
     snapshotSeenRef,
     onSnapshotTurnTerminal,
     onSettledAssistantMissing,
+    suppressTurnEventsRef,
   };
 }
 
@@ -98,6 +102,18 @@ const userMsg: MobileTranscriptEntry = {
 };
 
 describe('orchestrator socket — first-turn streaming race', () => {
+  it('drops late stream events after undo until the interrupted turn settles', () => {
+    const h = makeHarness({ status: 'ready', suppressTurnEvents: true });
+
+    h.fire({ channel: 'orchestrator', event: 'output', data: { text: 'late token' } });
+    expect(h.currentAssistantRef.current).toBeNull();
+    expect(h.scheduleFlushCurrentAssistant).not.toHaveBeenCalled();
+    expect(h.suppressTurnEventsRef.current).toBe(true);
+
+    h.fire({ channel: 'orchestrator', event: 'status', data: { status: 'ready' } });
+    expect(h.suppressTurnEventsRef.current).toBe(false);
+  });
+
   it('a subscribe-ack snapshot "ready" must not clobber an in-flight busy, and the next token still renders', () => {
     // send() just set busy and the user bubble is on screen; then the
     // threadId-mint re-subscribe replies with a stale snapshot:ready.

--- a/src/components/desktop/thoughts/use-orchestrator-stream/socket.ts
+++ b/src/components/desktop/thoughts/use-orchestrator-stream/socket.ts
@@ -65,6 +65,8 @@ interface CreateOrchestratorMessageHandlerOptions {
   activeTurnBackendRef?: RefLike<string | null>;
   /** Transcript-bearing events observed during the locally active turn. */
   turnTranscriptEventCountRef?: RefLike<number>;
+  /** Drop late stream deltas after undo until the interrupted turn settles. */
+  suppressTurnEventsRef?: RefLike<boolean>;
   /**
    * The thread this view is bound to (null = unbound fresh view). Drives the
    * thread-scope ingest guard: with drag-to-split, several live chat views
@@ -203,6 +205,13 @@ export function createOrchestratorMessageHandler(
       const ownThreadId = options.threadIdRef?.current ?? null;
       if (ownThreadId && evtThreadId !== ownThreadId) return;
       if (!ownThreadId && isPaneOwnedThread(evtThreadId)) return;
+    }
+
+    if (options.suppressTurnEventsRef?.current) {
+      const terminalStatus = msg.event === 'status'
+        && (msg.data?.status === 'ready' || msg.data?.status === 'dead');
+      if (terminalStatus) options.suppressTurnEventsRef.current = false;
+      return;
     }
 
     const observedAt = Date.now();

--- a/src/components/desktop/thoughts/use-orchestrator-stream/types.ts
+++ b/src/components/desktop/thoughts/use-orchestrator-stream/types.ts
@@ -1,0 +1,55 @@
+import type { OrchestratorBackendId } from '@/lib/lane/orchestrator-backends/types';
+import type { MobileTranscriptEntry } from '@/lib/mobile/types';
+import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
+import type { OrchestratorExecutionMode } from '@/lib/orchestrator/types';
+import type { ThoughtsOrchestratorBusyState } from '@/components/desktop/thoughts/chat-panel/types';
+import type { OrchestratorPermissionMode, OrchestratorStreamStatus } from './shared';
+
+export interface OrchestratorSendHandle {
+  clientMessageId: string;
+  userMessageId: string;
+  threadId: string;
+  backend: OrchestratorBackendId | null;
+  transcriptBeforeSend: MobileTranscriptEntry[];
+}
+
+export interface OrchestratorSendOptions {
+  permissionMode?: OrchestratorPermissionMode;
+  backend?: OrchestratorBackendId;
+  thinkingEffort?: ThinkingEffort;
+  model?: string;
+  displayMessage?: string;
+  localEntriesAfterUser?: MobileTranscriptEntry[];
+  orchestrationMode?: OrchestratorExecutionMode;
+  collide?: boolean;
+  attachments?: Array<{ dataUri: string; name?: string }>;
+}
+
+export interface OrchestratorStreamResult {
+  messages: MobileTranscriptEntry[];
+  planText: string | null;
+  status: OrchestratorStreamStatus;
+  busyState: ThoughtsOrchestratorBusyState;
+  tokenCount: number;
+  runningTotal: number;
+  estimateNextTurnTokens: (message: string) => number;
+  send: (message: string, options?: OrchestratorSendOptions) => OrchestratorSendHandle | null;
+  interrupt: () => void;
+  undoSend: (handle: OrchestratorSendHandle) => void;
+  appendLocalEntries: (entries: MobileTranscriptEntry[]) => void;
+  replaceTranscript: (entries: MobileTranscriptEntry[]) => void;
+  fetchTelemetrySnapshot: () => Promise<{
+    totalTokens: number | null;
+    estimatedCostUsd: number | null;
+    model: string | null;
+  }>;
+  compactNow: (options?: { keepTailCount?: number; source?: 'manual' | 'handoff' }) => Promise<{
+    applied: boolean;
+    transcript: MobileTranscriptEntry[];
+    resumePrelude: string | null;
+    tokensAfter: number;
+  } | null>;
+  reset: () => void;
+  retryPendingSend: (clientMessageId: string) => void;
+  connected: boolean;
+}

--- a/src/components/desktop/thoughts/useOrchestratorStream.ts
+++ b/src/components/desktop/thoughts/useOrchestratorStream.ts
@@ -15,9 +15,7 @@ import {
   subscribeOrchestratorMissionCompleted,
   type OrchestratorMissionCompletedDetail,
 } from '@/lib/orchestrator/store';
-import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import type { OrchestratorExecutionMode } from '@/lib/orchestrator/types';
-import type { ThoughtsOrchestratorBusyState } from '@/components/desktop/thoughts/chat-panel/types';
 import {
   createOrchestratorClientMessageId,
   deliverOrchestratorPayload,
@@ -60,6 +58,13 @@ import {
   type CurrentAssistantStreamState,
   type OrchestratorSnapshotTurn,
 } from './use-orchestrator-stream/socket';
+import type {
+  OrchestratorSendHandle,
+  OrchestratorSendOptions,
+  OrchestratorStreamResult,
+} from './use-orchestrator-stream/types';
+
+export type { OrchestratorSendHandle } from './use-orchestrator-stream/types';
 
 export {
   DEFAULT_ORCHESTRATOR_MODEL,
@@ -75,59 +80,6 @@ export type {
 // module-level so remounts (tab flaps) can't re-rotate a mission whose
 // completion event re-fires from boot-time state oscillation.
 const rotatedMissionIds = new Set<string>();
-
-interface OrchestratorStreamResult {
-  messages: MobileTranscriptEntry[];
-  planText: string | null;
-  status: OrchestratorStreamStatus;
-  busyState: ThoughtsOrchestratorBusyState;
-  tokenCount: number;
-  runningTotal: number;
-  estimateNextTurnTokens: (message: string) => number;
-  send: (message: string, options?: OrchestratorSendOptions) => void;
-  interrupt: () => void;
-  appendLocalEntries: (entries: MobileTranscriptEntry[]) => void;
-  replaceTranscript: (entries: MobileTranscriptEntry[]) => void;
-  fetchTelemetrySnapshot: () => Promise<{ totalTokens: number | null; estimatedCostUsd: number | null; model: string | null }>;
-  compactNow: (options?: { keepTailCount?: number; source?: 'manual' | 'handoff' }) => Promise<{
-    applied: boolean;
-    transcript: MobileTranscriptEntry[];
-    resumePrelude: string | null;
-    tokensAfter: number;
-  } | null>;
-  reset: () => void;
-  retryPendingSend: (clientMessageId: string) => void;
-  connected: boolean;
-}
-
-interface OrchestratorSendOptions {
-  permissionMode?: OrchestratorPermissionMode;
-  backend?: OrchestratorBackendId;
-  thinkingEffort?: ThinkingEffort;
-  model?: string;
-  /**
-   * Text shown in the transcript for the user's turn. The outbound `message`
-   * can be a structured dispatcher prompt while the visible chat stays clean.
-   */
-  displayMessage?: string;
-  /** Local system/command entries inserted immediately after the user bubble. */
-  localEntriesAfterUser?: MobileTranscriptEntry[];
-  /** Canonical per-turn dispatch policy shared with the canvas composer. */
-  orchestrationMode?: OrchestratorExecutionMode;
-  /**
-   * Collide / MoA mode. When true, the turn routes to the `collide` backend:
-   * Claude + Codex propose independently (read-only), Claude synthesizes + does
-   * the work. Forces `backend: 'collide'` on the outbound payload; the swarm
-   * directive is NOT applied (Collide is its own fusion).
-   */
-  collide?: boolean;
-  /**
-   * Composer picture pills. ThoughtsChatPanel has always passed these; the
-   * wire silently dropped them until 2026-06-12 — now they ride the
-   * orchestrator-send payload and reach the model as image blocks.
-   */
-  attachments?: Array<{ dataUri: string; name?: string }>;
-}
 
 interface ActiveTurnState {
   startedAt: number;
@@ -167,7 +119,7 @@ export function useOrchestratorStream(
   const [messages, setMessages] = useState<MobileTranscriptEntry[]>([]);
   const [planText, setPlanText] = useState<string | null>(null);
   const [status, setStatus] = useState<OrchestratorStreamStatus>('connecting');
-  const [busyState, setBusyState] = useState<ThoughtsOrchestratorBusyState>(() => createIdleBusyState());
+  const [busyState, setBusyState] = useState(() => createIdleBusyState());
   const [connected, setConnected] = useState(false);
   const [tokenCount, setTokenCount] = useState(0);
   const [runningTotal, setRunningTotal] = useState(0);
@@ -243,6 +195,7 @@ export function useOrchestratorStream(
   // after the socket opened means the turn is legitimately starting (and may be
   // cold-starting the orchestrator before its first event), not stale carryover.
   const lastSendAtRef = useRef(0);
+  const suppressTurnEventsRef = useRef(false);
   const RECONNECT_HEAL_DELAY_MS = 3000;
   useEffect(() => {
     messagesRef.current = messages;
@@ -674,6 +627,7 @@ export function useOrchestratorStream(
       setMessages,
       setStatus,
       statusRef,
+      suppressTurnEventsRef,
       turnTranscriptEventCountRef,
       wsRef,
     });
@@ -943,7 +897,7 @@ export function useOrchestratorStream(
               timestampLabel: formatTimestampLabel(at),
             }]
       ));
-      return;
+      return null;
     }
 
     const permissionMode: OrchestratorPermissionMode = options?.permissionMode ?? 'full';
@@ -963,6 +917,28 @@ export function useOrchestratorStream(
     const orchestrationMode: OrchestratorExecutionMode = collide
       ? 'fleet'
       : requestedOrchestrationMode;
+    suppressTurnEventsRef.current = false;
+    const clientMessageId = createOrchestratorClientMessageId();
+    const sentAtMs = Date.now();
+    const transcriptBeforeSend = messagesRef.current;
+
+    // Mint before returning the handle so undo always targets the exact durable
+    // thread even when this is the first message on a fresh tab.
+    if (!threadIdRef.current) {
+      const minted = `thoughts-${Date.now()}`;
+      threadIdRef.current = minted;
+      try { onThreadIdMintRef.current?.(minted); } catch { /* parent owns the consequence */ }
+    }
+    const sendHandle: OrchestratorSendHandle = {
+      clientMessageId,
+      userMessageId: `orch-user-${clientMessageId}`,
+      threadId: threadIdRef.current,
+      backend: backend ?? null,
+      transcriptBeforeSend,
+    };
+    lastSendAtRef.current = sentAtMs;
+    lastEventAtRef.current = sentAtMs;
+    setPendingStatusBusy();
 
     void (async () => {
       const activeRepoPath = repoPathRef.current;
@@ -970,7 +946,7 @@ export function useOrchestratorStream(
         activeTurnBackendRef.current = null;
         return;
       }
-      const transcriptSnapshot = messagesRef.current;
+      const transcriptSnapshot = transcriptBeforeSend;
       let planCaptureSource = transcriptSnapshot;
       const projectedTokens = estimateNextTurnTokens(message);
       if (projectedTokens >= ORCHESTRATOR_FORCE_COMPACT_THRESHOLD) {
@@ -1025,10 +1001,8 @@ export function useOrchestratorStream(
           return;
         }
       }
-      const clientMessageId = createOrchestratorClientMessageId();
-      const sentAtMs = Date.now();
       const userEntry: MobileTranscriptEntry = {
-        id: `orch-user-${clientMessageId}`,
+        id: sendHandle.userMessageId,
         role: 'user',
         text: displayMessage,
         timestamp: sentAtMs,
@@ -1043,20 +1017,8 @@ export function useOrchestratorStream(
       firstTurnPlanStartedRef.current = false;
       firstTurnPlanChunksRef.current = [];
 
-      // Mint a threadId synchronously if the parent's state hasn't landed
-      // yet. ws-server uses `threadId.startsWith('thoughts-')` to decide
-      // whether to persist the assistant reply — without an id here, the
-      // turn streams to the open client but never lands in
-      // ~/.o8/chat-history/<id>.json, so a reload shows the user message
-      // alone with no reply. Notify the parent so its `threadId` state
-      // catches up on the next render.
-      if (!threadIdRef.current) {
-        const minted = `thoughts-${Date.now()}`;
-        threadIdRef.current = minted;
-        try { onThreadIdMintRef.current?.(minted); } catch { /* parent owns the consequence */ }
-      }
       let outboundMessage = message;
-      const resumePrelude = consumeOrchestratorSessionPrelude(activeRepoPath, threadIdRef.current);
+      const resumePrelude = consumeOrchestratorSessionPrelude(activeRepoPath, sendHandle.threadId);
       if (resumePrelude) {
         outboundMessage = `${resumePrelude}\n\nOperator message:\n${message}`;
       }
@@ -1064,7 +1026,7 @@ export function useOrchestratorStream(
       const payload = JSON.stringify({
         type: 'orchestrator-send',
         repoPath: activeRepoPath,
-        ...(threadIdRef.current ? { threadId: threadIdRef.current } : {}),
+        threadId: sendHandle.threadId,
         clientMessageId,
         message: outboundMessage,
         // What the TRANSCRIPT stores/shows — the user's own words, never the
@@ -1083,7 +1045,7 @@ export function useOrchestratorStream(
       const pendingRecord = {
         text: outboundMessage,
         displayMessage,
-        threadId: threadIdRef.current!,
+        threadId: sendHandle.threadId,
         clientMessageId,
         sentAtMs,
         wirePayload: payload,
@@ -1107,7 +1069,39 @@ export function useOrchestratorStream(
       durablePendingSend.armRecord(pendingRecord, deliveredAt);
       setPendingStatusBusy();
     })();
+    return sendHandle;
   }, [connect, connected, durablePendingSend, estimateNextTurnTokens, primeCompactedSession, requestCompaction, setPendingStatusBusy]);
+
+  const undoSend = useCallback((handle: OrchestratorSendHandle) => {
+    const activeRepoPath = repoPathRef.current;
+    durablePendingSend.cancelPending(handle.clientMessageId);
+    syncMessages(handle.transcriptBeforeSend);
+    currentAssistantRef.current = null;
+    activeTurnRef.current = null;
+    activeTurnBackendRef.current = null;
+    suppressTurnEventsRef.current = true;
+    turnTranscriptEventCountRef.current = 0;
+    resetFirstTurnPlanCapture();
+    const nextStatus = connected ? 'ready' : 'connecting';
+    statusRef.current = nextStatus;
+    setStatus(nextStatus);
+    setBusyState(createIdleBusyState());
+
+    if (!activeRepoPath) return;
+    const payload = JSON.stringify({
+      type: 'orchestrator-undo-send',
+      repoPath: activeRepoPath,
+      threadId: handle.threadId,
+      clientMessageId: handle.clientMessageId,
+      userMessageId: handle.userMessageId,
+      ...(handle.backend ? { backend: handle.backend } : {}),
+    });
+    void deliverOrchestratorPayload({
+      payload,
+      getWebSocket: () => wsRef.current,
+      connect: () => { console.warn('[orchestrator-stream] WS not open, reconnecting to undo send...'); connect(); },
+    });
+  }, [connect, connected, durablePendingSend, resetFirstTurnPlanCapture, syncMessages]);
 
   return {
     messages,
@@ -1119,6 +1113,7 @@ export function useOrchestratorStream(
     estimateNextTurnTokens,
     send,
     interrupt,
+    undoSend,
     appendLocalEntries,
     replaceTranscript,
     fetchTelemetrySnapshot: async () => (

--- a/src/lib/hooks/use-composer-send-buffer.test.ts
+++ b/src/lib/hooks/use-composer-send-buffer.test.ts
@@ -1,0 +1,125 @@
+/** @vitest-environment jsdom */
+
+import { act, createElement, createRef, forwardRef, useImperativeHandle, type RefObject } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  SEND_UNDO_GRACE_MS,
+  useComposerSendBuffer,
+  type ComposerSendBuffer,
+  type ComposerSendBufferConfig,
+} from './use-composer-send-buffer';
+
+type Handle = { boundary: number };
+
+type HarnessProps = ComposerSendBufferConfig<Handle>;
+
+let bufferRef: RefObject<ComposerSendBuffer | null>;
+let root: Root;
+
+const Harness = forwardRef<ComposerSendBuffer, HarnessProps>(function Harness(props, ref) {
+  const buffer = useComposerSendBuffer(props);
+  useImperativeHandle(ref, () => buffer, [buffer]);
+  return null;
+});
+
+function currentBuffer(): ComposerSendBuffer {
+  if (!bufferRef.current) throw new Error('send buffer harness is not mounted');
+  return bufferRef.current;
+}
+
+describe('useComposerSendBuffer', () => {
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    bufferRef = createRef<ComposerSendBuffer>();
+    root = createRoot(document.createElement('div'));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    vi.useRealTimers();
+  });
+
+  it('undoes an in-flight send by interrupting, truncating, and restoring text plus images', () => {
+    const image = { name: 'proof.png', dataUri: 'data:image/png;base64,abc' };
+    const handle = { boundary: 7 };
+    const dispatch = vi.fn(() => handle);
+    const interrupt = vi.fn();
+    const restore = vi.fn();
+    const truncate = vi.fn();
+    act(() => root.render(createElement(Harness, {
+      busy: false,
+      dispatch,
+      interrupt,
+      restore,
+      truncate,
+      ref: bufferRef,
+    })));
+
+    act(() => {
+      expect(currentBuffer().send('  fix it  ', [image])).toBe(true);
+    });
+    expect(currentBuffer().undoArmed).toBe(true);
+
+    act(() => currentBuffer().stopOrUndo());
+    expect(interrupt).toHaveBeenCalledTimes(1);
+    expect(truncate).toHaveBeenCalledWith(handle);
+    expect(restore).toHaveBeenCalledWith('fix it', [image]);
+    expect(currentBuffer().undoArmed).toBe(false);
+  });
+
+  it('turns Stop into a plain interrupt after the grace window expires', () => {
+    vi.useFakeTimers();
+    const interrupt = vi.fn();
+    const restore = vi.fn();
+    const truncate = vi.fn();
+    act(() => root.render(createElement(Harness, {
+      busy: false,
+      dispatch: () => ({ boundary: 1 }),
+      interrupt,
+      restore,
+      truncate,
+      ref: bufferRef,
+    })));
+    act(() => { currentBuffer().send('keep this send'); });
+    act(() => vi.advanceTimersByTime(SEND_UNDO_GRACE_MS));
+
+    act(() => currentBuffer().stopOrUndo());
+    expect(interrupt).toHaveBeenCalledTimes(1);
+    expect(truncate).not.toHaveBeenCalled();
+    expect(restore).not.toHaveBeenCalled();
+  });
+
+  it('queues while busy and drains exactly one item on each busy-to-idle edge', async () => {
+    let boundary = 0;
+    const dispatch = vi.fn(() => ({ boundary: boundary += 1 }));
+    const config = {
+      dispatch,
+      interrupt: vi.fn(),
+      restore: vi.fn(),
+      truncate: vi.fn(),
+    };
+    act(() => root.render(createElement(Harness, { busy: true, ...config, ref: bufferRef })));
+
+    act(() => {
+      currentBuffer().send('first', [{ name: 'one.png', dataUri: 'data:image/png;base64,one' }]);
+      currentBuffer().send('second');
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(currentBuffer().queued.map((item) => item.text)).toEqual(['first', 'second']);
+
+    await act(async () => root.render(createElement(Harness, { busy: false, ...config, ref: bufferRef })));
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenLastCalledWith('first', [{ name: 'one.png', dataUri: 'data:image/png;base64,one' }]);
+    expect(currentBuffer().queued.map((item) => item.text)).toEqual(['second']);
+
+    act(() => root.render(createElement(Harness, { busy: false, ...config, ref: bufferRef })));
+    expect(dispatch).toHaveBeenCalledTimes(1);
+
+    act(() => root.render(createElement(Harness, { busy: true, ...config, ref: bufferRef })));
+    await act(async () => root.render(createElement(Harness, { busy: false, ...config, ref: bufferRef })));
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch).toHaveBeenLastCalledWith('second', []);
+    expect(currentBuffer().queued).toEqual([]);
+  });
+});

--- a/src/lib/hooks/use-composer-send-buffer.ts
+++ b/src/lib/hooks/use-composer-send-buffer.ts
@@ -1,0 +1,156 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export const SEND_UNDO_GRACE_MS = 4500;
+
+export interface ComposerSendImage {
+  name: string;
+  dataUri: string;
+}
+
+export interface QueuedComposerSend {
+  id: number;
+  text: string;
+  images: ComposerSendImage[];
+}
+
+export interface ComposerSendBufferConfig<DispatchHandle> {
+  busy: boolean;
+  graceMs?: number;
+  dispatch: (text: string, images: ComposerSendImage[]) => DispatchHandle | null;
+  interrupt: () => void;
+  restore: (text: string, images: ComposerSendImage[]) => void;
+  truncate: (handle: DispatchHandle) => void;
+}
+
+export interface ComposerSendBuffer {
+  send: (text: string, images?: ComposerSendImage[]) => boolean;
+  stopOrUndo: () => void;
+  undoArmed: boolean;
+  undoSequence: number;
+  queued: QueuedComposerSend[];
+  cancelQueued: (id: number) => void;
+  clear: () => void;
+}
+
+/**
+ * Conversation-agnostic send buffering shared by the canvas and desktop
+ * composers. Hosts own dispatch, interruption, transcript rewind, and draft
+ * restoration because those seams differ between transcript stores.
+ */
+export function useComposerSendBuffer<DispatchHandle>(
+  config: ComposerSendBufferConfig<DispatchHandle>,
+): ComposerSendBuffer {
+  const configRef = useRef(config);
+  const graceMs = config.graceMs ?? SEND_UNDO_GRACE_MS;
+
+  const [queued, setQueued] = useState<QueuedComposerSend[]>([]);
+  const queuedRef = useRef(queued);
+  const nextQueueIdRef = useRef(1);
+
+  useEffect(() => {
+    configRef.current = config;
+  }, [config]);
+
+  useEffect(() => {
+    queuedRef.current = queued;
+  }, [queued]);
+
+  const [undoArmed, setUndoArmed] = useState(false);
+  const [undoSequence, setUndoSequence] = useState(0);
+  const undoRef = useRef<{
+    text: string;
+    images: ComposerSendImage[];
+    handle: DispatchHandle;
+  } | null>(null);
+  const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const previousBusyRef = useRef(config.busy);
+
+  const disarm = useCallback(() => {
+    if (undoTimerRef.current) {
+      clearTimeout(undoTimerRef.current);
+      undoTimerRef.current = null;
+    }
+    undoRef.current = null;
+    setUndoArmed(false);
+  }, []);
+
+  const arm = useCallback((handle: DispatchHandle, text: string, images: ComposerSendImage[]) => {
+    if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
+    undoRef.current = { text, images, handle };
+    setUndoArmed(true);
+    setUndoSequence((current) => current + 1);
+    undoTimerRef.current = setTimeout(() => {
+      undoTimerRef.current = null;
+      undoRef.current = null;
+      setUndoArmed(false);
+    }, graceMs);
+  }, [graceMs]);
+
+  const send = useCallback((text: string, images: ComposerSendImage[] = []) => {
+    const trimmed = text.trim();
+    if (!trimmed) return false;
+    if (configRef.current.busy) {
+      const id = nextQueueIdRef.current;
+      nextQueueIdRef.current += 1;
+      setQueued((previous) => [...previous, { id, text: trimmed, images }]);
+      return true;
+    }
+
+    const handle = configRef.current.dispatch(trimmed, images);
+    if (!handle) return false;
+    arm(handle, trimmed, images);
+    return true;
+  }, [arm]);
+
+  const stopOrUndo = useCallback(() => {
+    configRef.current.interrupt();
+    const pendingUndo = undoRef.current;
+    if (!pendingUndo) return;
+    disarm();
+    configRef.current.truncate(pendingUndo.handle);
+    configRef.current.restore(pendingUndo.text, pendingUndo.images);
+  }, [disarm]);
+
+  const cancelQueued = useCallback((id: number) => {
+    setQueued((previous) => previous.filter((item) => item.id !== id));
+  }, []);
+
+  const clear = useCallback(() => {
+    disarm();
+    setQueued([]);
+  }, [disarm]);
+
+  useEffect(() => {
+    const wasBusy = previousBusyRef.current;
+    previousBusyRef.current = config.busy;
+    if (!wasBusy || config.busy) return;
+
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled || configRef.current.busy) return;
+      disarm();
+      const queue = queuedRef.current;
+      if (queue.length === 0) return;
+      const [head, ...rest] = queue;
+      setQueued(rest);
+      const handle = configRef.current.dispatch(head.text, head.images);
+      if (handle) {
+        arm(handle, head.text, head.images);
+        return;
+      }
+
+      // A queue drain must never silently lose operator intent. If dispatch is
+      // unavailable on the idle edge, put the full draft back in the composer.
+      configRef.current.restore(head.text, head.images);
+    });
+    return () => { cancelled = true; };
+  }, [arm, config.busy, disarm]);
+
+  useEffect(() => () => {
+    if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
+  }, []);
+
+  return { send, stopOrUndo, undoArmed, undoSequence, queued, cancelQueued, clear };
+}

--- a/src/lib/mobile/orchestrator-thread-history.test.ts
+++ b/src/lib/mobile/orchestrator-thread-history.test.ts
@@ -53,6 +53,55 @@ describe('orchestrator thread history persistence', () => {
     ]);
   });
 
+  it('rewinds an undone turn from its exact client message id', async () => {
+    const history = await loadHistoryModule();
+    const thread = history.createMobileOrchestratorThread({ repoPath: '/tmp/repo' });
+
+    history.appendMobileOrchestratorUserMessage({
+      tabId: thread.id,
+      repoPath: '/tmp/repo',
+      message: 'keep this turn',
+      messageId: 'orch-user-send-1',
+      backend: 'codex',
+      timestampMs: 1000,
+    });
+    history.upsertMobileOrchestratorAssistantMessage({
+      tabId: thread.id,
+      repoPath: '/tmp/repo',
+      messageId: 'assistant-1000',
+      content: 'kept',
+      backend: 'codex',
+      timestampMs: 1001,
+    });
+    history.appendMobileOrchestratorUserMessage({
+      tabId: thread.id,
+      repoPath: '/tmp/repo',
+      message: 'undo this turn',
+      messageId: 'orch-user-send-2',
+      backend: 'codex',
+      timestampMs: 2000,
+    });
+    history.upsertMobileOrchestratorAssistantMessage({
+      tabId: thread.id,
+      repoPath: '/tmp/repo',
+      messageId: 'assistant-2000',
+      content: 'partial response',
+      backend: 'codex',
+      timestampMs: 2001,
+    });
+
+    history.truncateMobileOrchestratorThreadFromMessage({
+      tabId: thread.id,
+      messageId: 'orch-user-send-2',
+    });
+
+    const persisted = JSON.parse(readFileSync(history.safeOrchestratorHistoryPath(thread.id), 'utf-8'));
+    expect(persisted.messages.map((message: { id?: string }) => message.id)).toEqual([
+      'orch-user-send-1',
+      'assistant-1000',
+    ]);
+  });
+
   it('reuses cached parses until the history file mtime or size changes', async () => {
     const history = await loadHistoryModule();
     const thread = history.createMobileOrchestratorThread({ repoPath: '/tmp/repo', title: 'Alpha' });

--- a/src/lib/mobile/orchestrator-thread-history.ts
+++ b/src/lib/mobile/orchestrator-thread-history.ts
@@ -2,10 +2,21 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSy
 import { readdir as readdirAsync, stat as statAsync } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { homedir } from 'node:os';
-import { isOrchestratorBackendId } from '@/lib/lane/orchestrator-backends/types';
 import type { MobileOrchestratorBackend, MobileOrchestratorThread } from '@/lib/mobile/types';
-import { stableOrchestratorThreadTitleForId } from '@/lib/orchestrator/thread-title';
-import { resolveRepoGithubIdentity } from '@/lib/repos/github-identity';
+import {
+  effectiveBackend,
+  inferBackendFromSessionIds,
+  modelForBackend,
+  normalizeAgent,
+  normalizeBackend,
+  normalizeErrorMessage,
+  normalizeSessionIds,
+  projectOrchestratorThread as projectThread,
+  repoNameFromPath,
+  trimTitle,
+  type ChatHistoryMessage,
+  type OrchestratorHistoryRecord,
+} from './orchestrator-thread-projection';
 
 export const ORCHESTRATOR_HISTORY_DIR = join(homedir(), '.o8', 'chat-history');
 const MAX_THREADS = 20;
@@ -16,42 +27,6 @@ export interface OrchestratorThreadRevealRequest {
   requestedAt: string;
   thread: MobileOrchestratorThread;
 }
-
-type ChatHistoryMessage = {
-  id?: string;
-  role?: string;
-  content?: string;
-  timestamp?: number;
-  // Task #8 — monotonic per-message persist version, bumped on every write of
-  // this message (incremental mid-stream persists included). The client's
-  // history merge compares versions instead of blind ID-membership replaces,
-  // so a stale fetch can never revert a completed answer to a partial one.
-  persistedVersion?: number;
-};
-
-type OrchestratorHistoryRecord = {
-  messages?: ChatHistoryMessage[];
-  model?: string | null;
-  savedAt?: string | null;
-  title?: string | null;
-  repoPath?: string | null;
-  repoName?: string | null;
-  repoBranch?: string | null;
-  remoteUrl?: string | null;
-  backend?: string | null;
-  agent?: string | null;
-  archivedAt?: string | null;
-  starred?: boolean;
-  pinned?: boolean;
-  orchestratorVisible?: boolean;
-  mobileCreatedAt?: string | null;
-  mobileRevealRequestedAt?: string | null;
-  orchestratorTerminalStatus?: 'failed' | null;
-  orchestratorTerminalError?: string | null;
-  orchestratorTerminalAt?: string | null;
-  orchestratorSessionIds?: Record<string, string | null>;
-  orchestratorSessionUpdatedAt?: string | null;
-};
 
 type OrchestratorHistoryFileStat = {
   file: string;
@@ -204,125 +179,6 @@ export function repairFlippedOrchestratorTranscripts(): void {
   } catch (err) {
     console.warn('[transcript-repair] skipped:', err);
   }
-}
-
-function normalizeSessionIds(value: unknown): Record<string, string | null> {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
-  const normalized: Record<string, string | null> = {};
-  for (const [key, rawSessionId] of Object.entries(value as Record<string, unknown>)) {
-    if (!key) continue;
-    if (rawSessionId === null) {
-      normalized[key] = null;
-      continue;
-    }
-    if (typeof rawSessionId !== 'string') continue;
-    const sessionId = rawSessionId.trim();
-    if (sessionId) normalized[key] = sessionId;
-  }
-  return normalized;
-}
-
-function normalizeBackend(value: unknown): MobileOrchestratorBackend | null {
-  return isOrchestratorBackendId(value) ? value : null;
-}
-
-function normalizeAgent(value: unknown): string | null {
-  return typeof value === 'string' && value.trim() ? value.trim().slice(0, 128) : null;
-}
-
-function normalizeErrorMessage(value: unknown): string | null {
-  if (typeof value !== 'string') return null;
-  const trimmed = value.trim();
-  return trimmed ? trimmed.slice(0, 500) : null;
-}
-
-function inferRuntime(model: string | undefined | null): MobileOrchestratorThread['runtime'] {
-  if (!model) return 'unknown';
-  const lower = model.toLowerCase();
-  if (lower.includes('claude')) return 'claude-code';
-  if (lower.includes('gemini')) return 'gemini';
-  if (lower.includes('opencode')) return 'opencode';
-  if (lower.includes('codex') || lower.startsWith('gpt')) return 'codex';
-  return 'unknown';
-}
-
-function inferBackendFromSessionIds(record: OrchestratorHistoryRecord): MobileOrchestratorBackend | null {
-  const sessionIds = normalizeSessionIds(record.orchestratorSessionIds);
-  if (sessionIds.claude) return 'claude';
-  if (sessionIds.codex) return 'codex';
-  return null;
-}
-
-function modelForBackend(backend: MobileOrchestratorBackend | null): string | null {
-  if (backend === 'claude') return 'claude-code';
-  if (backend === 'codex') return 'codex';
-  if (backend === 'openclaw') return 'openclaw';
-  if (backend === 'hermes') return 'hermes';
-  return null;
-}
-
-function effectiveBackend(record: OrchestratorHistoryRecord): MobileOrchestratorBackend | null {
-  return normalizeBackend(record.backend) ?? inferBackendFromSessionIds(record);
-}
-
-function effectiveModel(tabId: string, record: OrchestratorHistoryRecord): string | null {
-  if (typeof record.model === 'string' && record.model.trim()) return record.model.trim();
-  const backendModel = modelForBackend(effectiveBackend(record));
-  if (backendModel) return backendModel;
-  return tabId.startsWith('thoughts-') ? DEFAULT_MODEL : null;
-}
-
-function trimTitle(value: unknown, fallback: string): string {
-  if (typeof value !== 'string') return fallback;
-  const trimmed = value.trim();
-  if (!trimmed) return fallback;
-  return trimmed.slice(0, 80);
-}
-
-function repoNameFromPath(repoPath: string | null): string | null {
-  if (!repoPath) return null;
-  const name = basename(repoPath.replace(/[/\\]+$/, ''));
-  return name || null;
-}
-
-function projectThread(
-  tabId: string,
-  record: OrchestratorHistoryRecord,
-  modifiedAt: string,
-): MobileOrchestratorThread {
-  const messages = Array.isArray(record.messages) ? record.messages : [];
-  const lastMessage = messages[messages.length - 1];
-  const fallbackTitle = stableOrchestratorThreadTitleForId(tabId, record.savedAt || modifiedAt);
-  const repoPath = typeof record.repoPath === 'string' ? record.repoPath : null;
-  const githubIdentity = resolveRepoGithubIdentity(repoPath, record.remoteUrl);
-  // "Last spoke", not "last touched" (Q ruling 2026-07-16): savedAt restamps
-  // on every persist — merely OPENING a thread re-persisted it and bumped it
-  // to the top of every recency-ordered rail. The newest message timestamp is
-  // the truthful recency; savedAt/mtime only for empty or pre-timestamp files.
-  const lastSpokeMs = messages.reduce((max, m) => (
-    Number.isFinite(m?.timestamp) && (m.timestamp as number) > max ? (m.timestamp as number) : max
-  ), 0);
-
-  return {
-    id: tabId,
-    title: trimTitle(record.title, fallbackTitle),
-    lastMessageAt: lastSpokeMs > 0 ? new Date(lastSpokeMs).toISOString() : (record.savedAt || modifiedAt),
-    runtime: inferRuntime(effectiveModel(tabId, record)),
-    status: record.orchestratorTerminalStatus === 'failed'
-      ? 'failed'
-      : messages.length === 0 ? 'idle' : lastMessage?.role === 'user' ? 'busy' : 'ready',
-    messageCount: messages.length,
-    repoPath,
-    repoName: typeof record.repoName === 'string' && record.repoName.trim()
-      ? record.repoName
-      : repoNameFromPath(repoPath),
-    repoBranch: typeof record.repoBranch === 'string' ? record.repoBranch : null,
-    githubOwner: githubIdentity.githubOwner,
-    githubRepo: githubIdentity.githubRepo,
-    backend: effectiveBackend(record),
-    agent: normalizeAgent(record.agent),
-    pinned: record.pinned === true,
-  };
 }
 
 function readProjectedThread(tabId: string): MobileOrchestratorThread | null {
@@ -573,6 +429,7 @@ export function appendMobileOrchestratorUserMessage(input: {
   tabId: string | null | undefined;
   repoPath: string;
   message: string;
+  messageId?: string;
   backend?: MobileOrchestratorBackend | null;
   agent?: string | null;
   timestampMs?: number;
@@ -612,7 +469,7 @@ export function appendMobileOrchestratorUserMessage(input: {
     : [
       ...messages,
       {
-        id: `user-${now.getTime()}`,
+        id: input.messageId?.trim() || `user-${now.getTime()}`,
         role: 'user',
         content,
         timestamp,
@@ -640,6 +497,36 @@ export function appendMobileOrchestratorUserMessage(input: {
     orchestratorVisible: true,
   });
 
+  return readProjectedThread(tabId);
+}
+
+/**
+ * Remove an undone turn from durable history, including any partial assistant
+ * or tool entries persisted after its user message. Exact message ids keep a
+ * rapid pair of identical prompts from truncating the wrong turn.
+ */
+export function truncateMobileOrchestratorThreadFromMessage(input: {
+  tabId: string | null | undefined;
+  messageId: string;
+}): MobileOrchestratorThread | null {
+  const tabId = input.tabId;
+  const messageId = input.messageId.trim();
+  if (!tabId?.startsWith('thoughts-') || !messageId) return null;
+
+  const existing = readHistoryRecord(tabId);
+  if (!existing) return null;
+  const messages = Array.isArray(existing.messages) ? existing.messages : [];
+  const boundary = messages.findIndex((message) => message.id === messageId);
+  if (boundary < 0) return readProjectedThread(tabId);
+
+  writeHistoryRecord(tabId, {
+    ...existing,
+    messages: messages.slice(0, boundary),
+    savedAt: new Date().toISOString(),
+    orchestratorTerminalStatus: null,
+    orchestratorTerminalError: null,
+    orchestratorTerminalAt: null,
+  });
   return readProjectedThread(tabId);
 }
 

--- a/src/lib/mobile/orchestrator-thread-projection.ts
+++ b/src/lib/mobile/orchestrator-thread-projection.ts
@@ -1,0 +1,156 @@
+import { basename } from 'node:path';
+import { isOrchestratorBackendId } from '@/lib/lane/orchestrator-backends/types';
+import type { MobileOrchestratorBackend, MobileOrchestratorThread } from '@/lib/mobile/types';
+import { stableOrchestratorThreadTitleForId } from '@/lib/orchestrator/thread-title';
+import { resolveRepoGithubIdentity } from '@/lib/repos/github-identity';
+
+const DEFAULT_MODEL = 'claude-code';
+
+export type ChatHistoryMessage = {
+  id?: string;
+  role?: string;
+  content?: string;
+  timestamp?: number;
+  persistedVersion?: number;
+};
+
+export type OrchestratorHistoryRecord = {
+  messages?: ChatHistoryMessage[];
+  model?: string | null;
+  savedAt?: string | null;
+  title?: string | null;
+  repoPath?: string | null;
+  repoName?: string | null;
+  repoBranch?: string | null;
+  remoteUrl?: string | null;
+  backend?: string | null;
+  agent?: string | null;
+  archivedAt?: string | null;
+  starred?: boolean;
+  pinned?: boolean;
+  orchestratorVisible?: boolean;
+  mobileCreatedAt?: string | null;
+  mobileRevealRequestedAt?: string | null;
+  orchestratorTerminalStatus?: 'failed' | null;
+  orchestratorTerminalError?: string | null;
+  orchestratorTerminalAt?: string | null;
+  orchestratorSessionIds?: Record<string, string | null>;
+  orchestratorSessionUpdatedAt?: string | null;
+};
+
+export function normalizeSessionIds(value: unknown): Record<string, string | null> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  const normalized: Record<string, string | null> = {};
+  for (const [key, rawSessionId] of Object.entries(value as Record<string, unknown>)) {
+    if (!key) continue;
+    if (rawSessionId === null) {
+      normalized[key] = null;
+      continue;
+    }
+    if (typeof rawSessionId !== 'string') continue;
+    const sessionId = rawSessionId.trim();
+    if (sessionId) normalized[key] = sessionId;
+  }
+  return normalized;
+}
+
+export function normalizeBackend(value: unknown): MobileOrchestratorBackend | null {
+  return isOrchestratorBackendId(value) ? value : null;
+}
+
+export function normalizeAgent(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim().slice(0, 128) : null;
+}
+
+export function normalizeErrorMessage(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, 500) : null;
+}
+
+function inferRuntime(model: string | undefined | null): MobileOrchestratorThread['runtime'] {
+  if (!model) return 'unknown';
+  const lower = model.toLowerCase();
+  if (lower.includes('claude')) return 'claude-code';
+  if (lower.includes('gemini')) return 'gemini';
+  if (lower.includes('opencode')) return 'opencode';
+  if (lower.includes('codex') || lower.startsWith('gpt')) return 'codex';
+  return 'unknown';
+}
+
+export function inferBackendFromSessionIds(record: OrchestratorHistoryRecord): MobileOrchestratorBackend | null {
+  const sessionIds = normalizeSessionIds(record.orchestratorSessionIds);
+  if (sessionIds.claude) return 'claude';
+  if (sessionIds.codex) return 'codex';
+  return null;
+}
+
+export function modelForBackend(backend: MobileOrchestratorBackend | null): string | null {
+  if (backend === 'claude') return 'claude-code';
+  if (backend === 'codex') return 'codex';
+  if (backend === 'openclaw') return 'openclaw';
+  if (backend === 'hermes') return 'hermes';
+  return null;
+}
+
+export function effectiveBackend(record: OrchestratorHistoryRecord): MobileOrchestratorBackend | null {
+  return normalizeBackend(record.backend) ?? inferBackendFromSessionIds(record);
+}
+
+function effectiveModel(tabId: string, record: OrchestratorHistoryRecord): string | null {
+  if (typeof record.model === 'string' && record.model.trim()) return record.model.trim();
+  const backendModel = modelForBackend(effectiveBackend(record));
+  if (backendModel) return backendModel;
+  return tabId.startsWith('thoughts-') ? DEFAULT_MODEL : null;
+}
+
+export function trimTitle(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  if (!trimmed) return fallback;
+  return trimmed.slice(0, 80);
+}
+
+export function repoNameFromPath(repoPath: string | null): string | null {
+  if (!repoPath) return null;
+  const name = basename(repoPath.replace(/[/\\]+$/, ''));
+  return name || null;
+}
+
+export function projectOrchestratorThread(
+  tabId: string,
+  record: OrchestratorHistoryRecord,
+  modifiedAt: string,
+): MobileOrchestratorThread {
+  const messages = Array.isArray(record.messages) ? record.messages : [];
+  const lastMessage = messages[messages.length - 1];
+  const fallbackTitle = stableOrchestratorThreadTitleForId(tabId, record.savedAt || modifiedAt);
+  const repoPath = typeof record.repoPath === 'string' ? record.repoPath : null;
+  const githubIdentity = resolveRepoGithubIdentity(repoPath, record.remoteUrl);
+  const lastSpokeMs = messages.reduce((max, message) => (
+    Number.isFinite(message?.timestamp) && (message.timestamp as number) > max
+      ? (message.timestamp as number)
+      : max
+  ), 0);
+
+  return {
+    id: tabId,
+    title: trimTitle(record.title, fallbackTitle),
+    lastMessageAt: lastSpokeMs > 0 ? new Date(lastSpokeMs).toISOString() : (record.savedAt || modifiedAt),
+    runtime: inferRuntime(effectiveModel(tabId, record)),
+    status: record.orchestratorTerminalStatus === 'failed'
+      ? 'failed'
+      : messages.length === 0 ? 'idle' : lastMessage?.role === 'user' ? 'busy' : 'ready',
+    messageCount: messages.length,
+    repoPath,
+    repoName: typeof record.repoName === 'string' && record.repoName.trim()
+      ? record.repoName
+      : repoNameFromPath(repoPath),
+    repoBranch: typeof record.repoBranch === 'string' ? record.repoBranch : null,
+    githubOwner: githubIdentity.githubOwner,
+    githubRepo: githubIdentity.githubRepo,
+    backend: effectiveBackend(record),
+    agent: normalizeAgent(record.agent),
+    pinned: record.pinned === true,
+  };
+}

--- a/src/lib/orchestrator/turn-durability.test.ts
+++ b/src/lib/orchestrator/turn-durability.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -44,6 +44,49 @@ afterEach(() => {
 const REPO = '/tmp/repo';
 
 describe('orchestrator turn durability + reattach', () => {
+  it('routes desktop undo-send through the WebSocket entry point into durable transcript truncation', async () => {
+    const clientSource = readFileSync(join(process.cwd(), 'src/components/desktop/thoughts/useOrchestratorStream.ts'), 'utf-8');
+    const serverSource = readFileSync(join(process.cwd(), 'src/ws-server.ts'), 'utf-8');
+    expect(clientSource).toContain("type: 'orchestrator-undo-send'");
+    expect(serverSource).toContain("case 'orchestrator-undo-send':");
+    expect(serverSource).toContain('truncateMobileOrchestratorThreadFromMessage({');
+
+    const history = await loadHistory();
+    const threadId = 'thoughts-undo-reachability';
+    history.appendMobileOrchestratorUserMessage({
+      tabId: threadId,
+      repoPath: REPO,
+      message: 'keep',
+      messageId: 'orch-user-keep',
+      backend: 'codex',
+      timestampMs: 1000,
+    });
+    history.appendMobileOrchestratorUserMessage({
+      tabId: threadId,
+      repoPath: REPO,
+      message: 'undo me',
+      messageId: 'orch-user-orch-send-undo',
+      backend: 'codex',
+      timestampMs: 2000,
+    });
+    history.upsertMobileOrchestratorAssistantMessage({
+      tabId: threadId,
+      repoPath: REPO,
+      messageId: 'assistant-2000',
+      content: 'partial',
+      backend: 'codex',
+      timestampMs: 2001,
+    });
+    history.truncateMobileOrchestratorThreadFromMessage({
+      tabId: threadId,
+      messageId: 'orch-user-orch-send-undo',
+    });
+
+    expect(history.readOrchestratorThreadMessages(threadId)).toEqual([
+      { role: 'user', content: 'keep' },
+    ]);
+  });
+
   it('assistant text keeps persisting and the replay buffer serves a reattaching client after the origin client disconnects', async () => {
     const history = await loadHistory();
     const replay = new OrchestratorReplayBuffers();

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -103,6 +103,7 @@ import {
   listMobileOrchestratorThreads,
   markMobileOrchestratorThreadFailed,
   mobileOrchestratorThreadHistoryStatTokenAsync,
+  truncateMobileOrchestratorThreadFromMessage,
   upsertMobileOrchestratorAssistantMessage,
   writeOrchestratorBackendSessionId,
 } from './lib/mobile/orchestrator-thread-history';
@@ -961,6 +962,10 @@ const activeOrchestratorRoutes = new ActiveOrchestratorRouteRegistry();
 // turns on the same repo don't clobber each other. Entries are removed when the
 // turn resolves.
 const orchestratorInflightAborts = new Map<string, AbortController>();
+// Exact optimistic user-message ids currently being undone. The send handler
+// checks this before every durable append so an abort racing a final stream
+// flush cannot resurrect the turn after the transcript was rewound.
+const undoneOrchestratorUserMessageIds = new Set<string>();
 
 // ── Fable Slice 6 #2 — server-side metered-window valve state ────────────────
 // The metered auto-compact target mirrors ORCHESTRATOR_METERED_AUTO_COMPACT_
@@ -3212,6 +3217,9 @@ function handleClientMessage(client: ClientState, raw: string) {
     case 'orchestrator-interrupt':
       handleOrchestratorInterrupt(client, msg);
       break;
+    case 'orchestrator-undo-send':
+      handleOrchestratorUndoSend(client, msg);
+      break;
 
     // ── Symon Agent Mode channel (phone-hosted voice, Mac-executed tools) ──
     case 'symon-tool-call':
@@ -4212,6 +4220,9 @@ async function handleOrchestratorSendMsgOnce(
   // a later client POST that replaces the array can't double-write.
   const isThreadBacked = typeof threadId === 'string' && threadId.startsWith('thoughts-');
   const turnStartedAtMs = Date.now();
+  const userMessageId = correlationId
+    ? `orch-user-${correlationId}`
+    : `user-${turnStartedAtMs}`;
   const assistantMessageId = isThreadBacked ? `assistant-${turnStartedAtMs}` : null;
   const assistantStartedAtMs = turnStartedAtMs;
   let assistantTextAccum = '';
@@ -4227,6 +4238,7 @@ async function handleOrchestratorSendMsgOnce(
 
   const persistAssistantText = (sessionId: string | null, backendId: OrchestratorBackendId = activeBackend.id) => {
     if (!isThreadBacked || !assistantMessageId) return;
+    if (undoneOrchestratorUserMessageIds.has(userMessageId)) return;
     if (!assistantTextAccum || assistantTextAccum === lastPersistedAssistantText) return;
     try {
       const updatedThread = upsertMobileOrchestratorAssistantMessage({
@@ -4268,10 +4280,15 @@ async function handleOrchestratorSendMsgOnce(
     if (carryPrelude) {
       console.log(`[backend-switch-carry] Injected prior transcript into first ${activeBackend.id} turn (thread=${threadId ?? 'none'})`);
     }
+    // The undo can arrive while backend/session setup is still resolving. In
+    // that case the client already restored the draft and there is no turn to
+    // start or persist.
+    if (undoneOrchestratorUserMessageIds.has(userMessageId)) return;
     const updatedThread = appendMobileOrchestratorUserMessage({
       tabId: threadId,
       repoPath,
       message: transcriptMessage,
+      messageId: userMessageId,
       backend: activeBackend.id,
       agent: activeAgentTag,
       timestampMs: turnStartedAtMs,
@@ -4319,6 +4336,7 @@ async function handleOrchestratorSendMsgOnce(
         }));
       }
     }
+    if (undoneOrchestratorUserMessageIds.has(userMessageId)) return;
     const sendTurn = (
       turnBackend: OrchestratorBackend,
       turnAgentTag: string | undefined,
@@ -4720,6 +4738,7 @@ async function handleOrchestratorSendMsgOnce(
     // After the user message completes, drain any queued supervisor escalations.
     void drainOrchestratorAutoQueue();
   } catch (err) {
+    const turnWasUndone = undoneOrchestratorUserMessageIds.has(userMessageId);
     activeOrchestratorRoutes.release(activeRouteHandle);
     if (turnController) {
       for (const key of turnAbortKeys) {
@@ -4731,23 +4750,35 @@ async function handleOrchestratorSendMsgOnce(
     // Save any partial assistant text accumulated before the failure so
     // mobile listings still show what arrived rather than a blank turn.
     persistAssistantText(null);
-    try {
-      const failedThread = markMobileOrchestratorThreadFailed({
-        tabId: threadId,
-        repoPath,
-        error: err instanceof Error ? err.message : 'Failed to send message',
-        backend: activeBackend.id,
-        agent: activeAgentTag,
-      });
-      if (failedThread) {
-        broadcast({
-          channel: 'orchestrator-threads',
-          event: 'upsert',
-          data: { thread: failedThread },
+    if (!turnWasUndone) {
+      try {
+        const failedThread = markMobileOrchestratorThreadFailed({
+          tabId: threadId,
+          repoPath,
+          error: err instanceof Error ? err.message : 'Failed to send message',
+          backend: activeBackend.id,
+          agent: activeAgentTag,
         });
+        if (failedThread) {
+          broadcast({
+            channel: 'orchestrator-threads',
+            event: 'upsert',
+            data: { thread: failedThread },
+          });
+        }
+      } catch (markErr) {
+        console.warn('[ws-server][orchestrator] failed to mark thread failed', markErr);
       }
-    } catch (markErr) {
-      console.warn('[ws-server][orchestrator] failed to mark thread failed', markErr);
+    }
+    if (turnWasUndone) {
+      if (sessionName) {
+        broadcastToOrchestratorSession(sessionName, JSON.stringify({
+          channel: 'orchestrator',
+          event: 'status',
+          data: { status: 'ready', repoPath, threadId, backend: activeBackend.id, agent: activeAgentTag },
+        }));
+      }
+      return;
     }
     // Broadcast the error to EVERY subscriber on this thread, not just the
     // origin client — a phone-started turn that throws must also release the
@@ -4776,6 +4807,8 @@ async function handleOrchestratorSendMsgOnce(
     if (correlationId && !commandAccepted) {
       throw new OrchestratorSendRejectedBeforeAcceptance(err);
     }
+  } finally {
+    undoneOrchestratorUserMessageIds.delete(userMessageId);
   }
 }
 
@@ -4837,6 +4870,43 @@ function handleOrchestratorInterrupt(client: ClientState, msg: Record<string, un
   });
   // Leave the map entry in place; handleOrchestratorSendMsg removes it when
   // the turn resolves (the abort causes close to fire within 1-2s).
+}
+
+function handleOrchestratorUndoSend(client: ClientState, msg: Record<string, unknown>) {
+  const threadId = resolveMsgThreadId(msg);
+  const correlationId = resolveOrchestratorCommandCorrelationId(msg);
+  const userMessageId = typeof msg.userMessageId === 'string' ? msg.userMessageId.trim() : '';
+  if (!threadId?.startsWith('thoughts-') || !correlationId) return;
+  if (userMessageId !== `orch-user-${correlationId}`) return;
+
+  undoneOrchestratorUserMessageIds.add(userMessageId);
+  // A completed turn may receive undo just after its send handler released;
+  // bound the tombstone even when there is no handler left to clear it.
+  setTimeout(() => undoneOrchestratorUserMessageIds.delete(userMessageId), 60_000).unref?.();
+
+  handleOrchestratorInterrupt(client, msg);
+  const updatedThread = truncateMobileOrchestratorThreadFromMessage({
+    tabId: threadId,
+    messageId: userMessageId,
+  });
+  if (updatedThread) {
+    broadcast({
+      channel: 'orchestrator-threads',
+      event: 'upsert',
+      data: { thread: updatedThread },
+    });
+  }
+
+  send(client, {
+    channel: 'orchestrator',
+    event: 'undo-ack',
+    data: {
+      repoPath: typeof msg.repoPath === 'string' ? msg.repoPath : null,
+      threadId,
+      userMessageId,
+      ...orchestratorCommandAckCorrelation(correlationId),
+    },
+  });
 }
 
 async function handleOrchestratorStatus(client: ClientState, msg: Record<string, unknown>) {


### PR DESCRIPTION
Closes #1240.

Adds canvas-parity send handling to the default desktop composer: a 4.5-second undo window, text and image restoration, durable transcript truncation, late-token suppression, and a serialized cancelable queue. Canvas and desktop now share the headless composer send-buffer state machine.

Validation:
- npx tsc --noEmit
- focused Vitest coverage: 52/52 passed
- npm run rule-check -- --base=main
- touched-file ESLint: zero errors, with two pre-existing ComposerArea warnings
- full Vitest suite: 2,481 passed; one unrelated dogfood wrapper timeout passed 7/7 when rerun in isolation