### PR TITLE
feat: expose Symon capability discovery

### DIFF
--- a/src-tauri/src/agent/capabilities.rs
+++ b/src-tauri/src/agent/capabilities.rs
@@ -1,0 +1,303 @@
+//! Truthful, user-facing Symon capability discovery.
+//!
+//! The model schemas remain the executable contract. This module groups those
+//! registered tools into jobs a person recognizes and refuses to mark a group
+//! ready when a required tool is missing.
+
+use serde::Serialize;
+use serde_json::{json, Value};
+use std::collections::HashSet;
+
+use super::{safety, tools};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityAvailability {
+    Ready,
+    SetupRequired,
+    Unavailable,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityApproval {
+    ReadOnly,
+    MayRequireApproval,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SymonCapability {
+    pub id: String,
+    pub category: String,
+    pub title: String,
+    pub summary: String,
+    pub examples: Vec<String>,
+    pub tool_names: Vec<String>,
+    pub availability: CapabilityAvailability,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub availability_detail: Option<String>,
+    pub approval: CapabilityApproval,
+}
+
+struct CapabilitySpec {
+    id: &'static str,
+    category: &'static str,
+    title: &'static str,
+    summary: &'static str,
+    examples: &'static [&'static str],
+    tool_names: &'static [&'static str],
+    requires_screen_recording: bool,
+}
+
+const SPECS: &[CapabilitySpec] = &[
+    CapabilitySpec {
+        id: "screen_guidance",
+        category: "This screen",
+        title: "Understand and point at your screen",
+        summary: "Ask what is visible, explain an interface, or point to the next place to act.",
+        examples: &[
+            "What am I looking at?",
+            "Show me where to change this setting.",
+        ],
+        tool_names: &["read_screen"],
+        requires_screen_recording: true,
+    },
+    CapabilitySpec {
+        id: "operator_attention",
+        category: "o8 work",
+        title: "Tell you what needs attention",
+        summary: "Read the live fleet, approval queue, and work waiting on an operator decision.",
+        examples: &["What needs me right now?", "What is shipping?"],
+        tool_names: &["o8_needs_me", "o8_status"],
+        requires_screen_recording: false,
+    },
+    CapabilitySpec {
+        id: "governed_repository_work",
+        category: "o8 work",
+        title: "Start and review governed repository work",
+        summary: "Dispatch bounded work, wait for the result, and inspect the diff before approval.",
+        examples: &[
+            "Fix the failing test in this repository.",
+            "Review the current packet before I approve it.",
+        ],
+        tool_names: &["o8_dispatch", "o8_packet_wait", "o8_review_diff"],
+        requires_screen_recording: false,
+    },
+    CapabilitySpec {
+        id: "browser_terminal",
+        category: "Tools",
+        title: "Use the browser and terminal",
+        summary: "Read a page, act in the browser, or control a watched terminal without leaving o8.",
+        examples: &[
+            "Read the page I have open and summarize it.",
+            "Run the tests and tell me where they fail.",
+        ],
+        tool_names: &["o8_browser_read", "o8_browser_act", "term_read", "term_send"],
+        requires_screen_recording: false,
+    },
+    CapabilitySpec {
+        id: "planning_apps",
+        category: "Mac apps",
+        title: "Manage your calendar and reminders",
+        summary: "Read or update plans with the same approval cards used for other side effects.",
+        examples: &[
+            "What is on my calendar tomorrow?",
+            "Remind me to review the release at 4 PM.",
+        ],
+        tool_names: &[
+            "mac_calendar_list_events",
+            "mac_calendar_create_event",
+            "mac_reminders_list",
+            "mac_reminders_create",
+        ],
+        requires_screen_recording: false,
+    },
+    CapabilitySpec {
+        id: "mail_notes",
+        category: "Mac apps",
+        title: "Work with Mail and Notes",
+        summary: "Find mail, prepare a draft, search notes, or capture a new note.",
+        examples: &[
+            "Find the latest email about the release.",
+            "Create a note with the decisions from this conversation.",
+        ],
+        tool_names: &[
+            "mac_mail_search",
+            "mac_mail_draft",
+            "mac_notes_search",
+            "mac_notes_create",
+        ],
+        requires_screen_recording: false,
+    },
+    CapabilitySpec {
+        id: "code_and_github",
+        category: "Repositories",
+        title: "Inspect code and GitHub",
+        summary: "Read repository state, commits, issues, pull requests, and exact commit diffs.",
+        examples: &[
+            "What changed in the latest commit?",
+            "Read the open pull requests for this repository.",
+        ],
+        tool_names: &["git_status", "repo_commit_diff", "gh_issue_list", "gh_pr_list"],
+        requires_screen_recording: false,
+    },
+    CapabilitySpec {
+        id: "skills",
+        category: "Customize",
+        title: "Use your saved skills",
+        summary: "List and activate local instructions for recurring work without changing Symon itself.",
+        examples: &["What Symon skills do I have?"],
+        tool_names: &["symon_skills_list", "symon_skill_activate"],
+        requires_screen_recording: false,
+    },
+    CapabilitySpec {
+        id: "multi_step_plans",
+        category: "Tools",
+        title: "Handle a reviewed sequence",
+        summary: "Read back a short plan, confirm it once, then run the validated steps in order.",
+        examples: &[
+            "Check tomorrow's calendar, create a note for the day, then tell me what needs me in o8.",
+        ],
+        tool_names: &["symon_execute_plan"],
+        requires_screen_recording: false,
+    },
+];
+
+fn registered_tool_names() -> HashSet<String> {
+    tools::all_tools()
+        .into_iter()
+        .filter_map(|tool| tool.get("name").and_then(Value::as_str).map(str::to_string))
+        .collect()
+}
+
+fn approval_for(tool_names: &[&str]) -> CapabilityApproval {
+    if tool_names
+        .iter()
+        .any(|name| safety::tool_safety_class(name) != safety::SafetyClass::ReadOnly)
+    {
+        CapabilityApproval::MayRequireApproval
+    } else {
+        CapabilityApproval::ReadOnly
+    }
+}
+
+fn build_catalog(
+    available_tools: &HashSet<String>,
+    screen_recording_granted: bool,
+) -> Vec<SymonCapability> {
+    let mut catalog = SPECS
+        .iter()
+        .map(|spec| {
+            let missing_tools = spec
+                .tool_names
+                .iter()
+                .filter(|name| !available_tools.contains(**name))
+                .copied()
+                .collect::<Vec<_>>();
+            let (availability, availability_detail) = if !missing_tools.is_empty() {
+                (
+                    CapabilityAvailability::Unavailable,
+                    Some("This build does not include every required action.".to_string()),
+                )
+            } else if spec.requires_screen_recording && !screen_recording_granted {
+                (
+                    CapabilityAvailability::SetupRequired,
+                    Some(
+                        "Allow Screen Recording in System Settings to use this capability."
+                            .to_string(),
+                    ),
+                )
+            } else {
+                (CapabilityAvailability::Ready, None)
+            };
+            SymonCapability {
+                id: spec.id.to_string(),
+                category: spec.category.to_string(),
+                title: spec.title.to_string(),
+                summary: spec.summary.to_string(),
+                examples: spec
+                    .examples
+                    .iter()
+                    .map(|example| (*example).to_string())
+                    .collect(),
+                tool_names: spec
+                    .tool_names
+                    .iter()
+                    .map(|name| (*name).to_string())
+                    .collect(),
+                availability,
+                availability_detail,
+                approval: approval_for(spec.tool_names),
+            }
+        })
+        .collect::<Vec<_>>();
+    catalog.sort_by_key(|capability| match capability.availability {
+        CapabilityAvailability::Ready => 0,
+        CapabilityAvailability::SetupRequired => 1,
+        CapabilityAvailability::Unavailable => 2,
+    });
+    catalog
+}
+
+pub fn catalog() -> Vec<SymonCapability> {
+    build_catalog(
+        &registered_tool_names(),
+        crate::mac_perms::screen_capture_granted_cmd(),
+    )
+}
+
+pub fn catalog_json() -> Value {
+    json!({ "capabilities": catalog() })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_advertised_example_is_backed_by_registered_tools() {
+        let available = registered_tool_names();
+        assert!(available.contains("symon_capabilities"));
+        assert!(crate::agent::system_prompt().contains("call `symon_capabilities`"));
+        let catalog = build_catalog(&available, true);
+        assert!(!catalog.is_empty());
+        for capability in catalog {
+            assert!(
+                !capability.examples.is_empty(),
+                "{} has no examples",
+                capability.id
+            );
+            assert_eq!(
+                capability.availability,
+                CapabilityAvailability::Ready,
+                "{} is not backed by the tool registry",
+                capability.id
+            );
+        }
+    }
+
+    #[test]
+    fn missing_tool_makes_the_capability_unavailable() {
+        let mut available = registered_tool_names();
+        available.remove("o8_status");
+        let capability = build_catalog(&available, true)
+            .into_iter()
+            .find(|item| item.id == "operator_attention")
+            .expect("operator attention capability");
+        assert_eq!(capability.availability, CapabilityAvailability::Unavailable);
+    }
+
+    #[test]
+    fn missing_screen_permission_is_a_setup_state() {
+        let capability = build_catalog(&registered_tool_names(), false)
+            .into_iter()
+            .find(|item| item.id == "screen_guidance")
+            .expect("screen guidance capability");
+        assert_eq!(
+            capability.availability,
+            CapabilityAvailability::SetupRequired
+        );
+        assert!(capability.availability_detail.is_some());
+    }
+}

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -14,6 +14,7 @@
 //! the loop's `await` from a different thread.
 
 pub mod agent_turn;
+pub mod capabilities;
 pub mod claude;
 pub mod claude_pool;
 pub mod codex;

--- a/src-tauri/src/agent/realtime_bridge.rs
+++ b/src-tauri/src/agent/realtime_bridge.rs
@@ -279,6 +279,43 @@ mod tests {
     use super::*;
 
     #[test]
+    fn realtime_command_reaches_the_symon_capabilities_catalog() {
+        let data_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join(format!("realtime-capabilities-seam-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&data_dir);
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = super::super::store::with_test_data_dir(data_dir.clone(), || {
+            runtime
+                .block_on(realtime_invoke_tool_inner(
+                    None,
+                    "symon_capabilities".to_string(),
+                    json!({}),
+                    Some("desktop".to_string()),
+                    None,
+                    Some("Show Symon capabilities".to_string()),
+                    None,
+                ))
+                .unwrap()
+        });
+
+        let capabilities = result["capabilities"]
+            .as_array()
+            .expect("capability catalog through realtime command");
+        assert!(capabilities.iter().any(|capability| {
+            capability["id"] == "operator_attention"
+                && capability["availability"] == "ready"
+        }));
+
+        std::fs::remove_dir_all(data_dir).unwrap();
+    }
+
+    #[test]
     fn realtime_command_persists_phone_utterance_and_session() {
         let data_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("target")

--- a/src-tauri/src/agent/safety.rs
+++ b/src-tauri/src/agent/safety.rs
@@ -211,6 +211,7 @@ pub fn tool_safety_class(tool_name: &str) -> SafetyClass {
         "gh_triage" => SafetyClass::ReadOnly,
         // Reading the ledger is observational. Its undo executes a persisted
         // inverse and always receives a fresh confirmation card.
+        "symon_capabilities" => SafetyClass::ReadOnly,
         "symon_ledger_recent" => SafetyClass::ReadOnly,
         "symon_ledger_undo" => SafetyClass::Reversible,
         "symon_machine_list" => SafetyClass::ReadOnly,

--- a/src-tauri/src/agent/tools/mod.rs
+++ b/src-tauri/src/agent/tools/mod.rs
@@ -45,6 +45,11 @@ pub(crate) use safe_file::{
 pub fn all_tools() -> Vec<Value> {
     vec![
         json!({
+            "name": "symon_capabilities",
+            "description": "Return Symon's truthful user-facing capability catalog. Use whenever the user asks what Symon can do, asks for examples, or wants to discover available actions. Summarize the ready capabilities and use their exact starter prompts as examples. Mention setup-required capabilities only with their availability detail.",
+            "parameters": { "type": "object", "properties": {}, "required": [], "additionalProperties": false }
+        }),
+        json!({
             "name": "symon_machine_list",
             "description": "List the known machines Symon can control. The session has exactly one active machine at a time.",
             "parameters": { "type": "object", "properties": {}, "required": [], "additionalProperties": false }
@@ -1214,6 +1219,7 @@ pub async fn dispatch_tool_call(name: &str, args: Value, ctx: &TaskCtx) -> Resul
     }
 
     match name {
+        "symon_capabilities" => Ok(crate::agent::capabilities::catalog_json()),
         "symon_machine_list" | "symon_machine_switch" => {
             Err("Symon machine controls must run through the machine router".to_string())
         }

--- a/src/components/desktop/dictation/SymonCapabilitiesPanel.tsx
+++ b/src/components/desktop/dictation/SymonCapabilitiesPanel.tsx
@@ -1,0 +1,289 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+export interface SymonCapability {
+  id: string;
+  category: string;
+  title: string;
+  summary: string;
+  examples: string[];
+  toolNames: string[];
+  availability: 'ready' | 'setup_required' | 'unavailable';
+  availabilityDetail?: string;
+  approval: 'read_only' | 'may_require_approval';
+}
+
+interface SymonCapabilitiesPanelProps {
+  machineDisplayName: string;
+  onBack: () => void;
+  onStarted: () => void;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+export function capabilitiesFromToolResult(value: unknown): SymonCapability[] {
+  const result = recordValue(value);
+  const observed = recordValue(result?.observedData);
+  const payload = observed ?? result;
+  if (Array.isArray(payload?.capabilities)) {
+    return payload.capabilities as SymonCapability[];
+  }
+  const detail = payload?.error ?? result?.error;
+  throw new Error(typeof detail === 'string' ? detail : 'Capability list unavailable');
+}
+
+function capabilityMeta(capability: SymonCapability): string {
+  if (capability.availability === 'setup_required') return 'Setup needed';
+  if (capability.availability === 'unavailable') return 'Unavailable in this build';
+  return capability.approval === 'read_only' ? 'Read-only' : 'Approval when needed';
+}
+
+function CapabilityRow({
+  capability,
+  busyPrompt,
+  onRun,
+}: {
+  capability: SymonCapability;
+  busyPrompt: string;
+  onRun: (prompt: string) => void;
+}) {
+  const ready = capability.availability === 'ready';
+  return (
+    <section
+      aria-label={capability.title}
+      style={{
+        paddingTop: 10,
+        paddingRight: 0,
+        paddingBottom: 10,
+        paddingLeft: 0,
+        borderBottomWidth: 1,
+        borderBottomStyle: 'solid',
+        borderBottomColor: 'var(--t-divider-subtle)',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+        <div
+          style={{
+            color: ready ? 'var(--t-text)' : 'var(--t-text-muted)',
+            fontSize: 13.5,
+            fontWeight: 300,
+            letterSpacing: '-0.1px',
+            lineHeight: 1.25,
+          }}
+        >
+          {capability.title}
+        </div>
+        <div
+          style={{
+            marginLeft: 'auto',
+            color: capability.availability === 'setup_required' ? 'var(--t-warning)' : 'var(--t-text-faint)',
+            fontSize: 9.5,
+            fontWeight: 260,
+            letterSpacing: '-0.4px',
+            lineHeight: 1.25,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {capabilityMeta(capability)}
+        </div>
+      </div>
+      <div
+        style={{
+          marginTop: 4,
+          color: 'var(--t-text-muted)',
+          fontSize: 11,
+          fontWeight: 300,
+          letterSpacing: '-0.1px',
+          lineHeight: 1.4,
+        }}
+      >
+        {capability.availabilityDetail || capability.summary}
+      </div>
+      {ready ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 0, marginTop: 6 }}>
+          {capability.examples.map((prompt) => {
+            const busy = busyPrompt === prompt;
+            return (
+              <button
+                key={prompt}
+                type="button"
+                disabled={busy}
+                onClick={() => onRun(prompt)}
+                onMouseEnter={(event) => { if (!busy) event.currentTarget.style.background = 'var(--t-hover)'; }}
+                onMouseLeave={(event) => { event.currentTarget.style.background = 'transparent'; }}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  width: '100%',
+                  minHeight: 44,
+                  paddingTop: 7,
+                  paddingRight: 8,
+                  paddingBottom: 7,
+                  paddingLeft: 8,
+                  borderWidth: 0,
+                  borderRadius: 7,
+                  background: 'transparent',
+                  color: 'var(--t-text)',
+                  cursor: busy ? 'wait' : 'pointer',
+                  textAlign: 'left',
+                  fontFamily: 'var(--font-sans-system)',
+                  fontSize: 12,
+                  fontWeight: 300,
+                  letterSpacing: '-0.1px',
+                  lineHeight: 1.35,
+                  opacity: busy ? 0.6 : 1,
+                  transition: 'background 120ms ease, opacity 120ms ease',
+                }}
+              >
+                <span>{busy ? 'Starting…' : `“${prompt}”`}</span>
+                <span
+                  aria-hidden
+                  style={{
+                    marginLeft: 'auto',
+                    paddingLeft: 10,
+                    color: 'var(--t-text-faint)',
+                    fontSize: 11,
+                    flexShrink: 0,
+                  }}
+                >
+                  Ask
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+export function SymonCapabilitiesPanel({
+  machineDisplayName,
+  onBack,
+  onStarted,
+}: SymonCapabilitiesPanelProps) {
+  const [capabilities, setCapabilities] = useState<SymonCapability[] | null>(null);
+  const [error, setError] = useState('');
+  const [busyPrompt, setBusyPrompt] = useState('');
+
+  useEffect(() => {
+    let alive = true;
+    void import('@tauri-apps/api/core')
+      .then(({ invoke }) => invoke<unknown>('realtime_invoke_tool', {
+        name: 'symon_capabilities',
+        args: {},
+        sessionId: 'desktop',
+        utterance: 'Show Symon capabilities',
+      }))
+      .then((result) => {
+        const nextCapabilities = capabilitiesFromToolResult(result);
+        if (alive) setCapabilities(nextCapabilities);
+      })
+      .catch((reason) => {
+        if (alive) setError(reason instanceof Error ? reason.message : 'Capability list unavailable');
+      });
+    return () => { alive = false; };
+  }, []);
+
+  const grouped = useMemo(() => {
+    const groups = new Map<string, SymonCapability[]>();
+    for (const capability of capabilities ?? []) {
+      const group = groups.get(capability.category) ?? [];
+      group.push(capability);
+      groups.set(capability.category, group);
+    }
+    return Array.from(groups.entries());
+  }, [capabilities]);
+
+  const runPrompt = (prompt: string) => {
+    if (busyPrompt) return;
+    setBusyPrompt(prompt);
+    setError('');
+    void import('@tauri-apps/api/core')
+      .then(({ invoke }) => invoke('agent_run', { prompt }))
+      .then(() => onStarted())
+      .catch((reason) => {
+        setError(reason instanceof Error ? reason.message : 'Symon could not start that prompt');
+        setBusyPrompt('');
+      });
+  };
+
+  return (
+    <div style={{ width: '100%', minHeight: 180 }}>
+      <div style={{ display: 'flex', alignItems: 'center', minHeight: 44 }}>
+        <button
+          type="button"
+          aria-label="Back to Symon controls"
+          onClick={onBack}
+          onMouseEnter={(event) => { event.currentTarget.style.background = 'var(--t-hover)'; }}
+          onMouseLeave={(event) => { event.currentTarget.style.background = 'transparent'; }}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 44,
+            height: 44,
+            marginLeft: -8,
+            borderWidth: 0,
+            borderRadius: 7,
+            background: 'transparent',
+            color: 'var(--t-text-muted)',
+            cursor: 'pointer',
+            fontFamily: 'var(--font-sans-system)',
+            fontSize: 18,
+            fontWeight: 300,
+            transition: 'background 120ms ease',
+          }}
+        >
+          ‹
+        </button>
+        <div>
+          <div style={{ color: 'var(--t-text)', fontSize: 13.5, fontWeight: 300, letterSpacing: '-0.1px', lineHeight: 1.25 }}>
+            What Symon can do
+          </div>
+          <div style={{ marginTop: 4, color: 'var(--t-text-faint)', fontSize: 9.5, fontWeight: 260, letterSpacing: '-0.4px', lineHeight: 1.25 }}>
+            Live on {machineDisplayName}
+          </div>
+        </div>
+      </div>
+      {error ? (
+        <div role="status" style={{ color: 'var(--t-danger)', fontSize: 11, fontWeight: 300, lineHeight: 1.4, paddingTop: 8, paddingBottom: 8 }}>
+          {error}
+        </div>
+      ) : null}
+      {capabilities === null && !error ? (
+        <div style={{ color: 'var(--t-text-muted)', fontSize: 11, fontWeight: 300, paddingTop: 16 }}>
+          Reading this Mac…
+        </div>
+      ) : (
+        <div style={{ maxHeight: 410, overflowY: 'auto', paddingRight: 4 }}>
+          {grouped.map(([category, items]) => (
+            <div key={category}>
+              <div
+                style={{
+                  paddingTop: 12,
+                  color: 'var(--t-text-faint)',
+                  fontSize: 9,
+                  fontWeight: 300,
+                  letterSpacing: '0.04em',
+                  lineHeight: '14px',
+                  textTransform: 'uppercase',
+                }}
+              >
+                {category}
+              </div>
+              {items.map((capability) => (
+                <CapabilityRow key={capability.id} capability={capability} busyPrompt={busyPrompt} onRun={runPrompt} />
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/desktop/dictation/SymonMachineControl.test.ts
+++ b/src/components/desktop/dictation/SymonMachineControl.test.ts
@@ -5,6 +5,22 @@ import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const invoke = vi.fn(async (command: string) => {
+  if (command === 'realtime_invoke_tool') {
+    return { capabilities: [
+      {
+        id: 'operator_attention', category: 'o8 work', title: 'Tell you what needs attention',
+        summary: 'Read the live fleet.', examples: ['What needs me right now?'],
+        toolNames: ['o8_needs_me'], availability: 'ready', approval: 'read_only',
+      },
+      {
+        id: 'screen_guidance', category: 'This screen', title: 'Understand your screen',
+        summary: 'Read the current screen.', examples: ['What am I looking at?'],
+        toolNames: ['read_screen'], availability: 'setup_required',
+        availabilityDetail: 'Allow Screen Recording in System Settings to use this capability.',
+        approval: 'read_only',
+      },
+    ] };
+  }
   if (command === 'symon_machine_list') {
     return { machines: [
       { id: 'local', displayName: 'This Mac', available: true },
@@ -24,6 +40,7 @@ vi.mock('framer-motion', () => ({
 }));
 
 import { SymonMachineControl, SymonOrbStatusLine, setSymonOrbMinimized } from './SymonMachineControl';
+import { capabilitiesFromToolResult } from './SymonCapabilitiesPanel';
 
 const ACT_ENV = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
 ACT_ENV.IS_REACT_ACT_ENVIRONMENT = true;
@@ -60,6 +77,48 @@ describe('SymonMachineControl', () => {
     await act(async () => trigger?.click());
     expect(container.querySelector('select[aria-label="Active Symon machine"]')).not.toBeNull();
     expect(container.textContent).toContain('Symon on');
+  });
+
+  it('opens the truthful capability catalog and starts a selected prompt', async () => {
+    await act(async () => root.render(createElement(SymonMachineControl)));
+    await act(async () => {});
+
+    const trigger = container.querySelector<HTMLButtonElement>('button[aria-label="Symon machine: This Mac"]');
+    await act(async () => trigger?.click());
+    const discover = container.querySelector<HTMLButtonElement>('button[aria-label="What Symon can do"]');
+    expect(discover).not.toBeNull();
+
+    await act(async () => discover?.click());
+    await act(async () => {});
+    expect(invoke).toHaveBeenCalledWith('realtime_invoke_tool', {
+      name: 'symon_capabilities',
+      args: {},
+      sessionId: 'desktop',
+      utterance: 'Show Symon capabilities',
+    });
+    expect(container.textContent).toContain('Tell you what needs attention');
+    expect(container.textContent).toContain('Setup needed');
+
+    const starter = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
+      .find((button) => button.textContent?.includes('What needs me right now?'));
+    expect(starter).not.toBeUndefined();
+    await act(async () => starter?.click());
+    expect(invoke).toHaveBeenCalledWith('agent_run', { prompt: 'What needs me right now?' });
+    expect(container.querySelector('[aria-label="Symon capabilities"]')).toBeNull();
+  });
+
+  it('unwraps the catalog returned by an active remote machine', () => {
+    const capabilities = capabilitiesFromToolResult({
+      source: 'symon_remote_machine_tool',
+      observedData: {
+        capabilities: [{
+          id: 'remote_screen', category: 'This screen', title: 'Read the remote screen',
+          summary: 'Remote capability.', examples: ['What is on that screen?'],
+          toolNames: ['read_screen'], availability: 'ready', approval: 'read_only',
+        }],
+      },
+    });
+    expect(capabilities[0]?.id).toBe('remote_screen');
   });
 
   it('anchors to the center pane right edge when the workspace element exists', async () => {

--- a/src/components/desktop/dictation/SymonMachineControl.tsx
+++ b/src/components/desktop/dictation/SymonMachineControl.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { isTauri } from '@/lib/tauri/bridge';
 import {
@@ -8,6 +8,7 @@ import {
   parseSymonMachineIdentity,
   type SymonMachineIdentity,
 } from '@/lib/symon/machine-registry';
+import { SymonCapabilitiesPanel } from './SymonCapabilitiesPanel';
 
 interface ListedMachine extends SymonMachineIdentity {
   available: boolean;
@@ -34,17 +35,14 @@ export function setSymonOrbMinimized(minimized: boolean): void {
 }
 
 export function useSymonOrbMinimized(): boolean {
-  const [minimized, setMinimized] = useState(false);
-  useEffect(() => {
-    setMinimized(isSymonOrbMinimized());
-    const onChange = (event: Event) => {
-      const detail = (event as CustomEvent<{ minimized?: boolean }>).detail;
-      setMinimized(detail?.minimized === true);
-    };
-    window.addEventListener(ORB_MINIMIZED_EVENT, onChange);
-    return () => window.removeEventListener(ORB_MINIMIZED_EVENT, onChange);
-  }, []);
-  return minimized;
+  return useSyncExternalStore(
+    (onStoreChange) => {
+      window.addEventListener(ORB_MINIMIZED_EVENT, onStoreChange);
+      return () => window.removeEventListener(ORB_MINIMIZED_EVENT, onStoreChange);
+    },
+    isSymonOrbMinimized,
+    () => false,
+  );
 }
 
 /**
@@ -103,6 +101,7 @@ export function SymonMachineControl() {
   const [switching, setSwitching] = useState(false);
   const [error, setError] = useState('');
   const [open, setOpen] = useState(false);
+  const [view, setView] = useState<'machine' | 'capabilities'>('machine');
   const [rightOffset, setRightOffset] = useState(16);
   const minimized = useSymonOrbMinimized();
   const rootRef = useRef<HTMLDivElement>(null);
@@ -174,10 +173,16 @@ export function SymonMachineControl() {
   useEffect(() => {
     if (!open) return;
     const onPointerDown = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+        setView('machine');
+      }
     };
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setOpen(false);
+      if (event.key === 'Escape') {
+        setOpen(false);
+        setView('machine');
+      }
     };
     document.addEventListener('pointerdown', onPointerDown);
     window.addEventListener('keydown', onKeyDown);
@@ -209,7 +214,7 @@ export function SymonMachineControl() {
         {open ? (
           <motion.div
             role="dialog"
-            aria-label="Symon machine control"
+            aria-label={view === 'capabilities' ? 'Symon capabilities' : 'Symon machine control'}
             initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 8, scale: 0.96 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 6, scale: 0.97 }}
@@ -218,7 +223,7 @@ export function SymonMachineControl() {
               position: 'absolute',
               right: 0,
               bottom: 44,
-              width: 188,
+              width: view === 'capabilities' ? 360 : 220,
               paddingTop: 10,
               paddingRight: 11,
               paddingBottom: 10,
@@ -234,80 +239,122 @@ export function SymonMachineControl() {
               fontFamily: 'var(--font-sans-system)',
             }}
           >
-            <div style={{ color: error ? 'var(--t-danger)' : 'var(--t-text-muted)', fontSize: 10, lineHeight: 1.2, marginBottom: 5 }}>
-              {error || 'Symon on'}
-            </div>
-            <select
-              aria-label="Active Symon machine"
-              value={active.id}
-              disabled={switching}
-              onChange={(event) => {
-                const machineId = event.target.value;
-                setSwitching(true);
-                setError('');
-                void import('@tauri-apps/api/core')
-                  .then(({ invoke }) => invoke<unknown>('symon_machine_switch', {
-                    sessionId: 'desktop',
-                    machineId,
-                  }))
-                  .then((value) => {
-                    const identity = parseSymonMachineIdentity(value);
-                    if (identity) setActive(identity);
-                  })
-                  .catch((reason) => setError(reason instanceof Error ? reason.message : 'Machine switch refused'))
-                  .finally(() => setSwitching(false));
-              }}
-              style={{
-                width: '100%',
-                borderWidth: 0,
-                outline: 0,
-                background: 'transparent',
-                color: 'var(--t-text)',
-                font: 'inherit',
-                fontSize: 12,
-                fontWeight: 600,
-                cursor: switching ? 'wait' : 'pointer',
-              }}
-            >
-              {machines.map((machine) => (
-                <option key={machine.id} value={machine.id} disabled={!machine.available && machine.id !== active.id}>
-                  {machine.displayName}{machine.available ? '' : ' (offline)'}
-                </option>
-              ))}
-            </select>
-            <button
-              type="button"
-              aria-label="Minimize Symon to the status bar"
-              onClick={() => { setOpen(false); setSymonOrbMinimized(true); }}
-              onMouseEnter={(event) => { event.currentTarget.style.background = 'var(--t-hover)'; event.currentTarget.style.color = 'var(--t-text)'; }}
-              onMouseLeave={(event) => { event.currentTarget.style.background = 'transparent'; event.currentTarget.style.color = 'var(--t-text-muted)'; }}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 7,
-                width: '100%',
-                minHeight: 24,
-                marginTop: 7,
-                paddingTop: 0,
-                paddingRight: 6,
-                paddingBottom: 0,
-                paddingLeft: 6,
-                borderRadius: 7,
-                borderWidth: 0,
-                background: 'transparent',
-                color: 'var(--t-text-muted)',
-                cursor: 'pointer',
-                textAlign: 'left',
-                fontFamily: 'var(--font-sans-system)',
-                fontSize: 11.5,
-                fontWeight: 400,
-                letterSpacing: '-0.1px',
-                transition: 'background 120ms ease, color 120ms ease',
-              }}
-            >
-              <span aria-hidden style={{ display: 'inline-flex', width: 12, height: 2.5, borderRadius: 999, background: 'currentColor', opacity: 0.7, flexShrink: 0 }} />
-              Minimize to status bar
-            </button>
+            {view === 'capabilities' ? (
+              <SymonCapabilitiesPanel
+                machineDisplayName={active.displayName}
+                onBack={() => setView('machine')}
+                onStarted={() => { setOpen(false); setView('machine'); }}
+              />
+            ) : (
+              <>
+                <div style={{ color: error ? 'var(--t-danger)' : 'var(--t-text-muted)', fontSize: 10, lineHeight: 1.2, marginBottom: 5 }}>
+                  {error || 'Symon on'}
+                </div>
+                <select
+                  aria-label="Active Symon machine"
+                  value={active.id}
+                  disabled={switching}
+                  onChange={(event) => {
+                    const machineId = event.target.value;
+                    setSwitching(true);
+                    setError('');
+                    void import('@tauri-apps/api/core')
+                      .then(({ invoke }) => invoke<unknown>('symon_machine_switch', {
+                        sessionId: 'desktop',
+                        machineId,
+                      }))
+                      .then((value) => {
+                        const identity = parseSymonMachineIdentity(value);
+                        if (identity) setActive(identity);
+                      })
+                      .catch((reason) => setError(reason instanceof Error ? reason.message : 'Machine switch refused'))
+                      .finally(() => setSwitching(false));
+                  }}
+                  style={{
+                    width: '100%',
+                    borderWidth: 0,
+                    outline: 0,
+                    background: 'transparent',
+                    color: 'var(--t-text)',
+                    font: 'inherit',
+                    fontSize: 12,
+                    fontWeight: 300,
+                    cursor: switching ? 'wait' : 'pointer',
+                  }}
+                >
+                  {machines.map((machine) => (
+                    <option key={machine.id} value={machine.id} disabled={!machine.available && machine.id !== active.id}>
+                      {machine.displayName}{machine.available ? '' : ' (offline)'}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  aria-label="What Symon can do"
+                  onClick={() => setView('capabilities')}
+                  onMouseEnter={(event) => { event.currentTarget.style.background = 'var(--t-hover)'; event.currentTarget.style.color = 'var(--t-text)'; }}
+                  onMouseLeave={(event) => { event.currentTarget.style.background = 'transparent'; event.currentTarget.style.color = 'var(--t-text-muted)'; }}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    width: '100%',
+                    minHeight: 44,
+                    marginTop: 7,
+                    paddingTop: 0,
+                    paddingRight: 8,
+                    paddingBottom: 0,
+                    paddingLeft: 8,
+                    borderRadius: 7,
+                    borderWidth: 0,
+                    background: 'transparent',
+                    color: 'var(--t-text-muted)',
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    fontFamily: 'var(--font-sans-system)',
+                    fontSize: 11.5,
+                    fontWeight: 300,
+                    letterSpacing: '-0.1px',
+                    transition: 'background 120ms ease, color 120ms ease',
+                  }}
+                >
+                  What Symon can do
+                  <span aria-hidden style={{ marginLeft: 'auto', color: 'var(--t-text-faint)', fontSize: 16 }}>›</span>
+                </button>
+                <button
+                  type="button"
+                  aria-label="Minimize Symon to the status bar"
+                  onClick={() => { setOpen(false); setSymonOrbMinimized(true); }}
+                  onMouseEnter={(event) => { event.currentTarget.style.background = 'var(--t-hover)'; event.currentTarget.style.color = 'var(--t-text)'; }}
+                  onMouseLeave={(event) => { event.currentTarget.style.background = 'transparent'; event.currentTarget.style.color = 'var(--t-text-muted)'; }}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 7,
+                    width: '100%',
+                    minHeight: 24,
+                    marginTop: 7,
+                    paddingTop: 0,
+                    paddingRight: 6,
+                    paddingBottom: 0,
+                    paddingLeft: 6,
+                    borderRadius: 7,
+                    borderWidth: 0,
+                    background: 'transparent',
+                    color: 'var(--t-text-muted)',
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    fontFamily: 'var(--font-sans-system)',
+                    fontSize: 11.5,
+                    fontWeight: 300,
+                    letterSpacing: '-0.1px',
+                    transition: 'background 120ms ease, color 120ms ease',
+                  }}
+                >
+                  <span aria-hidden style={{ display: 'inline-flex', width: 12, height: 2.5, borderRadius: 999, background: 'currentColor', opacity: 0.7, flexShrink: 0 }} />
+                  Minimize to status bar
+                </button>
+              </>
+            )}
           </motion.div>
         ) : null}
       </AnimatePresence>

--- a/src/lib/prompts/v1/symon-native-system.txt
+++ b/src/lib/prompts/v1/symon-native-system.txt
@@ -1,6 +1,7 @@
 You are Symon, a fast, helpful macOS voice assistant for o8.
 You control the user's Mac through native tools (Reminders, Calendar, Notes, opening apps) — including CHANGING what exists: move or rename a reminder or an upcoming event with the update tools (list first, pass the exact title).
 You are also the operator's link into o8 itself: use `o8_status` to report what o8's autonomous coding agents are working on right now ("what's shipping?").
+When the user asks what you can do, asks for examples, or sounds unsure where to start, call `symon_capabilities`. Answer from that live catalog instead of reciting tools from memory. Lead with ready capabilities that fit the current context, give at most five exact starter prompts, and explain any setup-required item before suggesting it.
 o8_status also returns `peers` — the OTHER agents driving o8 alongside, each by its codename; when the user asks who's working or who else is here, name them naturally ("Atlas and Nova are both driving o8 right now").
 To pass a message to a running agent by name, use `o8_team_tell` ("tell Nova to hold the ship", "let Atlas know the API changed") — a peer note, NOT a coding task (use o8_dispatch for code); `o8_team_inbox` reads recent messages between the agents ("what are the agents saying?").
 Then `o8_ask` to ask o8's Engineering Brain about the code, recent work, or the fleet ("what did Codex do today?").


### PR DESCRIPTION
## Outcome

Give new and returning users a truthful way to discover Symon's native capabilities from the existing orb, then start a working prompt without reading documentation.

## What changed

- adds one native capability catalog derived from the registered Symon tool set
- exposes availability, setup state, and approval behavior in user-facing terms
- adds a compact `What Symon can do` panel to the existing orb
- routes spoken capability questions and the UI through the same catalog
- preserves active-machine routing, remote result handling, and existing confirmation gates

## Proof

- `npx vitest run src/components/desktop/dictation/SymonMachineControl.test.ts` — 5 passed
- `TAURI_CONFIG='{"bundle":{"resources":[]}}' cargo test capabilities --lib` — 4 passed
- `npm run typecheck` — passed
- `npm run rule-check -- --base=origin/main` — passed
- `npm run test:classification:check` — passed
- `npm test` — 582 files, 3,325 tests passed

Closes #1925
