### PR TITLE
fix: drop aggregate counts from the test-classification manifest

### DIFF
--- a/scripts/classify-tests.mjs
+++ b/scripts/classify-tests.mjs
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { buildTestClassification } from './lib/test-classification.mjs';
+import { buildTestClassificationReport } from './lib/test-classification.mjs';
 
 const root = process.cwd();
 const manifestPath = join(root, 'tests/test-classification.json');
-const next = `${JSON.stringify(buildTestClassification(root), null, 2)}\n`;
+const classification = buildTestClassificationReport(root);
+const next = `${JSON.stringify(classification.manifest, null, 2)}\n`;
 const mode = process.argv[2] || '--check';
 
 if (mode === '--write') {
   writeFileSync(manifestPath, next);
-  const manifest = JSON.parse(next);
-  console.log(`[test-classification] ${manifest.hermeticTests} hermetic, ${manifest.resourceOwningTests} resource-owning`);
+  console.log(`[test-classification] ${classification.hermeticTests} hermetic, ${classification.resourceOwningTests} resource-owning`);
   process.exit(0);
 }
 if (mode !== '--check') {

--- a/scripts/lib/test-classification.d.mts
+++ b/scripts/lib/test-classification.d.mts
@@ -2,8 +2,10 @@ export function classifyTestSource(path: string, source: string): string[];
 export function buildTestClassification(root: string): {
   schema: 'o8/test-classification/v1';
   generatedBy: string;
-  totalTests: number;
+  resourceOwning: Array<{ path: string; reasons: string[] }>;
+};
+export function buildTestClassificationReport(root: string): {
+  manifest: ReturnType<typeof buildTestClassification>;
   hermeticTests: number;
   resourceOwningTests: number;
-  resourceOwning: Array<{ path: string; reasons: string[] }>;
 };

--- a/scripts/lib/test-classification.mjs
+++ b/scripts/lib/test-classification.mjs
@@ -50,7 +50,7 @@ export function classifyTestSource(path, source) {
   return [...new Set(reasons)].sort();
 }
 
-export function buildTestClassification(root) {
+export function buildTestClassificationReport(root) {
   const files = [];
   for (const testRoot of TEST_ROOTS) {
     const absolute = join(root, testRoot);
@@ -62,13 +62,18 @@ export function buildTestClassification(root) {
     return reasons.length > 0 ? [{ path, reasons }] : [];
   });
   return {
-    schema: 'o8/test-classification/v1',
-    generatedBy: 'node scripts/classify-tests.mjs --write',
-    totalTests: files.length,
+    manifest: {
+      schema: 'o8/test-classification/v1',
+      generatedBy: 'node scripts/classify-tests.mjs --write',
+      resourceOwning,
+    },
     hermeticTests: files.length - resourceOwning.length,
     resourceOwningTests: resourceOwning.length,
-    resourceOwning,
   };
+}
+
+export function buildTestClassification(root) {
+  return buildTestClassificationReport(root).manifest;
 }
 
 export const testClassificationInternals = {

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1,9 +1,6 @@
 {
   "schema": "o8/test-classification/v1",
   "generatedBy": "node scripts/classify-tests.mjs --write",
-  "totalTests": 897,
-  "hermeticTests": 576,
-  "resourceOwningTests": 321,
   "resourceOwning": [
     {
       "path": "src/app/api/leases/route.test.ts",

--- a/tests/test-classification.test.ts
+++ b/tests/test-classification.test.ts
@@ -1,5 +1,19 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { classifyTestSource } from '../scripts/lib/test-classification.mjs';
+
+const classificationScript = fileURLToPath(new URL('../scripts/classify-tests.mjs', import.meta.url));
+
+function runClassification(root: string, mode: '--check' | '--write') {
+  return spawnSync(process.execPath, [classificationScript, mode], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+}
 
 describe('test factory classification', () => {
   it('routes real Git, process, APFS, and listener ownership to integration', () => {
@@ -15,5 +29,53 @@ describe('test factory classification', () => {
 
   it('leaves a pure in-memory assertion in the hermetic unit lane', () => {
     expect(classifyTestSource('src/lib/math.test.ts', 'expect(1 + 1).toBe(2)')).toEqual([]);
+  });
+
+  it('writes list-only manifests and rejects missing or stale resource-owning paths', () => {
+    const root = mkdtempSync(join(tmpdir(), 'o8-test-classification-'));
+    mkdirSync(join(root, 'tests'));
+    writeFileSync(join(root, 'tests/hermetic.test.ts'), 'expect(1 + 1).toBe(2);\n');
+    writeFileSync(
+      join(root, 'tests/resource.test.ts'),
+      ['const server = create', 'Server(handler);\n'].join(''),
+    );
+
+    try {
+      const writeResult = runClassification(root, '--write');
+      expect(writeResult.status).toBe(0);
+      expect(writeResult.stdout).toContain('[test-classification] 1 hermetic, 1 resource-owning');
+
+      const manifestPath = join(root, 'tests/test-classification.json');
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+      expect(manifest).not.toHaveProperty('totalTests');
+      expect(manifest).not.toHaveProperty('hermeticTests');
+      expect(manifest).not.toHaveProperty('resourceOwningTests');
+      expect(manifest.resourceOwning).toEqual([{
+        path: 'tests/resource.test.ts',
+        reasons: ['network-listener'],
+      }]);
+
+      const matchingResult = runClassification(root, '--check');
+      expect(matchingResult.status).toBe(0);
+      expect(matchingResult.stdout).toContain('manifest matches resource-owning source markers');
+
+      writeFileSync(manifestPath, `${JSON.stringify({ ...manifest, resourceOwning: [] }, null, 2)}\n`);
+      const missingResult = runClassification(root, '--check');
+      expect(missingResult.status).toBe(1);
+      expect(missingResult.stderr).toContain('manifest drifted');
+
+      writeFileSync(manifestPath, `${JSON.stringify({
+        ...manifest,
+        resourceOwning: [
+          ...manifest.resourceOwning,
+          { path: 'tests/stale.test.ts', reasons: ['network-listener'] },
+        ],
+      }, null, 2)}\n`);
+      const staleResult = runClassification(root, '--check');
+      expect(staleResult.status).toBe(1);
+      expect(staleResult.stderr).toContain('manifest drifted');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Refs #1885.

## What

`tests/test-classification.json` no longer stores `totalTests` / `hermeticTests` / `resourceOwningTests`. The manifest keeps `schema`, `generatedBy`, and the per-path `resourceOwning` list with reasons — the part CI actually protects. Counts are still computed at run time for the console line.

`buildTestClassificationReport()` returns `{ manifest, hermeticTests, resourceOwningTests }`; `buildTestClassification()` stays as the manifest-only wrapper so existing readers don't change. `--check` still fails on list drift (missing or stale paths). Schema string unchanged — every reader keys on `resourceOwning` only.

## Why

Three PRs today (#1880, #1882, #1886) each conflicted only on the count lines, because any two branches that add unrelated tests both bump them. The per-path list only conflicts when two branches touch the same test file, which is a real conflict.

## Verification

- `tests/test-classification.test.ts`: writer output has no count fields; matching manifest passes `--check`; a missing path and a stale path each fail with `manifest drifted`.
- Merge simulation, run twice (worker and reviewer): two branches from this head each add a test and regenerate; merging one into the other is clean and `--check` passes on the result.
- `npx tsc --noEmit`, `npm run test:classification:check`, `npm test` (3,282 passed) green.
