### PR TITLE
fix: refit and focus the terminal when Terminal Mode is entered

### DIFF
--- a/src/components/desktop/workspace-terminal/WorkspaceTerminalPanels.test.ts
+++ b/src/components/desktop/workspace-terminal/WorkspaceTerminalPanels.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, createElement, Fragment } from 'react';
+import { act, createElement, Fragment, type ForwardedRef } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TerminalTab } from './types';
@@ -10,22 +10,37 @@ import {
 } from '@/lib/orchestrator/outside-worker-split';
 import { useSessionTiles } from './use-session-tiles';
 
-const xtermMockState = vi.hoisted(() => ({ mounts: 0 }));
+const xtermMockState = vi.hoisted(() => ({
+  fits: vi.fn<(session: string, height: number) => void>(),
+  lastFitHeight: 480,
+  mounts: 0,
+}));
 
 vi.mock('@/components/desktop/workspace-terminal/XtermPanel', async () => {
-  const { createElement: mockCreateElement, useEffect } = await import('react');
+  const { createElement: mockCreateElement, forwardRef, useEffect, useImperativeHandle } = await import('react');
+  interface MockXtermPanelProps {
+    tmuxSession: string;
+    visible: boolean;
+    sendTerminalAttach: (session: string, cols: number, rows: number) => void;
+    sendTerminalDetach: (session: string) => void;
+  }
+  interface MockXtermPanelHandle {
+    fit: () => void;
+  }
   return {
-    XtermPanel: ({
+    XtermPanel: forwardRef(function MockXtermPanel({
       tmuxSession,
       visible,
       sendTerminalAttach,
       sendTerminalDetach,
-    }: {
-      tmuxSession: string;
-      visible: boolean;
-      sendTerminalAttach: (session: string, cols: number, rows: number) => void;
-      sendTerminalDetach: (session: string) => void;
-    }) => {
+    }: MockXtermPanelProps, ref: ForwardedRef<MockXtermPanelHandle>) {
+      useImperativeHandle(ref, () => ({
+        fit: () => {
+          const height = visible ? 1189 : 480;
+          xtermMockState.lastFitHeight = height;
+          xtermMockState.fits(tmuxSession, height);
+        },
+      }), [tmuxSession, visible]);
       useEffect(() => {
         xtermMockState.mounts += 1;
         sendTerminalAttach(tmuxSession, 120, 30);
@@ -35,7 +50,7 @@ vi.mock('@/components/desktop/workspace-terminal/XtermPanel', async () => {
         'data-tmux-session': tmuxSession,
         'data-visible': visible ? 'true' : 'false',
       });
-    },
+    }),
   };
 });
 
@@ -116,6 +131,8 @@ describe('WorkspaceTerminalPanels resident surface budget', () => {
 
   beforeEach(() => {
     resetOutsideWorkerSplitsForTest();
+    xtermMockState.fits.mockReset();
+    xtermMockState.lastFitHeight = 480;
     xtermMockState.mounts = 0;
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -126,6 +143,7 @@ describe('WorkspaceTerminalPanels resident surface budget', () => {
     await act(async () => root.unmount());
     resetOutsideWorkerSplitsForTest();
     container.remove();
+    vi.restoreAllMocks();
   });
 
   it('mounts at most three heavy tab surfaces from a large restored workspace', async () => {
@@ -170,6 +188,41 @@ describe('WorkspaceTerminalPanels resident surface budget', () => {
     expect(container.querySelector('[data-chat-tab="chat-before-mode"]')?.getAttribute('data-active')).toBe('true');
     expect(props.sendTerminalAttach).not.toHaveBeenCalled();
     expect(props.sendTerminalDetach).not.toHaveBeenCalled();
+  });
+
+  it('refits a terminal after its hidden container takes the active pane height', async () => {
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0);
+      return 1;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined);
+    const previousTab = {
+      id: 'chat-before-terminal',
+      label: 'Coding session',
+      kind: 'chat',
+      tmuxSession: null,
+      chatRuntime: 'codex',
+      createdAt: 1,
+      lastActivity: 1,
+    } satisfies TerminalTab;
+    const terminal = terminalTab(1);
+    const props = panelProps([previousTab, terminal]);
+
+    await act(async () => root.render(createElement(WorkspaceTerminalPanels, {
+      ...props,
+      effectiveActiveTabId: previousTab.id,
+    })));
+    expect(xtermMockState.lastFitHeight).toBe(480);
+    expect(xtermMockState.fits).not.toHaveBeenCalled();
+
+    await act(async () => root.render(createElement(WorkspaceTerminalPanels, {
+      ...props,
+      effectiveActiveTabId: terminal.id,
+    })));
+
+    expect(xtermMockState.fits).toHaveBeenCalledOnce();
+    expect(xtermMockState.fits).toHaveBeenCalledWith('tmux-1', 1189);
+    expect(xtermMockState.lastFitHeight).toBe(1189);
   });
 
   it('closes an automatic outside-worker host after its last durable leaf retires', async () => {

--- a/src/components/desktop/workspace-terminal/WorkspaceTerminalPanels.tsx
+++ b/src/components/desktop/workspace-terminal/WorkspaceTerminalPanels.tsx
@@ -113,6 +113,16 @@ function WorkspaceTerminalPanelsBase({
     )),
     [effectiveActiveTabId, residentTabIds, visibleTabIdsKey],
   );
+  const effectiveActiveTerminalSession = visibleTabs.find((tab) => (
+    tab.id === effectiveActiveTabId && tab.kind === 'terminal'
+  ))?.tmuxSession ?? null;
+  useEffect(() => {
+    if (!effectiveActiveTerminalSession) return;
+    const frame = window.requestAnimationFrame(() => {
+      panelRefs.current.get(effectiveActiveTerminalSession)?.fit();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [effectiveActiveTabId, effectiveActiveTerminalSession, panelRefs]);
   // Boot claim while the tab restore is UNSETTLED — even when default tabs
   // already render. The boot restore re-runs when the repo registry hydrates
   // late (restoreKey flips 'no-repo' → repo), and without this hold the

--- a/src/components/desktop/workspace-terminal/XtermPanel.tsx
+++ b/src/components/desktop/workspace-terminal/XtermPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 /* eslint-disable @next/next/no-img-element -- terminal image previews intentionally use raw panel-served URLs */
 
-import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { useTheme } from '@/lib/theme/context';
 import { buildXtermTheme } from '@/components/desktop/workspace-terminal/constants';
 import { startSpawnReveal } from '@/components/desktop/workspace-terminal/spawn-reveal';
@@ -52,6 +52,7 @@ export interface XtermPanelProps {
 }
 
 export interface XtermPanelHandle {
+  fit: () => void;
   focus: () => void;
   writeData: (data: string) => void;
   writeRaw: (data: string) => void;
@@ -93,7 +94,20 @@ export const XtermPanel = forwardRef<XtermPanelHandle, XtermPanelProps>(function
   const [inlineImages, setInlineImages] = useState<InlineImage[]>([]);
   const imageCountRef = useRef(0);
 
+  const fitTerminal = useCallback(() => {
+    const fitAddon = fitAddonRef.current;
+    const term = termRef.current;
+    if (!fitAddon || !term) return;
+    try {
+      fitAddon.fit();
+      sendTerminalResize(tmuxSession, term.cols, term.rows);
+    } catch {
+      // The terminal may be disposed while a queued fit is running.
+    }
+  }, [sendTerminalResize, tmuxSession]);
+
   useImperativeHandle(ref, () => ({
+    fit: fitTerminal,
     focus: () => termRef.current?.focus(),
     writeData: (data: string) => {
       if (!termRef.current) return;
@@ -153,24 +167,15 @@ export const XtermPanel = forwardRef<XtermPanelHandle, XtermPanelProps>(function
     },
     setError: (nextError: string) => setError(nextError),
     setExited: () => setExited(true),
-  }), []);
+  }), [fitTerminal]);
 
   useEffect(() => {
-    if (visible && fitAddonRef.current) {
-      const timer = setTimeout(() => {
-        try {
-          fitAddonRef.current?.fit();
-          if (termRef.current) {
-            sendTerminalResize(tmuxSession, termRef.current.cols, termRef.current.rows);
-          }
-        } catch {
-          return;
-        }
-      }, 50);
+    if (visible) {
+      const timer = setTimeout(fitTerminal, 50);
       return () => clearTimeout(timer);
     }
     return undefined;
-  }, [visible, tmuxSession, sendTerminalResize]);
+  }, [fitTerminal, visible]);
 
   useEffect(() => {
     if (!containerRef.current) return undefined;
@@ -250,13 +255,8 @@ export const XtermPanel = forwardRef<XtermPanelHandle, XtermPanelProps>(function
         });
 
         observerRef.current = new ResizeObserver(() => {
-          if (disposed || !visibleRef.current || !fitAddonRef.current) return;
-          try {
-            fitAddonRef.current.fit();
-            sendTerminalResize(tmuxSession, termRef.current.cols, termRef.current.rows);
-          } catch {
-            return;
-          }
+          if (disposed || !visibleRef.current) return;
+          fitTerminal();
         });
         if (containerRef.current) observerRef.current.observe(containerRef.current);
 
@@ -331,7 +331,7 @@ export const XtermPanel = forwardRef<XtermPanelHandle, XtermPanelProps>(function
       fitAddonRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- cancelReveal only touches refs
-  }, [tmuxSession, sendTerminalAttach, sendTerminalDetach, sendTerminalInput, sendTerminalResize, transparent, fontSize, lineHeight, spawnReveal, revealMinPlay]);
+  }, [tmuxSession, sendTerminalAttach, sendTerminalDetach, sendTerminalInput, fitTerminal, transparent, fontSize, lineHeight, spawnReveal, revealMinPlay]);
 
   // Re-attach after a transport (re)connect. The init effect's attach is
   // dropped silently if the socket isn't open yet, and the server never

--- a/src/components/desktop/workspace-terminal/use-terminal-mode.test.ts
+++ b/src/components/desktop/workspace-terminal/use-terminal-mode.test.ts
@@ -57,7 +57,9 @@ describe('useTerminalMode event toggle path', () => {
   let createShellTab: Mock<HookProps['createShellTab']>;
   let attachTerminalSession: Mock<HookProps['attachTerminalSession']>;
   let selectTab: Mock<HookProps['selectTab']>;
+  let fitPanel: Mock<XtermPanelHandle['fit']>;
   let focusPanel: Mock<XtermPanelHandle['focus']>;
+  let panelHandle: XtermPanelHandle;
 
   const render = (overrides: Partial<HookProps> = {}) => {
     props = { ...props, ...overrides };
@@ -77,8 +79,10 @@ describe('useTerminalMode event toggle path', () => {
     createShellTab = vi.fn<HookProps['createShellTab']>(() => 'terminal-new');
     attachTerminalSession = vi.fn<HookProps['attachTerminalSession']>(() => 'terminal-attached');
     selectTab = vi.fn<HookProps['selectTab']>();
+    fitPanel = vi.fn<XtermPanelHandle['fit']>();
     focusPanel = vi.fn<XtermPanelHandle['focus']>();
-    const panelHandle: XtermPanelHandle = {
+    panelHandle = {
+      fit: fitPanel,
       focus: focusPanel,
       writeData: vi.fn(),
       writeRaw: vi.fn(),
@@ -138,6 +142,31 @@ describe('useTerminalMode event toggle path', () => {
     expect(document.activeElement).toBe(priorFocus);
     priorFocus.remove();
     terminalFocus.remove();
+  });
+
+  it('fits and focuses once when a new shell receives its tmux session', async () => {
+    const activeTab = chatTab();
+    const pendingTerminal = terminalTab('terminal-new', null);
+    await act(async () => render({ activeTab, tabs: [activeTab] }));
+
+    await act(async () => {
+      requestTerminalModeToggle('workspace-a');
+      render({ tabs: [activeTab, pendingTerminal] });
+    });
+
+    expect(fitPanel).not.toHaveBeenCalled();
+    expect(focusPanel).not.toHaveBeenCalled();
+
+    const attachedTerminal = terminalTab('terminal-new', 'new-shell-session');
+    props.panelRefs.current.set('new-shell-session', panelHandle);
+    await act(async () => render({ tabs: [activeTab, attachedTerminal] }));
+
+    expect(fitPanel).toHaveBeenCalledOnce();
+    expect(focusPanel).toHaveBeenCalledOnce();
+
+    await act(async () => render({ tabs: [activeTab, { ...attachedTerminal }] }));
+    expect(fitPanel).toHaveBeenCalledOnce();
+    expect(focusPanel).toHaveBeenCalledOnce();
   });
 
   it('creates a shell in the preferred repo and restores on the second toggle', async () => {

--- a/src/components/desktop/workspace-terminal/use-terminal-mode.ts
+++ b/src/components/desktop/workspace-terminal/use-terminal-mode.ts
@@ -105,7 +105,11 @@ export function useTerminalMode({
   const terminalSession = terminalTab?.tmuxSession ?? mode?.tmuxSession ?? null;
   useEffect(() => {
     if (!mode || !terminalSession) return;
-    const frame = window.requestAnimationFrame(() => panelRefs.current.get(terminalSession)?.focus());
+    const frame = window.requestAnimationFrame(() => {
+      const panel = panelRefs.current.get(terminalSession);
+      panel?.fit();
+      panel?.focus();
+    });
     return () => window.cancelAnimationFrame(frame);
   }, [mode, panelRefs, terminalSession]);
 

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -92,6 +92,12 @@
       ]
     },
     {
+      "path": "src/components/desktop/workspace-terminal/use-terminal-mode.test.ts",
+      "reasons": [
+        "terminal-tool"
+      ]
+    },
+    {
       "path": "src/lib/broadcast/hourly-cap.integration.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
Refs #1930, #1720 — found live on v0.1.718.

## What

- **Refit.** `XtermPanel` now has one `fitTerminal` routine (fit addon + resize message) used by the visibility effect, the container resize observer, and a new effect in `WorkspaceTerminalPanels` that fits the terminal whenever it becomes the effective active tab. Terminal Mode's entry effect calls `fit()` through the panel handle before focusing, so a shell shown full-bleed takes the pane's rows instead of the 24 it was created with.
- **Focus.** The entry effect re-runs when the terminal tab's `tmuxSession` transitions from null to a value (new-shell case), so focus lands in the terminal once its panel handle exists — one frame deferred, once per entry.
- No new resize observer; inline styles only; nothing else in the UI.

## Verification

`use-terminal-mode.test.ts`: new-shell case (session null at entry, then set) → `fit` and `focus` each called once. `WorkspaceTerminalPanels.test.ts`: switching `effectiveActiveTabId` to a terminal invokes the handle's fit. `npx tsc --noEmit`, `npm run lint` (ratchet), `npm run test:classification:check`, `npm test` green on the merged head. The installed-app row/height measurement is repeated after the next release.
