### PR TITLE
feat: arm the pre-edit task contract by default for Claude Code and Codex packets

### DIFF
--- a/scripts/bench/coding-governed-pipeline.ts
+++ b/scripts/bench/coding-governed-pipeline.ts
@@ -211,6 +211,7 @@ async function assessDurableReview(input: {
     worktreePath: input.durable.worktreePath,
     repoPath: input.repoRoot,
     baseBranch: 'main',
+    runtime: 'codex',
   });
 }
 
@@ -344,6 +345,7 @@ export async function driveGovernedPipeline(input: {
         worktreePath: worktree,
         repoPath: input.repoRoot,
         baseBranch: 'main',
+        runtime: 'codex',
       });
       if (currentAttempt) currentAttempt.durableAssessment = durableReview;
     }
@@ -424,6 +426,7 @@ export async function driveGovernedPipeline(input: {
         worktreePath: worktree,
         repoPath: input.repoRoot,
         baseBranch: 'main',
+        runtime: 'codex',
       });
       durableReview = postDiffAssessment;
       if (currentAttempt) currentAttempt.durableAssessment = postDiffAssessment;

--- a/src/app/api/orchestrator/create-mission/route.ts
+++ b/src/app/api/orchestrator/create-mission/route.ts
@@ -255,6 +255,13 @@ export async function POST(request: NextRequest) {
   if (qualitySearch && record.huddle === true) {
     return operatorError('invalid_request', 'qualitySearch already uses a sealed contract and cannot be combined with huddle mode.', 400);
   }
+  if (record.taskContract !== undefined && record.taskContract !== 'off') {
+    return operatorError('invalid_request', 'taskContract must be "off" when provided.', 400);
+  }
+  const taskContract = record.taskContract === 'off' ? 'off' as const : undefined;
+  if (qualitySearch && taskContract === 'off') {
+    return operatorError('invalid_request', 'qualitySearch already uses a sealed contract and cannot be combined with taskContract: "off".', 400);
+  }
 
   const createInput = {
       issues,
@@ -272,6 +279,7 @@ export async function POST(request: NextRequest) {
       existingBranchPolicy,
       ...(typeof record.useBrain === 'boolean' ? { useBrain: record.useBrain } : {}),
       ...(!qualitySearch ? { huddle } : {}),
+      ...(taskContract ? { taskContract } : {}),
       // #1329 — carry the dispatching orchestrator thread id so workers inherit
       // its session rules. Optional; thread-less callers omit it.
       ...(typeof record.orchestratorThreadId === 'string' && record.orchestratorThreadId.trim()

--- a/src/lib/lane/auto-review.ts
+++ b/src/lib/lane/auto-review.ts
@@ -48,6 +48,7 @@ import {
 } from './review-cancellation';
 import { dispatchSecondPassMerge } from './second-pass-merge-dispatch';
 import { drainPacketExplainerQueue, enqueuePacketExplainer, startPacketExplainerQueueDrain } from './packet-explainer-queue';
+import { resolvePacketTaskContractGate } from './task-contract-gate';
 import type { Lane } from './types';
 
 const DRAIN_INTERVAL_MS = 10_000;
@@ -530,18 +531,12 @@ async function performAutoReview(review: QueuedReview): Promise<AutoReviewOutcom
   // where the worker went off-plan. Null (no notes file / no heading) persists
   // as null so the surfaces render the asserted "No deviations reported" line.
   let deviations: PacketDeviations | null = null;
-  let taskContractRequired = false;
+  let enforceCoverage = false;
+  let taskContract: PacketTaskContract | null = completionContext?.taskContract ?? null;
   if (lane.packetId) {
     try {
       deviations = readPacketDeviations(lane.worktreePath || lane.repoPath, lane.packetId);
-      const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
-      taskContractRequired = readOrchestratorControlPlaneState().packets
-        .find((packet) => packet.id === lane.packetId)?.taskContractRequired === true;
-      const { patchMissionPacket } = await import('@/lib/orchestrator/operator-mission-service/packet-patch');
-      await patchMissionPacket(lane.packetId, {
-        deviations: deviations ?? null,
-        taskContract: completionContext?.taskContract ?? null,
-      });
+      ({ taskContract, enforceCoverage } = await resolvePacketTaskContractGate({ lane, completionContext, deviations }));
     } catch (error) {
       console.warn(`[auto-review] Failed to capture deviations for lane ${lane.id}:`, error);
     }
@@ -583,8 +578,8 @@ async function performAutoReview(review: QueuedReview): Promise<AutoReviewOutcom
     reviewScreenshot,
     diffSummary.cwd,
     deviations,
-    completionContext?.taskContract,
-    taskContractRequired,
+    taskContract,
+    enforceCoverage,
   );
 
   if (isReviewAttemptCancelled(review.id, review.claim_owner)) {
@@ -698,8 +693,8 @@ async function performAutoReview(review: QueuedReview): Promise<AutoReviewOutcom
     lane,
     diffSummary,
     reviewRisk.reasons,
-    completionContext?.taskContract,
-    taskContractRequired,
+    taskContract,
+    enforceCoverage,
   );
   const secondPassThreadId = `thoughts-second-pass-${lane.id}-${randomUUID().slice(0, 8)}`;
   let secondPassText = '';

--- a/src/lib/lane/durable-review-approval.ts
+++ b/src/lib/lane/durable-review-approval.ts
@@ -4,6 +4,7 @@ import { resolveLaneAttributionBase } from '@/lib/lane/attribution-base';
 import type { Lane } from '@/lib/lane/types';
 import type { ContractCoverageResult } from '@/lib/orchestrator/task-contract-coverage';
 import type { PacketTaskContract } from '@/lib/orchestrator/types';
+import { resolvePacketTaskContractGate } from '@/lib/lane/task-contract-gate';
 
 export interface DurableReviewAssessment {
   approved: boolean;
@@ -57,26 +58,25 @@ function reviewFindingsAreResolved(approval: ApprovalRecord): boolean {
  * Resolve the sealed contract and the review's recorded evidence, then run the
  * deterministic gate.
  *
- * Fail-closed policy is deliberately narrow: it applies ONLY once we have
- * established that this packet requires a contract. If we cannot even determine
- * that, the packet is treated as legacy and judged exactly as before — blocking
- * work that predates the pipeline would be a regression, not a safety win.
+ * Fail-closed policy is deliberately narrow: explicit arming stays hard, while
+ * a runtime-default arm without a captured contract records an audit event and
+ * preserves the legacy approval path. If we cannot determine whether a bound
+ * packet requires a contract, review still fails closed.
  */
 async function assessContractCoverage(
-  lane: Pick<Lane, 'id' | 'packetId' | 'worktreePath' | 'repoPath' | 'baseBranch'>,
+  lane: Pick<Lane, 'id' | 'packetId' | 'worktreePath' | 'repoPath' | 'baseBranch' | 'runtime'>,
   approval: ApprovalRecord,
   reviewedHeadSha: string,
 ): Promise<ContractCoverageResult | null> {
   if (!lane.packetId) return null;
 
-  let contractRequired = false;
   let contract: PacketTaskContract | null = null;
+  let enforceCoverage = false;
   try {
-    const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
-    const packet = readOrchestratorControlPlaneState().packets.find((entry: { id: string }) => entry.id === lane.packetId);
-    if (!packet) return null;
-    contractRequired = packet.taskContractRequired === true;
-    contract = packet.taskContract ?? null;
+    const gate = await resolvePacketTaskContractGate({ lane });
+    if (!gate.packetFound) return null;
+    contract = gate.taskContract;
+    enforceCoverage = gate.enforceCoverage;
   } catch (error) {
     // A packet binding exists but its contract requirement could not be read.
     // Treating that as legacy would let an unverifiable packet merge, so this
@@ -94,7 +94,7 @@ async function assessContractCoverage(
       missingRequirementIds: [],
     };
   }
-  if (!contractRequired) return null;
+  if (!enforceCoverage) return null;
 
   try {
     const { evaluateContractCoverage, readCoverageEvidence } =
@@ -183,7 +183,7 @@ async function listChangedPathsForCoverage(
 // Durable approved-review reader. This is the only signal that authorizes a
 // non-user merge or PR action to skip the operator approval card.
 export async function assessDurableApprovedReview(
-  lane: Pick<Lane, 'id' | 'packetId' | 'sessionKey' | 'worktreePath' | 'repoPath' | 'baseBranch'>,
+  lane: Pick<Lane, 'id' | 'packetId' | 'sessionKey' | 'worktreePath' | 'repoPath' | 'baseBranch' | 'runtime'>,
 ): Promise<DurableReviewAssessment> {
   try {
     const [{ listApprovalsForContext }, { normalizeHeadSha, readHeadSha }] = await Promise.all([
@@ -314,5 +314,10 @@ export async function supersedeDurableApprovedReviews(packetId: string, reason: 
 export async function hasDurableApprovedReview(
   lane: Pick<Lane, 'id' | 'packetId' | 'sessionKey' | 'worktreePath' | 'repoPath' | 'baseBranch'>,
 ): Promise<boolean> {
-  return (await assessDurableApprovedReview(lane)).approved;
+  const runtime = Reflect.get(lane, 'runtime') as Lane['runtime'] | undefined;
+  if (!runtime) return false;
+  return (await assessDurableApprovedReview({
+    ...lane,
+    runtime,
+  })).approved;
 }

--- a/src/lib/lane/task-contract-gate.ts
+++ b/src/lib/lane/task-contract-gate.ts
@@ -1,0 +1,59 @@
+import type { PacketTaskContract, PacketTaskContractSource } from '@/lib/orchestrator/types';
+import type { PacketDeviations } from '@/lib/orchestrator/packet-deviations';
+import type { Lane } from '@/lib/lane/types';
+
+const DEFAULT_CONTRACT_MISSING_REASON = 'The runtime-default task contract was not captured from the worker transcript.';
+
+export async function resolveTaskContractCoverageRequirement(input: {
+  laneId: string;
+  runtime: string;
+  contractRequired: boolean;
+  contractSource?: PacketTaskContractSource;
+  contract?: PacketTaskContract | null;
+}): Promise<boolean> {
+  if (!input.contractRequired) return false;
+  if (input.contractSource !== 'default' || input.contract) return true;
+
+  try {
+    const { appendEvent, getLaneEvents } = await import('@/lib/lane/registry');
+    const alreadyRecorded = getLaneEvents(input.laneId, 1_000)
+      .some((event) => event.verb === 'task_contract_missing');
+    if (!alreadyRecorded) {
+      appendEvent(input.laneId, 'task_contract_missing', 'system', {
+        runtime: input.runtime,
+        reason: DEFAULT_CONTRACT_MISSING_REASON,
+      });
+    }
+  } catch (error) {
+    console.warn(
+      `[task-contract] failed to record missing default contract for lane ${input.laneId}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  return false;
+}
+
+export async function resolvePacketTaskContractGate(input: {
+  lane: Pick<Lane, 'id' | 'packetId' | 'runtime'>;
+  completionContext?: { taskContract?: PacketTaskContract } | null;
+  deviations?: PacketDeviations | null;
+}): Promise<{ taskContract: PacketTaskContract | null; enforceCoverage: boolean; packetFound: boolean }> {
+  const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+  const packet = readOrchestratorControlPlaneState().packets
+    .find((candidate) => candidate.id === input.lane.packetId);
+  const taskContract = input.completionContext?.taskContract ?? packet?.taskContract ?? null;
+  const enforceCoverage = await resolveTaskContractCoverageRequirement({
+    laneId: input.lane.id,
+    runtime: packet?.runtime ?? input.lane.runtime,
+    contractRequired: packet?.taskContractRequired === true,
+    contractSource: packet?.taskContractSource,
+    contract: taskContract,
+  });
+  if (input.lane.packetId && 'deviations' in input) {
+    const { patchMissionPacket } = await import('@/lib/orchestrator/operator-mission-service/packet-patch');
+    await patchMissionPacket(input.lane.packetId, {
+      deviations: input.deviations ?? null,
+      taskContract,
+    });
+  }
+  return { taskContract, enforceCoverage, packetFound: Boolean(packet) };
+}

--- a/src/lib/lane/types.ts
+++ b/src/lib/lane/types.ts
@@ -393,6 +393,12 @@ export type LaneEventVerb =
   // A terminal status-only transition retained an ambiguously owned storage
   // reservation while preserving the packet association for a later retry.
   | 'storage_release_deferred'
+  // Pre-edit contract turn usage, recorded when the first valid contract is captured.
+  // Payload: { runtime, turns, inputTokens?, outputTokens?, durationMs }
+  | 'task_contract_cost'
+  // A runtime-default contract was not captured, so review preserved the legacy gate behavior.
+  // Payload: { runtime, reason }
+  | 'task_contract_missing'
   | 'review_turn_started'
   | 'review_turn_finished'
   | 'worker_quota_exhausted'

--- a/src/lib/mcp/operator-handlers/mission-task-contract.test.ts
+++ b/src/lib/mcp/operator-handlers/mission-task-contract.test.ts
@@ -1,0 +1,128 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { OrchestratorRuntime, PacketTaskContract } from '@/lib/orchestrator/types';
+
+const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-mission-contract-default-'));
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.O8_DATA_DIR = dataDir;
+
+const repoPath = mkdtempSync(join(os.tmpdir(), 'o8-mission-contract-repo-'));
+const git = (...args: string[]) => execFileSync('git', args, { cwd: repoPath, stdio: 'pipe' });
+git('init', '--initial-branch=main');
+git('-c', 'user.email=test@o8.test', '-c', 'user.name=o8-test', 'commit', '--allow-empty', '-m', 'init');
+
+const taskContract: PacketTaskContract = {
+  version: 1,
+  requirements: [{
+    id: 'R1',
+    source: 'Arm the contract explicitly.',
+    expectedBehavior: 'The packet carries the contract gate.',
+    productionPath: 'handleCreateMission -> createMission -> persisted packet',
+    verification: 'real handler test',
+  }],
+  smallestRoute: [{
+    path: 'src/lib/orchestrator/operator-mission-service/mission.ts',
+    requirements: ['R1'],
+    reason: 'Mission creation owns packet defaults.',
+  }],
+  exclusions: [],
+};
+
+const { handleCreateMission, MISSION_TOOLS } = await import('./mission');
+const { currentMissionState } = await import('@/lib/orchestrator/operator-mission-service/shared');
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+afterAll(async () => {
+  const { closeDb } = await import('@/lib/db');
+  closeDb();
+});
+
+function stubRealMissionService() {
+  vi.stubGlobal('fetch', vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>;
+    const { createMission } = await import('@/lib/orchestrator/operator-mission-service/mission');
+    const result = await createMission(body as unknown as Parameters<typeof createMission>[0]);
+    return Response.json({ ok: true, result }, { status: 201 });
+  }));
+}
+
+async function createPacket(input: {
+  runtime: OrchestratorRuntime;
+  taskContract?: 'off';
+  qualitySearch?: { taskContract: PacketTaskContract };
+}) {
+  stubRealMissionService();
+  const result = await handleCreateMission({
+    repoPath,
+    issues_inline: [{ title: `${input.runtime} contract ${Date.now()}` }],
+    runtime: input.runtime,
+    taskContract: input.taskContract,
+    qualitySearch: input.qualitySearch,
+    dispatch: false,
+  });
+  expect(result.isError).not.toBe(true);
+  const payload = JSON.parse(result.content.find((entry) => entry.type === 'text')?.text ?? '{}') as {
+    packets?: Array<{ id: string }>;
+  };
+  return currentMissionState().packets.find((packet) => packet.id === payload.packets?.[0]?.id);
+}
+
+describe('create_mission task contract default', () => {
+  it('keeps the MCP input schema strict-mode plain and exposes the string opt-out', () => {
+    const schema = MISSION_TOOLS.find((tool) => tool.name === 'create_mission')?.inputSchema;
+    expect(schema).toMatchObject({
+      type: 'object',
+      properties: {
+        taskContract: { type: 'string', enum: ['off'] },
+      },
+      required: ['repoPath'],
+    });
+    expect(schema).not.toHaveProperty('oneOf');
+    expect(schema).not.toHaveProperty('anyOf');
+    expect(schema).not.toHaveProperty('allOf');
+  });
+
+  it.each(['claude-code', 'codex'] as const)('arms %s through the real handler and persisted packet', async (runtime) => {
+    expect(await createPacket({ runtime })).toMatchObject({
+      taskContractRequired: true,
+      taskContractSource: 'default',
+    });
+  });
+
+  it('leaves other runtimes disabled by default', async () => {
+    expect(await createPacket({ runtime: 'gemini' })).toMatchObject({
+      taskContractRequired: false,
+      taskContractSource: 'default',
+    });
+  });
+
+  it('lets the mission opt-out override the claude-code default', async () => {
+    expect(await createPacket({ runtime: 'claude-code', taskContract: 'off' })).toMatchObject({
+      taskContractRequired: false,
+      taskContractSource: 'default',
+    });
+  });
+
+  it('rejects quality search combined with the mission opt-out', async () => {
+    stubRealMissionService();
+    const result = await handleCreateMission({
+      repoPath,
+      issues_inline: [{ title: `contradictory contract ${Date.now()}` }],
+      runtime: 'codex',
+      taskContract: 'off',
+      qualitySearch: { taskContract },
+      dispatch: false,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content.find((entry) => entry.type === 'text')?.text)
+      .toContain('qualitySearch already uses a sealed contract and cannot be combined with taskContract: "off".');
+  });
+});

--- a/src/lib/mcp/operator-handlers/mission.ts
+++ b/src/lib/mcp/operator-handlers/mission.ts
@@ -43,10 +43,9 @@ import {
   textResult,
 } from './shared';
 import type { WorkerIntent } from '@/lib/orchestrator/types';
-import { parseMissionCandidateMode, QUALITY_SEARCH_INPUT_SCHEMA } from './quality-search-input';
+import { parseMissionCandidateMode, parseTaskContractSetting, QUALITY_SEARCH_INPUT_SCHEMA, TASK_CONTRACT_SETTING_SCHEMA } from './quality-search-input';
 import { MISSION_WORKER_PIN_PROPERTIES, parseMissionWorkerPinInput, parseWorkerProvider, WORKER_PROVIDER_OPTIONS } from './mission-worker-input';
 import { CONTRACT_COVERAGE_EVIDENCE_SCHEMA, parseContractCoverageEvidenceInput } from './review-coverage-input';
-
 export const MISSION_TOOLS: McpTool[] = [
   {
     name: 'create_mission',
@@ -117,6 +116,7 @@ export const MISSION_TOOLS: McpTool[] = [
           type: 'boolean',
           description: 'Huddle mode — a bidirectional alignment turn. When true, each worker reads the repo then posts its plan + any pushback (`o8 packet report --event huddle`) and STOPS before editing; you review it (the packet flips to awaiting_orchestrator) and steer it (steer_packet) to align before it implements. Arm it ONLY on packets worth aligning on first — ambiguous scope, risky/cross-cutting, or novel work. Omit (default off) for clear, well-specced packets so they don\'t pay the extra round-trip.',
         },
+        taskContract: TASK_CONTRACT_SETTING_SCHEMA,
         readOnly: { type: 'boolean', description: 'When true, the worker inspects and reports without editing. A clean zero-diff exit is recorded as a successful read-only completion.' },
         comparisonModels: {
           type: 'array',
@@ -834,7 +834,7 @@ export async function handleCreateMission(args: Record<string, unknown>): Promis
         sequential,
         existingBranchPolicy,
         useBrain,
-        huddle,
+        huddle, taskContract: parseTaskContractSetting(args.taskContract),
         comparisonModels,
         qualitySearch,
         orchestratorThreadId, parentWorkspaceId, caller, readOnly,
@@ -869,7 +869,7 @@ export async function handleCreateMission(args: Record<string, unknown>): Promis
       sequential,
       existingBranchPolicy,
       useBrain,
-      huddle,
+      huddle, taskContract: parseTaskContractSetting(args.taskContract),
       comparisonModels,
       qualitySearch,
       orchestratorThreadId, parentWorkspaceId, caller, readOnly,

--- a/src/lib/mcp/operator-handlers/quality-search-input.test.ts
+++ b/src/lib/mcp/operator-handlers/quality-search-input.test.ts
@@ -38,5 +38,12 @@ describe('mission candidate-mode input', () => {
       ok: false,
       error: 'qualitySearch already uses a sealed contract and cannot be combined with huddle mode.',
     });
+    expect(parseMissionCandidateMode({
+      qualitySearch: { taskContract },
+      taskContract: 'off',
+    }, false)).toEqual({
+      ok: false,
+      error: 'qualitySearch already uses a sealed contract and cannot be combined with taskContract: "off".',
+    });
   });
 });

--- a/src/lib/mcp/operator-handlers/quality-search-input.ts
+++ b/src/lib/mcp/operator-handlers/quality-search-input.ts
@@ -1,6 +1,18 @@
 import { normalizePacketTaskContract } from '@/lib/orchestrator/packet-task-contract';
 import type { PacketTaskContract } from '@/lib/orchestrator/types';
 
+export const TASK_CONTRACT_SETTING_SCHEMA = {
+  type: 'string',
+  enum: ['off'],
+  description: 'Mission-level opt-out for the pre-edit task contract. "off" wins over runtime defaults and cannot be combined with quality search.',
+} as const;
+
+export function parseTaskContractSetting(value: unknown): 'off' | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (value !== 'off') throw new Error('taskContract must be "off" when provided.');
+  return value;
+}
+
 export const QUALITY_SEARCH_INPUT_SCHEMA = {
   type: 'object',
   description: 'Bounded quality search for one task. Two isolated candidates receive different implementation roles from one sealed contract; o8 filters by review and merge evidence before using blast radius as a tie-breaker. Cannot be combined with huddle or comparisonModels.',
@@ -71,6 +83,9 @@ export function parseMissionCandidateMode(args: Record<string, unknown>, huddle:
   }
   if (taskContract && huddle) {
     return { ok: false, error: 'qualitySearch already uses a sealed contract and cannot be combined with huddle mode.' };
+  }
+  if (taskContract && args.taskContract === 'off') {
+    return { ok: false, error: 'qualitySearch already uses a sealed contract and cannot be combined with taskContract: "off".' };
   }
   return {
     ok: true,

--- a/src/lib/mcp/operator-mission-tools.ts
+++ b/src/lib/mcp/operator-mission-tools.ts
@@ -115,6 +115,7 @@ interface CreateMissionInput {
   existingBranchPolicy?: ExistingBranchPolicy;
   useBrain?: boolean;
   huddle?: boolean;
+  taskContract?: 'off';
   /** Best-of-N (item 3) — forwarded to the create-mission API, clamped ≤4 there. */
   comparisonModels?: string[];
   qualitySearch?: { taskContract: PacketTaskContract };
@@ -145,6 +146,7 @@ interface CreateMissionInlineInput {
   existingBranchPolicy?: ExistingBranchPolicy;
   useBrain?: boolean;
   huddle?: boolean;
+  taskContract?: 'off';
   /** Best-of-N (item 3) — forwarded to the create-mission API, clamped ≤4 there. */
   comparisonModels?: string[];
   qualitySearch?: { taskContract: PacketTaskContract };
@@ -404,6 +406,7 @@ export async function createMission(input: CreateMissionInput) {
           existingBranchPolicy: input.existingBranchPolicy,
           useBrain: input.useBrain,
           huddle: input.huddle,
+          taskContract: input.taskContract,
           comparisonModels: input.comparisonModels,
           qualitySearch: input.qualitySearch,
           orchestratorThreadId: input.orchestratorThreadId,
@@ -450,6 +453,7 @@ export async function createMissionInline(input: CreateMissionInlineInput) {
           existingBranchPolicy: input.existingBranchPolicy,
           useBrain: input.useBrain,
           huddle: input.huddle,
+          taskContract: input.taskContract,
           comparisonModels: input.comparisonModels,
           qualitySearch: input.qualitySearch,
           orchestratorThreadId: input.orchestratorThreadId,

--- a/src/lib/orchestrator/context-relay.ts
+++ b/src/lib/orchestrator/context-relay.ts
@@ -15,9 +15,12 @@ import {
   stripPacketSelfReview,
 } from '@/lib/orchestrator/self-review';
 import {
-  parsePacketTaskContract,
   stripPacketTaskContract,
 } from '@/lib/orchestrator/packet-task-contract';
+import {
+  findFirstTaskContractCapture,
+  recordTaskContractCostEvent,
+} from '@/lib/orchestrator/task-contract-cost';
 import type { OrchestratorRuntime, PacketContext } from '@/lib/orchestrator/types';
 import {
   isDispatchableRuntime,
@@ -168,19 +171,6 @@ function findLatestSelfReview(entries: RuntimeTranscriptEntry[]): PacketContext[
   }
 
   return buildMissingPacketSelfReview();
-}
-
-function findFirstTaskContract(entries: RuntimeTranscriptEntry[]): PacketContext['taskContract'] {
-  for (const entry of entries) {
-    if (entry.role !== 'assistant' || !entry.text.trim()) {
-      continue;
-    }
-    const taskContract = parsePacketTaskContract(entry.text);
-    if (taskContract) {
-      return taskContract;
-    }
-  }
-  return undefined;
 }
 
 function buildChangedFileList(entries: RuntimeTranscriptEntry[], runtimeChangedFiles: Array<{ path: string }>): string[] {
@@ -452,7 +442,8 @@ export async function capturePacketCompletionContext(packetId: string, sessionKe
   const telemetry = telemetryResult.status === 'fulfilled' ? telemetryResult.value : undefined;
   const lastAssistantEntry = findLastAssistantEntry(transcript);
   const selfReview = findLatestSelfReview(transcript);
-  const taskContract = findFirstTaskContract(transcript);
+  const taskContractCapture = findFirstTaskContractCapture(transcript);
+  const taskContract = taskContractCapture?.contract;
   const matchingApprovals = listApprovalsForContext({
     packetId: normalizedPacketId,
     laneId: lane?.id ?? undefined,
@@ -495,6 +486,13 @@ export async function capturePacketCompletionContext(packetId: string, sessionKe
   };
 
   packetCompletionContextStore.set(normalizedPacketId, context);
+  recordTaskContractCostEvent({
+    lane,
+    runtime: runtimeId,
+    transcript,
+    capture: taskContractCapture,
+    telemetry,
+  });
 
   // #984 Stage 1 — index the transcript once, at packet completion. Cmd+K
   // reads this durable FTS document and never scans runtime files per keystroke.

--- a/src/lib/orchestrator/normalize/decomposition.ts
+++ b/src/lib/orchestrator/normalize/decomposition.ts
@@ -25,11 +25,16 @@ export function normalizePacketLaunchContext(value: unknown): OrchestratorPacket
 }
 
 export function normalizePacketTaskContractFields(
-  packet: Pick<Partial<OrchestratorPacket>, 'taskContract' | 'taskContractRequired'>,
-): Pick<OrchestratorPacket, 'taskContract' | 'taskContractRequired'> {
+  packet: Pick<Partial<OrchestratorPacket>, 'taskContract' | 'taskContractRequired' | 'taskContractSource'>,
+): Pick<OrchestratorPacket, 'taskContract' | 'taskContractRequired' | 'taskContractSource'> {
   return {
     taskContract: normalizePacketTaskContract(packet.taskContract),
-    taskContractRequired: packet.taskContractRequired === true ? true : undefined,
+    taskContractRequired: typeof packet.taskContractRequired === 'boolean'
+      ? packet.taskContractRequired
+      : undefined,
+    taskContractSource: packet.taskContractSource === 'explicit' || packet.taskContractSource === 'default'
+      ? packet.taskContractSource
+      : undefined,
   };
 }
 

--- a/src/lib/orchestrator/operator-mission-service/create-mission-session-rules.test.ts
+++ b/src/lib/orchestrator/operator-mission-service/create-mission-session-rules.test.ts
@@ -61,19 +61,14 @@ describe('createMission stamps orchestratorThreadId onto persisted packets', () 
       caller: 'test orchestrator',
       parentThreadId: 'thoughts-e2e',
     });
-    // Contract-first is opt-in. An ordinary packet must NOT be armed: the
-    // coverage gate is mandatory once this is true, while contract capture is
-    // best-effort, so arming it here would make any packet whose contract failed
-    // to parse unmergeable through the governed path.
-    expect(packet!.taskContractRequired).toBeUndefined();
+    expect(packet!.taskContractRequired).toBe(true);
+    expect(packet!.taskContractSource).toBe('default');
 
     // And the worker prompt built from that persisted packet inherits the rules.
     const prompt = await buildPacketPrompt(packet!, persisted.packets);
     expect(prompt).toContain('<Operator session rules (binding)>');
     expect(prompt).toContain('- never bypass the review gate');
-    // An unarmed packet gets no contract instructions, so its worker is never
-    // asked for a contract the coverage gate would then demand evidence against.
-    expect(prompt).not.toContain('Pre-edit task contract:');
+    expect(prompt).toContain('Pre-edit task contract:');
   });
 
   it('omits the field when the input carries no thread id', async () => {
@@ -118,8 +113,9 @@ describe('createMission stamps orchestratorThreadId onto persisted packets', () 
     const packet = persisted.packets.find((candidate) => candidate.id === result.packets[0]!.id);
 
     expect(packet?.taskContract).toEqual(taskContract);
-    // The quality-search path is the one that arms the gate.
+    // Quality search remains explicitly armed with its sealed contract.
     expect(packet?.taskContractRequired).toBe(true);
+    expect(packet?.taskContractSource).toBe('explicit');
     expect(packet?.qualitySearch).toEqual({
       version: 1,
       role: null,
@@ -134,5 +130,14 @@ describe('createMission stamps orchestratorThreadId onto persisted packets', () 
       constraints: '',
       qualitySearch: { taskContract },
     })).rejects.toThrow('not supported by the selected worker runtime');
+
+    await expect(createMission({
+      issues: [{ number: 90005, title: 'inline: contradictory search', body: 'do the thing', url: '' }],
+      repoPath,
+      runtime: 'codex',
+      constraints: '',
+      taskContract: 'off',
+      qualitySearch: { taskContract },
+    })).rejects.toThrow('Quality search already uses a sealed contract and cannot be combined with taskContract: "off".');
   });
 });

--- a/src/lib/orchestrator/operator-mission-service/mission.ts
+++ b/src/lib/orchestrator/operator-mission-service/mission.ts
@@ -22,6 +22,7 @@ import {
 } from '@/lib/orchestrator/packet-transcript';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 import { bindWorkerLaunchParent } from '@/lib/orchestrator/worker-launch-context';
+import { assertQualitySearchMissionCompatibility, resolveTaskContractRequired } from '@/lib/orchestrator/task-contract-required';
 import { withMissionHandoffBarrier } from '@/lib/orchestrator/lifecycle-mutation-lock';
 import { releaseAbandonedMissionLifecycleHold } from '@/lib/orchestrator/mission-lifecycle-hold';
 import { getTopRulesForPacket, readRepoScopedRules } from '@/lib/dispatch/rules-store';
@@ -98,15 +99,7 @@ export async function createMission(input: CreateMissionInput) {
   if (!Array.isArray(input.issues) || input.issues.length === 0) {
     throw new Error('At least one loaded issue is required.');
   }
-  if (input.qualitySearch && input.issues.length !== 1) {
-    throw new Error('Quality search requires exactly one task per mission.');
-  }
-  if (input.qualitySearch && input.comparisonModels?.length) {
-    throw new Error('Quality search cannot be combined with a separate comparison fan-out.');
-  }
-  if (input.qualitySearch && input.huddle) {
-    throw new Error('Quality search already uses a sealed contract and cannot be combined with huddle mode.');
-  }
+  assertQualitySearchMissionCompatibility(input);
   const qualitySearchRuntime = input.issues[0]?.runtime ?? input.runtime;
   if (input.qualitySearch && qualitySearchRuntime !== 'codex' && qualitySearchRuntime !== 'claude-code') {
     throw new Error('Quality search is not supported by the selected worker runtime yet.');
@@ -245,14 +238,14 @@ export async function createMission(input: CreateMissionInput) {
       ...(issueMeta ? { issue: issueMeta } : {}),
       ...(typeof input.useBrain === 'boolean' ? { useBrain: input.useBrain } : {}),
       ...(typeof input.huddle === 'boolean' ? { huddle: input.huddle } : {}),
-      // Contract-first is opt-in, not ambient. `taskContractRequired` makes the
-      // coverage gate mandatory, and contract capture from the worker transcript
-      // is best-effort — so arming it universally would make any packet whose
-      // contract failed to parse unmergeable through the governed path. Ordinary
-      // dispatch keeps its prior behavior until the capture path has a record.
+      taskContractRequired: resolveTaskContractRequired({
+        runtime: packetRouting.selectedRuntime,
+        missionOptOut: input.taskContract === 'off',
+        explicit: Boolean(input.qualitySearch),
+      }),
+      taskContractSource: input.qualitySearch ? 'explicit' : 'default',
       ...(input.qualitySearch
         ? {
-            taskContractRequired: true,
             taskContract: input.qualitySearch.taskContract,
             qualitySearch: { version: 1 as const, role: null, repairAttempts: 0 },
           }

--- a/src/lib/orchestrator/operator-mission-service/types.ts
+++ b/src/lib/orchestrator/operator-mission-service/types.ts
@@ -72,6 +72,8 @@ export interface CreateMissionInput {
    * before editing. Armed per-mission; omit (default off) for clear packets.
    */
   huddle?: boolean;
+  /** Disable the pre-edit task contract for every packet in this mission. */
+  taskContract?: 'off';
   /**
    * Best-of-N — stamps the seed packet's
    * `comparisonModels` so the scheduler fans it into N sibling candidates (one

--- a/src/lib/orchestrator/task-contract-cost.test.ts
+++ b/src/lib/orchestrator/task-contract-cost.test.ts
@@ -1,0 +1,137 @@
+import { mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import type { AgentRuntime, RuntimeTranscriptEntry } from '@/lib/runtimes/types';
+
+process.env.CORTEX_IDE_DATA_DIR = mkdtempSync(join(os.tmpdir(), 'o8-contract-cost-'));
+
+vi.mock('@/lib/approvals/store', () => ({
+  listApprovalsForContext: () => [],
+}));
+
+vi.mock('@/lib/runtime/inventory', () => ({
+  getRuntimeInventorySnapshot: async () => ({ agents: [] }),
+}));
+
+vi.mock('@/lib/repos/projects', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/repos/projects')>(),
+  getActiveProjectScopeForRepoSync: () => ({ projectId: null }),
+}));
+
+vi.mock('@/lib/search/transcripts', () => ({
+  syncTranscriptSearchDocument: () => undefined,
+}));
+
+const packetId = 'pkt-contract-cost';
+const contract = {
+  version: 1 as const,
+  requirements: [{
+    id: 'R1',
+    source: 'Record contract cost.',
+    expectedBehavior: 'One durable cost event is recorded.',
+    productionPath: 'capturePacketCompletionContext -> lane event',
+    verification: 'persisted lane event test',
+  }],
+  smallestRoute: [{
+    path: 'src/lib/orchestrator/task-contract-cost.ts',
+    requirements: ['R1'],
+    reason: 'The completion capture owns this receipt.',
+  }],
+  exclusions: [],
+};
+
+const transcript: RuntimeTranscriptEntry[] = [{
+  id: 'user-1',
+  role: 'user',
+  text: 'Prepare the task contract.',
+  timestamp: new Date('2026-08-27T12:00:00.000Z'),
+}, {
+  id: 'assistant-1',
+  role: 'assistant',
+  text: `<task-contract>${JSON.stringify(contract)}</task-contract>`,
+  timestamp: new Date('2026-08-27T12:00:01.250Z'),
+}];
+
+let laneId = '';
+
+describe('task contract cost event', () => {
+  beforeAll(async () => {
+    const runtime: AgentRuntime = {
+      id: 'codex',
+      displayName: 'Codex contract cost test',
+      capabilities: {
+        discover: false,
+        readTranscript: true,
+        launch: false,
+        resume: false,
+        interrupt: false,
+        reviewDiffs: true,
+        costTelemetry: true,
+        streaming: false,
+      },
+      discoverSessions: async () => [],
+      readTranscript: async () => transcript,
+      launch: async () => ({ ok: false, note: 'not supported' }),
+      resume: async () => ({ ok: false, note: 'not supported' }),
+      interrupt: async () => ({ ok: false, note: 'not supported' }),
+      getChangedFiles: async () => [],
+      getTelemetry: async () => ({ inputTokens: 120, outputTokens: 30 }),
+    };
+    const { registerRuntime } = await import('@/lib/runtimes/registry');
+    registerRuntime(runtime);
+
+    const { createLane } = await import('@/lib/lane/registry');
+    const lane = createLane({
+      repoPath: '/tmp/o8-contract-cost-repo',
+      branch: 'test/contract-cost',
+      runtime: 'codex',
+      packetId,
+      sessionKey: 'codex:contract-cost',
+    });
+    laneId = lane.id;
+
+    const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+    const { writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+    const packet = {
+      id: packetId,
+      referenceLabel: 'P1',
+      title: 'Measure task contract cost',
+      summary: 'Record a persisted cost receipt.',
+      branchTarget: lane.branch,
+      workspaceTargetPath: lane.repoPath,
+      runtime: 'codex',
+      dependencyLabels: [],
+      dependencyPacketIds: [],
+      queueState: 'queued',
+      releaseState: 'pending',
+      status: 'running',
+      taskContractRequired: true,
+    } as unknown as OrchestratorPacket;
+    writeOrchestratorControlPlaneState({
+      ...createEmptyOrchestratorMissionState(),
+      missionId: 'mission-contract-cost',
+      repoPath: lane.repoPath,
+      packets: [packet],
+    });
+  });
+
+  it('records one persisted cost event when the contract turn completes', async () => {
+    const { capturePacketCompletionContext } = await import('./context-relay');
+    await capturePacketCompletionContext(packetId, 'codex:contract-cost');
+    await capturePacketCompletionContext(packetId, 'codex:contract-cost');
+
+    const { getLaneEvents } = await import('@/lib/lane/registry');
+    const events = getLaneEvents(laneId, 100).filter((event) => event.verb === 'task_contract_cost');
+    expect(events).toHaveLength(1);
+    expect(events[0]?.payload).toEqual({
+      runtime: 'codex',
+      turns: 1,
+      inputTokens: 120,
+      outputTokens: 30,
+      durationMs: 1250,
+    });
+  });
+});

--- a/src/lib/orchestrator/task-contract-cost.ts
+++ b/src/lib/orchestrator/task-contract-cost.ts
@@ -1,0 +1,79 @@
+import { recordLaneEvent } from '@/lib/lane/events';
+import { getLaneEvents } from '@/lib/lane/registry';
+import type { Lane } from '@/lib/lane/types';
+import { parsePacketTaskContract } from '@/lib/orchestrator/packet-task-contract';
+import type { PacketTaskContract } from '@/lib/orchestrator/types';
+import type { RuntimeId, RuntimeTelemetry, RuntimeTranscriptEntry } from '@/lib/runtimes/types';
+
+export interface PacketTaskContractCapture {
+  contract: PacketTaskContract;
+  entryIndex: number;
+}
+
+export function findFirstTaskContractCapture(
+  entries: RuntimeTranscriptEntry[],
+): PacketTaskContractCapture | null {
+  for (let entryIndex = 0; entryIndex < entries.length; entryIndex += 1) {
+    const entry = entries[entryIndex];
+    if (entry?.role !== 'assistant' || !entry.text.trim()) continue;
+    const contract = parsePacketTaskContract(entry.text);
+    if (contract) return { contract, entryIndex };
+  }
+  return null;
+}
+
+function eventDurationMs(entries: RuntimeTranscriptEntry[], entryIndex: number): number {
+  const contractAt = entries[entryIndex]?.timestamp.getTime() ?? Number.NaN;
+  const turnStart = entries
+    .slice(0, entryIndex + 1)
+    .findLast((entry) => entry.role === 'user')
+    ?? entries[0];
+  const startedAt = turnStart?.timestamp.getTime() ?? Number.NaN;
+  return Number.isFinite(contractAt) && Number.isFinite(startedAt)
+    ? Math.max(0, Math.round(contractAt - startedAt))
+    : 0;
+}
+
+function attributableTelemetry(
+  entries: RuntimeTranscriptEntry[],
+  capture: PacketTaskContractCapture,
+  telemetry?: RuntimeTelemetry,
+): Pick<RuntimeTelemetry, 'inputTokens' | 'outputTokens'> {
+  const assistantTurns = entries
+    .slice(0, capture.entryIndex + 1)
+    .filter((entry) => entry.role === 'assistant' && entry.text.trim()).length;
+  const hasLaterContent = entries
+    .slice(capture.entryIndex + 1)
+    .some((entry) => entry.text.trim() || entry.toolCalls?.length);
+  if (assistantTurns !== 1 || hasLaterContent) return {};
+
+  return {
+    ...(typeof telemetry?.inputTokens === 'number' && Number.isFinite(telemetry.inputTokens)
+      ? { inputTokens: telemetry.inputTokens }
+      : {}),
+    ...(typeof telemetry?.outputTokens === 'number' && Number.isFinite(telemetry.outputTokens)
+      ? { outputTokens: telemetry.outputTokens }
+      : {}),
+  };
+}
+
+export function recordTaskContractCostEvent(input: {
+  lane: Lane | null;
+  runtime: RuntimeId | null;
+  transcript: RuntimeTranscriptEntry[];
+  capture: PacketTaskContractCapture | null;
+  telemetry?: RuntimeTelemetry;
+}): void {
+  if (!input.lane || !input.capture) return;
+  if (getLaneEvents(input.lane.id, 10_000).some((event) => event.verb === 'task_contract_cost')) return;
+
+  const turns = input.transcript
+    .slice(0, input.capture.entryIndex + 1)
+    .filter((entry) => entry.role === 'assistant' && entry.text.trim()).length;
+  recordLaneEvent(input.lane.id, 'task_contract_cost', 'system', {
+    runtime: input.runtime ?? input.lane.runtime,
+    turns: Math.max(1, turns),
+    ...attributableTelemetry(input.transcript, input.capture, input.telemetry),
+    durationMs: eventDurationMs(input.transcript, input.capture.entryIndex),
+  });
+}

--- a/src/lib/orchestrator/task-contract-required.ts
+++ b/src/lib/orchestrator/task-contract-required.ts
@@ -1,0 +1,30 @@
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+import type { CreateMissionInput } from '@/lib/orchestrator/operator-mission-service/types';
+
+export function assertQualitySearchMissionCompatibility(
+  input: Pick<CreateMissionInput, 'issues' | 'qualitySearch' | 'comparisonModels' | 'huddle' | 'taskContract'>,
+): void {
+  if (!input.qualitySearch) return;
+  if (input.issues.length !== 1) {
+    throw new Error('Quality search requires exactly one task per mission.');
+  }
+  if (input.comparisonModels?.length) {
+    throw new Error('Quality search cannot be combined with a separate comparison fan-out.');
+  }
+  if (input.huddle) {
+    throw new Error('Quality search already uses a sealed contract and cannot be combined with huddle mode.');
+  }
+  if (input.taskContract === 'off') {
+    throw new Error('Quality search already uses a sealed contract and cannot be combined with taskContract: "off".');
+  }
+}
+
+export function resolveTaskContractRequired(input: {
+  runtime: OrchestratorRuntime;
+  missionOptOut?: boolean;
+  explicit?: boolean;
+}): boolean {
+  if (input.explicit === true) return true;
+  if (input.missionOptOut === true) return false;
+  return input.runtime === 'claude-code' || input.runtime === 'codex';
+}

--- a/src/lib/orchestrator/types.ts
+++ b/src/lib/orchestrator/types.ts
@@ -221,6 +221,8 @@ export interface PacketTaskContract {
   exclusions: string[];
 }
 
+export type PacketTaskContractSource = 'explicit' | 'default';
+
 export interface OrchestratorPacketStorageAdmission {
   schema: 'o8/packet-storage-admission/v1';
   state: 'reserved' | 'committed' | 'held' | 'released' | 'quarantined';
@@ -475,12 +477,13 @@ export interface OrchestratorPacket {
    * claimed smallest route were never made auditable.
    */
   taskContract?: PacketTaskContract | null;
-  /**
-   * True for packets created after the contract-first quality pipeline was
-   * enabled. Legacy/in-flight packets omit it so review does not retroactively
-   * fail work dispatched before the worker received contract instructions.
-   */
+  /** Explicit contract gate for newly created packets. Legacy/in-flight packets
+   * omit it so review does not retroactively fail work dispatched before the
+   * worker received contract instructions. */
   taskContractRequired?: boolean;
+  /** Why the contract gate was armed. Default-armed packets can fail soft when
+   * transcript capture never produced a contract; explicit packets remain hard. */
+  taskContractSource?: PacketTaskContractSource;
   /** Recurring-problem provenance. Execution still belongs to the normal task packet. */
   problemDossierId?: string | null;
   /** One dossier can reopen; each accepted remedy attempt gets a stable id. */

--- a/src/lib/tasks/actions.ts
+++ b/src/lib/tasks/actions.ts
@@ -31,6 +31,7 @@ import type {
 } from '@/lib/orchestrator/types';
 import { buildProjectTaskBrief, getProjectContext } from '@/lib/projects/context';
 import { buildProjectBriefPromptV1 } from '@/lib/prompts/v1';
+import { resolveTaskContractRequired } from '@/lib/orchestrator/task-contract-required';
 import { assertRuntimeDispatchable, DispatchPreflightError } from '@/lib/runtimes/shared/auth-detect';
 import { getTaskPoolTask, type TaskPoolTask } from './pool';
 
@@ -384,7 +385,11 @@ export async function createTask(input: TaskCreateInput): Promise<TaskMutationRe
         body: input.sourceIssue.body ?? summary,
         url: input.sourceIssue.url ?? undefined,
       } : null,
-      taskContractRequired: true,
+      taskContractRequired: resolveTaskContractRequired({
+        runtime: workerRouting.selectedRuntime,
+        explicit: true,
+      }),
+      taskContractSource: 'explicit',
       problemDossierId: input.problemDossierId ?? null,
       problemRemedyId: input.problemRemedyId ?? null,
       prompt: buildProjectBriefPromptV1(taskBrief, summary),

--- a/tests/contract-coverage-real-path.test.ts
+++ b/tests/contract-coverage-real-path.test.ts
@@ -15,13 +15,21 @@ import path from 'node:path';
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import type { PacketTaskContract } from '@/lib/orchestrator/types';
+import type { OrchestratorPacket, PacketTaskContract, PacketTaskContractSource } from '@/lib/orchestrator/types';
 
 const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'o8-coverage-realpath-'));
 process.env.CORTEX_IDE_DATA_DIR = dataDir;
 process.env.O8_DATA_DIR = dataDir;
 
 const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'o8-coverage-repo-'));
+const reviewRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'o8-coverage-review-repo-'));
+
+const { recordOrchestratorReview } = await import('@/lib/approvals/store');
+const { assessDurableApprovedReview } = await import('@/lib/lane/durable-review-approval');
+const { createLane, getLaneEvents } = await import('@/lib/lane/registry');
+const { readOrchestratorControlPlaneState, writeOrchestratorControlPlaneState } =
+  await import('@/lib/orchestrator/control-plane');
+const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
 
 function git(args: string[], cwd = repo): string {
   return execFileSync('git', args, { cwd, encoding: 'utf-8' }).trim();
@@ -50,6 +58,7 @@ const contract: PacketTaskContract = {
 };
 
 let headSha = '';
+let reviewHeadSha = '';
 
 beforeAll(() => {
   git(['init', '-q', '--initial-branch=main']);
@@ -69,12 +78,106 @@ beforeAll(() => {
   git(['add', '-A']);
   git(['commit', '-q', '-m', 'second packet commit']);
   headSha = git(['rev-parse', 'HEAD']);
+
+  git(['init', '-q', '--initial-branch=main'], reviewRepo);
+  git(['config', 'user.email', 'review@example.invalid'], reviewRepo);
+  git(['config', 'user.name', 'review'], reviewRepo);
+  fs.writeFileSync(path.join(reviewRepo, 'file.txt'), 'base\n');
+  git(['add', '-A'], reviewRepo);
+  git(['commit', '-q', '-m', 'base'], reviewRepo);
+  git(['checkout', '-q', '-b', 'inline/contract-review'], reviewRepo);
+  fs.writeFileSync(path.join(reviewRepo, 'file.txt'), 'base\npacket change\n');
+  git(['add', '-A'], reviewRepo);
+  git(['commit', '-q', '-m', 'packet change'], reviewRepo);
+  reviewHeadSha = git(['rev-parse', 'HEAD'], reviewRepo);
 });
 
 afterAll(() => {
   fs.rmSync(repo, { recursive: true, force: true });
+  fs.rmSync(reviewRepo, { recursive: true, force: true });
   fs.rmSync(dataDir, { recursive: true, force: true });
 });
+
+const capturedContract: PacketTaskContract = {
+  version: 1,
+  requirements: [{
+    id: 'R1',
+    source: 'Enforce a captured default contract.',
+    expectedBehavior: 'The durable approval path requires coverage evidence.',
+    productionPath: 'file.txt',
+    verification: 'real durable approval test',
+  }],
+  smallestRoute: [{
+    path: 'file.txt',
+    requirements: ['R1'],
+    reason: 'The packet changes one file.',
+  }],
+  exclusions: [],
+};
+
+async function assessPersistedContractPacket(input: {
+  source: PacketTaskContractSource;
+  taskContract?: PacketTaskContract;
+}) {
+  const packetId = `pkt-contract-review-${input.source}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const lane = createLane({
+    repoPath: reviewRepo,
+    worktreePath: reviewRepo,
+    branch: 'inline/contract-review',
+    baseBranch: 'main',
+    runtime: 'codex',
+    packetId,
+    sessionKey: `codex:${packetId}`,
+  });
+  const packet: OrchestratorPacket = {
+    id: packetId,
+    referenceLabel: 'P1',
+    title: 'Contract review',
+    summary: 'Contract review',
+    workspaceTargetPath: reviewRepo,
+    branchTarget: 'inline/contract-review',
+    runtime: 'codex',
+    dependencyLabels: [],
+    dependencyPacketIds: [],
+    queueState: 'queued',
+    releaseState: 'pending',
+    status: 'awaiting_review',
+    blockedReason: null,
+    lastEventAt: null,
+    lastEventLabel: null,
+    archivedAt: null,
+    review: null,
+    lane: null,
+    taskContractRequired: true,
+    taskContractSource: input.source,
+    taskContract: input.taskContract ?? null,
+  };
+  writeOrchestratorControlPlaneState({
+    ...createEmptyOrchestratorMissionState(),
+    missionId: `mission-${packetId}`,
+    prompt: 'Contract review',
+    summary: 'Contract review',
+    repoPath: reviewRepo,
+    packets: [packet],
+  });
+  expect(readOrchestratorControlPlaneState().packets[0]).toMatchObject({
+    id: packetId,
+    taskContractRequired: true,
+    taskContractSource: input.source,
+  });
+  recordOrchestratorReview(packetId, {
+    approved: true,
+    findings: [],
+    reviewer: 'codex',
+    reviewedHeadSha: reviewHeadSha,
+    requiresSecondPass: false,
+  });
+
+  return {
+    lane,
+    assessment: await assessDurableApprovedReview(lane),
+  };
+}
 
 describe('durable approval enforces contract coverage on the real path', () => {
   it('rejects an approved review that carries no coverage evidence', async () => {
@@ -178,23 +281,19 @@ describe('durable approval enforces contract coverage on the real path', () => {
   });
 });
 
-describe('contract-first is opt-in, so ordinary dispatch cannot be blocked by it', () => {
-  it('leaves an ordinary packet legacy, and arms only the quality-search path', async () => {
+describe('legacy packets remain outside the contract gate', () => {
+  it('leaves an unstamped packet legacy while enforcing an explicitly armed packet', async () => {
     const { evaluateContractCoverage } = await import('@/lib/orchestrator/task-contract-coverage');
 
-    // An ordinary packet: no quality-search, so no contract requirement. If this
-    // ever flips to `true` without a contract, every normal dispatch becomes
-    // unmergeable through the durable-approval path.
-    const ordinary = evaluateContractCoverage({
+    const legacy = evaluateContractCoverage({
       contract: null,
       contractRequired: undefined,
       evidence: null,
       reviewedHeadSha: headSha,
       changedPaths: ['src/publish.ts'],
     });
-    expect(ordinary.status).toBe('not-applicable');
+    expect(legacy.status).toBe('not-applicable');
 
-    // The quality-search path arms the gate and is judged strictly.
     const armed = evaluateContractCoverage({
       contract,
       contractRequired: true,
@@ -203,5 +302,43 @@ describe('contract-first is opt-in, so ordinary dispatch cannot be blocked by it
       changedPaths: ['src/publish.ts'],
     });
     expect(armed.status).toBe('failed');
+  });
+});
+
+describe('default-armed contract capture fails soft on the durable approval path', () => {
+  it('lets a default-armed packet without a captured contract proceed and records the missing event', async () => {
+    const { lane, assessment } = await assessPersistedContractPacket({ source: 'default' });
+
+    expect(assessment).toMatchObject({ approved: true, contractCoverage: null });
+    const missingEvents = getLaneEvents(lane.id)
+      .filter((event) => event.verb === 'task_contract_missing');
+    expect(missingEvents).toHaveLength(1);
+    expect(missingEvents[0]?.payload).toMatchObject({
+      runtime: 'codex',
+      reason: expect.any(String),
+    });
+  });
+
+  it('enforces coverage for a default-armed packet when the contract was captured', async () => {
+    const { lane, assessment } = await assessPersistedContractPacket({
+      source: 'default',
+      taskContract: capturedContract,
+    });
+
+    expect(assessment).toMatchObject({
+      approved: false,
+      contractCoverage: { status: 'failed', missingRequirementIds: ['R1'] },
+    });
+    expect(getLaneEvents(lane.id).some((event) => event.verb === 'task_contract_missing')).toBe(false);
+  });
+
+  it('keeps an explicitly armed packet without a captured contract blocked', async () => {
+    const { lane, assessment } = await assessPersistedContractPacket({ source: 'explicit' });
+
+    expect(assessment).toMatchObject({
+      approved: false,
+      contractCoverage: { status: 'failed' },
+    });
+    expect(getLaneEvents(lane.id).some((event) => event.verb === 'task_contract_missing')).toBe(false);
   });
 });

--- a/tests/packet-control-fields-survive-normalize.test.ts
+++ b/tests/packet-control-fields-survive-normalize.test.ts
@@ -201,6 +201,7 @@ function fullPacketFixture() {
       exclusions: ['No UI changes'],
     },
     taskContractRequired: true,
+    taskContractSource: 'explicit',
     problemDossierId: null,
     problemRemedyId: null,
     explainer: {
@@ -251,6 +252,7 @@ describe('packet fields survive normalize', () => {
       dispatchRuntimePin: undefined,
       orchestratorThreadId: undefined,
       taskContractRequired: undefined,
+      taskContractSource: undefined,
       storageAdmissionEpoch: undefined,
     }));
 
@@ -259,7 +261,19 @@ describe('packet fields survive normalize', () => {
     expect(normalized.packets[0].dispatchRuntimePin).toBeNull();
     expect(normalized.packets[0].orchestratorThreadId).toBeUndefined();
     expect(normalized.packets[0].taskContractRequired).toBeUndefined();
+    expect(normalized.packets[0].taskContractSource).toBeUndefined();
     expect(normalized.packets[0].storageAdmissionEpoch).toBe(1);
+  });
+
+  it('preserves an explicit disabled task-contract gate', () => {
+    const normalized = normalizeOrchestratorMissionState(stateWithPacket({
+      ...fullPacketFixture(),
+      taskContractRequired: false,
+      taskContractSource: 'default',
+    }));
+
+    expect(normalized.packets[0].taskContractRequired).toBe(false);
+    expect(normalized.packets[0].taskContractSource).toBe('default');
   });
 
   it('truncates an oversized deviations raw body with an explicit marker', () => {

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -290,6 +290,13 @@
       ]
     },
     {
+      "path": "src/lib/mcp/operator-handlers/mission-task-contract.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli"
+      ]
+    },
+    {
       "path": "src/lib/mcp/operator-node22-locator.test.ts",
       "reasons": [
         "executable-fixture"


### PR DESCRIPTION
Refs #1922, #1684.

## What

The pre-edit task contract is now armed **by default** for packets whose worker runtime is Claude Code or Codex. Other runtimes are unchanged (off unless explicitly armed). A mission-level `taskContract: 'off'` opt-out exists on `create_mission` (plain string enum — strict-mode safe) and wins over the runtime default.

- **One resolver**, `resolveTaskContractRequired({ runtime, missionOptOut, explicit })`, used by mission creation and task-pool dispatch. Explicit arming (quality search, task pool) is unchanged.
- **Quality search keeps its runtime guard** (Codex / Claude Code only) and rejects the contradictory `qualitySearch` + `taskContract: 'off'` combination, mirroring the existing huddle rule.
- **Soft gate for default arming.** `taskContractRequired` makes the merge-approval coverage gate mandatory, but transcript capture of the contract is best-effort — so a default-armed packet whose contract never parsed would have been unmergeable. The packet now records `taskContractSource: 'explicit' | 'default'` (preserved through normalize). One chokepoint, `resolveTaskContractCoverageRequirement` in `src/lib/lane/task-contract-gate.ts`, serves both review readers: default-armed with no captured contract → one `task_contract_missing` lane event and review proceeds as before; a captured contract → coverage trace enforced as today; explicit or legacy-armed → hard gate as today.
- **Cost is measurable.** When a packet's contract is captured, one `task_contract_cost` lane event records `{ runtime, turns, inputTokens?, outputTokens?, durationMs }`; token fields are omitted when telemetry can't be attributed to the contract turn.
- Both review readers stay under the file ceiling via extraction into the gate module (auto-review.ts 795).

## Verification

Through the real entry points: `create_mission` handler → persisted packet (claude-code and codex armed, gemini not, opt-out wins, quality-search runtime guard still rejects gemini, opt-out + quality search rejected); MCP input schema stays plain (no oneOf/anyOf/allOf); normalize preserves `false` and the source field; the coverage gate real-path test covers default-without-contract (proceeds + event), default-with-contract (enforced), explicit-without-contract (blocked); the cost event test drives the completion-context path. `npx tsc --noEmit`, `npm run rule-check`, `npm run lint` (ratchet), `npm run test:classification:check`, `npm test` green.

## Operator note

The overhead of the contract turn is now visible per packet in `task_contract_cost` events. If it proves too expensive for a runtime, the resolver is the one place to turn that runtime's default off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic pre-edit task contracts for supported runtimes, with mission-level `"off"` opt-out.
  - Added task-contract source tracking and coverage enforcement during review.
  - Added clear validation for incompatible task-contract and quality-search settings.
  - Added cost telemetry for captured task contracts.

- **Bug Fixes**
  - Improved handling of missing contracts while preserving legacy review behavior.
  - Ensured task-contract settings remain consistent through mission creation and processing.

- **Tests**
  - Added coverage for defaults, opt-outs, validation errors, contract enforcement, and cost tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->