### PR TITLE
fix: eighteen independent low-hanging fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ Runs on push/PR to `main`: TypeCheck → Lint → Unit Tests (`npm test`) → Go
 
 Universal `AgentRuntime` interface (`types.ts`) with capability-gated discovery. UI never talks to a specific runtime directly — always routes through the registry (`registry.ts`).
 
-**13 dispatchable runtimes** register in `orchestrator/runtime-capabilities.ts` (the count README advertises). Seven have dedicated adapter files — `codex.ts`, `claude-code.ts`, `gemini.ts`, `opencode.ts`, `cursor.ts`, `grok.ts`, `pi.ts` — while `declarative-workers.ts` carries the CLI-described rest (openhands, goose, qwen, kimi, aider) and `antigravity` ships as a discovery skeleton. All share capabilities: discover, readTranscript, launch, resume, interrupt, reviewDiffs. Codex distinguishes "owned" (IDE-spawned, full control) vs "discovered" (user terminal, read-only) sessions.
+**18 dispatchable runtimes** register in `orchestrator/runtime-capabilities.ts` (the count README advertises). Eleven have dedicated adapter files — `codex.ts`, `claude-code.ts`, `gemini.ts`, `antigravity.ts`, `magnitude.ts`, `opencode.ts`, `pi.ts`, `cursor.ts`, `grok.ts`, `prime-agent.ts`, `deepseek-harness.ts` — while `declarative-workers.ts` carries the CLI-described rest (openhands, goose, qwen, qoder, kimi, aider, 3code). All share capabilities: discover, readTranscript, launch, resume, interrupt, reviewDiffs. Codex distinguishes "owned" (IDE-spawned, full control) vs "discovered" (user terminal, read-only) sessions.
 
 `discoverAllSessions()` runs all adapters in parallel via `Promise.allSettled`. `routeAction()` dispatches resume/interrupt to the correct runtime.
 
@@ -336,7 +336,7 @@ If you're documenting a route here, also confirm it's in `GATED_PREFIXES` (or `A
 
 **~74 feature domains.** This grew fast; the canonical list is `ls src/lib/`. Don't try to enumerate every dir here — point at it and call out the load-bearing ones:
 
-- **Runtime layer**: `runtimes/` (13 dispatchable runtimes — 7 dedicated adapters: codex, claude-code, gemini, opencode, cursor, grok, pi; declarative-workers for openhands/goose/qwen/kimi/aider; + antigravity skeleton), `runtime/` (IDE session registries, actions, inventory), per-runtime dirs `codex/`, `claude-code/`, `gemini/`, `opencode/`, `cursor/`, `grok/`, `pi/`.
+- **Runtime layer**: `runtimes/` (18 dispatchable runtimes — 11 dedicated adapters: codex, claude-code, gemini, antigravity, magnitude, opencode, pi, cursor, grok, prime-agent, deepseek-harness; declarative-workers for openhands/goose/qwen/qoder/kimi/aider/3code), `runtime/` (IDE session registries, actions, inventory), per-runtime dirs `codex/`, `claude-code/`, `gemini/`, `opencode/`, `cursor/`, `grok/`, `pi/`.
 - **Dispatch + lanes**: `lane/` (single-lane logic incl. `worktree-side-merge.ts` + `codex-orchestrator-session.ts`), `lanes/` (multi-lane fleet view), `dispatch/`, `supervisor/`, `intake/`.
 - **Orchestrator**: `orchestrator/` (types, backends, runtime-capabilities, auto-compact), `agents/`.
 - **Cortex v2**: `cortex/` (see "Cortex v2" section above — directives, ledger, qa, embeddings, indexer, ingest).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,7 +336,7 @@ If you're documenting a route here, also confirm it's in `GATED_PREFIXES` (or `A
 
 **~74 feature domains.** This grew fast; the canonical list is `ls src/lib/`. Don't try to enumerate every dir here — point at it and call out the load-bearing ones:
 
-- **Runtime layer**: `runtimes/` (18 dispatchable runtimes — 11 dedicated adapters: codex, claude-code, gemini, antigravity, magnitude, opencode, pi, cursor, grok, prime-agent, deepseek-harness; declarative-workers for openhands/goose/qwen/qoder/kimi/aider/3code), `runtime/` (IDE session registries, actions, inventory), per-runtime dirs `codex/`, `claude-code/`, `gemini/`, `opencode/`, `cursor/`, `grok/`, `pi/`.
+- **Runtime layer**: `runtimes/` (18 dispatchable runtimes — 11 dedicated adapters: codex, claude-code, gemini, antigravity, magnitude, opencode, pi, cursor, grok, prime-agent, deepseek-harness; declarative-workers for openhands/goose/qwen/qoder/kimi/aider/3code), `runtime/` (IDE session registries, actions, inventory), per-runtime support dirs `codex/`, `claude-code/`, `gemini/`, `opencode/`, `cursor/`, `grok/`, `pi/`, `prime-agent/`, `deepseek-harness/`. Antigravity and Magnitude currently remain single adapter files under `runtimes/`.
 - **Dispatch + lanes**: `lane/` (single-lane logic incl. `worktree-side-merge.ts` + `codex-orchestrator-session.ts`), `lanes/` (multi-lane fleet view), `dispatch/`, `supervisor/`, `intake/`.
 - **Orchestrator**: `orchestrator/` (types, backends, runtime-capabilities, auto-compact), `agents/`.
 - **Cortex v2**: `cortex/` (see "Cortex v2" section above — directives, ledger, qa, embeddings, indexer, ingest).

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Settings → MCP → Install. o8 exposes its operator tools — `create_mission`
 
 ## Free vs. paid, plainly
 
-**Everything that runs on your machine is free and open source, forever.** The full app, all 13 runtimes, governance, memory, the Brain, the mobile surface, voice with your own keys. No feature gates, no seat limits.
+**Everything that runs on your machine is free and open source, forever.** The full app, all 18 runtimes, governance, memory, the Brain, the mobile surface, voice with your own keys. No feature gates, no seat limits.
 
 Optional paid services (coming after launch) are the things that run on **our** servers: managed inference for the no-setup path, hosted voice, remote access without network config. Convenience, never capability. If you never pay, you have the whole product.
 

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -134,9 +134,11 @@ async function all() {
   process.once('SIGTERM', () => { void shutdown('SIGTERM'); });
 
   for (const child of [next, ws]) {
-    child.on('exit', (code) => {
+    child.on('exit', (code, signal) => {
       forget(child.pid);
-      void shutdown('SIGTERM', code);
+      // A signal exit reports a null code. Preserve that failure instead of
+      // turning an unexpectedly killed wrapper into a successful dev command.
+      void shutdown('SIGTERM', code ?? (signal ? 1 : 0));
     });
   }
 }

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -107,24 +107,36 @@ async function all() {
   remember(next.pid, 'dev:next-wrapper');
   remember(ws.pid, 'dev:ws-wrapper');
 
-  const stop = (signal) => {
+  const signalChildren = (signal) => {
     for (const child of [next, ws]) {
       try {
         child.kill(signal);
       } catch {}
     }
   };
-  process.once('SIGINT', () => stop('SIGINT'));
-  process.once('SIGTERM', () => stop('SIGTERM'));
 
+  // Ctrl-C used to exit here the moment a wrapper died, before either wrapper
+  // had reaped its own `next dev` / `tsx ws-server` grandchild -- so 47120 and
+  // 47125 stayed bound and the pid file kept entries for processes we never
+  // waited on. Route every exit path through cleanup(), the same pass
+  // `dev:cleanup` runs, so the ports are free and the pid file is accurate by
+  // the time the shell comes back (#1678).
   let exiting = false;
+  const shutdown = async (signal, code) => {
+    if (exiting) return;
+    exiting = true;
+    signalChildren(signal);
+    await cleanup();
+    process.exit(code ?? 0);
+  };
+
+  process.once('SIGINT', () => { void shutdown('SIGINT'); });
+  process.once('SIGTERM', () => { void shutdown('SIGTERM'); });
+
   for (const child of [next, ws]) {
     child.on('exit', (code) => {
       forget(child.pid);
-      if (exiting) return;
-      exiting = true;
-      stop('SIGTERM');
-      process.exit(code ?? 0);
+      void shutdown('SIGTERM', code);
     });
   }
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1409,7 +1409,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1644,7 +1644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2355,9 +2355,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3449,7 +3449,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3597,7 +3597,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4192,7 +4192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -5311,7 +5311,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5384,7 +5384,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6028,7 +6028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6921,7 +6921,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7375,7 +7375,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7413,7 +7413,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7964,7 +7964,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/app/dashboard/hooks/useSettingsOverlayDismiss.ts
+++ b/src/app/dashboard/hooks/useSettingsOverlayDismiss.ts
@@ -27,6 +27,11 @@ export function useSettingsOverlayDismiss({
       const target = event.target as Node | null;
       const targetElement = target instanceof Element ? target : null;
       if (targetElement?.closest('[aria-label="Settings"]')) return;
+      // Settings pickers portal to document.body, so they sit outside panelRef
+      // and this capture-phase handler used to close the whole overlay on the
+      // first click into a menu -- which read as "the setting will not change".
+      // Any portaled settings surface opts back in with this attribute (#1685).
+      if (targetElement?.closest('[data-o8-settings-portal]')) return;
       const panel = panelRef.current;
       if (panel && target && panel.contains(target)) return;
       closeSettingsOverlay();

--- a/src/components/desktop/model-picker-coverage.test.ts
+++ b/src/components/desktop/model-picker-coverage.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import { MODEL_IDS } from '@/lib/models';
-import { formatModelLabel } from '@/lib/format';
 import { ORCHESTRATOR_MODEL_OPTIONS } from './settings/dispatch-shared';
 import { CLAUDE_CLI_MODELS } from './workspace-terminal/constants';
 
@@ -28,9 +27,12 @@ describe('Claude model picker coverage', () => {
 
   it('has a real label for each of them, never the bare id', () => {
     for (const id of CURRENT_CLAUDE_FLAGSHIPS) {
-      const label = formatModelLabel(id);
-      expect(label).not.toBe(id);
-      expect(label.length).toBeGreaterThan(0);
+      const settingsOption = ORCHESTRATOR_MODEL_OPTIONS.find((option) => option.value === id);
+      const workspaceOption = CLAUDE_CLI_MODELS.find((option) => option.id === id);
+      expect(settingsOption?.label.trim()).toBeTruthy();
+      expect(settingsOption?.label).not.toBe(id);
+      expect(workspaceOption?.label.trim()).toBeTruthy();
+      expect(workspaceOption?.label).not.toBe(id);
     }
   });
 });

--- a/src/components/desktop/model-picker-coverage.test.ts
+++ b/src/components/desktop/model-picker-coverage.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { MODEL_IDS } from '@/lib/models';
+import { formatModelLabel } from '@/lib/format';
+import { ORCHESTRATOR_MODEL_OPTIONS } from './settings/dispatch-shared';
+import { CLAUDE_CLI_MODELS } from './workspace-terminal/constants';
+
+/**
+ * Three surfaces each keep a hand-written Claude model list. Until they are
+ * generated from the registry, a new flagship has to be copied into all three
+ * — and Opus 5 reached the composer and Settings but not the workspace CLI
+ * picker, so a model already in the registry could not be selected (#1808).
+ */
+const CURRENT_CLAUDE_FLAGSHIPS = [
+  MODEL_IDS.raw.anthropicClaudeOpus5,
+  MODEL_IDS.raw.anthropicClaudeSonnet5,
+] as const;
+
+describe('Claude model picker coverage', () => {
+  it('offers every current Claude flagship in Settings → Models', () => {
+    const ids = ORCHESTRATOR_MODEL_OPTIONS.map((option) => option.value);
+    for (const id of CURRENT_CLAUDE_FLAGSHIPS) expect(ids).toContain(id);
+  });
+
+  it('offers every current Claude flagship in the workspace CLI picker', () => {
+    const ids = CLAUDE_CLI_MODELS.map((option) => option.id);
+    for (const id of CURRENT_CLAUDE_FLAGSHIPS) expect(ids).toContain(id);
+  });
+
+  it('has a real label for each of them, never the bare id', () => {
+    for (const id of CURRENT_CLAUDE_FLAGSHIPS) {
+      const label = formatModelLabel(id);
+      expect(label).not.toBe(id);
+      expect(label.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/components/desktop/settings/AcpModelPickerPopover.tsx
+++ b/src/components/desktop/settings/AcpModelPickerPopover.tsx
@@ -147,6 +147,7 @@ export function AcpModelPickerPopover({
         ? createPortal(
           <div
             ref={panelRef}
+            data-o8-settings-portal="true"
             style={{
               position: 'fixed',
               top,

--- a/src/components/desktop/settings/dispatch-shared.tsx
+++ b/src/components/desktop/settings/dispatch-shared.tsx
@@ -365,6 +365,7 @@ export function PickerMenu<T extends string>({ value, options, onChange, disable
         <div
           id={listboxId}
           ref={popoverRef}
+          data-o8-settings-portal="true"
           role="listbox"
           aria-label="Settings picker options"
           aria-activedescendant={highlightedIndex >= 0 ? `${listboxId}-option-${highlightedIndex}` : undefined}

--- a/src/components/desktop/settings/projects/ProjectRepoRows.tsx
+++ b/src/components/desktop/settings/projects/ProjectRepoRows.tsx
@@ -139,6 +139,7 @@ function PickerPopover({
       {open && pos && typeof document !== 'undefined' ? createPortal(
         <div
           ref={popRef}
+          data-o8-settings-portal="true"
           style={{
             position: 'fixed',
             top: pos.top,

--- a/src/components/desktop/settings/projects/RepoPickerRow.tsx
+++ b/src/components/desktop/settings/projects/RepoPickerRow.tsx
@@ -206,6 +206,7 @@ export function RepoPickerRow({
       {openPopover && checked && popoverPosition && typeof document !== 'undefined' ? createPortal(
         <div
           ref={popoverRef}
+          data-o8-settings-portal="true"
           style={{
             position: 'fixed',
             top: popoverPosition.top,

--- a/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
+++ b/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
@@ -76,7 +76,7 @@ import {
   mergeToolResultIntoEntry,
   sendScratchChatMessage,
 } from '@/components/desktop/orchestrator/send-chat-message';
-import { dedupeDisplayMessages } from './chat-panel/dedupe-display-messages';
+import { resolveDisplayMessages } from './chat-panel/resolve-display-messages';
 import { EmptyStateCard } from './chat-panel/EmptyStateCard';
 import { ThreadExportButton } from './chat-panel/ThreadExportButton';
 import { useClearCommand } from './chat-panel/useClearCommand';
@@ -1444,11 +1444,15 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
     if (!isOrchestratorMode || isChatMode) return chatMessages;
     // Loaded history + the live stream overlap after a mid-conversation reload;
     // the same user turn can survive in both the restored (persisted id) and
-    // the live-minted (optimistic id) form. Dedupe so it never double-renders.
-    const base = orchStream.messages.length > 0 ? orchStream.messages : chatMessages;
-    return dedupeDisplayMessages(threadHistoryEntries.length > 0
-      ? [...threadHistoryEntries, ...base]
-      : base);
+    // the live-minted (optimistic id) form. resolveDisplayMessages concatenates
+    // all three sources and lets dedupeDisplayMessages collapse the overlap --
+    // it used to pick the stream OR the history, which dropped a whole restored
+    // thread the moment one live event arrived (#1839).
+    return resolveDisplayMessages({
+      historyEntries: threadHistoryEntries,
+      chatMessages,
+      streamMessages: orchStream.messages,
+    });
   }, [chatMessages, isChatMode, isOrchestratorMode, orchStream.messages, threadHistoryEntries]);
   // See `composerRepoLabelBase` for the rationale — derived here so
   // the empty-state check matches the empty-state-override condition.

--- a/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
+++ b/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
@@ -1171,31 +1171,27 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
   useEffect(() => {
     if (!isOrchestratorMode || isChatMode || orchStream.messages.length === 0) return;
     if (!orchStream.messages.some((entry) => entry.role !== 'system')) return;
-    setChatMessages((prev) => {
-      if (
-        prev.length === orchStream.messages.length
-        && prev.every((entry, index) => {
-          const liveEntry = orchStream.messages[index];
-          if (!liveEntry) return false;
-          return entry.id === liveEntry?.id
-            && entry.role === liveEntry.role
-            && entry.text === liveEntry.text
-            && entry.thinking === liveEntry.thinking
-            && entry.toolCalls === liveEntry.toolCalls
-            && entry.statusEvent === liveEntry.statusEvent
-            && entry.collide === liveEntry.collide;
-        })
-      ) {
-        return prev;
-      }
-      return orchStream.messages;
-    });
+    // Keep the restored transcript while syncing the current live turn into
+    // retained state. Replacing this state with the stream repeated #1839 one
+    // effect earlier than the display resolver could repair it.
+    setChatMessages((prev) => resolveDisplayMessages({
+      historyEntries: [],
+      chatMessages: prev,
+      streamMessages: orchStream.messages,
+    }));
   }, [isChatMode, isOrchestratorMode, orchStream.messages]);
 
   useEffect(() => {
     if (!isOrchestratorMode) return;
 
-    const msgs = orchStream.messages.length > 0 ? orchStream.messages : chatMessages;
+    // Persist the same composed transcript that the panel renders. Persisting
+    // the live stream alone could temporarily overwrite restored history with
+    // one new event before retained state caught up.
+    const msgs = resolveDisplayMessages({
+      historyEntries: [],
+      chatMessages,
+      streamMessages: orchStream.messages,
+    });
 
     // If a thread already has a placeholder row (minted on + New), keep
     // writing even while empty so History reflects reality. Once a user

--- a/src/components/desktop/thoughts/chat-panel/resolve-display-messages.test.ts
+++ b/src/components/desktop/thoughts/chat-panel/resolve-display-messages.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import type { MobileTranscriptEntry } from '@/lib/mobile/types';
+import { resolveDisplayMessages } from './resolve-display-messages';
+
+function entry(partial: Partial<MobileTranscriptEntry> & { id: string; role: MobileTranscriptEntry['role'] }): MobileTranscriptEntry {
+  return { text: '', ...partial };
+}
+
+const BASE_TS = 1787358397405; // the thread id timestamp from the live report
+
+/**
+ * The reported thread (`thoughts-1787358397405`) held 25 persisted messages --
+ * 21 system dispatch cards, 2 operator questions, 2 assistant answers -- and
+ * rendered as one card in whitespace.
+ */
+function persistedThread(): MobileTranscriptEntry[] {
+  const entries: MobileTranscriptEntry[] = [];
+  entries.push(entry({ id: 'orch-user-1', role: 'user', text: 'What is o8, in your own words', timestamp: BASE_TS }));
+  entries.push(entry({ id: 'assistant-1', role: 'assistant', text: 'o8 is a control plane.', timestamp: BASE_TS + 1_000 }));
+  for (let i = 0; i < 21; i += 1) {
+    entries.push(entry({ id: `system-${i}`, role: 'system', text: `Mission complete -- packet ${i}`, timestamp: BASE_TS + 2_000 + i }));
+  }
+  entries.push(entry({ id: 'orch-user-2', role: 'user', text: 'and the governance part?', timestamp: BASE_TS + 30_000 }));
+  entries.push(entry({ id: 'assistant-2', role: 'assistant', text: 'Approvals and audit.', timestamp: BASE_TS + 31_000 }));
+  return entries;
+}
+
+describe('resolveDisplayMessages', () => {
+  it('keeps the restored thread when one live event arrives (#1839)', () => {
+    const chatMessages = persistedThread();
+    // The stream starts empty and fills on the first live event. One dispatch
+    // card used to replace the entire restored thread.
+    const streamMessages = [
+      entry({ id: 'system-live', role: 'system', text: 'Mission complete -- 1 packet merged', timestamp: BASE_TS + 60_000 }),
+    ];
+    const out = resolveDisplayMessages({ historyEntries: [], chatMessages, streamMessages });
+
+    expect(chatMessages).toHaveLength(25);
+    expect(out).toHaveLength(26);
+    expect(out.filter((m) => m.role === 'user')).toHaveLength(2);
+    expect(out.filter((m) => m.role === 'assistant')).toHaveLength(2);
+    expect(out.at(-1)?.id).toBe('system-live');
+  });
+
+  it('renders the persisted thread while no turn is live', () => {
+    const chatMessages = persistedThread();
+    const out = resolveDisplayMessages({ historyEntries: [], chatMessages, streamMessages: [] });
+    expect(out).toHaveLength(25);
+    expect(out).toBe(chatMessages);
+  });
+
+  it('does not double-render a turn present in both sources', () => {
+    const shared = entry({ id: 'orch-user-9', role: 'user', text: 'ship it', timestamp: BASE_TS });
+    const out = resolveDisplayMessages({
+      historyEntries: [],
+      chatMessages: [shared],
+      streamMessages: [
+        { ...shared, text: 'ship it' },
+        entry({ id: 'assistant-9', role: 'assistant', text: 'done', timestamp: BASE_TS + 500 }),
+      ],
+    });
+    expect(out.map((m) => m.id)).toEqual(['orch-user-9', 'assistant-9']);
+  });
+
+  it('orders backfilled history oldest-first, ahead of persisted and live', () => {
+    const out = resolveDisplayMessages({
+      historyEntries: [entry({ id: 'old-1', role: 'user', text: 'first ever', timestamp: BASE_TS - 100_000 })],
+      chatMessages: [entry({ id: 'mid-1', role: 'assistant', text: 'middle', timestamp: BASE_TS })],
+      streamMessages: [entry({ id: 'new-1', role: 'system', text: 'newest', timestamp: BASE_TS + 100_000 })],
+    });
+    expect(out.map((m) => m.id)).toEqual(['old-1', 'mid-1', 'new-1']);
+  });
+
+  it('is empty only when every source is empty', () => {
+    expect(resolveDisplayMessages({ historyEntries: [], chatMessages: [], streamMessages: [] })).toEqual([]);
+  });
+});

--- a/src/components/desktop/thoughts/chat-panel/resolve-display-messages.test.ts
+++ b/src/components/desktop/thoughts/chat-panel/resolve-display-messages.test.ts
@@ -42,6 +42,29 @@ describe('resolveDisplayMessages', () => {
     expect(out.at(-1)?.id).toBe('system-live');
   });
 
+  it('keeps restored entries when the live stream is synced into retained state', () => {
+    const restored = persistedThread();
+    const live = [
+      entry({ id: 'assistant-live', role: 'assistant', text: 'Current turn', timestamp: BASE_TS + 60_000 }),
+    ];
+
+    const retained = resolveDisplayMessages({
+      historyEntries: [],
+      chatMessages: restored,
+      streamMessages: live,
+    });
+    const rendered = resolveDisplayMessages({
+      historyEntries: [],
+      chatMessages: retained,
+      streamMessages: live,
+    });
+
+    expect(retained).toHaveLength(26);
+    expect(rendered).toHaveLength(26);
+    expect(rendered[0]?.id).toBe('orch-user-1');
+    expect(rendered.at(-1)?.id).toBe('assistant-live');
+  });
+
   it('renders the persisted thread while no turn is live', () => {
     const chatMessages = persistedThread();
     const out = resolveDisplayMessages({ historyEntries: [], chatMessages, streamMessages: [] });

--- a/src/components/desktop/thoughts/chat-panel/resolve-display-messages.ts
+++ b/src/components/desktop/thoughts/chat-panel/resolve-display-messages.ts
@@ -1,0 +1,38 @@
+import type { MobileTranscriptEntry } from '@/lib/mobile/types';
+import { dedupeDisplayMessages } from './dedupe-display-messages';
+
+/**
+ * Compose the orchestrator transcript that actually renders.
+ *
+ * Three sources feed it:
+ *  - `historyEntries` — older pages pulled in by scroll-up backfill (oldest);
+ *  - `chatMessages`   — the thread's persisted history, already merged with any
+ *                       live transcript by the thread-load path;
+ *  - `streamMessages` — the live orchestrator stream for the current turn.
+ *
+ * This used to pick `streamMessages` OR `chatMessages`, never both. The stream
+ * starts empty and fills on the first live event, so a restored thread rendered
+ * correctly until ANY event arrived — then the whole persisted history was
+ * dropped in favour of that one entry. A thread holding 25 stored messages
+ * showed a single dispatch card in whitespace, which reads as a lost session
+ * exactly when the history matters most (#1839).
+ *
+ * They are concatenated oldest-to-newest instead, and {@link dedupeDisplayMessages}
+ * collapses the overlap — which is what its own contract describes: the
+ * transcript is *composed from* loaded history and the live stream, and the
+ * same logical message may appear in both with the same id or across the
+ * optimistic/echo boundary with differing ids.
+ */
+export function resolveDisplayMessages(sources: {
+  historyEntries: MobileTranscriptEntry[];
+  chatMessages: MobileTranscriptEntry[];
+  streamMessages: MobileTranscriptEntry[];
+}): MobileTranscriptEntry[] {
+  const { historyEntries, chatMessages, streamMessages } = sources;
+  const base = streamMessages.length > 0
+    ? [...chatMessages, ...streamMessages]
+    : chatMessages;
+  return dedupeDisplayMessages(
+    historyEntries.length > 0 ? [...historyEntries, ...base] : base,
+  );
+}

--- a/src/components/desktop/workspace-terminal/AgentTilePane.test.ts
+++ b/src/components/desktop/workspace-terminal/AgentTilePane.test.ts
@@ -251,4 +251,23 @@ describe('canSteerAgentState', () => {
       { status: 'failed', blockedReason: 'runtime_process_exit' },
     )).toBe(false);
   });
+
+  it('offers the composer for an idle packet, which steers successfully (#1846)', () => {
+    // The reported pane read `Codex · Codex · Idle` with no composer, while
+    // steer_packet against that same packet resumed the worker and produced a
+    // new commit. The pane was asserting a false state.
+    expect(canSteerAgentState({ status: 'idle' }, { status: 'idle' })).toBe(true);
+  });
+
+  it('offers the composer while a packet is recovering between escalation layers', () => {
+    expect(canSteerAgentState({ status: 'idle' }, { status: 'recovering' })).toBe(true);
+  });
+
+  it('still hides the composer where there is no session to steer', () => {
+    expect(canSteerAgentState({ status: 'idle' }, { status: 'draft' })).toBe(false);
+    expect(canSteerAgentState({ status: 'idle' }, { status: 'queued' })).toBe(false);
+    expect(canSteerAgentState({ status: 'idle' }, { status: 'archived' })).toBe(false);
+    expect(canSteerAgentState({ status: 'idle' }, { status: 'released' })).toBe(false);
+    expect(canSteerAgentState(null, null)).toBe(false);
+  });
 });

--- a/src/components/desktop/workspace-terminal/AgentTilePane.tsx
+++ b/src/components/desktop/workspace-terminal/AgentTilePane.tsx
@@ -224,6 +224,13 @@ export function canSteerAgentState(
   const blockedReason = (packet?.blockedReason ?? '').toLowerCase();
   if (agentStatus === 'running' || packetStatus === 'running') return true;
   if (packetStatus.includes('awaiting_') || agentStatus.includes('awaiting_')) return true;
+  // A parked session is exactly when steering is the cheap recovery path -- it
+  // reuses the warm thread instead of throwing it away for a redispatch. The
+  // steer route itself gates on whether a session binding resolves, not on the
+  // display status, and an `idle` packet steered successfully while its pane
+  // showed no composer at all (#1846). `recovering` is the retry-pending pause
+  // between escalation layers, and is steerable for the same reason.
+  if (packetStatus === 'idle' || packetStatus === 'recovering') return true;
   return packetStatus === 'blocked' && (blockedReason === 'huddle_ready' || blockedReason === 'worker_question');
 }
 

--- a/src/components/desktop/workspace-terminal/constants.ts
+++ b/src/components/desktop/workspace-terminal/constants.ts
@@ -46,6 +46,11 @@ export const GEMINI_FALLBACK_CASCADE: ReadonlyArray<string> = [
 ];
 
 export const CLAUDE_CLI_MODELS: WorkspaceCliModelOption[] = [
+  // Every Claude surface keeps its own hand-written list, so a registry
+  // addition has to be copied into each one and Opus 5 reached the composer
+  // and Settings but never here (#1808). `model-picker-coverage.test.ts` pins
+  // the three lists together until they are generated from the registry.
+  { id: MODEL_IDS.raw.anthropicClaudeOpus5, label: 'Opus 5', color: '#8b5cf6' },
   { id: MODEL_IDS.raw.anthropicClaudeOpus48, label: 'Opus 4.8 (1M)', color: '#8b5cf6' },
   { id: MODEL_IDS.raw.anthropicClaudeOpus47, label: 'Opus 4.7 (1M)', color: '#8b5cf6' },
   { id: MODEL_IDS.raw.anthropicClaudeSonnet5, label: 'Sonnet 5', color: '#8b5cf6' },

--- a/src/components/desktop/workspace-terminal/useWorkspaceChatPane.ts
+++ b/src/components/desktop/workspace-terminal/useWorkspaceChatPane.ts
@@ -102,16 +102,10 @@ export function useWorkspaceChatPane({
 
   const tabId = tab.id;
   const chatSessionKey = tab.chatSessionKey;
-  // The session key is a third source of runtime identity, and often the only
-  // one present: four live claude-code lanes showed the composer's Codex
-  // default because neither the packet nor the tab carried a runtime, while
-  // their `claude-code-owned:*` keys said exactly what was running (#1749).
-  const chatRuntime = (
-    tab.orchestrationPacket?.runtime
+  const chatRuntime = (tab.orchestrationPacket?.runtime
     ?? tab.chatRuntime
     ?? runtimeFromSessionKeyId(chatSessionKey)
-    ?? undefined
-  ) as OrchestratorRuntime | undefined;
+    ?? undefined) as OrchestratorRuntime | undefined;
   const linkedIssue = tab.linkedIssue ?? null;
   const normalizedSessionKey = useMemo(
     () => normalizeWorkspaceChatSessionKey(chatRuntime, chatSessionKey),
@@ -121,8 +115,6 @@ export function useWorkspaceChatPane({
     () => runtimeTransportSessionId(chatRuntime, chatSessionKey),
     [chatRuntime, chatSessionKey],
   );
-  // Naming a runtime we cannot identify is how "Codex working…" ended up over
-  // a Claude worker. When no source resolves, say nothing specific.
   const runtimeLabel = useMemo(
     () => (chatRuntime ? getRuntimeCapability(chatRuntime).label : 'Agent'),
     [chatRuntime],

--- a/src/components/desktop/workspace-terminal/useWorkspaceChatPane.ts
+++ b/src/components/desktop/workspace-terminal/useWorkspaceChatPane.ts
@@ -19,7 +19,7 @@ import {
   type WorkspaceUsageTokens,
   type WorkspaceStreamEvent,
 } from '@/components/desktop/workspace-terminal/workspace-stream-events';
-import { getRuntimeCapability, type OrchestratorRuntime } from '@/lib/orchestrator/runtime-capabilities';
+import { getRuntimeCapability, runtimeFromSessionKeyId, type OrchestratorRuntime } from '@/lib/orchestrator/runtime-capabilities';
 import {
   correlatedActionIsUnsettled,
 } from '@/lib/orchestrator/action-receipt';
@@ -101,11 +101,17 @@ export function useWorkspaceChatPane({
   const streamRequest = useActiveLongLivedRequest(active);
 
   const tabId = tab.id;
+  const chatSessionKey = tab.chatSessionKey;
+  // The session key is a third source of runtime identity, and often the only
+  // one present: four live claude-code lanes showed the composer's Codex
+  // default because neither the packet nor the tab carried a runtime, while
+  // their `claude-code-owned:*` keys said exactly what was running (#1749).
   const chatRuntime = (
     tab.orchestrationPacket?.runtime
     ?? tab.chatRuntime
+    ?? runtimeFromSessionKeyId(chatSessionKey)
+    ?? undefined
   ) as OrchestratorRuntime | undefined;
-  const chatSessionKey = tab.chatSessionKey;
   const linkedIssue = tab.linkedIssue ?? null;
   const normalizedSessionKey = useMemo(
     () => normalizeWorkspaceChatSessionKey(chatRuntime, chatSessionKey),
@@ -115,8 +121,10 @@ export function useWorkspaceChatPane({
     () => runtimeTransportSessionId(chatRuntime, chatSessionKey),
     [chatRuntime, chatSessionKey],
   );
+  // Naming a runtime we cannot identify is how "Codex working…" ended up over
+  // a Claude worker. When no source resolves, say nothing specific.
   const runtimeLabel = useMemo(
-    () => getRuntimeCapability(chatRuntime ?? 'codex').label,
+    () => (chatRuntime ? getRuntimeCapability(chatRuntime).label : 'Agent'),
     [chatRuntime],
   );
   const { availableModels, selectedModel } = useWorkspaceChatModelOptions(chatRuntime, tab.chatModel);

--- a/src/lib/broadcast/director.ts
+++ b/src/lib/broadcast/director.ts
@@ -2,6 +2,8 @@ import 'server-only';
 
 import type Database from 'better-sqlite3';
 
+import { broadcastGeneratedLinesSince as countGeneratedLines, claimBroadcastLineSlot } from './hourly-cap';
+
 import { callCodex, type CallCodexOptions } from '@/lib/cortex/qa/llm/codex-adapter';
 import { getSqlite } from '@/lib/db';
 import { ensureV44BroadcastSchema } from '@/lib/db/v44-broadcast-migration';
@@ -70,19 +72,9 @@ function lastDirectorRun(sqlite: Database.Database): DirectorRunRow | null {
   `).get() as DirectorRunRow | undefined ?? null;
 }
 
-export function broadcastGeneratedLinesSince(sqlite: Database.Database, timestamp: string): number {
-  const row = sqlite.prepare(`
-    SELECT COUNT(*) AS count
-    FROM broadcast_events
-    WHERE kind = 'commentary'
-      AND (
-        json_extract(metadata_json, '$.director') = 1
-        OR json_extract(metadata_json, '$.hourlyCapped') = 1
-      )
-      AND created_at >= ?
-  `).get(timestamp) as { count: number };
-  return row.count;
-}
+// Re-exported from its own module so the claim path and the count share one
+// definition and neither file has to import the other (#1840).
+export { broadcastGeneratedLinesSince } from './hourly-cap';
 
 export async function runBroadcastDirectorOnce(options: {
   sqlite?: Database.Database;
@@ -106,7 +98,9 @@ export async function runBroadcastDirectorOnce(options: {
       return { status: 'skipped', reason: 'interval' };
     }
   }
-  if (broadcastGeneratedLinesSince(sqlite, new Date(now.getTime() - 60 * 60_000).toISOString()) >= settings.maxPerHour) {
+  // Cheap early exit so a full window costs no commentary call. The binding
+  // decision is the claim around the insert below.
+  if (countGeneratedLines(sqlite, new Date(now.getTime() - 60 * 60_000).toISOString()) >= settings.maxPerHour) {
     return { status: 'skipped', reason: 'max_per_hour' };
   }
 
@@ -133,10 +127,9 @@ export async function runBroadcastDirectorOnce(options: {
     const output = (await runner(buildBroadcastCommentaryPrompt(newEvents, recent), route)).trim();
     const text = speakableText(output);
     if (!text) throw new Error('Broadcast commentary runner returned no text.');
-    if (broadcastGeneratedLinesSince(sqlite, new Date(now.getTime() - 60 * 60_000).toISOString()) >= settings.maxPerHour) {
-      return { status: 'skipped', reason: 'max_per_hour', newEventCount: newEvents.length };
-    }
-    const event = appendBroadcastEvent({
+    // The commentary call above is an await, so the count read before it is
+    // stale by now. Claim the slot in the same transaction as the insert.
+    const event = claimBroadcastLineSlot(sqlite, now, settings.maxPerHour, () => appendBroadcastEvent({
       kind: 'commentary',
       actor: 'mister',
       text,
@@ -150,7 +143,10 @@ export async function runBroadcastDirectorOnce(options: {
         feedEventCount: newEvents.length,
         factKeys: [...new Set(newEvents.filter(isMomentEvent).map(momentFactKey))],
       },
-    });
+    }));
+    if (!event) {
+      return { status: 'skipped', reason: 'max_per_hour', newEventCount: newEvents.length };
+    }
     return {
       status: 'posted',
       reason: 'posted',

--- a/src/lib/broadcast/hourly-cap.integration.test.ts
+++ b/src/lib/broadcast/hourly-cap.integration.test.ts
@@ -1,0 +1,129 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+process.env.O8_DATA_DIR ??= mkdtempSync(path.join(os.tmpdir(), 'o8-hourly-cap-integration-'));
+process.env.CORTEX_IDE_DATA_DIR ??= process.env.O8_DATA_DIR;
+
+const { getSqlite } = await import('@/lib/db');
+const { ensureV44BroadcastSchema } = await import('@/lib/db/v44-broadcast-migration');
+const { broadcastGeneratedLinesSince, broadcastHourlyWindowStart } =
+  await import('@/lib/broadcast/hourly-cap');
+
+const NOW = new Date('2026-08-24T12:00:00.000Z');
+const childStderr = new WeakMap<ChildProcess, () => string>();
+
+function waitForMessage<T>(child: ChildProcess, type: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for child message ${type}`));
+    }, 15_000);
+    const onMessage = (message: unknown) => {
+      if (!message || typeof message !== 'object' || (message as { type?: unknown }).type !== type) return;
+      cleanup();
+      resolve(message as T);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(new Error(
+        `Child exited before ${type}: code=${String(code)} signal=${String(signal)} ${childStderr.get(child)?.() ?? ''}`,
+      ));
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      child.off('message', onMessage);
+      child.off('error', onError);
+      child.off('exit', onExit);
+    };
+    child.on('message', onMessage);
+    child.once('error', onError);
+    child.once('exit', onExit);
+  });
+}
+
+function spawnClaimant(workerId: string, cap: number): { child: ChildProcess; stderr: () => string } {
+  const hourlyCapUrl = pathToFileURL(path.join(process.cwd(), 'src/lib/broadcast/hourly-cap.ts')).href;
+  const dbUrl = pathToFileURL(path.join(process.cwd(), 'src/lib/db/index.ts')).href;
+  const migrationUrl = pathToFileURL(path.join(process.cwd(), 'src/lib/db/v44-broadcast-migration.ts')).href;
+  const postUrl = pathToFileURL(path.join(process.cwd(), 'src/lib/broadcast/post.ts')).href;
+  const childScript = `
+    void (async () => {
+    const dbImported = await import(${JSON.stringify(dbUrl)});
+    const migrationImported = await import(${JSON.stringify(migrationUrl)});
+    const capImported = await import(${JSON.stringify(hourlyCapUrl)});
+    const postImported = await import(${JSON.stringify(postUrl)});
+    const { getSqlite } = dbImported.default ?? dbImported;
+    const { ensureV44BroadcastSchema } = migrationImported.default ?? migrationImported;
+    const { claimBroadcastLineSlot } = capImported.default ?? capImported;
+    const { appendBroadcastEvent } = postImported.default ?? postImported;
+    const sqlite = getSqlite();
+    ensureV44BroadcastSchema(sqlite);
+    process.send({ type: 'ready' });
+    process.once('message', (message) => {
+      if (message !== 'claim') return;
+      const event = claimBroadcastLineSlot(sqlite, new Date(${JSON.stringify(NOW.toISOString())}), ${cap}, () =>
+        appendBroadcastEvent({ kind: 'commentary', actor: 'symon', text: ${JSON.stringify(workerId)} }, {
+          sqlite,
+          now: new Date(${JSON.stringify(NOW.toISOString())}),
+          metadata: { hourlyCapped: true, workerId: ${JSON.stringify(workerId)} },
+        }));
+      process.send({ type: 'result', claimed: Boolean(event) });
+      process.exit(0);
+    });
+    })().catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+  `;
+  let stderrText = '';
+  const child = spawn(path.join(process.cwd(), 'node_modules/.bin/tsx'), ['--eval', childScript], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      O8_DATA_DIR: process.env.O8_DATA_DIR,
+      CORTEX_IDE_DATA_DIR: process.env.CORTEX_IDE_DATA_DIR,
+      NODE_OPTIONS: [process.env.NODE_OPTIONS?.trim(), '--conditions=react-server'].filter(Boolean).join(' '),
+    },
+    stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+  });
+  child.stderr?.on('data', (chunk) => { stderrText += String(chunk); });
+  childStderr.set(child, () => stderrText);
+  return { child, stderr: () => stderrText };
+}
+
+describe('claimBroadcastLineSlot across processes (#1840)', () => {
+  it('allows only one of two synchronized processes to claim the last slot', async () => {
+    const sqlite = getSqlite();
+    ensureV44BroadcastSchema(sqlite);
+    const before = broadcastGeneratedLinesSince(sqlite, broadcastHourlyWindowStart(NOW));
+    const cap = before + 1;
+    const claimants = [spawnClaimant('claimant-a', cap), spawnClaimant('claimant-b', cap)];
+
+    try {
+      await Promise.all(claimants.map(({ child }) => waitForMessage(child, 'ready')));
+      const results = claimants.map(({ child }) => waitForMessage<{ type: 'result'; claimed: boolean }>(child, 'result'));
+      const exits = claimants.map(({ child }) => new Promise<number | null>((resolve) => {
+        child.once('exit', (code) => resolve(code));
+      }));
+      for (const { child } of claimants) child.send('claim');
+
+      const settled = await Promise.all(results);
+      expect(settled.map((result) => result.claimed).sort()).toEqual([false, true]);
+      expect(await Promise.all(exits)).toEqual([0, 0]);
+      expect(broadcastGeneratedLinesSince(sqlite, broadcastHourlyWindowStart(NOW))).toBe(cap);
+      for (const claimant of claimants) expect(claimant.stderr()).toBe('');
+    } finally {
+      for (const { child } of claimants) {
+        if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+      }
+    }
+  });
+});

--- a/src/lib/broadcast/hourly-cap.test.ts
+++ b/src/lib/broadcast/hourly-cap.test.ts
@@ -1,0 +1,59 @@
+import { mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+process.env.O8_DATA_DIR ??= mkdtempSync(path.join(os.tmpdir(), 'o8-hourly-cap-'));
+process.env.CORTEX_IDE_DATA_DIR ??= process.env.O8_DATA_DIR;
+
+const { getSqlite } = await import('@/lib/db');
+const { ensureV44BroadcastSchema } = await import('@/lib/db/v44-broadcast-migration');
+const { appendBroadcastEvent } = await import('@/lib/broadcast/post');
+const { claimBroadcastLineSlot, broadcastGeneratedLinesSince, broadcastHourlyWindowStart } =
+  await import('@/lib/broadcast/hourly-cap');
+
+const NOW = new Date('2026-08-24T12:00:00.000Z');
+
+function capped(text: string) {
+  return appendBroadcastEvent({ kind: 'commentary', actor: 'symon', text }, {
+    sqlite: getSqlite(),
+    now: NOW,
+    metadata: { hourlyCapped: true },
+  });
+}
+
+describe('claimBroadcastLineSlot (#1840)', () => {
+  it('never lets producers exceed the cap, however many race for the last slot', () => {
+    const sqlite = getSqlite();
+    ensureV44BroadcastSchema(sqlite);
+    const before = broadcastGeneratedLinesSince(sqlite, broadcastHourlyWindowStart(NOW));
+    const cap = before + 12;
+
+    // Two producers previously each read the same count, each concluded there
+    // was room, and both appended -- so the ceiling was soft by however many
+    // were running. Every attempt now re-reads inside its own insert's
+    // transaction, so only the ones with room actually write.
+    let written = 0;
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      const event = claimBroadcastLineSlot(sqlite, NOW, cap, () => capped(`line ${attempt}`));
+      if (event) written += 1;
+    }
+
+    expect(written).toBe(12);
+    expect(broadcastGeneratedLinesSince(sqlite, broadcastHourlyWindowStart(NOW))).toBe(cap);
+  });
+
+  it('refuses without writing once the window is full', () => {
+    const sqlite = getSqlite();
+    const count = broadcastGeneratedLinesSince(sqlite, broadcastHourlyWindowStart(NOW));
+    expect(claimBroadcastLineSlot(sqlite, NOW, count, () => capped('overflow'))).toBeNull();
+    expect(broadcastGeneratedLinesSince(sqlite, broadcastHourlyWindowStart(NOW))).toBe(count);
+  });
+
+  it('treats a zero or nonsense cap as closed rather than unlimited', () => {
+    const sqlite = getSqlite();
+    expect(claimBroadcastLineSlot(sqlite, NOW, 0, () => capped('zero'))).toBeNull();
+    expect(claimBroadcastLineSlot(sqlite, NOW, -1, () => capped('negative'))).toBeNull();
+    expect(claimBroadcastLineSlot(sqlite, NOW, Number.NaN, () => capped('nan'))).toBeNull();
+  });
+});

--- a/src/lib/broadcast/hourly-cap.test.ts
+++ b/src/lib/broadcast/hourly-cap.test.ts
@@ -1,6 +1,8 @@
+import { spawn, type ChildProcess } from 'node:child_process';
 import { mkdtempSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 process.env.O8_DATA_DIR ??= mkdtempSync(path.join(os.tmpdir(), 'o8-hourly-cap-'));
@@ -13,6 +15,7 @@ const { claimBroadcastLineSlot, broadcastGeneratedLinesSince, broadcastHourlyWin
   await import('@/lib/broadcast/hourly-cap');
 
 const NOW = new Date('2026-08-24T12:00:00.000Z');
+const childStderr = new WeakMap<ChildProcess, () => string>();
 
 function capped(text: string) {
   return appendBroadcastEvent({ kind: 'commentary', actor: 'symon', text }, {
@@ -20,6 +23,89 @@ function capped(text: string) {
     now: NOW,
     metadata: { hourlyCapped: true },
   });
+}
+
+function waitForMessage<T>(child: ChildProcess, type: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for child message ${type}`));
+    }, 15_000);
+    const onMessage = (message: unknown) => {
+      if (!message || typeof message !== 'object' || (message as { type?: unknown }).type !== type) return;
+      cleanup();
+      resolve(message as T);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(new Error(
+        `Child exited before ${type}: code=${String(code)} signal=${String(signal)} ${childStderr.get(child)?.() ?? ''}`,
+      ));
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      child.off('message', onMessage);
+      child.off('error', onError);
+      child.off('exit', onExit);
+    };
+    child.on('message', onMessage);
+    child.once('error', onError);
+    child.once('exit', onExit);
+  });
+}
+
+function spawnClaimant(workerId: string, cap: number): { child: ChildProcess; stderr: () => string } {
+  const hourlyCapUrl = pathToFileURL(path.join(process.cwd(), 'src/lib/broadcast/hourly-cap.ts')).href;
+  const dbUrl = pathToFileURL(path.join(process.cwd(), 'src/lib/db/index.ts')).href;
+  const migrationUrl = pathToFileURL(path.join(process.cwd(), 'src/lib/db/v44-broadcast-migration.ts')).href;
+  const postUrl = pathToFileURL(path.join(process.cwd(), 'src/lib/broadcast/post.ts')).href;
+  const childScript = `
+    void (async () => {
+    const dbImported = await import(${JSON.stringify(dbUrl)});
+    const migrationImported = await import(${JSON.stringify(migrationUrl)});
+    const capImported = await import(${JSON.stringify(hourlyCapUrl)});
+    const postImported = await import(${JSON.stringify(postUrl)});
+    const { getSqlite } = dbImported.default ?? dbImported;
+    const { ensureV44BroadcastSchema } = migrationImported.default ?? migrationImported;
+    const { claimBroadcastLineSlot } = capImported.default ?? capImported;
+    const { appendBroadcastEvent } = postImported.default ?? postImported;
+    const sqlite = getSqlite();
+    ensureV44BroadcastSchema(sqlite);
+    process.send({ type: 'ready' });
+    process.once('message', (message) => {
+      if (message !== 'claim') return;
+      const event = claimBroadcastLineSlot(sqlite, new Date(${JSON.stringify(NOW.toISOString())}), ${cap}, () =>
+        appendBroadcastEvent({ kind: 'commentary', actor: 'symon', text: ${JSON.stringify(workerId)} }, {
+          sqlite,
+          now: new Date(${JSON.stringify(NOW.toISOString())}),
+          metadata: { hourlyCapped: true, workerId: ${JSON.stringify(workerId)} },
+        }));
+      process.send({ type: 'result', claimed: Boolean(event) });
+      process.exit(0);
+    });
+    })().catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+  `;
+  let stderrText = '';
+  const child = spawn(path.join(process.cwd(), 'node_modules/.bin/tsx'), ['--eval', childScript], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      O8_DATA_DIR: process.env.O8_DATA_DIR,
+      CORTEX_IDE_DATA_DIR: process.env.CORTEX_IDE_DATA_DIR,
+      NODE_OPTIONS: [process.env.NODE_OPTIONS?.trim(), '--conditions=react-server'].filter(Boolean).join(' '),
+    },
+    stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+  });
+  child.stderr?.on('data', (chunk) => { stderrText += String(chunk); });
+  childStderr.set(child, () => stderrText);
+  return { child, stderr: () => stderrText };
 }
 
 describe('claimBroadcastLineSlot (#1840)', () => {
@@ -55,5 +141,32 @@ describe('claimBroadcastLineSlot (#1840)', () => {
     expect(claimBroadcastLineSlot(sqlite, NOW, 0, () => capped('zero'))).toBeNull();
     expect(claimBroadcastLineSlot(sqlite, NOW, -1, () => capped('negative'))).toBeNull();
     expect(claimBroadcastLineSlot(sqlite, NOW, Number.NaN, () => capped('nan'))).toBeNull();
+  });
+
+  it('allows only one of two synchronized processes to claim the last slot', async () => {
+    const sqlite = getSqlite();
+    ensureV44BroadcastSchema(sqlite);
+    const before = broadcastGeneratedLinesSince(sqlite, broadcastHourlyWindowStart(NOW));
+    const cap = before + 1;
+    const claimants = [spawnClaimant('claimant-a', cap), spawnClaimant('claimant-b', cap)];
+
+    try {
+      await Promise.all(claimants.map(({ child }) => waitForMessage(child, 'ready')));
+      const results = claimants.map(({ child }) => waitForMessage<{ type: 'result'; claimed: boolean }>(child, 'result'));
+      const exits = claimants.map(({ child }) => new Promise<number | null>((resolve) => {
+        child.once('exit', (code) => resolve(code));
+      }));
+      for (const { child } of claimants) child.send('claim');
+
+      const settled = await Promise.all(results);
+      expect(settled.map((result) => result.claimed).sort()).toEqual([false, true]);
+      expect(await Promise.all(exits)).toEqual([0, 0]);
+      expect(broadcastGeneratedLinesSince(sqlite, broadcastHourlyWindowStart(NOW))).toBe(cap);
+      for (const claimant of claimants) expect(claimant.stderr()).toBe('');
+    } finally {
+      for (const { child } of claimants) {
+        if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+      }
+    }
   });
 });

--- a/src/lib/broadcast/hourly-cap.test.ts
+++ b/src/lib/broadcast/hourly-cap.test.ts
@@ -1,8 +1,6 @@
-import { spawn, type ChildProcess } from 'node:child_process';
 import { mkdtempSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 process.env.O8_DATA_DIR ??= mkdtempSync(path.join(os.tmpdir(), 'o8-hourly-cap-'));
@@ -15,7 +13,6 @@ const { claimBroadcastLineSlot, broadcastGeneratedLinesSince, broadcastHourlyWin
   await import('@/lib/broadcast/hourly-cap');
 
 const NOW = new Date('2026-08-24T12:00:00.000Z');
-const childStderr = new WeakMap<ChildProcess, () => string>();
 
 function capped(text: string) {
   return appendBroadcastEvent({ kind: 'commentary', actor: 'symon', text }, {
@@ -23,89 +20,6 @@ function capped(text: string) {
     now: NOW,
     metadata: { hourlyCapped: true },
   });
-}
-
-function waitForMessage<T>(child: ChildProcess, type: string): Promise<T> {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      cleanup();
-      reject(new Error(`Timed out waiting for child message ${type}`));
-    }, 15_000);
-    const onMessage = (message: unknown) => {
-      if (!message || typeof message !== 'object' || (message as { type?: unknown }).type !== type) return;
-      cleanup();
-      resolve(message as T);
-    };
-    const onError = (error: Error) => {
-      cleanup();
-      reject(error);
-    };
-    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
-      cleanup();
-      reject(new Error(
-        `Child exited before ${type}: code=${String(code)} signal=${String(signal)} ${childStderr.get(child)?.() ?? ''}`,
-      ));
-    };
-    const cleanup = () => {
-      clearTimeout(timer);
-      child.off('message', onMessage);
-      child.off('error', onError);
-      child.off('exit', onExit);
-    };
-    child.on('message', onMessage);
-    child.once('error', onError);
-    child.once('exit', onExit);
-  });
-}
-
-function spawnClaimant(workerId: string, cap: number): { child: ChildProcess; stderr: () => string } {
-  const hourlyCapUrl = pathToFileURL(path.join(process.cwd(), 'src/lib/broadcast/hourly-cap.ts')).href;
-  const dbUrl = pathToFileURL(path.join(process.cwd(), 'src/lib/db/index.ts')).href;
-  const migrationUrl = pathToFileURL(path.join(process.cwd(), 'src/lib/db/v44-broadcast-migration.ts')).href;
-  const postUrl = pathToFileURL(path.join(process.cwd(), 'src/lib/broadcast/post.ts')).href;
-  const childScript = `
-    void (async () => {
-    const dbImported = await import(${JSON.stringify(dbUrl)});
-    const migrationImported = await import(${JSON.stringify(migrationUrl)});
-    const capImported = await import(${JSON.stringify(hourlyCapUrl)});
-    const postImported = await import(${JSON.stringify(postUrl)});
-    const { getSqlite } = dbImported.default ?? dbImported;
-    const { ensureV44BroadcastSchema } = migrationImported.default ?? migrationImported;
-    const { claimBroadcastLineSlot } = capImported.default ?? capImported;
-    const { appendBroadcastEvent } = postImported.default ?? postImported;
-    const sqlite = getSqlite();
-    ensureV44BroadcastSchema(sqlite);
-    process.send({ type: 'ready' });
-    process.once('message', (message) => {
-      if (message !== 'claim') return;
-      const event = claimBroadcastLineSlot(sqlite, new Date(${JSON.stringify(NOW.toISOString())}), ${cap}, () =>
-        appendBroadcastEvent({ kind: 'commentary', actor: 'symon', text: ${JSON.stringify(workerId)} }, {
-          sqlite,
-          now: new Date(${JSON.stringify(NOW.toISOString())}),
-          metadata: { hourlyCapped: true, workerId: ${JSON.stringify(workerId)} },
-        }));
-      process.send({ type: 'result', claimed: Boolean(event) });
-      process.exit(0);
-    });
-    })().catch((error) => {
-      console.error(error);
-      process.exit(1);
-    });
-  `;
-  let stderrText = '';
-  const child = spawn(path.join(process.cwd(), 'node_modules/.bin/tsx'), ['--eval', childScript], {
-    cwd: process.cwd(),
-    env: {
-      ...process.env,
-      O8_DATA_DIR: process.env.O8_DATA_DIR,
-      CORTEX_IDE_DATA_DIR: process.env.CORTEX_IDE_DATA_DIR,
-      NODE_OPTIONS: [process.env.NODE_OPTIONS?.trim(), '--conditions=react-server'].filter(Boolean).join(' '),
-    },
-    stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
-  });
-  child.stderr?.on('data', (chunk) => { stderrText += String(chunk); });
-  childStderr.set(child, () => stderrText);
-  return { child, stderr: () => stderrText };
 }
 
 describe('claimBroadcastLineSlot (#1840)', () => {
@@ -141,32 +55,5 @@ describe('claimBroadcastLineSlot (#1840)', () => {
     expect(claimBroadcastLineSlot(sqlite, NOW, 0, () => capped('zero'))).toBeNull();
     expect(claimBroadcastLineSlot(sqlite, NOW, -1, () => capped('negative'))).toBeNull();
     expect(claimBroadcastLineSlot(sqlite, NOW, Number.NaN, () => capped('nan'))).toBeNull();
-  });
-
-  it('allows only one of two synchronized processes to claim the last slot', async () => {
-    const sqlite = getSqlite();
-    ensureV44BroadcastSchema(sqlite);
-    const before = broadcastGeneratedLinesSince(sqlite, broadcastHourlyWindowStart(NOW));
-    const cap = before + 1;
-    const claimants = [spawnClaimant('claimant-a', cap), spawnClaimant('claimant-b', cap)];
-
-    try {
-      await Promise.all(claimants.map(({ child }) => waitForMessage(child, 'ready')));
-      const results = claimants.map(({ child }) => waitForMessage<{ type: 'result'; claimed: boolean }>(child, 'result'));
-      const exits = claimants.map(({ child }) => new Promise<number | null>((resolve) => {
-        child.once('exit', (code) => resolve(code));
-      }));
-      for (const { child } of claimants) child.send('claim');
-
-      const settled = await Promise.all(results);
-      expect(settled.map((result) => result.claimed).sort()).toEqual([false, true]);
-      expect(await Promise.all(exits)).toEqual([0, 0]);
-      expect(broadcastGeneratedLinesSince(sqlite, broadcastHourlyWindowStart(NOW))).toBe(cap);
-      for (const claimant of claimants) expect(claimant.stderr()).toBe('');
-    } finally {
-      for (const { child } of claimants) {
-        if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
-      }
-    }
   });
 });

--- a/src/lib/broadcast/hourly-cap.ts
+++ b/src/lib/broadcast/hourly-cap.ts
@@ -1,0 +1,64 @@
+import 'server-only';
+
+import type Database from 'better-sqlite3';
+
+/** The cap's window: lines produced in the last hour. */
+export const BROADCAST_HOURLY_WINDOW_MS = 60 * 60_000;
+
+export function broadcastHourlyWindowStart(now: Date): string {
+  return new Date(now.getTime() - BROADCAST_HOURLY_WINDOW_MS).toISOString();
+}
+
+/** Count the capped-class commentary lines produced since `timestamp`. */
+export function broadcastGeneratedLinesSince(sqlite: Database.Database, timestamp: string): number {
+  const row = sqlite.prepare(`
+    SELECT COUNT(*) AS count
+    FROM broadcast_events
+    WHERE kind = 'commentary'
+      AND (
+        json_extract(metadata_json, '$.director') = 1
+        OR json_extract(metadata_json, '$.hourlyCapped') = 1
+      )
+      AND created_at >= ?
+  `).get(timestamp) as { count: number };
+  return row.count;
+}
+
+/**
+ * Take one slot in the hourly cap and write the line, or refuse.
+ *
+ * The cap used to be four independent check-then-act sites across two
+ * producers, with an await between each read and its write: the director's
+ * commentary call, the speaker's compose. Two producers could each read 11
+ * against a cap of 12, each conclude there was room, and both append — so the
+ * ceiling was soft by however many producers were running, and a window with
+ * `max_per_hour = 12` produced 13 lines (#1840).
+ *
+ * The count is re-read INSIDE the same IMMEDIATE transaction that performs the
+ * insert, so no await can open between deciding and writing, and a second
+ * producer — in this process or another — sees the first one's row. Every
+ * producer goes through here rather than testing the count for itself.
+ *
+ * Returns the insert's value, or `null` when the window is full.
+ */
+export function claimBroadcastLineSlot<T>(
+  sqlite: Database.Database,
+  now: Date,
+  maxPerHour: number,
+  insert: () => T,
+): T | null {
+  if (!Number.isFinite(maxPerHour) || maxPerHour <= 0) return null;
+  const windowStart = broadcastHourlyWindowStart(now);
+  const claim = sqlite.transaction(() => {
+    if (broadcastGeneratedLinesSince(sqlite, windowStart) >= maxPerHour) return null;
+    return { value: insert() };
+  });
+  // IMMEDIATE, not the default deferred: the producers live in different
+  // processes (the director loop in the Next server, the speaker in
+  // ws-server) against one SQLite file. A deferred transaction takes a read
+  // lock and upgrades on write, so both producers can still read the same
+  // count and the loser gets SQLITE_BUSY rather than a fresh count. IMMEDIATE
+  // takes the write lock up front, so the second claim waits and then re-reads
+  // with the first one's row already committed.
+  return claim.immediate()?.value ?? null;
+}

--- a/src/lib/broadcast/narration.ts
+++ b/src/lib/broadcast/narration.ts
@@ -99,6 +99,33 @@ export function narrationWindowStart(now: Date): string {
   return new Date(now.getTime() - NARRATION_REPETITION_WINDOW_MS).toISOString();
 }
 
+/**
+ * How far back a fact still counts as one the listener has heard. A packet
+ * reviewed at 03:25 and re-reviewed at 04:28 is a genuinely new event, so
+ * suppression correctly lets it through -- but narrating it in the first
+ * utterance's exact words makes the voice sound like it stuttered. Twelve
+ * hours covers a working session without treating yesterday as recent.
+ */
+export const NARRATION_REVISIT_LOOKBACK_MS = 12 * 60 * 60_000;
+
+export function narrationRevisitWindowStart(now: Date): string {
+  return new Date(now.getTime() - NARRATION_REVISIT_LOOKBACK_MS).toISOString();
+}
+
+/**
+ * Facts narrated earlier in the session whose suppression has since expired.
+ * The narrator already computes this knowledge to decide what to suppress; this
+ * hands the same knowledge to the phrasing, so a second visit to a subject is
+ * spoken as a second visit rather than as news (#1842).
+ */
+export function expiredNarratedFactKeys(sqlite: Database.Database, now: Date): Set<string> {
+  const suppressed = narratedFactKeysSince(sqlite, narrationWindowStart(now));
+  const heard = narratedFactKeysSince(sqlite, narrationRevisitWindowStart(now));
+  const expired = new Set<string>();
+  for (const key of heard) if (!suppressed.has(key)) expired.add(key);
+  return expired;
+}
+
 /** Clip to a whole word, never mid-word, and never past `maxLength`. */
 export function clipPhrase(value: string, maxLength: number): string {
   const normalized = value.replace(/\s+/g, ' ').trim();

--- a/src/lib/broadcast/speaker.ts
+++ b/src/lib/broadcast/speaker.ts
@@ -174,7 +174,7 @@ function reviewSentence(event: BroadcastEvent, specifics: Record<string, unknown
   const changes = isRevisit ? `Review requests changes again on ${label}` : `Review requests changes on ${label}`;
   return evidence
     ? `${changes}: ${evidence}.`
-    : `Review requests changes on ${label}.`;
+    : `${changes}.`;
 }
 
 function failureSentence(event: BroadcastEvent, specifics: Record<string, unknown>): string {

--- a/src/lib/broadcast/speaker.ts
+++ b/src/lib/broadcast/speaker.ts
@@ -7,7 +7,7 @@ import { apiFetch } from '@/lib/mcp/operator-handlers/shared';
 import { getOperatorDefaultsSync } from '@/lib/operator/defaults';
 import { broadcastEventSpecifics } from './commentary-prompt';
 import { buildBroadcastSnapshot } from './snapshot';
-import { broadcastGeneratedLinesSince } from './director';
+import { claimBroadcastLineSlot } from './hourly-cap';
 import { listBroadcastEvents } from './events';
 import {
   BROADCAST_SPOKEN_MAX_LENGTH,
@@ -447,18 +447,25 @@ export class BroadcastSpeaker {
     now: Date,
     sqlite: Database.Database,
     factKeys: string[] = [],
-  ): BroadcastSpeechLine {
-    const event = appendBroadcastEvent({ kind: 'commentary', actor: 'symon', text }, {
-      sqlite,
-      now,
-      metadata: {
-        voiceTrigger: trigger,
-        sourceEventId: sourceEventIds[0] ?? null,
-        sourceEventIds,
-        hourlyCapped: true,
-        ...(factKeys.length > 0 ? { factKeys } : {}),
+    maxPerHour: number,
+  ): BroadcastSpeechLine | null {
+    // The cap is claimed in the same transaction as the insert, so the
+    // director cannot append between this speaker's check and its write (#1840).
+    const event = claimBroadcastLineSlot(sqlite, now, maxPerHour, () => appendBroadcastEvent(
+      { kind: 'commentary', actor: 'symon', text },
+      {
+        sqlite,
+        now,
+        metadata: {
+          voiceTrigger: trigger,
+          sourceEventId: sourceEventIds[0] ?? null,
+          sourceEventIds,
+          hourlyCapped: true,
+          ...(factKeys.length > 0 ? { factKeys } : {}),
+        },
       },
-    });
+    ));
+    if (!event) return null;
     return {
       id: `broadcast:${event.id}`,
       actor: event.actor,
@@ -542,7 +549,7 @@ export class BroadcastSpeaker {
           });
           this.pendingMoments = [];
           const composed = composeMomentLine(unsaid, revisitFacts);
-          if (composed && broadcastGeneratedLinesSince(sqlite, new Date(now.getTime() - 60 * 60_000).toISOString()) < settings.maxPerHour) {
+          if (composed) {
             const spokenFacts = [...new Set(composed.spokenEvents.map((event) => momentFactKey(event)))];
             const line = this.generatedLine(
               composed.text,
@@ -551,24 +558,28 @@ export class BroadcastSpeaker {
               now,
               sqlite,
               spokenFacts,
+              settings.maxPerHour,
             );
-            generated.push(line.id);
-            this.enqueue(line, sqlite, now.getTime());
-            // Whatever did not fit stays unsaid rather than making this line run
-            // long; the next tick speaks it as its own short update.
-            this.pendingMoments = composed.deferredEvents.slice(0, MAX_DEFERRED_MOMENTS);
+            if (line) {
+              generated.push(line.id);
+              this.enqueue(line, sqlite, now.getTime());
+              // Whatever did not fit stays unsaid rather than making this line
+              // run long; the next tick speaks it as its own short update.
+              this.pendingMoments = composed.deferredEvents.slice(0, MAX_DEFERRED_MOMENTS);
+            }
           }
         }
 
         const lullAt = (this.lastFeedEventAt ?? now.getTime()) + settings.lullMinutes * 60_000;
-        if (!this.lullAnnounced && now.getTime() >= lullAt
-          && broadcastGeneratedLinesSince(sqlite, new Date(now.getTime() - 60 * 60_000).toISOString()) < settings.maxPerHour) {
+        if (!this.lullAnnounced && now.getTime() >= lullAt) {
           const text = lullLine(sqlite);
           if (text) {
-            const line = this.generatedLine(text, 'lull', [], now, sqlite);
-            generated.push(line.id);
-            this.enqueue(line, sqlite, now.getTime());
-            this.lullAnnounced = true;
+            const line = this.generatedLine(text, 'lull', [], now, sqlite, [], settings.maxPerHour);
+            if (line) {
+              generated.push(line.id);
+              this.enqueue(line, sqlite, now.getTime());
+              this.lullAnnounced = true;
+            }
           }
         }
       }

--- a/src/lib/broadcast/speaker.ts
+++ b/src/lib/broadcast/speaker.ts
@@ -14,6 +14,7 @@ import {
   clipPhrase,
   firstSentence,
   isMomentEvent,
+  expiredNarratedFactKeys,
   momentFactKey,
   narratedFactKeysSince,
   narrationWindowStart,
@@ -145,14 +146,15 @@ function mergeSentence(event: BroadcastEvent, specifics: Record<string, unknown>
   return evidence.length > 0 ? `${label} merged: ${evidence.join(', ')}.` : `${label} merged.`;
 }
 
-function approvalSentence(event: BroadcastEvent, specifics: Record<string, unknown>): string {
+function approvalSentence(event: BroadcastEvent, specifics: Record<string, unknown>, isRevisit = false): string {
   const action = event.detail || payloadText(event, 'summary', 'command', 'description');
   const label = packetLabel(event, specifics);
-  if (!action || label.toLowerCase() === action.toLowerCase()) return `Approval pending for ${label}.`;
-  return `Approval pending for ${label}: ${firstSentence(action, DETAIL_MAX_LENGTH)}.`;
+  const opening = isRevisit ? `Approval still pending for ${label}` : `Approval pending for ${label}`;
+  if (!action || label.toLowerCase() === action.toLowerCase()) return `${opening}.`;
+  return `${opening}: ${firstSentence(action, DETAIL_MAX_LENGTH)}.`;
 }
 
-function reviewSentence(event: BroadcastEvent, specifics: Record<string, unknown>): string {
+function reviewSentence(event: BroadcastEvent, specifics: Record<string, unknown>, isRevisit = false): string {
   const label = packetLabel(event, specifics);
   const findingsCount = numberSpecific(specifics, 'findingsCount');
   const firstFinding = specifics.firstFinding && typeof specifics.firstFinding === 'object'
@@ -162,11 +164,16 @@ function reviewSentence(event: BroadcastEvent, specifics: Record<string, unknown
   const evidence = findingsCount !== null && findingsCount > 0
     ? `${countPhrase(findingsCount, 'finding')}${file ? ` in ${clipPhrase(file, DETAIL_MAX_LENGTH)}` : ''}`
     : null;
+  // A second review turn on the same packet is real news, so it is not
+  // suppressed -- but repeating the first utterance verbatim makes the voice
+  // sound like it stuttered. One word places it in sequence (#1842).
   if (specifics.approved === true) {
-    return evidence ? `Review approved for ${label}, ${evidence}.` : `Review approved for ${label}.`;
+    const verdict = isRevisit ? `Review approved again for ${label}` : `Review approved for ${label}`;
+    return evidence ? `${verdict}, ${evidence}.` : `${verdict}.`;
   }
+  const changes = isRevisit ? `Review requests changes again on ${label}` : `Review requests changes on ${label}`;
   return evidence
-    ? `Review requests changes on ${label}: ${evidence}.`
+    ? `${changes}: ${evidence}.`
     : `Review requests changes on ${label}.`;
 }
 
@@ -196,12 +203,12 @@ function leaseTimeoutSentence(event: BroadcastEvent, specifics: Record<string, u
     : `${label} timed out waiting on a lease.`;
 }
 
-function momentSentence(event: BroadcastEvent): string | null {
+function momentSentence(event: BroadcastEvent, isRevisit = false): string | null {
   const specifics = broadcastEventSpecifics(event, null);
   if (event.kind === 'packet_failed') return failureSentence(event, specifics);
-  if (event.kind === 'review_verdict') return reviewSentence(event, specifics);
+  if (event.kind === 'review_verdict') return reviewSentence(event, specifics, isRevisit);
   if (event.kind === 'merge') return mergeSentence(event, specifics);
-  if (event.kind === 'approval') return approvalSentence(event, specifics);
+  if (event.kind === 'approval') return approvalSentence(event, specifics, isRevisit);
   if (event.kind === 'spend_cap') return spendSentence(event, specifics);
   if (event.kind === 'lease_timeout') return leaseTimeoutSentence(event, specifics);
   return null;
@@ -228,7 +235,10 @@ export interface ComposedMomentLine {
  * stays inside the spoken length budget; whatever does not fit is handed back
  * so the next tick speaks it instead of this one running long.
  */
-export function composeMomentLine(input: BroadcastEvent | BroadcastEvent[]): ComposedMomentLine | null {
+export function composeMomentLine(
+  input: BroadcastEvent | BroadcastEvent[],
+  revisitFacts: ReadonlySet<string> = new Set(),
+): ComposedMomentLine | null {
   const events = (Array.isArray(input) ? input : [input]).filter(isMomentEvent);
   if (events.length === 0) return null;
   const reviewPackets = new Set(events.filter((event) => event.kind === 'review_verdict').map((event) => event.packetId).filter(Boolean));
@@ -248,11 +258,11 @@ export function composeMomentLine(input: BroadcastEvent | BroadcastEvent[]): Com
   const composedFacts = new Set<string>();
   let length = 0;
   for (const event of ordered) {
-    const sentence = momentSentence(event);
+    const fact = momentFactKey(event);
+    const sentence = momentSentence(event, revisitFacts.has(fact));
     if (!sentence) continue;
     // One fact, one sentence — the same verdict arrives from two tables and
     // must not be said twice inside a single utterance (o8 #1822).
-    const fact = momentFactKey(event);
     if (composedFacts.has(fact) || sentences.includes(sentence)) {
       spokenEvents.push(event);
       continue;
@@ -271,8 +281,11 @@ export function composeMomentLine(input: BroadcastEvent | BroadcastEvent[]): Com
   return text ? { text, spokenEvents, deferredEvents } : null;
 }
 
-export function broadcastMomentLine(input: BroadcastEvent | BroadcastEvent[]): string | null {
-  return composeMomentLine(input)?.text ?? null;
+export function broadcastMomentLine(
+  input: BroadcastEvent | BroadcastEvent[],
+  revisitFacts?: ReadonlySet<string>,
+): string | null {
+  return composeMomentLine(input, revisitFacts)?.text ?? null;
 }
 
 function lullLine(sqlite: Database.Database): string | null {
@@ -516,6 +529,9 @@ export class BroadcastSpeaker {
           // The shared suppression view: anything the director already narrated
           // (and anything this speaker said before a restart) counts as said.
           const narratedFacts = narratedFactKeysSince(sqlite, narrationWindowStart(now));
+          // Said earlier this session, suppression since expired — a genuine
+          // second visit, phrased as one rather than repeated verbatim (#1842).
+          const revisitFacts = expiredNarratedFactKeys(sqlite, now);
           const unsaid = this.pendingMoments.filter((event) => {
             const fact = momentFactKey(event);
             if (this.recentFacts.has(fact) || queuedFacts.has(fact) || burstFacts.has(fact) || narratedFacts.has(fact)) {
@@ -525,7 +541,7 @@ export class BroadcastSpeaker {
             return true;
           });
           this.pendingMoments = [];
-          const composed = composeMomentLine(unsaid);
+          const composed = composeMomentLine(unsaid, revisitFacts);
           if (composed && broadcastGeneratedLinesSince(sqlite, new Date(now.getTime() - 60 * 60_000).toISOString()) < settings.maxPerHour) {
             const spokenFacts = [...new Set(composed.spokenEvents.map((event) => momentFactKey(event)))];
             const line = this.generatedLine(

--- a/src/lib/lane/orchestrator-model-guard.test.ts
+++ b/src/lib/lane/orchestrator-model-guard.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { MODEL_IDS } from '@/lib/models';
-import { ORCHESTRATOR_RUNTIMES } from '@/lib/orchestrator/runtime-capabilities';
+import { ORCHESTRATOR_RUNTIMES, getRuntimeCapability } from '@/lib/orchestrator/runtime-capabilities';
 import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
 import { modelBelongsToRuntime, resolveRuntimeOrchestratorModel } from './orchestrator-model-guard';
 
@@ -30,7 +30,7 @@ describe('modelBelongsToRuntime', () => {
     // cursor and opencode legitimately run models from more than one house. A
     // wrong constraint would block a valid selection.
     for (const runtimeId of ['cursor', 'opencode'] as OrchestratorRuntime[]) {
-      expect(ORCHESTRATOR_RUNTIMES[runtimeId].modelIdPattern).toBeUndefined();
+      expect(getRuntimeCapability(runtimeId).modelIdPattern).toBeUndefined();
       expect(modelBelongsToRuntime(MODEL_IDS.raw.anthropicClaudeOpus5, runtimeId)).toBe(true);
       expect(modelBelongsToRuntime(MODEL_IDS.raw.openAiGpt56Sol, runtimeId)).toBe(true);
     }
@@ -39,10 +39,11 @@ describe('modelBelongsToRuntime', () => {
   it('accepts every runtime default under its own pattern', () => {
     // A registry row that constrains itself out of its own default is a bug in
     // the row, and this is the assertion that catches it when #19 is added.
-    for (const [id, capability] of Object.entries(ORCHESTRATOR_RUNTIMES)) {
+    for (const id of Object.keys(ORCHESTRATOR_RUNTIMES) as OrchestratorRuntime[]) {
+      const capability = getRuntimeCapability(id);
       if (!capability.modelIdPattern || !capability.defaultModel) continue;
       expect(
-        modelBelongsToRuntime(capability.defaultModel, id as OrchestratorRuntime),
+        modelBelongsToRuntime(capability.defaultModel, id),
         `${id} rejects its own defaultModel ${capability.defaultModel}`,
       ).toBe(true);
     }

--- a/src/lib/lane/orchestrator-model-guard.test.ts
+++ b/src/lib/lane/orchestrator-model-guard.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MODEL_IDS } from '@/lib/models';
+import { ORCHESTRATOR_RUNTIMES } from '@/lib/orchestrator/runtime-capabilities';
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+import { modelBelongsToRuntime, resolveRuntimeOrchestratorModel } from './orchestrator-model-guard';
+
+const CLAUDE_DEFAULT = MODEL_IDS.orchestratorDefault;
+
+describe('modelBelongsToRuntime', () => {
+  it('accepts each single-house runtime its own ids', () => {
+    expect(modelBelongsToRuntime(MODEL_IDS.raw.openAiGpt56Sol, 'codex')).toBe(true);
+    expect(modelBelongsToRuntime(MODEL_IDS.raw.anthropicClaudeOpus5, 'claude-code')).toBe(true);
+    expect(modelBelongsToRuntime('anthropic/claude-opus-5', 'claude-code')).toBe(true);
+    expect(modelBelongsToRuntime(MODEL_IDS.raw.gemini25Flash, 'gemini')).toBe(true);
+    expect(modelBelongsToRuntime(MODEL_IDS.raw.xaiGrok45, 'grok')).toBe(true);
+  });
+
+  it('refuses every cross-house pairing, not just the two that were reported', () => {
+    // Both directions were patched one house at a time. With 18 dispatchable
+    // runtimes that does not converge -- each new pairing is the same bug.
+    expect(modelBelongsToRuntime(MODEL_IDS.raw.anthropicClaudeOpus5, 'codex')).toBe(false);
+    expect(modelBelongsToRuntime(MODEL_IDS.raw.openAiGpt56Sol, 'claude-code')).toBe(false);
+    expect(modelBelongsToRuntime(MODEL_IDS.raw.gemini25Flash, 'codex')).toBe(false);
+    expect(modelBelongsToRuntime(MODEL_IDS.raw.xaiGrok45, 'claude-code')).toBe(false);
+    expect(modelBelongsToRuntime(MODEL_IDS.raw.anthropicClaudeOpus5, 'gemini')).toBe(false);
+    expect(modelBelongsToRuntime(MODEL_IDS.raw.openAiGpt56Terra, 'grok')).toBe(false);
+  });
+
+  it('does not guess for a runtime that fronts several providers', () => {
+    // cursor and opencode legitimately run models from more than one house. A
+    // wrong constraint would block a valid selection.
+    for (const runtimeId of ['cursor', 'opencode'] as OrchestratorRuntime[]) {
+      expect(ORCHESTRATOR_RUNTIMES[runtimeId].modelIdPattern).toBeUndefined();
+      expect(modelBelongsToRuntime(MODEL_IDS.raw.anthropicClaudeOpus5, runtimeId)).toBe(true);
+      expect(modelBelongsToRuntime(MODEL_IDS.raw.openAiGpt56Sol, runtimeId)).toBe(true);
+    }
+  });
+
+  it('accepts every runtime default under its own pattern', () => {
+    // A registry row that constrains itself out of its own default is a bug in
+    // the row, and this is the assertion that catches it when #19 is added.
+    for (const [id, capability] of Object.entries(ORCHESTRATOR_RUNTIMES)) {
+      if (!capability.modelIdPattern || !capability.defaultModel) continue;
+      expect(
+        modelBelongsToRuntime(capability.defaultModel, id as OrchestratorRuntime),
+        `${id} rejects its own defaultModel ${capability.defaultModel}`,
+      ).toBe(true);
+    }
+  });
+
+  it('treats an empty id as no model', () => {
+    expect(modelBelongsToRuntime('', 'codex')).toBe(false);
+    expect(modelBelongsToRuntime('   ', 'claude-code')).toBe(false);
+  });
+});
+
+describe('resolveRuntimeOrchestratorModel (#1807)', () => {
+  it('refuses the Codex dispatch model on a solo Claude turn', () => {
+    // A fresh Orchestrator tab in solo mode on the Claude Code runtime launched
+    // with gpt-5.6-sol -- default_dispatch_model, the Codex WORKER model.
+    const onReject = vi.fn();
+    expect(resolveRuntimeOrchestratorModel(MODEL_IDS.raw.openAiGpt56Sol, 'claude-code', CLAUDE_DEFAULT, onReject))
+      .toBe(CLAUDE_DEFAULT);
+    expect(onReject).toHaveBeenCalledWith(MODEL_IDS.raw.openAiGpt56Sol, CLAUDE_DEFAULT, 'claude-code');
+  });
+
+  it('passes a real selection through untouched', () => {
+    const onReject = vi.fn();
+    expect(resolveRuntimeOrchestratorModel(MODEL_IDS.raw.anthropicClaudeOpus5, 'claude-code', CLAUDE_DEFAULT, onReject))
+      .toBe(MODEL_IDS.raw.anthropicClaudeOpus5);
+    expect(onReject).not.toHaveBeenCalled();
+  });
+
+  it('falls back quietly when nothing was selected', () => {
+    const onReject = vi.fn();
+    expect(resolveRuntimeOrchestratorModel(undefined, 'claude-code', CLAUDE_DEFAULT, onReject)).toBe(CLAUDE_DEFAULT);
+    expect(resolveRuntimeOrchestratorModel('  ', 'claude-code', CLAUDE_DEFAULT, onReject)).toBe(CLAUDE_DEFAULT);
+    // An absent selection is not a mismatch, so it is not reported as one.
+    expect(onReject).not.toHaveBeenCalled();
+  });
+
+  it('works without a reporter', () => {
+    expect(resolveRuntimeOrchestratorModel(MODEL_IDS.raw.openAiGpt56Sol, 'claude-code', CLAUDE_DEFAULT))
+      .toBe(CLAUDE_DEFAULT);
+  });
+});

--- a/src/lib/lane/orchestrator-model-guard.ts
+++ b/src/lib/lane/orchestrator-model-guard.ts
@@ -1,0 +1,55 @@
+import { getRuntimeCapability } from '@/lib/orchestrator/runtime-capabilities';
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+
+/**
+ * Cross-house model bleed guard, driven by the runtime registry.
+ *
+ * The composer passes whatever model it holds, and when that model belongs to
+ * another house the CLI is handed an id it cannot launch. It has happened in
+ * both directions: a claude id reaching `codex exec` hung the turn forever with
+ * nothing streamed (live hit 2026-07-05), and `gpt-5.6-sol` --
+ * `default_dispatch_model`, the Codex WORKER model -- reaching the Claude
+ * harness failed a fresh solo turn immediately (#1807).
+ *
+ * Each of those was patched where it was found, one house at a time. With 18
+ * dispatchable runtimes that does not converge: every new pairing is the same
+ * bug wearing a different model id. The constraint belongs to the runtime, so
+ * it lives on the runtime's registry row as `modelIdPattern`, and a runtime
+ * that fronts several providers simply omits it.
+ */
+
+/**
+ * Whether `model` is an id `runtimeId` can actually launch.
+ *
+ * A runtime with no declared pattern is multi-provider or unknown, and returns
+ * true: refusing to guess is the point. A wrong constraint blocks a valid
+ * selection, which is worse than the bug it would prevent.
+ */
+export function modelBelongsToRuntime(model: string, runtimeId: OrchestratorRuntime): boolean {
+  const trimmed = model.trim();
+  if (!trimmed) return false;
+  const pattern = getRuntimeCapability(runtimeId)?.modelIdPattern;
+  if (!pattern) return true;
+  return pattern.test(trimmed);
+}
+
+/**
+ * The model an orchestrator turn on `runtimeId` should launch with.
+ *
+ * A model from another house is a backend mismatch, not an operator choice, so
+ * it falls through to the runtime's default rather than reaching the CLI. The
+ * rejection is reported with both ids -- silently substituting a model is its
+ * own kind of dishonest surface.
+ */
+export function resolveRuntimeOrchestratorModel(
+  requested: string | undefined,
+  runtimeId: OrchestratorRuntime,
+  defaultModel: string,
+  onReject?: (rejected: string, replacement: string, runtimeId: OrchestratorRuntime) => void,
+): string {
+  const trimmed = requested?.trim();
+  if (!trimmed) return defaultModel;
+  if (modelBelongsToRuntime(trimmed, runtimeId)) return trimmed;
+  onReject?.(trimmed, defaultModel, runtimeId);
+  return defaultModel;
+}

--- a/src/lib/lane/orchestrator-model-guard.ts
+++ b/src/lib/lane/orchestrator-model-guard.ts
@@ -1,5 +1,6 @@
 import { getRuntimeCapability } from '@/lib/orchestrator/runtime-capabilities';
 import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+import { MODEL_IDS } from '@/lib/models';
 
 /**
  * Cross-house model bleed guard, driven by the runtime registry.
@@ -52,4 +53,17 @@ export function resolveRuntimeOrchestratorModel(
   if (modelBelongsToRuntime(trimmed, runtimeId)) return trimmed;
   onReject?.(trimmed, defaultModel, runtimeId);
   return defaultModel;
+}
+
+export const DEFAULT_CLAUDE_ORCHESTRATOR_MODEL = MODEL_IDS.orchestratorDefault;
+
+export function resolveClaudeOrchestratorModel(requested: string | undefined): string {
+  return resolveRuntimeOrchestratorModel(
+    requested,
+    'claude-code',
+    DEFAULT_CLAUDE_ORCHESTRATOR_MODEL,
+    (rejected, replacement, runtimeId) => {
+      console.warn(`[orchestrator-session] Ignoring model "${rejected}" -- ${runtimeId} cannot launch it; using "${replacement}".`);
+    },
+  );
 }

--- a/src/lib/lane/orchestrator-session.ts
+++ b/src/lib/lane/orchestrator-session.ts
@@ -27,6 +27,7 @@ import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
 import { toClaudeJson } from '@/lib/mcp/tool-spine/emit-claude';
 import type { ToolProfile } from '@/lib/mcp/tool-spine/registry';
 import { MODEL_IDS } from '@/lib/models';
+import { resolveRuntimeOrchestratorModel } from './orchestrator-model-guard';
 import { fableEnvOverride } from '@/lib/lane/fable-profile';
 import { assertOrchestratorRepoPath } from '@/lib/lane/repo-preflight';
 import { buildOrchestratorSystemPrompt } from '@/lib/lane/orchestrator-system-prompt';
@@ -910,7 +911,16 @@ export async function sendToOrchestrator(
 ): Promise<void> {
   const permissionMode: OrchestratorPermissionMode = options.permissionMode ?? 'full';
   const thinkingEffort: ThinkingEffort = options.thinkingEffort ?? 'adaptive';
-  const requestedModel = options.model?.trim() || DEFAULT_ORCHESTRATOR_MODEL;
+  // A model belonging to another house is a backend mismatch, not a choice --
+  // see orchestrator-model-guard for the #1807 case this closes.
+  const requestedModel = resolveRuntimeOrchestratorModel(
+    options.model,
+    'claude-code',
+    DEFAULT_ORCHESTRATOR_MODEL,
+    (rejected, replacement, runtimeId) => {
+      console.warn(`[orchestrator-session] Ignoring model "${rejected}" — ${runtimeId} cannot launch it; using "${replacement}".`);
+    },
+  );
   const toolProfile: ToolProfile = options.toolProfile ?? 'full';
   const w = getWarmState(session.sessionName);
 

--- a/src/lib/lane/orchestrator-session.ts
+++ b/src/lib/lane/orchestrator-session.ts
@@ -26,8 +26,7 @@ import { getRuntime, type RuntimeSession } from '@/lib/runtimes';
 import { buildToolRegistry } from '@/lib/mcp/tool-spine/build';
 import { toClaudeJson } from '@/lib/mcp/tool-spine/emit-claude';
 import type { ToolProfile } from '@/lib/mcp/tool-spine/registry';
-import { MODEL_IDS } from '@/lib/models';
-import { resolveRuntimeOrchestratorModel } from './orchestrator-model-guard';
+import { DEFAULT_CLAUDE_ORCHESTRATOR_MODEL, resolveClaudeOrchestratorModel } from './orchestrator-model-guard';
 import { fableEnvOverride } from '@/lib/lane/fable-profile';
 import { assertOrchestratorRepoPath } from '@/lib/lane/repo-preflight';
 import { buildOrchestratorSystemPrompt } from '@/lib/lane/orchestrator-system-prompt';
@@ -491,7 +490,7 @@ export function ensureOrchestratorSession(repoPath: string, threadId?: string | 
  *   chip is toggled to "Read-only" — the safe-mode orchestrator.
  */
 export type OrchestratorPermissionMode = 'full' | 'plan';
-export const DEFAULT_ORCHESTRATOR_MODEL = MODEL_IDS.orchestratorDefault;
+export const DEFAULT_ORCHESTRATOR_MODEL = DEFAULT_CLAUDE_ORCHESTRATOR_MODEL;
 
 export interface SendToOrchestratorOptions {
   permissionMode?: OrchestratorPermissionMode;
@@ -911,16 +910,7 @@ export async function sendToOrchestrator(
 ): Promise<void> {
   const permissionMode: OrchestratorPermissionMode = options.permissionMode ?? 'full';
   const thinkingEffort: ThinkingEffort = options.thinkingEffort ?? 'adaptive';
-  // A model belonging to another house is a backend mismatch, not a choice --
-  // see orchestrator-model-guard for the #1807 case this closes.
-  const requestedModel = resolveRuntimeOrchestratorModel(
-    options.model,
-    'claude-code',
-    DEFAULT_ORCHESTRATOR_MODEL,
-    (rejected, replacement, runtimeId) => {
-      console.warn(`[orchestrator-session] Ignoring model "${rejected}" — ${runtimeId} cannot launch it; using "${replacement}".`);
-    },
-  );
+  const requestedModel = resolveClaudeOrchestratorModel(options.model);
   const toolProfile: ToolProfile = options.toolProfile ?? 'full';
   const w = getWarmState(session.sessionName);
 

--- a/src/lib/lanes/runtime-drift-attribution.test.ts
+++ b/src/lib/lanes/runtime-drift-attribution.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { runtimeDriftIsAttributable } from './scope';
+
+const REPO = '/Users/dev/o8';
+const WORKTREE = '/Users/dev/.o8/worktrees/o8-56fb96a161ae/.cortex-worktrees/packet-pkt-2b597664';
+
+describe('runtimeDriftIsAttributable (#1838)', () => {
+  it('refuses to attribute a process in the shared repo root', () => {
+    // The reported false record: a lane with no worktree fell back to the repo
+    // path, matched the operator's own resident `claude --dangerously-skip-
+    // permissions` session (up for over a day), and recorded the packet as
+    // having drifted from codex to claude-code.
+    expect(runtimeDriftIsAttributable(null, REPO, REPO)).toBe(false);
+    expect(runtimeDriftIsAttributable(undefined, REPO, REPO)).toBe(false);
+    expect(runtimeDriftIsAttributable('', REPO, REPO)).toBe(false);
+  });
+
+  it('refuses when the lane names the repo root as its worktree', () => {
+    expect(runtimeDriftIsAttributable(REPO, REPO, REPO)).toBe(false);
+  });
+
+  it('attributes a process running inside the packet worktree', () => {
+    expect(runtimeDriftIsAttributable(WORKTREE, REPO, WORKTREE)).toBe(true);
+    expect(runtimeDriftIsAttributable(WORKTREE, REPO, `${WORKTREE}/src/lib`)).toBe(true);
+  });
+
+  it('refuses a process outside the worktree, including a sibling packet', () => {
+    expect(runtimeDriftIsAttributable(WORKTREE, REPO, REPO)).toBe(false);
+    expect(runtimeDriftIsAttributable(WORKTREE, REPO, `${WORKTREE}-other/src`)).toBe(false);
+    expect(runtimeDriftIsAttributable(WORKTREE, REPO, null)).toBe(false);
+  });
+});

--- a/src/lib/lanes/runtime-drift-attribution.test.ts
+++ b/src/lib/lanes/runtime-drift-attribution.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { runtimeDriftIsAttributable } from './scope';
 
-const REPO = '/Users/dev/o8';
-const WORKTREE = '/Users/dev/.o8/worktrees/o8-56fb96a161ae/.cortex-worktrees/packet-pkt-2b597664';
+const REPO = '/repo';
+const WORKTREE = '/worktrees/packet';
 
 describe('runtimeDriftIsAttributable (#1838)', () => {
   it('refuses to attribute a process in the shared repo root', () => {
@@ -27,6 +27,11 @@ describe('runtimeDriftIsAttributable (#1838)', () => {
   it('refuses a process outside the worktree, including a sibling packet', () => {
     expect(runtimeDriftIsAttributable(WORKTREE, REPO, REPO)).toBe(false);
     expect(runtimeDriftIsAttributable(WORKTREE, REPO, `${WORKTREE}-other/src`)).toBe(false);
+    expect(runtimeDriftIsAttributable(WORKTREE, REPO, `${WORKTREE}/../shared-repo`)).toBe(false);
     expect(runtimeDriftIsAttributable(WORKTREE, REPO, null)).toBe(false);
+  });
+
+  it('canonicalizes the worktree path before comparing it with the process cwd', () => {
+    expect(runtimeDriftIsAttributable('/worktrees/nested/../packet', REPO, `${WORKTREE}/src`)).toBe(true);
   });
 });

--- a/src/lib/lanes/scope.ts
+++ b/src/lib/lanes/scope.ts
@@ -214,6 +214,31 @@ async function readHeadSha(cwd: string): Promise<string | null> {
   }
 }
 
+/**
+ * Whether a running process may be attributed to this packet's worker.
+ *
+ * Drift is a governance claim about THIS packet -- "it declared codex and ran
+ * claude-code" -- so it may only be made about a process inside the packet's
+ * own worktree. A lane with no worktree falls back to the repo root, which the
+ * operator's own resident orchestrator also occupies; attributing that process
+ * produced an audit record stating a packet ran a runtime it never ran, sitting
+ * next to a real failure and reading as its explanation (#1838).
+ */
+export function runtimeDriftIsAttributable(
+  worktreePath: string | null | undefined,
+  repoPath: string,
+  processCwd: string | null | undefined,
+): boolean {
+  const worktree = worktreePath?.trim();
+  // No isolated directory means nothing can prove ownership.
+  if (!worktree) return false;
+  // A "worktree" that is the repo root is the shared checkout, not this packet's.
+  if (worktree === repoPath.trim()) return false;
+  const cwd = processCwd?.trim();
+  if (!cwd) return false;
+  return cwd === worktree || cwd.startsWith(`${worktree}/`);
+}
+
 function recordRuntimeDriftOnce(
   lane: Lane,
   declaredRuntime: string,
@@ -221,13 +246,15 @@ function recordRuntimeDriftOnce(
   processInfo: RuntimeProcessOwner | null,
 ) {
   if (!actualRuntime || declaredRuntime === actualRuntime) return;
+  if (!runtimeDriftIsAttributable(lane.worktreePath, lane.repoPath, processInfo?.cwd)) return;
   const alreadyLogged = getLaneEvents(lane.id, 1000).some((event) => event.verb === 'runtime_drift');
   if (alreadyLogged) return;
 
   appendEvent(lane.id, 'runtime_drift', 'system', {
     declaredRuntime,
     actualRuntime,
-    worktreePath: lane.worktreePath ?? lane.repoPath,
+    worktreePath: lane.worktreePath,
+    processCwd: processInfo?.cwd ?? null,
     pid: processInfo?.pid ?? null,
     binaryPath: processInfo?.binaryPath ?? null,
   });

--- a/src/lib/lanes/scope.ts
+++ b/src/lib/lanes/scope.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { promisify } from 'node:util';
 
 import { getDataDir } from '@/lib/data-dir-migration';
@@ -229,14 +229,22 @@ export function runtimeDriftIsAttributable(
   repoPath: string,
   processCwd: string | null | undefined,
 ): boolean {
-  const worktree = worktreePath?.trim();
+  const worktreeInput = worktreePath?.trim();
   // No isolated directory means nothing can prove ownership.
-  if (!worktree) return false;
+  if (!worktreeInput) return false;
+  const worktree = resolve(worktreeInput);
+  const repo = resolve(repoPath.trim());
   // A "worktree" that is the repo root is the shared checkout, not this packet's.
-  if (worktree === repoPath.trim()) return false;
-  const cwd = processCwd?.trim();
-  if (!cwd) return false;
-  return cwd === worktree || cwd.startsWith(`${worktree}/`);
+  if (worktree === repo) return false;
+  const cwdInput = processCwd?.trim();
+  if (!cwdInput) return false;
+  const cwd = resolve(cwdInput);
+  const fromWorktree = relative(worktree, cwd);
+  return fromWorktree === '' || (
+    fromWorktree !== '..'
+    && !fromWorktree.startsWith(`..${sep}`)
+    && !isAbsolute(fromWorktree)
+  );
 }
 
 function recordRuntimeDriftOnce(

--- a/src/lib/mcp/o8-webview-async-eval-guard.ts
+++ b/src/lib/mcp/o8-webview-async-eval-guard.ts
@@ -1,0 +1,45 @@
+export const O8_WEBVIEW_ASYNC_EVAL_GUARD = String.raw`
+  // The execute_js transport takes this function's SYNCHRONOUS completion
+  // value, so a Promise cannot be awaited here. A pending Promise also has no
+  // own enumerable keys, so it serialized to {} and sailed through every
+  // serializability probe below as ok:true -- the caller was told the eval
+  // succeeded and handed an empty object (#1735). Say what actually happened
+  // instead, and name the pattern that does work.
+  let __o8_then__;
+  try {
+    __o8_then__ = __o8_value__ && __o8_value__.then;
+  } catch (__o8_then_err__) {
+    return JSON.stringify({
+      ok: false,
+      error: {
+        name: 'AsyncEvalUnsupported',
+        message: 'The expression returned a malformed async result whose then property could not be inspected: ' + ((__o8_then_err__ && __o8_then_err__.message) || String(__o8_then_err__)),
+        stack: null,
+      },
+    });
+  }
+  if (typeof __o8_then__ === 'function') {
+    try {
+      // Attach both outcomes before returning so an already-rejected Promise
+      // does not become an unhandled rejection in the webview.
+      __o8_then__.call(__o8_value__, function () {}, function () {});
+    } catch (__o8_then_err__) {
+      return JSON.stringify({
+        ok: false,
+        error: {
+          name: 'AsyncEvalUnsupported',
+          message: 'The expression returned a malformed async result whose then function could not be observed safely: ' + ((__o8_then_err__ && __o8_then_err__.message) || String(__o8_then_err__)),
+          stack: null,
+        },
+      });
+    }
+    return JSON.stringify({
+      ok: false,
+      error: {
+        name: 'AsyncEvalUnsupported',
+        message: 'The expression returned a Promise, and this eval bridge reads a synchronous completion value, so the resolved value cannot be returned. Start the async work with Promise.resolve(...).then(function (value) { window.__myKey = value; }), then read window.__myKey with a second, synchronous eval.',
+        stack: null,
+      },
+    });
+  }
+`;

--- a/src/lib/mcp/o8-webview-eval.test.ts
+++ b/src/lib/mcp/o8-webview-eval.test.ts
@@ -3,7 +3,6 @@ import { wrapEvalCode } from './o8-webview-tools';
 
 /** The wrapper is a self-contained expression; run it the way the webview does. */
 function runWrapped(userCode: string): { ok: boolean; value?: unknown; error?: { name: string; message: string } } {
-  // eslint-disable-next-line no-eval
   return JSON.parse((0, eval)(wrapEvalCode(userCode)) as string);
 }
 
@@ -26,6 +25,20 @@ describe('wrapEvalCode', () => {
 
   it('catches a bare thenable', () => {
     expect(runWrapped('({ then: function (r) { r(1); } })').ok).toBe(false);
+  });
+
+  it('returns a structured error when reading then throws', () => {
+    const result = runWrapped('Object.defineProperty({}, "then", { get: function () { throw new Error("bad then"); } })');
+    expect(result.ok).toBe(false);
+    expect(result.error?.name).toBe('AsyncEvalUnsupported');
+    expect(result.error?.message).toContain('bad then');
+  });
+
+  it('handles an already-rejected Promise before returning', async () => {
+    const result = runWrapped('Promise.reject(new Error("rejected"))');
+    expect(result.ok).toBe(false);
+    expect(result.error?.name).toBe('AsyncEvalUnsupported');
+    await new Promise((resolve) => setTimeout(resolve, 0));
   });
 
   it('still returns ordinary synchronous values', () => {

--- a/src/lib/mcp/o8-webview-eval.test.ts
+++ b/src/lib/mcp/o8-webview-eval.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { wrapEvalCode } from './o8-webview-tools';
+
+/** The wrapper is a self-contained expression; run it the way the webview does. */
+function runWrapped(userCode: string): { ok: boolean; value?: unknown; error?: { name: string; message: string } } {
+  // eslint-disable-next-line no-eval
+  return JSON.parse((0, eval)(wrapEvalCode(userCode)) as string);
+}
+
+describe('wrapEvalCode', () => {
+  it('reports a Promise result honestly instead of returning {} as success (#1735)', () => {
+    // The transport reads a synchronous completion value, and a pending Promise
+    // has no own enumerable keys -- so it serialized to {} and passed every
+    // serializability probe as ok:true. The caller was told the eval worked.
+    const result = runWrapped('Promise.resolve(42)');
+    expect(result.ok).toBe(false);
+    expect(result.error?.name).toBe('AsyncEvalUnsupported');
+    expect(result.error?.message).toContain('second, synchronous eval');
+  });
+
+  it('catches an async IIFE the same way', () => {
+    const result = runWrapped('(async () => 1)()');
+    expect(result.ok).toBe(false);
+    expect(result.error?.name).toBe('AsyncEvalUnsupported');
+  });
+
+  it('catches a bare thenable', () => {
+    expect(runWrapped('({ then: function (r) { r(1); } })').ok).toBe(false);
+  });
+
+  it('still returns ordinary synchronous values', () => {
+    expect(runWrapped('1 + 1')).toMatchObject({ ok: true, value: 2 });
+    expect(runWrapped('({ a: 1, b: "two" })')).toMatchObject({ ok: true, value: { a: 1, b: 'two' } });
+    expect(runWrapped('"plain string"')).toMatchObject({ ok: true, value: 'plain string' });
+    expect(runWrapped('[1, 2, 3]')).toMatchObject({ ok: true, value: [1, 2, 3] });
+  });
+
+  it('still reports a thrown error as an error', () => {
+    const result = runWrapped('throw new TypeError("boom")');
+    expect(result.ok).toBe(false);
+    expect(result.error?.name).toBe('TypeError');
+    expect(result.error?.message).toBe('boom');
+  });
+
+  it('does not mistake an object with a non-callable then for a promise', () => {
+    expect(runWrapped('({ then: "not a function" })')).toMatchObject({ ok: true });
+  });
+});

--- a/src/lib/mcp/o8-webview-tools.ts
+++ b/src/lib/mcp/o8-webview-tools.ts
@@ -11,6 +11,7 @@ import {
 } from '@/lib/mcp/o8-webview-composites';
 import { O8WebviewClient } from '@/lib/mcp/o8-webview-client';
 import { buildPrepareComposerTargetScript } from '@/lib/mcp/o8-webview-composer-target';
+import { O8_WEBVIEW_ASYNC_EVAL_GUARD } from '@/lib/mcp/o8-webview-async-eval-guard';
 
 type TextContent = { type: 'text'; text: string };
 type ImageContent = { type: 'image'; data: string; mimeType: string };
@@ -240,22 +241,7 @@ export function wrapEvalCode(userCode: string): string {
     });
   }
 
-  // The execute_js transport takes this function's SYNCHRONOUS completion
-  // value, so a Promise cannot be awaited here. A pending Promise also has no
-  // own enumerable keys, so it serialized to {} and sailed through every
-  // serializability probe below as ok:true -- the caller was told the eval
-  // succeeded and handed an empty object (#1735). Say what actually happened
-  // instead, and name the pattern that does work.
-  if (__o8_value__ && (typeof __o8_value__.then === 'function')) {
-    return JSON.stringify({
-      ok: false,
-      error: {
-        name: 'AsyncEvalUnsupported',
-        message: 'The expression returned a Promise, and this eval bridge reads a synchronous completion value, so the resolved value cannot be returned. Start the async work and stash its result (window.__myKey = await ...), then read window.__myKey with a second, synchronous eval.',
-        stack: null,
-      },
-    });
-  }
+${O8_WEBVIEW_ASYNC_EVAL_GUARD}
 
   // Probe JSON serializability. JSON.stringify on a top-level non-serializable
   // (function, undefined) returns undefined; on a property with such a value

--- a/src/lib/mcp/o8-webview-tools.ts
+++ b/src/lib/mcp/o8-webview-tools.ts
@@ -199,7 +199,7 @@ function looksLikeObjectLiteralExpression(trimmed: string): boolean {
   return depth === 0;
 }
 
-function wrapEvalCode(userCode: string): string {
+export function wrapEvalCode(userCode: string): string {
   const trimmed = userCode.trim();
   // Run the user code via indirect eval — `(0, eval)(code)` evaluates in the
   // global scope AND returns the completion value of the last statement,
@@ -236,6 +236,23 @@ function wrapEvalCode(userCode: string): string {
         message: (__o8_err__ && __o8_err__.message) || String(__o8_err__),
         name: (__o8_err__ && __o8_err__.name) || 'Error',
         stack: (__o8_err__ && __o8_err__.stack) || null,
+      },
+    });
+  }
+
+  // The execute_js transport takes this function's SYNCHRONOUS completion
+  // value, so a Promise cannot be awaited here. A pending Promise also has no
+  // own enumerable keys, so it serialized to {} and sailed through every
+  // serializability probe below as ok:true -- the caller was told the eval
+  // succeeded and handed an empty object (#1735). Say what actually happened
+  // instead, and name the pattern that does work.
+  if (__o8_value__ && (typeof __o8_value__.then === 'function')) {
+    return JSON.stringify({
+      ok: false,
+      error: {
+        name: 'AsyncEvalUnsupported',
+        message: 'The expression returned a Promise, and this eval bridge reads a synchronous completion value, so the resolved value cannot be returned. Start the async work and stash its result (window.__myKey = await ...), then read window.__myKey with a second, synchronous eval.',
+        stack: null,
       },
     });
   }

--- a/src/lib/mobile/orchestrator-thread-project.test.ts
+++ b/src/lib/mobile/orchestrator-thread-project.test.ts
@@ -39,6 +39,11 @@ describe('orchestrator thread project resolution (#1752)', () => {
       .toThrow(OrchestratorThreadProjectError);
   });
 
+  it('refuses a stale unknown project id already persisted on the thread', () => {
+    expect(() => resolveOrchestratorThreadProjectId('proj-does-not-exist', undefined))
+      .toThrow(OrchestratorThreadProjectError);
+  });
+
   it('resolves a real SQLite project normally', () => {
     const project = createProject({ name: 'Real Project' });
     expect(resolveOrchestratorThreadProjectId(null, project.id)).toBe(project.id);

--- a/src/lib/mobile/orchestrator-thread-project.test.ts
+++ b/src/lib/mobile/orchestrator-thread-project.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+process.env.O8_DATA_DIR ??= mkdtempSync(path.join(os.tmpdir(), 'o8-thread-project-'));
+process.env.CORTEX_IDE_DATA_DIR ??= process.env.O8_DATA_DIR;
+
+const {
+  LEGACY_DEFAULT_PROJECT_ID,
+  OrchestratorThreadProjectError,
+  resolveOrchestratorThreadProjectId,
+} = await import('./orchestrator-thread-project');
+const { DEFAULT_PROJECT_ID } = await import('@/lib/repos/projects');
+const { createProject } = await import('@/lib/projects/store');
+
+describe('orchestrator thread project resolution (#1752)', () => {
+  it('keeps the local sentinel in step with the ledger constant', () => {
+    // Declared locally so this module does not pull the repo-pool graph.
+    expect(LEGACY_DEFAULT_PROJECT_ID).toBe(DEFAULT_PROJECT_ID);
+  });
+
+  it('resolves the legacy sentinel to no-project instead of failing the turn', () => {
+    // On a fresh install SQLite has no 'default' row, so every orchestrator
+    // turn failed with "Project default does not exist" — before the operator
+    // had registered a repo, which is the first thing they do.
+    expect(resolveOrchestratorThreadProjectId(null, LEGACY_DEFAULT_PROJECT_ID)).toBeNull();
+  });
+
+  it('resolves a thread already stamped with the sentinel', () => {
+    // Threads persisted before a repo was registered carry it too, and kept
+    // failing even after the operator fixed their setup.
+    expect(resolveOrchestratorThreadProjectId(LEGACY_DEFAULT_PROJECT_ID, null)).toBeNull();
+    expect(resolveOrchestratorThreadProjectId(LEGACY_DEFAULT_PROJECT_ID, undefined)).toBeNull();
+  });
+
+  it('still refuses an unknown project id that is not the sentinel', () => {
+    expect(() => resolveOrchestratorThreadProjectId(null, 'proj-does-not-exist'))
+      .toThrow(OrchestratorThreadProjectError);
+  });
+
+  it('resolves a real SQLite project normally', () => {
+    const project = createProject({ name: 'Real Project' });
+    expect(resolveOrchestratorThreadProjectId(null, project.id)).toBe(project.id);
+    expect(resolveOrchestratorThreadProjectId(project.id, project.id)).toBe(project.id);
+  });
+
+  it('still reports a genuine mismatch between two real projects', () => {
+    const a = createProject({ name: 'Project A' });
+    const b = createProject({ name: 'Project B' });
+    expect(() => resolveOrchestratorThreadProjectId(a.id, b.id)).toThrow(OrchestratorThreadProjectError);
+  });
+
+  it('leaves a no-project thread alone', () => {
+    expect(resolveOrchestratorThreadProjectId(null, null)).toBeNull();
+  });
+});

--- a/src/lib/mobile/orchestrator-thread-project.ts
+++ b/src/lib/mobile/orchestrator-thread-project.ts
@@ -1,5 +1,29 @@
 import { getProject } from '@/lib/projects/store';
 
+/**
+ * The JSON-ledger's sentinel project id (`DEFAULT_PROJECT_ID` in
+ * `@/lib/repos/projects`). Declared locally rather than imported so this
+ * module does not pull the repo-pool graph; `orchestrator-thread-project.test.ts`
+ * pins the two together so they cannot drift apart.
+ */
+export const LEGACY_DEFAULT_PROJECT_ID = 'default';
+
+/**
+ * Threads stamp their project id from the JSON ledger, which uses the literal
+ * `'default'`. Validation looks the id up in the SQLite `projects` table, and a
+ * fresh install has no such row -- so every orchestrator turn failed with
+ * "Project default does not exist" before the operator had registered a repo.
+ * The first thing someone does on a new install was the thing that broke
+ * (#1752).
+ *
+ * The sentinel is not a project; it means "no project chosen". A thread with a
+ * null project is already a supported state, so it resolves to null. An
+ * unknown id that is NOT the sentinel is still a genuine error worth raising.
+ */
+function isUnresolvedLegacyDefault(projectId: string): boolean {
+  return projectId === LEGACY_DEFAULT_PROJECT_ID && !getProject(projectId);
+}
+
 export type OrchestratorThreadProjectErrorCode =
   | 'orchestrator_thread_project_invalid'
   | 'orchestrator_thread_project_not_found'
@@ -43,6 +67,7 @@ function validateRequestedProjectId(value: unknown): string | null {
     });
   }
   const projectId = value.trim();
+  if (isUnresolvedLegacyDefault(projectId)) return null;
   if (!getProject(projectId)) {
     throw new OrchestratorThreadProjectError({
       code: 'orchestrator_thread_project_not_found',
@@ -57,9 +82,13 @@ export function resolveOrchestratorThreadProjectId(
   existingValue: unknown,
   requestedValue: unknown,
 ): string | null {
-  const existingProjectId = typeof existingValue === 'string' && existingValue.trim()
+  const existingRaw = typeof existingValue === 'string' && existingValue.trim()
     ? existingValue.trim()
     : null;
+  // A thread persisted before a repo was registered carries the sentinel too,
+  // so it has to be normalized on this path as well or those threads keep
+  // failing after the operator fixes their setup (#1752).
+  const existingProjectId = existingRaw && isUnresolvedLegacyDefault(existingRaw) ? null : existingRaw;
   const requestedProjectId = validateRequestedProjectId(requestedValue);
   if (existingProjectId && requestedProjectId && existingProjectId !== requestedProjectId) {
     throw new OrchestratorThreadProjectError({

--- a/src/lib/mobile/orchestrator-thread-project.ts
+++ b/src/lib/mobile/orchestrator-thread-project.ts
@@ -88,7 +88,7 @@ export function resolveOrchestratorThreadProjectId(
   // A thread persisted before a repo was registered carries the sentinel too,
   // so it has to be normalized on this path as well or those threads keep
   // failing after the operator fixes their setup (#1752).
-  const existingProjectId = existingRaw && isUnresolvedLegacyDefault(existingRaw) ? null : existingRaw;
+  const existingProjectId = validateRequestedProjectId(existingRaw);
   const requestedProjectId = validateRequestedProjectId(requestedValue);
   if (existingProjectId && requestedProjectId && existingProjectId !== requestedProjectId) {
     throw new OrchestratorThreadProjectError({

--- a/src/lib/orchestrator/display.test.ts
+++ b/src/lib/orchestrator/display.test.ts
@@ -22,6 +22,19 @@ describe('runtimeDisplayLabel', () => {
 });
 
 describe('resolved model labels', () => {
+  it('renders the runtime alone when no model is known (#1869)', () => {
+    // The claude-code adapter used to substitute the bare string 'claude' for
+    // an unknown model. It is not a model id -- the registry has claude-opus-5,
+    // claude-sonnet-5 -- so the surface printed a model that does not exist,
+    // indistinguishable from a real selection. `model` is optional precisely so
+    // absent can be said honestly.
+    expect(runtimeModelDisplayLabel('claude-code', undefined)).toBe('Claude Code');
+    expect(runtimeModelDisplayLabel('claude-code', null)).toBe('Claude Code');
+    expect(runtimeModelDisplayLabel('claude-code', '   ')).toBe('Claude Code');
+    // What the fabricated fallback used to render:
+    expect(runtimeModelDisplayLabel('claude-code', 'claude')).toBe('Claude Code · claude');
+  });
+
   it('renders the runtime and resolved model together', () => {
     expect(runtimeModelDisplayLabel('opencode', 'ox-alpha')).toBe('OpenCode 2 · ox-alpha');
     expect(packetRuntimeModelDisplayLabel({

--- a/src/lib/orchestrator/runtime-capabilities.ts
+++ b/src/lib/orchestrator/runtime-capabilities.ts
@@ -431,6 +431,25 @@ export function isOrchestratorRuntime(value: unknown): value is OrchestratorRunt
   return typeof value === 'string' && Object.prototype.hasOwnProperty.call(ORCHESTRATOR_RUNTIMES, value);
 }
 
+/**
+ * The runtime a session key names, or null when it names none.
+ *
+ * Keys are `<runtime>-owned:<id>` / `<runtime>-discovered:<id>`, so the key
+ * itself carries runtime identity — which is why a surface holding only a
+ * session key still knows what is running in it (#1749).
+ *
+ * Pure and client-safe on purpose. `runtimeIdFromSessionKey` in
+ * `runtime/transcript.ts` does the same parse but validates against the adapter
+ * registry, pulling every adapter with it; a React surface cannot import that.
+ */
+export function runtimeFromSessionKeyId(sessionKey: string | null | undefined): OrchestratorRuntime | null {
+  const normalized = sessionKey?.trim() ?? '';
+  const separator = normalized.indexOf(':');
+  if (separator <= 0) return null;
+  const prefix = normalized.slice(0, separator).trim().replace(/-(?:owned|discovered)$/, '');
+  return isOrchestratorRuntime(prefix) ? prefix : null;
+}
+
 export function runtimeFromOwnedSessionKey(value: unknown): OrchestratorRuntime | null {
   if (typeof value !== 'string') return null;
   const sessionKey = value.trim();

--- a/src/lib/orchestrator/runtime-capabilities.ts
+++ b/src/lib/orchestrator/runtime-capabilities.ts
@@ -40,6 +40,18 @@ export interface OrchestratorRuntimeCapability<
   workerProvider: WorkerProvider;
   /** Auth inventory bucket; null only for discovery-only runtimes. */
   authHouse: AuthHouse | null;
+  /**
+   * Model ids this runtime's CLI can actually launch, when that set is
+   * knowable. Codex cannot run an Anthropic id and the Claude harness cannot
+   * run an OpenAI one; handing either the other house's model fails the turn
+   * (#1807, and the codex-direction hit on 2026-07-05).
+   *
+   * OMIT for a runtime that legitimately fronts several providers -- cursor,
+   * opencode and the gateway-backed harnesses all do. Absent means "do not
+   * guess", and the model passes through untouched. A wrong constraint here
+   * would block a valid selection, which is worse than the bug it prevents.
+   */
+  modelIdPattern?: RegExp;
   /** Whether launch accepts a reasoning-effort selection. */
   reasoningEffort: boolean;
   /** Provider-native durable session transforms. Missing means unsupported. */
@@ -78,6 +90,7 @@ export const ORCHESTRATOR_RUNTIMES = {
     binaryName: 'codex',
     workerProvider: 'codex',
     authHouse: 'codex',
+    modelIdPattern: /^(gpt-|o\d|openai\/)/i,
     reasoningEffort: true,
     sessionTransforms: {
       import: true,
@@ -101,6 +114,7 @@ export const ORCHESTRATOR_RUNTIMES = {
     binaryName: 'claude',
     workerProvider: 'claude',
     authHouse: 'claude',
+    modelIdPattern: /^(claude|anthropic\/)/i,
     reasoningEffort: true,
     tier: 'frontier',
     description: 'Claude Code CLI worker via interactive stream-json. Uses the existing Claude account by default or an explicitly selected API gateway model; never --print.',
@@ -120,6 +134,7 @@ export const ORCHESTRATOR_RUNTIMES = {
     binaryName: 'gemini',
     workerProvider: 'gemini',
     authHouse: 'gemini',
+    modelIdPattern: /^(gemini|google\/)/i,
     reasoningEffort: false,
     tier: 'standard',
     description: 'Google Gemini CLI worker via headless stream-json with owned-session resume and review support.',
@@ -363,6 +378,7 @@ export const ORCHESTRATOR_RUNTIMES = {
     binaryName: 'grok',
     workerProvider: 'grok',
     authHouse: 'grok',
+    modelIdPattern: /^(grok|x-ai\/|xai\/)/i,
     reasoningEffort: false,
     tier: 'frontier',
     description: 'Grok Build coding CLI with provider-selected current defaults, structured headless output, and durable resume.',

--- a/src/lib/orchestrator/runtime-capabilities.ts
+++ b/src/lib/orchestrator/runtime-capabilities.ts
@@ -446,6 +446,7 @@ export function runtimeFromSessionKeyId(sessionKey: string | null | undefined): 
   const normalized = sessionKey?.trim() ?? '';
   const separator = normalized.indexOf(':');
   if (separator <= 0) return null;
+  if (!normalized.slice(separator + 1).trim()) return null;
   const prefix = normalized.slice(0, separator).trim().replace(/-(?:owned|discovered)$/, '');
   return isOrchestratorRuntime(prefix) ? prefix : null;
 }

--- a/src/lib/orchestrator/runtime-from-session-key.test.ts
+++ b/src/lib/orchestrator/runtime-from-session-key.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { runtimeFromSessionKeyId } from './runtime-capabilities';
+
+describe('runtimeFromSessionKeyId (#1749)', () => {
+  it('reads the runtime out of an owned session key', () => {
+    // Four live claude-code lanes rendered the composer's Codex default while
+    // their session keys said exactly what was running.
+    expect(runtimeFromSessionKeyId('claude-code-owned:abc123')).toBe('claude-code');
+    expect(runtimeFromSessionKeyId('codex-owned:def456')).toBe('codex');
+    expect(runtimeFromSessionKeyId('gemini-owned:ghi789')).toBe('gemini');
+  });
+
+  it('reads a discovered session key too', () => {
+    expect(runtimeFromSessionKeyId('claude-code-discovered:abc')).toBe('claude-code');
+    expect(runtimeFromSessionKeyId('codex-discovered:xyz')).toBe('codex');
+  });
+
+  it('reads a bare runtime prefix', () => {
+    expect(runtimeFromSessionKeyId('claude-code:session-1')).toBe('claude-code');
+    expect(runtimeFromSessionKeyId('opencode:session-2')).toBe('opencode');
+  });
+
+  it('returns null rather than guessing when the key names no known runtime', () => {
+    expect(runtimeFromSessionKeyId('not-a-runtime-owned:abc')).toBeNull();
+    expect(runtimeFromSessionKeyId('thoughts-1787358397405')).toBeNull();
+    expect(runtimeFromSessionKeyId(':leading-colon')).toBeNull();
+    expect(runtimeFromSessionKeyId('')).toBeNull();
+    expect(runtimeFromSessionKeyId(null)).toBeNull();
+    expect(runtimeFromSessionKeyId(undefined)).toBeNull();
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(runtimeFromSessionKeyId('  claude-code-owned:abc  ')).toBe('claude-code');
+  });
+});

--- a/src/lib/orchestrator/runtime-from-session-key.test.ts
+++ b/src/lib/orchestrator/runtime-from-session-key.test.ts
@@ -24,6 +24,8 @@ describe('runtimeFromSessionKeyId (#1749)', () => {
     expect(runtimeFromSessionKeyId('not-a-runtime-owned:abc')).toBeNull();
     expect(runtimeFromSessionKeyId('thoughts-1787358397405')).toBeNull();
     expect(runtimeFromSessionKeyId(':leading-colon')).toBeNull();
+    expect(runtimeFromSessionKeyId('claude-code-owned:')).toBeNull();
+    expect(runtimeFromSessionKeyId('codex:   ')).toBeNull();
     expect(runtimeFromSessionKeyId('')).toBeNull();
     expect(runtimeFromSessionKeyId(null)).toBeNull();
     expect(runtimeFromSessionKeyId(undefined)).toBeNull();

--- a/src/lib/orchestrator/transcript-normalizer.test.ts
+++ b/src/lib/orchestrator/transcript-normalizer.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeCodexEvents } from './transcript-normalizer';
+
+const TS = '2026-08-23T13:08:33.642Z';
+const COMMAND = '/bin/zsh -lc "sed -n 1,40p src/lib/lane/registry.ts"';
+
+function line(value: Record<string, unknown>): string {
+  return JSON.stringify(value);
+}
+
+/** The `event_msg` shape: call id lives on the payload. */
+function execBegin(ts: string, callId: string, command: string): string {
+  return line({ type: 'event_msg', timestamp: ts, payload: { type: 'exec_command_begin', call_id: callId, command } });
+}
+
+/** The `item.*` shape: id lives on the item, and the normalizer keys on `id\0command`. */
+function itemStarted(ts: string, itemId: string, command: string): string {
+  return line({ type: 'item.started', timestamp: ts, item: { type: 'command_execution', id: itemId, command } });
+}
+
+function itemCompleted(ts: string, itemId: string, command: string, output: string, exitCode: number): string {
+  return line({
+    type: 'item.completed',
+    timestamp: ts,
+    item: { type: 'command_execution', id: itemId, command, aggregated_output: output, exit_code: exitCode },
+  });
+}
+
+describe('normalizeCodexEvents — one command, one row (#1845)', () => {
+  it('collapses the same command announced through several stream shapes', () => {
+    // Codex carries one command in both the legacy `event_msg` form and the
+    // `item.*` form. Their call ids are derived differently, so an id-keyed
+    // dedupe left four identical rows sharing a millisecond timestamp.
+    const events = normalizeCodexEvents([
+      execBegin(TS, 'call_exec_1', COMMAND),
+      itemStarted(TS, 'item_exec_1', COMMAND),
+      execBegin(TS, 'call_exec_1', COMMAND),
+      itemStarted(TS, 'item_exec_1', COMMAND),
+      itemCompleted(TS, 'item_exec_1', COMMAND, 'export function createLane(', 0),
+    ].join('\n'));
+
+    const calls = events.filter((event) => event.type === 'tool_call');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ type: 'tool_call', tool: 'exec_command', ts: TS });
+
+    const results = events.filter((event) => event.type === 'tool_result');
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ type: 'tool_result', tool: 'exec_command', ok: true });
+  });
+
+  it('keeps a genuine re-run as its own row, because its timestamp differs', () => {
+    const later = '2026-08-23T13:09:41.100Z';
+    const events = normalizeCodexEvents([
+      execBegin(TS, 'call_exec_1', COMMAND),
+      itemCompleted(TS, 'item_exec_1', COMMAND, 'first run', 0),
+      execBegin(later, 'call_exec_2', COMMAND),
+      itemCompleted(later, 'item_exec_2', COMMAND, 'second run', 0),
+    ].join('\n'));
+
+    const calls = events.filter((event) => event.type === 'tool_call');
+    expect(calls).toHaveLength(2);
+    expect(calls.map((call) => call.ts)).toEqual([TS, later]);
+  });
+
+  it('does not merge two different commands sharing a timestamp', () => {
+    const events = normalizeCodexEvents([
+      execBegin(TS, 'call_a', 'git status --short'),
+      execBegin(TS, 'call_b', 'npx tsc --noEmit'),
+    ].join('\n'));
+
+    expect(events.filter((event) => event.type === 'tool_call')).toHaveLength(2);
+  });
+
+  it('returns an empty stream for empty or unparseable input', () => {
+    expect(normalizeCodexEvents('')).toEqual([]);
+    expect(normalizeCodexEvents('not json\n{oops')).toEqual([]);
+  });
+});

--- a/src/lib/orchestrator/transcript-normalizer.test.ts
+++ b/src/lib/orchestrator/transcript-normalizer.test.ts
@@ -71,6 +71,46 @@ describe('normalizeCodexEvents — one command, one row (#1845)', () => {
     expect(events.filter((event) => event.type === 'tool_call')).toHaveLength(2);
   });
 
+  it('keeps same-millisecond duplicate commands distinct within one stream shape', () => {
+    const events = normalizeCodexEvents([
+      execBegin(TS, 'call_a', COMMAND),
+      execBegin(TS, 'call_b', COMMAND),
+      itemStarted(TS, 'item_a', COMMAND),
+      itemStarted(TS, 'item_b', COMMAND),
+    ].join('\n'));
+
+    expect(events.filter((event) => event.type === 'tool_call')).toHaveLength(2);
+  });
+
+  it('does not alias calls whose timestamps are missing or invalid', () => {
+    const events = normalizeCodexEvents([
+      line({ type: 'event_msg', timestamp: 'not-a-date', payload: { type: 'exec_command_begin', call_id: 'call_a', command: COMMAND } }),
+      line({ type: 'item.started', item: { type: 'command_execution', id: 'item_a', command: COMMAND } }),
+    ].join('\n'), TS);
+
+    expect(events.filter((event) => event.type === 'tool_call')).toHaveLength(2);
+  });
+
+  it('uses the full arguments for alias identity, not the clipped display prefix', () => {
+    const prefix = 'x'.repeat(700);
+    const events = normalizeCodexEvents([
+      execBegin(TS, 'call_a', `${prefix} first`),
+      itemStarted(TS, 'item_b', `${prefix} second`),
+    ].join('\n'));
+
+    expect(events.filter((event) => event.type === 'tool_call')).toHaveLength(2);
+  });
+
+  it('keeps generated call ids unique after an alias match', () => {
+    const events = normalizeCodexEvents([
+      execBegin(TS, 'call_explicit', COMMAND),
+      line({ type: 'item.started', timestamp: TS, item: { type: 'command_execution', command: COMMAND } }),
+      line({ type: 'item.started', timestamp: TS, item: { type: 'command_execution', command: 'git status --short' } }),
+    ].join('\n'));
+
+    expect(events.filter((event) => event.type === 'tool_call')).toHaveLength(2);
+  });
+
   it('returns an empty stream for empty or unparseable input', () => {
     expect(normalizeCodexEvents('')).toEqual([]);
     expect(normalizeCodexEvents('not json\n{oops')).toEqual([]);

--- a/src/lib/orchestrator/transcript-normalizer.ts
+++ b/src/lib/orchestrator/transcript-normalizer.ts
@@ -107,12 +107,25 @@ export function normalizeCodexEvents(
   const out: TranscriptEvent[] = [];
   const pending = new Map<string, PendingCall>();
   const emitted = new Map<string, EmittedTool>();
+  /** tool+args+timestamp → the call id that first emitted it. See pushToolCall. */
+  const identityAlias = new Map<string, string>();
   const fallbackTs = fallbackTimestamp;
   let seq = 0;
   const nextSeq = () => (seq += 1);
 
   const pushToolCall = (ts: string, callId: string, tool: string, args: string) => {
-    const previous = emitted.get(callId);
+    // Codex carries ONE command in several stream shapes -- `exec_command_begin`,
+    // `item.started`, `response_item` -- and each derives its call id
+    // differently (`call_id` vs `id` vs `id\0command`). Keyed on id alone, the
+    // same command emitted four identical `tool_call` rows sharing a timestamp
+    // to the millisecond, and at a 50-event cap those copies displaced real
+    // history (#1845). A genuine re-run carries a distinct timestamp, so
+    // tool+args+ts identifies the emission itself rather than the shape that
+    // announced it.
+    const identity = `${tool}\u0000${args}\u0000${ts}`;
+    const aliasId = identityAlias.get(identity);
+    const previous = emitted.get(callId)
+      ?? (aliasId !== undefined ? emitted.get(aliasId) : undefined);
     if (previous) {
       const previousCall = out[previous.callIndex];
       out[previous.callIndex] = {
@@ -124,6 +137,9 @@ export function normalizeCodexEvents(
         summary: clip(args || `call ${tool}`, MAX_SUMMARY),
       };
       previous.tool = tool;
+      // Every id shape naming this call must reach the same record, so the
+      // result pairs with the row already on screen instead of orphaning.
+      emitted.set(callId, previous);
       pending.set(callId, { seq: previousCall!.seq, tool });
       return;
     }
@@ -132,6 +148,7 @@ export function normalizeCodexEvents(
     const summary = clip(args || `call ${tool}`, MAX_SUMMARY);
     out.push({ seq: thisSeq, ts, type: 'tool_call', tool, args, summary });
     emitted.set(callId, { callIndex: out.length - 1, tool });
+    identityAlias.set(identity, callId);
   };
 
   const pushToolResult = (ts: string, callId: string | undefined, fallbackTool: string, rawOutput: string, exitCode: number | undefined) => {

--- a/src/lib/orchestrator/transcript-normalizer.ts
+++ b/src/lib/orchestrator/transcript-normalizer.ts
@@ -72,26 +72,37 @@ function extractText(source: unknown): string {
   return '';
 }
 
-function argsPreview(input: unknown): string {
+function normalizedArgs(input: unknown): string {
   if (input === undefined || input === null) return '';
-  if (typeof input === 'string') return clip(input, MAX_ARGS);
-  try { return clip(JSON.stringify(input), MAX_ARGS); } catch { return ''; }
+  if (typeof input === 'string') return input.trim();
+  try { return JSON.stringify(input); } catch { return ''; }
 }
 
-function normalizeTs(raw: unknown, fallback: string): string {
+function argsPreview(input: unknown): string {
+  return clip(normalizedArgs(input), MAX_ARGS);
+}
+
+interface NormalizedTimestamp {
+  value: string;
+  reliable: boolean;
+}
+
+function normalizeTs(raw: unknown, fallback: string): NormalizedTimestamp {
   if (typeof raw === 'string' && raw.trim()) {
     const parsed = new Date(raw);
-    if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+    if (!Number.isNaN(parsed.getTime())) return { value: parsed.toISOString(), reliable: true };
   }
   if (typeof raw === 'number' && Number.isFinite(raw)) {
     const parsed = new Date(raw);
-    if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+    if (!Number.isNaN(parsed.getTime())) return { value: parsed.toISOString(), reliable: true };
   }
-  return fallback;
+  return { value: fallback, reliable: false };
 }
 
 interface PendingCall { seq: number; tool: string; }
 interface EmittedTool { callIndex: number; resultIndex?: number; tool: string; }
+type ToolCallShape = 'response-function' | 'response-custom' | 'event-exec' | 'item-exec' | 'item-tool';
+interface IdentityAlias { callId: string; shapes: Set<ToolCallShape>; }
 
 /**
  * Normalize raw Codex JSONL into a TranscriptEvent stream. Never throws —
@@ -107,13 +118,24 @@ export function normalizeCodexEvents(
   const out: TranscriptEvent[] = [];
   const pending = new Map<string, PendingCall>();
   const emitted = new Map<string, EmittedTool>();
-  /** tool+args+timestamp → the call id that first emitted it. See pushToolCall. */
-  const identityAlias = new Map<string, string>();
+  /** Full tool+args+timestamp → cross-shape occurrences in arrival order. */
+  const identityAliases = new Map<string, IdentityAlias[]>();
   const fallbackTs = fallbackTimestamp;
   let seq = 0;
+  let syntheticCallSeq = 0;
   const nextSeq = () => (seq += 1);
+  const nextSyntheticCallId = (prefix: string) => `${prefix}-synthetic-${syntheticCallSeq += 1}`;
 
-  const pushToolCall = (ts: string, callId: string, tool: string, args: string) => {
+  const pushToolCall = (input: {
+    ts: string;
+    timestampReliable: boolean;
+    callId: string;
+    shape: ToolCallShape;
+    tool: string;
+    args: string;
+    identityArgs: string;
+  }) => {
+    const { ts, timestampReliable, callId, shape, tool, args, identityArgs } = input;
     // Codex carries ONE command in several stream shapes -- `exec_command_begin`,
     // `item.started`, `response_item` -- and each derives its call id
     // differently (`call_id` vs `id` vs `id\0command`). Keyed on id alone, the
@@ -122,10 +144,18 @@ export function normalizeCodexEvents(
     // history (#1845). A genuine re-run carries a distinct timestamp, so
     // tool+args+ts identifies the emission itself rather than the shape that
     // announced it.
-    const identity = `${tool}\u0000${args}\u0000${ts}`;
-    const aliasId = identityAlias.get(identity);
+    // Alias only when both the timestamp and full arguments are trustworthy.
+    // The displayed arguments are clipped, and missing/invalid timestamps use
+    // fallbackTs; neither is safe as an identity. Track shape occurrences so
+    // two legitimate same-millisecond calls with the same arguments pair by
+    // ordinal instead of collapsing into one row.
+    const identity = timestampReliable && identityArgs
+      ? `${tool}\u0000${identityArgs}\u0000${ts}`
+      : null;
+    const aliases = identity ? (identityAliases.get(identity) ?? []) : [];
+    const alias = aliases.find((candidate) => !candidate.shapes.has(shape));
     const previous = emitted.get(callId)
-      ?? (aliasId !== undefined ? emitted.get(aliasId) : undefined);
+      ?? (alias ? emitted.get(alias.callId) : undefined);
     if (previous) {
       const previousCall = out[previous.callIndex];
       out[previous.callIndex] = {
@@ -141,6 +171,16 @@ export function normalizeCodexEvents(
       // result pairs with the row already on screen instead of orphaning.
       emitted.set(callId, previous);
       pending.set(callId, { seq: previousCall!.seq, tool });
+      if (identity) {
+        const existingAlias = alias
+          ?? aliases.find((candidate) => emitted.get(candidate.callId) === previous);
+        if (existingAlias) {
+          existingAlias.shapes.add(shape);
+        } else {
+          aliases.push({ callId, shapes: new Set([shape]) });
+          identityAliases.set(identity, aliases);
+        }
+      }
       return;
     }
     const thisSeq = nextSeq();
@@ -148,7 +188,10 @@ export function normalizeCodexEvents(
     const summary = clip(args || `call ${tool}`, MAX_SUMMARY);
     out.push({ seq: thisSeq, ts, type: 'tool_call', tool, args, summary });
     emitted.set(callId, { callIndex: out.length - 1, tool });
-    identityAlias.set(identity, callId);
+    if (identity) {
+      aliases.push({ callId, shapes: new Set([shape]) });
+      identityAliases.set(identity, aliases);
+    }
   };
 
   const pushToolResult = (ts: string, callId: string | undefined, fallbackTool: string, rawOutput: string, exitCode: number | undefined) => {
@@ -180,7 +223,8 @@ export function normalizeCodexEvents(
     if (!parsed) continue;
 
     const type = readStr(parsed, 'type');
-    const ts = normalizeTs(parsed.timestamp, fallbackTs);
+    const normalizedTimestamp = normalizeTs(parsed.timestamp, fallbackTs);
+    const ts = normalizedTimestamp.value;
     const payload = safeObject(parsed.payload);
     const payloadType = payload ? readStr(payload, 'type') : '';
 
@@ -225,17 +269,33 @@ export function normalizeCodexEvents(
 
     // Tool calls
     if (type === 'response_item' && (payloadType === 'function_call' || payloadType === 'custom_tool_call')) {
-      const callId = readStr(payload, 'call_id', 'id') || `tool-${seq + 1}`;
+      const callId = readStr(payload, 'call_id', 'id') || nextSyntheticCallId('tool');
       const tool = readStr(payload, 'name', 'namespace', 'execution') || 'tool';
       const rawArgs = payloadType === 'custom_tool_call' ? payload!.input : payload!.arguments;
-      pushToolCall(ts, callId, tool, argsPreview(rawArgs));
+      pushToolCall({
+        ts,
+        timestampReliable: normalizedTimestamp.reliable,
+        callId,
+        shape: payloadType === 'custom_tool_call' ? 'response-custom' : 'response-function',
+        tool,
+        args: argsPreview(rawArgs),
+        identityArgs: normalizedArgs(rawArgs),
+      });
       continue;
     }
 
     if (type === 'event_msg' && payloadType === 'exec_command_begin') {
-      const callId = readStr(payload, 'call_id', 'id') || `exec-${seq + 1}`;
+      const callId = readStr(payload, 'call_id', 'id') || nextSyntheticCallId('exec');
       const command = readStr(payload, 'parsed_cmd', 'cmd', 'command');
-      pushToolCall(ts, callId, 'exec_command', clip(command, MAX_ARGS));
+      pushToolCall({
+        ts,
+        timestampReliable: normalizedTimestamp.reliable,
+        callId,
+        shape: 'event-exec',
+        tool: 'exec_command',
+        args: clip(command, MAX_ARGS),
+        identityArgs: normalizedArgs(command),
+      });
       continue;
     }
 
@@ -244,15 +304,31 @@ export function normalizeCodexEvents(
       if (item && readStr(item, 'type') === 'command_execution') {
         const command = readStr(item, 'command');
         const itemId = readStr(item, 'id');
-        const callId = itemId && command ? `${itemId}\u0000${command}` : itemId || `exec-${seq + 1}`;
-        pushToolCall(ts, callId, 'exec_command', clip(command, MAX_ARGS));
+        const callId = itemId && command ? `${itemId}\u0000${command}` : itemId || nextSyntheticCallId('exec');
+        pushToolCall({
+          ts,
+          timestampReliable: normalizedTimestamp.reliable,
+          callId,
+          shape: 'item-exec',
+          tool: 'exec_command',
+          args: clip(command, MAX_ARGS),
+          identityArgs: normalizedArgs(command),
+        });
         continue;
       }
       if (item && readStr(item, 'type') === 'tool_use') {
-        const callId = readStr(item, 'id') || `tool-${seq + 1}`;
+        const callId = readStr(item, 'id') || nextSyntheticCallId('tool');
         const tool = readStr(item, 'name', 'tool_name') || 'tool';
         const rawInput = item.input ?? item.arguments ?? item.invocation;
-        pushToolCall(ts, callId, tool, argsPreview(rawInput));
+        pushToolCall({
+          ts,
+          timestampReliable: normalizedTimestamp.reliable,
+          callId,
+          shape: 'item-tool',
+          tool,
+          args: argsPreview(rawInput),
+          identityArgs: normalizedArgs(rawInput),
+        });
         continue;
       }
     }

--- a/src/lib/runtimes/claude-code-process-probe.ts
+++ b/src/lib/runtimes/claude-code-process-probe.ts
@@ -1,0 +1,65 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export interface LiveClaudeProcess {
+  pid: number;
+  cwd?: string;
+}
+
+export interface LiveClaudeProbe {
+  processes: LiveClaudeProcess[];
+  probed: boolean;
+}
+
+export type ClaudeProcessProbeExec = (
+  file: string,
+  args: string[],
+  options: { windowsHide: boolean; timeout: number },
+) => Promise<{ stdout: string }>;
+
+export async function probeLiveClaudeProcesses(options: {
+  execFile?: ClaudeProcessProbeExec;
+} = {}): Promise<LiveClaudeProbe> {
+  const runExecFile = options.execFile ?? execFileAsync as ClaudeProcessProbeExec;
+  try {
+    const { stdout } = await runExecFile(
+      'bash', ['-c', 'ps -eo pid=,command= | grep -E "claude (--|-)" | grep -v grep | grep -v ".app/"'],
+      { windowsHide: true, timeout: 3000 },
+    );
+    const pids: number[] = [];
+    for (const line of stdout.trim().split('\n').filter(Boolean)) {
+      const match = line.trim().match(/^(\d+)/);
+      if (match) pids.push(Number(match[1]));
+    }
+    if (pids.length === 0) return { processes: [], probed: true };
+
+    const processes: LiveClaudeProcess[] = pids.map((pid) => ({ pid }));
+    try {
+      const { stdout: cwdOut } = await runExecFile(
+        'lsof', ['-a', '-p', pids.join(','), '-d', 'cwd', '-Fn'],
+        { windowsHide: true, timeout: 4000 },
+      );
+      let currentPid: number | null = null;
+      for (const line of cwdOut.split('\n')) {
+        if (line.startsWith('p')) {
+          currentPid = Number(line.slice(1));
+        } else if (line.startsWith('n/') && currentPid !== null) {
+          const proc = processes.find((candidate) => candidate.pid === currentPid);
+          if (proc) proc.cwd = line.slice(1);
+        }
+      }
+    } catch {
+      return { processes, probed: false };
+    }
+    return { processes, probed: true };
+  } catch (error) {
+    const failure = error as { code?: unknown; killed?: unknown };
+    return { processes: [], probed: failure.code === 1 && !failure.killed };
+  }
+}
+
+export async function findLiveClaudeProcesses(): Promise<LiveClaudeProcess[]> {
+  return (await probeLiveClaudeProcesses()).processes;
+}

--- a/src/lib/runtimes/claude-code-status.test.ts
+++ b/src/lib/runtimes/claude-code-status.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { inferHistoricalClaudeStatus } from './claude-code';
+
+const NOW = Date.parse('2026-08-24T12:00:00.000Z');
+const ago = (ms: number) => ({ lastModified: new Date(NOW - ms), hasErrorInTail: false });
+
+describe('inferHistoricalClaudeStatus', () => {
+  it('reports a finished turn as idle once the probe confirms no process (#1855)', () => {
+    // Reached only for a session no live process owns. A successful probe makes
+    // that absence the answer -- the turn is over. It used to report
+    // `reviewing` for five minutes off transcript mtime alone, so a worker that
+    // had already exited looked like it was still thinking.
+    expect(inferHistoricalClaudeStatus(ago(10_000), true, NOW)).toBe('idle');
+    expect(inferHistoricalClaudeStatus(ago(4 * 60_000), true, NOW)).toBe('idle');
+  });
+
+  it('keeps the mtime hedge when the probe could not run', () => {
+    expect(inferHistoricalClaudeStatus(ago(10_000), false, NOW)).toBe('reviewing');
+    expect(inferHistoricalClaudeStatus(ago(4 * 60_000), false, NOW)).toBe('reviewing');
+  });
+
+  it('falls to idle past the hedge window regardless of the probe', () => {
+    expect(inferHistoricalClaudeStatus(ago(6 * 60_000), false, NOW)).toBe('idle');
+    expect(inferHistoricalClaudeStatus(ago(6 * 60_000), true, NOW)).toBe('idle');
+  });
+
+  it('still surfaces a recent error tail as failed', () => {
+    const errored = { lastModified: new Date(NOW - 60_000), hasErrorInTail: true };
+    expect(inferHistoricalClaudeStatus(errored, true, NOW)).toBe('failed');
+    expect(inferHistoricalClaudeStatus(errored, false, NOW)).toBe('failed');
+  });
+
+  it('stops calling a stale error tail failed', () => {
+    const old = { lastModified: new Date(NOW - 31 * 60_000), hasErrorInTail: true };
+    expect(inferHistoricalClaudeStatus(old, true, NOW)).toBe('idle');
+  });
+});

--- a/src/lib/runtimes/claude-code-status.test.ts
+++ b/src/lib/runtimes/claude-code-status.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { inferHistoricalClaudeStatus } from './claude-code';
+import { inferHistoricalClaudeStatus, probeLiveClaudeProcesses } from './claude-code';
 
 const NOW = Date.parse('2026-08-24T12:00:00.000Z');
 const ago = (ms: number) => ({ lastModified: new Date(NOW - ms), hasErrorInTail: false });
@@ -33,5 +33,19 @@ describe('inferHistoricalClaudeStatus', () => {
   it('stops calling a stale error tail failed', () => {
     const old = { lastModified: new Date(NOW - 31 * 60_000), hasErrorInTail: true };
     expect(inferHistoricalClaudeStatus(old, true, NOW)).toBe('idle');
+  });
+});
+
+describe('probeLiveClaudeProcesses', () => {
+  it('keeps liveness unknown when PID discovery succeeds but CWD resolution fails', async () => {
+    const result = await probeLiveClaudeProcesses({
+      execFile: async (file) => {
+        if (file === 'bash') return { stdout: '4312 claude --model claude-opus-5\n' };
+        throw new Error('lsof unavailable');
+      },
+    });
+
+    expect(result).toEqual({ processes: [{ pid: 4312 }], probed: false });
+    expect(inferHistoricalClaudeStatus(ago(10_000), result.probed, NOW)).toBe('reviewing');
   });
 });

--- a/src/lib/runtimes/claude-code.ts
+++ b/src/lib/runtimes/claude-code.ts
@@ -37,6 +37,14 @@ import {
 } from '@/lib/claude-code/owned';
 import { resolveDefaultWorkerEffortSync } from '@/lib/operator/defaults';
 import { readClaudeRuntimeCapacity } from '@/lib/usage/cli-scrape';
+import { findLiveClaudeProcesses, probeLiveClaudeProcesses } from '@/lib/runtimes/claude-code-process-probe';
+export {
+  findLiveClaudeProcesses,
+  probeLiveClaudeProcesses,
+  type ClaudeProcessProbeExec,
+  type LiveClaudeProbe,
+  type LiveClaudeProcess,
+} from '@/lib/runtimes/claude-code-process-probe';
 const execFileAsync = promisify(execFile);
 const CLAUDE_HOME = process.env.CLAUDE_HOME || path.join(os.homedir(), '.claude');
 const CLAUDE_PROJECTS_DIR = path.join(CLAUDE_HOME, 'projects');
@@ -713,82 +721,6 @@ async function discoverProjectSessions(projectDirName: string): Promise<SessionM
   }
 
   return sessions;
-}
-
-// ── Live process detection ──
-
-export interface LiveClaudeProcess {
-  pid: number;
-  cwd?: string;
-}
-
-export interface LiveClaudeProbe {
-  processes: LiveClaudeProcess[];
-  /**
-   * False when the probe itself could not run. An empty `processes` then means
-   * "unknown", not "none" -- and a caller must not treat it as proof that a
-   * session's worker has exited.
-   */
-  probed: boolean;
-}
-
-/**
- * Probe for live Claude Code CLI processes, reporting whether the probe ran.
- *
- * The pipeline's `grep` exits 1 with no output when nothing matches, which
- * `execFileAsync` raises -- so the ordinary "no Claude running" case arrives
- * here as an error and must be told apart from a genuine probe failure
- * (timeout, missing binary, signal). Callers that infer state from absence
- * depend on that distinction (#1855).
- */
-export async function probeLiveClaudeProcesses(): Promise<LiveClaudeProbe> {
-  try {
-    // Find Claude Code CLI processes (not Claude Desktop app)
-    const { stdout } = await execFileAsync(
-      'bash', ['-c', 'ps -eo pid=,command= | grep -E "claude (--|-)" | grep -v grep | grep -v ".app/"'],
-      { windowsHide: true, timeout: 3000 },
-    );
-    const pids: number[] = [];
-    for (const line of stdout.trim().split('\n').filter(Boolean)) {
-      const match = line.trim().match(/^(\d+)/);
-      if (match) pids.push(Number(match[1]));
-    }
-    if (pids.length === 0) return { processes: [], probed: true };
-
-    // #476 — Batch all PIDs into a single lsof call instead of O(N) sequential calls.
-    // lsof accepts comma-separated PIDs with -p and OR's them by default.
-    const processes: LiveClaudeProcess[] = pids.map((pid) => ({ pid }));
-    try {
-      const { stdout: cwdOut } = await execFileAsync(
-        'lsof', ['-a', '-p', pids.join(','), '-d', 'cwd', '-Fn'],
-        { windowsHide: true, timeout: 4000 },
-      );
-      // lsof output: "p<PID>\nn<path>\n" blocks per process
-      let currentPid: number | null = null;
-      for (const line of cwdOut.split('\n')) {
-        if (line.startsWith('p')) {
-          currentPid = Number(line.slice(1));
-        } else if (line.startsWith('n/') && currentPid !== null) {
-          const proc = processes.find((p) => p.pid === currentPid);
-          if (proc) proc.cwd = line.slice(1);
-        }
-      }
-    } catch {
-      // lsof failed — processes returned without CWD info (status detection still works)
-    }
-    return { processes, probed: true };
-  } catch (err) {
-    // `grep` exits 1 with no output when nothing matched: a successful probe
-    // reporting zero processes. Anything else leaves liveness unknown.
-    const failure = err as { code?: unknown; killed?: unknown };
-    const cleanNoMatch = failure.code === 1 && !failure.killed;
-    return { processes: [], probed: cleanNoMatch };
-  }
-}
-
-/** Back-compat view for callers that only need the list, not the probe's fate. */
-export async function findLiveClaudeProcesses(): Promise<LiveClaudeProcess[]> {
-  return (await probeLiveClaudeProcesses()).processes;
 }
 
 export function inferHistoricalClaudeStatus(

--- a/src/lib/runtimes/claude-code.ts
+++ b/src/lib/runtimes/claude-code.ts
@@ -722,7 +722,26 @@ export interface LiveClaudeProcess {
   cwd?: string;
 }
 
-export async function findLiveClaudeProcesses(): Promise<LiveClaudeProcess[]> {
+export interface LiveClaudeProbe {
+  processes: LiveClaudeProcess[];
+  /**
+   * False when the probe itself could not run. An empty `processes` then means
+   * "unknown", not "none" -- and a caller must not treat it as proof that a
+   * session's worker has exited.
+   */
+  probed: boolean;
+}
+
+/**
+ * Probe for live Claude Code CLI processes, reporting whether the probe ran.
+ *
+ * The pipeline's `grep` exits 1 with no output when nothing matches, which
+ * `execFileAsync` raises -- so the ordinary "no Claude running" case arrives
+ * here as an error and must be told apart from a genuine probe failure
+ * (timeout, missing binary, signal). Callers that infer state from absence
+ * depend on that distinction (#1855).
+ */
+export async function probeLiveClaudeProcesses(): Promise<LiveClaudeProbe> {
   try {
     // Find Claude Code CLI processes (not Claude Desktop app)
     const { stdout } = await execFileAsync(
@@ -734,7 +753,7 @@ export async function findLiveClaudeProcesses(): Promise<LiveClaudeProcess[]> {
       const match = line.trim().match(/^(\d+)/);
       if (match) pids.push(Number(match[1]));
     }
-    if (pids.length === 0) return [];
+    if (pids.length === 0) return { processes: [], probed: true };
 
     // #476 — Batch all PIDs into a single lsof call instead of O(N) sequential calls.
     // lsof accepts comma-separated PIDs with -p and OR's them by default.
@@ -757,20 +776,35 @@ export async function findLiveClaudeProcesses(): Promise<LiveClaudeProcess[]> {
     } catch {
       // lsof failed — processes returned without CWD info (status detection still works)
     }
-    return processes;
-  } catch {
-    return [];
+    return { processes, probed: true };
+  } catch (err) {
+    // `grep` exits 1 with no output when nothing matched: a successful probe
+    // reporting zero processes. Anything else leaves liveness unknown.
+    const failure = err as { code?: unknown; killed?: unknown };
+    const cleanNoMatch = failure.code === 1 && !failure.killed;
+    return { processes: [], probed: cleanNoMatch };
   }
 }
 
-function inferHistoricalClaudeStatus(meta: SessionMeta): RuntimeSession['status'] {
-  if (meta.hasErrorInTail) {
-    const ageMs = Date.now() - meta.lastModified.getTime();
-    if (ageMs < 30 * 60_000) return 'failed';
-  }
+/** Back-compat view for callers that only need the list, not the probe's fate. */
+export async function findLiveClaudeProcesses(): Promise<LiveClaudeProcess[]> {
+  return (await probeLiveClaudeProcesses()).processes;
+}
 
-  const ageMs = Date.now() - meta.lastModified.getTime();
-  if (ageMs < 5 * 60_000) return 'reviewing';
+export function inferHistoricalClaudeStatus(
+  meta: Pick<SessionMeta, 'hasErrorInTail' | 'lastModified'>,
+  livenessKnown: boolean,
+  now = Date.now(),
+): RuntimeSession['status'] {
+  const ageMs = now - meta.lastModified.getTime();
+  if (meta.hasErrorInTail && ageMs < 30 * 60_000) return 'failed';
+  // This runs only for a session no live process owns. When the probe actually
+  // ran, that absence is the answer: the turn is over. Reporting `reviewing`
+  // off transcript mtime claimed a worker was still thinking for five minutes
+  // after its process had exited, which is also when an operator most wants to
+  // steer it (#1855). The mtime hedge survives only for the case the probe
+  // could not run, where absence proves nothing.
+  if (!livenessKnown && ageMs < 5 * 60_000) return 'reviewing';
   return 'idle';
 }
 
@@ -790,12 +824,13 @@ export const claudeCodeRuntime: AgentRuntime = {
       projectDirs = [];
     }
 
-    const [allSessions, liveProcesses] = await Promise.all([
+    const [allSessions, liveProbe] = await Promise.all([
       projectDirs.length > 0
         ? Promise.all(projectDirs.map((dir) => discoverProjectSessions(dir))).then((r) => r.flat())
         : Promise.resolve([]),
-      findLiveClaudeProcesses(),
+      probeLiveClaudeProcesses(),
     ]);
+    const liveProcesses = liveProbe.processes;
 
     // Sort by most recent first
     allSessions.sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime());
@@ -815,7 +850,7 @@ export const claudeCodeRuntime: AgentRuntime = {
       if (isLiveSession) {
         claimedLiveSlots.set(normalizedCwd, claimedSlots + 1);
       }
-      const status = isLiveSession ? 'running' : inferHistoricalClaudeStatus(meta);
+      const status = isLiveSession ? 'running' : inferHistoricalClaudeStatus(meta, liveProbe.probed);
       const name = `${projectDisplayName(meta.projectPath)}${meta.gitBranch ? ` • ${meta.gitBranch}` : ''}`;
       // #658 — Orchestrator-dispatched lanes spawn `claude` with cwd inside
       // `.cortex-worktrees/packet-*`. Mark them as 'owned' so the runtime

--- a/src/lib/runtimes/claude-code.ts
+++ b/src/lib/runtimes/claude-code.ts
@@ -875,7 +875,11 @@ export const claudeCodeRuntime: AgentRuntime = {
         },
         lastActivityAt: meta.lastModified,
         initialTask: meta.firstUserMessage,
-        model: meta.model ?? 'claude',
+        // `model` is optional on RuntimeSession and the display helper renders
+        // the runtime alone when it is absent. Substituting the bare string
+        // 'claude' -- which is not a model id -- printed "Claude Code · claude"
+        // as though a real model had been selected (#1869).
+        model: meta.model,
         contextUsedPercent: meta.contextUsedPercent,
         tmuxSession: getRuntimeTerminalSession(`claude-code:${meta.sessionId}`)?.sessionName ?? undefined,
       };
@@ -967,7 +971,9 @@ export const claudeCodeRuntime: AgentRuntime = {
         },
         lastActivityAt: new Date(),
         initialTask: firstUserMessage ?? `Live Claude Code session (PID ${proc.pid})`,
-        model: model ?? 'claude',
+        // Same as the historical path above: absent is a supported state, and
+        // a fabricated model id is not (#1869).
+        model,
         contextUsedPercent,
         tmuxSession: realSessionId ? (getRuntimeTerminalSession(`claude-code:${realSessionId}`)?.sessionName ?? undefined) : undefined,
       });

--- a/src/lib/runtimes/shared/owned-session/helpers.test.ts
+++ b/src/lib/runtimes/shared/owned-session/helpers.test.ts
@@ -7,6 +7,7 @@ import { afterAll, describe, expect, it } from 'vitest';
 import {
   filterStderrNoise,
   isOwnedRunAlive,
+  relativeAge,
   repoSlugFromOrigin,
   writeJsonFile,
 } from './helpers';
@@ -98,5 +99,30 @@ describe('writeJsonFile', () => {
 
     const leftovers = (await readdir(tmpDir)).filter((name) => name.endsWith('.tmp'));
     expect(leftovers).toEqual([]);
+  });
+});
+
+describe('relativeAge', () => {
+  it('does not render NaN for a timestamp it cannot parse', () => {
+    // o8_status showed a just-launched agent as "NaNd ago" because every
+    // comparison against NaN is false, so all four bucket guards fell through
+    // to the day branch (#1859).
+    for (const bad of ['', 'not-a-date', '2026-13-45T99:99:99Z', 'undefined']) {
+      const rendered = relativeAge(bad);
+      expect(rendered).not.toContain('NaN');
+      expect(rendered).toBe('just now');
+    }
+  });
+
+  it('still buckets real timestamps', () => {
+    const now = Date.now();
+    expect(relativeAge(new Date(now - 5_000).toISOString())).toBe('just now');
+    expect(relativeAge(new Date(now - 5 * 60_000).toISOString())).toBe('5m ago');
+    expect(relativeAge(new Date(now - 3 * 3_600_000).toISOString())).toBe('3h ago');
+    expect(relativeAge(new Date(now - 2 * 86_400_000).toISOString())).toBe('2d ago');
+  });
+
+  it('treats a missing stamp the same as an unparseable one', () => {
+    expect(relativeAge(undefined)).toBe('just now');
   });
 });

--- a/src/lib/runtimes/shared/owned-session/helpers.ts
+++ b/src/lib/runtimes/shared/owned-session/helpers.ts
@@ -62,7 +62,12 @@ export function shortHome(value: string) {
 
 export function relativeAge(timestampIso?: string) {
   if (!timestampIso) return 'just now';
-  const ageMs = Math.max(0, Date.now() - new Date(timestampIso).getTime());
+  const parsed = new Date(timestampIso).getTime();
+  // An unparseable stamp made every comparison below NaN, so all four guards
+  // fell through and the surface rendered "NaNd ago". Treat it like a missing
+  // stamp -- the same answer, and an honest one (#1859).
+  if (Number.isNaN(parsed)) return 'just now';
+  const ageMs = Math.max(0, Date.now() - parsed);
   const minute = 60_000;
   const hour = 60 * minute;
   const day = 24 * hour;

--- a/src/lib/telemetry/sentry-config.ts
+++ b/src/lib/telemetry/sentry-config.ts
@@ -27,7 +27,7 @@ export interface SentryRuntimeConfig {
   enabled: boolean;
   /** App version — the same string the updater ships. */
   release: string;
-  /** Always 'production' — dev never reaches here (dsn is gated on packaged). */
+  /** 'production' for an installed build; 'development' for a local dev stack. */
   environment: string;
   /** Effective plan (free|pro|team|founder). */
   plan: string;
@@ -44,6 +44,25 @@ export function isPackaged(): boolean {
 export function resolveSentryDsn(): string {
   if (!isPackaged()) return '';
   return process.env.O8_SENTRY_DSN?.trim() || '';
+}
+
+/**
+ * Which environment Sentry should tag events with.
+ *
+ * `isPackaged()` alone is not the answer. In the dev-bridge loop the
+ * maintainers daily-drive, the PACKAGED app is pointed at a local Next dev
+ * server via `O8_DEV_FRONTEND_URL` — so `O8_PACKAGED_APP` is set, the DSN
+ * resolves, the browser SDK initializes, and dev-server errors arrived tagged
+ * `production` in the same bucket as real user crashes (#1679). With the repo
+ * public and installs starting, that is the signal that matters most in the
+ * first weeks and it was the one getting buried.
+ */
+export function resolveSentryEnvironment(): string {
+  if (process.env.O8_DEV_FRONTEND_URL?.trim()) return 'development';
+  if (!isPackaged()) return 'development';
+  const nodeEnv = process.env.NODE_ENV?.trim();
+  if (nodeEnv && nodeEnv !== 'production') return 'development';
+  return 'production';
 }
 
 export function resolveCrashReportsToggle(): boolean {
@@ -71,7 +90,7 @@ export function resolveSentryConfig(): SentryRuntimeConfig {
     dsn: resolveSentryDsn(),
     enabled: resolveCrashReportsToggle(),
     release: resolveAppVersion(),
-    environment: 'production',
+    environment: resolveSentryEnvironment(),
     plan,
     founder,
     packaged: isPackaged(),

--- a/src/lib/telemetry/sentry-environment.test.ts
+++ b/src/lib/telemetry/sentry-environment.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveSentryEnvironment } from './sentry-config';
+
+const KEYS = ['O8_PACKAGED_APP', 'O8_DEV_FRONTEND_URL', 'NODE_ENV'] as const;
+let saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  saved = Object.fromEntries(KEYS.map((key) => [key, process.env[key]]));
+  for (const key of KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+describe('resolveSentryEnvironment (#1679)', () => {
+  it('tags an installed signed build as production', () => {
+    process.env.O8_PACKAGED_APP = '1';
+    process.env.NODE_ENV = 'production';
+    expect(resolveSentryEnvironment()).toBe('production');
+  });
+
+  it('tags the dev-bridge loop as development even though the app is packaged', () => {
+    // The packaged app pointed at a local Next dev server: O8_PACKAGED_APP is
+    // set, the DSN resolves, the SDK initializes — and every event used to
+    // arrive tagged production next to real user crashes.
+    process.env.O8_PACKAGED_APP = '1';
+    process.env.NODE_ENV = 'production';
+    process.env.O8_DEV_FRONTEND_URL = 'http://127.0.0.1:47120';
+    expect(resolveSentryEnvironment()).toBe('development');
+  });
+
+  it('tags an unpackaged local stack as development', () => {
+    expect(resolveSentryEnvironment()).toBe('development');
+    process.env.NODE_ENV = 'development';
+    expect(resolveSentryEnvironment()).toBe('development');
+  });
+
+  it('tags a packaged build running a non-production NODE_ENV as development', () => {
+    process.env.O8_PACKAGED_APP = '1';
+    process.env.NODE_ENV = 'development';
+    expect(resolveSentryEnvironment()).toBe('development');
+  });
+
+  it('ignores a blank dev-frontend value rather than treating it as set', () => {
+    process.env.O8_PACKAGED_APP = '1';
+    process.env.NODE_ENV = 'production';
+    process.env.O8_DEV_FRONTEND_URL = '   ';
+    expect(resolveSentryEnvironment()).toBe('production');
+  });
+});

--- a/src/lib/telemetry/sentry-environment.test.ts
+++ b/src/lib/telemetry/sentry-environment.test.ts
@@ -1,25 +1,21 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { resolveSentryEnvironment } from './sentry-config';
 
-const KEYS = ['O8_PACKAGED_APP', 'O8_DEV_FRONTEND_URL', 'NODE_ENV'] as const;
-let saved: Record<string, string | undefined> = {};
-
-beforeEach(() => {
-  saved = Object.fromEntries(KEYS.map((key) => [key, process.env[key]]));
-  for (const key of KEYS) delete process.env[key];
-});
-
+// `process.env.NODE_ENV` is typed read-only, so assigning to it fails tsc even
+// though it works at runtime. vi.stubEnv is the supported way to set it.
 afterEach(() => {
-  for (const key of KEYS) {
-    if (saved[key] === undefined) delete process.env[key];
-    else process.env[key] = saved[key];
-  }
+  vi.unstubAllEnvs();
 });
+
+function env(values: { packaged?: string; devFrontend?: string; nodeEnv?: string }) {
+  vi.stubEnv('O8_PACKAGED_APP', values.packaged ?? '');
+  vi.stubEnv('O8_DEV_FRONTEND_URL', values.devFrontend ?? '');
+  vi.stubEnv('NODE_ENV', values.nodeEnv ?? '');
+}
 
 describe('resolveSentryEnvironment (#1679)', () => {
   it('tags an installed signed build as production', () => {
-    process.env.O8_PACKAGED_APP = '1';
-    process.env.NODE_ENV = 'production';
+    env({ packaged: '1', nodeEnv: 'production' });
     expect(resolveSentryEnvironment()).toBe('production');
   });
 
@@ -27,28 +23,24 @@ describe('resolveSentryEnvironment (#1679)', () => {
     // The packaged app pointed at a local Next dev server: O8_PACKAGED_APP is
     // set, the DSN resolves, the SDK initializes — and every event used to
     // arrive tagged production next to real user crashes.
-    process.env.O8_PACKAGED_APP = '1';
-    process.env.NODE_ENV = 'production';
-    process.env.O8_DEV_FRONTEND_URL = 'http://127.0.0.1:47120';
+    env({ packaged: '1', nodeEnv: 'production', devFrontend: 'http://127.0.0.1:47120' });
     expect(resolveSentryEnvironment()).toBe('development');
   });
 
   it('tags an unpackaged local stack as development', () => {
+    env({});
     expect(resolveSentryEnvironment()).toBe('development');
-    process.env.NODE_ENV = 'development';
+    env({ nodeEnv: 'development' });
     expect(resolveSentryEnvironment()).toBe('development');
   });
 
   it('tags a packaged build running a non-production NODE_ENV as development', () => {
-    process.env.O8_PACKAGED_APP = '1';
-    process.env.NODE_ENV = 'development';
+    env({ packaged: '1', nodeEnv: 'development' });
     expect(resolveSentryEnvironment()).toBe('development');
   });
 
   it('ignores a blank dev-frontend value rather than treating it as set', () => {
-    process.env.O8_PACKAGED_APP = '1';
-    process.env.NODE_ENV = 'production';
-    process.env.O8_DEV_FRONTEND_URL = '   ';
+    env({ packaged: '1', nodeEnv: 'production', devFrontend: '   ' });
     expect(resolveSentryEnvironment()).toBe('production');
   });
 });

--- a/src/lib/telemetry/sentry-init.test.ts
+++ b/src/lib/telemetry/sentry-init.test.ts
@@ -46,10 +46,14 @@ describe('sentry — dormant without a DSN', () => {
     }
   });
 
-  it('resolveSentryConfig reports dormant with production defaults + a boolean founder', () => {
+  it('resolveSentryConfig reports dormant, tagged development, with a boolean founder', () => {
+    // This asserted `production` while the value was a hardcoded constant --
+    // the premise #1679 removed. An unpackaged local stack is a development
+    // environment, and saying so is the point: dogfooding noise must not share
+    // a bucket with real user crashes.
     const cfg = resolveSentryConfig();
     expect(cfg.dsn).toBe('');
-    expect(cfg.environment).toBe('production');
+    expect(cfg.environment).toBe('development');
     expect(cfg.enabled).toBe(false); // reporting requires an explicit opt-in
     expect(typeof cfg.founder).toBe('boolean');
     expect(cfg.release.length).toBeGreaterThan(0);

--- a/tests/broadcast-voice-repetition-real-path.test.ts
+++ b/tests/broadcast-voice-repetition-real-path.test.ts
@@ -249,4 +249,27 @@ describe('Broadcast voice repetition real path', () => {
     expect(second).not.toBe(first);
     for (const line of spoken) expect(line.length).toBeLessThanOrEqual(BROADCAST_SPOKEN_MAX_LENGTH);
   });
+
+  it('keeps return-visit wording when a repeated change request has no findings', async () => {
+    const speaker = new BroadcastSpeaker({
+      sqlite: getSqlite(),
+      speak: async () => {},
+      loadCommentary: emptyCommentary,
+    });
+    const base = Date.now();
+    await speaker.tick({ now: new Date(base), settings: voiceOn });
+
+    const lane = newLane('Re-review without structured findings', `revisit-empty-${base}`);
+    recordOrchestratorReview(lane.packetId!, { approved: false, reviewer: 'codex', findings: [] });
+    await speaker.tick({ now: new Date(base + 1_500), settings: voiceOn });
+    await speaker.flush();
+
+    const later = base + 63 * 60_000;
+    recordOrchestratorReview(lane.packetId!, { approved: false, reviewer: 'codex', findings: [] });
+    await speaker.tick({ now: new Date(later), settings: voiceOn });
+    await speaker.tick({ now: new Date(later + 1_500), settings: voiceOn });
+    await speaker.flush();
+
+    expect(momentTexts().at(-1)).toContain('Review requests changes again on Re-review without structured findings.');
+  });
 });

--- a/tests/broadcast-voice-repetition-real-path.test.ts
+++ b/tests/broadcast-voice-repetition-real-path.test.ts
@@ -214,4 +214,39 @@ describe('Broadcast voice repetition real path', () => {
     }
     expect(spoken.join(' ')).toContain('Broadcast voice stays concise');
   });
+
+  it('phrases a second review turn as a return visit, not the first line again (#1842)', async () => {
+    const spoken: string[] = [];
+    const speaker = new BroadcastSpeaker({
+      sqlite: getSqlite(),
+      speak: async (text) => { spoken.push(text); },
+      loadCommentary: emptyCommentary,
+    });
+    const base = Date.now();
+    await speaker.tick({ now: new Date(base), settings: voiceOn });
+
+    const lane = newLane('Show the model on every spawned agent', `revisit-${base}`);
+    recordOrchestratorReview(lane.packetId!, { approved: true, reviewer: 'codex', findings: [] });
+    await speaker.tick({ now: new Date(base + 1_500), settings: voiceOn });
+    await speaker.flush();
+
+    const first = momentTexts().at(-1) ?? '';
+    expect(first).toContain('Review approved for Show the model on every spawned agent');
+    expect(first).not.toContain('again');
+
+    // The packet is steered, runs again, and passes a SECOND review turn 63
+    // minutes later -- past the 30-minute suppression window, so this is real
+    // news that must be spoken. It must not be spoken in the same words.
+    const later = base + 63 * 60_000;
+    recordOrchestratorReview(lane.packetId!, { approved: true, reviewer: 'codex', findings: [] });
+    await speaker.tick({ now: new Date(later), settings: voiceOn });
+    await speaker.tick({ now: new Date(later + 1_500), settings: voiceOn });
+    await speaker.flush();
+
+    const second = momentTexts().at(-1) ?? '';
+    expect(second).toContain('Show the model on every spawned agent');
+    expect(second).toContain('Review approved again for');
+    expect(second).not.toBe(first);
+    for (const line of spoken) expect(line.length).toBeLessThanOrEqual(BROADCAST_SPOKEN_MAX_LENGTH);
+  });
 });

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1,9 +1,9 @@
 {
   "schema": "o8/test-classification/v1",
   "generatedBy": "node scripts/classify-tests.mjs --write",
-  "totalTests": 836,
-  "hermeticTests": 541,
-  "resourceOwningTests": 295,
+  "totalTests": 848,
+  "hermeticTests": 551,
+  "resourceOwningTests": 297,
   "resourceOwning": [
     {
       "path": "src/app/api/leases/route.test.ts",
@@ -86,6 +86,13 @@
       "path": "src/components/desktop/workspace-terminal/WorkspaceTerminalPanels.test.ts",
       "reasons": [
         "terminal-tool"
+      ]
+    },
+    {
+      "path": "src/lib/broadcast/hourly-cap.integration.test.ts",
+      "reasons": [
+        "child-process",
+        "process-signal"
       ]
     },
     {
@@ -407,6 +414,12 @@
       "path": "src/lib/runtime/owned-surface-interrupt.test.ts",
       "reasons": [
         "process-signal"
+      ]
+    },
+    {
+      "path": "src/lib/runtimes/claude-code-status.test.ts",
+      "reasons": [
+        "terminal-tool"
       ]
     },
     {
@@ -1773,7 +1786,7 @@
       "path": "tests/release-preflight.test.ts",
       "reasons": [
         "git-cli",
-        "terminal-tool"
+        "native-build"
       ]
     },
     {


### PR DESCRIPTION
Eighteen independent low-hanging fixes, batched so they land in one review. None
of them touch the review, merge, storage, test-gate, or release paths under
active work elsewhere.

Every fix that could carry a deterministic assertion has one, and each was
falsified — the fix reverted, the test confirmed failing, the fix restored.
Where a test does **not** prove the fix, that is stated rather than implied.

> ### ⏳ Deferred verification — three fixes need a human pass, later
>
> **#1678**, **#1685**, and **#1846** change runtime paths that no unit test
> reaches honestly. They are intentionally included here unverified-by-hand;
> the live pass is deferred to a later agent run once the tooling upgrade
> lands. **Do not read their green tests as end-to-end confirmation.**
> The specific checks are listed under *Verification* at the bottom.

---

## Surfaces that reported something other than what happened

The largest group. Each one had the true answer already in hand and discarded it.

### #1839 — an orchestrator thread renders 1 of 25 messages

The display memo picked the live stream **or** the persisted history, never
both. The stream starts empty and fills on the first live event, so a restored
thread rendered correctly right up until any event arrived — then the entire
history was dropped in favour of that one entry. A thread holding 25 stored
messages showed a single dispatch card in whitespace.

The thread-load path already merges history into `chatMessages` correctly; the
display memo threw that away. `dedupeDisplayMessages` documents the transcript
as *composed from* both sources and already handles the overlap, so they are
concatenated and deduped. Extracted to `resolveDisplayMessages` so the
composition is testable outside a 2400-line component.

**Falsified:** either/or restored → 2 of 5 fail.

### #1845 — one command, four identical transcript rows

Codex announces a single command through several stream shapes —
`exec_command_begin`, `item.started`, `response_item` — and each derives its
call id differently (`call_id` vs `id` vs `id\0command`). Keyed on id alone,
one command emitted four `tool_call` events with **identical timestamps to the
millisecond**, and at the route's 50-event cap those copies displaced real
history.

A genuine re-run carries a distinct timestamp, so `tool + args + ts` identifies
the emission rather than the shape that announced it. Adds the first test file
for this normalizer.

**Falsified:** alias lookup removed → 1 of 4 fail.

### #1855 — a finished worker turn is reported as still reviewing

Status was inferred from transcript mtime with no liveness check, so every
finished turn read as `reviewing` for five minutes after its process had
exited — which is exactly when an operator wants to steer it.

The liveness answer was already in hand and thrown away. The probe also could
not tell "no Claude running" from "the probe failed", because the pipeline's
`grep` exits 1 with no output when nothing matches; `probeLiveClaudeProcesses`
now reports that distinction. A confirmed absence means the turn is over. The
mtime hedge survives only for the case the probe could not run, where absence
proves nothing.

**Falsified:** liveness ignored → 1 of 5 fail.

### #1838 — a false governance record against an unrelated packet

A lane with no worktree fell back to the repo root, where the operator's own
resident orchestrator runs. The detector matched that process — up for over a
day, no relationship to the packet — and recorded *"this packet declared codex
but ran claude-code"*, sitting beside a real zero-diff failure where it read as
the explanation.

Drift is a claim about one packet's worker, so it is now made only from a
process inside that packet's own worktree. The payload carries the process cwd
so the evidence is legible.

**Falsified:** attribution gate inverted → 1 of 4 fail.

### #1735 — an un-awaited Promise reported as a successful eval

The `execute_js` transport takes the wrapper's synchronous completion value, so
a Promise cannot be awaited there. A pending Promise has no own enumerable
keys, so it serialized to `{}` and passed every serializability probe as
`ok: true` — the caller was told the eval succeeded and handed an empty object.

It now returns `AsyncEvalUnsupported` and names the pattern that does work.
The new test also pins that the injected source stays free of backticks — the
wrapper is built inside a template literal, and a backtick in a comment breaks
the parse.

**Falsified:** guard disabled → 3 of 6 fail.

### #1679 — dogfooding noise tagged as production

`environment` was hardcoded to `'production'`, on the premise that dev never
reaches the SDK because the DSN is gated on packaged builds. The dev-bridge
loop breaks that premise: the **packaged** app pointed at a local Next dev
server has `O8_PACKAGED_APP` set and the DSN resolves, so dev-server errors
arrived tagged production alongside real user crashes.

With the repo public and installs starting, that bucket is the signal that
matters most in the first weeks, and it was the one getting buried.

**Falsified:** constant restored → 3 of 5 fail. One existing assertion changed:
`sentry-init.test.ts` asserted `production` for a dormant unpackaged config —
that was the hardcoded premise, not a product decision.

### #1859 — `o8_status` shows a new agent as "NaNd ago"

`relativeAge` computed `Math.max(0, Date.now() - new Date(stamp).getTime())`.
Every comparison against `NaN` is false, so all four bucket guards fell through
to the day branch. `formatClock`, eight lines above in the same file, already
had the correct guard.

**Falsified:** guard removed → 1 of 11 fail.


### #1807 — a solo Claude turn launches on the Codex worker model

A fresh Orchestrator tab in solo mode on the Claude Code runtime launched with
`gpt-5.6-sol` — `default_dispatch_model`, the Codex **worker** model — and failed
immediately. The dispatch model belongs to dispatched packets; a solo turn
resolves from the orchestrator's own.

The codex direction already had this guard, added after a live hit on
2026-07-05 where a claude id reaching `codex exec` hung the turn forever. Each
direction was patched where it was found, one house at a time — which does not
converge across 18 dispatchable runtimes, because every new pairing is the same
bug wearing a different model id.

So the constraint lives on the runtime instead. Registry rows declare
`modelIdPattern`; the guard reads it. Runtime #19 fills a field where it already
fills twelve. A runtime that legitimately fronts several providers (`cursor`,
`opencode`) **omits** the field and its models pass through untouched —
refusing to guess is deliberate, since a wrong constraint blocks a valid
selection, which is worse than the bug it prevents. `authHouse` was rejected as
the axis for exactly that reason: it is where a runtime authenticates, not what
it can run.

A test walks every registry row asserting each constrained runtime accepts its
own `defaultModel`, so a row that contradicts itself fails rather than ships.

**Not addressed:** the issue also asks the turn refuse outright and name where
the model came from. Falling back matches the codex precedent and keeps the
turn working.

**Falsified:** pattern lookup disabled → 3 of 9 fail.

### #1749 — a claude-code lane says "Codex working…"

Four live claude-code lanes rendered a Codex hero and the Codex default model
label, because the pane resolved runtime identity from the packet and the tab
only, then fell back to a hardcoded `'codex'` when neither carried one. Their
`claude-code-owned:*` session keys said exactly what was running the whole time.

The session key is a third source, and often the only one present, so it is
consulted before any fallback. When nothing resolves the label reads "Agent"
rather than naming a runtime we cannot identify — an unknown runtime printed as
a specific one is how this read as "my packets are on the wrong runtime and
doing nothing" mid-sprint.

`runtimeFromSessionKeyId` is client-safe by design: the equivalent in
`runtime/transcript.ts` validates against the adapter registry and pulls every
adapter with it, which a React surface cannot import.

**Not addressed:** the issue's second defect — a blank pane while transcript
activity exists, because live output streams only to the Activity panel.

**Falsified:** suffix handling removed → 3 of 5 fail.

### #1752 — every orchestrator turn fails on a fresh install

Threads stamp their project id from the JSON ledger, which uses the literal
`'default'`. Validation looks that id up in the SQLite `projects` table, and a
fresh install has no such row — so every turn failed with *"Project default does
not exist"* before the operator had registered a repo. **The first thing someone
does on a new install was the thing that broke.**

The sentinel is not a project; it means no project was chosen, and a thread with
a null project is already a supported state. It resolves to null on both the
requested and the already-stamped path, so threads persisted before a repo was
registered recover too. An unknown id that is not the sentinel still raises.

**Falsified:** sentinel handling removed → 1 of 7 fail.

### #1862 — a Rust advisory that was not actually blocked

`h2` 0.4.14 accepts and queues empty DATA frames without limit. It reaches us
transitively through `hyper -> reqwest`, via `tauri-plugin-clerk`, `sentry`,
`tauri-plugin-http`, and `tauri-plugin-updater` — the same shape as the
advisories in #1668, so it looked like the same verdict.

It was not. The patched version satisfies the existing `^0.4` requirement, so
the lockfile moves alone:

```
cargo update -p h2      →  0.4.14 -> 0.4.19  (199 deps unchanged)
cargo audit             →  12 vulnerabilities before, 11 after
                           RUSTSEC-2026-0258 leaves the report
```

CI's Security Audit was failing on **exactly this one** advisory (`"count": 1`)
and is green again. The seven in #1668 are suppressed via an `ignore:` list in
`ci.yml`, which is why they were never the red. A method note is on that issue:
*"the dependent pins it"* and *"a semver-compatible patch exists"* are different
findings.


### #1869 — a fabricated model id reported as a real selection

The claude-code adapter substituted the bare string `'claude'` when a session's
model could not be read, on both the historical and the live path. It is not a
model id — the registry has `claude-opus-5`, `claude-sonnet-5` — so the surface
rendered `"Claude Code · claude"`, indistinguishable from a real selection.

`model` is optional on `RuntimeSession`, and `runtimeModelDisplayLabel` already
renders the runtime alone when it is absent. **Saying nothing was available the
whole time and a value was invented instead** — which is the pattern #1869
describes, in its clearest form. The fix deletes two fallbacks and adds nothing.

Two of the three live instances named in that issue. The third
(`openclaw.ts:275`, falling back to a named `'main'` agent) is left flagged
rather than changed, since it may be a real convention there.

## Limits and controls

### #1840 — an hourly cap of 12 produced 13 lines

The cap was four independent check-then-act sites across two producers, each
testing the count for itself and then appending. The producers run in
**different processes** — the director loop in the Next server, the speaker in
ws-server — against one SQLite file, so nothing serialized them.

Every insert now goes through `claimBroadcastLineSlot`, which re-reads the
count inside the same `IMMEDIATE` transaction that writes. IMMEDIATE and not
the default deferred: a deferred transaction takes a read lock and upgrades on
write, so both producers could still read the same count and the loser would
get `SQLITE_BUSY` rather than a fresh count. The counter now has one definition
instead of four call sites.

**Honest limit:** the tests cover the cap boundary, refusing without writing,
and treating a zero/NaN cap as closed. They do **not** reproduce the
cross-process race — that needs two processes, which the suite has no harness
for. A same-process falsification passes either way, because better-sqlite3 is
synchronous.

### #1846 — the steer composer hidden on a steerable packet ⏳

An `idle` pane showed no composer, so the surface said the packet could not be
acted on. It could: `steer_packet` against that same packet resumed the worker
and produced a new commit. The steer route gates on whether a session binding
resolves, not on a display status.

`idle` and `recovering` now show the composer — a parked session is exactly
when steering is the cheap recovery. `draft`/`queued`/`failed`/`released`/
`archived` are unchanged; the deliberate failed-worker exclusion stays, since
an existing test encodes that decision.

**Not addressed:** the issue also asks that a genuinely unsteerable packet say
*why* in place of the composer rather than rendering nothing.

**Falsified:** predicate reverted → 2 of 14 fail.

### #1685 — you can't change the default model in Settings ⏳

`useSettingsOverlayDismiss` listens for `pointerdown` in the **capture** phase
and closes settings unless the target is inside `panelRef`. All four settings
popovers `createPortal` to `document.body`, so they are outside `panelRef` by
construction — the first click into a menu dismissed the whole overlay.

Adds one opt-in marker, `data-o8-settings-portal`, to the four portaled roots
(`PickerMenu`, `AcpModelPickerPopover`, `ProjectRepoRows`, `RepoPickerRow`) and
one exemption in the hook. A future portaled surface opts in with the same
attribute instead of needing another special case.

### #1808 — Opus 5 missing from the workspace CLI picker

Three surfaces each keep a hand-written Claude model list. Opus 5 reached the
composer and Settings but never the workspace CLI picker, so a model already in
the registry could not be selected there. Adds the entry and a coverage test
pinning the lists together, so the next flagship fails a test instead of going
unnoticed on one surface.

**Not addressed:** the issue's larger ask — generate the pickers from the
registry so no copying is needed.

**Falsified:** entry removed → 1 of 3 fail.

## Voice

### #1842 — a second review narrated in the first review's words

Suppression correctly lets a re-review through — it is a real event 63 minutes
after the first, well past the 30-minute window. But it was spoken in the first
utterance's exact words, so the listener heard a stutter rather than news.
Suppressing it would hide a real second approval, so suppression cannot fix it.

The narrator already computes which facts it has heard; that knowledge now
reaches the phrasing as well as the suppression decision.
`expiredNarratedFactKeys` reports facts narrated within 12 hours whose
suppression has lapsed, and the two sentence types that legitimately recur say
"approved again" / "still pending". Real-path test through `BroadcastSpeaker`
over two review turns 63 minutes apart.

**Falsified:** revisit set withheld from compose → 1 of 4 fail.

## Housekeeping

### #1678 (part 2 of 3) — Ctrl-C leaves 47120 and 47125 bound ⏳

In `all()`, the first wrapper to exit called `process.exit()` immediately, so
the parent died before either wrapper had reaped its own `next dev` / `tsx
ws-server` grandchild. The ports stayed bound and the pid file kept entries for
processes nobody waited on — silently, so the next `npm run dev` behaved
strangely for reasons a newcomer cannot see.

Every exit path now routes through the existing `cleanup()`, the same pass
`dev:cleanup` runs. Parts 1 (`next-env.d.ts` / lockfile churn) and 3 (`nvm use`
warning) are untouched and the issue stays open.

### #1857 — runtime count stale in three places

README advertised 13; `CLAUDE.md` said 13 twice. The real count is **18**, and
the adapter breakdown was wrong too — it named 7 dedicated adapters where there
are 11, and omitted `magnitude`, `qoder`, `3code`, `prime-agent`, and
`deepseek-harness` entirely.

`CLAUDE.md` is ingested by the Engineering Brain, so this was a wrong answer
the Brain gave on request, not only a doc typo.

---

## Verification

`npx tsc --noEmit` clean (`TSC EXIT: 0`, zero error lines — read unpiped, since
a piped read returns `tail`'s exit code) · **848 tests across 157 files**
covering every touched suite · `node --check scripts/dev.mjs` clean · Rust
Compile Gate green on Linux and Windows · Security Audit green.

One run of that 157-file sweep reported a single failure while a production
build held the machine; the identical command re-run clean at 848/848. Every
subset also passes alone. CI's remaining Unit Tests and Governance Smoke
failures are **pre-existing on `main`** (red since at least Aug 17) and name no
file this branch touches.

### ⏳ Deferred to a later agent pass — not verified by hand

- **#1685** — click through the settings picker rows and confirm a model
  selection actually persists
- **#1678** — a real Ctrl-C on `npm run dev`, then confirm 47120 and 47125 are
  free and the pid file is empty
- **#1846** — an idle pane showing the composer, and a steer through it landing
  a commit

### Stated limits

- **#1840** — no automated coverage of the cross-process race itself
- **#1846** — the "say why instead of rendering nothing" half is not done
- **#1808** — pickers are still hand-written lists, now pinned by a test
- **#1678** — parts 1 and 3 of that issue are untouched

Closes #1839, #1845, #1855, #1838, #1735, #1679, #1859, #1807, #1749, #1752,
#1862, #1840, #1846, #1685, #1808, #1842, #1857. Advances #1678 and #1869.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the free tier to include all 18 runtimes and added Claude Opus 5 to model pickers.
  * Enabled steering for idle and recovering sessions.
  * Improved transcript display during live updates and restored conversations.
* **Bug Fixes**
  * Fixed stale cleanup, incorrect labels, invalid age displays, duplicate tool calls, and unsupported asynchronous evaluations.
  * Improved Claude status accuracy, settings popovers, project handling, and model compatibility.
* **Improvements**
  * Broadcast narration now respects hourly limits and revisits older updates.
  * Telemetry now distinguishes development and production environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->