### PR TITLE
fix: prune closed GitHub mirror rows past the attention window

### DIFF
--- a/src/lib/github-broker/store.ts
+++ b/src/lib/github-broker/store.ts
@@ -458,6 +458,26 @@ export function replaceGitHubPullRequests(repoFullName: string, pulls: GitHubPul
   transaction(pulls);
 }
 
+export function pruneClosedGitHubThreads(
+  repoFullName: string,
+  kind: OutsiderAttentionThreadKind,
+  cutoffIso: string,
+  keepNumbers: number[],
+): number {
+  const table = kind === 'issue' ? 'github_issues' : 'github_pull_requests';
+  const keepClause = keepNumbers.length > 0
+    ? `AND number NOT IN (${keepNumbers.map(() => '?').join(', ')})`
+    : '';
+  const result = getSqlite().prepare(`
+    DELETE FROM ${table}
+    WHERE repo_full_name = ?
+      AND state != 'open'
+      AND datetime(closed_at) < datetime(?)
+      ${keepClause}
+  `).run(repoFullName, cutoffIso, ...keepNumbers);
+  return result.changes;
+}
+
 export function listGitHubIssues(repoFullName: string): GitHubIssueSnapshot[] {
   const sqlite = getSqlite();
   const rows = sqlite.prepare(`

--- a/src/lib/github-broker/sync.test.ts
+++ b/src/lib/github-broker/sync.test.ts
@@ -4,6 +4,11 @@ import { join } from 'node:path';
 
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type {
+  GitHubIssueSnapshot,
+  GitHubPullRequestSnapshot,
+} from './store';
+
 const installationFetchMock = vi.hoisted(() => vi.fn());
 
 vi.mock('./auth', () => ({
@@ -16,7 +21,19 @@ process.env.O8_DATA_DIR = dataDir;
 process.env.CORTEX_IDE_DATA_DIR = dataDir;
 
 const { closeDb, getSqlite } = await import('@/lib/db');
-const { ensureGitHubIssues } = await import('./sync');
+const {
+  buildOutsideHumanWaitingInbox,
+  enqueueInboxItem,
+  resolveInboxItem,
+} = await import('@/lib/supervisor/inbox');
+const {
+  invalidateGitHubSync,
+  upsertGitHubIssue,
+  upsertGitHubPullRequest,
+} = await import('./store');
+const { ensureGitHubIssues, ensureGitHubPullRequests } = await import('./sync');
+
+const NOW = new Date('2026-08-27T16:00:00.000Z');
 
 const installation = {
   id: 1881,
@@ -50,9 +67,120 @@ function openIssue(number: number, comments: number) {
   };
 }
 
+function issueSnapshot(
+  number: number,
+  state: 'open' | 'closed',
+  closedAt: string | null,
+  repoFullName = 'example/widgets',
+): GitHubIssueSnapshot {
+  return {
+    issueId: 18_810 + number,
+    repoFullName,
+    number,
+    title: `Issue ${number}`,
+    state,
+    author: { login: 'thread-author' },
+    assignees: [],
+    labels: [],
+    comments: 0,
+    body: 'Initial thread body.',
+    url: `https://github.com/${repoFullName}/issues/${number}`,
+    createdAt: '2026-08-01T10:00:00.000Z',
+    updatedAt: closedAt ?? '2026-08-27T13:00:00.000Z',
+    closedAt,
+  };
+}
+
+function pullRequestSnapshot(
+  number: number,
+  state: 'open' | 'closed',
+  closedAt: string | null,
+  repoFullName = 'example/widgets',
+): GitHubPullRequestSnapshot {
+  return {
+    pullRequestId: 30_000 + number,
+    repoFullName,
+    number,
+    title: `Pull request ${number}`,
+    state,
+    author: { login: 'thread-author' },
+    body: 'Initial pull request body.',
+    headRefName: `contributor/change-${number}`,
+    baseRefName: 'main',
+    additions: 4,
+    deletions: 1,
+    changedFiles: 1,
+    reviewDecision: null,
+    statusCheckRollup: [],
+    url: `https://github.com/${repoFullName}/pull/${number}`,
+    createdAt: '2026-08-01T10:00:00.000Z',
+    updatedAt: closedAt ?? '2026-08-27T13:00:00.000Z',
+    closedAt,
+    mergedAt: null,
+  };
+}
+
+function pullRequestPayload(number: number) {
+  const snapshot = pullRequestSnapshot(number, 'open', null);
+  return {
+    id: snapshot.pullRequestId,
+    number,
+    title: snapshot.title,
+    state: snapshot.state,
+    body: snapshot.body,
+    html_url: snapshot.url,
+    created_at: snapshot.createdAt,
+    updated_at: snapshot.updatedAt,
+    closed_at: snapshot.closedAt,
+    merged_at: snapshot.mergedAt,
+    user: { login: snapshot.author!.login, type: 'User' },
+    author_association: 'CONTRIBUTOR',
+    head: { ref: snapshot.headRefName },
+    base: { ref: snapshot.baseRefName },
+    additions: snapshot.additions,
+    deletions: snapshot.deletions,
+    changed_files: snapshot.changedFiles,
+    comments: 0,
+  };
+}
+
+function enqueueWaitingCard(kind: 'issue' | 'pr', number: number) {
+  return enqueueInboxItem({
+    repoPath: dataDir,
+    kind: 'outside_human_waiting',
+    status: 'human_required',
+    payload: {
+      title: `Contributor waiting on example/widgets#${number}`,
+      body: 'Waiting for a maintainer response.',
+      url: `https://github.com/example/widgets/${kind === 'issue' ? 'issues' : 'pull'}/${number}`,
+      threadRepo: 'example/widgets',
+      threadKind: kind,
+      threadNumber: number,
+      threadTitle: `Thread ${number}`,
+      waitingLogin: 'outside-contributor',
+      waitingSince: '2026-08-18T16:00:00.000Z',
+      hours: 216,
+    },
+  });
+}
+
+function mirrorNumbers(table: 'github_issues' | 'github_pull_requests', repoFullName: string): number[] {
+  const rows = getSqlite().prepare(`
+    SELECT number
+    FROM ${table}
+    WHERE repo_full_name = ?
+    ORDER BY number
+  `).all(repoFullName) as Array<{ number: number }>;
+  return rows.map((row) => row.number);
+}
+
 beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
   installationFetchMock.mockReset();
+  buildOutsideHumanWaitingInbox(NOW, 24 * 60 * 60_000);
   const sqlite = getSqlite();
+  sqlite.prepare("DELETE FROM supervisor_inbox WHERE kind = 'outside_human_waiting'").run();
   sqlite.prepare('DELETE FROM github_issues').run();
   sqlite.prepare('DELETE FROM github_pull_requests').run();
   sqlite.prepare('DELETE FROM github_sync_state').run();
@@ -60,6 +188,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -144,5 +273,62 @@ describe('GitHub outsider attention sync', () => {
     expect(warning).toHaveBeenCalledWith(expect.stringContaining(
       '[github-broker] Attention sync skipped for example/widgets#52: attention request unavailable',
     ));
+  });
+
+  it('prunes expired closed issues after their active waiting card resolves', async () => {
+    upsertGitHubIssue(issueSnapshot(101, 'closed', '2026-08-19T15:59:59.000Z'));
+    upsertGitHubIssue(issueSnapshot(102, 'closed', '2026-08-25T16:00:00.000Z'));
+    upsertGitHubIssue(issueSnapshot(103, 'open', null));
+    upsertGitHubIssue(issueSnapshot(104, 'closed', '2026-08-19T15:59:59.000Z'));
+    upsertGitHubIssue(issueSnapshot(105, 'closed', '2026-08-19T15:59:59.000Z', 'other/widgets'));
+    const card = enqueueWaitingCard('issue', 104);
+
+    installationFetchMock.mockImplementation(async (_repo: string, path: string) => {
+      if (path.includes('/issues?state=open')) return fetched([openIssue(103, 0)]);
+      if (path.includes('/issues?state=closed')) return fetched([]);
+      throw new Error(`Unexpected GitHub path: ${path}`);
+    });
+
+    await expect(ensureGitHubIssues('example/widgets', { fresh: true })).resolves.toMatchObject({
+      error: null,
+      stale: false,
+    });
+    expect(mirrorNumbers('github_issues', 'example/widgets')).toEqual([102, 103, 104]);
+    expect(mirrorNumbers('github_issues', 'other/widgets')).toEqual([105]);
+
+    resolveInboxItem(card.id, null);
+    await ensureGitHubIssues('example/widgets', { fresh: true });
+
+    expect(mirrorNumbers('github_issues', 'example/widgets')).toEqual([102, 103]);
+  });
+
+  it('prunes expired closed pull requests after their active waiting card resolves', async () => {
+    upsertGitHubPullRequest(pullRequestSnapshot(201, 'closed', '2026-08-19T15:59:59.000Z'));
+    upsertGitHubPullRequest(pullRequestSnapshot(202, 'closed', '2026-08-25T16:00:00.000Z'));
+    upsertGitHubPullRequest(pullRequestSnapshot(203, 'open', null));
+    upsertGitHubPullRequest(pullRequestSnapshot(204, 'closed', '2026-08-19T15:59:59.000Z'));
+    upsertGitHubPullRequest(pullRequestSnapshot(205, 'closed', '2026-08-19T15:59:59.000Z', 'other/widgets'));
+    const card = enqueueWaitingCard('pr', 204);
+    const openPull = pullRequestPayload(203);
+
+    installationFetchMock.mockImplementation(async (_repo: string, path: string) => {
+      if (path.includes('/pulls?state=open')) return fetched([openPull]);
+      if (path.includes('/pulls?state=closed')) return fetched([]);
+      if (path.endsWith('/pulls/203')) return fetched(openPull);
+      throw new Error(`Unexpected GitHub path: ${path}`);
+    });
+
+    await expect(ensureGitHubPullRequests('example/widgets')).resolves.toMatchObject({
+      error: null,
+      stale: false,
+    });
+    expect(mirrorNumbers('github_pull_requests', 'example/widgets')).toEqual([202, 203, 204]);
+    expect(mirrorNumbers('github_pull_requests', 'other/widgets')).toEqual([205]);
+
+    resolveInboxItem(card.id, null);
+    invalidateGitHubSync('example/widgets', 'pull_requests');
+    await ensureGitHubPullRequests('example/widgets');
+
+    expect(mirrorNumbers('github_pull_requests', 'example/widgets')).toEqual([202, 203]);
   });
 });

--- a/src/lib/github-broker/sync.ts
+++ b/src/lib/github-broker/sync.ts
@@ -7,6 +7,7 @@ import {
   listGitHubPullRequests,
   markGitHubSyncError,
   markGitHubSyncSuccess,
+  pruneClosedGitHubThreads,
   readGitHubSyncState,
   replaceGitHubIssues,
   replaceGitHubPullRequests,
@@ -28,6 +29,7 @@ import {
   OUTSIDER_ATTENTION_RECENTLY_CLOSED_MS,
   type OutsiderAttentionThreadKind,
 } from '@/lib/supervisor/outsider-attention';
+import { listActiveOutsideHumanWaitingThreadNumbers } from '@/lib/supervisor/inbox';
 
 const GITHUB_SNAPSHOT_TTL_MS = 120_000; // 2 min — balance freshness with rate limit budget
 
@@ -435,6 +437,12 @@ async function syncIssues(repoFullName: string) {
     for (const issue of closedIssues) upsertGitHubIssue(issue);
   }
   applyThreadAttention(attention);
+  pruneClosedGitHubThreads(
+    repoFullName,
+    'issue',
+    cutoffIso,
+    listActiveOutsideHumanWaitingThreadNumbers(repoFullName, 'issue'),
+  );
   markGitHubSyncSuccess(repoFullName, 'issues', response.status === 304 ? etag : lastEtag);
 }
 
@@ -502,6 +510,12 @@ async function syncPullRequests(repoFullName: string) {
     for (const pull of closedPulls) upsertGitHubPullRequest(pull);
   }
   applyThreadAttention(attention);
+  pruneClosedGitHubThreads(
+    repoFullName,
+    'pr',
+    cutoffIso,
+    listActiveOutsideHumanWaitingThreadNumbers(repoFullName, 'pr'),
+  );
   markGitHubSyncSuccess(
     repoFullName,
     'pull_requests',

--- a/src/lib/supervisor/inbox.ts
+++ b/src/lib/supervisor/inbox.ts
@@ -12,7 +12,12 @@ import {
   DEFAULT_PROJECT_ID,
   getActiveProjectScopeForRepoSync,
 } from '@/lib/repos/projects';
-import { reconcileOutsideHumanWaitingInbox } from './outsider-inbox-builder';
+import type { OutsiderAttentionThreadKind } from './outsider-attention';
+import {
+  ACTIVE_OUTSIDE_INCIDENT_STATUSES,
+  parseOutsideIncidentPayload,
+  reconcileOutsideHumanWaitingInbox,
+} from './outsider-inbox-builder';
 
 export { summarizeInboxItems, type SupervisorInboxSummary } from './inbox-summary';
 
@@ -644,6 +649,29 @@ export function buildOutsideHumanWaitingInbox(
       resolvedAt,
     }),
   });
+}
+
+export function listActiveOutsideHumanWaitingThreadNumbers(
+  repoFullName: string,
+  kind: OutsiderAttentionThreadKind,
+): number[] {
+  ensureSupervisorInboxTable();
+  const placeholders = ACTIVE_OUTSIDE_INCIDENT_STATUSES.map(() => '?').join(', ');
+  const rows = getSqlite().prepare(`
+    SELECT payload
+    FROM supervisor_inbox
+    WHERE kind = 'outside_human_waiting'
+      AND status IN (${placeholders})
+  `).all(...ACTIVE_OUTSIDE_INCIDENT_STATUSES) as Array<{ payload: string }>;
+
+  const numbers = new Set<number>();
+  for (const row of rows) {
+    const payload = parseOutsideIncidentPayload(row.payload);
+    if (payload?.threadRepo === repoFullName && payload.threadKind === kind) {
+      numbers.add(payload.threadNumber);
+    }
+  }
+  return [...numbers];
 }
 
 export function listInboxItems(options: {

--- a/src/lib/supervisor/outsider-inbox-builder.ts
+++ b/src/lib/supervisor/outsider-inbox-builder.ts
@@ -8,7 +8,13 @@ import {
 } from './outsider-attention';
 
 const DEFAULT_WAIT_HOURS = 24;
-const ACTIVE_STATUSES = new Set(['pending', 'healing', 'human_required', 'escalated']);
+export const ACTIVE_OUTSIDE_INCIDENT_STATUSES = [
+  'pending',
+  'healing',
+  'human_required',
+  'escalated',
+] as const;
+const ACTIVE_STATUSES = new Set<string>(ACTIVE_OUTSIDE_INCIDENT_STATUSES);
 
 type ExistingOutsideIncident = {
   id: string;
@@ -54,7 +60,7 @@ function threadKey(repo: string, kind: OutsiderAttentionThreadKind, number: numb
   return `${repo}\u0000${kind}\u0000${number}`;
 }
 
-function parsePayload(raw: string): OutsideIncidentPayload | null {
+export function parseOutsideIncidentPayload(raw: string): OutsideIncidentPayload | null {
   try {
     const payload = JSON.parse(raw) as Partial<OutsideIncidentPayload>;
     if (
@@ -104,7 +110,7 @@ export function reconcileOutsideHumanWaitingInbox(input: ReconcileOutsideInboxIn
   const latestByThread = new Map<string, { row: ExistingOutsideIncident; payload: OutsideIncidentPayload }>();
   const activeByThread = new Map<string, { row: ExistingOutsideIncident; payload: OutsideIncidentPayload }>();
   for (const row of rows) {
-    const payload = parsePayload(row.payload);
+    const payload = parseOutsideIncidentPayload(row.payload);
     if (!payload) continue;
     const key = threadKey(payload.threadRepo, payload.threadKind, payload.threadNumber);
     if (!latestByThread.has(key)) latestByThread.set(key, { row, payload });


### PR DESCRIPTION
Refs #1892 — follow-up to #1890.

## What

After the attention pass on every successful issue or PR sync (including 304 short paths — the prune is cheap and idempotent), closed mirror rows for that repo whose `closed_at` is older than the 7-day attention window are deleted, unless an active `outside_human_waiting` card still references the thread. Open rows and other repos are never touched.

`pruneClosedGitHubThreads(repo, kind, cutoffIso, keepNumbers)` in the store; `listActiveOutsideHumanWaitingThreadNumbers(repo, kind)` in the inbox module reuses the card payload parser and active-status list (exported from the inbox builder rather than duplicated). No schema, migration, or UI change.

## Verification

`src/lib/github-broker/sync.test.ts`, through the real `ensureGitHubIssues` and `ensureGitHubPullRequests` with only the auth boundary mocked: an 8-day-old closed row is pruned, a 2-day-old one stays, the open row stays, another repo's row stays, and an 8-day-old row with an active waiting card survives until the card is resolved and the next sync runs. `npx tsc --noEmit`, `npm run test:classification:check`, `npm test` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically removes outdated closed GitHub issues and pull requests from synchronized records.
  * Preserves threads that still have active human-waiting items.
  * Applies cleanup only after associated waiting items are resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->