### PR TITLE
feat: open the command palette on canvas surfaces

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -39,6 +39,7 @@ import { DesktopStatusBar } from '@/components/desktop/DesktopStatusBar';
 import { DesktopCloseCoordinator } from '@/components/desktop/DesktopCloseCoordinator';
 import { useProjects, type ProjectRecord } from '@/components/desktop/repo-registry/useProjects';
 import type { CommandPaletteActionItem } from '@/components/desktop/CommandPalette';
+import { useCommandPaletteHotkey } from '@/components/desktop/use-command-palette-hotkey';
 import { SessionTimeline } from '@/components/desktop/SessionTimeline';
 import { DictationHost } from '@/components/desktop/dictation/DictationHost';
 import { BrowserPipCard, BROWSER_PIP_EVENT } from '@/components/desktop/BrowserPipCard';
@@ -1392,6 +1393,7 @@ function DashboardInner() {
   // listener below yields only to terminal surfaces; composer focus still
   // opens the palette.
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  useCommandPaletteHotkey(setCommandPaletteOpen);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const dashboardProjects = useProjects();
 
@@ -1890,29 +1892,6 @@ function DashboardInner() {
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, [activeTileId, workspaceTerminalHandlesRef]);
-
-  // ── Cmd+K command palette hotkey (#661) ──
-  // Toggles the full-screen palette overlay from anywhere except xterm.
-  // Esc closes the overlay inside CommandPalette.
-  useEffect(() => {
-    const handler = (event: KeyboardEvent) => {
-      const isPaletteShortcut = (event.metaKey || event.ctrlKey)
-        && !event.altKey
-        && !event.shiftKey
-        && event.key.toLowerCase() === 'k';
-      if (!isPaletteShortcut) return;
-
-      const target = event.target as HTMLElement | null;
-      const insideTerminal = Boolean(target?.closest('.xterm, .cortex-terminal-fade'));
-      if (insideTerminal) return;
-
-      event.preventDefault();
-      event.stopPropagation();
-      setCommandPaletteOpen((current) => !current);
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, []);
 
   // ── ⌘/ (and bare `?`) opens the keyboard-shortcuts reference overlay ──
   // ⌘/ is the macOS-convention "show shortcuts" binding; `?` is a fallback

--- a/src/app/preview/canvas-glass/canvas-command-palette.test.ts
+++ b/src/app/preview/canvas-glass/canvas-command-palette.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import { act, createElement, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CommandPaletteActionItem } from '@/components/desktop/CommandPalette';
+import type { CanvasCommands } from './canvas-commands';
+import { CanvasCommandPalette } from './canvas-command-palette';
+
+vi.mock('@/components/desktop/CommandPalette', () => ({
+  CommandPalette: ({
+    open,
+    onClose,
+    actionItems,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    actionItems: CommandPaletteActionItem[];
+  }): ReactNode => {
+    if (!open) return null;
+    return createElement(
+      'div',
+      { 'data-canvas-palette': 'open' },
+      ...actionItems.map((item) => createElement(
+        'button',
+        {
+          key: item.id,
+          type: 'button',
+          onClick: () => {
+            item.onActivate();
+            onClose();
+          },
+        },
+        item.title,
+      )),
+    );
+  },
+}));
+
+const ACT_ENV = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+ACT_ENV.IS_REACT_ACT_ENVIRONMENT = true;
+
+function createCommands(spawnFile: CanvasCommands['spawnFile']): CanvasCommands {
+  return {
+    spawnTerminal: vi.fn(),
+    spawnFile,
+    spawnImage: vi.fn(),
+    spawnVideo: vi.fn(),
+    spawnBrowser: vi.fn(),
+    spawnChat: vi.fn(),
+    spawnDiff: vi.fn(),
+    spawnSpec: vi.fn(),
+    spawnBrain: vi.fn(),
+    spawnMarkdown: vi.fn(),
+    spawnAgent: vi.fn(),
+    openSearch: vi.fn(),
+    closeActiveCard: vi.fn(),
+    zoomIn: vi.fn(),
+    zoomToFit: vi.fn(),
+    zoomOut: vi.fn(),
+  };
+}
+
+describe('CanvasCommandPalette', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('opens on Command-K and activates the file-card command', async () => {
+    const spawnFile = vi.fn();
+    act(() => root.render(createElement(CanvasCommandPalette, { commands: createCommands(spawnFile) })));
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'k',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      }));
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-canvas-palette="open"]')).not.toBeNull();
+
+    const button = Array.from(container.querySelectorAll('button')).find((entry) => entry.textContent === 'New file card');
+    expect(button).toBeDefined();
+    act(() => button?.click());
+
+    expect(spawnFile).toHaveBeenCalledOnce();
+    expect(container.querySelector('[data-canvas-palette="open"]')).toBeNull();
+  });
+});

--- a/src/app/preview/canvas-glass/canvas-command-palette.tsx
+++ b/src/app/preview/canvas-glass/canvas-command-palette.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { lazy, Suspense, useMemo, useState } from 'react';
+import { useCommandPaletteHotkey } from '@/components/desktop/use-command-palette-hotkey';
+import { canvasCommandActionItems, type CanvasCommands } from './canvas-commands';
+
+const LazyCommandPalette = lazy(() => import('@/components/desktop/CommandPalette').then((module) => ({
+  default: module.CommandPalette,
+})));
+
+export interface CanvasCommandPaletteProps {
+  commands: CanvasCommands;
+  repo?: string | null;
+}
+
+const ignoreSelection = () => {};
+
+export function CanvasCommandPalette({ commands, repo }: CanvasCommandPaletteProps) {
+  const [open, setOpen] = useState(false);
+  useCommandPaletteHotkey(setOpen);
+  const actionItems = useMemo(() => canvasCommandActionItems(commands), [commands]);
+
+  if (!open) return null;
+  return (
+    <Suspense fallback={null}>
+      <LazyCommandPalette
+        open
+        onClose={() => setOpen(false)}
+        workspace={repo}
+        repo={repo}
+        actionItems={actionItems}
+        onSelectIssue={ignoreSelection}
+        onSelectFile={(filePath) => commands.spawnFile(filePath)}
+        onSelectAgent={(sessionKey) => commands.spawnChat(sessionKey)}
+        onSelectChat={(chatTabId) => commands.spawnChat(chatTabId)}
+        onSelectPacket={ignoreSelection}
+        onSelectInbox={ignoreSelection}
+        onSelectDirective={ignoreSelection}
+      />
+    </Suspense>
+  );
+}

--- a/src/app/preview/canvas-glass/canvas-commands.ts
+++ b/src/app/preview/canvas-glass/canvas-commands.ts
@@ -1,0 +1,135 @@
+'use client';
+
+import { useEffect, type Dispatch, type SetStateAction } from 'react';
+import type { CommandPaletteActionItem } from '@/components/desktop/CommandPalette';
+
+export type CanvasCardKind = 'term' | 'file' | 'image' | 'video' | 'browser' | 'chat' | 'diff' | 'spec' | 'brain' | 'markdown' | 'agent';
+
+export const CANVAS_CARD_KINDS: CanvasCardKind[] = [
+  'term',
+  'file',
+  'image',
+  'video',
+  'browser',
+  'chat',
+  'diff',
+  'spec',
+  'brain',
+  'markdown',
+  'agent',
+];
+
+// Ordered most zoomed-in to most zoomed-out. The label is the operator-facing
+// percentage; the value is the CSS zoom used by canvas pointer math.
+export const CANVAS_ZOOM_STEPS = [
+  { label: 130, value: 0.91 },
+  { label: 115, value: 0.805 },
+  { label: 100, value: 0.7 },
+  { label: 85, value: 0.595 },
+  { label: 70, value: 0.49 },
+] as const;
+
+export const CANVAS_FIT_ZOOM = CANVAS_ZOOM_STEPS.find((step) => step.label === 100)?.value ?? 0.7;
+
+export function stepCanvasZoom(current: number, direction: 'in' | 'out'): number {
+  const currentIndex = Math.max(0, CANVAS_ZOOM_STEPS.findIndex((step) => step.value === current));
+  const delta = direction === 'out' ? 1 : -1;
+  const nextIndex = Math.min(CANVAS_ZOOM_STEPS.length - 1, Math.max(0, currentIndex + delta));
+  return CANVAS_ZOOM_STEPS[nextIndex]?.value ?? current;
+}
+
+export function useCanvasZoomHotkeys(
+  setZoom: Dispatch<SetStateAction<number>>,
+): void {
+  useEffect(() => {
+    const onZoomKey = (event: KeyboardEvent) => {
+      if (!event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target;
+      if (target instanceof Element && target.closest('input, textarea, [contenteditable=""], [contenteditable="true"]')) return;
+
+      if (event.key === '=' || event.key === '+') {
+        event.preventDefault();
+        setZoom((current) => stepCanvasZoom(current, 'in'));
+      } else if (event.key === '-' || event.key === '_') {
+        event.preventDefault();
+        setZoom((current) => stepCanvasZoom(current, 'out'));
+      } else if (event.key === '0') {
+        event.preventDefault();
+        setZoom(CANVAS_FIT_ZOOM);
+      }
+    };
+    window.addEventListener('keydown', onZoomKey);
+    return () => window.removeEventListener('keydown', onZoomKey);
+  }, [setZoom]);
+}
+
+export type CanvasCardAddressMap = Record<CanvasCardKind, ReadonlyArray<{ id: number; z: number }>>;
+
+export function closeActiveCanvasCard(
+  cards: CanvasCardAddressMap,
+  closeCard: (kind: CanvasCardKind, id: number) => void,
+): boolean {
+  let active: { kind: CanvasCardKind; id: number; z: number } | null = null;
+  for (const kind of CANVAS_CARD_KINDS) {
+    for (const card of cards[kind]) {
+      if (!active || card.z > active.z) active = { kind, id: card.id, z: card.z };
+    }
+  }
+  if (!active) return false;
+  closeCard(active.kind, active.id);
+  return true;
+}
+
+export function selectCanvasMedia(
+  kind: 'image' | 'video',
+  onSelect: (file: File) => void,
+): void {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = kind === 'image' ? 'image/*' : 'video/*';
+  input.addEventListener('change', () => {
+    const file = input.files?.[0];
+    if (file) onSelect(file);
+  }, { once: true });
+  input.click();
+}
+
+export interface CanvasCommands {
+  spawnTerminal: () => void;
+  spawnFile: (filePath?: string) => void;
+  spawnImage: () => void;
+  spawnVideo: () => void;
+  spawnBrowser: () => void;
+  spawnChat: (threadId?: string) => void;
+  spawnDiff: () => void;
+  spawnSpec: () => void;
+  spawnBrain: () => void;
+  spawnMarkdown: () => void;
+  spawnAgent: () => void;
+  openSearch: () => void;
+  closeActiveCard: () => void;
+  zoomIn: () => void;
+  zoomToFit: () => void;
+  zoomOut: () => void;
+}
+
+export function canvasCommandActionItems(commands: CanvasCommands): CommandPaletteActionItem[] {
+  return [
+    { id: 'canvas:search', title: 'Search the canvas', detail: 'Find cards, files, repositories, and sessions', onActivate: commands.openSearch },
+    { id: 'canvas:new-terminal', title: 'New terminal card', detail: 'Open a shell in the active repository', onActivate: commands.spawnTerminal },
+    { id: 'canvas:new-file', title: 'New file card', detail: 'Choose a file to open on the canvas', onActivate: () => commands.spawnFile() },
+    { id: 'canvas:new-image', title: 'New image card', detail: 'Choose an image from this device', onActivate: commands.spawnImage },
+    { id: 'canvas:new-video', title: 'New video card', detail: 'Choose a video from this device', onActivate: commands.spawnVideo },
+    { id: 'canvas:new-browser', title: 'New browser card', detail: 'Open the dashboard in a browser card', onActivate: commands.spawnBrowser },
+    { id: 'canvas:new-chat', title: 'New chat card', detail: 'Choose a recent orchestrator session', onActivate: () => commands.spawnChat() },
+    { id: 'canvas:new-diff', title: 'New diff card', detail: 'Show the active repository working-tree diff', onActivate: commands.spawnDiff },
+    { id: 'canvas:new-spec', title: 'New spec card', detail: 'Open the active repository o8.md', onActivate: commands.spawnSpec },
+    { id: 'canvas:new-brain', title: 'New Brain card', detail: 'Ask the Engineering Brain about this repository', onActivate: commands.spawnBrain },
+    { id: 'canvas:new-markdown', title: 'New markdown card', detail: 'Place a new note on the canvas', onActivate: commands.spawnMarkdown },
+    { id: 'canvas:new-agent', title: 'New agent card', detail: 'Describe the work in the canvas composer', onActivate: commands.spawnAgent },
+    { id: 'canvas:close-active', title: 'Close active card', detail: 'Close the frontmost canvas card', onActivate: commands.closeActiveCard },
+    { id: 'canvas:zoom-in', title: 'Zoom in', detail: 'Move one step up the canvas zoom ladder', shortcut: '⌘+', onActivate: commands.zoomIn },
+    { id: 'canvas:zoom-fit', title: 'Fit canvas', detail: 'Return to the tuned 100% canvas view', shortcut: '⌘0', onActivate: commands.zoomToFit },
+    { id: 'canvas:zoom-out', title: 'Zoom out', detail: 'Move one step down the canvas zoom ladder', shortcut: '⌘−', onActivate: commands.zoomOut },
+  ];
+}

--- a/src/app/preview/canvas-glass/page.tsx
+++ b/src/app/preview/canvas-glass/page.tsx
@@ -95,6 +95,18 @@ import { useCanvasQuickActions } from './use-canvas-quick-actions';
 import { useCanvasMediaLifecycle } from './use-canvas-media-lifecycle';
 import { clearCanvasTurnAccumulators, removeCanvasConversations, setCanvasConversation, updateCanvasConversation } from './canvas-conversation-retention';
 import { CanvasSearchOverlay } from './canvas-search';
+import { CanvasCommandPalette } from './canvas-command-palette';
+import {
+  CANVAS_CARD_KINDS,
+  CANVAS_FIT_ZOOM,
+  CANVAS_ZOOM_STEPS as ZOOM_STEPS,
+  closeActiveCanvasCard,
+  selectCanvasMedia,
+  stepCanvasZoom,
+  useCanvasZoomHotkeys,
+  type CanvasCardKind,
+  type CanvasCommands,
+} from './canvas-commands';
 import type { OrchestratorExecutionMode } from '@/lib/orchestrator/types';
 /** Live rows for the wired chrome — inbox items, active lanes, commits. */
 interface InboxRow {
@@ -161,24 +173,9 @@ const GRID_MODE_KEY = 'o8:canvas-grid-mode';
 const LOUPE_SIZE_KEY = 'o8:canvas-loupe-size';
 const LOUPE_SIZE_DEFAULT = 160;
 const LOUPE_SIZE_RANGE = { min: 120, max: 240, step: 4 };
-// Ordered most-zoomed-IN (index 0) → most-out. "100%" is the home/fit anchor
-// (0.7 actual — cards fit comfortably); 115/130 let the operator zoom IN and
-// make cards + text bigger (the loupe could previously only go smaller). The
-// default + the loupe "Fit" both resolve the label===100 step, NOT index 0.
-const ZOOM_STEPS = [
-  { label: 130, value: 0.91 },
-  { label: 115, value: 0.805 },
-  { label: 100, value: 0.7 },
-  { label: 85, value: 0.595 },
-  { label: 70, value: 0.49 },
-] as const;
-
-// ── Canvas control surface (agent parity) ──────────────────────────────────
 // Module-scope so the intent listener's deps stay stable. The card verbs let an
 // agent drive the canvas the way a human can: SEE every card (list), then move
 // / resize / focus / close one by (kind, id).
-type CanvasCardKind = 'term' | 'file' | 'image' | 'video' | 'browser' | 'chat' | 'diff' | 'spec' | 'brain' | 'markdown' | 'agent';
-const CANVAS_CARD_KINDS: CanvasCardKind[] = ['term', 'file', 'image', 'video', 'browser', 'chat', 'diff', 'spec', 'brain', 'markdown', 'agent'];
 const CANVAS_GEOM_FLOOR = 140;
 const SPAWN_CHOREOGRAPHY_TTL_MS = 20_000;
 // Broad lite shape every card satisfies — enough to list + title + resize
@@ -324,7 +321,8 @@ export default function CanvasGlassPreviewPage() {
   const [dockTrayExpanded, setDockTrayExpanded] = useState(false);
   const [tunerOpen, setTunerOpen] = useState(false);
   const [orbSettings, setOrbSettings] = useState<OrbSettings>(ORB_DEFAULTS);
-  const [canvasZoomLevel, setCanvasZoomLevel] = useState<number>(ZOOM_STEPS.find((step) => step.label === 100)?.value ?? 0.7);
+  const [canvasZoomLevel, setCanvasZoomLevel] = useState<number>(CANVAS_FIT_ZOOM);
+  useCanvasZoomHotkeys(setCanvasZoomLevel);
   const [loupeSize, setLoupeSize] = useState<number>(LOUPE_SIZE_DEFAULT);
   const [personalDefault, setPersonalDefault] = useState<CanvasGlassSettings | null>(null);
   const [activeRepoPath, setActiveRepoPath] = useState<string | null>(null);
@@ -619,41 +617,6 @@ export default function CanvasGlassPreviewPage() {
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, []);
-
-  // ⌘= / ⌘+ zoom IN · ⌘- / ⌘_ zoom OUT · ⌘0 reset to 100% — the keyboard peer of
-  // the loupe's −/fit/+ cluster. Steps the SAME ZOOM_STEPS array through the same
-  // setCanvasZoomLevel the loupe's onZoomChange drives (index −1 = more zoomed in
-  // = bigger cards + text, +1 = more out), so every path lands on the identical
-  // discrete rungs. preventDefault stops WebKit's native page zoom, which would
-  // scale the whole chrome instead of only the canvas layer. Never fires while
-  // typing — a focused input / textarea / CodeMirror editor keeps ⌘-/⌘= for
-  // itself so the file-card editor is untouched.
-  useEffect(() => {
-    const onZoomKey = (event: KeyboardEvent) => {
-      if (!event.metaKey || event.ctrlKey || event.altKey) return;
-      const target = event.target;
-      if (target instanceof Element && target.closest('input, textarea, [contenteditable=""], [contenteditable="true"]')) return;
-      const stepZoom = (delta: number) => {
-        setCanvasZoomLevel((current) => {
-          const idx = Math.max(0, ZOOM_STEPS.findIndex((step) => step.value === current));
-          const next = ZOOM_STEPS[Math.min(ZOOM_STEPS.length - 1, Math.max(0, idx + delta))];
-          return next ? next.value : current;
-        });
-      };
-      if (event.key === '=' || event.key === '+') {
-        event.preventDefault();
-        stepZoom(-1);
-      } else if (event.key === '-' || event.key === '_') {
-        event.preventDefault();
-        stepZoom(1);
-      } else if (event.key === '0') {
-        event.preventDefault();
-        setCanvasZoomLevel(ZOOM_STEPS.find((step) => step.label === 100)?.value ?? 0.7);
-      }
-    };
-    window.addEventListener('keydown', onZoomKey);
-    return () => window.removeEventListener('keydown', onZoomKey);
   }, []);
 
   // Repos load at mount — the composer is scoped to a repo from the first
@@ -3123,6 +3086,46 @@ export default function CanvasGlassPreviewPage() {
     }
   }, [closeTerminal, closeFileCard, closeImageCard, closeVideoCard, closeBrowserCard, closeChatCard]);
 
+  const commandPaletteCommands = useMemo<CanvasCommands>(() => ({
+    spawnTerminal: () => {
+      const path = activeRepoPath ?? null;
+      spawnTerminal(path, path ? repos?.find((repo) => repo.path === path)?.name ?? null : null);
+    },
+    spawnFile: (filePath) => {
+      if (filePath) spawnFileCard(filePath);
+      else openFilePicker();
+    },
+    spawnImage: () => selectCanvasMedia('image', (file) => {
+      const origin = viewportSpawnOrigin();
+      spawnImageCard(file, { x: origin.x + 140, y: origin.y + 64 });
+    }),
+    spawnVideo: () => selectCanvasMedia('video', (file) => {
+      const origin = viewportSpawnOrigin();
+      spawnVideoCard(file, { x: origin.x + 140, y: origin.y + 64 });
+    }),
+    spawnBrowser: spawnBrowserCard,
+    spawnChat: (threadId) => {
+      if (threadId) void pickThread(threadId, activeRepoPath);
+      else setSessionsOpen(true);
+    },
+    spawnDiff: () => { void spawnWorktreeDiffCard(); },
+    spawnSpec: spawnSpecCard,
+    spawnBrain: () => spawnBrainCard(),
+    spawnMarkdown: () => spawnMarkdownCard('Note', '# New note'),
+    spawnAgent: () => {
+      if ((convos[activeRepoPath ?? '']?.length ?? 0) > 0) redockActiveLane();
+      composerInputRef.current?.focus();
+    },
+    openSearch: () => {
+      setSearchQuery('');
+      setSearchOpen(true);
+    },
+    closeActiveCard: () => { closeActiveCanvasCard(canvasCardsRef.current, dismissCanvasCard); },
+    zoomIn: () => setCanvasZoomLevel((current) => stepCanvasZoom(current, 'in')),
+    zoomToFit: () => setCanvasZoomLevel(CANVAS_FIT_ZOOM),
+    zoomOut: () => setCanvasZoomLevel((current) => stepCanvasZoom(current, 'out')),
+  }), [activeRepoPath, convos, dismissCanvasCard, openFilePicker, pickThread, redockActiveLane, repos, spawnBrainCard, spawnBrowserCard, spawnFileCard, spawnImageCard, spawnMarkdownCard, spawnSpecCard, spawnTerminal, spawnVideoCard, spawnWorktreeDiffCard, viewportSpawnOrigin]);
+
   // Canvas intent bus (#1232 phase 2) — Symon and the gated /api/canvas/intent
   // route drive the canvas through the SAME handlers the rail buttons call.
   // Listeners run synchronously on dispatchEvent, so the ack stamped on
@@ -3176,11 +3179,7 @@ export default function CanvasGlassPreviewPage() {
             if (ZOOM_STEPS.some((step) => step.value === level)) {
               setCanvasZoomLevel(level);
             } else if (args.direction === 'in' || args.direction === 'out') {
-              setCanvasZoomLevel((previous) => {
-                const index = ZOOM_STEPS.findIndex((step) => step.value === previous);
-                const next = args.direction === 'out' ? index + 1 : index - 1;
-                return ZOOM_STEPS[Math.max(0, Math.min(ZOOM_STEPS.length - 1, next))].value;
-              });
+              setCanvasZoomLevel((previous) => stepCanvasZoom(previous, args.direction as 'in' | 'out'));
             } else {
               ok = false;
               note = `zoom needs level (${ZOOM_STEPS.map((step) => step.value).join(', ')}) or direction in|out`;
@@ -3543,6 +3542,7 @@ export default function CanvasGlassPreviewPage() {
           instead of going silent. Renders only its own fixed pill. */}
       <RealtimeVoiceHost />
       <SymonVoicePresencePill />
+      <CanvasCommandPalette commands={commandPaletteCommands} repo={activeRepoPath} />
 
       {/* In the app the desktop IS the backdrop (native material). The
           diffusion only stands in where there is no desktop to show. */}

--- a/src/components/desktop/use-command-palette-hotkey.test.ts
+++ b/src/components/desktop/use-command-palette-hotkey.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { act, createElement, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useCommandPaletteHotkey } from './use-command-palette-hotkey';
+
+const ACT_ENV = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+ACT_ENV.IS_REACT_ACT_ENVIRONMENT = true;
+
+function Harness() {
+  const [open, setOpen] = useState(false);
+  useCommandPaletteHotkey(setOpen);
+  return createElement(
+    'div',
+    null,
+    createElement('output', { 'data-open': String(open) }),
+    createElement('input', { 'aria-label': 'Composer' }),
+    createElement('div', { className: 'xterm' }, createElement('textarea', { 'aria-label': 'Terminal' })),
+  );
+}
+
+function paletteShortcut(init: KeyboardEventInit = {}): KeyboardEvent {
+  return new KeyboardEvent('keydown', {
+    key: 'k',
+    metaKey: true,
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+}
+
+describe('useCommandPaletteHotkey', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => root.render(createElement(Harness)));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('toggles on Command-K', () => {
+    act(() => window.dispatchEvent(paletteShortcut()));
+    expect(container.querySelector('output')?.dataset.open).toBe('true');
+
+    act(() => window.dispatchEvent(paletteShortcut()));
+    expect(container.querySelector('output')?.dataset.open).toBe('false');
+  });
+
+  it('leaves Command-Shift-K untouched', () => {
+    const event = paletteShortcut({ shiftKey: true });
+    act(() => window.dispatchEvent(event));
+
+    expect(container.querySelector('output')?.dataset.open).toBe('false');
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('opens from a normal input but yields inside a terminal', () => {
+    const input = container.querySelector<HTMLInputElement>('[aria-label="Composer"]');
+    const terminal = container.querySelector<HTMLTextAreaElement>('[aria-label="Terminal"]');
+    expect(input).not.toBeNull();
+    expect(terminal).not.toBeNull();
+
+    const inputEvent = paletteShortcut();
+    act(() => input?.dispatchEvent(inputEvent));
+    expect(container.querySelector('output')?.dataset.open).toBe('true');
+    expect(inputEvent.defaultPrevented).toBe(true);
+
+    const terminalEvent = paletteShortcut();
+    act(() => terminal?.dispatchEvent(terminalEvent));
+    expect(container.querySelector('output')?.dataset.open).toBe('true');
+    expect(terminalEvent.defaultPrevented).toBe(false);
+  });
+});

--- a/src/components/desktop/use-command-palette-hotkey.ts
+++ b/src/components/desktop/use-command-palette-hotkey.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect, type Dispatch, type SetStateAction } from 'react';
+
+export function useCommandPaletteHotkey(
+  setOpen: Dispatch<SetStateAction<boolean>>,
+): void {
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      const isPaletteShortcut = (event.metaKey || event.ctrlKey)
+        && !event.altKey
+        && !event.shiftKey
+        && event.key.toLowerCase() === 'k';
+      if (!isPaletteShortcut) return;
+
+      const target = event.target;
+      const insideTerminal = target instanceof Element
+        && Boolean(target.closest('.xterm, .cortex-terminal-fade'));
+      if (insideTerminal) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      setOpen((current) => !current);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [setOpen]);
+}


### PR DESCRIPTION
Refs #1916, #1664.

## What

⌘K did nothing on the canvas because `/preview/canvas-glass` is its own Next route: the palette was never mounted there and no listener existed. The dashboard's inline ⌘K effect is extracted into `useCommandPaletteHotkey` (used by both routes, no behavior change on the dashboard), and the canvas route mounts a lazy-loaded wrapper around the existing `CommandPalette` with a canvas-scoped action list built in `canvas-commands.ts`: spawn each card kind (mirroring the `o8_canvas` verbs), open canvas search, close the active card, and the zoom-ladder steps — all calling the same functions the toolbar and MCP verbs already call. Chrome sizes route through `CHROME`; inline styles only.

Ceiling receipts: canvas `page.tsx` 5,465 → 5,465, `CommandPalette.tsx` 726 → 726, dashboard `page.tsx` 5,922 → 5,901.

## Verification

`use-command-palette-hotkey.test.ts`: ⌘K toggles; ⌘⇧K is untouched; the dashboard's existing typing rule is preserved. `canvas-command-palette.test.ts` (createRoot + act, heavy deps mocked): mounting the canvas wrapper and dispatching ⌘K opens the palette; activating "New file card" calls the injected spawn function once. `npx tsc --noEmit`, `npm run lint` (ratchet), `npm run test:classification:check`, `npm test` green on the merged head.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command palette to the canvas for creating files, agents, and chats, searching, closing cards, and adjusting zoom.
  * Added keyboard shortcuts for opening the command palette and changing canvas zoom.
  * Added support for selecting image and video files on the canvas.

* **Bug Fixes**
  * Improved command-palette shortcut handling while preserving terminal text input behavior.

* **Tests**
  * Added coverage for command-palette shortcuts, canvas actions, and palette closing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->