### PR TITLE
feat: surface outside contributors waiting on a reply in the inbox

### DIFF
--- a/src/components/desktop/O8InboxPane.tsx
+++ b/src/components/desktop/O8InboxPane.tsx
@@ -7,8 +7,9 @@ import { composeSupervisorInboxCardCopy } from '@/lib/inbox/card-copy';
 import { actionReceiptIsInProgress, correlatedActionIsUnsettled, fetchCorrelatedActionReceipt } from '@/lib/orchestrator/action-receipt';
 import { useCorrelatedActionLatch } from '@/components/desktop/use-correlated-action-latch';
 import { fireInvalidation } from '@/lib/query/use-reactive-query';
+import { openExternalUrl } from '@/lib/desktop/open-external';
 import { O8ApprovalCards } from './o8-panel/O8ApprovalCards';
-import { ArchiveGlyph, ChatGlyph, FileTextGlyph, FolderGlyph, RetryGlyph, StopGlyph } from './o8-inbox-glyphs';
+import { ArchiveGlyph, ChatGlyph, ExternalLinkGlyph, FileTextGlyph, FolderGlyph, RetryGlyph, StopGlyph } from './o8-inbox-glyphs';
 
 const KIND_LABELS: Record<SupervisorInboxItem['kind'], string> = {
   verification_failed: 'Verification Failed',
@@ -25,6 +26,7 @@ const KIND_LABELS: Record<SupervisorInboxItem['kind'], string> = {
   silent_exit_no_work: 'Silent Exit · No Work',
   silent_exit_but_work_present: 'Silent Exit · Work Salvaged',
   no_session_binding: 'No Session Binding',
+  outside_human_waiting: 'Outside Human Waiting',
 };
 
 const STATUS_LABELS: Record<SupervisorInboxItem['status'], string> = {
@@ -478,6 +480,8 @@ export function O8InboxPane({ active = true }: { active?: boolean }) {
             const isEscalated = item.status === 'escalated';
             const isSelfHealed = item.status === 'self_healed';
             const isResolved = item.status === 'resolved';
+            const isOutsideHumanWaiting = item.kind === 'outside_human_waiting';
+            const threadUrl = typeof item.payload.url === 'string' ? item.payload.url : null;
             const transcriptPreview = expandedTranscriptById[item.id] ?? null;
             const actionNote = actionNoteById[item.id] ?? null;
             const copy = composeSupervisorInboxCardCopy(item);
@@ -583,7 +587,16 @@ export function O8InboxPane({ active = true }: { active?: boolean }) {
                   <div style={{ minWidth: 0, flex: 1, fontSize: 10, color: 'var(--t-text-faint)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                     {actionNote}
                   </div>
-                  {isHumanRequired && item.packetId ? (
+                  {isOutsideHumanWaiting ? (
+                    <InboxActionButton
+                      title="Open GitHub thread"
+                      onClick={() => openExternalUrl(threadUrl)}
+                      disabled={!threadUrl}
+                    >
+                      <ExternalLinkGlyph />
+                    </InboxActionButton>
+                  ) : null}
+                  {!isOutsideHumanWaiting && isHumanRequired && item.packetId ? (
                     <>
                       <InboxActionButton
                         title="Retry packet (fresh worker)"
@@ -601,25 +614,29 @@ export function O8InboxPane({ active = true }: { active?: boolean }) {
                       </InboxActionButton>
                     </>
                   ) : null}
-                  <InboxActionButton
-                    title={transcriptPreview ? 'Hide transcript' : 'Preview transcript'}
-                    onClick={() => { void openTranscript(item); }}
-                    disabled={!item.transcriptLink}
-                  >
-                    <FileTextGlyph />
-                  </InboxActionButton>
-                  <InboxActionButton
-                    title="Open worktree"
-                    onClick={() => { void openWorktree(item); }}
-                  >
-                    <FolderGlyph />
-                  </InboxActionButton>
-                  <InboxActionButton
-                    title="Add to orchestrator chat"
-                    onClick={() => addToChat(item)}
-                  >
-                    <ChatGlyph />
-                  </InboxActionButton>
+                  {!isOutsideHumanWaiting ? (
+                    <>
+                      <InboxActionButton
+                        title={transcriptPreview ? 'Hide transcript' : 'Preview transcript'}
+                        onClick={() => { void openTranscript(item); }}
+                        disabled={!item.transcriptLink}
+                      >
+                        <FileTextGlyph />
+                      </InboxActionButton>
+                      <InboxActionButton
+                        title="Open worktree"
+                        onClick={() => { void openWorktree(item); }}
+                      >
+                        <FolderGlyph />
+                      </InboxActionButton>
+                      <InboxActionButton
+                        title="Add to orchestrator chat"
+                        onClick={() => addToChat(item)}
+                      >
+                        <ChatGlyph />
+                      </InboxActionButton>
+                    </>
+                  ) : null}
                   {!isSelfHealed && !isResolved ? (
                     <InboxActionButton
                       title="Dismiss incident"

--- a/src/components/desktop/o8-inbox-glyphs.tsx
+++ b/src/components/desktop/o8-inbox-glyphs.tsx
@@ -34,3 +34,7 @@ export function StopGlyph() {
 export function ArchiveGlyph() {
   return <svg {...glyphProps}><path d="M4 5.5h16v4H4z" /><path d="M6 9.5V19a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V9.5" /><path d="M9.5 14h5" /></svg>;
 }
+
+export function ExternalLinkGlyph() {
+  return <svg {...glyphProps}><path d="M14 4h6v6" /><path d="M20 4 11 13" /><path d="M18 13v5a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h5" /></svg>;
+}

--- a/src/lib/db/latest-schema-migrations.ts
+++ b/src/lib/db/latest-schema-migrations.ts
@@ -18,6 +18,7 @@ import { ensureV51AutomationPrecheckSchema } from '@/lib/db/v51-automation-prech
 import { ensureV52AutomationWatchSchema } from '@/lib/db/v52-automation-watch-migration';
 import { ensureV53PromptLibrarySchema } from '@/lib/db/v53-prompt-library-migration';
 import { ensureV54WorkerMcpInjectionSchema } from '@/lib/db/v54-worker-mcp-injection-migration';
+import { ensureV55OutsiderAttentionSchema } from '@/lib/db/v55-outsider-attention-migration';
 
 /**
  * Keep the current additive migrations behind one boot hook. `db/index.ts` is
@@ -47,4 +48,5 @@ export function ensurePostAutomationSchemas(sqlite: Database.Database): void {
   ensureV52AutomationWatchSchema(sqlite);
   ensureV53PromptLibrarySchema(sqlite);
   ensureV54WorkerMcpInjectionSchema(sqlite);
+  ensureV55OutsiderAttentionSchema(sqlite);
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -331,6 +331,10 @@ export const githubIssues = sqliteTable('github_issues', {
   createdAt: text('created_at'),
   updatedAt: text('updated_at'),
   closedAt: text('closed_at'),
+  lastHumanCommentAuthorLogin: text('last_human_comment_author_login'),
+  lastHumanCommentAuthorAssociation: text('last_human_comment_author_association'),
+  lastHumanCommentAt: text('last_human_comment_at'),
+  lastInsiderCommentAt: text('last_insider_comment_at'),
 });
 
 export const githubPullRequests = sqliteTable('github_pull_requests', {
@@ -353,6 +357,10 @@ export const githubPullRequests = sqliteTable('github_pull_requests', {
   updatedAt: text('updated_at'),
   closedAt: text('closed_at'),
   mergedAt: text('merged_at'),
+  lastHumanCommentAuthorLogin: text('last_human_comment_author_login'),
+  lastHumanCommentAuthorAssociation: text('last_human_comment_author_association'),
+  lastHumanCommentAt: text('last_human_comment_at'),
+  lastInsiderCommentAt: text('last_insider_comment_at'),
 });
 
 // ══════════════════════════════════════════════════════════════════
@@ -601,7 +609,7 @@ export const supervisorInbox = sqliteTable('supervisor_inbox', {
   repoPath: text('repo_path').notNull(),
   packetId: text('packet_id'),
   kind: text('kind', {
-    enum: ['verification_failed', 'session_lost', 'packet_missing', 'bounded_retry_exhausted', 'merge_blocked', 'fetch_unreachable', 'repo_misconfigured', 'silent_exit_verification_failed', 'silent_exit_no_work', 'silent_exit_but_work_present', 'worker_quota_exhausted'],
+    enum: ['verification_failed', 'session_lost', 'packet_missing', 'bounded_retry_exhausted', 'merge_blocked', 'fetch_unreachable', 'repo_misconfigured', 'silent_exit_verification_failed', 'silent_exit_no_work', 'silent_exit_but_work_present', 'worker_quota_exhausted', 'outside_human_waiting'],
   }).notNull(),
   payload: text('payload').notNull().default('{}'),
   status: text('status', {

--- a/src/lib/db/v55-outsider-attention-migration.test.ts
+++ b/src/lib/db/v55-outsider-attention-migration.test.ts
@@ -1,0 +1,61 @@
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+
+import { ensureV55OutsiderAttentionSchema } from './v55-outsider-attention-migration';
+
+const ATTENTION_COLUMNS = [
+  'last_human_comment_author_login',
+  'last_human_comment_author_association',
+  'last_human_comment_at',
+  'last_insider_comment_at',
+];
+
+describe('outsider attention migration', () => {
+  it('adds nullable attention columns idempotently and leaves existing rows null', () => {
+    const sqlite = new Database(':memory:');
+    try {
+      sqlite.exec(`
+        CREATE TABLE github_issues (
+          issue_id INTEGER PRIMARY KEY,
+          repo_full_name TEXT NOT NULL,
+          number INTEGER NOT NULL
+        );
+        CREATE TABLE github_pull_requests (
+          pull_request_id INTEGER PRIMARY KEY,
+          repo_full_name TEXT NOT NULL,
+          number INTEGER NOT NULL
+        );
+        INSERT INTO github_issues (issue_id, repo_full_name, number)
+          VALUES (1, 'example/repo', 11);
+        INSERT INTO github_pull_requests (pull_request_id, repo_full_name, number)
+          VALUES (2, 'example/repo', 12);
+      `);
+
+      ensureV55OutsiderAttentionSchema(sqlite);
+      ensureV55OutsiderAttentionSchema(sqlite);
+
+      for (const table of ['github_issues', 'github_pull_requests']) {
+        const columns = sqlite.prepare(`PRAGMA table_info(${table})`).all() as Array<{
+          name: string;
+          notnull: number;
+          dflt_value: string | null;
+        }>;
+        for (const columnName of ATTENTION_COLUMNS) {
+          expect(columns.find((column) => column.name === columnName)).toMatchObject({
+            notnull: 0,
+            dflt_value: null,
+          });
+        }
+
+        const row = sqlite.prepare(`
+          SELECT ${ATTENTION_COLUMNS.join(', ')}
+          FROM ${table}
+          LIMIT 1
+        `).get() as Record<string, string | null>;
+        expect(row).toEqual(Object.fromEntries(ATTENTION_COLUMNS.map((column) => [column, null])));
+      }
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/src/lib/db/v55-outsider-attention-migration.ts
+++ b/src/lib/db/v55-outsider-attention-migration.ts
@@ -1,0 +1,36 @@
+import type Database from 'better-sqlite3';
+
+const ATTENTION_COLUMNS = [
+  'last_human_comment_author_login',
+  'last_human_comment_author_association',
+  'last_human_comment_at',
+  'last_insider_comment_at',
+] as const;
+
+function columnExists(sqlite: Database.Database, table: string, column: string): boolean {
+  const columns = sqlite.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return columns.some((candidate) => candidate.name === column);
+}
+
+function ensureNullableTextColumn(
+  sqlite: Database.Database,
+  table: 'github_issues' | 'github_pull_requests',
+  column: typeof ATTENTION_COLUMNS[number],
+): void {
+  if (columnExists(sqlite, table, column)) return;
+  try {
+    sqlite.exec(`ALTER TABLE ${table} ADD COLUMN ${column} TEXT`);
+  } catch (error) {
+    if (error instanceof Error && /duplicate column name/i.test(error.message)) return;
+    throw error;
+  }
+}
+
+/** Schema v55: minimal per-thread human-attention state for the supervisor inbox. */
+export function ensureV55OutsiderAttentionSchema(sqlite: Database.Database): void {
+  for (const table of ['github_issues', 'github_pull_requests'] as const) {
+    for (const column of ATTENTION_COLUMNS) {
+      ensureNullableTextColumn(sqlite, table, column);
+    }
+  }
+}

--- a/src/lib/github-broker/store.ts
+++ b/src/lib/github-broker/store.ts
@@ -1,6 +1,11 @@
 import 'server-only';
 
 import { getSqlite } from '@/lib/db';
+import { resolveRepoPath } from '@/lib/intake/resolve-repo';
+import type {
+  OutsiderAttentionThread,
+  OutsiderAttentionThreadKind,
+} from '@/lib/supervisor/outsider-attention';
 
 export type GitHubSyncResource = 'issues' | 'pull_requests';
 
@@ -53,6 +58,16 @@ export interface GitHubPullRequestSnapshot {
   updatedAt: string;
   closedAt: string | null;
   mergedAt: string | null;
+}
+
+export interface GitHubThreadAttentionSnapshot {
+  repoFullName: string;
+  kind: OutsiderAttentionThreadKind;
+  number: number;
+  lastHumanCommentAuthorLogin: string | null;
+  lastHumanCommentAuthorAssociation: string | null;
+  lastHumanCommentAt: string | null;
+  lastInsiderCommentAt: string | null;
 }
 
 type GitHubPullRequestRow = {
@@ -534,4 +549,71 @@ export function getGitHubPullRequestByHead(repoFullName: string, headRefName: st
     LIMIT 1
   `).get(repoFullName, headRefName) as GitHubPullRequestRow | undefined;
   return row ? mapPullRequestRow(row) : null;
+}
+
+export function readGitHubThreadUpdatedAt(
+  repoFullName: string,
+  kind: OutsiderAttentionThreadKind,
+): Map<number, string | null> {
+  const table = kind === 'issue' ? 'github_issues' : 'github_pull_requests';
+  const rows = getSqlite().prepare(`
+    SELECT number, updated_at as updatedAt
+    FROM ${table}
+    WHERE repo_full_name = ?
+  `).all(repoFullName) as Array<{ number: number; updatedAt: string | null }>;
+  return new Map(rows.map((row) => [row.number, row.updatedAt]));
+}
+
+export function updateGitHubThreadAttention(attention: GitHubThreadAttentionSnapshot): boolean {
+  const table = attention.kind === 'issue' ? 'github_issues' : 'github_pull_requests';
+  const result = getSqlite().prepare(`
+    UPDATE ${table}
+    SET last_human_comment_author_login = ?,
+        last_human_comment_author_association = ?,
+        last_human_comment_at = ?,
+        last_insider_comment_at = ?
+    WHERE repo_full_name = ? AND number = ?
+  `).run(
+    attention.lastHumanCommentAuthorLogin,
+    attention.lastHumanCommentAuthorAssociation,
+    attention.lastHumanCommentAt,
+    attention.lastInsiderCommentAt,
+    attention.repoFullName,
+    attention.number,
+  );
+  return result.changes > 0;
+}
+
+export function listGitHubAttentionThreads(): OutsiderAttentionThread[] {
+  const sqlite = getSqlite();
+  const repoRows = sqlite.prepare(`
+    SELECT repo_full_name as repo FROM github_issues
+    UNION
+    SELECT repo_full_name as repo FROM github_pull_requests
+  `).all() as Array<{ repo: string }>;
+  const connectedRepos = repoRows
+    .map((row) => row.repo)
+    .filter((repo) => Boolean(resolveRepoPath(repo)));
+  if (connectedRepos.length === 0) return [];
+
+  const placeholders = connectedRepos.map(() => '?').join(', ');
+  return sqlite.prepare(`
+    SELECT repo_full_name as repo, 'issue' as kind, number, url, title, state,
+           closed_at as closedAt,
+           last_human_comment_author_login as lastHumanCommentAuthorLogin,
+           last_human_comment_author_association as lastHumanCommentAuthorAssociation,
+           last_human_comment_at as lastHumanCommentAt,
+           last_insider_comment_at as lastInsiderCommentAt
+    FROM github_issues
+    WHERE repo_full_name IN (${placeholders})
+    UNION ALL
+    SELECT repo_full_name as repo, 'pr' as kind, number, url, title, state,
+           closed_at as closedAt,
+           last_human_comment_author_login as lastHumanCommentAuthorLogin,
+           last_human_comment_author_association as lastHumanCommentAuthorAssociation,
+           last_human_comment_at as lastHumanCommentAt,
+           last_insider_comment_at as lastInsiderCommentAt
+    FROM github_pull_requests
+    WHERE repo_full_name IN (${placeholders})
+  `).all(...connectedRepos, ...connectedRepos) as OutsiderAttentionThread[];
 }

--- a/src/lib/github-broker/sync.test.ts
+++ b/src/lib/github-broker/sync.test.ts
@@ -1,0 +1,148 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const installationFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('./auth', () => ({
+  githubInstallationFetch: installationFetchMock,
+  hasGitHubBrokerAccess: () => true,
+}));
+
+const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-github-attention-sync-'));
+process.env.O8_DATA_DIR = dataDir;
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+
+const { closeDb, getSqlite } = await import('@/lib/db');
+const { ensureGitHubIssues } = await import('./sync');
+
+const installation = {
+  id: 1881,
+  account: { login: 'example', type: 'Organization' },
+  target_type: 'Organization',
+  permissions: { issues: 'read' },
+};
+
+function fetched(body: unknown, status = 200) {
+  return {
+    response: Response.json(body, { status }),
+    installation,
+  };
+}
+
+function openIssue(number: number, comments: number) {
+  return {
+    id: 18_810 + number,
+    number,
+    title: 'Follow up on the extension contract',
+    state: 'open',
+    body: 'Initial thread body.',
+    html_url: `https://github.com/example/widgets/issues/${number}`,
+    created_at: '2026-08-24T10:00:00.000Z',
+    updated_at: '2026-08-27T13:00:00.000Z',
+    user: { login: 'thread-author', type: 'User' },
+    author_association: 'CONTRIBUTOR',
+    assignees: [],
+    labels: [],
+    comments,
+  };
+}
+
+beforeEach(() => {
+  installationFetchMock.mockReset();
+  const sqlite = getSqlite();
+  sqlite.prepare('DELETE FROM github_issues').run();
+  sqlite.prepare('DELETE FROM github_pull_requests').run();
+  sqlite.prepare('DELETE FROM github_sync_state').run();
+  sqlite.prepare('DELETE FROM github_installations').run();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterAll(() => {
+  closeDb();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('GitHub outsider attention sync', () => {
+  it('keeps the latest human and insider comments across ascending comment pages', async () => {
+    installationFetchMock.mockImplementation(async (_repo: string, path: string) => {
+      if (path.includes('/comments?') && path.endsWith('page=2')) {
+        return fetched([{
+          user: { login: 'outside-follow-up', type: 'User' },
+          author_association: 'CONTRIBUTOR',
+          created_at: '2026-08-27T13:00:00.000Z',
+        }]);
+      }
+      if (path.includes('/comments?') && path.endsWith('page=1')) {
+        return fetched([
+          {
+            user: { login: 'outside-first', type: 'User' },
+            author_association: 'CONTRIBUTOR',
+            created_at: '2026-08-25T10:00:00.000Z',
+          },
+          {
+            user: { login: 'maintainer-reply', type: 'User' },
+            author_association: 'MEMBER',
+            created_at: '2026-08-26T10:00:00.000Z',
+          },
+        ]);
+      }
+      if (path.includes('/issues?state=open')) return fetched([openIssue(51, 101)]);
+      if (path.includes('/issues?state=closed')) return fetched([]);
+      throw new Error(`Unexpected GitHub path: ${path}`);
+    });
+
+    const result = await ensureGitHubIssues('example/widgets', { fresh: true });
+
+    expect(result.error).toBeNull();
+    expect(getSqlite().prepare(`
+      SELECT last_human_comment_author_login as lastHumanLogin,
+             last_human_comment_at as lastHumanAt,
+             last_insider_comment_at as lastInsiderAt
+      FROM github_issues
+      WHERE repo_full_name = 'example/widgets' AND number = 51
+    `).get()).toEqual({
+      lastHumanLogin: 'outside-follow-up',
+      lastHumanAt: '2026-08-27T13:00:00.000Z',
+      lastInsiderAt: '2026-08-26T10:00:00.000Z',
+    });
+    expect(installationFetchMock.mock.calls
+      .map((call) => String(call[1]))
+      .filter((path) => path.includes('/comments?'))).toEqual([
+      '/repos/example/widgets/issues/51/comments?per_page=100&page=2',
+      '/repos/example/widgets/issues/51/comments?per_page=100&page=1',
+    ]);
+  });
+
+  it('keeps the open issue mirror when attention fetching fails', async () => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    installationFetchMock.mockImplementation(async (_repo: string, path: string) => {
+      if (path.includes('/comments?')) throw new Error('attention request unavailable');
+      if (path.includes('/issues?state=open')) return fetched([openIssue(52, 1)]);
+      if (path.includes('/issues?state=closed')) return fetched([]);
+      throw new Error(`Unexpected GitHub path: ${path}`);
+    });
+
+    await expect(ensureGitHubIssues('example/widgets', { fresh: true })).resolves.toMatchObject({
+      error: null,
+      issues: [expect.objectContaining({ number: 52 })],
+      stale: false,
+    });
+    expect(getSqlite().prepare(`
+      SELECT number, title
+      FROM github_issues
+      WHERE repo_full_name = 'example/widgets'
+    `).all()).toEqual([{
+      number: 52,
+      title: 'Follow up on the extension contract',
+    }]);
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining(
+      '[github-broker] Attention sync skipped for example/widgets#52: attention request unavailable',
+    ));
+  });
+});

--- a/src/lib/github-broker/sync.ts
+++ b/src/lib/github-broker/sync.ts
@@ -10,24 +10,48 @@ import {
   readGitHubSyncState,
   replaceGitHubIssues,
   replaceGitHubPullRequests,
+  readGitHubThreadUpdatedAt,
+  updateGitHubThreadAttention,
+  upsertGitHubIssue,
   upsertGitHubPullRequest,
   upsertGitHubInstallation,
   type GitHubIssueSnapshot,
   type GitHubPullRequestSnapshot,
   type GitHubSyncResource,
+  type GitHubThreadAttentionSnapshot,
 } from './store';
 import { githubInstallationFetch } from './auth';
 import { hasGitHubBrokerAccess } from './auth';
+import {
+  isGitHubBotLogin,
+  isGitHubInsiderAssociation,
+  OUTSIDER_ATTENTION_RECENTLY_CLOSED_MS,
+  type OutsiderAttentionThreadKind,
+} from '@/lib/supervisor/outsider-attention';
 
 const GITHUB_SNAPSHOT_TTL_MS = 120_000; // 2 min — balance freshness with rate limit budget
 
 const MAX_ISSUE_PAGES = 5; // 5 pages * 100 = 500 issues max
+const MAX_ATTENTION_COMMENT_PAGES = 5;
+const MAX_RECENTLY_CLOSED_PAGES = 5;
 
 function resourcePath(repoFullName: string, resource: GitHubSyncResource, page = 1) {
   if (resource === 'issues') {
     return `/repos/${repoFullName}/issues?state=open&per_page=100&sort=updated&direction=desc&page=${page}`;
   }
   return `/repos/${repoFullName}/pulls?state=open&per_page=20&sort=updated&direction=desc`;
+}
+
+function recentlyClosedPath(
+  repoFullName: string,
+  resource: GitHubSyncResource,
+  cutoffIso: string,
+  page: number,
+): string {
+  if (resource === 'issues') {
+    return `/repos/${repoFullName}/issues?state=closed&since=${encodeURIComponent(cutoffIso)}&per_page=100&sort=updated&direction=desc&page=${page}`;
+  }
+  return `/repos/${repoFullName}/pulls?state=closed&per_page=100&sort=updated&direction=desc&page=${page}`;
 }
 
 function isFresh(lastSuccessfulAt?: string | null) {
@@ -47,6 +71,10 @@ function buildGitHubError(response: Response, bodyText: string) {
   return new Error(parts.join(' · '));
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 type GitHubIssuePayloadItem = {
   id: number;
   number: number;
@@ -57,7 +85,8 @@ type GitHubIssuePayloadItem = {
   created_at: string;
   updated_at: string;
   closed_at?: string | null;
-  user?: { login?: string | null } | null;
+  user?: { login?: string | null; type?: string | null } | null;
+  author_association?: string | null;
   assignees?: Array<{ login?: string | null }>;
   labels?: Array<{ name?: string | null; color?: string | null }>;
   comments?: number;
@@ -76,13 +105,136 @@ type GitHubPullRequestPayload = {
   updated_at?: string;
   closed_at?: string | null;
   merged_at?: string | null;
-  user?: { login?: string | null } | null;
+  user?: { login?: string | null; type?: string | null } | null;
+  author_association?: string | null;
   head?: { ref?: string | null };
   base?: { ref?: string | null };
   additions?: number;
   deletions?: number;
   changed_files?: number;
+  comments?: number;
 };
+
+type GitHubCommentPayload = {
+  user?: { login?: string | null; type?: string | null } | null;
+  author_association?: string | null;
+  created_at?: string | null;
+};
+
+type AttentionSyncSource = {
+  repoFullName: string;
+  kind: OutsiderAttentionThreadKind;
+  number: number;
+  updatedAt: string;
+  commentsCount: number;
+  bodyAuthorLogin: string | null;
+  bodyAuthorType: string | null;
+  bodyAuthorAssociation: string | null;
+  bodyCreatedAt: string;
+};
+
+function isHumanActor(user: { login?: string | null; type?: string | null } | null | undefined): user is { login: string; type?: string | null } {
+  const login = user?.login?.trim() ?? '';
+  return Boolean(login) && user?.type?.toLowerCase() !== 'bot' && !isGitHubBotLogin(login);
+}
+
+function bodyFallbackAttention(source: AttentionSyncSource): GitHubThreadAttentionSnapshot {
+  const bodyIsHuman = source.bodyAuthorLogin
+    && source.bodyAuthorType?.toLowerCase() !== 'bot'
+    && !isGitHubBotLogin(source.bodyAuthorLogin);
+  return {
+    repoFullName: source.repoFullName,
+    kind: source.kind,
+    number: source.number,
+    lastHumanCommentAuthorLogin: bodyIsHuman ? source.bodyAuthorLogin : null,
+    lastHumanCommentAuthorAssociation: bodyIsHuman ? source.bodyAuthorAssociation : null,
+    lastHumanCommentAt: bodyIsHuman ? source.bodyCreatedAt : null,
+    lastInsiderCommentAt: null,
+  };
+}
+
+async function fetchThreadAttention(source: AttentionSyncSource): Promise<GitHubThreadAttentionSnapshot> {
+  if (source.commentsCount <= 0) return bodyFallbackAttention(source);
+
+  let lastHumanComment: GitHubCommentPayload | null = null;
+  let lastInsiderCommentAt: string | null = null;
+  const lastPage = Math.max(1, Math.ceil(source.commentsCount / 100));
+  const firstPage = Math.max(1, lastPage - MAX_ATTENTION_COMMENT_PAGES + 1);
+  for (let page = lastPage; page >= firstPage; page -= 1) {
+    const { response } = await githubInstallationFetch(
+      source.repoFullName,
+      `/repos/${source.repoFullName}/issues/${source.number}/comments?per_page=100&page=${page}`,
+    );
+    const bodyText = await response.text();
+    if (!response.ok) throw buildGitHubError(response, bodyText);
+    const comments = JSON.parse(bodyText) as GitHubCommentPayload[];
+
+    for (const comment of comments) {
+      if (!isHumanActor(comment.user) || !comment.created_at) continue;
+      if (!lastHumanComment || Date.parse(comment.created_at) > Date.parse(lastHumanComment.created_at!)) {
+        lastHumanComment = comment;
+      }
+      if (
+        isGitHubInsiderAssociation(comment.author_association)
+        && (!lastInsiderCommentAt || Date.parse(comment.created_at) > Date.parse(lastInsiderCommentAt))
+      ) {
+        lastInsiderCommentAt = comment.created_at;
+      }
+    }
+
+    if (lastHumanComment && lastInsiderCommentAt) break;
+  }
+
+  if (!lastHumanComment || !isHumanActor(lastHumanComment.user) || !lastHumanComment.created_at) {
+    return bodyFallbackAttention(source);
+  }
+  return {
+    repoFullName: source.repoFullName,
+    kind: source.kind,
+    number: source.number,
+    lastHumanCommentAuthorLogin: lastHumanComment.user.login,
+    lastHumanCommentAuthorAssociation: lastHumanComment.author_association ?? null,
+    lastHumanCommentAt: lastHumanComment.created_at,
+    lastInsiderCommentAt,
+  };
+}
+
+async function fetchMovedThreadAttention(
+  sources: AttentionSyncSource[],
+  previousUpdatedAt: Map<number, string | null>,
+): Promise<GitHubThreadAttentionSnapshot[]> {
+  const attention: GitHubThreadAttentionSnapshot[] = [];
+  for (const source of sources) {
+    if (previousUpdatedAt.get(source.number) === source.updatedAt) continue;
+    try {
+      attention.push(await fetchThreadAttention(source));
+    } catch (error) {
+      console.warn(
+        `[github-broker] Attention sync skipped for ${source.repoFullName}#${source.number}: ${errorMessage(error)}`,
+      );
+    }
+  }
+  return attention;
+}
+
+function attentionSource(
+  repoFullName: string,
+  kind: OutsiderAttentionThreadKind,
+  item: GitHubIssuePayloadItem | GitHubPullRequestPayload,
+  commentsCount: number,
+): AttentionSyncSource {
+  return {
+    repoFullName,
+    kind,
+    number: item.number,
+    updatedAt: item.updated_at ?? item.created_at ?? '',
+    commentsCount,
+    bodyAuthorLogin: item.user?.login?.trim() || null,
+    bodyAuthorType: item.user?.type ?? null,
+    bodyAuthorAssociation: item.author_association ?? null,
+    bodyCreatedAt: item.created_at ?? '',
+  };
+}
 
 function mapPullRequestSnapshot(
   repoFullName: string,
@@ -112,9 +264,114 @@ function mapPullRequestSnapshot(
   };
 }
 
+function mapIssueSnapshot(repoFullName: string, issue: GitHubIssuePayloadItem): GitHubIssueSnapshot {
+  return {
+    issueId: issue.id,
+    repoFullName,
+    number: issue.number,
+    title: issue.title,
+    state: issue.state,
+    author: issue.user?.login ? { login: issue.user.login } : null,
+    assignees: (issue.assignees ?? [])
+      .map((assignee) => assignee.login ? { login: assignee.login } : null)
+      .filter((assignee): assignee is { login: string } => Boolean(assignee)),
+    labels: (issue.labels ?? [])
+      .map((label) => label.name ? { name: label.name, color: label.color ?? '000000' } : null)
+      .filter((label): label is { name: string; color: string } => Boolean(label)),
+    comments: issue.comments ?? 0,
+    body: issue.body ?? '',
+    url: issue.html_url,
+    createdAt: issue.created_at,
+    updatedAt: issue.updated_at,
+    closedAt: issue.closed_at ?? null,
+  };
+}
+
+function isRecentlyClosed(closedAt: string | null | undefined, cutoffMs: number): boolean {
+  const closedAtMs = closedAt ? Date.parse(closedAt) : Number.NaN;
+  return Number.isFinite(closedAtMs) && closedAtMs >= cutoffMs;
+}
+
+async function fetchRecentlyClosedIssues(
+  repoFullName: string,
+  cutoffIso: string,
+  cutoffMs: number,
+): Promise<GitHubIssuePayloadItem[]> {
+  const issues: GitHubIssuePayloadItem[] = [];
+  for (let page = 1; page <= MAX_RECENTLY_CLOSED_PAGES; page += 1) {
+    try {
+      const { response } = await githubInstallationFetch(
+        repoFullName,
+        recentlyClosedPath(repoFullName, 'issues', cutoffIso, page),
+      );
+      const bodyText = await response.text();
+      if (!response.ok) throw buildGitHubError(response, bodyText);
+      const pageItems = JSON.parse(bodyText) as GitHubIssuePayloadItem[];
+      issues.push(...pageItems.filter((item) => (
+        !item.pull_request && isRecentlyClosed(item.closed_at, cutoffMs)
+      )));
+      if (pageItems.length < 100) break;
+    } catch (error) {
+      console.warn(
+        `[github-broker] Recently closed issue sync stopped for ${repoFullName} at page ${page}: ${errorMessage(error)}`,
+      );
+      break;
+    }
+  }
+  return issues;
+}
+
+async function fetchRecentlyClosedPullRequests(
+  repoFullName: string,
+  cutoffIso: string,
+  cutoffMs: number,
+): Promise<GitHubPullRequestPayload[]> {
+  const pulls: GitHubPullRequestPayload[] = [];
+  for (let page = 1; page <= MAX_RECENTLY_CLOSED_PAGES; page += 1) {
+    try {
+      const { response } = await githubInstallationFetch(
+        repoFullName,
+        recentlyClosedPath(repoFullName, 'pull_requests', cutoffIso, page),
+      );
+      const bodyText = await response.text();
+      if (!response.ok) throw buildGitHubError(response, bodyText);
+      const pageItems = JSON.parse(bodyText) as GitHubPullRequestPayload[];
+      pulls.push(...pageItems.filter((item) => isRecentlyClosed(item.closed_at, cutoffMs)));
+      const oldestUpdatedAt = pageItems.at(-1)?.updated_at;
+      if (pageItems.length < 100 || (oldestUpdatedAt && Date.parse(oldestUpdatedAt) < cutoffMs)) break;
+    } catch (error) {
+      console.warn(
+        `[github-broker] Recently closed pull request sync stopped for ${repoFullName} at page ${page}: ${errorMessage(error)}`,
+      );
+      break;
+    }
+  }
+  return pulls;
+}
+
+async function fetchPullRequestDetail(
+  repoFullName: string,
+  item: GitHubPullRequestPayload,
+): Promise<GitHubPullRequestPayload> {
+  const { response } = await githubInstallationFetch(
+    repoFullName,
+    `/repos/${repoFullName}/pulls/${item.number}`,
+  );
+  const detailText = await response.text();
+  if (!response.ok) throw buildGitHubError(response, detailText);
+  return JSON.parse(detailText) as GitHubPullRequestPayload;
+}
+
+function applyThreadAttention(attention: GitHubThreadAttentionSnapshot[]): void {
+  for (const item of attention) updateGitHubThreadAttention(item);
+}
+
 async function syncIssues(repoFullName: string) {
   const syncState = readGitHubSyncState(repoFullName, 'issues');
   const etag = syncState?.etag ?? null;
+  const previousUpdatedAt = readGitHubThreadUpdatedAt(repoFullName, 'issue');
+  const cutoffMs = Date.now() - OUTSIDER_ATTENTION_RECENTLY_CLOSED_MS;
+  const cutoffIso = new Date(cutoffMs).toISOString();
   // Skip ETag when TTL has expired — forces a fresh fetch so pagination runs
   const useEtag = etag && isFresh(syncState?.lastSuccessfulAt);
 
@@ -131,68 +388,62 @@ async function syncIssues(repoFullName: string) {
     permissions: installation.permissions ?? null,
   });
 
-  if (response.status === 304) {
-    markGitHubSyncSuccess(repoFullName, 'issues', etag);
-    return;
-  }
-
-  const bodyText = await response.text();
-  if (!response.ok) {
-    throw buildGitHubError(response, bodyText);
-  }
-
-  const firstPage = JSON.parse(bodyText) as GitHubIssuePayloadItem[];
-  const allItems: GitHubIssuePayloadItem[] = [...firstPage];
+  let openItems: GitHubIssuePayloadItem[] | null = null;
   const lastEtag = response.headers.get('etag');
 
-  // Paginate if first page was full (may have more)
-  if (firstPage.length >= 100) {
-    for (let page = 2; page <= MAX_ISSUE_PAGES; page++) {
-      const { response: pageResponse } = await githubInstallationFetch(
-        repoFullName,
-        resourcePath(repoFullName, 'issues', page),
-      );
-      const pageText = await pageResponse.text();
-      if (!pageResponse.ok) {
-        console.warn(`[github-broker] Issues page ${page} failed (${pageResponse.status}), stopping pagination`);
-        break;
+  if (response.status !== 304) {
+    const bodyText = await response.text();
+    if (!response.ok) throw buildGitHubError(response, bodyText);
+
+    const firstPage = JSON.parse(bodyText) as GitHubIssuePayloadItem[];
+    openItems = [...firstPage];
+    if (firstPage.length >= 100) {
+      for (let page = 2; page <= MAX_ISSUE_PAGES; page += 1) {
+        const { response: pageResponse } = await githubInstallationFetch(
+          repoFullName,
+          resourcePath(repoFullName, 'issues', page),
+        );
+        const pageText = await pageResponse.text();
+        if (!pageResponse.ok) {
+          console.warn(`[github-broker] Issues page ${page} failed (${pageResponse.status}), stopping pagination`);
+          break;
+        }
+        const pageItems = JSON.parse(pageText) as GitHubIssuePayloadItem[];
+        openItems.push(...pageItems);
+        if (pageItems.length < 100) break;
       }
-      const pageItems = JSON.parse(pageText) as GitHubIssuePayloadItem[];
-      allItems.push(...pageItems);
-      if (pageItems.length < 100) break; // last page
     }
   }
 
-  const issues: GitHubIssueSnapshot[] = allItems
-    .filter((item) => !item.pull_request)
-    .map((issue) => ({
-      issueId: issue.id,
-      repoFullName,
-      number: issue.number,
-      title: issue.title,
-      state: issue.state,
-      author: issue.user?.login ? { login: issue.user.login } : null,
-      assignees: (issue.assignees ?? [])
-        .map((assignee) => assignee.login ? { login: assignee.login } : null)
-        .filter((assignee): assignee is { login: string } => Boolean(assignee)),
-      labels: (issue.labels ?? [])
-        .map((label) => label.name ? { name: label.name, color: label.color ?? '000000' } : null)
-        .filter((label): label is { name: string; color: string } => Boolean(label)),
-      comments: issue.comments ?? 0,
-      body: issue.body ?? '',
-      url: issue.html_url,
-      createdAt: issue.created_at,
-      updatedAt: issue.updated_at,
-      closedAt: issue.closed_at ?? null,
-    }));
+  const closedItems = await fetchRecentlyClosedIssues(repoFullName, cutoffIso, cutoffMs);
+  const threadItems = [
+    ...(openItems ?? []).filter((item) => !item.pull_request),
+    ...closedItems,
+  ];
+  const attention = await fetchMovedThreadAttention(
+    threadItems.map((item) => attentionSource(repoFullName, 'issue', item, item.comments ?? 0)),
+    previousUpdatedAt,
+  );
+  const closedIssues = closedItems.map((issue) => mapIssueSnapshot(repoFullName, issue));
 
-  replaceGitHubIssues(repoFullName, issues);
-  markGitHubSyncSuccess(repoFullName, 'issues', lastEtag);
+  if (openItems) {
+    replaceGitHubIssues(repoFullName, [
+      ...openItems.filter((item) => !item.pull_request).map((issue) => mapIssueSnapshot(repoFullName, issue)),
+      ...closedIssues,
+    ]);
+  } else {
+    for (const issue of closedIssues) upsertGitHubIssue(issue);
+  }
+  applyThreadAttention(attention);
+  markGitHubSyncSuccess(repoFullName, 'issues', response.status === 304 ? etag : lastEtag);
 }
 
 async function syncPullRequests(repoFullName: string) {
   const syncState = readGitHubSyncState(repoFullName, 'pull_requests');
   const etag = syncState?.etag ?? null;
+  const previousUpdatedAt = readGitHubThreadUpdatedAt(repoFullName, 'pr');
+  const cutoffMs = Date.now() - OUTSIDER_ATTENTION_RECENTLY_CLOSED_MS;
+  const cutoffIso = new Date(cutoffMs).toISOString();
   const useEtag = etag && isFresh(syncState?.lastSuccessfulAt);
   const { response, installation } = await githubInstallationFetch(repoFullName, resourcePath(repoFullName, 'pull_requests'), {
     headers: useEtag ? { 'If-None-Match': etag } : undefined,
@@ -206,32 +457,56 @@ async function syncPullRequests(repoFullName: string) {
     permissions: installation.permissions ?? null,
   });
 
-  if (response.status === 304) {
-    markGitHubSyncSuccess(repoFullName, 'pull_requests', etag);
-    return;
-  }
-
-  const bodyText = await response.text();
-  if (!response.ok) {
-    throw buildGitHubError(response, bodyText);
-  }
-
-  const listPayload = JSON.parse(bodyText) as GitHubPullRequestPayload[];
-
-  const pulls: GitHubPullRequestSnapshot[] = [];
-
-  for (const item of listPayload) {
-    const { response: detailResponse } = await githubInstallationFetch(repoFullName, `/repos/${repoFullName}/pulls/${item.number}`);
-    const detailText = await detailResponse.text();
-    if (!detailResponse.ok) {
-      throw buildGitHubError(detailResponse, detailText);
+  let openPairs: Array<{ item: GitHubPullRequestPayload; detail: GitHubPullRequestPayload }> | null = null;
+  if (response.status !== 304) {
+    const bodyText = await response.text();
+    if (!response.ok) throw buildGitHubError(response, bodyText);
+    const listPayload = JSON.parse(bodyText) as GitHubPullRequestPayload[];
+    openPairs = [];
+    for (const item of listPayload) {
+      openPairs.push({ item, detail: await fetchPullRequestDetail(repoFullName, item) });
     }
-    const detail = JSON.parse(detailText) as GitHubPullRequestPayload;
-    pulls.push(mapPullRequestSnapshot(repoFullName, item, detail));
   }
 
-  replaceGitHubPullRequests(repoFullName, pulls);
-  markGitHubSyncSuccess(repoFullName, 'pull_requests', response.headers.get('etag'));
+  const closedItems = await fetchRecentlyClosedPullRequests(repoFullName, cutoffIso, cutoffMs);
+  const closedPairs: Array<{ item: GitHubPullRequestPayload; detail: GitHubPullRequestPayload }> = [];
+  for (const item of closedItems) {
+    if (previousUpdatedAt.get(item.number) === (item.updated_at ?? item.created_at ?? '')) continue;
+    try {
+      closedPairs.push({ item, detail: await fetchPullRequestDetail(repoFullName, item) });
+    } catch (error) {
+      console.warn(
+        `[github-broker] Recently closed pull request sync skipped for ${repoFullName}#${item.number}: ${errorMessage(error)}`,
+      );
+    }
+  }
+
+  const changedPairs = [...(openPairs ?? []), ...closedPairs];
+  const attention = await fetchMovedThreadAttention(
+    changedPairs.map(({ detail }) => attentionSource(
+      repoFullName,
+      'pr',
+      detail,
+      detail.comments ?? 0,
+    )),
+    previousUpdatedAt,
+  );
+  const closedPulls = closedPairs.map(({ item, detail }) => mapPullRequestSnapshot(repoFullName, item, detail));
+
+  if (openPairs) {
+    replaceGitHubPullRequests(repoFullName, [
+      ...openPairs.map(({ item, detail }) => mapPullRequestSnapshot(repoFullName, item, detail)),
+      ...closedPulls,
+    ]);
+  } else {
+    for (const pull of closedPulls) upsertGitHubPullRequest(pull);
+  }
+  applyThreadAttention(attention);
+  markGitHubSyncSuccess(
+    repoFullName,
+    'pull_requests',
+    response.status === 304 ? etag : response.headers.get('etag'),
+  );
 }
 
 async function syncPullRequest(repoFullName: string, prNumber: number) {

--- a/src/lib/inbox/card-copy.ts
+++ b/src/lib/inbox/card-copy.ts
@@ -51,6 +51,11 @@ export function composeSupervisorInboxCardCopy(item: SupervisorInboxItem): Inbox
   const worktree = clean(item.worktreePath ?? item.repoPath);
 
   switch (item.kind) {
+    case 'outside_human_waiting':
+      return {
+        headline: clean(item.payload.title) ?? 'An outside contributor is waiting for a reply.',
+        subline: clean(item.payload.body) ?? 'Open the GitHub thread to respond.',
+      };
     case 'silent_exit_verification_failed':
       return {
         headline: 'The worker finished but o8 could not verify its work; review the diff and approve or retry.',

--- a/src/lib/supervisor/inbox-summary.ts
+++ b/src/lib/supervisor/inbox-summary.ts
@@ -1,0 +1,59 @@
+import type { SupervisorInboxItem } from './inbox';
+
+export interface SupervisorInboxSummary {
+  active: number;
+  humanRequired: number;
+  pending: number;
+  healing: number;
+  escalated: number;
+  selfHealed: number;
+  resolved: number;
+  dismissed: number;
+  total: number;
+}
+
+export function summarizeInboxItems(items: SupervisorInboxItem[]): SupervisorInboxSummary {
+  return items.reduce<SupervisorInboxSummary>((summary, item) => {
+    summary.total += 1;
+    switch (item.status) {
+      case 'human_required':
+        summary.humanRequired += 1;
+        summary.active += 1;
+        break;
+      case 'pending':
+        summary.pending += 1;
+        summary.active += 1;
+        break;
+      case 'healing':
+        summary.healing += 1;
+        summary.active += 1;
+        break;
+      case 'escalated':
+        summary.escalated += 1;
+        summary.active += 1;
+        break;
+      case 'self_healed':
+        summary.selfHealed += 1;
+        break;
+      case 'resolved':
+        summary.resolved += 1;
+        break;
+      case 'dismissed':
+        summary.dismissed += 1;
+        break;
+      default:
+        break;
+    }
+    return summary;
+  }, {
+    active: 0,
+    humanRequired: 0,
+    pending: 0,
+    healing: 0,
+    escalated: 0,
+    selfHealed: 0,
+    resolved: 0,
+    dismissed: 0,
+    total: 0,
+  });
+}

--- a/src/lib/supervisor/inbox.ts
+++ b/src/lib/supervisor/inbox.ts
@@ -12,6 +12,9 @@ import {
   DEFAULT_PROJECT_ID,
   getActiveProjectScopeForRepoSync,
 } from '@/lib/repos/projects';
+import { reconcileOutsideHumanWaitingInbox } from './outsider-inbox-builder';
+
+export { summarizeInboxItems, type SupervisorInboxSummary } from './inbox-summary';
 
 export type SupervisorInboxKind =
   | 'verification_failed'
@@ -24,6 +27,7 @@ export type SupervisorInboxKind =
   | 'launch_agent_crash_loop'
   | 'packet_no_changes'
   | 'worker_quota_exhausted'
+  | 'outside_human_waiting'
   // #1502 — a lane reported progress/heartbeat while its sessionKey was null:
   // the worker is running into the void (no transcript, no completion signal).
   // FAULT queue item — never self-closes.
@@ -129,6 +133,7 @@ export const RETENTION_POLICY: Partial<Record<SupervisorInboxKind, {
   no_session_binding: { defaultStatus: 'human_required' },
   packet_no_changes: { defaultStatus: 'pending', autoDismissAfterMs: 7 * 24 * HOUR_MS },
   worker_quota_exhausted: { defaultStatus: 'human_required' },
+  outside_human_waiting: { defaultStatus: 'human_required' },
 };
 
 function ensureSupervisorInboxTable() {
@@ -252,6 +257,13 @@ function buildIncidentKey(input: {
   kind: SupervisorInboxKind;
   payload: SupervisorInboxPayload;
 }): string {
+  if (input.kind === 'outside_human_waiting') {
+    const threadKind = payloadString(input.payload, 'threadKind') ?? '';
+    const threadNumber = typeof input.payload.threadNumber === 'number'
+      ? String(input.payload.threadNumber)
+      : '';
+    return [input.repoPath, input.kind, threadKind, threadNumber].join('\u0000');
+  }
   const laneId = payloadString(input.payload, 'laneId');
   const worktreePath = payloadString(input.payload, 'worktreePath');
   const stage = payloadString(input.payload, 'stage');
@@ -614,12 +626,33 @@ function payloadStringFromRaw(rawPayload: string, key: string): string | null {
   }
 }
 
+export function buildOutsideHumanWaitingInbox(
+  now = new Date(),
+  thresholdMs?: number,
+): { created: number; resolved: number } {
+  ensureSupervisorInboxTable();
+  return reconcileOutsideHumanWaitingInbox({
+    now,
+    thresholdMs,
+    enqueue: enqueueInboxItem,
+    resolve: (id, resolvedAt, payload, insiderReplyAt) => resolveInboxItem(id, null, {
+      note: 'GitHub mirror recorded an insider reply after the outside contributor.',
+      packetId: null,
+      laneId: null,
+      event: 'outside_human_waiting_cleared',
+      evidence: { url: payload.url, waitingSince: payload.waitingSince, insiderReplyAt },
+      resolvedAt,
+    }),
+  });
+}
+
 export function listInboxItems(options: {
   includeDismissed?: boolean;
   includeAllProjects?: boolean;
   projectId?: string | null;
 } = {}): SupervisorInboxItem[] {
   ensureSupervisorInboxTable();
+  buildOutsideHumanWaitingInbox();
   collapseActiveInboxIncidents();
   const projectId = options.projectId ?? getActiveProjectScopeForRepoSync().projectId;
 
@@ -721,62 +754,4 @@ export function listInboxItems(options: {
       }
       return right.lastSeenAt.localeCompare(left.lastSeenAt);
     });
-}
-
-export interface SupervisorInboxSummary {
-  active: number;
-  humanRequired: number;
-  pending: number;
-  healing: number;
-  escalated: number;
-  selfHealed: number;
-  resolved: number;
-  dismissed: number;
-  total: number;
-}
-
-export function summarizeInboxItems(items: SupervisorInboxItem[]): SupervisorInboxSummary {
-  return items.reduce<SupervisorInboxSummary>((summary, item) => {
-    summary.total += 1;
-    switch (item.status) {
-      case 'human_required':
-        summary.humanRequired += 1;
-        summary.active += 1;
-        break;
-      case 'pending':
-        summary.pending += 1;
-        summary.active += 1;
-        break;
-      case 'healing':
-        summary.healing += 1;
-        summary.active += 1;
-        break;
-      case 'escalated':
-        summary.escalated += 1;
-        summary.active += 1;
-        break;
-      case 'self_healed':
-        summary.selfHealed += 1;
-        break;
-      case 'resolved':
-        summary.resolved += 1;
-        break;
-      case 'dismissed':
-        summary.dismissed += 1;
-        break;
-      default:
-        break;
-    }
-    return summary;
-  }, {
-    active: 0,
-    humanRequired: 0,
-    pending: 0,
-    healing: 0,
-    escalated: 0,
-    selfHealed: 0,
-    resolved: 0,
-    dismissed: 0,
-    total: 0,
-  });
 }

--- a/src/lib/supervisor/outsider-attention.test.ts
+++ b/src/lib/supervisor/outsider-attention.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  findWaitingOutsiders,
+  type OutsiderAttentionThread,
+} from './outsider-attention';
+
+const NOW = new Date('2026-08-27T16:00:00.000Z');
+const DAY_MS = 24 * 60 * 60_000;
+
+function thread(overrides: Partial<OutsiderAttentionThread> = {}): OutsiderAttentionThread {
+  return {
+    repo: 'example/repo',
+    kind: 'issue',
+    number: 1881,
+    url: 'https://github.com/example/repo/issues/1881',
+    title: 'Answer the contributor',
+    state: 'open',
+    closedAt: null,
+    lastHumanCommentAuthorLogin: 'outside-contributor',
+    lastHumanCommentAuthorAssociation: 'CONTRIBUTOR',
+    lastHumanCommentAt: '2026-08-26T15:00:00.000Z',
+    lastInsiderCommentAt: null,
+    ...overrides,
+  };
+}
+
+describe('findWaitingOutsiders', () => {
+  it('returns an outsider followed by silence', () => {
+    expect(findWaitingOutsiders([thread()], NOW, DAY_MS)).toEqual([{
+      repo: 'example/repo',
+      kind: 'issue',
+      number: 1881,
+      url: 'https://github.com/example/repo/issues/1881',
+      title: 'Answer the contributor',
+      waitingLogin: 'outside-contributor',
+      waitingSince: '2026-08-26T15:00:00.000Z',
+      hours: 25,
+    }]);
+  });
+
+  it('clears an outsider after a newer insider reply', () => {
+    expect(findWaitingOutsiders([thread({
+      lastInsiderCommentAt: '2026-08-26T15:05:00.000Z',
+    })], NOW, DAY_MS)).toEqual([]);
+  });
+
+  it('ignores bot-only activity', () => {
+    expect(findWaitingOutsiders([thread({
+      lastHumanCommentAuthorLogin: 'automation[bot]',
+      lastHumanCommentAuthorAssociation: 'NONE',
+    })], NOW, DAY_MS)).toEqual([]);
+  });
+
+  it('includes the exact threshold boundary and excludes one millisecond before it', () => {
+    const boundary = '2026-08-26T16:00:00.000Z';
+    expect(findWaitingOutsiders([thread({ lastHumanCommentAt: boundary })], NOW, DAY_MS)).toHaveLength(1);
+    expect(findWaitingOutsiders([thread({
+      lastHumanCommentAt: '2026-08-26T16:00:00.001Z',
+    })], NOW, DAY_MS)).toEqual([]);
+  });
+
+  it('ignores threads closed more than seven days ago', () => {
+    expect(findWaitingOutsiders([thread({
+      state: 'closed',
+      closedAt: '2026-08-20T15:59:59.999Z',
+    })], NOW, DAY_MS)).toEqual([]);
+  });
+});

--- a/src/lib/supervisor/outsider-attention.ts
+++ b/src/lib/supervisor/outsider-attention.ts
@@ -1,0 +1,83 @@
+export type OutsiderAttentionThreadKind = 'issue' | 'pr';
+
+export interface OutsiderAttentionThread {
+  repo: string;
+  kind: OutsiderAttentionThreadKind;
+  number: number;
+  url: string;
+  title: string;
+  state: string;
+  closedAt: string | null;
+  lastHumanCommentAuthorLogin: string | null;
+  lastHumanCommentAuthorAssociation: string | null;
+  lastHumanCommentAt: string | null;
+  lastInsiderCommentAt: string | null;
+}
+
+export interface WaitingOutsider {
+  repo: string;
+  kind: OutsiderAttentionThreadKind;
+  number: number;
+  url: string;
+  title: string;
+  waitingLogin: string;
+  waitingSince: string;
+  hours: number;
+}
+
+export const OUTSIDER_ATTENTION_RECENTLY_CLOSED_MS = 7 * 24 * 60 * 60_000;
+
+const INSIDER_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+
+export function isGitHubBotLogin(login: string | null | undefined): boolean {
+  return typeof login === 'string' && login.trim().toLowerCase().endsWith('[bot]');
+}
+
+export function isGitHubInsiderAssociation(association: string | null | undefined): boolean {
+  return INSIDER_ASSOCIATIONS.has(association?.trim().toUpperCase() ?? '');
+}
+
+function validTimestamp(value: string | null): number | null {
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+export function findWaitingOutsiders(
+  threads: OutsiderAttentionThread[],
+  now: Date,
+  thresholdMs: number,
+): WaitingOutsider[] {
+  const nowMs = now.getTime();
+  if (!Number.isFinite(nowMs)) return [];
+  const boundedThresholdMs = Math.max(0, thresholdMs);
+
+  return threads.flatMap((thread) => {
+    const waitingLogin = thread.lastHumanCommentAuthorLogin?.trim() ?? '';
+    const waitingSinceMs = validTimestamp(thread.lastHumanCommentAt);
+    if (!waitingLogin || waitingSinceMs === null || isGitHubBotLogin(waitingLogin)) return [];
+    if (isGitHubInsiderAssociation(thread.lastHumanCommentAuthorAssociation)) return [];
+
+    if (thread.state.toLowerCase() !== 'open') {
+      const closedAtMs = validTimestamp(thread.closedAt);
+      if (closedAtMs === null || nowMs - closedAtMs > OUTSIDER_ATTENTION_RECENTLY_CLOSED_MS) return [];
+    }
+
+    const lastInsiderCommentMs = validTimestamp(thread.lastInsiderCommentAt);
+    if (lastInsiderCommentMs !== null && lastInsiderCommentMs > waitingSinceMs) return [];
+
+    const waitingMs = nowMs - waitingSinceMs;
+    if (waitingMs < boundedThresholdMs) return [];
+
+    return [{
+      repo: thread.repo,
+      kind: thread.kind,
+      number: thread.number,
+      url: thread.url,
+      title: thread.title,
+      waitingLogin,
+      waitingSince: thread.lastHumanCommentAt!,
+      hours: Math.floor(waitingMs / (60 * 60_000)),
+    }];
+  });
+}

--- a/src/lib/supervisor/outsider-inbox-builder.ts
+++ b/src/lib/supervisor/outsider-inbox-builder.ts
@@ -1,0 +1,164 @@
+import { getSqlite } from '@/lib/db';
+import { listGitHubAttentionThreads } from '@/lib/github-broker/store';
+import { resolveRepoPath } from '@/lib/intake/resolve-repo';
+import {
+  findWaitingOutsiders,
+  type OutsiderAttentionThreadKind,
+  type WaitingOutsider,
+} from './outsider-attention';
+
+const DEFAULT_WAIT_HOURS = 24;
+const ACTIVE_STATUSES = new Set(['pending', 'healing', 'human_required', 'escalated']);
+
+type ExistingOutsideIncident = {
+  id: string;
+  repo_path: string;
+  payload: string;
+  status: string;
+  created_at: string;
+};
+
+type OutsideIncidentPayload = {
+  title: string;
+  body: string;
+  url: string;
+  threadRepo: string;
+  threadKind: OutsiderAttentionThreadKind;
+  threadNumber: number;
+  threadTitle: string;
+  waitingLogin: string;
+  waitingSince: string;
+  hours: number;
+};
+
+type ReconcileOutsideInboxInput = {
+  now?: Date;
+  thresholdMs?: number;
+  enqueue: (input: {
+    repoPath: string;
+    kind: 'outside_human_waiting';
+    payload: OutsideIncidentPayload;
+    status: 'human_required';
+  }) => { id: string };
+  resolve: (id: string, resolvedAt: string, payload: OutsideIncidentPayload, insiderReplyAt: string) => void;
+};
+
+function configuredThresholdMs(): number {
+  // TODO(#1881 follow-up): Promote the reply threshold to an operator setting when the operator-defaults seam is available.
+  const override = Number(process.env.O8_OUTSIDER_WAIT_HOURS);
+  const hours = Number.isFinite(override) && override > 0 ? override : DEFAULT_WAIT_HOURS;
+  return hours * 60 * 60_000;
+}
+
+function threadKey(repo: string, kind: OutsiderAttentionThreadKind, number: number): string {
+  return `${repo}\u0000${kind}\u0000${number}`;
+}
+
+function parsePayload(raw: string): OutsideIncidentPayload | null {
+  try {
+    const payload = JSON.parse(raw) as Partial<OutsideIncidentPayload>;
+    if (
+      typeof payload.threadRepo === 'string'
+      && (payload.threadKind === 'issue' || payload.threadKind === 'pr')
+      && typeof payload.threadNumber === 'number'
+      && typeof payload.waitingSince === 'string'
+    ) {
+      return payload as OutsideIncidentPayload;
+    }
+  } catch {
+    // A malformed historical row must not block the rest of the inbox pass.
+  }
+  return null;
+}
+
+function incidentPayload(waiting: WaitingOutsider): OutsideIncidentPayload {
+  return {
+    title: `${waiting.waitingLogin} is waiting on ${waiting.repo}#${waiting.number}`,
+    body: `${waiting.title} · waiting ${waiting.hours}h`,
+    url: waiting.url,
+    threadRepo: waiting.repo,
+    threadKind: waiting.kind,
+    threadNumber: waiting.number,
+    threadTitle: waiting.title,
+    waitingLogin: waiting.waitingLogin,
+    waitingSince: waiting.waitingSince,
+    hours: waiting.hours,
+  };
+}
+
+export function reconcileOutsideHumanWaitingInbox(input: ReconcileOutsideInboxInput): {
+  created: number;
+  resolved: number;
+} {
+  const now = input.now ?? new Date();
+  const thresholdMs = input.thresholdMs ?? configuredThresholdMs();
+  const threads = listGitHubAttentionThreads();
+  const waiting = findWaitingOutsiders(threads, now, thresholdMs);
+  const rows = getSqlite().prepare(`
+    SELECT id, repo_path, payload, status, created_at
+    FROM supervisor_inbox
+    WHERE kind = 'outside_human_waiting'
+    ORDER BY datetime(created_at) DESC
+  `).all() as ExistingOutsideIncident[];
+
+  const latestByThread = new Map<string, { row: ExistingOutsideIncident; payload: OutsideIncidentPayload }>();
+  const activeByThread = new Map<string, { row: ExistingOutsideIncident; payload: OutsideIncidentPayload }>();
+  for (const row of rows) {
+    const payload = parsePayload(row.payload);
+    if (!payload) continue;
+    const key = threadKey(payload.threadRepo, payload.threadKind, payload.threadNumber);
+    if (!latestByThread.has(key)) latestByThread.set(key, { row, payload });
+    if (ACTIVE_STATUSES.has(row.status) && !activeByThread.has(key)) {
+      activeByThread.set(key, { row, payload });
+    }
+  }
+
+  const waitingKeys = new Set<string>();
+  const localRepoPaths = new Map<string, string | null>();
+  let created = 0;
+  for (const candidate of waiting) {
+    if (!localRepoPaths.has(candidate.repo)) {
+      localRepoPaths.set(candidate.repo, resolveRepoPath(candidate.repo));
+    }
+    const repoPath = localRepoPaths.get(candidate.repo);
+    if (!repoPath) continue;
+    const key = threadKey(candidate.repo, candidate.kind, candidate.number);
+    waitingKeys.add(key);
+    const payload = incidentPayload(candidate);
+    const active = activeByThread.get(key);
+    if (active) {
+      getSqlite().prepare('UPDATE supervisor_inbox SET payload = ? WHERE id = ?')
+        .run(JSON.stringify(payload), active.row.id);
+      continue;
+    }
+
+    const latest = latestByThread.get(key);
+    if (latest?.payload.waitingSince === candidate.waitingSince) continue;
+    input.enqueue({
+      repoPath,
+      kind: 'outside_human_waiting',
+      payload,
+      status: 'human_required',
+    });
+    created += 1;
+  }
+
+  const threadByKey = new Map(threads.map((thread) => [
+    threadKey(thread.repo, thread.kind, thread.number),
+    thread,
+  ]));
+  let resolved = 0;
+  for (const [key, active] of activeByThread) {
+    if (waitingKeys.has(key)) continue;
+    const thread = threadByKey.get(key);
+    const insiderReplyMs = thread?.lastInsiderCommentAt
+      ? Date.parse(thread.lastInsiderCommentAt)
+      : Number.NaN;
+    const waitingSinceMs = Date.parse(active.payload.waitingSince);
+    if (!Number.isFinite(insiderReplyMs) || insiderReplyMs <= waitingSinceMs) continue;
+    input.resolve(active.row.id, now.toISOString(), active.payload, thread!.lastInsiderCommentAt!);
+    resolved += 1;
+  }
+
+  return { created, resolved };
+}

--- a/tests/outsider-waiting-inbox-real-path.test.ts
+++ b/tests/outsider-waiting-inbox-real-path.test.ts
@@ -1,0 +1,216 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-outsider-waiting-'));
+const repoDir = join(dataDir, 'widgets');
+process.env.O8_DATA_DIR = dataDir;
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+
+execFileSync('git', ['init', '--quiet', '--initial-branch=main', repoDir]);
+const repoPath = realpathSync(repoDir);
+execFileSync(
+  'git',
+  ['remote', 'add', 'origin', 'https://github.com/example/widgets.git'],
+  { cwd: repoPath },
+);
+
+const { addRepo } = await import('@/lib/repos/registry');
+await addRepo(repoPath);
+const { closeDb, getSqlite } = await import('@/lib/db');
+const {
+  updateGitHubThreadAttention,
+  upsertGitHubIssue,
+  upsertGitHubPullRequest,
+} = await import('@/lib/github-broker/store');
+const { getActiveProjectScopeForRepoSync } = await import('@/lib/repos/projects');
+const { buildOutsideHumanWaitingInbox, listInboxItems } = await import('@/lib/supervisor/inbox');
+
+const NOW = new Date('2026-08-27T16:00:00.000Z');
+const WAITING_SINCE = '2026-08-26T10:00:00.000Z';
+const INSIDER_REPLY_AT = '2026-08-27T12:00:00.000Z';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  buildOutsideHumanWaitingInbox(NOW, 24 * 60 * 60_000);
+  const sqlite = getSqlite();
+  sqlite.prepare("DELETE FROM supervisor_inbox WHERE kind = 'outside_human_waiting'").run();
+  sqlite.prepare('DELETE FROM github_issues').run();
+  sqlite.prepare('DELETE FROM github_pull_requests').run();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+afterAll(() => {
+  closeDb();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+function persistIssue(): void {
+  upsertGitHubIssue({
+    issueId: 18_810,
+    repoFullName: 'example/widgets',
+    number: 41,
+    title: 'Clarify the extension contract',
+    state: 'open',
+    author: { login: 'issue-author' },
+    assignees: [],
+    labels: [],
+    comments: 1,
+    body: 'Could a maintainer confirm this behavior?',
+    url: 'https://github.com/example/widgets/issues/41',
+    createdAt: '2026-08-25T09:00:00.000Z',
+    updatedAt: WAITING_SINCE,
+    closedAt: null,
+  });
+  updateGitHubThreadAttention({
+    repoFullName: 'example/widgets',
+    kind: 'issue',
+    number: 41,
+    lastHumanCommentAuthorLogin: 'outside-issue-author',
+    lastHumanCommentAuthorAssociation: 'CONTRIBUTOR',
+    lastHumanCommentAt: WAITING_SINCE,
+    lastInsiderCommentAt: null,
+  });
+}
+
+function persistPullRequest(): void {
+  upsertGitHubPullRequest({
+    pullRequestId: 18_811,
+    repoFullName: 'example/widgets',
+    number: 42,
+    title: 'Add a bounded retry guard',
+    state: 'open',
+    author: { login: 'pr-author' },
+    body: 'This is ready for a maintainer response.',
+    headRefName: 'contributor/retry-guard',
+    baseRefName: 'main',
+    additions: 12,
+    deletions: 2,
+    changedFiles: 1,
+    reviewDecision: null,
+    statusCheckRollup: [],
+    url: 'https://github.com/example/widgets/pull/42',
+    createdAt: '2026-08-25T10:00:00.000Z',
+    updatedAt: WAITING_SINCE,
+    closedAt: null,
+    mergedAt: null,
+  });
+  updateGitHubThreadAttention({
+    repoFullName: 'example/widgets',
+    kind: 'pr',
+    number: 42,
+    lastHumanCommentAuthorLogin: 'outside-pr-author',
+    lastHumanCommentAuthorAssociation: 'FIRST_TIME_CONTRIBUTOR',
+    lastHumanCommentAt: WAITING_SINCE,
+    lastInsiderCommentAt: null,
+  });
+}
+
+function persistUnconnectedIssue(): void {
+  upsertGitHubIssue({
+    issueId: 18_812,
+    repoFullName: 'unconnected/tools',
+    number: 43,
+    title: 'This repository is not connected',
+    state: 'open',
+    author: { login: 'outside-unconnected-author' },
+    assignees: [],
+    labels: [],
+    comments: 1,
+    body: 'This thread must not enter a local project inbox.',
+    url: 'https://github.com/unconnected/tools/issues/43',
+    createdAt: '2026-08-25T11:00:00.000Z',
+    updatedAt: WAITING_SINCE,
+    closedAt: null,
+  });
+  updateGitHubThreadAttention({
+    repoFullName: 'unconnected/tools',
+    kind: 'issue',
+    number: 43,
+    lastHumanCommentAuthorLogin: 'outside-unconnected-author',
+    lastHumanCommentAuthorAssociation: 'CONTRIBUTOR',
+    lastHumanCommentAt: WAITING_SINCE,
+    lastInsiderCommentAt: null,
+  });
+}
+
+describe('outside human waiting inbox real path', () => {
+  it('builds issue and PR cards from persisted mirror rows and resolves them after an insider reply', () => {
+    persistIssue();
+    persistPullRequest();
+    persistUnconnectedIssue();
+
+    expect(buildOutsideHumanWaitingInbox(NOW, 24 * 60 * 60_000)).toEqual({
+      created: 2,
+      resolved: 0,
+    });
+
+    const activeProject = getActiveProjectScopeForRepoSync();
+    expect(activeProject.projectId).toBe(getActiveProjectScopeForRepoSync(repoPath).projectId);
+    const activeRows = listInboxItems()
+      .filter((row) => row.kind === 'outside_human_waiting')
+      .sort((left, right) => (
+        Number(left.payload.threadNumber) - Number(right.payload.threadNumber)
+      ));
+    expect(activeRows.map((row) => ({
+      payload: row.payload,
+      projectId: row.projectId,
+      repoPath: row.repoPath,
+      status: row.status,
+    }))).toEqual([
+      {
+        payload: expect.objectContaining({
+          title: 'outside-issue-author is waiting on example/widgets#41',
+          body: 'Clarify the extension contract · waiting 30h',
+          url: 'https://github.com/example/widgets/issues/41',
+        }),
+        projectId: activeProject.projectId,
+        repoPath,
+        status: 'human_required',
+      },
+      {
+        payload: expect.objectContaining({
+          title: 'outside-pr-author is waiting on example/widgets#42',
+          body: 'Add a bounded retry guard · waiting 30h',
+          url: 'https://github.com/example/widgets/pull/42',
+        }),
+        projectId: activeProject.projectId,
+        repoPath,
+        status: 'human_required',
+      },
+    ]);
+    expect(getSqlite().prepare(`
+      SELECT COUNT(*) as count
+      FROM supervisor_inbox
+      WHERE kind = 'outside_human_waiting'
+        AND json_extract(payload, '$.threadRepo') = 'unconnected/tools'
+    `).get()).toEqual({ count: 0 });
+
+    for (const kind of ['issue', 'pr'] as const) {
+      updateGitHubThreadAttention({
+        repoFullName: 'example/widgets',
+        kind,
+        number: kind === 'issue' ? 41 : 42,
+        lastHumanCommentAuthorLogin: kind === 'issue' ? 'outside-issue-author' : 'outside-pr-author',
+        lastHumanCommentAuthorAssociation: 'CONTRIBUTOR',
+        lastHumanCommentAt: WAITING_SINCE,
+        lastInsiderCommentAt: INSIDER_REPLY_AT,
+      });
+    }
+
+    expect(buildOutsideHumanWaitingInbox(NOW, 24 * 60 * 60_000)).toEqual({
+      created: 0,
+      resolved: 2,
+    });
+    expect(listInboxItems()
+      .filter((row) => row.kind === 'outside_human_waiting')
+      .map((row) => row.status)).toEqual(['resolved', 'resolved']);
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1,9 +1,9 @@
 {
   "schema": "o8/test-classification/v1",
   "generatedBy": "node scripts/classify-tests.mjs --write",
-  "totalTests": 897,
-  "hermeticTests": 576,
-  "resourceOwningTests": 321,
+  "totalTests": 901,
+  "hermeticTests": 579,
+  "resourceOwningTests": 322,
   "resourceOwning": [
     {
       "path": "src/app/api/leases/route.test.ts",
@@ -1784,6 +1784,14 @@
         "child-process",
         "network-listener",
         "process-signal"
+      ]
+    },
+    {
+      "path": "tests/outsider-waiting-inbox-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path"
       ]
     },
     {


### PR DESCRIPTION
Refs #1881.

## What

A new Inbox card kind, `outside_human_waiting`: an open (or closed within 7 days) issue or PR on a connected repo where the most recent human comment — or the body, if there are no comments — is from someone outside the repo and no insider has replied within the threshold (24h; `O8_OUTSIDER_WAIT_HOURS` override until this becomes an operator setting).

- **Insider test** uses GitHub's `author_association` (`OWNER` / `MEMBER` / `COLLABORATOR` are insiders); no collaborator-list fetch. Bots (`type: Bot` or `[bot]` logins) never count on either side.
- **Sync** mirrors the minimum: per thread, the latest human comment (login, association, time) and the latest insider comment time, as additive v55 columns on the issue/PR mirror tables. Only threads whose `updated_at` moved are refetched, plus threads closed in the last 7 days. Comment pages are walked newest→oldest and the maximum timestamps kept — the per-issue comments endpoint ignores `sort`/`direction`, so first-seen ≠ latest. Attention and closed-thread fetch failures log and skip; they never fail the primary mirror.
- **Resolver** is one pure function, `findWaitingOutsiders(threads, now, thresholdMs)`.
- **Card** reuses the incident-card geometry: `<login> is waiting on <repo>#<n>`, thread title + hours waiting, one action that opens the thread, plus dismiss. One active card per thread. It auto-resolves when a later sync records an insider reply newer than the outsider's, with an `outside_human_waiting_cleared` event. Cards are scoped to the active project via the connected repo's local path; threads on unconnected repos are ignored.
- No new API routes; nothing under settings, operator defaults, runtime inventory, routing, or history.

## Verification

- `src/lib/supervisor/outsider-attention.test.ts` — resolver: outsider-then-silence, cleared by a newer insider reply, bot-only ignored, exact threshold boundary, closed >7d ignored.
- `src/lib/db/v55-outsider-attention-migration.test.ts` — idempotent, nullable, existing rows null.
- `src/lib/github-broker/sync.test.ts` — drives the real `ensureGitHubIssues` with only the auth boundary mocked: outsider → insider → outsider across two comment pages yields the follow-up as latest human and the reply as latest insider; an attention fetch failure still lands the open mirror.
- `tests/outsider-waiting-inbox-real-path.test.ts` — registered fixture repo → persisted mirror rows → the real `listInboxItems()` for the active project shows issue + PR cards with the right title/link/repo path; an unconnected repo produces no row; an insider reply resolves both.
- `npx tsc --noEmit`, `npm run test:classification:check`, `npm test` green.

## Follow-ups (not in this PR)

- Promote the threshold to an operator setting once that seam is free.
- Prune closed mirror rows older than the 7-day window (the replace only removes open rows).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inbox alerts for GitHub issues and pull requests awaiting a response to an outside contributor.
  * Added an “Open GitHub thread” action for these alerts.
  * Alerts automatically resolve after an insider replies.
  * Added inbox summary counts by status.

* **Bug Fixes**
  * GitHub synchronization now preserves open-item updates when comment or attention data is temporarily unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->