### PR TITLE
feat: add a reversible Terminal Mode to the center workspace

### DIFF
--- a/src/app/dashboard/dashboard-chrome-shortcuts.test.ts
+++ b/src/app/dashboard/dashboard-chrome-shortcuts.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createDashboardChromeKeydownHandler, type DashboardChromeShortcutActions } from './dashboard-chrome-shortcuts';
+
+const listeners: Array<(event: KeyboardEvent) => void> = [];
+
+afterEach(() => {
+  for (const listener of listeners.splice(0)) window.removeEventListener('keydown', listener);
+});
+
+function installHandler() {
+  const actions: DashboardChromeShortcutActions = {
+    openCanvas: vi.fn(),
+    openSettings: vi.fn(),
+    spawnOrchestrator: vi.fn(),
+    toggleBottomPanel: vi.fn(),
+    toggleRightPanel: vi.fn(),
+    toggleSidebar: vi.fn(),
+    toggleTerminalMode: vi.fn(),
+  };
+  const handler = createDashboardChromeKeydownHandler(actions);
+  window.addEventListener('keydown', handler);
+  listeners.push(handler);
+  return actions;
+}
+
+describe('dashboard chrome terminal shortcuts', () => {
+  it('routes Command-Shift-J to Terminal Mode without toggling the bottom panel', () => {
+    const actions = installHandler();
+    window.dispatchEvent(new KeyboardEvent('keydown', {
+      code: 'KeyJ',
+      key: 'j',
+      metaKey: true,
+      shiftKey: true,
+      cancelable: true,
+    }));
+
+    expect(actions.toggleTerminalMode).toHaveBeenCalledOnce();
+    expect(actions.toggleBottomPanel).not.toHaveBeenCalled();
+  });
+
+  it('keeps Command-J assigned to the bottom panel', () => {
+    const actions = installHandler();
+    window.dispatchEvent(new KeyboardEvent('keydown', {
+      code: 'KeyJ',
+      key: 'j',
+      metaKey: true,
+      cancelable: true,
+    }));
+
+    expect(actions.toggleBottomPanel).toHaveBeenCalledOnce();
+    expect(actions.toggleTerminalMode).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/dashboard/dashboard-chrome-shortcuts.ts
+++ b/src/app/dashboard/dashboard-chrome-shortcuts.ts
@@ -1,0 +1,52 @@
+export interface DashboardChromeShortcutActions {
+  openCanvas: () => void;
+  openSettings: () => void;
+  spawnOrchestrator: () => void;
+  toggleBottomPanel: () => void;
+  toggleRightPanel: () => void;
+  toggleSidebar: () => void;
+  toggleTerminalMode: () => void;
+}
+
+export function createDashboardChromeKeydownHandler(actions: DashboardChromeShortcutActions) {
+  return (event: KeyboardEvent) => {
+    if (!(event.metaKey || event.ctrlKey)) return;
+    if (event.altKey) {
+      if (event.code === 'KeyB' && !event.shiftKey) {
+        event.preventDefault();
+        actions.toggleRightPanel();
+      }
+      if (event.code === 'KeyC' && !event.shiftKey) {
+        event.preventDefault();
+        actions.openCanvas();
+      }
+      return;
+    }
+    if (event.shiftKey && event.code === 'KeyJ') {
+      event.preventDefault();
+      actions.toggleTerminalMode();
+      return;
+    }
+    if (event.shiftKey) return;
+    switch (event.key.toLowerCase()) {
+      case 't':
+        event.preventDefault();
+        actions.spawnOrchestrator();
+        break;
+      case 'b':
+        event.preventDefault();
+        actions.toggleSidebar();
+        break;
+      case 'j':
+        event.preventDefault();
+        actions.toggleBottomPanel();
+        break;
+      case ',':
+        event.preventDefault();
+        actions.openSettings();
+        break;
+      default:
+        break;
+    }
+  };
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -33,6 +33,7 @@ import { ConfirmToastHost, toast } from '@/components/shared/ConfirmToastHost';
 import type { BottomPanelSurfaceKind, ContextualPanelHandle } from '@/components/desktop/ContextualPanel';
 import { LeftHeaderStrip } from '@/components/desktop/shell/LeftHeaderStrip';
 import { WorkspaceHeaderStrip } from '@/components/desktop/shell/WorkspaceHeaderStrip';
+import { requestTerminalModeToggle } from '@/components/desktop/shell/TerminalModePill';
 import { PanelHeaderStrip } from '@/components/desktop/shell/PanelHeaderStrip';
 import { DesktopStatusBar } from '@/components/desktop/DesktopStatusBar';
 import { DesktopCloseCoordinator } from '@/components/desktop/DesktopCloseCoordinator';
@@ -151,6 +152,7 @@ import { createTileRegistry } from './tileRegistry';
 import type { TerminalTabHandle } from '@/components/desktop/workspace-terminal/types';
 import type { SavedChatRepoContext } from '@/lib/llm/chat-history';
 import { retryingLazy } from '@/lib/react/retrying-lazy';
+import { createDashboardChromeKeydownHandler } from './dashboard-chrome-shortcuts';
 
 // Mark the dashboard module load as early as possible. Runs once when the
 // bundle is first parsed, before the React component is even invoked, so
@@ -806,6 +808,8 @@ function DashboardInner() {
     finishedTabCount: number;
     contextRailAvailable: boolean;
     contextRailVisible: boolean;
+    terminalModeActive: boolean;
+    activeWorkspaceSurface: boolean;
   };
   const [workspaceActiveMap, setWorkspaceActiveMap] = useState<Map<string, WorkspaceActivePayload>>(() => new Map());
   const [pendingHistoryRailSessionKey, setPendingHistoryRailSessionKey] = useState<string | null>(null);
@@ -821,6 +825,8 @@ function DashboardInner() {
         finishedTabCount?: number;
         contextRailAvailable?: boolean;
         contextRailVisible?: boolean;
+        terminalModeActive?: boolean;
+        activeWorkspaceSurface?: boolean;
         removed?: boolean;
       }>).detail;
       const id = detail?.workspaceId;
@@ -841,6 +847,8 @@ function DashboardInner() {
           finishedTabCount: typeof detail?.finishedTabCount === 'number' ? detail.finishedTabCount : 0,
           contextRailAvailable: Boolean(detail?.contextRailAvailable),
           contextRailVisible: detail?.contextRailVisible !== false,
+          terminalModeActive: Boolean(detail?.terminalModeActive),
+          activeWorkspaceSurface: Boolean(detail?.activeWorkspaceSurface),
         };
         const previous = current.get(id);
         const sameTabs = previous?.tabs.length === payload.tabs.length
@@ -853,7 +861,9 @@ function DashboardInner() {
         if (previous && previous.label === payload.label && previous.tabId === payload.tabId
           && previous.kind === payload.kind && previous.finishedTabCount === payload.finishedTabCount
           && previous.contextRailAvailable === payload.contextRailAvailable
-          && previous.contextRailVisible === payload.contextRailVisible && sameTabs) return current;
+          && previous.contextRailVisible === payload.contextRailVisible
+          && previous.terminalModeActive === payload.terminalModeActive
+          && previous.activeWorkspaceSurface === payload.activeWorkspaceSurface && sameTabs) return current;
         const next = new Map(current);
         next.set(id, payload);
         return next;
@@ -871,7 +881,13 @@ function DashboardInner() {
       const [only] = workspaceActiveMap.values();
       return only;
     }
-    return { workspaceId: null, label: null, tabId: null, kind: null, tabs: [], finishedTabCount: 0, contextRailAvailable: false, contextRailVisible: false };
+    return { workspaceId: null, label: null, tabId: null, kind: null, tabs: [], finishedTabCount: 0, contextRailAvailable: false, contextRailVisible: false, terminalModeActive: false, activeWorkspaceSurface: false };
+  }, [workspaceActiveMap]);
+  const toggleActiveTerminalMode = useCallback(() => {
+    const workspaces = Array.from(workspaceActiveMap.values());
+    const target = workspaces.find((workspace) => workspace.activeWorkspaceSurface)
+      ?? (workspaces.length === 1 ? workspaces[0] : null);
+    if (target?.workspaceId) requestTerminalModeToggle(target.workspaceId);
   }, [workspaceActiveMap]);
   const activeWorkspaceTabIdsRef = useRef<Set<string>>(new Set());
   useEffect(() => {
@@ -894,6 +910,7 @@ function DashboardInner() {
       finishedTabCount: payload.finishedTabCount,
       contextRailAvailable: payload.contextRailAvailable,
       contextRailVisible: payload.contextRailVisible,
+      terminalModeActive: payload.terminalModeActive,
     }));
   }, [workspaceActiveMap]);
 
@@ -4507,57 +4524,25 @@ function DashboardInner() {
 
   // ── Power-user chrome shortcuts ──
   // macOS / VS Code conventions, each mapped to a real existing action:
-  //   ⌘T new tab · ⌘, settings · ⌘B left sidebar · ⌘⌥B right panel · ⌘J terminal
+  //   ⌘T new tab · ⌘, settings · ⌘B left sidebar · ⌘⌥B right panel
+  //   ⌘J bottom terminal · ⌘⇧J Terminal Mode
   // Allowed even while typing — these are app-chrome toggles, none emit text,
   // and power users expect them to fire mid-compose (matches VS Code). Placed
   // here (not with the other hotkey effects above) so toggleSettingsOverlay is
   // already defined — referencing it earlier would hit its const TDZ.
   useEffect(() => {
-    const handler = (event: KeyboardEvent) => {
-      if (!(event.metaKey || event.ctrlKey)) return;
-      // ⌘⌥B — toggle right panel. Calls the same handler as the header
-      // button so the panel kind + commit context stay in lockstep. Option
-      // remaps event.key on macOS (⌥B → '∫'), so match the physical key via
-      // event.code. Other Option combos (⌘⌥← / →, handled elsewhere) fall
-      // through untouched.
-      if (event.altKey) {
-        if (event.code === 'KeyB' && !event.shiftKey) {
-          event.preventDefault();
-          handleToggleO8Panel();
-        }
-        // ⌘⌥C — Canvas mode. Same destination as the header button. `event.code`
-        // for the same reason as ⌘⌥B above: Option remaps event.key (⌥C → 'ç').
-        if (event.code === 'KeyC' && !event.shiftKey) {
-          event.preventDefault();
-          window.location.assign('/preview/canvas-glass');
-        }
-        return;
-      }
-      if (event.shiftKey) return;
-      switch (event.key.toLowerCase()) {
-        case 't':
-          event.preventDefault();
-          dispatchSpawn('orchestrator');
-          break;
-        case 'b':
-          event.preventDefault();
-          toggleSidebarFromChrome();
-          break;
-        case 'j':
-          event.preventDefault();
-          toggleContextualPanelTile();
-          break;
-        case ',':
-          event.preventDefault();
-          toggleSettingsOverlay();
-          break;
-        default:
-          break;
-      }
-    };
+    const handler = createDashboardChromeKeydownHandler({
+      openCanvas: () => window.location.assign('/preview/canvas-glass'),
+      openSettings: toggleSettingsOverlay,
+      spawnOrchestrator: () => dispatchSpawn('orchestrator'),
+      toggleBottomPanel: toggleContextualPanelTile,
+      toggleRightPanel: handleToggleO8Panel,
+      toggleSidebar: toggleSidebarFromChrome,
+      toggleTerminalMode: toggleActiveTerminalMode,
+    });
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [dispatchSpawn, handleToggleO8Panel, toggleContextualPanelTile, toggleSettingsOverlay, toggleSidebarFromChrome]);
+  }, [dispatchSpawn, handleToggleO8Panel, toggleActiveTerminalMode, toggleContextualPanelTile, toggleSettingsOverlay, toggleSidebarFromChrome]);
 
   // ── Symon o8-control: `o8:ui-command` → open a named o8 surface ──
   // The voice agent's `o8_ui_open` tool emits this (src-tauri/src/agent/tools/
@@ -4958,6 +4943,14 @@ function DashboardInner() {
                 ?? workspaceTerminalPreferredRepo?.name
                 ?? null;
 
+              items.push({
+                id: 'workspace:terminal-mode',
+                title: 'Toggle Terminal Mode',
+                detail: 'Show the active workspace terminal full-bleed',
+                shortcut: '⌘⇧J',
+                onActivate: toggleActiveTerminalMode,
+              });
+
               for (const repoEntry of globalRepoEntries) {
                 items.push({
                   id: `repo:focus:${repoEntry.id}`,
@@ -5357,6 +5350,7 @@ function DashboardInner() {
           headerLabel={workspaceHeaderActive.label}
           headerTabs={workspaceHeaderActive.tabs}
           workspaceId={workspaceHeaderActive.workspaceId}
+          terminalModeActive={workspaceHeaderActive.terminalModeActive}
           headerActiveTabId={workspaceHeaderActive.tabId}
           finishedTabCount={workspaceHeaderActive.finishedTabCount}
           splitHeaderWorkspaces={splitHeaderWorkspaces}

--- a/src/app/dashboard/tileRegistry.tsx
+++ b/src/app/dashboard/tileRegistry.tsx
@@ -308,6 +308,23 @@ export function createTileRegistry({
             splitCreated={content.kind === 'terminal' ? effectiveSplitCreated : false}
             availableRepos={workspaceScopeEntries}
             openRepoPaths={openRepoPaths}
+            attachedTerminalSessions={parsedAgents.flatMap((agent) => {
+              const tmuxSession = agent.tmuxSession?.trim();
+              if (!tmuxSession) return [];
+              const repoPath = agent.worktree?.path ?? agent.runtimeSurface?.cwd ?? agent.workspace;
+              return [{
+                sessionKey: agent.sessionKey,
+                tmuxSession,
+                label: agent.surfaceLabel ?? agent.name,
+                repo: repoPath ? {
+                  name: repoPath.split('/').filter(Boolean).pop() ?? repoPath,
+                  localPath: repoPath,
+                  branch: agent.worktree?.branch ?? agent.branch ?? null,
+                  isWorktree: Boolean(agent.worktree),
+                  worktreeStatus: agent.worktree?.status ?? null,
+                } : undefined,
+              }];
+            })}
             canCloseTile={canCloseTerminalTile}
             onActiveChatSessionChange={(sessionKey) => {
               setWorkspaceChatSessionByTileId((current) => (

--- a/src/app/dashboard/types.ts
+++ b/src/app/dashboard/types.ts
@@ -44,6 +44,8 @@ export interface PaletteAgentSummary {
   status?: string;
   currentTask?: string;
   sessionKey: string;
+  surfaceLabel?: string;
+  tmuxSession?: string;
   alerts?: number;
   approvalStatus?: string;
   isCurrentSession?: boolean;

--- a/src/components/desktop/shell/SplitPaneCloseButton.tsx
+++ b/src/components/desktop/shell/SplitPaneCloseButton.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useState } from 'react';
+
+export function SplitPaneCloseButton({ onClick, paneLabel }: { onClick: () => void; paneLabel?: string }) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <button
+      type="button"
+      data-no-drag
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      aria-label={paneLabel ? `Close split (${paneLabel})` : 'Close split'}
+      title="Close split"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: 22,
+        height: 22,
+        borderRadius: 6,
+        borderWidth: 0,
+        background: hovered ? 'var(--t-hover)' : 'transparent',
+        color: hovered ? 'var(--t-text)' : 'var(--t-text-secondary)',
+        cursor: 'pointer',
+        padding: 0,
+        transition: 'background 120ms ease, color 120ms ease',
+      }}
+    >
+      <svg width={12} height={12} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d="M6 6l12 12M18 6L6 18" />
+      </svg>
+    </button>
+  );
+}

--- a/src/components/desktop/shell/TerminalModePill.tsx
+++ b/src/components/desktop/shell/TerminalModePill.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { Expand } from '@/components/desktop/lucide-shims';
+import { HeaderIconPill } from '@/components/desktop/shell/HeaderIconPill';
+
+export const TERMINAL_MODE_TOGGLE_EVENT = 'o8:request-toggle-terminal-mode';
+
+export function requestTerminalModeToggle(workspaceId?: string | null) {
+  window.dispatchEvent(new CustomEvent(TERMINAL_MODE_TOGGLE_EVENT, {
+    detail: { workspaceId: workspaceId ?? null },
+  }));
+}
+
+export function TerminalModePill({
+  active,
+  workspaceId,
+  paneLabel,
+}: {
+  active: boolean;
+  workspaceId: string;
+  paneLabel?: string;
+}) {
+  const action = active ? 'Exit Terminal Mode' : 'Enter Terminal Mode';
+  const label = paneLabel ? `${action} (${paneLabel})` : action;
+  return (
+    <HeaderIconPill
+      icon={<Expand size={15} strokeWidth={1.9} />}
+      label={label}
+      title={`${action} (⌘⇧J)`}
+      onClick={() => requestTerminalModeToggle(workspaceId)}
+      yNudge={1.3}
+    />
+  );
+}

--- a/src/components/desktop/shell/WorkspaceHeaderStrip.tsx
+++ b/src/components/desktop/shell/WorkspaceHeaderStrip.tsx
@@ -25,6 +25,7 @@ import { RightPanelMorphButton } from '../title-bar/RightPanelMorphButton';
 import { CanvasModeButton } from '../title-bar/CanvasModeButton';
 import { TerminalModePill } from './TerminalModePill';
 import { SplitPaneCloseButton } from './SplitPaneCloseButton';
+import type { WorkspaceHeaderStripProps } from './workspace-header-strip-types';
 
 /** Right-edge inset that lands the header's rightmost control on the branch rail
  *  capsule's centre, one row below. Measured, not guessed.
@@ -42,78 +43,6 @@ const RAIL_COLUMN_ALIGN_NUDGE = 4;
  *  the two look unrelated. Closed, they read ~14.6px apart — the same rhythm
  *  the rail capsule's stacked glyphs already use (Q 2026-07-16). */
 const HEADER_CLUSTER_GAP = 4;
-
-interface WorkspaceHeaderStripProps {
-  /** Render the 78px macOS traffic-light spacer — set when this strip is leftmost. */
-  leadingInset?: boolean;
-  /** Sidebar toggle — shown only when a handler is provided (left column collapsed). */
-  sidebarVisible?: boolean;
-  onToggleSidebar?: () => void;
-  /** When the sidebar is collapsed, hovering the toggle pill drops the
-   *  hover-preview overlay (Claude pattern). These handlers wire that
-   *  trigger to the same callbacks the overlay itself uses, so moving
-   *  between pill and overlay doesn't dismiss. 2026-05-27. */
-  onSidebarHoverEnter?: () => void;
-  onSidebarHoverLeave?: () => void;
-  /** Terminal toggle — shown only when a handler is provided. */
-  bottomPanelVisible?: boolean;
-  onToggleBottomPanel?: () => void;
-  /** Split the active workspace tile into a second pane. */
-  onSplitWorkspacePanel?: () => void;
-  /**
-   * O8 panel re-open toggle. Rendered as the rightmost icon ONLY when the
-   * panel is collapsed — when it's open, the toggle in PanelHeaderStrip is
-   * already visible, so we don't duplicate. Operator regression catch
-   * post-#1089: when the panel column disappears, its toggle goes with it,
-   * leaving no re-open affordance.
-   */
-  rightPanelOpen?: boolean;
-  onToggleRightPanel?: () => void;
-  /** Pending approvals badge shown only when the right panel header is absent. */
-  approvalCount?: number;
-  onOpenInbox?: () => void;
-  /** Active workspace tab title rendered in the center slot. Codex / Claude
-   *  put the conversation name in the title bar itself instead of a
-   *  separate strip below. Supports "repo / chat" split styling. Used
-   *  when there's exactly one open tab. */
-  headerLabel?: string | null;
-  /** Full visible-tab list for the single workspace. When length > 1
-   *  the center slot morphs from "title" to a horizontal pill strip
-   *  (Codex pattern). When length <= 1 we fall back to headerLabel. */
-  headerTabs?: Array<{
-    id: string;
-    label: string;
-    kind: string;
-    runtime: string | null;
-    packetStatus: string | null;
-  }>;
-  /** Stable workspace id for routing header pill events back to the owning tile. */
-  workspaceId?: string | null;
-  terminalModeActive?: boolean;
-  /** Active tab id from the headerTabs list — drives which pill renders
-   *  as filled. */
-  headerActiveTabId?: string | null;
-  /** Number of non-active finished CLI-session tabs eligible for explicit cleanup. */
-  finishedTabCount?: number;
-  /** Header-owned toggle for the project context rail.
-   *  Hidden unless the active workspace tab can render that rail. */
-  projectContextRailAvailable?: boolean;
-  projectContextRailVisible?: boolean;
-  onToggleProjectContextRail?: () => void;
-  /** Side-by-side pill strips for splits — when populated (2+ entries)
-   *  the center slot renders two pill rows separated by a small vertical
-   *  divider, one per split workspace. Replaces headerLabel + headerTabs
-   *  in this mode. */
-  splitHeaderWorkspaces?: Array<{
-    workspaceId: string;
-    tabs: Array<{ id: string; label: string; kind: string; runtime: string | null; packetStatus: string | null }>;
-    activeTabId: string | null;
-    finishedTabCount?: number;
-    contextRailAvailable?: boolean;
-    contextRailVisible?: boolean;
-    terminalModeActive?: boolean;
-  }> | null;
-}
 
 export function WorkspaceHeaderStrip({
   leadingInset = false,

--- a/src/components/desktop/shell/WorkspaceHeaderStrip.tsx
+++ b/src/components/desktop/shell/WorkspaceHeaderStrip.tsx
@@ -23,6 +23,8 @@ import { ApprovalInboxBadge } from '../title-bar/ApprovalInboxBadge';
 import { IconColumns, IconTerminal } from '../title-bar/icons';
 import { RightPanelMorphButton } from '../title-bar/RightPanelMorphButton';
 import { CanvasModeButton } from '../title-bar/CanvasModeButton';
+import { TerminalModePill } from './TerminalModePill';
+import { SplitPaneCloseButton } from './SplitPaneCloseButton';
 
 /** Right-edge inset that lands the header's rightmost control on the branch rail
  *  capsule's centre, one row below. Measured, not guessed.
@@ -87,6 +89,7 @@ interface WorkspaceHeaderStripProps {
   }>;
   /** Stable workspace id for routing header pill events back to the owning tile. */
   workspaceId?: string | null;
+  terminalModeActive?: boolean;
   /** Active tab id from the headerTabs list — drives which pill renders
    *  as filled. */
   headerActiveTabId?: string | null;
@@ -108,6 +111,7 @@ interface WorkspaceHeaderStripProps {
     finishedTabCount?: number;
     contextRailAvailable?: boolean;
     contextRailVisible?: boolean;
+    terminalModeActive?: boolean;
   }> | null;
 }
 
@@ -127,6 +131,7 @@ export function WorkspaceHeaderStrip({
   headerLabel,
   headerTabs,
   workspaceId,
+  terminalModeActive = false,
   headerActiveTabId,
   finishedTabCount = 0,
   projectContextRailAvailable = false,
@@ -196,6 +201,7 @@ export function WorkspaceHeaderStrip({
             {showApprovalBadge && onOpenInbox ? (
               <ApprovalInboxBadge count={approvalCount} onClick={onOpenInbox} />
             ) : null}
+            {workspaceId ? <TerminalModePill active={terminalModeActive} workspaceId={workspaceId} /> : null}
             {onToggleBottomPanel ? (
               <HeaderIconPill
                 icon={<IconTerminal />}
@@ -264,6 +270,7 @@ function SplitHeaderPillStrips({
     finishedTabCount?: number;
     contextRailAvailable?: boolean;
     contextRailVisible?: boolean;
+    terminalModeActive?: boolean;
   }>;
 }) {
   const dispatchSpawn = useCallback((workspaceId: string, kind: 'orchestrator' | 'chat' | 'terminal') => {
@@ -312,6 +319,7 @@ function SplitHeaderPillStrips({
               />
             </div>
             <div style={{ display: 'inline-flex', alignItems: 'center', gap: 2, paddingLeft: 4, paddingRight: 6, flexShrink: 0 }}>
+              <TerminalModePill active={workspace.terminalModeActive === true} workspaceId={workspace.workspaceId} paneLabel={paneLabel(index)} />
               {workspace.contextRailAvailable ? (
                 <HeaderIconPill
                   icon={<IconInfoCircle />}
@@ -335,39 +343,6 @@ function SplitHeaderPillStrips({
         );
       })}
     </div>
-  );
-}
-
-function SplitPaneCloseButton({ onClick, paneLabel }: { onClick: () => void; paneLabel?: string }) {
-  const [hovered, setHovered] = useState(false);
-  return (
-    <button
-      type="button"
-      data-no-drag
-      onClick={onClick}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      aria-label={paneLabel ? `Close split (${paneLabel})` : 'Close split'}
-      title="Close split"
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: 22,
-        height: 22,
-        borderRadius: 6,
-        borderWidth: 0,
-        background: hovered ? 'var(--t-hover)' : 'transparent',
-        color: hovered ? 'var(--t-text)' : 'var(--t-text-secondary)',
-        cursor: 'pointer',
-        padding: 0,
-        transition: 'background 120ms ease, color 120ms ease',
-      }}
-    >
-      <svg width={12} height={12} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-        <path d="M6 6l12 12M18 6L6 18" />
-      </svg>
-    </button>
   );
 }
 

--- a/src/components/desktop/shell/workspace-header-strip-types.ts
+++ b/src/components/desktop/shell/workspace-header-strip-types.ts
@@ -1,0 +1,62 @@
+export interface WorkspaceHeaderStripProps {
+  /** Render the 78px macOS traffic-light spacer. Set when this strip is leftmost. */
+  leadingInset?: boolean;
+  /** Sidebar toggle. Shown only when a handler is provided (left column collapsed). */
+  sidebarVisible?: boolean;
+  onToggleSidebar?: () => void;
+  /** When the sidebar is collapsed, hovering the toggle pill drops the
+   *  hover-preview overlay. These handlers wire that trigger to the same
+   *  callbacks the overlay itself uses, so moving between pill and overlay
+   *  does not dismiss it. */
+  onSidebarHoverEnter?: () => void;
+  onSidebarHoverLeave?: () => void;
+  /** Terminal toggle. Shown only when a handler is provided. */
+  bottomPanelVisible?: boolean;
+  onToggleBottomPanel?: () => void;
+  /** Split the active workspace tile into a second pane. */
+  onSplitWorkspacePanel?: () => void;
+  /** O8 panel re-open toggle. Rendered as the rightmost icon only when the
+   *  panel is collapsed, because the open panel owns its toggle. */
+  rightPanelOpen?: boolean;
+  onToggleRightPanel?: () => void;
+  /** Pending approvals badge shown only when the right panel header is absent. */
+  approvalCount?: number;
+  onOpenInbox?: () => void;
+  /** Active workspace tab title rendered in the center slot. */
+  headerLabel?: string | null;
+  /** Full visible-tab list for the single workspace. */
+  headerTabs?: Array<{
+    id: string;
+    label: string;
+    kind: string;
+    runtime: string | null;
+    packetStatus: string | null;
+  }>;
+  /** Stable workspace id for routing header pill events back to the owning tile. */
+  workspaceId?: string | null;
+  terminalModeActive?: boolean;
+  /** Active tab id from the headerTabs list. */
+  headerActiveTabId?: string | null;
+  /** Number of non-active finished CLI-session tabs eligible for explicit cleanup. */
+  finishedTabCount?: number;
+  /** Header-owned toggle for the project context rail. */
+  projectContextRailAvailable?: boolean;
+  projectContextRailVisible?: boolean;
+  onToggleProjectContextRail?: () => void;
+  /** Side-by-side pill strips for split workspaces. */
+  splitHeaderWorkspaces?: Array<{
+    workspaceId: string;
+    tabs: Array<{
+      id: string;
+      label: string;
+      kind: string;
+      runtime: string | null;
+      packetStatus: string | null;
+    }>;
+    activeTabId: string | null;
+    finishedTabCount?: number;
+    contextRailAvailable?: boolean;
+    contextRailVisible?: boolean;
+    terminalModeActive?: boolean;
+  }> | null;
+}

--- a/src/components/desktop/workspace-terminal/WorkspaceTerminalPanels.test.ts
+++ b/src/components/desktop/workspace-terminal/WorkspaceTerminalPanels.test.ts
@@ -10,12 +10,40 @@ import {
 } from '@/lib/orchestrator/outside-worker-split';
 import { useSessionTiles } from './use-session-tiles';
 
-vi.mock('@/components/desktop/workspace-terminal/XtermPanel', () => ({
-  XtermPanel: ({ tmuxSession }: { tmuxSession: string }) => createElement('div', { 'data-tmux-session': tmuxSession }),
-}));
+const xtermMockState = vi.hoisted(() => ({ mounts: 0 }));
+
+vi.mock('@/components/desktop/workspace-terminal/XtermPanel', async () => {
+  const { createElement: mockCreateElement, useEffect } = await import('react');
+  return {
+    XtermPanel: ({
+      tmuxSession,
+      visible,
+      sendTerminalAttach,
+      sendTerminalDetach,
+    }: {
+      tmuxSession: string;
+      visible: boolean;
+      sendTerminalAttach: (session: string, cols: number, rows: number) => void;
+      sendTerminalDetach: (session: string) => void;
+    }) => {
+      useEffect(() => {
+        xtermMockState.mounts += 1;
+        sendTerminalAttach(tmuxSession, 120, 30);
+        return () => sendTerminalDetach(tmuxSession);
+      }, [sendTerminalAttach, sendTerminalDetach, tmuxSession]);
+      return mockCreateElement('div', {
+        'data-tmux-session': tmuxSession,
+        'data-visible': visible ? 'true' : 'false',
+      });
+    },
+  };
+});
 
 vi.mock('@/components/desktop/workspace-terminal/WorkspaceChatPane', () => ({
-  WorkspaceChatPane: () => null,
+  WorkspaceChatPane: ({ tab, active }: { tab: TerminalTab; active: boolean }) => createElement('div', {
+    'data-chat-tab': tab.id,
+    'data-active': active ? 'true' : 'false',
+  }),
 }));
 
 vi.mock('@/components/desktop/workspace-terminal/workspace-boot-loader-claim', () => ({
@@ -88,6 +116,7 @@ describe('WorkspaceTerminalPanels resident surface budget', () => {
 
   beforeEach(() => {
     resetOutsideWorkerSplitsForTest();
+    xtermMockState.mounts = 0;
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -105,6 +134,42 @@ describe('WorkspaceTerminalPanels resident surface budget', () => {
 
     expect(container.querySelectorAll('[data-tmux-session]')).toHaveLength(3);
     expect(container.querySelector('[data-tmux-session="tmux-0"]')).not.toBeNull();
+  });
+
+  it('enters and exits Terminal Mode 100 times without replacing the resident XtermPanel', async () => {
+    const previousTab = {
+      id: 'chat-before-mode',
+      label: 'Coding session',
+      kind: 'chat',
+      tmuxSession: null,
+      chatRuntime: 'codex',
+      createdAt: 1,
+      lastActivity: 1,
+    } satisfies TerminalTab;
+    const terminal = terminalTab(1);
+    const props = panelProps([previousTab, terminal]);
+    const renderActive = (effectiveActiveTabId: string) => root.render(createElement(WorkspaceTerminalPanels, {
+      ...props,
+      effectiveActiveTabId,
+    }));
+
+    await act(async () => renderActive(previousTab.id));
+    expect(xtermMockState.mounts).toBe(1);
+    expect(props.sendTerminalAttach).toHaveBeenCalledOnce();
+    props.sendTerminalAttach.mockClear();
+    props.sendTerminalDetach.mockClear();
+
+    for (let index = 0; index < 100; index += 1) {
+      await act(async () => renderActive(terminal.id));
+      await act(async () => renderActive(previousTab.id));
+    }
+
+    expect(xtermMockState.mounts).toBe(1);
+    expect(container.querySelectorAll('[data-tmux-session="tmux-1"]')).toHaveLength(1);
+    expect(container.querySelector('[data-tmux-session="tmux-1"]')?.getAttribute('data-visible')).toBe('false');
+    expect(container.querySelector('[data-chat-tab="chat-before-mode"]')?.getAttribute('data-active')).toBe('true');
+    expect(props.sendTerminalAttach).not.toHaveBeenCalled();
+    expect(props.sendTerminalDetach).not.toHaveBeenCalled();
   });
 
   it('closes an automatic outside-worker host after its last durable leaf retires', async () => {

--- a/src/components/desktop/workspace-terminal/WorkspaceTerminalRoot.tsx
+++ b/src/components/desktop/workspace-terminal/WorkspaceTerminalRoot.tsx
@@ -9,6 +9,7 @@ import { PreviewPane } from '@/components/desktop/workspace-terminal/PreviewPane
 import { THEME_ACCENT, THEME_ACCENT_SOFT_STRONG } from '@/components/desktop/workspace-terminal/constants';
 import { useWorkspaceTerminalController } from '@/components/desktop/workspace-terminal/useWorkspaceTerminalController';
 import { WorkspaceTerminalPanels } from '@/components/desktop/workspace-terminal/WorkspaceTerminalPanels';
+import { useTerminalMode } from '@/components/desktop/workspace-terminal/use-terminal-mode';
 import { useOutsideWorkerSplitMount } from '@/components/desktop/workspace-terminal/use-outside-worker-split-mount';
 import { WorkspaceSpawnProvider, type WorkspaceSpawnHandlers } from '@/components/desktop/workspace-terminal/spawn-context';
 import { workspaceConversationHeaderLabel } from '@/components/desktop/workspace-terminal/utils';
@@ -17,6 +18,26 @@ import type { TerminalTab, TerminalTabHandle, WorkspaceTerminalProps } from '@/c
 export const WorkspaceTerminalRoot = forwardRef<TerminalTabHandle, WorkspaceTerminalProps>(
   function WorkspaceTerminalRoot(props, ref) {
     const controller = useWorkspaceTerminalController(props, ref);
+    const workspaceInstanceId = useId();
+    const handleNewTab = controller.handleNewTab;
+    const createTerminalModeShellTab = useCallback(
+      (repo?: import('@/components/desktop/workspace-terminal/types').RegisteredRepo) => handleNewTab('shell', repo),
+      [handleNewTab],
+    );
+    const terminalMode = useTerminalMode({
+      activeTab: controller.activeTab,
+      activeTabId: controller.effectiveActiveTabId,
+      attachedSessions: props.attachedTerminalSessions ?? [],
+      canCloseTile: props.canCloseTile === true,
+      createShellTab: createTerminalModeShellTab,
+      attachTerminalSession: controller.attachWorkspaceTerminalSession,
+      panelRefs: controller.panelRefs,
+      preferredRepo: props.preferredRepo ?? null,
+      selectTab: controller.handleSelectTab,
+      tabs: controller.visibleTabs,
+      workspaceActive: props.activeWorkspaceSurface === true,
+      workspaceId: workspaceInstanceId,
+    });
     const hasPreviews = (props.showPreviewPane ?? true) && controller.previews.length > 0;
     const [cleanupToast, setCleanupToast] = useState<{
       id: number;
@@ -30,7 +51,7 @@ export const WorkspaceTerminalRoot = forwardRef<TerminalTabHandle, WorkspaceTerm
       spawnFleetCanvasTab: controller.spawnFleetCanvasTab,
       updateTabMode: controller.handleUpdateTabMode,
     }), [controller.handleUpdateTabMode, controller.spawnChatTab, controller.spawnFleetCanvasTab, controller.spawnOrchestratorTab, controller.spawnSingleRuntimeTab]);
-    const activeTab = controller.activeTab;
+    const activeTab = terminalMode.terminalTab ?? controller.activeTab;
     // workspaceConversationHeaderLabel only knows chat-shaped tabs
     // (orchestrator / llm-chat / single-runtime chat). For terminals
     // and canvas tabs we fall back to "<repo> / Shell" or "<repo> /
@@ -50,9 +71,6 @@ export const WorkspaceTerminalRoot = forwardRef<TerminalTabHandle, WorkspaceTerm
       return repoName ? `${repoName} / ${kindLabel}` : kindLabel;
     })();
 
-    // Stable workspace instance id — declared early so the spawn /
-    // close event listeners below can use it.
-    const workspaceInstanceId = useId();
     useOutsideWorkerSplitMount({
       active: props.activeWorkspaceSurface === true,
       activeTabId: controller.activeTab?.id ?? null,
@@ -67,7 +85,6 @@ export const WorkspaceTerminalRoot = forwardRef<TerminalTabHandle, WorkspaceTerm
     // pane responds. Untargeted events (single-mode global play) only
     // the lone pane responds (canCloseTile = false). Lets two split
     // panes' header play buttons drive their own spawns.
-    const handleNewTab = controller.handleNewTab;
     const handleNewLLMChatTab = controller.handleNewLLMChatTab;
     const spawnOrchestratorTab = controller.spawnOrchestratorTab;
     const spawnFleetCanvasTab = controller.spawnFleetCanvasTab;
@@ -158,6 +175,8 @@ export const WorkspaceTerminalRoot = forwardRef<TerminalTabHandle, WorkspaceTerm
           finishedTabCount: controller.finishedTabCount,
           contextRailAvailable: projectContextRailAvailable,
           contextRailVisible: projectContextRailVisible,
+          terminalModeActive: terminalMode.active,
+          activeWorkspaceSurface: props.activeWorkspaceSurface === true,
         },
       }));
       return () => {
@@ -171,12 +190,14 @@ export const WorkspaceTerminalRoot = forwardRef<TerminalTabHandle, WorkspaceTerm
             finishedTabCount: 0,
             contextRailAvailable: false,
             contextRailVisible: false,
+            terminalModeActive: false,
+            activeWorkspaceSurface: false,
             removed: true,
           },
         }));
       };
 
-    }, [conversationHeaderLabel, activeTabId, activeTabKind, workspaceInstanceId, tabsBroadcastSignature, controller.finishedTabCount, projectContextRailAvailable, projectContextRailVisible]);
+    }, [conversationHeaderLabel, activeTabId, activeTabKind, workspaceInstanceId, tabsBroadcastSignature, controller.finishedTabCount, projectContextRailAvailable, projectContextRailVisible, terminalMode.active, props.activeWorkspaceSurface]);
 
     // Listen for chat-history rename so the workspace tab's label
     // refreshes in sync with the chat-history PATCH. The header strip
@@ -283,7 +304,7 @@ export const WorkspaceTerminalRoot = forwardRef<TerminalTabHandle, WorkspaceTerm
             style={{
               height: `${controller.previewHeight * 100}%`,
               minHeight: 120,
-              display: 'flex',
+              display: terminalMode.active ? 'none' : 'flex',
               flexDirection: 'column',
               overflow: 'hidden',
               flexShrink: 0,
@@ -300,7 +321,7 @@ export const WorkspaceTerminalRoot = forwardRef<TerminalTabHandle, WorkspaceTerm
           </div>
         ) : null}
 
-        {hasPreviews ? (
+        {hasPreviews && !terminalMode.active ? (
           <div
             onMouseDown={controller.handleDragStart}
             style={{
@@ -337,7 +358,7 @@ export const WorkspaceTerminalRoot = forwardRef<TerminalTabHandle, WorkspaceTerm
           workspaceId={workspaceInstanceId}
           visibleTabs={controller.visibleTabs}
           restoreSettled={controller.primaryRestoreSettled}
-          effectiveActiveTabId={controller.effectiveActiveTabId}
+          effectiveActiveTabId={terminalMode.effectiveActiveTabId}
           termWsConnected={controller.termWsConnected}
           panelRefs={controller.panelRefs}
           onCloseTab={controller.handleCloseTab}

--- a/src/components/desktop/workspace-terminal/XtermPanel.tsx
+++ b/src/components/desktop/workspace-terminal/XtermPanel.tsx
@@ -52,6 +52,7 @@ export interface XtermPanelProps {
 }
 
 export interface XtermPanelHandle {
+  focus: () => void;
   writeData: (data: string) => void;
   writeRaw: (data: string) => void;
   readText: (lines?: number) => string;
@@ -93,6 +94,7 @@ export const XtermPanel = forwardRef<XtermPanelHandle, XtermPanelProps>(function
   const imageCountRef = useRef(0);
 
   useImperativeHandle(ref, () => ({
+    focus: () => termRef.current?.focus(),
     writeData: (data: string) => {
       if (!termRef.current) return;
       if (revealHoldRef.current) {

--- a/src/components/desktop/workspace-terminal/terminal-mode.test.ts
+++ b/src/components/desktop/workspace-terminal/terminal-mode.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import type { TerminalTab } from './types';
+import {
+  captureTerminalModeSnapshot,
+  resolveTerminalModeEntry,
+  resolveTerminalModeReturnTab,
+  restoreTerminalModeFocus,
+  setWorkspaceTerminalMode,
+  type TerminalModePresentation,
+} from './terminal-mode';
+
+function tab(overrides: Partial<TerminalTab> & Pick<TerminalTab, 'id' | 'kind'>): TerminalTab {
+  return {
+    label: overrides.id,
+    tmuxSession: null,
+    createdAt: 1,
+    lastActivity: 1,
+    ...overrides,
+  } as TerminalTab;
+}
+
+describe('Terminal Mode state and resolution', () => {
+  it('prefers the active coding session terminal over an existing repo shell', () => {
+    const repo = { name: 'repo', localPath: '/repo' };
+    const worktree = { name: 'packet', localPath: '/repo/.worktrees/packet', isWorktree: true };
+    const activeTab = tab({
+      id: 'coding',
+      kind: 'chat',
+      chatRuntime: 'codex',
+      chatSessionKey: 'codex-owned:active',
+      repo,
+    });
+    const resolution = resolveTerminalModeEntry({
+      activeTab,
+      attachedSessions: [{
+        sessionKey: 'codex-owned:active',
+        tmuxSession: 'agent-session',
+        repo: worktree,
+      }],
+      preferredRepo: repo,
+      tabs: [activeTab, tab({ id: 'shell', kind: 'terminal', tmuxSession: 'shell-session', repo })],
+    });
+
+    expect(resolution).toMatchObject({
+      kind: 'attached-session',
+      session: { tmuxSession: 'agent-session' },
+      repo: worktree,
+    });
+  });
+
+  it('uses an existing terminal tab for the active repo when no coding session is attached', () => {
+    const repo = { name: 'repo', localPath: '/repo' };
+    const shell = tab({ id: 'shell', kind: 'terminal', tmuxSession: 'shell-session', repo });
+    const resolution = resolveTerminalModeEntry({
+      activeTab: tab({ id: 'chat', kind: 'orchestrator', repo }),
+      attachedSessions: [],
+      preferredRepo: repo,
+      tabs: [shell],
+    });
+
+    expect(resolution).toEqual({ kind: 'existing-terminal', tabId: 'shell', tmuxSession: 'shell-session' });
+  });
+
+  it('requests a new shell in the active repo when neither earlier target exists', () => {
+    const repo = { name: 'repo', localPath: '/repo' };
+    const resolution = resolveTerminalModeEntry({
+      activeTab: tab({ id: 'canvas', kind: 'canvas', repo }),
+      attachedSessions: [],
+      preferredRepo: null,
+      tabs: [],
+    });
+
+    expect(resolution).toEqual({ kind: 'new-shell', repo });
+  });
+
+  it('scopes presentation state by workspace id', () => {
+    const focusTarget = document.createElement('button');
+    const presentation = (workspaceId: string): TerminalModePresentation => ({
+      terminalTabId: `${workspaceId}-terminal`,
+      tmuxSession: `${workspaceId}-session`,
+      snapshot: { workspaceId, activeTabId: `${workspaceId}-chat`, focusTarget },
+    });
+    let state = new Map();
+    state = new Map(setWorkspaceTerminalMode(state, 'workspace-a', presentation('workspace-a')));
+
+    expect(state.get('workspace-a')?.terminalTabId).toBe('workspace-a-terminal');
+    expect(state.has('workspace-b')).toBe(false);
+
+    state = new Map(setWorkspaceTerminalMode(state, 'workspace-b', presentation('workspace-b')));
+    state = new Map(setWorkspaceTerminalMode(state, 'workspace-a', null));
+    expect(state.has('workspace-a')).toBe(false);
+    expect(state.get('workspace-b')?.terminalTabId).toBe('workspace-b-terminal');
+  });
+
+  it('restores the exact active tab and focus target from the entry snapshot', () => {
+    const composer = document.createElement('button');
+    const terminal = document.createElement('button');
+    document.body.append(composer, terminal);
+    composer.focus();
+    const snapshot = captureTerminalModeSnapshot('workspace-a', 'chat', document.activeElement);
+    terminal.focus();
+
+    const restored = resolveTerminalModeReturnTab(snapshot, [
+      tab({ id: 'chat', kind: 'orchestrator' }),
+      tab({ id: 'terminal', kind: 'terminal', tmuxSession: 'workspace-a-session' }),
+    ]);
+
+    expect(restored).toEqual({ tabId: 'chat', substituted: false });
+    expect(restoreTerminalModeFocus(snapshot)).toBe(true);
+    expect(document.activeElement).toBe(composer);
+    composer.remove();
+    terminal.remove();
+  });
+});

--- a/src/components/desktop/workspace-terminal/terminal-mode.ts
+++ b/src/components/desktop/workspace-terminal/terminal-mode.ts
@@ -1,0 +1,115 @@
+import type { RegisteredRepo, TerminalTab } from '@/components/desktop/workspace-terminal/types';
+import { normalizeWorkspaceChatSessionKey } from '@/components/desktop/workspace-terminal/utils';
+
+export interface WorkspaceAttachedTerminalSession {
+  sessionKey: string;
+  tmuxSession: string;
+  label?: string;
+  repo?: RegisteredRepo;
+}
+
+export interface TerminalModeSnapshot {
+  workspaceId: string;
+  activeTabId: string;
+  focusTarget: HTMLElement | null;
+}
+
+export interface TerminalModePresentation {
+  terminalTabId: string;
+  tmuxSession: string | null;
+  snapshot: TerminalModeSnapshot;
+}
+
+export type TerminalModesByWorkspace = ReadonlyMap<string, TerminalModePresentation>;
+
+export type TerminalModeEntryResolution =
+  | { kind: 'attached-session'; session: WorkspaceAttachedTerminalSession; repo: RegisteredRepo | null }
+  | { kind: 'existing-terminal'; tabId: string; tmuxSession: string | null }
+  | { kind: 'new-shell'; repo: RegisteredRepo | null };
+
+export function captureTerminalModeSnapshot(
+  workspaceId: string,
+  activeTabId: string,
+  focusTarget: Element | null,
+): TerminalModeSnapshot {
+  return {
+    workspaceId,
+    activeTabId,
+    focusTarget: focusTarget instanceof HTMLElement && focusTarget !== document.body
+      ? focusTarget
+      : null,
+  };
+}
+
+export function resolveTerminalModeEntry({
+  activeTab,
+  attachedSessions,
+  preferredRepo,
+  tabs,
+}: {
+  activeTab: TerminalTab | null;
+  attachedSessions: WorkspaceAttachedTerminalSession[];
+  preferredRepo: RegisteredRepo | null;
+  tabs: TerminalTab[];
+}): TerminalModeEntryResolution {
+  const activeSessionKey = activeTab?.kind === 'chat'
+    ? normalizeWorkspaceChatSessionKey(activeTab.chatRuntime, activeTab.chatSessionKey)
+    : null;
+  const attachedSession = activeSessionKey
+    ? attachedSessions.find((session) => session.sessionKey === activeSessionKey && session.tmuxSession.trim())
+    : null;
+  if (attachedSession) {
+    const existing = tabs.find((tab) => (
+      tab.kind === 'terminal' && tab.tmuxSession === attachedSession.tmuxSession
+    ));
+    if (existing) {
+      return { kind: 'existing-terminal', tabId: existing.id, tmuxSession: existing.tmuxSession };
+    }
+    return {
+      kind: 'attached-session',
+      session: attachedSession,
+      repo: attachedSession.repo ?? activeTab?.repo ?? preferredRepo,
+    };
+  }
+
+  const targetRepo = activeTab?.repo ?? preferredRepo;
+  const existing = tabs.find((tab) => (
+    tab.kind === 'terminal'
+    && (targetRepo ? tab.repo?.localPath === targetRepo.localPath : true)
+  ));
+  if (existing) {
+    return { kind: 'existing-terminal', tabId: existing.id, tmuxSession: existing.tmuxSession };
+  }
+  return { kind: 'new-shell', repo: targetRepo };
+}
+
+export function setWorkspaceTerminalMode(
+  current: TerminalModesByWorkspace,
+  workspaceId: string,
+  presentation: TerminalModePresentation | null,
+): TerminalModesByWorkspace {
+  const next = new Map(current);
+  if (presentation) next.set(workspaceId, presentation);
+  else next.delete(workspaceId);
+  return next;
+}
+
+export function resolveTerminalModeReturnTab(
+  snapshot: TerminalModeSnapshot,
+  tabs: TerminalTab[],
+): { tabId: string; substituted: boolean } {
+  if (tabs.some((tab) => tab.id === snapshot.activeTabId)) {
+    return { tabId: snapshot.activeTabId, substituted: false };
+  }
+  return {
+    tabId: tabs[tabs.length - 1]?.id ?? '',
+    substituted: true,
+  };
+}
+
+export function restoreTerminalModeFocus(snapshot: TerminalModeSnapshot): boolean {
+  const target = snapshot.focusTarget;
+  if (!target?.isConnected) return false;
+  target.focus({ preventScroll: true });
+  return document.activeElement === target;
+}

--- a/src/components/desktop/workspace-terminal/types.ts
+++ b/src/components/desktop/workspace-terminal/types.ts
@@ -16,6 +16,7 @@ import type {
   DetectedLocalhostPreview,
   PreviewSelectionPayload,
 } from '@/lib/panel/preview';
+import type { WorkspaceAttachedTerminalSession } from '@/components/desktop/workspace-terminal/terminal-mode';
 
 export interface RegisteredRepo {
   name: string;
@@ -262,6 +263,8 @@ export interface WorkspaceTerminalProps {
   splitCreated?: boolean;
   availableRepos?: RegisteredRepo[];
   openRepoPaths?: string[];
+  /** Live runtime terminals available for exact session-key attachment. */
+  attachedTerminalSessions?: WorkspaceAttachedTerminalSession[];
   onActiveChatSessionChange?: (sessionKey: string | null) => void;
   onActiveTabKindChange?: (kind: TerminalTab['kind'] | null, tabId: string) => void;
   onChatSessionsChange?: (sessions: MobileInboxSnapshot['sessions']) => void;

--- a/src/components/desktop/workspace-terminal/use-terminal-mode.test.ts
+++ b/src/components/desktop/workspace-terminal/use-terminal-mode.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { requestTerminalModeToggle } from '@/components/desktop/shell/TerminalModePill';
+import type { XtermPanelHandle } from '@/components/desktop/workspace-terminal/XtermPanel';
+import type { RegisteredRepo, TerminalTab } from '@/components/desktop/workspace-terminal/types';
+import { useTerminalMode } from '@/components/desktop/workspace-terminal/use-terminal-mode';
+
+type HookProps = Parameters<typeof useTerminalMode>[0];
+
+const preferredRepo: RegisteredRepo = {
+  name: 'repo',
+  localPath: '/repo',
+};
+
+function chatTab(): TerminalTab {
+  return {
+    id: 'chat-before-mode',
+    label: 'Coding session',
+    kind: 'chat',
+    tmuxSession: null,
+    chatRuntime: 'codex',
+    chatSessionKey: 'codex-owned:active',
+    repo: preferredRepo,
+    createdAt: 1,
+    lastActivity: 1,
+  };
+}
+
+function terminalTab(id = 'terminal-existing', session: string | null = 'existing-session'): TerminalTab {
+  return {
+    id,
+    label: 'Terminal',
+    kind: 'terminal',
+    tmuxSession: session,
+    repo: preferredRepo,
+    createdAt: 2,
+    lastActivity: 2,
+  };
+}
+
+function TerminalModeHarness(props: HookProps) {
+  const mode = useTerminalMode(props);
+  return createElement('output', {
+    'data-active': mode.active ? 'true' : 'false',
+    'data-effective-tab-id': mode.effectiveActiveTabId,
+    'data-terminal-tab-id': mode.terminalTab?.id ?? '',
+  });
+}
+
+describe('useTerminalMode event toggle path', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let props: HookProps;
+  let createShellTab: Mock<HookProps['createShellTab']>;
+  let attachTerminalSession: Mock<HookProps['attachTerminalSession']>;
+  let selectTab: Mock<HookProps['selectTab']>;
+  let focusPanel: Mock<XtermPanelHandle['focus']>;
+
+  const render = (overrides: Partial<HookProps> = {}) => {
+    props = { ...props, ...overrides };
+    root.render(createElement(TerminalModeHarness, props));
+  };
+
+  const modeOutput = () => {
+    const output = container.querySelector('output');
+    if (!output) throw new Error('Terminal Mode harness did not render');
+    return output;
+  };
+
+  beforeEach(async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    createShellTab = vi.fn<HookProps['createShellTab']>(() => 'terminal-new');
+    attachTerminalSession = vi.fn<HookProps['attachTerminalSession']>(() => 'terminal-attached');
+    selectTab = vi.fn<HookProps['selectTab']>();
+    focusPanel = vi.fn<XtermPanelHandle['focus']>();
+    const panelHandle: XtermPanelHandle = {
+      focus: focusPanel,
+      writeData: vi.fn(),
+      writeRaw: vi.fn(),
+      readText: vi.fn(() => ''),
+      showImage: vi.fn(),
+      setError: vi.fn(),
+      setExited: vi.fn(),
+    };
+    const activeTab = chatTab();
+    const terminal = terminalTab();
+    props = {
+      activeTab,
+      activeTabId: activeTab.id,
+      attachedSessions: [],
+      canCloseTile: false,
+      createShellTab,
+      attachTerminalSession,
+      panelRefs: { current: new Map([['existing-session', panelHandle]]) },
+      preferredRepo,
+      selectTab,
+      tabs: [activeTab, terminal],
+      workspaceActive: true,
+      workspaceId: 'workspace-a',
+    };
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0);
+      return 1;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined);
+    await act(async () => render());
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('enters an existing terminal and restores the prior tab and focus on exit', async () => {
+    const priorFocus = document.createElement('button');
+    const terminalFocus = document.createElement('button');
+    document.body.append(priorFocus, terminalFocus);
+    priorFocus.focus();
+
+    await act(async () => requestTerminalModeToggle('workspace-a'));
+
+    expect(modeOutput().getAttribute('data-active')).toBe('true');
+    expect(modeOutput().getAttribute('data-effective-tab-id')).toBe('terminal-existing');
+    expect(focusPanel).toHaveBeenCalledOnce();
+
+    terminalFocus.focus();
+    await act(async () => requestTerminalModeToggle('workspace-a'));
+
+    expect(selectTab).toHaveBeenCalledWith('chat-before-mode');
+    expect(modeOutput().getAttribute('data-active')).toBe('false');
+    expect(modeOutput().getAttribute('data-effective-tab-id')).toBe('chat-before-mode');
+    expect(document.activeElement).toBe(priorFocus);
+    priorFocus.remove();
+    terminalFocus.remove();
+  });
+
+  it('creates a shell in the preferred repo and restores on the second toggle', async () => {
+    const activeTab = chatTab();
+    const createdTerminal = terminalTab('terminal-new', null);
+    await act(async () => render({ activeTab, tabs: [activeTab] }));
+
+    await act(async () => {
+      requestTerminalModeToggle('workspace-a');
+      render({ tabs: [activeTab, createdTerminal] });
+    });
+
+    expect(createShellTab).toHaveBeenCalledOnce();
+    expect(createShellTab).toHaveBeenCalledWith(preferredRepo);
+    expect(modeOutput().getAttribute('data-active')).toBe('true');
+    expect(modeOutput().getAttribute('data-effective-tab-id')).toBe('terminal-new');
+
+    await act(async () => requestTerminalModeToggle('workspace-a'));
+    expect(selectTab).toHaveBeenCalledWith('chat-before-mode');
+    expect(modeOutput().getAttribute('data-active')).toBe('false');
+  });
+
+  it('attaches the active coding session without creating a shell', async () => {
+    const activeTab = chatTab();
+    const attachedSession = {
+      sessionKey: 'codex-owned:active',
+      tmuxSession: 'agent-session',
+      label: 'Agent terminal',
+      repo: preferredRepo,
+    };
+    const attachedTerminal = terminalTab('terminal-attached', attachedSession.tmuxSession);
+    await act(async () => render({ activeTab, tabs: [activeTab], attachedSessions: [attachedSession] }));
+
+    await act(async () => {
+      requestTerminalModeToggle('workspace-a');
+      render({ tabs: [activeTab, attachedTerminal] });
+    });
+
+    expect(attachTerminalSession).toHaveBeenCalledOnce();
+    expect(attachTerminalSession).toHaveBeenCalledWith(attachedSession, preferredRepo);
+    expect(createShellTab).not.toHaveBeenCalled();
+    expect(modeOutput().getAttribute('data-effective-tab-id')).toBe('terminal-attached');
+  });
+
+  it('ignores events for another workspace and untargeted events for an inactive split', async () => {
+    await act(async () => render({ workspaceActive: false, canCloseTile: true }));
+
+    await act(async () => requestTerminalModeToggle('workspace-b'));
+    await act(async () => requestTerminalModeToggle());
+
+    expect(modeOutput().getAttribute('data-active')).toBe('false');
+    expect(modeOutput().getAttribute('data-effective-tab-id')).toBe('chat-before-mode');
+    expect(createShellTab).not.toHaveBeenCalled();
+    expect(attachTerminalSession).not.toHaveBeenCalled();
+    expect(selectTab).not.toHaveBeenCalled();
+  });
+
+  it('exits and restores the prior tab when the active terminal disappears', async () => {
+    const activeTab = chatTab();
+    await act(async () => requestTerminalModeToggle('workspace-a'));
+    expect(modeOutput().getAttribute('data-active')).toBe('true');
+
+    await act(async () => {
+      render({ tabs: [activeTab] });
+      await Promise.resolve();
+    });
+    await act(async () => Promise.resolve());
+
+    expect(selectTab).toHaveBeenCalledWith('chat-before-mode');
+    expect(modeOutput().getAttribute('data-active')).toBe('false');
+    expect(modeOutput().getAttribute('data-effective-tab-id')).toBe('chat-before-mode');
+  });
+});

--- a/src/components/desktop/workspace-terminal/use-terminal-mode.ts
+++ b/src/components/desktop/workspace-terminal/use-terminal-mode.ts
@@ -1,0 +1,129 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { RegisteredRepo, TerminalTab } from '@/components/desktop/workspace-terminal/types';
+import {
+  captureTerminalModeSnapshot,
+  resolveTerminalModeEntry,
+  resolveTerminalModeReturnTab,
+  restoreTerminalModeFocus,
+  setWorkspaceTerminalMode,
+  type TerminalModesByWorkspace,
+  type WorkspaceAttachedTerminalSession,
+} from '@/components/desktop/workspace-terminal/terminal-mode';
+import type { XtermPanelHandle } from '@/components/desktop/workspace-terminal/XtermPanel';
+import { TERMINAL_MODE_TOGGLE_EVENT } from '@/components/desktop/shell/TerminalModePill';
+
+export function useTerminalMode({
+  activeTab,
+  activeTabId,
+  attachedSessions,
+  canCloseTile,
+  createShellTab,
+  attachTerminalSession,
+  panelRefs,
+  preferredRepo,
+  selectTab,
+  tabs,
+  workspaceActive,
+  workspaceId,
+}: {
+  activeTab: TerminalTab | null;
+  activeTabId: string;
+  attachedSessions: WorkspaceAttachedTerminalSession[];
+  canCloseTile: boolean;
+  createShellTab: (repo?: RegisteredRepo) => string;
+  attachTerminalSession: (session: WorkspaceAttachedTerminalSession, repo: RegisteredRepo | null) => string;
+  panelRefs: React.MutableRefObject<Map<string, XtermPanelHandle>>;
+  preferredRepo: RegisteredRepo | null;
+  selectTab: (tabId: string) => void;
+  tabs: TerminalTab[];
+  workspaceActive: boolean;
+  workspaceId: string;
+}) {
+  const [modes, setModes] = useState<TerminalModesByWorkspace>(() => new Map());
+  const tabsRef = useRef(tabs);
+  useEffect(() => {
+    tabsRef.current = tabs;
+  }, [tabs]);
+  const mode = modes.get(workspaceId) ?? null;
+
+  const exit = useCallback(() => {
+    const current = modes.get(workspaceId);
+    if (!current) return;
+    const restored = resolveTerminalModeReturnTab(current.snapshot, tabsRef.current);
+    if (restored.tabId) selectTab(restored.tabId);
+    if (restored.substituted) {
+      console.info('[terminal-mode] return tab closed; restored the deterministic surviving tab');
+    }
+    setModes((previous) => setWorkspaceTerminalMode(previous, workspaceId, null));
+    window.requestAnimationFrame(() => restoreTerminalModeFocus(current.snapshot));
+  }, [modes, selectTab, workspaceId]);
+
+  const enter = useCallback(() => {
+    const resolution = resolveTerminalModeEntry({ activeTab, attachedSessions, preferredRepo, tabs: tabsRef.current });
+    let terminalTabId: string;
+    let tmuxSession: string | null;
+    if (resolution.kind === 'attached-session') {
+      terminalTabId = attachTerminalSession(resolution.session, resolution.repo);
+      tmuxSession = resolution.session.tmuxSession;
+    } else if (resolution.kind === 'existing-terminal') {
+      terminalTabId = resolution.tabId;
+      tmuxSession = resolution.tmuxSession;
+    } else {
+      terminalTabId = createShellTab(resolution.repo ?? undefined);
+      tmuxSession = null;
+    }
+    if (!terminalTabId) return;
+    const snapshot = captureTerminalModeSnapshot(workspaceId, activeTabId, document.activeElement);
+    setModes((previous) => setWorkspaceTerminalMode(previous, workspaceId, {
+      terminalTabId,
+      tmuxSession,
+      snapshot,
+    }));
+  }, [activeTab, activeTabId, attachTerminalSession, attachedSessions, createShellTab, preferredRepo, workspaceId]);
+
+  const toggle = useCallback(() => {
+    if (modes.has(workspaceId)) exit();
+    else enter();
+  }, [enter, exit, modes, workspaceId]);
+
+  useEffect(() => {
+    const onToggle = (event: Event) => {
+      const eventWorkspaceId = (event as CustomEvent<{ workspaceId?: string | null }>).detail?.workspaceId;
+      if (eventWorkspaceId ? eventWorkspaceId !== workspaceId : (!workspaceActive && canCloseTile)) return;
+      toggle();
+    };
+    window.addEventListener(TERMINAL_MODE_TOGGLE_EVENT, onToggle as EventListener);
+    return () => window.removeEventListener(TERMINAL_MODE_TOGGLE_EVENT, onToggle as EventListener);
+  }, [canCloseTile, toggle, workspaceActive, workspaceId]);
+
+  const terminalTab = useMemo(
+    () => mode ? tabs.find((tab) => tab.id === mode.terminalTabId) ?? null : null,
+    [mode, tabs],
+  );
+  const terminalSession = terminalTab?.tmuxSession ?? mode?.tmuxSession ?? null;
+  useEffect(() => {
+    if (!mode || !terminalSession) return;
+    const frame = window.requestAnimationFrame(() => panelRefs.current.get(terminalSession)?.focus());
+    return () => window.cancelAnimationFrame(frame);
+  }, [mode, panelRefs, terminalSession]);
+
+  useEffect(() => {
+    if (!mode || terminalTab) return;
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (!cancelled) exit();
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [exit, mode, terminalTab]);
+
+  return {
+    active: Boolean(mode),
+    effectiveActiveTabId: mode?.terminalTabId ?? activeTabId,
+    terminalTab,
+    toggle,
+  };
+}

--- a/src/components/desktop/workspace-terminal/use-workspace-tab-label-updater.ts
+++ b/src/components/desktop/workspace-terminal/use-workspace-tab-label-updater.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useCallback, type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
+import type { TerminalTab } from '@/components/desktop/workspace-terminal/types';
+
+export function useWorkspaceTabLabelUpdater(
+  setTabs: Dispatch<SetStateAction<TerminalTab[]>>,
+  tabsRef: MutableRefObject<TerminalTab[]>,
+) {
+  return useCallback((
+    tabId: string,
+    label: string,
+    options?: { threadId?: string | null; source?: 'auto' | 'user' },
+  ) => {
+    const nextLabel = label.trim();
+    if (!nextLabel) return;
+    setTabs((previous) => {
+      let changed = false;
+      const next = previous.map((tab) => {
+        if (tab.id !== tabId) return tab;
+        if (
+          options?.threadId
+          && tab.kind === 'orchestrator'
+          && tab.orchestratorThreadId
+          && tab.orchestratorThreadId !== options.threadId
+        ) {
+          return tab;
+        }
+        if (options?.source !== 'user' && tab.labelSource === 'user') return tab;
+        const labelSource = options?.source === 'user' ? 'user' as const : tab.labelSource;
+        if (tab.label === nextLabel && tab.labelSource === labelSource) return tab;
+        changed = true;
+        return { ...tab, label: nextLabel, labelSource };
+      });
+      if (changed) tabsRef.current = next;
+      return changed ? next : previous;
+    });
+  }, [setTabs, tabsRef]);
+}

--- a/src/components/desktop/workspace-terminal/useWorkspaceTerminalController.ts
+++ b/src/components/desktop/workspace-terminal/useWorkspaceTerminalController.ts
@@ -65,6 +65,8 @@ import {
   computeUpdatedChatSessionKey,
 } from '@/components/desktop/workspace-terminal/terminal-tab-handlers';
 import { useWorkspaceTabCleanup } from '@/components/desktop/workspace-terminal/useWorkspaceTabCleanup';
+import type { WorkspaceAttachedTerminalSession } from '@/components/desktop/workspace-terminal/terminal-mode';
+import { useWorkspaceTabLabelUpdater } from '@/components/desktop/workspace-terminal/use-workspace-tab-label-updater';
 import { recordSpawnEvent, registerIntrospectionContributor } from '@/lib/feedback/workspace-introspect';
 
 type ControllerProps = WorkspaceTerminalProps;
@@ -1009,6 +1011,30 @@ export function useWorkspaceTerminalController(
     return result.activeTabId;
   }, [requestTerminalForTab, setActiveTabIdFromUser]);
 
+  const attachWorkspaceTerminalSession = useCallback((
+    session: WorkspaceAttachedTerminalSession,
+    repo: RegisteredRepo | null,
+  ): string => {
+    const existing = tabsRef.current.find((tab) => (
+      tab.kind === 'terminal' && tab.tmuxSession === session.tmuxSession
+    ));
+    if (existing) return existing.id;
+    const now = Date.now();
+    const newTab: TerminalTab = {
+      id: createWorkspaceTabId('terminal'),
+      label: session.label?.trim() || 'Terminal',
+      kind: 'terminal',
+      tmuxSession: session.tmuxSession,
+      repo: repo ?? undefined,
+      createdAt: now,
+      lastActivity: now,
+    };
+    const nextTabs = [...tabsRef.current, newTab];
+    tabsRef.current = nextTabs;
+    setTabs(nextTabs);
+    return newTab.id;
+  }, []);
+
   useImperativeHandle(ref, () => buildTerminalTabHandle({
     tabsRef,
     panelRefs,
@@ -1049,7 +1075,7 @@ export function useWorkspaceTerminalController(
   }, []);
 
   const handleNewTab = useCallback((agentId: string, repo?: RegisteredRepo) => {
-    openWorkspaceTerminalTab(agentId, repo);
+    return openWorkspaceTerminalTab(agentId, repo);
   }, [openWorkspaceTerminalTab]);
 
   const handleNewChatTab = useCallback((runtime: Exclude<WorkspaceChatRuntime, 'chat'>, repo?: RegisteredRepo) => {
@@ -1103,38 +1129,7 @@ export function useWorkspaceTerminalController(
     )));
   }, []);
 
-  // Operator-initiated rename — keeps the workspace tab's label in
-  // sync with a chat-history PATCH so the header strip reflects the
-  // new title without waiting for a remount.
-  const handleUpdateTabLabel = useCallback((
-    tabId: string,
-    label: string,
-    options?: { threadId?: string | null; source?: 'auto' | 'user' },
-  ) => {
-    const nextLabel = label.trim();
-    if (!nextLabel) return;
-    setTabs((previous) => {
-      let changed = false;
-      const next = previous.map((tab) => {
-        if (tab.id !== tabId) return tab;
-        if (
-          options?.threadId
-          && tab.kind === 'orchestrator'
-          && tab.orchestratorThreadId
-          && tab.orchestratorThreadId !== options.threadId
-        ) {
-          return tab;
-        }
-        if (options?.source !== 'user' && tab.labelSource === 'user') return tab;
-        const labelSource = options?.source === 'user' ? 'user' as const : tab.labelSource;
-        if (tab.label === nextLabel && tab.labelSource === labelSource) return tab;
-        changed = true;
-        return { ...tab, label: nextLabel, labelSource };
-      });
-      if (changed) tabsRef.current = next;
-      return changed ? next : previous;
-    });
-  }, []);
+  const handleUpdateTabLabel = useWorkspaceTabLabelUpdater(setTabs, tabsRef);
 
   const handleSaveCheckpoint = useCallback((tabId: string) => {
     setTabs((previous) => previous.map((tab) => (
@@ -1304,6 +1299,7 @@ export function useWorkspaceTerminalController(
     activeCheckpoint,
     activeRepo,
     activeTab,
+    attachWorkspaceTerminalSession,
     containerDivRef,
     effectiveActiveTabId,
     cleanupFinishedTabs,


### PR DESCRIPTION
Refs #1720.

## What

A reversible **Terminal Mode** for the center workspace: one toggle shows the workspace's terminal full-bleed while the resident tabs (orchestrator / chat / canvas) stay mounted underneath; toggling again restores the exact prior tab and focus target.

- **Identity preserved.** Terminal Mode selects a terminal tab and renders it through the existing resident-tab switch (`effectiveActiveTabId` → visibility), so the same `XtermPanel` and the same `tmuxSession` are used. No second mount, no new PTY, no re-attach.
- **Entry resolution:** the active coding session's own terminal (fed from the fleet snapshot's `tmuxSession`) → an existing terminal tab for the repo/worktree → a new shell tab in that repo (a real tab that stays in the strip after exit).
- **Per-workspace, in-memory.** State is a `Map<workspaceId, presentation>` in React state; splits don't cross-toggle; nothing is persisted; reload = normal workspace. No tile-layout version change.
- **Entry points:** a header pill (also per pane in split view), **⌘⇧J** as its own branch ahead of the shift early-return (⌘J / bottom panel untouched), and a Command Palette action. The page-level chrome shortcut handler is extracted to `dashboard-chrome-shortcuts.ts` so it's testable.
- **Ceiling:** new logic lives in new modules (`terminal-mode.ts`, `use-terminal-mode.ts`, `TerminalModePill.tsx`, `SplitPaneCloseButton.tsx`, `use-workspace-tab-label-updater.ts`, `workspace-header-strip-types.ts`). Over-800 files touched only shrank: `WorkspaceHeaderStrip.tsx` 826 → 730, `useWorkspaceTerminalController.ts` 1351 → 1347, `page.tsx` 5924 → 5918. `ContextualPanel.tsx` untouched.

## Verification

- `WorkspaceTerminalPanels.test.ts`: enter/exit 100× around a resident terminal — one `XtermPanel` mount, same `tmuxSession`, no attach/detach resent, prior tab active after the last exit.
- `use-terminal-mode.test.ts`: the real toggle event through the hook — existing-terminal enter + focus, exit restore + focus target, new-shell creation, attached-session selection, workspace event isolation, automatic exit when the terminal tab disappears.
- `terminal-mode.test.ts`: resolution order, workspace scoping, snapshot/restore.
- `dashboard-chrome-shortcuts.test.ts`: ⌘⇧J → Terminal Mode, ⌘J still → bottom panel.
- `npx tsc --noEmit`, `npm run test:classification:check`, `npm test` green.

## Not covered here

The <50ms / <200ms timing targets and TUI/IME/mouse/paste behavior need a live check in the installed app after the next release.
