### PR TITLE
chore: ratchet the lint gate at the current warning count

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Rust changes also need the relevant Cargo check or test from `src-tauri/`.
 Three things about those gates that will otherwise waste your time:
 
 - **The suite prints alarming output on purpose.** Negative-path tests emit things like `LOCKOUT BREACH`, authorization failures, and timeouts to stderr while passing. The Vitest summary and exit code are the verdict.
-- **Lint the files you touched, not the repo.** A repo-wide `npm run lint` still reports known baseline warnings; fixing unrelated ones expands your diff and makes review harder.
+- **Treat repo-wide lint as a ratchet.** `npm run lint` permits the current warning baseline, and that ceiling only goes down. Keep lint fixes focused: when a pull request clears warnings, lower `--max-warnings` in `package.json` in the same pull request instead of leaving unused headroom.
 - **Tests are not yet fully isolated from a running install.** A few suites reach global paths outside `CORTEX_IDE_DATA_DIR`, so quit the desktop app before running the full suite, or expect flakes that are not your fault.
 
 Use one of the established commit prefixes: `feat:`, `fix:`, `chore:`, `docs:`, `perf:`, or `refactor:`. Files have an 800-line ceiling unless an existing waiver applies. New TSX styling uses inline style objects rather than new CSS classes.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev:all": "node scripts/dev.mjs all",
     "build": "node scripts/build.mjs",
     "start": "node scripts/start.mjs",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 301",
     "typecheck": "npm run verify:routes && node scripts/typecheck.mjs",
     "verify:routes": "vitest run tests/route-coverage.test.ts -t \"route module shape\"",
     "rule-check": "tsx scripts/rule-check.ts",

--- a/tests/lint-ratchet.test.ts
+++ b/tests/lint-ratchet.test.ts
@@ -1,0 +1,41 @@
+import { createRequire } from 'node:module';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+type EslintCli = {
+  execute(args: string[], text: string | null, allowFlatConfig?: boolean): Promise<number>;
+};
+
+const require = createRequire(import.meta.url);
+const eslintRoot = dirname(require.resolve('eslint/package.json'));
+const eslintCli = require(join(eslintRoot, 'lib/cli.js')) as EslintCli;
+
+function runEslint(file: string, maxWarnings: number): Promise<number> {
+  return eslintCli.execute([
+    process.execPath,
+    'eslint',
+    file,
+    '--no-config-lookup',
+    '--rule',
+    'no-unused-vars: warn',
+    '--max-warnings',
+    String(maxWarnings),
+  ], null, true);
+}
+
+describe('lint warning ratchet', () => {
+  it('fails above the warning ceiling and passes at the ceiling', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'o8-lint-ratchet-'));
+    const fixture = join(root, 'warning.js');
+    writeFileSync(fixture, 'const unused = 1;\n');
+
+    try {
+      expect(await runEslint(fixture, 0)).not.toBe(0);
+      expect(await runEslint(fixture, 1)).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Refs #1894, #1670.

## What

`npm run lint` exited 0 with 301 warnings, so CI could not detect a lint regression. The script is now `eslint . --max-warnings 301` — the number measured on the current head (verified independently by the reviewer on the same commit). CI already runs `npm run lint`, so the gate takes effect without workflow changes.

CONTRIBUTING's lint note now states the rule: the ceiling only goes down; when a PR clears warnings, lower the number in the same PR.

## Verification

- `tests/lint-ratchet.test.ts` (hermetic): runs eslint on a temp file with one deliberate warning — non-zero exit at `--max-warnings 0`, zero at `--max-warnings 1` — proving the flag gates. It does not lint the repo.
- `npm run lint` on the merged head: 301 warnings, 0 errors, exit 0. `npx tsc --noEmit`, `npm run test:classification:check`, `npm test` green.

## Note

The test reaches eslint through its `lib/cli.js` entry rather than the public bin; if an eslint upgrade moves that file, the test will fail loudly and should switch to spawning the bin.

Next children lower the number: #1895 (dead disables), #1896 (no-unused-vars), #1897 (hooks pass).
