### PR TITLE
fix: backfill outside-contributor attention and sync on the supervisor cadence

### DIFF
--- a/src/lib/github-broker/store.ts
+++ b/src/lib/github-broker/store.ts
@@ -571,17 +571,30 @@ export function getGitHubPullRequestByHead(repoFullName: string, headRefName: st
   return row ? mapPullRequestRow(row) : null;
 }
 
-export function readGitHubThreadUpdatedAt(
+export interface GitHubThreadSyncState {
+  updatedAt: string | null;
+  attentionAssessed: boolean;
+}
+
+export function readGitHubThreadSyncState(
   repoFullName: string,
   kind: OutsiderAttentionThreadKind,
-): Map<number, string | null> {
+): Map<number, GitHubThreadSyncState> {
   const table = kind === 'issue' ? 'github_issues' : 'github_pull_requests';
   const rows = getSqlite().prepare(`
-    SELECT number, updated_at as updatedAt
+    SELECT number, updated_at as updatedAt,
+           last_human_comment_at IS NOT NULL as attentionAssessed
     FROM ${table}
     WHERE repo_full_name = ?
-  `).all(repoFullName) as Array<{ number: number; updatedAt: string | null }>;
-  return new Map(rows.map((row) => [row.number, row.updatedAt]));
+  `).all(repoFullName) as Array<{
+    number: number;
+    updatedAt: string | null;
+    attentionAssessed: number;
+  }>;
+  return new Map(rows.map((row) => [row.number, {
+    updatedAt: row.updatedAt,
+    attentionAssessed: Boolean(row.attentionAssessed),
+  }]));
 }
 
 export function updateGitHubThreadAttention(attention: GitHubThreadAttentionSnapshot): boolean {

--- a/src/lib/github-broker/sync.test.ts
+++ b/src/lib/github-broker/sync.test.ts
@@ -28,6 +28,7 @@ const {
 } = await import('@/lib/supervisor/inbox');
 const {
   invalidateGitHubSync,
+  updateGitHubThreadAttention,
   upsertGitHubIssue,
   upsertGitHubPullRequest,
 } = await import('./store');
@@ -120,8 +121,12 @@ function pullRequestSnapshot(
   };
 }
 
-function pullRequestPayload(number: number) {
-  const snapshot = pullRequestSnapshot(number, 'open', null);
+function pullRequestPayload(
+  number: number,
+  state: 'open' | 'closed' = 'open',
+  closedAt: string | null = null,
+) {
+  const snapshot = pullRequestSnapshot(number, state, closedAt);
   return {
     id: snapshot.pullRequestId,
     number,
@@ -273,6 +278,111 @@ describe('GitHub outsider attention sync', () => {
     expect(warning).toHaveBeenCalledWith(expect.stringContaining(
       '[github-broker] Attention sync skipped for example/widgets#52: attention request unavailable',
     ));
+  });
+
+  it('backfills matching issues with null attention without refetching assessed rows', async () => {
+    upsertGitHubIssue(issueSnapshot(61, 'open', null));
+    upsertGitHubIssue(issueSnapshot(62, 'open', null));
+    updateGitHubThreadAttention({
+      repoFullName: 'example/widgets',
+      kind: 'issue',
+      number: 62,
+      lastHumanCommentAuthorLogin: 'already-assessed',
+      lastHumanCommentAuthorAssociation: 'CONTRIBUTOR',
+      lastHumanCommentAt: '2026-08-26T11:00:00.000Z',
+      lastInsiderCommentAt: null,
+    });
+
+    installationFetchMock.mockImplementation(async (_repo: string, path: string) => {
+      if (path.includes('/issues?state=open')) {
+        return fetched([openIssue(61, 1), openIssue(62, 1)]);
+      }
+      if (path.includes('/issues?state=closed')) return fetched([]);
+      if (path.includes('/issues/61/comments?')) {
+        return fetched([{
+          user: { login: 'backfilled-contributor', type: 'User' },
+          author_association: 'CONTRIBUTOR',
+          created_at: '2026-08-27T12:00:00.000Z',
+        }]);
+      }
+      throw new Error(`Unexpected GitHub path: ${path}`);
+    });
+
+    await expect(ensureGitHubIssues('example/widgets', { fresh: true })).resolves.toMatchObject({
+      error: null,
+      stale: false,
+    });
+
+    expect(installationFetchMock.mock.calls
+      .map((call) => String(call[1]))
+      .filter((path) => path.includes('/comments?'))).toEqual([
+      '/repos/example/widgets/issues/61/comments?per_page=100&page=1',
+    ]);
+    expect(getSqlite().prepare(`
+      SELECT number, last_human_comment_author_login as login
+      FROM github_issues
+      WHERE repo_full_name = 'example/widgets' AND number IN (61, 62)
+      ORDER BY number
+    `).all()).toEqual([
+      { number: 61, login: 'backfilled-contributor' },
+      { number: 62, login: 'already-assessed' },
+    ]);
+  });
+
+  it('backfills matching recently closed pull requests with null attention only', async () => {
+    const closedAt = '2026-08-26T15:00:00.000Z';
+    const unassessed = { ...pullRequestPayload(211, 'closed', closedAt), comments: 1 };
+    const assessed = { ...pullRequestPayload(212, 'closed', closedAt), comments: 1 };
+    upsertGitHubPullRequest(pullRequestSnapshot(211, 'closed', closedAt));
+    upsertGitHubPullRequest(pullRequestSnapshot(212, 'closed', closedAt));
+    updateGitHubThreadAttention({
+      repoFullName: 'example/widgets',
+      kind: 'pr',
+      number: 212,
+      lastHumanCommentAuthorLogin: 'already-assessed',
+      lastHumanCommentAuthorAssociation: 'CONTRIBUTOR',
+      lastHumanCommentAt: '2026-08-26T14:00:00.000Z',
+      lastInsiderCommentAt: null,
+    });
+
+    installationFetchMock.mockImplementation(async (_repo: string, path: string) => {
+      if (path.includes('/pulls?state=open')) return fetched([]);
+      if (path.includes('/pulls?state=closed')) return fetched([unassessed, assessed]);
+      if (path.endsWith('/pulls/211')) return fetched(unassessed);
+      if (path.includes('/issues/211/comments?')) {
+        return fetched([{
+          user: { login: 'backfilled-contributor', type: 'User' },
+          author_association: 'CONTRIBUTOR',
+          created_at: '2026-08-26T14:30:00.000Z',
+        }]);
+      }
+      throw new Error(`Unexpected GitHub path: ${path}`);
+    });
+
+    await expect(ensureGitHubPullRequests('example/widgets')).resolves.toMatchObject({
+      error: null,
+      stale: false,
+    });
+
+    expect(installationFetchMock.mock.calls
+      .map((call) => String(call[1]))
+      .filter((path) => /\/pulls\/\d+$/.test(path))).toEqual([
+      '/repos/example/widgets/pulls/211',
+    ]);
+    expect(installationFetchMock.mock.calls
+      .map((call) => String(call[1]))
+      .filter((path) => path.includes('/comments?'))).toEqual([
+      '/repos/example/widgets/issues/211/comments?per_page=100&page=1',
+    ]);
+    expect(getSqlite().prepare(`
+      SELECT number, last_human_comment_author_login as login
+      FROM github_pull_requests
+      WHERE repo_full_name = 'example/widgets' AND number IN (211, 212)
+      ORDER BY number
+    `).all()).toEqual([
+      { number: 211, login: 'backfilled-contributor' },
+      { number: 212, login: 'already-assessed' },
+    ]);
   });
 
   it('prunes expired closed issues after their active waiting card resolves', async () => {

--- a/src/lib/github-broker/sync.ts
+++ b/src/lib/github-broker/sync.ts
@@ -11,7 +11,7 @@ import {
   readGitHubSyncState,
   replaceGitHubIssues,
   replaceGitHubPullRequests,
-  readGitHubThreadUpdatedAt,
+  readGitHubThreadSyncState,
   updateGitHubThreadAttention,
   upsertGitHubIssue,
   upsertGitHubPullRequest,
@@ -19,6 +19,7 @@ import {
   type GitHubIssueSnapshot,
   type GitHubPullRequestSnapshot,
   type GitHubSyncResource,
+  type GitHubThreadSyncState,
   type GitHubThreadAttentionSnapshot,
 } from './store';
 import { githubInstallationFetch } from './auth';
@@ -203,11 +204,12 @@ async function fetchThreadAttention(source: AttentionSyncSource): Promise<GitHub
 
 async function fetchMovedThreadAttention(
   sources: AttentionSyncSource[],
-  previousUpdatedAt: Map<number, string | null>,
+  previousState: Map<number, GitHubThreadSyncState>,
 ): Promise<GitHubThreadAttentionSnapshot[]> {
   const attention: GitHubThreadAttentionSnapshot[] = [];
   for (const source of sources) {
-    if (previousUpdatedAt.get(source.number) === source.updatedAt) continue;
+    const stored = previousState.get(source.number);
+    if (stored?.updatedAt === source.updatedAt && stored.attentionAssessed) continue;
     try {
       attention.push(await fetchThreadAttention(source));
     } catch (error) {
@@ -371,7 +373,7 @@ function applyThreadAttention(attention: GitHubThreadAttentionSnapshot[]): void 
 async function syncIssues(repoFullName: string) {
   const syncState = readGitHubSyncState(repoFullName, 'issues');
   const etag = syncState?.etag ?? null;
-  const previousUpdatedAt = readGitHubThreadUpdatedAt(repoFullName, 'issue');
+  const previousState = readGitHubThreadSyncState(repoFullName, 'issue');
   const cutoffMs = Date.now() - OUTSIDER_ATTENTION_RECENTLY_CLOSED_MS;
   const cutoffIso = new Date(cutoffMs).toISOString();
   // Skip ETag when TTL has expired — forces a fresh fetch so pagination runs
@@ -424,7 +426,7 @@ async function syncIssues(repoFullName: string) {
   ];
   const attention = await fetchMovedThreadAttention(
     threadItems.map((item) => attentionSource(repoFullName, 'issue', item, item.comments ?? 0)),
-    previousUpdatedAt,
+    previousState,
   );
   const closedIssues = closedItems.map((issue) => mapIssueSnapshot(repoFullName, issue));
 
@@ -449,7 +451,7 @@ async function syncIssues(repoFullName: string) {
 async function syncPullRequests(repoFullName: string) {
   const syncState = readGitHubSyncState(repoFullName, 'pull_requests');
   const etag = syncState?.etag ?? null;
-  const previousUpdatedAt = readGitHubThreadUpdatedAt(repoFullName, 'pr');
+  const previousState = readGitHubThreadSyncState(repoFullName, 'pr');
   const cutoffMs = Date.now() - OUTSIDER_ATTENTION_RECENTLY_CLOSED_MS;
   const cutoffIso = new Date(cutoffMs).toISOString();
   const useEtag = etag && isFresh(syncState?.lastSuccessfulAt);
@@ -479,7 +481,11 @@ async function syncPullRequests(repoFullName: string) {
   const closedItems = await fetchRecentlyClosedPullRequests(repoFullName, cutoffIso, cutoffMs);
   const closedPairs: Array<{ item: GitHubPullRequestPayload; detail: GitHubPullRequestPayload }> = [];
   for (const item of closedItems) {
-    if (previousUpdatedAt.get(item.number) === (item.updated_at ?? item.created_at ?? '')) continue;
+    const stored = previousState.get(item.number);
+    if (
+      stored?.updatedAt === (item.updated_at ?? item.created_at ?? '')
+      && stored.attentionAssessed
+    ) continue;
     try {
       closedPairs.push({ item, detail: await fetchPullRequestDetail(repoFullName, item) });
     } catch (error) {
@@ -497,7 +503,7 @@ async function syncPullRequests(repoFullName: string) {
       detail,
       detail.comments ?? 0,
     )),
-    previousUpdatedAt,
+    previousState,
   );
   const closedPulls = closedPairs.map(({ item, detail }) => mapPullRequestSnapshot(repoFullName, item, detail));
 

--- a/src/lib/supervisor/github-broker-sync.ts
+++ b/src/lib/supervisor/github-broker-sync.ts
@@ -1,0 +1,46 @@
+import { hasGitHubBrokerAccess } from '@/lib/github-broker/auth';
+import { normalizeRepoSlug } from '@/lib/github-broker/repo';
+import {
+  ensureGitHubIssues,
+  ensureGitHubPullRequests,
+} from '@/lib/github-broker/sync';
+import { listRepos } from '@/lib/repos/registry';
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function runGitHubBrokerSyncSweep(): Promise<void> {
+  if (!hasGitHubBrokerAccess()) return;
+
+  let repos: Awaited<ReturnType<typeof listRepos>>;
+  try {
+    repos = await listRepos();
+  } catch (error) {
+    console.warn(`[github-broker] Supervisor sync could not list connected repos: ${errorMessage(error)}`);
+    return;
+  }
+
+  for (const repo of repos) {
+    const repoFullName = normalizeRepoSlug(repo.remoteUrl);
+    if (!repoFullName) continue;
+
+    try {
+      const result = await ensureGitHubIssues(repoFullName);
+      if (result.error) {
+        console.warn(`[github-broker] Supervisor issue sync failed for ${repoFullName}: ${result.error}`);
+      }
+    } catch (error) {
+      console.warn(`[github-broker] Supervisor issue sync failed for ${repoFullName}: ${errorMessage(error)}`);
+    }
+
+    try {
+      const result = await ensureGitHubPullRequests(repoFullName);
+      if (result.error) {
+        console.warn(`[github-broker] Supervisor pull request sync failed for ${repoFullName}: ${result.error}`);
+      }
+    } catch (error) {
+      console.warn(`[github-broker] Supervisor pull request sync failed for ${repoFullName}: ${errorMessage(error)}`);
+    }
+  }
+}

--- a/src/lib/supervisor/heal-bot.ts
+++ b/src/lib/supervisor/heal-bot.ts
@@ -7,10 +7,9 @@ import { getSqlite } from '@/lib/db';
 import { markRepoOriginConfigured } from '@/lib/repos/origin-readiness';
 import { DEFAULT_PROJECT_ID } from '@/lib/repos/projects';
 import { runAwaitingReviewAutoReleaseSweep } from '@/lib/supervisor/heal-bot-auto-release';
+import { runGitHubBrokerSyncSweep } from '@/lib/supervisor/github-broker-sync';
 import { enqueueInboxItem, runRetentionSweep, selfHealActiveByKindAndRepo } from '@/lib/supervisor/inbox';
-
 export { runAwaitingReviewAutoReleaseSweep } from '@/lib/supervisor/heal-bot-auto-release';
-
 const execFileAsync = promisify(execFile);
 
 const HEAL_BOT_TICK_MS = 60_000;
@@ -724,6 +723,7 @@ async function runHealBotMaintenance(): Promise<void> {
     console.log(`[heal-bot] Retention sweep dismissed ${dismissed} stale inbox item(s)`);
   }
   await import('@/lib/problems/service').then(({ reconcileProblemDossiers }) => reconcileProblemDossiers()).catch((error) => console.warn('[heal-bot] Problem dossier reconciliation failed:', error));
+  await runGitHubBrokerSyncSweep();
   await runFetchUnreachableSweep();
   await runAwaitingReviewAutoReleaseSweep();
   const resolved = await runLivenessProbeSweep();

--- a/tests/github-broker-supervisor-sync-real-path.test.ts
+++ b/tests/github-broker-supervisor-sync-real-path.test.ts
@@ -1,0 +1,190 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+const installationFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/github-broker/auth', () => ({
+  githubInstallationFetch: installationFetchMock,
+  hasGitHubBrokerAccess: () => true,
+}));
+
+const previousDataDir = process.env.CORTEX_IDE_DATA_DIR;
+const previousO8DataDir = process.env.O8_DATA_DIR;
+const dataDir = mkdtempSync(path.join(os.tmpdir(), 'o8-github-supervisor-sync-'));
+const repoPath = path.join(dataDir, 'widgets');
+mkdirSync(repoPath, { recursive: true });
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.O8_DATA_DIR = dataDir;
+writeFileSync(path.join(dataDir, 'repos.json'), JSON.stringify({
+  version: 1,
+  repos: [{
+    id: 'repo-widgets',
+    name: 'widgets',
+    localPath: repoPath,
+    remoteUrl: 'https://github.com/example/widgets.git',
+    defaultBranch: 'main',
+    isGitRepo: true,
+    addedAt: '2026-08-01T00:00:00.000Z',
+    lastOpenedAt: null,
+    storagePressureParkingDisabled: false,
+    setup: {
+      envMode: 'copy',
+      envFiles: [],
+      installCommand: null,
+      installOnCreateWorkspace: false,
+      buildCommand: null,
+      runBuildOnCreateWorkspace: false,
+      devCommand: null,
+      defaultPort: null,
+      workspaceIsolationPreference: 'auto',
+    },
+  }],
+}));
+
+const { closeDb, getSqlite } = await import('@/lib/db');
+const {
+  markGitHubSyncSuccess,
+  upsertGitHubIssue,
+  upsertGitHubPullRequest,
+} = await import('@/lib/github-broker/store');
+const { runHealBotTickOnce } = await import('@/lib/supervisor/heal-bot');
+
+const issue = {
+  issueId: 19_290,
+  repoFullName: 'example/widgets',
+  number: 1929,
+  title: 'Keep the mirror current',
+  state: 'open',
+  author: { login: 'contributor' },
+  assignees: [],
+  labels: [],
+  comments: 0,
+  body: 'Issue body.',
+  url: 'https://github.com/example/widgets/issues/1929',
+  createdAt: '2026-08-20T10:00:00.000Z',
+  updatedAt: '2026-08-27T10:00:00.000Z',
+  closedAt: null,
+};
+
+const pullRequest = {
+  pullRequestId: 19_291,
+  repoFullName: 'example/widgets',
+  number: 1930,
+  title: 'Keep the pull request mirror current',
+  state: 'open',
+  author: { login: 'contributor' },
+  body: 'Pull request body.',
+  headRefName: 'contributor/change',
+  baseRefName: 'main',
+  additions: 2,
+  deletions: 1,
+  changedFiles: 1,
+  reviewDecision: null,
+  statusCheckRollup: [],
+  url: 'https://github.com/example/widgets/pull/1930',
+  createdAt: '2026-08-20T11:00:00.000Z',
+  updatedAt: '2026-08-27T11:00:00.000Z',
+  closedAt: null,
+  mergedAt: null,
+};
+
+const installation = {
+  id: 1929,
+  account: { login: 'example', type: 'Organization' },
+  target_type: 'Organization',
+  permissions: { issues: 'read', pull_requests: 'read' },
+};
+
+function fetched(body: unknown) {
+  return { response: Response.json(body), installation };
+}
+
+afterAll(() => {
+  closeDb();
+  rmSync(dataDir, { recursive: true, force: true });
+  if (previousDataDir === undefined) delete process.env.CORTEX_IDE_DATA_DIR;
+  else process.env.CORTEX_IDE_DATA_DIR = previousDataDir;
+  if (previousO8DataDir === undefined) delete process.env.O8_DATA_DIR;
+  else process.env.O8_DATA_DIR = previousO8DataDir;
+});
+
+describe('supervisor GitHub broker sync cadence', () => {
+  it('syncs a stale connected repo once and lets the TTL skip a fresh tick', async () => {
+    upsertGitHubIssue(issue);
+    upsertGitHubPullRequest(pullRequest);
+    markGitHubSyncSuccess('example/widgets', 'issues');
+    markGitHubSyncSuccess('example/widgets', 'pull_requests');
+    getSqlite().prepare(`
+      UPDATE github_sync_state
+      SET last_successful_at = ?
+      WHERE repo_full_name = 'example/widgets'
+    `).run(new Date(Date.now() - 10 * 60_000).toISOString());
+
+    installationFetchMock.mockImplementation(async (_repo: string, requestPath: string) => {
+      if (requestPath.includes('/issues?state=open')) return fetched([{
+        id: issue.issueId,
+        number: issue.number,
+        title: issue.title,
+        state: issue.state,
+        body: issue.body,
+        html_url: issue.url,
+        created_at: issue.createdAt,
+        updated_at: issue.updatedAt,
+        user: { login: issue.author.login, type: 'User' },
+        author_association: 'CONTRIBUTOR',
+        assignees: [],
+        labels: [],
+        comments: 0,
+      }]);
+      if (requestPath.includes('/issues?state=closed')) return fetched([]);
+      if (requestPath.includes('/pulls?state=open')) return fetched([{
+        id: pullRequest.pullRequestId,
+        number: pullRequest.number,
+        title: pullRequest.title,
+        state: pullRequest.state,
+        body: pullRequest.body,
+        html_url: pullRequest.url,
+        created_at: pullRequest.createdAt,
+        updated_at: pullRequest.updatedAt,
+        user: { login: pullRequest.author.login, type: 'User' },
+        author_association: 'CONTRIBUTOR',
+        head: { ref: pullRequest.headRefName },
+        base: { ref: pullRequest.baseRefName },
+        additions: pullRequest.additions,
+        deletions: pullRequest.deletions,
+        changed_files: pullRequest.changedFiles,
+        comments: 0,
+      }]);
+      if (requestPath.endsWith('/pulls/1930')) return fetched({
+        id: pullRequest.pullRequestId,
+        number: pullRequest.number,
+        title: pullRequest.title,
+        state: pullRequest.state,
+        body: pullRequest.body,
+        html_url: pullRequest.url,
+        created_at: pullRequest.createdAt,
+        updated_at: pullRequest.updatedAt,
+        user: { login: pullRequest.author.login, type: 'User' },
+        author_association: 'CONTRIBUTOR',
+        head: { ref: pullRequest.headRefName },
+        base: { ref: pullRequest.baseRefName },
+        additions: pullRequest.additions,
+        deletions: pullRequest.deletions,
+        changed_files: pullRequest.changedFiles,
+        comments: 0,
+      });
+      if (requestPath.includes('/pulls?state=closed')) return fetched([]);
+      throw new Error(`Unexpected GitHub path: ${requestPath}`);
+    });
+
+    await runHealBotTickOnce();
+    const staleTickCalls = installationFetchMock.mock.calls.length;
+    expect(staleTickCalls).toBe(5);
+
+    await runHealBotTickOnce();
+    expect(installationFetchMock).toHaveBeenCalledTimes(staleTickCalls);
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1357,6 +1357,12 @@
       ]
     },
     {
+      "path": "tests/github-broker-supervisor-sync-real-path.test.ts",
+      "reasons": [
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/github-device-consolidation.test.ts",
       "reasons": [
         "child-process"


### PR DESCRIPTION
Refs #1929 — follow-up to #1890 / #1893, found on the first release carrying them.

## What

- **Backfill.** The attention pass skipped any thread whose stored `updated_at` matched GitHub's, so after the upgrade no existing thread was ever assessed — including the quiet ones the card exists for. The stored state now carries `attentionAssessed` (`last_human_comment_at IS NOT NULL`), and a thread is skipped only when its timestamp matches *and* it has been assessed. Existing rows get assessed once on the next sync; bounded by the same page caps and 7-day closed window.
- **Cadence.** The issues sync previously ran only when the Issues panel, universal search, or the enhance route asked for it. A new `runGitHubBrokerSyncSweep` runs inside the existing 60-second heal-bot maintenance tick (no new timer), calling `ensureGitHubIssues` / `ensureGitHubPullRequests` for every connected repo with broker access. The existing 2-minute TTL returns from cache without a network call, and ETags keep real refreshes cheap. Failures log with the `[github-broker]` prefix and continue.
- No UI change.

## Verification

- `src/lib/github-broker/sync.test.ts`: rows with matching `updated_at` and null attention are assessed on the next sync; rows already assessed with matching `updated_at` are not refetched (comment fetches counted).
- `tests/github-broker-supervisor-sync-real-path.test.ts`: drives the real `runHealBotTickOnce` with the auth boundary mocked — a stale connected repo triggers the sync (5 fetches), a fresh tick triggers none.
- `npx tsc --noEmit`, `npm run lint`, `npm run test:classification:check`, `npm test` green on the merged head.
