### PR TITLE
feat: inject attached MCP servers into Codex workers via config overrides

### DIFF
--- a/docs/internals/runtime-adapter-contract.md
+++ b/docs/internals/runtime-adapter-contract.md
@@ -82,12 +82,15 @@ Runtime-specific switches are acceptable only when behavior actually diverges,
 such as a resume protocol or session-key format. Labels, colors, picker options,
 auth houses, validation, and runtime membership come from the catalog.
 
-Owned-session adapters advertise `workerMcpInjection` only when their launch
-protocol can accept a per-run MCP config. The shared controller derives that
-config exclusively from opted-in operator records, writes it inside the run's
-o8-owned session directory, and supplies its path through `launchArgs`. The packet
-prompt names attached servers only for runtimes whose current launch path can attach
-them. Adapters that omit the flag keep their existing launch behavior.
+Owned-session adapters advertise `workerMcpInjection: 'config-file'` when their
+launch protocol accepts a per-run MCP config file, or `'config-override'` when
+launch and resume accept equivalent command-line configuration overrides. The
+shared controller derives both shapes exclusively from opted-in operator records.
+Config files live inside the run's o8-owned session directory and reach the
+adapter through `workerMcpConfigPath`; override adapters receive resolved servers
+through `workerMcpServers` on every launch and resume. The packet prompt names
+attached servers only for runtimes whose current adapter advertises one of these
+capabilities. Adapters that omit the capability keep their existing behavior.
 
 ### OpenCode: standalone workers, resident service for the operator only
 

--- a/src/lib/claude-code/owned.ts
+++ b/src/lib/claude-code/owned.ts
@@ -96,7 +96,7 @@ function parseClaudeOwnedRunLog(raw: string, run: OwnedRunRecord): ParsedRunLog 
   };
 }
 
-const claudeCodeOwnedAdapter: OwnedRuntimeAdapter = {
+export const claudeCodeOwnedAdapter: OwnedRuntimeAdapter = {
   runtimeId: 'claude-code',
   surfaceIdPrefix: 'claude-code-owned:',
   rootEnvVar: 'CORTEX_IDE_OWNED_CLAUDE_CODE_ROOT',
@@ -105,7 +105,7 @@ const claudeCodeOwnedAdapter: OwnedRuntimeAdapter = {
   binaryEnvOverride: 'O8_CLAUDE_CODE_BIN',
   binaryExtraEnvOverrides: ['CLAUDE_BIN'],
   isolatedConfigHomeEnv: 'CLAUDE_CONFIG_DIR',
-  workerMcpInjection: true,
+  workerMcpInjection: 'config-file',
   extraSpawnEnv: async (session) => {
     const configuredSource = session.runtimeConfig?.modelSource;
     const source = configuredSource === 'openrouter' || configuredSource === 'codex-subscription'

--- a/src/lib/codex/owned-worker-mcp-args.test.ts
+++ b/src/lib/codex/owned-worker-mcp-args.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { codexWorkerMcpOverrideArgs } from './owned';
+
+describe('codexWorkerMcpOverrideArgs', () => {
+  it('encodes strings, arrays, and quoted inline-table env keys as TOML overrides', () => {
+    expect(codexWorkerMcpOverrideArgs([
+      {
+        id: 'server-valid',
+        name: 'packet-observer',
+        command: '/tmp/MCP "server"\\bin',
+        args: ['quote "this"', 'C:\\tools\\mcp'],
+        env: {
+          'API KEY': 'value "quoted"',
+          WINDOWS_PATH: 'C:\\Users\\worker',
+        },
+      },
+      {
+        id: 'server-invalid',
+        name: 'bad name',
+        command: '/usr/bin/false',
+        args: [],
+        env: null,
+      },
+    ])).toEqual([
+      '-c', 'mcp_servers.packet-observer.command="/tmp/MCP \\"server\\"\\\\bin"',
+      '-c', 'mcp_servers.packet-observer.args=["quote \\"this\\"", "C:\\\\tools\\\\mcp"]',
+      '-c', 'mcp_servers.packet-observer.env={"API KEY"="value \\"quoted\\"", "WINDOWS_PATH"="C:\\\\Users\\\\worker"}',
+    ]);
+  });
+});

--- a/src/lib/codex/owned.ts
+++ b/src/lib/codex/owned.ts
@@ -40,6 +40,10 @@ import {
   type OwnedTailEntry,
   type ParsedRunLog,
 } from '@/lib/runtimes/shared/owned-session';
+import {
+  workerMcpServerNameIsValid,
+  type ResolvedWorkerMcpServer,
+} from '@/lib/mcp/worker-injection';
 import { codexModelArgs } from './local-model';
 import { resolveCodexReasoningEffort } from './reasoning-effort';
 import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
@@ -239,10 +243,10 @@ const DISABLE_IMAGE_TOOL = ['-c', 'tools.image_generation=false'];
 // Inherited MCP servers were killing workers: a dead/auth-broken HTTP MCP entry
 // makes rmcp transport workers crash-loop at spawn (slow launches) and the
 // session-cleanup DELETE-404 signature preceded 6 silent worker deaths in one
-// night. Workers never need MCP — repo answers come from the `o8 ask` CLI and
-// reports go through `o8 packet report`. Everything a worker DOES need (model,
-// effort, sandbox, image-tool off) is passed by flag. The user's interactive
-// Codex and the codex orchestrator session are untouched.
+// night. Workers inherit no user MCP config; operator-attached packet servers
+// are added explicitly through per-run overrides below. Everything else a
+// worker needs (model, effort, sandbox, image-tool off) is passed by flag. The
+// user's interactive Codex and the codex orchestrator session are untouched.
 const IGNORE_USER_CONFIG = ['--ignore-user-config'];
 
 /**
@@ -257,7 +261,30 @@ export function codexReasoningEffortArgs(effort?: ThinkingEffort, model?: string
   return ['-c', `model_reasoning_effort=${resolveCodexReasoningEffort(effort, model)}`];
 }
 
-export function codexLaunchArgs(ctx: { cwd: string; prompt: string; model?: string; effort?: ThinkingEffort }): string[] {
+export function codexWorkerMcpOverrideArgs(servers: ResolvedWorkerMcpServer[]): string[] {
+  return servers
+    .filter((server) => workerMcpServerNameIsValid(server.name))
+    .flatMap((server) => {
+      const prefix = `mcp_servers.${server.name}`;
+      const args = `[${server.args.map((arg) => JSON.stringify(arg)).join(', ')}]`;
+      const env = `{${Object.entries(server.env ?? {})
+        .map(([key, value]) => `${JSON.stringify(key)}=${JSON.stringify(value)}`)
+        .join(', ')}}`;
+      return [
+        '-c', `${prefix}.command=${JSON.stringify(server.command)}`,
+        '-c', `${prefix}.args=${args}`,
+        '-c', `${prefix}.env=${env}`,
+      ];
+    });
+}
+
+export function codexLaunchArgs(ctx: {
+  cwd: string;
+  prompt: string;
+  model?: string;
+  effort?: ThinkingEffort;
+  workerMcpServers?: ResolvedWorkerMcpServer[];
+}): string[] {
   return [
     'exec',
     '--json',
@@ -266,6 +293,7 @@ export function codexLaunchArgs(ctx: { cwd: string; prompt: string; model?: stri
     'danger-full-access',
     ...DISABLE_IMAGE_TOOL,
     ...IGNORE_USER_CONFIG,
+    ...codexWorkerMcpOverrideArgs(ctx.workerMcpServers ?? []),
     '-C',
     ctx.cwd,
     // `ollama:<model>` / `lmstudio:<model>` → run this worker on a LOCAL model
@@ -277,7 +305,12 @@ export function codexLaunchArgs(ctx: { cwd: string; prompt: string; model?: stri
   ];
 }
 
-export function codexResumeArgs(ctx: { threadId: string; prompt: string; model?: string }): string[] {
+export function codexResumeArgs(ctx: {
+  threadId: string;
+  prompt: string;
+  model?: string;
+  workerMcpServers?: ResolvedWorkerMcpServer[];
+}): string[] {
   return [
     'exec',
     'resume',
@@ -290,6 +323,7 @@ export function codexResumeArgs(ctx: { threadId: string; prompt: string; model?:
     '--dangerously-bypass-approvals-and-sandbox',
     ...DISABLE_IMAGE_TOOL,
     ...IGNORE_USER_CONFIG,
+    ...codexWorkerMcpOverrideArgs(ctx.workerMcpServers ?? []),
     ctx.prompt,
   ];
 }
@@ -658,7 +692,7 @@ const CODEX_STDERR_NOISE_PATTERNS: RegExp[] = [
   /mcp.*transport channel closed/i,
 ];
 
-const codexAdapter: OwnedRuntimeAdapter = {
+export const codexOwnedAdapter: OwnedRuntimeAdapter = {
   runtimeId: 'codex',
   // IMPORTANT: Keep 'codex-owned:' prefix — load-bearing for session routing.
   surfaceIdPrefix: 'codex-owned:',
@@ -668,6 +702,7 @@ const codexAdapter: OwnedRuntimeAdapter = {
   binaryEnvOverride: 'O8_CODEX_BIN',
   isolatedConfigHomeEnv: 'CODEX_HOME',
   defaultConfigHome: () => process.env.CODEX_HOME?.trim() || path.join(os.homedir(), '.codex'),
+  workerMcpInjection: 'config-override',
   humanLabel: 'Owned Codex',
   squadShortName: 'Codex',
   sessionIdPrefix: 'codex-owned-',
@@ -681,7 +716,7 @@ const codexAdapter: OwnedRuntimeAdapter = {
   resumeGroupLabel: 'Resume turn',
 };
 
-const codexStore = createOwnedSessionStore(codexAdapter);
+const codexStore = createOwnedSessionStore(codexOwnedAdapter);
 
 // ── Public API (identical signatures to the pre-Wave-2b implementation) ─────
 

--- a/src/lib/lane/types.ts
+++ b/src/lib/lane/types.ts
@@ -333,7 +333,7 @@ export type LaneEventVerb =
   // { runtime, surfaceId, runId, operation, resource, denialLine, message }
   | 'sandbox_denied'
   // Operator-registered MCP servers attached to a packet worker. Payload:
-  // { servers, configPath }
+  // { servers, configPath?, mode: 'launch' | 'resume' }
   | 'mcp_injected'
   // An MCP server or attachment set was skipped without blocking spawn. Payload:
   // { server?, command?, servers?, reason }

--- a/src/lib/mcp/worker-injection.ts
+++ b/src/lib/mcp/worker-injection.ts
@@ -5,6 +5,22 @@ import {
   listEnabledExternalMcpServers,
   type ExternalMcpServerRecord,
 } from '@/lib/mcp/external-servers';
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+
+export const WORKER_MCP_INJECTION_SUPPORTED_RUNTIMES: ReadonlySet<OrchestratorRuntime> = new Set([
+  'claude-code',
+  'codex',
+]);
+
+const WORKER_MCP_CONFIG_KEY_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+export function workerMcpInjectionSupported(runtime: OrchestratorRuntime): boolean {
+  return WORKER_MCP_INJECTION_SUPPORTED_RUNTIMES.has(runtime);
+}
+
+export function workerMcpServerNameIsValid(name: string): boolean {
+  return WORKER_MCP_CONFIG_KEY_PATTERN.test(name);
+}
 
 export interface WorkerMcpInjectionContext {
   packetId: string;
@@ -75,11 +91,23 @@ export async function resolveWorkerMcpInjection(
         && (server.teamId === null || server.teamId === context.teamId)
       ))
       .map((server) => templateServer(server, context));
-    if (!options.resolveCommands) return { servers: configuredServers, skipped: [] };
-
-    const servers: ResolvedWorkerMcpServer[] = [];
+    const validServers: ResolvedWorkerMcpServer[] = [];
     const skipped: WorkerMcpInjectionResolution['skipped'] = [];
     for (const server of configuredServers) {
+      if (workerMcpServerNameIsValid(server.name)) {
+        validServers.push(server);
+      } else {
+        skipped.push({
+          server: server.name,
+          command: server.command,
+          reason: 'name is not a valid config key',
+        });
+      }
+    }
+    if (!options.resolveCommands) return { servers: validServers, skipped };
+
+    const servers: ResolvedWorkerMcpServer[] = [];
+    for (const server of validServers) {
       try {
         servers.push({
           ...server,

--- a/src/lib/orchestrator/packet-prompt.ts
+++ b/src/lib/orchestrator/packet-prompt.ts
@@ -22,7 +22,10 @@ import {
   buildReadOnlyPacketSelfReviewInstructions,
 } from '@/lib/orchestrator/self-review';
 import { buildWorkerOutcomeOwnershipPromptV1 } from '@/lib/prompts/v1';
-import { resolveWorkerMcpInjection } from '@/lib/mcp/worker-injection';
+import {
+  resolveWorkerMcpInjection,
+  workerMcpInjectionSupported,
+} from '@/lib/mcp/worker-injection';
 import { workerSandboxEnabled } from '@/lib/runtimes/shared/owned-session/sandbox';
 import { pathWithNodeRuntime } from '@/lib/util/node-on-path';
 import {
@@ -372,7 +375,7 @@ export async function buildPacketPrompt(
   // Null when the packet has no originating thread or that thread has no rules.
   const sessionRulesSection = buildSessionRulesBlock(packet.orchestratorThreadId);
   const claudeCodeSkillSections = buildClaudeCodeSkillSections(packet);
-  const workerMcpResolution = packet.runtime === 'claude-code'
+  const workerMcpResolution = workerMcpInjectionSupported(packet.runtime)
     ? await resolveWorkerMcpInjection({
         packetId: packet.id,
         worktreePath: worktreePath ?? packet.lane?.worktreePath ?? packet.workspaceTargetPath ?? '',

--- a/src/lib/runtimes/shared/owned-session/launch-args.ts
+++ b/src/lib/runtimes/shared/owned-session/launch-args.ts
@@ -28,13 +28,18 @@ export async function prepareOwnedLaunchArgs({
   sandboxEnabled: boolean;
   humanLabel: string;
 }): Promise<PreparedOwnedLaunchArgs> {
+  const workerMcp: PreparedOwnedWorkerMcpConfig = mode === 'launch'
+    || adapter.workerMcpInjection === 'config-override'
+    ? await prepareOwnedWorkerMcpConfig({
+        adapter,
+        session,
+        runId,
+        mode,
+        sandboxEnabled,
+      })
+    : { sandboxReadPaths: [], servers: [] };
+
   if (mode === 'launch') {
-    const workerMcp = await prepareOwnedWorkerMcpConfig({
-      adapter,
-      session,
-      runId,
-      sandboxEnabled,
-    });
     return {
       args: adapter.launchArgs({
         cwd: session.repoPath,
@@ -43,6 +48,7 @@ export async function prepareOwnedLaunchArgs({
         model: session.model,
         effort: session.effort,
         workerMcpConfigPath: workerMcp.configPath,
+        workerMcpServers: workerMcp.servers,
       }),
       stdinPayload: adapter.launchStdin?.({
         cwd: session.repoPath,
@@ -59,6 +65,7 @@ export async function prepareOwnedLaunchArgs({
     sessionDir: session.sessionDir,
     prompt,
     model: session.model,
+    workerMcpServers: workerMcp.servers,
   });
   if (!args) {
     throw new Error(`Resume is not supported by the ${humanLabel} runtime adapter.`);
@@ -66,6 +73,6 @@ export async function prepareOwnedLaunchArgs({
   return {
     args,
     stdinPayload: null,
-    workerMcp: { sandboxReadPaths: [] },
+    workerMcp,
   };
 }

--- a/src/lib/runtimes/shared/owned-session/types.ts
+++ b/src/lib/runtimes/shared/owned-session/types.ts
@@ -14,6 +14,7 @@ import type {
 } from '@/lib/fleet/types';
 import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import type { LaneTurnContextUsage } from '@/lib/lane/types';
+import type { ResolvedWorkerMcpServer } from '@/lib/mcp/worker-injection';
 import type { SandboxDenial } from './sandbox-denial';
 
 // ── Run / session primitives ─────────────────────────────────────────────────
@@ -297,8 +298,8 @@ export interface OwnedRuntimeAdapter {
   /** Supported isolated config-home variable for session-pinned identities. */
   isolatedConfigHomeEnv?: string;
 
-  /** This adapter can attach operator-registered MCP servers to packet workers. */
-  workerMcpInjection?: boolean;
+  /** How this adapter attaches operator-registered MCP servers to packet workers. */
+  workerMcpInjection?: 'config-file' | 'config-override';
 
   /** Current local config home captured when a packet has no named identity. */
   defaultConfigHome?: () => string;
@@ -326,6 +327,7 @@ export interface OwnedRuntimeAdapter {
     model?: string;
     effort?: ThinkingEffort;
     workerMcpConfigPath?: string;
+    workerMcpServers?: ResolvedWorkerMcpServer[];
   }): string[];
 
   /** Optional stdin payload for runtimes launched as interactive stream processors. */
@@ -341,6 +343,7 @@ export interface OwnedRuntimeAdapter {
     sessionDir?: string;
     prompt: string;
     model?: string;
+    workerMcpServers?: ResolvedWorkerMcpServer[];
   }): string[] | null;
 
   /** Parse a run's stdout into normalized entries + outcome + discovered thread id. */

--- a/src/lib/runtimes/shared/owned-session/worker-mcp-config.ts
+++ b/src/lib/runtimes/shared/owned-session/worker-mcp-config.ts
@@ -1,15 +1,19 @@
-import { writeFile } from 'node:fs/promises';
+import { readdir, unlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { recordLaneEvent } from '@/lib/lane/events';
-import { resolveWorkerMcpInjection } from '@/lib/mcp/worker-injection';
+import {
+  resolveWorkerMcpInjection,
+  type ResolvedWorkerMcpServer,
+} from '@/lib/mcp/worker-injection';
 import { pathWithNodeRuntime } from '@/lib/util/node-on-path';
 
-import type { OwnedRuntimeAdapter, OwnedSessionRecord } from './types';
+import type { OwnedRunMode, OwnedRuntimeAdapter, OwnedSessionRecord } from './types';
 
 export interface PreparedOwnedWorkerMcpConfig {
   configPath?: string;
   sandboxReadPaths: string[];
+  servers: ResolvedWorkerMcpServer[];
 }
 
 function recordWorkerMcpEvent(
@@ -29,15 +33,17 @@ export async function prepareOwnedWorkerMcpConfig({
   adapter,
   session,
   runId,
+  mode,
   sandboxEnabled,
 }: {
   adapter: OwnedRuntimeAdapter;
   session: OwnedSessionRecord;
   runId: string;
+  mode: OwnedRunMode;
   sandboxEnabled: boolean;
 }): Promise<PreparedOwnedWorkerMcpConfig> {
   if (!session.packetId || !adapter.workerMcpInjection) {
-    return { sandboxReadPaths: [] };
+    return { sandboxReadPaths: [], servers: [] };
   }
 
   const resolution = await resolveWorkerMcpInjection({
@@ -56,13 +62,31 @@ export async function prepareOwnedWorkerMcpConfig({
     recordWorkerMcpEvent(session, 'mcp_injection_skipped', {
       reason: `Unable to load operator-registered MCP servers: ${resolution.error}`,
     });
-    return { sandboxReadPaths: [] };
+    return { sandboxReadPaths: [], servers: [] };
   }
-  if (resolution.servers.length === 0) return { sandboxReadPaths: [] };
+  if (resolution.servers.length === 0) return { sandboxReadPaths: [], servers: [] };
 
   const injectableServers = resolution.servers;
+  const commandReadPaths = sandboxEnabled
+    ? injectableServers.map((server) => path.dirname(server.command))
+    : [];
+  if (adapter.workerMcpInjection === 'config-override') {
+    recordWorkerMcpEvent(session, 'mcp_injected', {
+      servers: injectableServers.map((server) => server.name),
+      mode,
+    });
+    return {
+      sandboxReadPaths: commandReadPaths,
+      servers: injectableServers,
+    };
+  }
+
   try {
     const configPath = path.join(session.sessionDir, `o8-worker-mcp-${runId}.json`);
+    const staleConfigNames = (await readdir(session.sessionDir, { withFileTypes: true }))
+      .filter((entry) => entry.isFile() && /^o8-worker-mcp-.*\.json$/.test(entry.name))
+      .map((entry) => entry.name);
+    await Promise.all(staleConfigNames.map((name) => unlink(path.join(session.sessionDir, name))));
     const mcpServers = Object.fromEntries(injectableServers.map((server) => [
       server.name,
       {
@@ -79,18 +103,20 @@ export async function prepareOwnedWorkerMcpConfig({
     recordWorkerMcpEvent(session, 'mcp_injected', {
       servers: injectableServers.map((server) => server.name),
       configPath,
+      mode,
     });
     return {
       configPath,
       sandboxReadPaths: sandboxEnabled
-        ? [configPath, ...injectableServers.map((server) => path.dirname(server.command))]
+        ? [configPath, ...commandReadPaths]
         : [],
+      servers: injectableServers,
     };
   } catch (error) {
     recordWorkerMcpEvent(session, 'mcp_injection_skipped', {
       servers: injectableServers.map((server) => server.name),
       reason: error instanceof Error ? error.message : String(error),
     });
-    return { sandboxReadPaths: [] };
+    return { sandboxReadPaths: [], servers: [] };
   }
 }

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1,9 +1,9 @@
 {
   "schema": "o8/test-classification/v1",
   "generatedBy": "node scripts/classify-tests.mjs --write",
-  "totalTests": 894,
-  "hermeticTests": 575,
-  "resourceOwningTests": 319,
+  "totalTests": 896,
+  "hermeticTests": 576,
+  "resourceOwningTests": 320,
   "resourceOwning": [
     {
       "path": "src/app/api/leases/route.test.ts",
@@ -2222,6 +2222,15 @@
       "path": "tests/voice-codex-realtime-route.test.ts",
       "reasons": [
         "executable-fixture"
+      ]
+    },
+    {
+      "path": "tests/worker-mcp-injection-codex-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path",
+        "worktree-api"
       ]
     },
     {

--- a/tests/worker-mcp-injection-codex-real-path.test.ts
+++ b/tests/worker-mcp-injection-codex-real-path.test.ts
@@ -1,0 +1,346 @@
+import { execFileSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import type { OwnedSessionRecord } from '@/lib/runtimes/shared/owned-session/types';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+const ensureDispatchBackendReadyMock = vi.hoisted(() => vi.fn(async () => ({
+  ready: true,
+  reason: 'http_200',
+  waitedMs: 0,
+  attempts: 1,
+})));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: (
+      command: string,
+      args: string[] = [],
+      options: import('node:child_process').SpawnOptions = {},
+    ) => options.env?.O8_OWNED_RUN_MARKER
+      ? spawnMock(command, args, options)
+      : actual.spawn(command, args, options),
+  };
+});
+
+vi.mock('@/lib/runtimes/shared/dispatch-readiness', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/runtimes/shared/dispatch-readiness')>(),
+  ensureDispatchBackendReady: ensureDispatchBackendReadyMock,
+}));
+
+vi.mock('@/lib/runtimes/shared/auth-detect', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/runtimes/shared/auth-detect')>(),
+  assertRuntimeDispatchable: vi.fn(async () => undefined),
+}));
+
+const tempRoot = realpathSync(mkdtempSync(path.join(os.homedir(), '.tmp-o8-codex-worker-mcp-')));
+const dataDir = path.join(tempRoot, 'data');
+const repoPath = path.join(tempRoot, 'repo');
+const ownedRoot = path.join(tempRoot, 'owned');
+const codexHome = path.join(tempRoot, 'codex-home');
+const priorEnv: Record<string, string | undefined> = {};
+const controlledEnvKeys = [
+  'CODEX_HOME',
+  'CORTEX_IDE_DATA_DIR',
+  'O8_DATA_DIR',
+  'CORTEX_IDE_OWNED_CODEX_ROOT',
+  'O8_CODEX_BIN',
+  'O8_CRASH_SURVIVABLE_WORKERS',
+  'O8_SKIP_PRELAUNCH_TYPECHECK',
+  'O8_WORKER_SANDBOX',
+] as const;
+
+function packet(packetId: string, branch: string): OrchestratorPacket {
+  return {
+    id: packetId,
+    referenceLabel: packetId.toUpperCase(),
+    title: `Codex worker MCP test ${packetId}`,
+    summary: 'Drive persisted worker MCP attachment through Codex launch and resume.',
+    workspaceTargetPath: repoPath,
+    branchTarget: branch,
+    runtime: 'codex',
+    dependencyLabels: [],
+    dependencyPacketIds: [],
+    queueState: 'queued',
+    releaseState: 'pending',
+    status: 'queued',
+    lane: null,
+  };
+}
+
+async function createManagedLane(packetId: string, branch: string) {
+  const { captureWorktreeMaterializationIdentity } = await import(
+    '@/lib/worktree/materialization-identity'
+  );
+  const { withWorktreeMetaTransaction } = await import('@/lib/worktree/metadata-store');
+  const { managedPacketWorktreeId } = await import('@/lib/worktree/root-layout');
+  const { createLane } = await import('@/lib/lane/registry');
+  const worktreeId = managedPacketWorktreeId(packetId);
+  if (!worktreeId) throw new Error(`Unable to resolve a worktree id for ${packetId}`);
+  const worktreeBase = path.join(repoPath, '.cortex-worktrees');
+  const worktreePath = path.join(worktreeBase, worktreeId);
+  mkdirSync(worktreeBase, { recursive: true });
+  execFileSync('git', ['worktree', 'add', worktreePath, '-b', branch], { cwd: repoPath });
+  const materializationIdentity = await captureWorktreeMaterializationIdentity(worktreePath);
+  const materializationParentIdentity = await captureWorktreeMaterializationIdentity(worktreeBase);
+  await withWorktreeMetaTransaction(repoPath, (transaction) => transaction.save(worktreeId, {
+    id: worktreeId,
+    agentType: 'codex',
+    baseBranch: 'main',
+    createdAt: Date.now(),
+    claudeManaged: false,
+    taskName: packetId,
+    branchName: branch,
+    status: 'ready',
+    isolationKind: 'git-worktree',
+    materializationIdentity,
+    materializationParentIdentity,
+  }));
+  return createLane({
+    repoPath,
+    worktreePath,
+    branch,
+    runtime: 'codex',
+    label: packetId,
+    packetId,
+  });
+}
+
+function spawnedArgs(callIndex: number): string[] {
+  return (spawnMock.mock.calls[callIndex]?.[1] ?? []) as string[];
+}
+
+function configOverrides(args: string[]): string[] {
+  return args.flatMap((arg, index) => (
+    arg === '-c' && args[index + 1] ? [args[index + 1]!] : []
+  ));
+}
+
+function sessionDirForSurface(surfaceId: string): string {
+  return path.join(ownedRoot, surfaceId.replace(/^codex-owned:/, ''));
+}
+
+function finishLaunchForResume(surfaceId: string, threadId: string): void {
+  const sessionPath = path.join(sessionDirForSurface(surfaceId), 'session.json');
+  const session = JSON.parse(readFileSync(sessionPath, 'utf8')) as OwnedSessionRecord;
+  const finishedAt = new Date().toISOString();
+  session.threadId = threadId;
+  session.activeRun = undefined;
+  session.autoRetry = false;
+  session.recentRuns = session.recentRuns.map((run) => ({
+    ...run,
+    pid: 987_654_321,
+    outcome: 'finished',
+    finishedAt,
+  }));
+  writeFileSync(sessionPath, `${JSON.stringify(session, null, 2)}\n`);
+}
+
+describe.sequential('Codex worker MCP injection real path', () => {
+  beforeAll(async () => {
+    for (const key of controlledEnvKeys) priorEnv[key] = process.env[key];
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(codexHome, { recursive: true });
+    execFileSync('git', ['init', '-q', '-b', 'main', repoPath]);
+    writeFileSync(path.join(repoPath, 'README.md'), 'Codex worker MCP injection fixture\n');
+    execFileSync('git', ['add', 'README.md'], { cwd: repoPath });
+    execFileSync('git', [
+      '-c', 'user.email=test@o8.test',
+      '-c', 'user.name=o8-test',
+      'commit', '-qm', 'fixture',
+    ], { cwd: repoPath });
+
+    process.env.CODEX_HOME = codexHome;
+    process.env.CORTEX_IDE_DATA_DIR = dataDir;
+    process.env.O8_DATA_DIR = dataDir;
+    process.env.CORTEX_IDE_OWNED_CODEX_ROOT = ownedRoot;
+    process.env.O8_CODEX_BIN = process.execPath;
+    process.env.O8_CRASH_SURVIVABLE_WORKERS = '1';
+    process.env.O8_SKIP_PRELAUNCH_TYPECHECK = '1';
+    delete process.env.O8_WORKER_SANDBOX;
+
+    spawnMock.mockImplementation(() => ({
+      pid: 424_242,
+      stdin: { end: vi.fn() },
+      unref: vi.fn(),
+      once: vi.fn(),
+    }));
+    vi.stubGlobal('fetch', vi.fn(async () => Response.json({ ok: true })));
+
+    const { addRepo } = await import('@/lib/repos/registry');
+    await addRepo(repoPath);
+  });
+
+  afterAll(async () => {
+    const { closeDb } = await import('@/lib/db');
+    closeDb();
+    vi.unstubAllGlobals();
+    for (const key of controlledEnvKeys) {
+      const prior = priorEnv[key];
+      if (prior === undefined) delete process.env[key];
+      else process.env[key] = prior;
+    }
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('keeps the prompt support set equal to the owned adapters advertising injection', async () => {
+    const { claudeCodeOwnedAdapter } = await import('@/lib/claude-code/owned');
+    const { codexOwnedAdapter } = await import('@/lib/codex/owned');
+    const { WORKER_MCP_INJECTION_SUPPORTED_RUNTIMES } = await import(
+      '@/lib/mcp/worker-injection'
+    );
+    const adapters = [claudeCodeOwnedAdapter, codexOwnedAdapter];
+
+    expect([...WORKER_MCP_INJECTION_SUPPORTED_RUNTIMES].sort()).toEqual(
+      adapters
+        .filter((adapter) => Boolean(adapter.workerMcpInjection))
+        .map((adapter) => adapter.runtimeId)
+        .sort(),
+    );
+    expect(claudeCodeOwnedAdapter.workerMcpInjection).toBe('config-file');
+    expect(codexOwnedAdapter.workerMcpInjection).toBe('config-override');
+    expect(codexOwnedAdapter.binaryEnvOverride).toBe('O8_CODEX_BIN');
+  });
+
+  it('injects overrides on launch and lane resume, then audits an invalid name', async () => {
+    const { buildPacketPrompt } = await import('@/lib/orchestrator/packet-prompt');
+    const {
+      insertExternalMcpServer,
+      listExternalMcpServers,
+      removeExternalMcpServer,
+    } = await import('@/lib/mcp/external-servers');
+    const { dispatch: dispatchLaneCommand } = await import('@/lib/lane/commands');
+    const { getLane, getLaneEvents } = await import('@/lib/lane/registry');
+
+    for (const server of listExternalMcpServers()) removeExternalMcpServer(server.id);
+    const attached = insertExternalMcpServer({
+      name: 'packet-observer',
+      transport: 'stdio',
+      command: process.execPath,
+      args: ['fixture-server.mjs'],
+      env: {
+        PACKET_ID: '{{packetId}}',
+        WORKTREE: '{{worktreePath}}',
+        BRANCH: '{{branch}}',
+        LANE_ID: '{{laneId}}',
+      },
+      enabled: true,
+      workerInjection: true,
+    });
+    const launchPacket = packet('pkt-codex-worker-mcp', 'test/codex-worker-mcp');
+    const launchLane = await createManagedLane(launchPacket.id, launchPacket.branchTarget);
+    const launchPrompt = await buildPacketPrompt(
+      launchPacket,
+      [],
+      'main',
+      launchLane.worktreePath,
+    );
+    expect(launchPrompt).toContain(
+      `MCP servers attached to this packet: packet-observer (${process.execPath}).`,
+    );
+
+    const launchCall = spawnMock.mock.calls.length;
+    const launchResult = await dispatchLaneCommand({
+      verb: 'launch_session',
+      laneId: launchLane.id,
+      prompt: launchPrompt,
+      actor: 'orchestrator',
+    });
+    expect(launchResult.ok).toBe(true);
+    const launchArgs = spawnedArgs(launchCall);
+    const expectedOverrides = [
+      `mcp_servers.packet-observer.command=${JSON.stringify(process.execPath)}`,
+      'mcp_servers.packet-observer.args=["fixture-server.mjs"]',
+      `mcp_servers.packet-observer.env={"PACKET_ID"=${JSON.stringify(launchPacket.id)}, "WORKTREE"=${JSON.stringify(launchLane.worktreePath)}, "BRANCH"=${JSON.stringify(launchPacket.branchTarget)}, "LANE_ID"=${JSON.stringify(launchLane.id)}}`,
+    ];
+    expect(configOverrides(launchArgs).filter((value) => (
+      value.startsWith('mcp_servers.packet-observer.')
+    ))).toEqual(expectedOverrides);
+    expect(launchArgs).not.toContain('--mcp-config');
+    const surfaceId = getLane(launchLane.id)?.sessionKey;
+    expect(surfaceId).toMatch(/^codex-owned:/);
+    const sessionDir = sessionDirForSurface(surfaceId!);
+    expect(readdirSync(sessionDir).some((name) => /^o8-worker-mcp-.*\.json$/.test(name))).toBe(false);
+    expect(getLaneEvents(launchLane.id, 100)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        verb: 'mcp_injected',
+        payload: { servers: ['packet-observer'], mode: 'launch' },
+      }),
+    ]));
+
+    const threadId = 'thread-codex-worker-mcp-resume';
+    finishLaunchForResume(surfaceId!, threadId);
+    const resumeCall = spawnMock.mock.calls.length;
+    const resumeResult = await dispatchLaneCommand({
+      verb: 'send_turn',
+      laneId: launchLane.id,
+      message: 'continue with the attached observer',
+      actor: 'orchestrator',
+    });
+    expect(resumeResult.ok).toBe(true);
+    const resumeArgs = spawnedArgs(resumeCall);
+    expect(resumeArgs).toEqual(expect.arrayContaining(['exec', 'resume', threadId]));
+    expect(configOverrides(resumeArgs).filter((value) => (
+      value.startsWith('mcp_servers.packet-observer.')
+    ))).toEqual(expectedOverrides);
+    expect(resumeArgs).not.toContain('--mcp-config');
+    expect(getLaneEvents(launchLane.id, 100)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        verb: 'mcp_injected',
+        payload: { servers: ['packet-observer'], mode: 'resume' },
+      }),
+    ]));
+
+    removeExternalMcpServer(attached.id);
+    insertExternalMcpServer({
+      name: 'bad name',
+      transport: 'stdio',
+      command: process.execPath,
+      enabled: true,
+      workerInjection: true,
+    });
+    const invalidPacket = packet('pkt-codex-worker-mcp-invalid', 'test/codex-worker-mcp-invalid');
+    const invalidLane = await createManagedLane(invalidPacket.id, invalidPacket.branchTarget);
+    const invalidPrompt = await buildPacketPrompt(
+      invalidPacket,
+      [],
+      'main',
+      invalidLane.worktreePath,
+    );
+    expect(invalidPrompt).not.toContain('bad name');
+    expect(invalidPrompt).not.toContain('MCP servers attached to this packet:');
+    const invalidCall = spawnMock.mock.calls.length;
+    expect((await dispatchLaneCommand({
+      verb: 'launch_session',
+      laneId: invalidLane.id,
+      prompt: invalidPrompt,
+      actor: 'orchestrator',
+    })).ok).toBe(true);
+    expect(spawnedArgs(invalidCall).join('\n')).not.toContain('bad name');
+    expect(getLaneEvents(invalidLane.id, 100)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        verb: 'mcp_injection_skipped',
+        payload: expect.objectContaining({
+          server: 'bad name',
+          command: process.execPath,
+          reason: 'name is not a valid config key',
+        }),
+      }),
+    ]));
+  }, 120_000);
+});

--- a/tests/worker-mcp-injection-real-path.test.ts
+++ b/tests/worker-mcp-injection-real-path.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -13,6 +14,7 @@ import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import type { OwnedSessionRecord } from '@/lib/runtimes/shared/owned-session/types';
 
 const spawnMock = vi.hoisted(() => vi.fn());
 const ensureDispatchBackendReadyMock = vi.hoisted(() => vi.fn(async () => ({
@@ -243,7 +245,7 @@ describe.sequential('worker MCP injection real path', () => {
 
     const unsupportedPrompt = await buildPacketPrompt({
       ...packet('pkt-worker-mcp-unsupported', 'test/worker-mcp-unsupported'),
-      runtime: 'codex',
+      runtime: 'gemini',
     }, [], 'main', firstLane.worktreePath);
     expect(unsupportedPrompt).not.toContain('MCP servers attached to this packet:');
 
@@ -278,9 +280,34 @@ describe.sequential('worker MCP injection real path', () => {
     expect(getLaneEvents(firstLane.id, 100)).toEqual(expect.arrayContaining([
       expect.objectContaining({
         verb: 'mcp_injected',
-        payload: { servers: ['packet-observer'], configPath },
+        payload: { servers: ['packet-observer'], configPath, mode: 'launch' },
       }),
     ]));
+
+    const staleConfigPath = path.join(path.dirname(configPath), 'o8-worker-mcp-stale.json');
+    writeFileSync(staleConfigPath, '{}\n');
+    const session = JSON.parse(readFileSync(
+      path.join(path.dirname(configPath), 'session.json'),
+      'utf8',
+    )) as OwnedSessionRecord;
+    const { claudeCodeOwnedAdapter } = await import('@/lib/claude-code/owned');
+    const { prepareOwnedWorkerMcpConfig } = await import(
+      '@/lib/runtimes/shared/owned-session/worker-mcp-config'
+    );
+    const replacement = await prepareOwnedWorkerMcpConfig({
+      adapter: claudeCodeOwnedAdapter,
+      session,
+      runId: 'replacement',
+      mode: 'launch',
+      sandboxEnabled: false,
+    });
+    expect(existsSync(configPath)).toBe(false);
+    expect(existsSync(staleConfigPath)).toBe(false);
+    expect(replacement.configPath).toBe(path.join(
+      path.dirname(configPath),
+      'o8-worker-mcp-replacement.json',
+    ));
+    expect(existsSync(replacement.configPath!)).toBe(true);
 
     updateExternalMcpServer(attached.id, { workerInjection: false });
     const detachedPacket = packet('pkt-worker-mcp-detached', 'test/worker-mcp-detached');


### PR DESCRIPTION
Refs #1750 — slice 2: Codex workers.

## What

Attached MCP servers now reach Codex packet workers through per-run config overrides, on launch and on every resume.

- **Mechanism.** A Codex packet's `CODEX_HOME` is the pinned identity's real config home, so nothing is written there. The adapter emits `-c mcp_servers.<name>.command=…`, `.args=[…]`, `.env={…}` as TOML overrides next to the flags it already passes. `--ignore-user-config` still applies, so workers inherit no user MCP servers; only opted-in operator records are added.
- **Resume.** Codex sessions resume (`codex exec resume`), unlike Claude Code. The overrides are repeated on resume so a steer doesn't silently drop the tools. `mcp_injected` events carry `mode: 'launch' | 'resume'`.
- **Capability shape.** `workerMcpInjection` is now `'config-file'` (Claude Code) or `'config-override'` (Codex). The packet-prompt gate uses a `workerMcpInjectionSupported(runtime)` helper backed by a constant set; a test asserts that set equals the adapters advertising the capability so it can't drift.
- **Name filter.** Only server names matching `^[A-Za-z0-9_-]+$` are injected (they become TOML dotted keys); others are skipped with an audit event, and the prompt agrees with the argv.
- **Housekeeping.** Stale per-run config files in a Claude Code session dir are removed before a new one is written.

## Verification

- `npx tsc --noEmit` clean; unit test for the TOML encoder (quotes, backslashes, quoted env keys); Claude and Codex real-path tests (launch → resume via the real lane `send_turn` → invalid-name skip); classification manifest check; full hermetic suite green.
- Live, Codex CLI 0.149: `codex mcp list --json -c …` parses the override shape including inline-table env. A real `codex exec --json --dangerously-bypass-approvals-and-sandbox --ignore-user-config -c mcp_servers.o8probe.…` turn against a stdio fixture discovered the server, called its tool, and returned its output — the exact flag set the worker uses on launch and resume.
