### PR TITLE
fix: preserve mounted build cache roots

### DIFF
--- a/scripts/bust-stale-patch-cache.mjs
+++ b/scripts/bust-stale-patch-cache.mjs
@@ -31,5 +31,10 @@ const cacheMs = statSync(cacheDir).mtimeMs;
 
 if (newestPatchMs > cacheMs) {
   console.log('[bust-stale-patch-cache] patches/ newer than .next/cache — clearing webpack cache so patched dependencies rebundle');
-  rmSync(cacheDir, { recursive: true, force: true });
+  // Build systems can mount `.next/cache` as a persistent cache volume. Removing
+  // the mount root fails with EBUSY on Linux, while removing its contents keeps
+  // the mount intact and invalidates the same webpack artifacts.
+  for (const entry of readdirSync(cacheDir)) {
+    rmSync(join(cacheDir, entry), { recursive: true, force: true });
+  }
 }

--- a/tests/bust-stale-patch-cache.test.ts
+++ b/tests/bust-stale-patch-cache.test.ts
@@ -1,0 +1,70 @@
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const roots: string[] = [];
+const scriptPath = join(process.cwd(), 'scripts', 'bust-stale-patch-cache.mjs');
+
+afterEach(() => {
+  while (roots.length > 0) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'o8-patch-cache-bust-'));
+  const patchesDir = join(root, 'patches');
+  const cacheDir = join(root, '.next', 'cache');
+  const webpackDir = join(cacheDir, 'webpack');
+  mkdirSync(patchesDir, { recursive: true });
+  mkdirSync(webpackDir, { recursive: true });
+  writeFileSync(join(patchesDir, 'dependency.patch'), 'patch');
+  writeFileSync(join(webpackDir, 'entry.bin'), 'stale cache');
+  roots.push(root);
+  return { root, patchesDir, cacheDir };
+}
+
+describe('patch cache invalidation', () => {
+  it('clears stale cache contents without removing the cache root', () => {
+    const { root, patchesDir, cacheDir } = fixture();
+    const old = new Date('2026-01-01T00:00:00.000Z');
+    const fresh = new Date('2026-01-02T00:00:00.000Z');
+    utimesSync(cacheDir, old, old);
+    utimesSync(join(patchesDir, 'dependency.patch'), fresh, fresh);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('clearing webpack cache');
+    expect(existsSync(cacheDir)).toBe(true);
+    expect(readdirSync(cacheDir)).toEqual([]);
+  });
+
+  it('preserves cache contents when patches are not newer', () => {
+    const { root, patchesDir, cacheDir } = fixture();
+    const old = new Date('2026-01-01T00:00:00.000Z');
+    const fresh = new Date('2026-01-02T00:00:00.000Z');
+    utimesSync(join(patchesDir, 'dependency.patch'), old, old);
+    utimesSync(cacheDir, fresh, fresh);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(existsSync(join(cacheDir, 'webpack', 'entry.bin'))).toBe(true);
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1,9 +1,9 @@
 {
   "schema": "o8/test-classification/v1",
   "generatedBy": "node scripts/classify-tests.mjs --write",
-  "totalTests": 894,
+  "totalTests": 895,
   "hermeticTests": 575,
-  "resourceOwningTests": 319,
+  "resourceOwningTests": 320,
   "resourceOwning": [
     {
       "path": "src/app/api/leases/route.test.ts",
@@ -998,6 +998,12 @@
       "path": "tests/broadcast-voice-repetition-real-path.test.ts",
       "reasons": [
         "real-path"
+      ]
+    },
+    {
+      "path": "tests/bust-stale-patch-cache.test.ts",
+      "reasons": [
+        "child-process"
       ]
     },
     {


### PR DESCRIPTION
## Outcome

Keep persistent build-cache mount roots intact while invalidating stale bundled dependency artifacts.

## Cause

The prebuild guard recursively removed `.next/cache`. On hosted Linux builders where that directory is a mounted cache volume, removing the mount root fails with `EBUSY` before the application build begins.

## Fix

- remove each entry inside the cache directory instead of deleting the directory itself
- prove the root survives while stale contents are cleared
- prove a fresh cache remains untouched

## Verification

- `node --check scripts/bust-stale-patch-cache.mjs`
- `npx vitest run tests/bust-stale-patch-cache.test.ts`
- `npx tsc --noEmit`
- `npm run test:classification:check`
- `npx eslint tests/bust-stale-patch-cache.test.ts`
- `npm run rule-check -- --base=origin/main`