### PR TITLE
chore: delete dead eslint-disable directives

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,11 @@ const config = [
     ],
   },
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+  },
+  {
     files: ['**/*.cjs'],
     plugins: { 'react-hooks': reactHooks },
     rules: {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev:all": "node scripts/dev.mjs all",
     "build": "node scripts/build.mjs",
     "start": "node scripts/start.mjs",
-    "lint": "eslint . --max-warnings 301",
+    "lint": "eslint . --max-warnings 300",
     "typecheck": "npm run verify:routes && node scripts/typecheck.mjs",
     "verify:routes": "vitest run tests/route-coverage.test.ts -t \"route module shape\"",
     "rule-check": "tsx scripts/rule-check.ts",

--- a/src/lib/theme/pre-paint-stamp.test.ts
+++ b/src/lib/theme/pre-paint-stamp.test.ts
@@ -11,7 +11,6 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { PRE_PAINT_THEME_STAMP } from './pre-paint-stamp';
 
 function runStamp(): void {
-  // eslint-disable-next-line @typescript-eslint/no-implied-eval
   new Function(PRE_PAINT_THEME_STAMP)();
 }
 


### PR DESCRIPTION
Refs #1895, #1670.

## What

`npx eslint . --report-unused-disable-directives` found exactly one dead directive in the repo (a `no-implied-eval` disable in a theme test); it is removed. The flat config now sets `linterOptions.reportUnusedDisableDirectives: 'error'`, so any future dead directive fails `npm run lint` instead of accumulating. The lint ratchet is lowered from 301 to 300 to match the measured count.

## Verification

`npx eslint . --report-unused-disable-directives`: zero unused directives. `npm run lint`: exit 0 at exactly 300 warnings, 0 errors. `npx tsc --noEmit`, `npm run test:classification:check`, `npm test` green on the merged head.

Next in the series: #1896 (`no-unused-vars`, the bulk of the remaining warnings) and #1897 (hooks pass on the two largest workspace files).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved linting to flag unused suppression directives as errors.
  * Tightened the maximum allowed lint warnings.
  * Removed an unnecessary lint suppression from the theme test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->