### PR TITLE
feat: add the versioned repository workspace manifest schema

### DIFF
--- a/docs/internals/workspace-manifest.md
+++ b/docs/internals/workspace-manifest.md
@@ -1,0 +1,94 @@
+# Repository workspace manifest
+
+`o8.workspace.json` is a versioned repository workspace declaration. Keep it at the repository root, next to `o8.md`, and check it into the repository so clones receive the same contract. `~/.o8/repos.json` can cache the manifest version, path, service names, or a validation error, but the checked-in file is the source of truth.
+
+## Version 1 schema
+
+```ts
+interface WorkspaceManifestV1 {
+  version: 1;
+  setup?: string[];
+  teardown?: string[];
+  services?: Array<{
+    name: string;
+    command: string;
+    cwd?: string;
+    env?: Record<string, string>;
+    port?: {
+      preferred: number;
+      env?: string;
+    };
+    health?: {
+      http?: string;
+      tcp?: true;
+      timeoutMs?: number;
+    };
+  }>;
+  preview?: {
+    url: string;
+  };
+}
+```
+
+`setup` and `teardown` list commands that run from the repository root. A service `cwd`, when present, is relative to that root. `preview.url` can contain `{{port}}` or `{{service:<name>}}` placeholders.
+
+## Complete example
+
+```json
+{
+  "version": 1,
+  "setup": [
+    "npm install",
+    "npm run build"
+  ],
+  "teardown": [
+    "npm run cleanup"
+  ],
+  "services": [
+    {
+      "name": "api",
+      "command": "npm run dev:api",
+      "cwd": "apps/api",
+      "env": {
+        "LOG_LEVEL": "debug"
+      },
+      "port": {
+        "preferred": 4100,
+        "env": "PORT"
+      },
+      "health": {
+        "http": "http://127.0.0.1:4100/health",
+        "timeoutMs": 30000
+      }
+    },
+    {
+      "name": "web",
+      "command": "npm run dev:web",
+      "cwd": "apps/web",
+      "port": {
+        "preferred": 4173,
+        "env": "PORT"
+      },
+      "health": {
+        "tcp": true,
+        "timeoutMs": 30000
+      }
+    }
+  ],
+  "preview": {
+    "url": "http://127.0.0.1:{{service:web}}"
+  }
+}
+```
+
+## Validation and discovery rules
+
+- Parsing is strict at every schema object. An unknown key fails validation and the error names its JSON path, such as `$.services[0].restart`.
+- `version` is required. Version 1 passes through `migrateManifest()` unchanged. Unsupported versions fail with an error at `$.version`.
+- Service names must be unique within one manifest.
+- A preferred port must be an integer from 1 through 65535. It cannot use o8's current production, reserved, or development blocks: `47100` through `47111` and `47120` through `47129`. `src/lib/panel/port-constants.ts` is authoritative.
+- `loadWorkspaceManifest(repoPath)` reads only `<repoPath>/o8.workspace.json`. A missing file returns `null`.
+- Repository connection never fails because of an invalid manifest. The registry caches `{ manifest: { error } }` and leaves the checked-in file unchanged.
+- Discovery does not run setup, teardown, services, health checks, placeholder resolution, or port allocation.
+
+#1909 wires launch-time consumption of this declaration.

--- a/src/lib/repos/registry.ts
+++ b/src/lib/repos/registry.ts
@@ -13,12 +13,14 @@ import type {
   RepoRegistryEntry,
   RepoRegistryStore,
   RepoSetupConfig,
+  RepoWorkspaceManifestCache,
   ValidatedRepoCandidate,
 } from './types';
 import { isRepoWorkspaceIsolationPreference } from './types';
 import { emitProductEvent } from '@/lib/analytics/server';
 import { withStoragePressurePolicyLock } from '@/lib/orchestrator/storage-pressure-policy-lock';
 import { dependencyInstallCommandForManager } from '@/lib/workspace/dependency-manager-contract';
+import { loadWorkspaceManifest, workspaceManifestPath } from '@/lib/workspace/manifest';
 
 const execFileAsync = promisify(execFile);
 
@@ -88,6 +90,22 @@ async function pathExists(target: string) {
     return true;
   } catch {
     return false;
+  }
+}
+
+async function loadWorkspaceManifestCache(
+  repoRoot: string,
+): Promise<RepoWorkspaceManifestCache | undefined> {
+  try {
+    const manifest = await loadWorkspaceManifest(repoRoot);
+    if (!manifest) return undefined;
+    return {
+      version: manifest.version,
+      path: workspaceManifestPath(repoRoot),
+      serviceNames: manifest.services?.map((service) => service.name) ?? [],
+    };
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) };
   }
 }
 
@@ -463,6 +481,7 @@ export async function validateRepo(localPath: string) {
 
 export async function addRepo(localPath: string) {
   const candidate = await inspectLocalRepo(localPath);
+  const manifest = await loadWorkspaceManifestCache(candidate.localPath);
   const { entry, created } = await withRegistryMutation(async () => {
     const store = await readStoreFresh();
     const now = nowIso();
@@ -476,6 +495,7 @@ export async function addRepo(localPath: string) {
         defaultBranch: candidate.defaultBranch,
         isGitRepo: candidate.isGitRepo ?? true,
         setup: reconcileDetectedSetup(existing.setup, candidate.setup),
+        manifest,
         lastOpenedAt: now,
       };
       const repos = store.repos.map((repo) => (repo.id === existing.id ? updated : repo));
@@ -494,6 +514,7 @@ export async function addRepo(localPath: string) {
       lastOpenedAt: now,
       storagePressureParkingDisabled: false,
       setup: candidate.setup,
+      manifest,
     };
     await writeStore({ version: 1, repos: [...store.repos, added] });
     return { entry: added, created: true };
@@ -563,6 +584,7 @@ export async function updateRepo(
   },
 ) {
   const candidate = updates.localPath === undefined ? null : await inspectLocalRepo(updates.localPath);
+  const manifest = candidate ? await loadWorkspaceManifestCache(candidate.localPath) : undefined;
   const next = await withRegistryMutation(async () => {
     const store = await readStoreFresh();
     const existing = store.repos.find((repo) => repo.id === id);
@@ -578,6 +600,7 @@ export async function updateRepo(
         remoteUrl: candidate.remoteUrl,
         defaultBranch: candidate.defaultBranch,
         isGitRepo: candidate.isGitRepo,
+        manifest,
       } : {}),
       setup: normalizeSetupConfig(updates.setup ?? existing.setup),
       lastOpenedAt: updates.lastOpenedAt === undefined ? existing.lastOpenedAt : updates.lastOpenedAt,

--- a/src/lib/repos/types.ts
+++ b/src/lib/repos/types.ts
@@ -42,6 +42,10 @@ export interface RepoSetupConfig {
   workspaceIsolationPreference: RepoWorkspaceIsolationPreference;
 }
 
+export type RepoWorkspaceManifestCache =
+  | { version: 1; path: string; serviceNames: string[] }
+  | { error: string };
+
 export interface RepoRegistryEntry {
   id: string;
   name: string;
@@ -54,6 +58,7 @@ export interface RepoRegistryEntry {
   /** Durable opt-out from global storage-pressure parking. Missing legacy values normalize to false. */
   storagePressureParkingDisabled: boolean;
   setup: RepoSetupConfig;
+  manifest?: RepoWorkspaceManifestCache;
   readiness?: RepoReadiness;
 }
 

--- a/src/lib/workspace/manifest/index.ts
+++ b/src/lib/workspace/manifest/index.ts
@@ -1,0 +1,16 @@
+export { loadWorkspaceManifest, workspaceManifestPath } from './loader';
+export {
+  migrateManifest,
+  parseWorkspaceManifest,
+  WorkspaceManifestValidationError,
+} from './schema';
+export {
+  WORKSPACE_MANIFEST_FILENAME,
+  WORKSPACE_MANIFEST_VERSION,
+  type WorkspaceManifest,
+  type WorkspaceManifestPreview,
+  type WorkspaceManifestService,
+  type WorkspaceManifestServiceHealth,
+  type WorkspaceManifestServicePort,
+  type WorkspaceManifestV1,
+} from './types';

--- a/src/lib/workspace/manifest/loader.ts
+++ b/src/lib/workspace/manifest/loader.ts
@@ -1,0 +1,38 @@
+import 'server-only';
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { parseWorkspaceManifest, WorkspaceManifestValidationError } from './schema';
+import { WORKSPACE_MANIFEST_FILENAME, type WorkspaceManifest } from './types';
+
+export function workspaceManifestPath(repoPath: string): string {
+  return path.join(path.resolve(repoPath), WORKSPACE_MANIFEST_FILENAME);
+}
+
+export async function loadWorkspaceManifest(repoPath: string): Promise<WorkspaceManifest | null> {
+  const manifestPath = workspaceManifestPath(repoPath);
+  let raw: string;
+  try {
+    raw = await readFile(manifestPath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw new WorkspaceManifestValidationError(
+      '$',
+      `could not read the file: ${error instanceof Error ? error.message : String(error)}.`,
+      { cause: error },
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new WorkspaceManifestValidationError(
+      '$',
+      `invalid JSON: ${error instanceof Error ? error.message : String(error)}.`,
+      { cause: error },
+    );
+  }
+  return parseWorkspaceManifest(parsed);
+}

--- a/src/lib/workspace/manifest/manifest.test.ts
+++ b/src/lib/workspace/manifest/manifest.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { DEV_API_PORT_BLOCK } from '@/lib/panel/port-constants';
+import {
+  loadWorkspaceManifest,
+  migrateManifest,
+  parseWorkspaceManifest,
+  type WorkspaceManifestV1,
+} from './index';
+
+const validManifest: WorkspaceManifestV1 = {
+  version: 1,
+  setup: ['npm install', 'npm run build'],
+  teardown: ['npm run cleanup'],
+  services: [
+    {
+      name: 'api',
+      command: 'npm run dev:api',
+      cwd: 'apps/api',
+      env: { LOG_LEVEL: 'debug' },
+      port: { preferred: 4100, env: 'PORT' },
+      health: { http: 'http://127.0.0.1:4100/health', timeoutMs: 30_000 },
+    },
+    {
+      name: 'web',
+      command: 'npm run dev:web',
+      port: { preferred: 4173 },
+      health: { tcp: true },
+    },
+  ],
+  preview: { url: 'http://127.0.0.1:{{service:web}}' },
+};
+
+describe('workspace manifest v1', () => {
+  it('round-trips a valid v1 record', () => {
+    const serialized = JSON.stringify(validManifest);
+    const parsed = parseWorkspaceManifest(JSON.parse(serialized));
+
+    expect(parsed).toEqual(validManifest);
+    expect(JSON.stringify(parsed)).toBe(serialized);
+  });
+
+  it('rejects an unknown key with its JSON path', () => {
+    expect(() => parseWorkspaceManifest({
+      version: 1,
+      services: [{ name: 'api', command: 'npm run api', restart: 'always' }],
+    })).toThrow('$.services[0].restart: unknown key');
+  });
+
+  it('rejects a preferred port reserved by o8', () => {
+    expect(() => parseWorkspaceManifest({
+      version: 1,
+      services: [{
+        name: 'api',
+        command: 'npm run api',
+        port: { preferred: DEV_API_PORT_BLOCK[0] },
+      }],
+    })).toThrow(`$.services[0].port.preferred: port ${DEV_API_PORT_BLOCK[0]} is reserved by o8`);
+  });
+
+  it('rejects duplicate service names', () => {
+    expect(() => parseWorkspaceManifest({
+      version: 1,
+      services: [
+        { name: 'api', command: 'npm run api' },
+        { name: 'api', command: 'npm run api:second' },
+      ],
+    })).toThrow('$.services[1].name: duplicate service name "api"');
+  });
+
+  it('returns null when the repository has no manifest file', async () => {
+    const repoPath = mkdtempSync(path.join(os.tmpdir(), 'o8-workspace-manifest-missing-'));
+    try {
+      await expect(loadWorkspaceManifest(repoPath)).resolves.toBeNull();
+    } finally {
+      rmSync(repoPath, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps v1 as an identity migration and rejects unsupported versions', () => {
+    expect(migrateManifest(validManifest)).toBe(validManifest);
+    expect(() => migrateManifest({ version: 0 })).toThrow(
+      '$.version: unsupported workspace manifest version 0; expected 1',
+    );
+  });
+});

--- a/src/lib/workspace/manifest/schema.ts
+++ b/src/lib/workspace/manifest/schema.ts
@@ -1,0 +1,176 @@
+import {
+  DEV_API_PORT_BLOCK,
+  DEV_WS_PORT_BLOCK,
+  PROD_API_PORT_BLOCK,
+  PROD_WS_PORT_BLOCK,
+  RESERVED_PORT_BLOCK,
+} from '@/lib/panel/port-constants';
+
+import {
+  WORKSPACE_MANIFEST_FILENAME,
+  WORKSPACE_MANIFEST_VERSION,
+  type WorkspaceManifest,
+  type WorkspaceManifestService,
+  type WorkspaceManifestV1,
+} from './types';
+
+type JsonObject = Record<string, unknown>;
+
+const O8_RESERVED_PORTS = new Set<number>([
+  ...PROD_API_PORT_BLOCK,
+  ...PROD_WS_PORT_BLOCK,
+  ...RESERVED_PORT_BLOCK,
+  ...DEV_API_PORT_BLOCK,
+  ...DEV_WS_PORT_BLOCK,
+]);
+
+export class WorkspaceManifestValidationError extends Error {
+  constructor(
+    public readonly jsonPath: string,
+    detail: string,
+    options?: ErrorOptions,
+  ) {
+    super(`Invalid ${WORKSPACE_MANIFEST_FILENAME} at ${jsonPath}: ${detail}`, options);
+    this.name = 'WorkspaceManifestValidationError';
+  }
+}
+
+function fail(jsonPath: string, detail: string, options?: ErrorOptions): never {
+  throw new WorkspaceManifestValidationError(jsonPath, detail, options);
+}
+
+function valueKind(value: unknown): string {
+  if (value === undefined) return 'a missing value';
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'an array';
+  return typeof value === 'object' ? 'an object' : `${typeof value} ${JSON.stringify(value)}`;
+}
+
+function propertyPath(parent: string, key: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)
+    ? `${parent}.${key}`
+    : `${parent}[${JSON.stringify(key)}]`;
+}
+
+function expectObject(value: unknown, jsonPath: string): JsonObject {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    fail(jsonPath, `expected an object, received ${valueKind(value)}.`);
+  }
+  return value as JsonObject;
+}
+
+function assertAllowedKeys(value: JsonObject, allowed: readonly string[], jsonPath: string): void {
+  const allowedKeys = new Set(allowed);
+  const unknown = Object.keys(value).find((key) => !allowedKeys.has(key));
+  if (unknown) {
+    fail(propertyPath(jsonPath, unknown), 'unknown key.');
+  }
+}
+
+function expectString(value: unknown, jsonPath: string): asserts value is string {
+  if (typeof value !== 'string') {
+    fail(jsonPath, `expected a string, received ${valueKind(value)}.`);
+  }
+}
+
+function expectStringArray(value: unknown, jsonPath: string): asserts value is string[] {
+  if (!Array.isArray(value)) {
+    fail(jsonPath, `expected an array, received ${valueKind(value)}.`);
+  }
+  value.forEach((entry, index) => expectString(entry, `${jsonPath}[${index}]`));
+}
+
+function validateEnvironment(value: unknown, jsonPath: string): void {
+  const environment = expectObject(value, jsonPath);
+  for (const [key, entry] of Object.entries(environment)) {
+    expectString(entry, propertyPath(jsonPath, key));
+  }
+}
+
+function validatePort(value: unknown, jsonPath: string): void {
+  const port = expectObject(value, jsonPath);
+  assertAllowedKeys(port, ['preferred', 'env'], jsonPath);
+  const preferredPath = propertyPath(jsonPath, 'preferred');
+  if (!Number.isInteger(port.preferred) || (port.preferred as number) < 1 || (port.preferred as number) > 65_535) {
+    fail(preferredPath, `expected an integer from 1 through 65535, received ${valueKind(port.preferred)}.`);
+  }
+  if (O8_RESERVED_PORTS.has(port.preferred as number)) {
+    fail(preferredPath, `port ${port.preferred} is reserved by o8.`);
+  }
+  if (port.env !== undefined) expectString(port.env, propertyPath(jsonPath, 'env'));
+}
+
+function validateHealth(value: unknown, jsonPath: string): void {
+  const health = expectObject(value, jsonPath);
+  assertAllowedKeys(health, ['http', 'tcp', 'timeoutMs'], jsonPath);
+  if (health.http !== undefined) expectString(health.http, propertyPath(jsonPath, 'http'));
+  if (health.tcp !== undefined && health.tcp !== true) {
+    fail(propertyPath(jsonPath, 'tcp'), `expected true, received ${valueKind(health.tcp)}.`);
+  }
+  if (health.timeoutMs !== undefined
+    && (!Number.isInteger(health.timeoutMs) || (health.timeoutMs as number) < 0)) {
+    fail(
+      propertyPath(jsonPath, 'timeoutMs'),
+      `expected a non-negative integer, received ${valueKind(health.timeoutMs)}.`,
+    );
+  }
+}
+
+function validateService(value: unknown, jsonPath: string): WorkspaceManifestService {
+  const service = expectObject(value, jsonPath);
+  assertAllowedKeys(service, ['name', 'command', 'cwd', 'env', 'port', 'health'], jsonPath);
+  expectString(service.name, propertyPath(jsonPath, 'name'));
+  expectString(service.command, propertyPath(jsonPath, 'command'));
+  if (service.cwd !== undefined) expectString(service.cwd, propertyPath(jsonPath, 'cwd'));
+  if (service.env !== undefined) validateEnvironment(service.env, propertyPath(jsonPath, 'env'));
+  if (service.port !== undefined) validatePort(service.port, propertyPath(jsonPath, 'port'));
+  if (service.health !== undefined) validateHealth(service.health, propertyPath(jsonPath, 'health'));
+  return service as unknown as WorkspaceManifestService;
+}
+
+function validateServices(value: unknown, jsonPath: string): void {
+  if (!Array.isArray(value)) {
+    fail(jsonPath, `expected an array, received ${valueKind(value)}.`);
+  }
+  const names = new Set<string>();
+  value.forEach((entry, index) => {
+    const servicePath = `${jsonPath}[${index}]`;
+    const service = validateService(entry, servicePath);
+    if (names.has(service.name)) {
+      fail(propertyPath(servicePath, 'name'), `duplicate service name ${JSON.stringify(service.name)}.`);
+    }
+    names.add(service.name);
+  });
+}
+
+function validatePreview(value: unknown, jsonPath: string): void {
+  const preview = expectObject(value, jsonPath);
+  assertAllowedKeys(preview, ['url'], jsonPath);
+  expectString(preview.url, propertyPath(jsonPath, 'url'));
+}
+
+function validateManifestV1(value: JsonObject): WorkspaceManifestV1 {
+  assertAllowedKeys(value, ['version', 'setup', 'teardown', 'services', 'preview'], '$');
+  if (value.setup !== undefined) expectStringArray(value.setup, '$.setup');
+  if (value.teardown !== undefined) expectStringArray(value.teardown, '$.teardown');
+  if (value.services !== undefined) validateServices(value.services, '$.services');
+  if (value.preview !== undefined) validatePreview(value.preview, '$.preview');
+  return value as unknown as WorkspaceManifestV1;
+}
+
+export function migrateManifest(value: unknown): WorkspaceManifest {
+  const manifest = expectObject(value, '$');
+  switch (manifest.version) {
+    case WORKSPACE_MANIFEST_VERSION:
+      return validateManifestV1(manifest);
+    default:
+      fail(
+        '$.version',
+        `unsupported workspace manifest version ${JSON.stringify(manifest.version)}; expected ${WORKSPACE_MANIFEST_VERSION}.`,
+      );
+  }
+}
+
+export function parseWorkspaceManifest(value: unknown): WorkspaceManifest {
+  return migrateManifest(value);
+}

--- a/src/lib/workspace/manifest/types.ts
+++ b/src/lib/workspace/manifest/types.ts
@@ -1,0 +1,36 @@
+export const WORKSPACE_MANIFEST_FILENAME = 'o8.workspace.json';
+export const WORKSPACE_MANIFEST_VERSION = 1 as const;
+
+export interface WorkspaceManifestServicePort {
+  preferred: number;
+  env?: string;
+}
+
+export interface WorkspaceManifestServiceHealth {
+  http?: string;
+  tcp?: true;
+  timeoutMs?: number;
+}
+
+export interface WorkspaceManifestService {
+  name: string;
+  command: string;
+  cwd?: string;
+  env?: Record<string, string>;
+  port?: WorkspaceManifestServicePort;
+  health?: WorkspaceManifestServiceHealth;
+}
+
+export interface WorkspaceManifestPreview {
+  url: string;
+}
+
+export interface WorkspaceManifestV1 {
+  version: typeof WORKSPACE_MANIFEST_VERSION;
+  setup?: string[];
+  teardown?: string[];
+  services?: WorkspaceManifestService[];
+  preview?: WorkspaceManifestPreview;
+}
+
+export type WorkspaceManifest = WorkspaceManifestV1;

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2318,6 +2318,14 @@
       ]
     },
     {
+      "path": "tests/workspace-manifest-registry-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/workspace-park-real-path.test.ts",
       "reasons": [
         "child-process",

--- a/tests/workspace-manifest-registry-real-path.test.ts
+++ b/tests/workspace-manifest-registry-real-path.test.ts
@@ -1,0 +1,71 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const root = mkdtempSync(path.join(os.tmpdir(), 'o8-workspace-manifest-registry-'));
+const dataDir = path.join(root, 'data');
+const previousDataDir = process.env.CORTEX_IDE_DATA_DIR;
+mkdirSync(dataDir);
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+
+function fixture(name: string, manifest: unknown): string {
+  const repoPath = path.join(root, name);
+  mkdirSync(repoPath);
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repoPath });
+  execFileSync('git', ['config', 'user.name', 'o8-test'], { cwd: repoPath });
+  execFileSync('git', ['config', 'user.email', 'test@invalid'], { cwd: repoPath });
+  writeFileSync(
+    path.join(repoPath, 'o8.workspace.json'),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  execFileSync('git', ['add', 'o8.workspace.json'], { cwd: repoPath });
+  execFileSync('git', ['commit', '-qm', 'fixture'], { cwd: repoPath });
+  return repoPath;
+}
+
+const { addRepo, listRepos } = await import('@/lib/repos/registry');
+
+afterAll(() => {
+  if (previousDataDir === undefined) delete process.env.CORTEX_IDE_DATA_DIR;
+  else process.env.CORTEX_IDE_DATA_DIR = previousDataDir;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('workspace manifest repository-connect path', () => {
+  it('caches the checked-in manifest summary through addRepo and persisted readback', async () => {
+    const repoPath = fixture('valid-repo', {
+      version: 1,
+      services: [
+        { name: 'api', command: 'npm run api' },
+        { name: 'web', command: 'npm run web' },
+      ],
+    });
+
+    const entry = await addRepo(repoPath);
+    const expected = {
+      version: 1,
+      path: path.join(entry.localPath, 'o8.workspace.json'),
+      serviceNames: ['api', 'web'],
+    };
+    expect(entry.manifest).toEqual(expected);
+    expect((await listRepos()).find((repo) => repo.id === entry.id)?.manifest).toEqual(expected);
+
+    const persisted = JSON.parse(readFileSync(path.join(dataDir, 'repos.json'), 'utf8')) as {
+      repos: Array<{ id: string; manifest?: unknown }>;
+    };
+    expect(persisted.repos.find((repo) => repo.id === entry.id)?.manifest).toEqual(expected);
+  });
+
+  it('records an invalid manifest without blocking addRepo', async () => {
+    const repoPath = fixture('invalid-repo', { version: 1, launch: 'npm start' });
+
+    const entry = await addRepo(repoPath);
+
+    expect(entry.manifest).toEqual({
+      error: expect.stringContaining('$.launch: unknown key'),
+    });
+  });
+});


### PR DESCRIPTION
Refs #1908, #1725, #1727.

## What

A checked-in `o8.workspace.json` (sibling to `o8.md`) so a repository's workspace setup travels with clones. This PR is the schema and its discovery only; launch-time consumption (running setup, allocating ports, health checks) is #1909.

- `src/lib/workspace/manifest/`: v1 contract — `setup` / `teardown` command lists, `services` (name, command, cwd, env, preferred port with an env name, http or tcp health with a timeout), `preview` URL template. Strict parsing: unknown keys, wrong types, duplicate service names, and ports inside o8's own reserved blocks fail with an error naming the JSON path. `migrateManifest()` is keyed on `version` (v1 is identity; unsupported versions are rejected with a clear message) so v2 has a home.
- `loadWorkspaceManifest(repoPath)`: reads the file if present; absent is `null`, not an error.
- Repo connect: the registry entry caches `{ version, path, serviceNames }` or `{ error }` — an invalid manifest never blocks connect. `registry.ts` 619 → 642 lines; `worktree/manager.ts` untouched.
- `docs/internals/workspace-manifest.md`: the schema, a full example, the rules, and the #1909 hand-off.

## Verification

`manifest.test.ts`: valid v1 round-trips; unknown key, reserved port, duplicate service, and a fabricated `version: 0` each fail with the expected path/message; missing file → null. `tests/workspace-manifest-registry-real-path.test.ts`: `addRepo` on a fixture git repo containing the file asserts the cached summary, and an invalid file records the error without blocking. `npx tsc --noEmit`, `npm run lint` (ratchet), `npm run test:classification:check`, `npm test` green on the merged head.
