### PR TITLE
docs: point readers at the issue tracker from the docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,3 +57,5 @@ For maintainers who build, verify, release, recover, or harden o8.
 | [Crash survival](operations/daemon-crash-survival.md) | How worker processes and transcripts recover after app or server failure. |
 | [Project hardening](operations/project-hardening.md) | The multi-repo project contract, retrieval scope, locks, and expected invariants. |
 | [Substrate evaluation gate](operations/substrate-eval-gate.md) | The thresholds and sustainment checks for memory and retrieval quality. |
+
+Questions or problems? [Open an issue](https://github.com/hurttlocker/o8/issues) — the bug template asks for the details that make reports actionable.


### PR DESCRIPTION
One-line docs change whose real job is to prove the PR pipeline end-to-end now that Actions billing is fixed:

- `ci.yml` on the `pull_request` trigger (billable-minutes baseline)
- `pr-size.yml` — should label this size/XS
- `pr-author-triage.yml` — first-ever execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcpKu7nivttKBQqkt5WQyP