### PR TITLE
docs: open the runtime adapter contract with a contributor welcome

### DIFF
--- a/docs/internals/runtime-adapter-contract.md
+++ b/docs/internals/runtime-adapter-contract.md
@@ -4,8 +4,9 @@
 
 This page is for anyone who wants o8 to dispatch work to a coding-agent CLI it
 does not support yet. Pick the shape that matches your CLI below, copy the
-example, and open a pull request. If you are not sure which shape fits, reply on
-the standing "add your agent CLI" issue (#1671) with a link to the CLI's docs.
+example, and open a pull request. If you are not sure which shape fits, open a
+focused issue with a link to the CLI's docs and describe its launch and resume
+protocol.
 
 The adapter contract feeds the product-facing `RuntimeSurface` / `TerminalSession`
 model used for launch, discovery, transcript reads, resume, interrupt, review, and

--- a/docs/internals/runtime-adapter-contract.md
+++ b/docs/internals/runtime-adapter-contract.md
@@ -2,6 +2,11 @@
 
 # Runtime Adapter Contract
 
+This page is for anyone who wants o8 to dispatch work to a coding-agent CLI it
+does not support yet. Pick the shape that matches your CLI below, copy the
+example, and open a pull request. If you are not sure which shape fits, reply on
+the standing "add your agent CLI" issue (#1671) with a link to the CLI's docs.
+
 The adapter contract feeds the product-facing `RuntimeSurface` / `TerminalSession`
 model used for launch, discovery, transcript reads, resume, interrupt, review, and
 telemetry. Capabilities must stay truthful: a one-shot CLI advertises no resume,


### PR DESCRIPTION
Refs #1671.

Adds a short "who this page is for" opening to `docs/internals/runtime-adapter-contract.md` so someone arriving from #1671 (the standing call for outside runtime adapters) knows this is the recipe to follow and where to ask questions. Docs only; no code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for integrating unsupported coding-agent command-line tools.
  * Explained how to choose an adapter format, use an example, and reference the relevant documentation in issue reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->