### PR TITLE
feat: apply the workspace manifest at packet launch with port isolation

### DIFF
--- a/src/lib/lane/terminal-lane-cleanup.ts
+++ b/src/lib/lane/terminal-lane-cleanup.ts
@@ -1,6 +1,7 @@
 import type { Lane } from './types';
 import { cleanupLaneWorktree } from './worktree-cleanup';
 import { releaseTerminalPacketStorageReservations } from '@/lib/orchestrator/terminal-storage-release';
+import { scheduleWorkspaceManifestLeaseRelease } from '@/lib/workspace/manifest/terminal-release';
 import { laneOwnsWorktree } from './lane-storage-release';
 
 type TerminalCleanupLane = Pick<Lane, 'id' | 'repoPath' | 'worktreePath' | 'packetId'>
@@ -22,6 +23,7 @@ function releaseWithoutWorktree(lane: TerminalCleanupLane): void {
 }
 
 export function scheduleTerminalLaneCleanup(lane: TerminalCleanupLane): void {
+  scheduleWorkspaceManifestLeaseRelease({ packetId: lane.packetId, laneId: lane.id });
   if (!lane.worktreePath || !laneOwnsWorktree(lane)) {
     releaseWithoutWorktree(lane);
     if (lane.worktreePath) {

--- a/src/lib/lane/types.ts
+++ b/src/lib/lane/types.ts
@@ -315,6 +315,13 @@ export type LaneEventVerb =
   // base snapshot). Payload: { packetId, baseBranch, note }
   | 'worktree_refreshed'
   | 'worktree_refresh_failed'
+  // A checked-in workspace manifest allocated service ports and completed its
+  // setup and one-shot health probes. Payload:
+  // { services: [{ name, port }], preview?, durationMs }
+  | 'workspace_manifest_applied'
+  // Workspace manifest application failed without blocking packet launch.
+  // Payload: { step, error }
+  | 'workspace_manifest_failed'
   // Discard could not prove its preserved branch exists. Payload:
   // { code, reason, packetId, branch, ref, note, gcRisk }
   | 'branch_preservation_failed'

--- a/src/lib/panel/port-constants.ts
+++ b/src/lib/panel/port-constants.ts
@@ -4,6 +4,14 @@ export const RESERVED_PORT_BLOCK = [47110, 47111] as const;
 export const DEV_API_PORT_BLOCK = [47120, 47121, 47122, 47123, 47124] as const;
 export const DEV_WS_PORT_BLOCK = [47125, 47126, 47127, 47128, 47129] as const;
 
+export const O8_RESERVED_PORTS: ReadonlySet<number> = new Set([
+  ...PROD_API_PORT_BLOCK,
+  ...PROD_WS_PORT_BLOCK,
+  ...RESERVED_PORT_BLOCK,
+  ...DEV_API_PORT_BLOCK,
+  ...DEV_WS_PORT_BLOCK,
+]);
+
 export const DEFAULT_API_PORT = PROD_API_PORT_BLOCK[0];
 export const DEFAULT_WS_PORT = PROD_WS_PORT_BLOCK[0];
 export const DEFAULT_DEV_API_PORT = DEV_API_PORT_BLOCK[0];

--- a/src/lib/runtime/actions.ts
+++ b/src/lib/runtime/actions.ts
@@ -231,6 +231,7 @@ export async function launchRuntimeSurface(payload: RuntimeLaunchRequest): Promi
         repoSetup: repoEntry?.setup,
         isolationPreference: repoEntry?.setup.workspaceIsolationPreference,
         packetId: payload.packetId,
+        laneId: payload.existingLaneId,
         storageAdmissionReservationId: payload.storageAdmissionReservationId,
       });
       if (launchWorktree?.worktree) {

--- a/src/lib/workspace/manifest/apply.ts
+++ b/src/lib/workspace/manifest/apply.ts
@@ -1,0 +1,307 @@
+import 'server-only';
+
+import { createHash } from 'node:crypto';
+import { connect } from 'node:net';
+import path from 'node:path';
+
+import { recordLaneEvent } from '@/lib/lane/events';
+import { runRepoSetupCommand } from '@/lib/workspace/repo-setup';
+import { loadWorkspaceManifest } from './loader';
+import { allocateWorkspaceServicePorts } from './port-leases';
+import type {
+  WorkspaceManifest,
+  WorkspaceManifestService,
+  WorkspaceManifestServiceHealth,
+} from './types';
+
+const SETUP_TIMEOUT_MS = 45 * 60_000;
+const DEFAULT_HEALTH_TIMEOUT_MS = 5_000;
+
+export interface WorkspaceManifestHealthReceipt {
+  kind: 'http' | 'tcp';
+  target: string;
+  ok: boolean;
+  durationMs: number;
+  checkedAt: string;
+  error?: string;
+}
+
+export interface WorkspaceManifestSetupReceipt {
+  index: number;
+  commandId: string;
+  durationMs: number;
+  completedAt: string;
+}
+
+export interface WorkspaceManifestServiceReceipt {
+  name: string;
+  commandId: string;
+  cwd: string;
+  port: number | null;
+  environment: NodeJS.ProcessEnv;
+  health: WorkspaceManifestHealthReceipt | null;
+}
+
+export interface WorkspaceManifestApplyResult {
+  ports: Record<string, number>;
+  preview?: string;
+  receipts: {
+    setup: WorkspaceManifestSetupReceipt[];
+    services: WorkspaceManifestServiceReceipt[];
+    completedAt: string;
+  };
+}
+
+type ApplyStep = 'load' | 'ports' | 'preview' | `setup:${number}`;
+
+function commandId(command: string): string {
+  return createHash('sha256').update(command).digest('hex');
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function pathInside(candidate: string, root: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function setupShell(command: string): { command: string; args: string[] } {
+  if (process.platform === 'win32') {
+    return {
+      command: process.env.ComSpec || 'cmd.exe',
+      args: ['/d', '/s', '/c', command],
+    };
+  }
+  return { command: '/bin/sh', args: ['-lc', command] };
+}
+
+function portEnvironment(
+  manifest: WorkspaceManifest,
+  ports: Record<string, number>,
+): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {
+    NODE_ENV: process.env.NODE_ENV ?? 'development',
+  };
+  for (const service of manifest.services ?? []) {
+    const name = service.port?.env;
+    if (!name) continue;
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+      throw new Error(`Service ${service.name} has an invalid port environment name.`);
+    }
+    const value = String(ports[service.name]);
+    if (environment[name] !== undefined && environment[name] !== value) {
+      throw new Error(`Workspace services assign different ports to environment variable ${name}.`);
+    }
+    environment[name] = value;
+  }
+  return environment;
+}
+
+function resolveTemplate(
+  template: string,
+  ports: Record<string, number>,
+  defaultPort?: number,
+): string {
+  let resolved = template.replaceAll('{{port}}', () => {
+    if (defaultPort === undefined) throw new Error('Preview {{port}} has no allocated service port.');
+    return String(defaultPort);
+  });
+  resolved = resolved.replace(/\{\{service:([^}]+)\}\}/g, (_match, serviceName: string) => {
+    const port = ports[serviceName];
+    if (port === undefined) {
+      throw new Error(`Template references service ${JSON.stringify(serviceName)} without an allocated port.`);
+    }
+    return String(port);
+  });
+  if (/\{\{[^}]+\}\}/.test(resolved)) {
+    throw new Error(`Template contains an unsupported placeholder: ${resolved}.`);
+  }
+  return resolved;
+}
+
+function tcpHealth(port: number, timeoutMs: number): Promise<{ ok: boolean; error?: string }> {
+  return new Promise((resolve) => {
+    const socket = connect({ host: '127.0.0.1', port });
+    let settled = false;
+    const finish = (result: { ok: boolean; error?: string }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(result);
+    };
+    const timer = setTimeout(
+      () => finish({ ok: false, error: `TCP health probe timed out after ${timeoutMs}ms.` }),
+      timeoutMs,
+    );
+    socket.once('connect', () => finish({ ok: true }));
+    socket.once('error', (error) => finish({ ok: false, error: error.message }));
+  });
+}
+
+async function httpHealth(
+  url: string,
+  timeoutMs: number,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const response = await fetch(url, {
+      redirect: 'manual',
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    return response.ok
+      ? { ok: true }
+      : { ok: false, error: `HTTP health probe returned ${response.status}.` };
+  } catch (error) {
+    return { ok: false, error: formatError(error) };
+  }
+}
+
+async function probeHealth(input: {
+  health: WorkspaceManifestServiceHealth;
+  service: WorkspaceManifestService;
+  ports: Record<string, number>;
+}): Promise<WorkspaceManifestHealthReceipt> {
+  const startedAt = Date.now();
+  const timeoutMs = input.health.timeoutMs ?? DEFAULT_HEALTH_TIMEOUT_MS;
+  const port = input.ports[input.service.name];
+  let kind: WorkspaceManifestHealthReceipt['kind'];
+  let target: string;
+  let result: { ok: boolean; error?: string };
+  if (input.health.http !== undefined) {
+    kind = 'http';
+    target = resolveTemplate(input.health.http, input.ports, port);
+    result = await httpHealth(target, timeoutMs);
+  } else {
+    kind = 'tcp';
+    target = port === undefined ? '127.0.0.1:(unallocated)' : `127.0.0.1:${port}`;
+    result = port === undefined
+      ? { ok: false, error: 'TCP health probe requires an allocated service port.' }
+      : await tcpHealth(port, timeoutMs);
+  }
+  return {
+    kind,
+    target,
+    ok: result.ok,
+    durationMs: Date.now() - startedAt,
+    checkedAt: new Date().toISOString(),
+    ...(result.error ? { error: result.error } : {}),
+  };
+}
+
+async function applyLoadedManifest(input: {
+  manifest: WorkspaceManifest;
+  worktreePath: string;
+  packetId: string;
+  laneId: string;
+  setStep: (step: ApplyStep) => void;
+}): Promise<WorkspaceManifestApplyResult> {
+  input.setStep('ports');
+  const services = input.manifest.services ?? [];
+  const ports = await allocateWorkspaceServicePorts({
+    packetId: input.packetId,
+    laneId: input.laneId,
+    services: services.flatMap((service) => service.port
+      ? [{ name: service.name, preferred: service.port.preferred }]
+      : []),
+  });
+  const allocatedEnvironment = portEnvironment(input.manifest, ports);
+  const setupEnvironment = { ...process.env, ...allocatedEnvironment };
+  const setupReceipts: WorkspaceManifestSetupReceipt[] = [];
+  for (const [index, setupCommand] of (input.manifest.setup ?? []).entries()) {
+    input.setStep(`setup:${index + 1}`);
+    const startedAt = Date.now();
+    const shell = setupShell(setupCommand);
+    await runRepoSetupCommand({
+      ...shell,
+      cwd: input.worktreePath,
+      timeoutMs: SETUP_TIMEOUT_MS,
+      env: setupEnvironment,
+    });
+    setupReceipts.push({
+      index,
+      commandId: commandId(setupCommand),
+      durationMs: Date.now() - startedAt,
+      completedAt: new Date().toISOString(),
+    });
+  }
+  const serviceReceipts: WorkspaceManifestServiceReceipt[] = [];
+  for (const service of services) {
+    const cwd = path.resolve(input.worktreePath, service.cwd ?? '.');
+    if (!pathInside(cwd, input.worktreePath)) {
+      throw new Error(`Service ${service.name} cwd escapes the packet worktree.`);
+    }
+    const health = service.health
+      ? await probeHealth({ health: service.health, service, ports })
+      : null;
+    serviceReceipts.push({
+      name: service.name,
+      commandId: commandId(service.command),
+      cwd,
+      port: ports[service.name] ?? null,
+      environment: { ...service.env, ...allocatedEnvironment },
+      health,
+    });
+  }
+  input.setStep('preview');
+  const firstPort = services.map((service) => ports[service.name]).find((port) => port !== undefined);
+  const preview = input.manifest.preview
+    ? resolveTemplate(input.manifest.preview.url, ports, firstPort)
+    : undefined;
+  return {
+    ports,
+    ...(preview ? { preview } : {}),
+    receipts: {
+      setup: setupReceipts,
+      services: serviceReceipts,
+      completedAt: new Date().toISOString(),
+    },
+  };
+}
+
+function recordEventSafely(
+  laneId: string,
+  verb: 'workspace_manifest_applied' | 'workspace_manifest_failed',
+  payload: Record<string, unknown>,
+): void {
+  try {
+    recordLaneEvent(laneId, verb, 'system', payload);
+  } catch (error) {
+    console.warn(`[workspace-manifest] Could not record ${verb} for ${laneId}: ${formatError(error)}`);
+  }
+}
+
+export async function applyWorkspaceManifest(input: {
+  repoPath: string;
+  worktreePath: string;
+  packetId: string;
+  laneId: string;
+}): Promise<WorkspaceManifestApplyResult | null> {
+  const startedAt = Date.now();
+  let step: ApplyStep = 'load';
+  try {
+    const manifest = await loadWorkspaceManifest(input.worktreePath);
+    if (!manifest) return null;
+    const result = await applyLoadedManifest({
+      manifest,
+      worktreePath: path.resolve(input.worktreePath),
+      packetId: input.packetId,
+      laneId: input.laneId,
+      setStep: (next) => { step = next; },
+    });
+    recordEventSafely(input.laneId, 'workspace_manifest_applied', {
+      services: Object.entries(result.ports).map(([name, port]) => ({ name, port })),
+      ...(result.preview ? { preview: result.preview } : {}),
+      durationMs: Date.now() - startedAt,
+    });
+    return result;
+  } catch (error) {
+    const message = formatError(error);
+    console.warn(
+      `[workspace-manifest] Apply failed for packet ${input.packetId} in ${path.resolve(input.repoPath)} at ${step}: ${message}`,
+    );
+    recordEventSafely(input.laneId, 'workspace_manifest_failed', { step, error: message });
+    return null;
+  }
+}

--- a/src/lib/workspace/manifest/index.ts
+++ b/src/lib/workspace/manifest/index.ts
@@ -1,4 +1,10 @@
 export { loadWorkspaceManifest, workspaceManifestPath } from './loader';
+export { applyWorkspaceManifest } from './apply';
+export {
+  allocateWorkspaceServicePorts,
+  readWorkspacePortLeases,
+  releaseWorkspacePortLeases,
+} from './port-leases';
 export {
   migrateManifest,
   parseWorkspaceManifest,

--- a/src/lib/workspace/manifest/port-leases.test.ts
+++ b/src/lib/workspace/manifest/port-leases.test.ts
@@ -1,0 +1,114 @@
+import { createServer, type Server } from 'node:net';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const dataDir = mkdtempSync(`${os.tmpdir()}/o8-workspace-port-leases-`);
+const priorDataDir = process.env.CORTEX_IDE_DATA_DIR;
+const priorO8DataDir = process.env.O8_DATA_DIR;
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.O8_DATA_DIR = dataDir;
+
+const {
+  allocateWorkspaceServicePorts,
+  releaseWorkspacePortLeases,
+} = await import('./port-leases');
+
+function listenEphemeral(): Promise<{ server: Server; port: number }> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen({ host: '127.0.0.1', port: 0 }, () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Listener returned no TCP port.'));
+        return;
+      }
+      resolve({ server, port: address.port });
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+afterAll(() => {
+  if (priorDataDir === undefined) delete process.env.CORTEX_IDE_DATA_DIR;
+  else process.env.CORTEX_IDE_DATA_DIR = priorDataDir;
+  if (priorO8DataDir === undefined) delete process.env.O8_DATA_DIR;
+  else process.env.O8_DATA_DIR = priorO8DataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe.sequential('workspace manifest port leases', () => {
+  it('walks past the complete o8 reserved port block', async () => {
+    const ports = await allocateWorkspaceServicePorts({
+      packetId: 'packet-reserved',
+      laneId: 'lane-reserved',
+      services: [{ name: 'api', preferred: 47_100 }],
+    });
+
+    expect(ports.api).toBe(47_112);
+    expect(await releaseWorkspacePortLeases({
+      packetId: 'packet-reserved',
+      laneId: 'lane-reserved',
+    })).toBe(1);
+  });
+
+  it('walks past a port held by a real TCP listener', async () => {
+    const { server, port } = await listenEphemeral();
+    try {
+      const ports = await allocateWorkspaceServicePorts({
+        packetId: 'packet-bound',
+        laneId: 'lane-bound',
+        services: [{ name: 'web', preferred: port }],
+      });
+
+      expect(ports.web).toBeGreaterThan(port);
+      expect(await releaseWorkspacePortLeases({
+        packetId: 'packet-bound',
+        laneId: 'lane-bound',
+      })).toBe(1);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('isolates lanes and makes released ports available again', async () => {
+    const preferred = 43_210;
+    const first = await allocateWorkspaceServicePorts({
+      packetId: 'packet-first',
+      laneId: 'lane-first',
+      services: [{ name: 'api', preferred }],
+    });
+    const second = await allocateWorkspaceServicePorts({
+      packetId: 'packet-second',
+      laneId: 'lane-second',
+      services: [{ name: 'api', preferred }],
+    });
+
+    expect(first.api).toBe(preferred);
+    expect(second.api).toBeGreaterThan(preferred);
+    expect(await releaseWorkspacePortLeases({
+      packetId: 'packet-first',
+      laneId: 'lane-first',
+    })).toBe(1);
+
+    const replacement = await allocateWorkspaceServicePorts({
+      packetId: 'packet-replacement',
+      laneId: 'lane-replacement',
+      services: [{ name: 'api', preferred }],
+    });
+    expect(replacement.api).toBe(preferred);
+
+    await releaseWorkspacePortLeases({ packetId: 'packet-second', laneId: 'lane-second' });
+    await releaseWorkspacePortLeases({
+      packetId: 'packet-replacement',
+      laneId: 'lane-replacement',
+    });
+  });
+});

--- a/src/lib/workspace/manifest/port-leases.ts
+++ b/src/lib/workspace/manifest/port-leases.ts
@@ -1,0 +1,207 @@
+import 'server-only';
+
+import { randomUUID } from 'node:crypto';
+import { createServer } from 'node:net';
+import { chmod, readFile, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { getDataDir } from '@/lib/data-dir-migration';
+import { O8_RESERVED_PORTS } from '@/lib/panel/port-constants';
+import {
+  acquireMetadataTransactionLease,
+  releaseMetadataTransactionLease,
+} from '@/lib/worktree/metadata-transaction-lease';
+
+const STORE_VERSION = 1 as const;
+const STORE_FILENAME = 'workspace-port-leases.json';
+
+export interface WorkspacePortLease {
+  packetId: string;
+  laneId: string;
+  service: string;
+  acquiredAt: number;
+}
+
+interface WorkspacePortLeaseStore {
+  version: typeof STORE_VERSION;
+  leases: Record<string, WorkspacePortLease>;
+}
+
+export interface WorkspacePortRequest {
+  name: string;
+  preferred: number;
+}
+
+function emptyStore(): WorkspacePortLeaseStore {
+  return { version: STORE_VERSION, leases: {} };
+}
+
+function requiredText(value: string, name: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) throw new Error(`${name} is required.`);
+  return trimmed;
+}
+
+function isLease(value: unknown): value is WorkspacePortLease {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const lease = value as Partial<WorkspacePortLease>;
+  return typeof lease.packetId === 'string' && lease.packetId.length > 0
+    && typeof lease.laneId === 'string' && lease.laneId.length > 0
+    && typeof lease.service === 'string' && lease.service.length > 0
+    && Number.isSafeInteger(lease.acquiredAt) && lease.acquiredAt! > 0;
+}
+
+function validateStore(value: unknown): WorkspacePortLeaseStore {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Workspace port lease store is not an object.');
+  }
+  const store = value as Partial<WorkspacePortLeaseStore>;
+  if (store.version !== STORE_VERSION
+    || !store.leases
+    || typeof store.leases !== 'object'
+    || Array.isArray(store.leases)
+    || !Object.entries(store.leases).every(([port, lease]) => (
+      /^(?:[1-9]\d{0,4})$/.test(port)
+      && Number(port) <= 65_535
+      && isLease(lease)
+    ))) {
+    throw new Error('Workspace port lease store has an unsupported shape.');
+  }
+  return store as WorkspacePortLeaseStore;
+}
+
+export function workspacePortLeaseStorePath(): string {
+  return path.join(getDataDir(), STORE_FILENAME);
+}
+
+async function readStore(): Promise<WorkspacePortLeaseStore> {
+  try {
+    return validateStore(JSON.parse(await readFile(workspacePortLeaseStorePath(), 'utf8')) as unknown);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return emptyStore();
+    throw error;
+  }
+}
+
+async function writeStore(store: WorkspacePortLeaseStore): Promise<void> {
+  const storePath = workspacePortLeaseStorePath();
+  const temporaryPath = `${storePath}.${process.pid}.${randomUUID()}.tmp`;
+  await writeFile(temporaryPath, `${JSON.stringify(store, null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600,
+  });
+  await rename(temporaryPath, storePath);
+  await chmod(storePath, 0o600).catch(() => {});
+}
+
+async function withStoreMutation<T>(
+  operation: (store: WorkspacePortLeaseStore) => Promise<{ result: T; changed: boolean }>,
+): Promise<T> {
+  const lease = await acquireMetadataTransactionLease(getDataDir());
+  try {
+    const store = await readStore();
+    const { result, changed } = await operation(store);
+    if (changed) await writeStore(store);
+    return result;
+  } finally {
+    releaseMetadataTransactionLease(lease);
+  }
+}
+
+export function probeWorkspacePortAvailable(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    let settled = false;
+    const finish = (available: boolean) => {
+      if (settled) return;
+      settled = true;
+      server.removeAllListeners();
+      if (!server.listening) {
+        resolve(available);
+        return;
+      }
+      server.close(() => resolve(available));
+    };
+    server.once('error', () => finish(false));
+    server.once('listening', () => finish(true));
+    server.listen({ host: '127.0.0.1', port, exclusive: true });
+  });
+}
+
+async function nextAvailablePort(
+  preferred: number,
+  leases: Record<string, WorkspacePortLease>,
+): Promise<number> {
+  for (let port = preferred; port <= 65_535; port += 1) {
+    if (O8_RESERVED_PORTS.has(port) || leases[String(port)]) continue;
+    if (await probeWorkspacePortAvailable(port)) return port;
+  }
+  throw new Error(`No workspace service port is available at or above ${preferred}.`);
+}
+
+export async function allocateWorkspaceServicePorts(input: {
+  packetId: string;
+  laneId: string;
+  services: WorkspacePortRequest[];
+  now?: () => number;
+}): Promise<Record<string, number>> {
+  const packetId = requiredText(input.packetId, 'packetId');
+  const laneId = requiredText(input.laneId, 'laneId');
+  const requests = input.services.map((service) => ({
+    name: requiredText(service.name, 'service name'),
+    preferred: service.preferred,
+  }));
+  for (const request of requests) {
+    if (!Number.isInteger(request.preferred) || request.preferred < 1 || request.preferred > 65_535) {
+      throw new Error(`Service ${request.name} preferred port must be an integer from 1 through 65535.`);
+    }
+  }
+  return withStoreMutation(async (store) => {
+    const ports: Record<string, number> = {};
+    let changed = false;
+    for (const request of requests) {
+      const existing = Object.entries(store.leases).find(([, lease]) => (
+        lease.packetId === packetId
+        && lease.laneId === laneId
+        && lease.service === request.name
+      ));
+      if (existing) {
+        ports[request.name] = Number(existing[0]);
+        continue;
+      }
+      const port = await nextAvailablePort(request.preferred, store.leases);
+      store.leases[String(port)] = {
+        packetId,
+        laneId,
+        service: request.name,
+        acquiredAt: (input.now ?? Date.now)(),
+      };
+      ports[request.name] = port;
+      changed = true;
+    }
+    return { result: ports, changed };
+  });
+}
+
+export async function releaseWorkspacePortLeases(input: {
+  packetId?: string | null;
+  laneId: string;
+}): Promise<number> {
+  const laneId = requiredText(input.laneId, 'laneId');
+  const packetId = input.packetId?.trim() || null;
+  return withStoreMutation(async (store) => {
+    let released = 0;
+    for (const [port, lease] of Object.entries(store.leases)) {
+      if (lease.laneId !== laneId || (packetId && lease.packetId !== packetId)) continue;
+      delete store.leases[port];
+      released += 1;
+    }
+    return { result: released, changed: released > 0 };
+  });
+}
+
+export async function readWorkspacePortLeases(): Promise<Record<number, WorkspacePortLease>> {
+  return Object.fromEntries(
+    Object.entries((await readStore()).leases).map(([port, lease]) => [Number(port), lease]),
+  );
+}

--- a/src/lib/workspace/manifest/schema.ts
+++ b/src/lib/workspace/manifest/schema.ts
@@ -1,9 +1,5 @@
 import {
-  DEV_API_PORT_BLOCK,
-  DEV_WS_PORT_BLOCK,
-  PROD_API_PORT_BLOCK,
-  PROD_WS_PORT_BLOCK,
-  RESERVED_PORT_BLOCK,
+  O8_RESERVED_PORTS,
 } from '@/lib/panel/port-constants';
 
 import {
@@ -15,14 +11,6 @@ import {
 } from './types';
 
 type JsonObject = Record<string, unknown>;
-
-const O8_RESERVED_PORTS = new Set<number>([
-  ...PROD_API_PORT_BLOCK,
-  ...PROD_WS_PORT_BLOCK,
-  ...RESERVED_PORT_BLOCK,
-  ...DEV_API_PORT_BLOCK,
-  ...DEV_WS_PORT_BLOCK,
-]);
 
 export class WorkspaceManifestValidationError extends Error {
   constructor(

--- a/src/lib/workspace/manifest/terminal-release.ts
+++ b/src/lib/workspace/manifest/terminal-release.ts
@@ -1,0 +1,14 @@
+import 'server-only';
+
+import { releaseWorkspacePortLeases } from './port-leases';
+
+export function scheduleWorkspaceManifestLeaseRelease(input: {
+  packetId?: string | null;
+  laneId: string;
+}): void {
+  void releaseWorkspacePortLeases(input).catch((error) => {
+    console.error(
+      `[workspace-manifest] Terminal port lease release failed for ${input.laneId}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  });
+}

--- a/src/lib/workspace/repo-setup.ts
+++ b/src/lib/workspace/repo-setup.ts
@@ -8,6 +8,7 @@ import {
   assertWorktreeMaterializationIdentity,
   type WorktreeMaterializationIdentity,
 } from '@/lib/worktree/materialization-identity';
+import { materializationAwareExecFile } from '@/lib/worktree/materialization-execution';
 import {
   captureWorkspaceRegularFileIdentity,
   type WorkspaceCopyBindingRequirement,
@@ -26,6 +27,18 @@ import {
 } from './dependency-materializer';
 
 export type RepoSetupCommandInvocation = DependencyInstallInvocation;
+
+export async function runRepoSetupCommand(
+  invocation: RepoSetupCommandInvocation,
+): Promise<void> {
+  await materializationAwareExecFile(invocation.command, invocation.args, {
+    cwd: invocation.cwd,
+    timeout: invocation.timeoutMs,
+    maxBuffer: 8 * 1024 * 1024,
+    windowsHide: true,
+    env: invocation.env,
+  });
+}
 
 export const REPO_SETUP_POLICY_IDENTITY_KIND = 'repo-setup-policy';
 

--- a/src/lib/worktree/launch.ts
+++ b/src/lib/worktree/launch.ts
@@ -90,6 +90,8 @@ export interface WorktreeLaunchOptions {
    * own clone instead of colliding on a taskName-derived slot.
    */
   packetId?: string;
+  /** Existing lane that owns this packet launch and its workspace receipts. */
+  laneId?: string;
   /** Scheduler-owned reservation reused at the materialization boundary. */
   storageAdmissionReservationId?: string;
 }
@@ -147,6 +149,7 @@ export async function prepareLaunchWorktree(
     repoSetup: opts.repoSetup,
     isolationPreference: opts.isolationPreference,
     packetId: opts.packetId,
+    laneId: opts.laneId,
     storageAdmissionReservationId: opts.storageAdmissionReservationId,
     managed: opts.agentType === 'claude-code' ? true : undefined,
   });

--- a/src/lib/worktree/manager.ts
+++ b/src/lib/worktree/manager.ts
@@ -87,6 +87,7 @@ import {
   queueDependencyImagePublication,
   type DependencyMaterializationReceipt,
 } from '@/lib/workspace/dependency-materializer';
+import { applyWorkspaceManifest } from '@/lib/workspace/manifest/apply';
 import {
   probeMetadataLockProcessIdentity,
   sameMetadataLockProcessIdentity,
@@ -578,14 +579,14 @@ export class WorktreeManager {
     await this.bootstrapEnvFiles(worktreePath, createdExecutionIdentity, opts);
     await this.injectSafetyHooks(worktreePath, createdExecutionIdentity);
 
-    // Run project setup unless skipped
-    if (!opts.skipSetup) {
+    if (!opts.skipSetup || (opts.packetId && opts.laneId)) {
       info.status = 'setup';
       await this.updateMetaStatus(taskId, 'setup');
       const dependencyMaterialization = await this.runSetupWithMaterialization(
         worktreePath,
         createdExecutionIdentity,
         opts.repoSetup,
+        opts,
       );
       if (dependencyMaterialization) {
         info.dependencyRecipeKey = dependencyMaterialization.recipeKey;
@@ -817,13 +818,14 @@ export class WorktreeManager {
       await this.bootstrapEnvFiles(worktreePath, capturedExecutionIdentity, opts);
       await this.injectSafetyHooks(worktreePath, capturedExecutionIdentity);
 
-      if (!opts.skipSetup) {
+      if (!opts.skipSetup || (opts.packetId && opts.laneId)) {
         info.status = 'setup';
         await this.updateMetaStatus(taskId, 'setup');
         const dependencyMaterialization = await this.runSetupWithMaterialization(
           worktreePath,
           capturedExecutionIdentity,
           opts.repoSetup,
+          opts,
         );
         if (dependencyMaterialization) {
           info.dependencyRecipeKey = dependencyMaterialization.recipeKey;
@@ -1223,64 +1225,62 @@ export class WorktreeManager {
     worktreePath: string,
     identity?: Awaited<ReturnType<typeof captureWorktreeMaterializationIdentity>>,
     repoSetup?: CreateWorktreeOptions['repoSetup'],
+    launch?: Pick<CreateWorktreeOptions, 'laneId' | 'packetId' | 'skipSetup'>,
   ): Promise<DependencyMaterializationReceipt | null> {
-    const hasPackageJson = await this.pathExists(path.join(worktreePath, 'package.json'));
     let dependencyMaterialization: DependencyMaterializationReceipt | null = null;
-    const installCommand = repoSetup
-      ? repoSetup.installOnCreateWorkspace
-        ? repoSetup.installCommand?.trim() || null
-        : null
-      : hasPackageJson
-        ? await detectDependencyInstallCommand(worktreePath)
-        : null;
-    if (repoSetup?.installOnCreateWorkspace && !installCommand) {
-      throw new Error('The registered repo requires install-on-create but has no install command.');
+    if (!launch?.skipSetup) {
+      const hasPackageJson = await this.pathExists(path.join(worktreePath, 'package.json'));
+      const installCommand = repoSetup
+        ? repoSetup.installOnCreateWorkspace
+          ? repoSetup.installCommand?.trim() || null
+          : null
+        : hasPackageJson
+          ? await detectDependencyInstallCommand(worktreePath)
+          : null;
+      if (repoSetup?.installOnCreateWorkspace && !installCommand) {
+        throw new Error('The registered repo requires install-on-create but has no install command.');
+      }
+      if (hasPackageJson) {
+        await this.assertInstallableLocalNodeModules(worktreePath, identity);
+      }
+      if (installCommand) {
+        const result = await materializeDependencyInstall(worktreePath, installCommand, {
+          materializationIdentity: identity,
+          persistReceipt: (receipt) => (
+            receipt
+              ? this.recordDependencyMaterialization(path.basename(worktreePath), receipt)
+              : this.clearDependencyMaterialization(path.basename(worktreePath))
+          ),
+        });
+        dependencyMaterialization = result.receipt;
+      }
+      if (await this.pathExists(path.join(worktreePath, 'requirements.txt'))) {
+        await execFileAsync('pip', ['install', '-r', 'requirements.txt'], {
+          windowsHide: true,
+          cwd: worktreePath,
+          timeout: 120_000,
+        }).catch(() => { /* pip may not be available */ });
+      }
+      if (await this.pathExists(path.join(worktreePath, 'go.mod'))) {
+        await execFileAsync('go', ['mod', 'download'], {
+          windowsHide: true,
+          cwd: worktreePath,
+          timeout: 60_000,
+        }).catch(() => { /* go may not be available */ });
+      }
+      if (await this.pathExists(path.join(worktreePath, 'Cargo.toml'))) {
+        await execFileAsync('cargo', ['fetch'], {
+          windowsHide: true,
+          cwd: worktreePath,
+          timeout: 120_000,
+        }).catch(() => { /* cargo may not be available */ });
+      }
     }
-    // A legacy link is retired whenever the workspace has Node dependencies at
-    // all, not only when an install command was detected. A repository with no
-    // lockfile and no packageManager declaration installs nothing here, and
-    // leaving the link in place would hand the packet's own `npm ci` a path
-    // straight into the operator's checkout.
-    if (hasPackageJson) {
-      await this.assertInstallableLocalNodeModules(worktreePath, identity);
-    }
-    if (installCommand) {
-      const result = await materializeDependencyInstall(worktreePath, installCommand, {
-        materializationIdentity: identity,
-        persistReceipt: (receipt) => (
-          receipt
-            ? this.recordDependencyMaterialization(path.basename(worktreePath), receipt)
-            : this.clearDependencyMaterialization(path.basename(worktreePath))
-        ),
+    if (launch?.packetId && launch.laneId) {
+      await applyWorkspaceManifest({
+        repoPath: this.repoRoot, worktreePath,
+        packetId: launch.packetId, laneId: launch.laneId,
       });
-      dependencyMaterialization = result.receipt;
-    }
-
-    // Python
-    if (await this.pathExists(path.join(worktreePath, 'requirements.txt'))) {
-      await execFileAsync('pip', ['install', '-r', 'requirements.txt'], {
-        windowsHide: true,
-        cwd: worktreePath,
-        timeout: 120_000,
-      }).catch(() => { /* pip may not be available */ });
-    }
-
-    // Go
-    if (await this.pathExists(path.join(worktreePath, 'go.mod'))) {
-      await execFileAsync('go', ['mod', 'download'], {
-        windowsHide: true,
-        cwd: worktreePath,
-        timeout: 60_000,
-      }).catch(() => { /* go may not be available */ });
-    }
-
-    // Rust
-    if (await this.pathExists(path.join(worktreePath, 'Cargo.toml'))) {
-      await execFileAsync('cargo', ['fetch'], {
-        windowsHide: true,
-        cwd: worktreePath,
-        timeout: 120_000,
-      }).catch(() => { /* cargo may not be available */ });
     }
     return dependencyMaterialization;
   }

--- a/src/lib/worktree/types.ts
+++ b/src/lib/worktree/types.ts
@@ -109,6 +109,8 @@ export interface CreateWorktreeOptions {
    * session detection stays in sync.
    */
   packetId?: string;
+  /** Existing lane that owns this packet launch and its workspace receipts. */
+  laneId?: string;
   /** Scheduler-owned reservation reused by the manager admission boundary. */
   storageAdmissionReservationId?: string;
 }

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -647,6 +647,12 @@
       ]
     },
     {
+      "path": "src/lib/workspace/manifest/port-leases.test.ts",
+      "reasons": [
+        "network-listener"
+      ]
+    },
+    {
       "path": "src/lib/workspace/mutation-materialization-guard.test.ts",
       "reasons": [
         "apfs-tool",
@@ -2314,6 +2320,15 @@
         "child-process",
         "git-cli",
         "process-signal",
+        "real-path"
+      ]
+    },
+    {
+      "path": "tests/workspace-manifest-launch-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "network-listener",
         "real-path"
       ]
     },

--- a/tests/workspace-manifest-launch-real-path.test.ts
+++ b/tests/workspace-manifest-launch-real-path.test.ts
@@ -1,0 +1,227 @@
+import type { ExecFileOptions } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
+import { createServer, type Server, type Socket } from 'node:net';
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const setupInvocations = vi.hoisted(() => [] as Array<{
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}>);
+const healthConnections = vi.hoisted(() => [] as number[]);
+const setupServers = vi.hoisted(() => [] as Server[]);
+const setupSockets = vi.hoisted(() => [] as Socket[]);
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  const execFile = (
+    file: string,
+    args: string[] = [],
+    options: ExecFileOptions = {},
+    callback?: (error: Error | null, stdout: string, stderr: string) => void,
+  ) => {
+    if (!args.includes('prepare-workspace')) {
+      return actual.execFile(file, args, options, callback as never);
+    }
+    const cwd = String(options.cwd);
+    const env = options.env ?? process.env;
+    setupInvocations.push({ cwd, env });
+    const healthPort = Number(env.WEB_PORT);
+    const server = createServer((socket) => {
+      setupSockets.push(socket);
+      healthConnections.push(healthPort);
+      socket.end();
+    });
+    setupServers.push(server);
+    server.once('error', (error) => callback?.(error, '', error.message));
+    server.listen({ host: '127.0.0.1', port: healthPort }, () => callback?.(null, '', ''));
+    return server as never;
+  };
+  const promisifySymbol = Symbol.for('nodejs.util.promisify.custom');
+  Object.defineProperty(execFile, promisifySymbol, {
+    value: (actual.execFile as unknown as Record<symbol, unknown>)[promisifySymbol],
+  });
+  return {
+    ...actual,
+    execFile,
+  };
+});
+
+const tempRoot = realpathSync(mkdtempSync(path.join(os.homedir(), '.tmp-o8-manifest-launch-')));
+const dataDir = path.join(tempRoot, 'data');
+const repoPath = path.join(tempRoot, 'repo');
+const worktreeRoot = path.join(tempRoot, 'worktrees');
+const controlledEnvKeys = [
+  'CORTEX_IDE_DATA_DIR',
+  'O8_DATA_DIR',
+  'O8_WORKTREE_ROOT',
+  'O8_SKIP_PRELAUNCH_TYPECHECK',
+] as const;
+const priorEnv: Record<string, string | undefined> = {};
+
+function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe.sequential('workspace manifest packet launch real path', () => {
+  beforeAll(async () => {
+    for (const key of controlledEnvKeys) priorEnv[key] = process.env[key];
+    mkdirSync(dataDir, { recursive: true });
+    execFileSync('git', ['init', '-q', '-b', 'main', repoPath]);
+    writeFileSync(path.join(repoPath, 'README.md'), 'workspace manifest launch fixture\n');
+    writeFileSync(path.join(repoPath, 'o8.workspace.json'), JSON.stringify({
+      version: 1,
+      setup: ['prepare-workspace'],
+      services: [
+        {
+          name: 'api',
+          command: 'run-api',
+          port: { preferred: 43_300, env: 'API_PORT' },
+        },
+        {
+          name: 'web',
+          command: 'run-web',
+          port: { preferred: 43_300, env: 'WEB_PORT' },
+          health: { tcp: true, timeoutMs: 2_000 },
+        },
+      ],
+      preview: { url: 'http://127.0.0.1:{{service:web}}' },
+    }, null, 2));
+    execFileSync('git', ['add', 'README.md', 'o8.workspace.json'], { cwd: repoPath });
+    execFileSync('git', [
+      '-c', 'user.email=test@o8.test',
+      '-c', 'user.name=o8-test',
+      'commit', '-qm', 'fixture',
+    ], { cwd: repoPath });
+    execFileSync('git', ['remote', 'add', 'origin', repoPath], { cwd: repoPath });
+
+    process.env.CORTEX_IDE_DATA_DIR = dataDir;
+    process.env.O8_DATA_DIR = dataDir;
+    process.env.O8_WORKTREE_ROOT = worktreeRoot;
+    process.env.O8_SKIP_PRELAUNCH_TYPECHECK = '1';
+    const { updateOperatorDefaults } = await import('@/lib/operator/defaults');
+    await updateOperatorDefaults({
+      productTelemetryEnabled: false,
+      storageReserveRatio: 0.0001,
+      storageReserveFloorGb: 0.001,
+    });
+  });
+
+  afterAll(async () => {
+    for (const socket of setupSockets) socket.destroy();
+    await Promise.all(setupServers.map(closeServer));
+    const { closeDb } = await import('@/lib/db');
+    closeDb();
+    for (const key of controlledEnvKeys) {
+      const prior = priorEnv[key];
+      if (prior === undefined) delete process.env[key];
+      else process.env[key] = prior;
+    }
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('allocates isolated ports, injects setup env, resolves previews, and releases terminal leases', async () => {
+    const { createLane, getLane, getLaneEvents, setLaneStatus, updateLane } = await import(
+      '@/lib/lane/registry'
+    );
+    const { prepareLaunchWorktree } = await import('@/lib/worktree/launch');
+    const {
+      allocateWorkspaceServicePorts,
+      readWorkspacePortLeases,
+      releaseWorkspacePortLeases,
+    } = await import('@/lib/workspace/manifest/port-leases');
+
+    const launch = async (packetId: string, branch: string) => {
+      const lane = createLane({
+        repoPath,
+        branch,
+        baseBranch: 'main',
+        runtime: 'codex',
+        label: packetId,
+        packetId,
+      });
+      const prepared = await prepareLaunchWorktree({
+        repoRoot: repoPath,
+        agentType: 'codex',
+        taskName: packetId,
+        branchName: branch,
+        baseBranch: 'main',
+        isolate: true,
+        skipSetup: true,
+        packetId,
+        laneId: lane.id,
+      });
+      if (!prepared) throw new Error(`Worktree launch returned no workspace for ${packetId}.`);
+      updateLane(lane.id, { worktreePath: prepared.cwd }, 'system');
+      return { lane, prepared };
+    };
+
+    const first = await launch('packet-manifest-first', 'test/manifest-first');
+    const second = await launch('packet-manifest-second', 'test/manifest-second');
+    const firstEvent = getLaneEvents(first.lane.id, 100).find(
+      (event) => event.verb === 'workspace_manifest_applied',
+    );
+    const secondEvent = getLaneEvents(second.lane.id, 100).find(
+      (event) => event.verb === 'workspace_manifest_applied',
+    );
+    expect(firstEvent).toBeDefined();
+    expect(secondEvent).toBeDefined();
+
+    const eventPorts = (event: NonNullable<typeof firstEvent>) => Object.fromEntries(
+      (event.payload.services as Array<{ name: string; port: number }>)
+        .map((service) => [service.name, service.port]),
+    );
+    const firstPorts = eventPorts(firstEvent!);
+    const secondPorts = eventPorts(secondEvent!);
+    expect(firstPorts).toEqual({ api: 43_300, web: 43_301 });
+    expect(secondPorts.api).toBeGreaterThan(firstPorts.web);
+    expect(secondPorts.web).toBeGreaterThan(secondPorts.api);
+    expect(firstEvent?.payload.preview).toBe(`http://127.0.0.1:${firstPorts.web}`);
+    expect(secondEvent?.payload.preview).toBe(`http://127.0.0.1:${secondPorts.web}`);
+
+    const firstSetup = setupInvocations.find((invocation) => (
+      invocation.cwd === first.prepared.cwd
+    ));
+    const secondSetup = setupInvocations.find((invocation) => (
+      invocation.cwd === second.prepared.cwd
+    ));
+    expect(firstSetup?.env.API_PORT).toBe(String(firstPorts.api));
+    expect(firstSetup?.env.WEB_PORT).toBe(String(firstPorts.web));
+    expect(secondSetup?.env.API_PORT).toBe(String(secondPorts.api));
+    expect(secondSetup?.env.WEB_PORT).toBe(String(secondPorts.web));
+    expect(healthConnections).toEqual(expect.arrayContaining([firstPorts.web, secondPorts.web]));
+
+    setLaneStatus(first.lane.id, 'completed', 'system', 'completed');
+    await vi.waitFor(async () => {
+      const leases = Object.values(await readWorkspacePortLeases());
+      expect(leases.some((lease) => lease.laneId === first.lane.id)).toBe(false);
+    }, { timeout: 30_000 });
+
+    const replacement = await allocateWorkspaceServicePorts({
+      packetId: 'packet-manifest-replacement',
+      laneId: 'lane-manifest-replacement',
+      services: [{ name: 'api', preferred: 43_300 }],
+    });
+    expect(replacement.api).toBe(firstPorts.api);
+    await releaseWorkspacePortLeases({
+      packetId: 'packet-manifest-replacement',
+      laneId: 'lane-manifest-replacement',
+    });
+
+    setLaneStatus(second.lane.id, 'completed', 'system', 'completed');
+    await vi.waitFor(() => {
+      expect(getLane(first.lane.id)?.worktreePath).toBeNull();
+      expect(getLane(second.lane.id)?.worktreePath).toBeNull();
+    }, { timeout: 60_000 });
+  }, 120_000);
+});


### PR DESCRIPTION
Closes #1909. Refs #1725.

## What

Applies a checked-in `o8.workspace.json` (#1946) when a packet worktree launches.

- `src/lib/workspace/manifest/apply.ts` — `applyWorkspaceManifest({ repoPath, worktreePath, packetId, laneId })`: loads the manifest from the worktree (none → no-op), allocates one port per declared service, exports each port through the service's declared env name into the setup environment, runs `setup` commands in order through the existing setup runner (`runRepoSetupCommand`), probes each declared `health` once (http or tcp, with its timeout), resolves `{{port}}` / `{{service:<name>}}` in the preview template, and returns `{ ports, preview, receipts }`. A failure records `workspace_manifest_failed { step, error }` and does not block the launch (a policy gate is #1911).
- `port-leases.ts` — a JSON lease store under the o8 data dir keyed by port (`{ packetId, laneId, service, acquiredAt }`), written atomically under the metadata transaction lease. Allocation starts at `preferred` and walks upward past ports that are leased, in any o8 reserved block (`O8_RESERVED_PORTS`, now exported from `port-constants.ts`), or currently bound (real TCP bind probe). Re-allocating for the same packet/lane/service is idempotent.
- Leases release from `scheduleTerminalLaneCleanup`, the same place the worktree's other terminal cleanup runs.
- Lane events `workspace_manifest_applied { services: [{ name, port }], preview?, durationMs }` and `workspace_manifest_failed { step, error }`.
- `laneId` now threads through `CreateWorktreeOptions` → `prepareLaunchWorktree` → `WorktreeManager`; real packet dispatch already passes `existingLaneId`, so this applies on every packet launch.
- `manager.ts` stays at 2,782 lines: the language-specific install steps moved under a `skipSetup` guard inside `runSetupWithMaterialization`, and the manifest apply is one call. A manifest applies even when `skipSetup` is set for a packet launch — the manifest is the repo's explicit opt-in, separate from o8's dependency-install heuristics.

Service processes are still out of scope: setup commands may background something, but o8 does not manage long-running manifest services yet.

## Proof

- `tests/workspace-manifest-launch-real-path.test.ts` — fixture repo with two services on the same preferred port (one with a tcp health check), launched twice through the real `prepareLaunchWorktree` path with only the setup command stubbed at the process boundary. Asserts distinct ports per packet (the second walked past the first's leases), the env var carries the port into the setup command, the preview URL resolves, both lane events exist, the health probe connected, and marking the first lane terminal releases its leases (a fresh allocation gets its port back).
- `src/lib/workspace/manifest/port-leases.test.ts` — walks the whole reserved block, walks past a real listener on an ephemeral port, isolates lanes and reuses released ports.

## Gates

tsc · focused tests · lint ratchet · classification check · full suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspace manifests can now configure services during launches, including setup commands, environment variables, health checks, and preview URL detection.
  - Services receive isolated, automatically allocated ports while avoiding reserved or unavailable ports.
  - Workspace launches are associated with their assigned lane for improved lifecycle management.

- **Bug Fixes**
  - Service port leases are released when a lane’s workspace is cleaned up, allowing ports to be reused safely.

- **Tests**
  - Added coverage for port isolation, availability checks, manifest launches, health monitoring, and lease reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->