### PR TITLE
feat: detect on-disk conflicts with a content hash on file save

### DIFF
--- a/src/app/api/panel/file-content/route.ts
+++ b/src/app/api/panel/file-content/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server';
 import { getDefaultLlmRepoRoot, resolveRegisteredRepoScope } from '@/lib/llm/repo-scope';
 import { expandHome } from '@/lib/fs/safe-path';
 import { isWorkspaceFileError, readWorkspaceFile } from '@/lib/fs/workspace-file';
+import { contentHash } from '@/lib/markdown/transport';
 
 export async function GET(request: Request) {
   try {
@@ -31,15 +32,17 @@ export async function GET(request: Request) {
 
     const opened = await readWorkspaceFile(root, filePath);
     const content = opened.bytes.toString('utf-8');
+    const fullContentHash = await contentHash(content);
     // Truncate large files
     if (content.length > 100000) {
       return NextResponse.json({
         content: content.slice(0, 100000) + '\n\n... (truncated at 100KB)',
+        contentHash: fullContentHash,
         path: filePath,
         truncated: true,
       });
     }
-    return NextResponse.json({ content, path: filePath });
+    return NextResponse.json({ content, contentHash: fullContentHash, path: filePath });
   } catch (error) {
     console.error('[panel/file-content] Could not read file', error);
     if (isWorkspaceFileError(error)) {

--- a/src/app/api/repo-spec/route.ts
+++ b/src/app/api/repo-spec/route.ts
@@ -9,6 +9,7 @@ import {
 } from '@/lib/o8md/rfm';
 import { cleanupOrphanedRoughdraftAnnotations } from '@/lib/o8md/cleanup';
 import { appendComment, applySuggestion, insertSuggestion, type SuggestionKind } from '@/lib/o8md/mutate';
+import { contentHash } from '@/lib/markdown/transport';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -71,7 +72,13 @@ export async function GET(request: NextRequest) {
   if (view === 'validate') {
     return NextResponse.json({ ok: true, validation: validateRoughdraftMarkdown(content), exists, path: specPath });
   }
-  return NextResponse.json({ ok: true, content, exists, path: specPath });
+  return NextResponse.json({
+    ok: true,
+    content,
+    contentHash: await contentHash(content),
+    exists,
+    path: specPath,
+  });
 }
 
 export async function PUT(request: NextRequest) {
@@ -80,7 +87,11 @@ export async function PUT(request: NextRequest) {
   if (!specPath) {
     return NextResponse.json({ ok: false, error: 'repoPath invalid' }, { status: 400 });
   }
-  const body = await request.json().catch(() => null) as { content?: unknown } | null;
+  const body = await request.json().catch(() => null) as {
+    content?: unknown;
+    expectedHash?: unknown;
+    force?: unknown;
+  } | null;
   const content = typeof body?.content === 'string' ? body.content : null;
   if (content === null) {
     return NextResponse.json({ ok: false, error: 'content must be a string' }, { status: 400 });
@@ -89,6 +100,18 @@ export async function PUT(request: NextRequest) {
   if (Buffer.byteLength(cleanup.content, 'utf-8') > MAX_BYTES) {
     return NextResponse.json({ ok: false, error: `content exceeds ${MAX_BYTES} bytes` }, { status: 400 });
   }
+  const expectedHash = typeof body?.expectedHash === 'string' ? body.expectedHash : undefined;
+  if (expectedHash !== undefined && body?.force !== true) {
+    const currentContent = existsSync(specPath) ? readFileSync(specPath, 'utf-8') : null;
+    const currentHash = currentContent === null ? null : await contentHash(currentContent);
+    if (currentHash !== expectedHash) {
+      return NextResponse.json({
+        error: 'changed-on-disk',
+        contentHash: currentHash,
+        content: currentContent,
+      }, { status: 409 });
+    }
+  }
   mkdirSync(dirname(specPath), { recursive: true });
   writeFileSync(specPath, cleanup.content, 'utf-8');
   return NextResponse.json({
@@ -96,6 +119,7 @@ export async function PUT(request: NextRequest) {
     path: specPath,
     bytes: Buffer.byteLength(cleanup.content, 'utf-8'),
     content: cleanup.content,
+    contentHash: await contentHash(cleanup.content),
     orphanedAnnotationsRemoved: cleanup.removedAnnotations,
   });
 }

--- a/src/app/api/v2/files/route.ts
+++ b/src/app/api/v2/files/route.ts
@@ -21,6 +21,7 @@ import {
   resolveAllowedOperatorConfigPath,
   resolveRepoRelativeFilePath,
 } from '@/lib/files/operator-config-docs';
+import { contentHash } from '@/lib/markdown/transport';
 
 async function resolveRoot(workspace?: string | null) {
   if (!workspace) return getDefaultLlmRepoRoot();
@@ -89,7 +90,7 @@ export async function GET(request: NextRequest) {
   try {
     const opened = await readWorkspaceFile(target.root, target.relativePath);
     const content = opened.bytes.toString('utf-8');
-    return NextResponse.json({ content, path, exists: true });
+    return NextResponse.json({ content, contentHash: await contentHash(content), path, exists: true });
   } catch (err) {
     if (isWorkspaceFileError(err) && err.code === 'workspace_file_not_found') {
       return NextResponse.json({ error: 'File not found', code: err.code, exists: false }, { status: 404 });
@@ -104,6 +105,8 @@ export async function POST(request: NextRequest) {
     const path = typeof body?.path === 'string' ? body.path : '';
     const content = typeof body?.content === 'string' ? body.content : undefined;
     const workspace = typeof body?.workspace === 'string' ? body.workspace : undefined;
+    const expectedHash = typeof body?.expectedHash === 'string' ? body.expectedHash : undefined;
+    const force = body?.force === true;
 
     if (!path || content === undefined) {
       return NextResponse.json({ error: 'path and content required' }, { status: 400 });
@@ -114,6 +117,24 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: target.error, code: target.code }, { status: target.status });
     }
 
+    if (expectedHash !== undefined && !force) {
+      let currentContent: string | null = null;
+      try {
+        const current = await readWorkspaceFile(target.root, target.relativePath);
+        currentContent = current.bytes.toString('utf-8');
+      } catch (err) {
+        if (!isWorkspaceFileError(err) || err.code !== 'workspace_file_not_found') throw err;
+      }
+      const currentHash = currentContent === null ? null : await contentHash(currentContent);
+      if (currentHash !== expectedHash) {
+        return NextResponse.json({
+          error: 'changed-on-disk',
+          contentHash: currentHash,
+          content: currentContent,
+        }, { status: 409 });
+      }
+    }
+
     const result = await writeWorkspaceFile(target.root, target.relativePath, content);
     const oldContent = result.previousBytes?.toString('utf-8') ?? null;
 
@@ -122,6 +143,7 @@ export async function POST(request: NextRequest) {
       path,
       isNew: result.created,
       oldContent,
+      contentHash: await contentHash(content),
     });
   } catch (err) {
     return fileError(err);

--- a/src/components/desktop/FileViewer.tsx
+++ b/src/components/desktop/FileViewer.tsx
@@ -9,6 +9,10 @@ import { loader } from '@monaco-editor/react';
 import { useTheme } from '@/lib/theme/context';
 import { renderDiffLines } from './diff-utils';
 import { MODEL_IDS } from '@/lib/models';
+import { SaveConflictStrip, type SaveConflict } from './SaveConflictStrip';
+import { defineCortexMonacoThemes, getMonacoLanguage } from './file-viewer-monaco';
+
+export { defineCortexMonacoThemes, getMonacoLanguage };
 
 const MonacoEditor = dynamic(() => import('@/lib/monaco-polyfills').then(() =>
   import('@monaco-editor/react').then((mod) => mod.default)
@@ -18,115 +22,6 @@ const MonacoEditor = dynamic(() => import('@/lib/monaco-polyfills').then(() =>
 });
 
 // ── File Viewer ──
-
-// Monaco language mapping from file extension
-export function getMonacoLanguage(path: string): string {
-  const ext = path.split('.').pop()?.toLowerCase() ?? '';
-  const name = path.split('/').pop()?.toLowerCase() ?? '';
-  if (name.startsWith('.env')) return 'ini';
-  if (name === 'dockerfile') return 'dockerfile';
-  if (name === '.gitignore' || name === '.dockerignore') return 'plaintext';
-  const map: Record<string, string> = {
-    ts: 'typescript', tsx: 'typescript', js: 'javascript', jsx: 'javascript',
-    json: 'json', yaml: 'yaml', yml: 'yaml', toml: 'toml',
-    md: 'markdown', mdx: 'markdown', html: 'html', xml: 'xml',
-    css: 'css', scss: 'scss', less: 'less',
-    py: 'python', rs: 'rust', go: 'go', rb: 'ruby', java: 'java',
-    c: 'c', cpp: 'cpp', h: 'c', hpp: 'cpp',
-    sh: 'shell', bash: 'shell', zsh: 'shell',
-    sql: 'sql', graphql: 'graphql', gql: 'graphql',
-    swift: 'swift', kt: 'kotlin',
-    r: 'r', lua: 'lua', php: 'php', perl: 'perl',
-    ini: 'ini', conf: 'ini', cfg: 'ini',
-  };
-  return map[ext] || 'plaintext';
-}
-
-export function defineCortexMonacoThemes(monaco: typeof import('monaco-editor')) {
-  monaco.editor.defineTheme('cortex-graphite', {
-    base: 'vs-dark',
-    inherit: true,
-    rules: [
-      { token: 'comment', foreground: '8f99a6', fontStyle: 'italic' },
-      { token: 'keyword', foreground: '9db5ff' },
-      { token: 'string', foreground: '7fd6b7' },
-      { token: 'number', foreground: 'f1b57f' },
-      { token: 'type', foreground: 'd6c48f' },
-      { token: 'variable', foreground: 'f2a8b8' },
-      { token: 'function', foreground: '8fc0ff' },
-    ],
-    colors: {
-      'editor.background': '#3d434b',
-      'editor.foreground': '#eef3f8',
-      'editor.lineHighlightBackground': '#49515b',
-      'editor.selectionBackground': '#7aa2ff33',
-      'editorLineNumber.foreground': '#8893a0',
-      'editorLineNumber.activeForeground': '#dbe4ee',
-      'editor.inactiveSelectionBackground': '#7aa2ff1f',
-      'editorCursor.foreground': '#7aa2ff',
-      'editorGutter.background': '#3d434b',
-      'editorWidget.background': '#444b55',
-      'editorWidget.border': '#65707d',
-      'input.background': '#343a42',
-      'input.border': '#65707d',
-      'focusBorder': '#7aa2ff',
-      'minimap.background': '#3d434b',
-      'scrollbarSlider.background': '#65707d88',
-      'scrollbarSlider.hoverBackground': '#7b879488',
-      'diffEditor.insertedTextBackground': '#16653433',
-      'diffEditor.insertedLineBackground': '#1665341f',
-      'diffEditor.removedTextBackground': '#1d4ed833',
-      'diffEditor.removedLineBackground': '#1d4ed81f',
-      'diffEditor.diagonalFill': '#3d434b',
-    },
-  });
-
-  monaco.editor.defineTheme('cortex-frost', {
-    base: 'vs',
-    inherit: true,
-    rules: [
-      { token: 'comment', foreground: '94a3b8', fontStyle: 'italic' },
-      { token: 'keyword', foreground: '6366f1' },
-      { token: 'string', foreground: '0d9488' },
-      { token: 'number', foreground: 'e879a0' },
-      { token: 'type', foreground: '8b5cf6' },
-      { token: 'variable', foreground: '0284c7' },
-      { token: 'function', foreground: '4f46e5' },
-      { token: 'delimiter', foreground: '94a3b8' },
-      { token: 'tag', foreground: 'e879a0' },
-      { token: 'attribute.name', foreground: '8b5cf6' },
-      { token: 'attribute.value', foreground: '0d9488' },
-      { token: 'operator', foreground: '64748b' },
-      { token: 'regexp', foreground: 'e879a0' },
-    ],
-    colors: {
-      'editor.background': '#f0f7ff',
-      'editor.foreground': '#1e293b',
-      'editor.lineHighlightBackground': '#e8f1fc',
-      'editor.selectionBackground': '#c7d2fe',
-      'editorLineNumber.foreground': '#94a3b8',
-      'editorLineNumber.activeForeground': '#475569',
-      'editor.inactiveSelectionBackground': '#c7d2fe60',
-      'editorCursor.foreground': '#4f46e5',
-      'editorGutter.background': '#f0f7ff',
-      'editorWidget.background': '#f8fafc',
-      'editorWidget.border': '#cbd5e1',
-      'input.background': '#ffffff',
-      'input.border': '#cbd5e1',
-      'focusBorder': '#6366f1',
-      'minimap.background': '#f0f7ff',
-      'scrollbarSlider.background': '#94a3b840',
-      'scrollbarSlider.hoverBackground': '#64748b40',
-      'editorBracketMatch.background': '#e0e7ff',
-      'editorBracketMatch.border': '#a5b4fc',
-      'diffEditor.insertedTextBackground': '#dcfce766',
-      'diffEditor.insertedLineBackground': '#dcfce740',
-      'diffEditor.removedTextBackground': '#dbeafe88',
-      'diffEditor.removedLineBackground': '#dbeafe55',
-      'diffEditor.diagonalFill': '#f0f7ff',
-    },
-  });
-}
 
 export const FileViewer = memo(function FileViewer({ filePath, workspace }: { filePath: string; workspace?: string }) {
   const { themeId } = useTheme();
@@ -138,6 +33,8 @@ export const FileViewer = memo(function FileViewer({ filePath, workspace }: { fi
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [saveNote, setSaveNote] = useState<string | null>(null);
+  const [fileHash, setFileHash] = useState<string | null>(null);
+  const [saveConflict, setSaveConflict] = useState<SaveConflict | null>(null);
   const [activeView, setActiveView] = useState<'content' | 'diff'>('content');
   const [editing, setEditing] = useState(true); // Always editable — click in, start typing
   const editorRef = useRef<unknown>(null);
@@ -145,6 +42,10 @@ export const FileViewer = memo(function FileViewer({ filePath, workspace }: { fi
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
+    setDirty(false);
+    setSaveNote(null);
+    setSaveConflict(null);
+    setFileHash(null);
 
     // Fetch file content
     const wsParam = workspace ? `&workspace=${encodeURIComponent(workspace)}` : '';
@@ -157,6 +58,7 @@ export const FileViewer = memo(function FileViewer({ filePath, workspace }: { fi
       if (!cancelled) {
         setContent(contentData.content ?? null);
         setEditContent(contentData.content ?? '');
+        setFileHash(typeof contentData.contentHash === 'string' ? contentData.contentHash : null);
         setDiff(diffData.diff ?? '');
         setHasDiff(diffData.hasDiff ?? false);
         if (diffData.hasDiff) setActiveView('diff');
@@ -172,31 +74,54 @@ export const FileViewer = memo(function FileViewer({ filePath, workspace }: { fi
   }, [filePath, workspace]);
 
   // Save file via API
-  const handleSave = useCallback(async () => {
-    if (!dirty || saving) return;
+  const handleSave = useCallback(async (force = false) => {
+    if ((!dirty && !force) || saving || (saveConflict && !force)) return;
     setSaving(true);
     setSaveNote(null);
     try {
       const res = await fetch('/api/v2/files', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ path: filePath, content: editContent, workspace }),
+        body: JSON.stringify({
+          path: filePath,
+          content: editContent,
+          workspace,
+          ...(fileHash ? { expectedHash: fileHash } : {}),
+          ...(force ? { force: true } : {}),
+        }),
       });
+      const data = await res.json().catch(() => ({})) as Record<string, unknown>;
       if (res.ok) {
         setContent(editContent);
+        setFileHash(typeof data.contentHash === 'string' ? data.contentHash : null);
+        setSaveConflict(null);
         setDirty(false);
         setSaveNote('Saved');
         setTimeout(() => setSaveNote(null), 2000);
+      } else if (res.status === 409 && data.error === 'changed-on-disk') {
+        setSaveConflict({
+          content: typeof data.content === 'string' ? data.content : null,
+          contentHash: typeof data.contentHash === 'string' ? data.contentHash : null,
+        });
       } else {
-        const data = await res.json().catch(() => ({}));
-        setSaveNote(`Error: ${(data as Record<string, string>).error ?? 'Save failed'}`);
+        setSaveNote(`Error: ${typeof data.error === 'string' ? data.error : 'Save failed'}`);
       }
     } catch (err) {
       setSaveNote(`Error: ${err instanceof Error ? err.message : 'Save failed'}`);
     } finally {
       setSaving(false);
     }
-  }, [dirty, saving, filePath, editContent]);
+  }, [dirty, saving, saveConflict, filePath, editContent, workspace, fileHash]);
+
+  const reloadConflict = useCallback(() => {
+    if (!saveConflict) return;
+    setContent(saveConflict.content);
+    setEditContent(saveConflict.content ?? '');
+    setFileHash(saveConflict.contentHash);
+    setSaveConflict(null);
+    setDirty(false);
+    setSaveNote(null);
+  }, [saveConflict]);
 
   // Cmd+S keyboard shortcut
   useEffect(() => {
@@ -515,6 +440,14 @@ export const FileViewer = memo(function FileViewer({ filePath, workspace }: { fi
           </div>
         ) : null}
       </div>
+
+      {saveConflict ? (
+        <SaveConflictStrip
+          busy={saving}
+          onReload={reloadConflict}
+          onOverwrite={() => { void handleSave(true); }}
+        />
+      ) : null}
 
       {/* Inline Edit Widget — renders into Monaco content widget via portal */}
       {inlineEditOpen && inlineWidgetDomRef.current && createPortal(

--- a/src/components/desktop/SaveConflictStrip.tsx
+++ b/src/components/desktop/SaveConflictStrip.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import type { CSSProperties } from 'react';
+
+export interface SaveConflict {
+  content: string | null;
+  contentHash: string | null;
+}
+
+const actionStyle: CSSProperties = {
+  minHeight: 44,
+  paddingTop: 0,
+  paddingRight: 12,
+  paddingBottom: 0,
+  paddingLeft: 12,
+  border: 'none',
+  borderRadius: 7,
+  fontFamily: 'var(--font-sans-system)',
+  fontSize: 11,
+  fontWeight: 300,
+  letterSpacing: '-0.1px',
+};
+
+export function SaveConflictStrip({
+  busy,
+  onReload,
+  onOverwrite,
+}: {
+  busy: boolean;
+  onReload: () => void;
+  onOverwrite: () => void;
+}) {
+  return (
+    <div
+      role="alert"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        minHeight: 52,
+        paddingTop: 4,
+        paddingRight: 12,
+        paddingBottom: 4,
+        paddingLeft: 16,
+        borderBottom: '1px solid var(--t-divider-subtle)',
+        background: 'var(--t-input-bg)',
+        color: 'var(--t-text)',
+        fontFamily: 'var(--font-sans-system)',
+        flexShrink: 0,
+      }}
+    >
+      <span style={{ flex: 1, minWidth: 0, fontSize: 11, fontWeight: 300, letterSpacing: '-0.1px' }}>
+        Changed on disk while you were editing
+      </span>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onReload}
+          style={{
+            ...actionStyle,
+            background: 'var(--t-bg-card)',
+            color: 'var(--t-text)',
+            cursor: busy ? 'default' : 'pointer',
+            opacity: busy ? 0.6 : 1,
+          }}
+        >
+          Reload
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onOverwrite}
+          style={{
+            ...actionStyle,
+            background: 'transparent',
+            color: 'var(--t-danger)',
+            cursor: busy ? 'default' : 'pointer',
+            opacity: busy ? 0.6 : 1,
+          }}
+        >
+          {busy ? 'Overwriting…' : 'Overwrite'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/desktop/file-viewer-monaco.ts
+++ b/src/components/desktop/file-viewer-monaco.ts
@@ -1,0 +1,107 @@
+export function getMonacoLanguage(path: string): string {
+  const ext = path.split('.').pop()?.toLowerCase() ?? '';
+  const name = path.split('/').pop()?.toLowerCase() ?? '';
+  if (name.startsWith('.env')) return 'ini';
+  if (name === 'dockerfile') return 'dockerfile';
+  if (name === '.gitignore' || name === '.dockerignore') return 'plaintext';
+  const map: Record<string, string> = {
+    ts: 'typescript', tsx: 'typescript', js: 'javascript', jsx: 'javascript',
+    json: 'json', yaml: 'yaml', yml: 'yaml', toml: 'toml',
+    md: 'markdown', mdx: 'markdown', html: 'html', xml: 'xml',
+    css: 'css', scss: 'scss', less: 'less',
+    py: 'python', rs: 'rust', go: 'go', rb: 'ruby', java: 'java',
+    c: 'c', cpp: 'cpp', h: 'c', hpp: 'cpp',
+    sh: 'shell', bash: 'shell', zsh: 'shell',
+    sql: 'sql', graphql: 'graphql', gql: 'graphql',
+    swift: 'swift', kt: 'kotlin',
+    r: 'r', lua: 'lua', php: 'php', perl: 'perl',
+    ini: 'ini', conf: 'ini', cfg: 'ini',
+  };
+  return map[ext] || 'plaintext';
+}
+
+export function defineCortexMonacoThemes(monaco: typeof import('monaco-editor')) {
+  monaco.editor.defineTheme('cortex-graphite', {
+    base: 'vs-dark',
+    inherit: true,
+    rules: [
+      { token: 'comment', foreground: '8f99a6', fontStyle: 'italic' },
+      { token: 'keyword', foreground: '9db5ff' },
+      { token: 'string', foreground: '7fd6b7' },
+      { token: 'number', foreground: 'f1b57f' },
+      { token: 'type', foreground: 'd6c48f' },
+      { token: 'variable', foreground: 'f2a8b8' },
+      { token: 'function', foreground: '8fc0ff' },
+    ],
+    colors: {
+      'editor.background': '#3d434b',
+      'editor.foreground': '#eef3f8',
+      'editor.lineHighlightBackground': '#49515b',
+      'editor.selectionBackground': '#7aa2ff33',
+      'editorLineNumber.foreground': '#8893a0',
+      'editorLineNumber.activeForeground': '#dbe4ee',
+      'editor.inactiveSelectionBackground': '#7aa2ff1f',
+      'editorCursor.foreground': '#7aa2ff',
+      'editorGutter.background': '#3d434b',
+      'editorWidget.background': '#444b55',
+      'editorWidget.border': '#65707d',
+      'input.background': '#343a42',
+      'input.border': '#65707d',
+      'focusBorder': '#7aa2ff',
+      'minimap.background': '#3d434b',
+      'scrollbarSlider.background': '#65707d88',
+      'scrollbarSlider.hoverBackground': '#7b879488',
+      'diffEditor.insertedTextBackground': '#16653433',
+      'diffEditor.insertedLineBackground': '#1665341f',
+      'diffEditor.removedTextBackground': '#1d4ed833',
+      'diffEditor.removedLineBackground': '#1d4ed81f',
+      'diffEditor.diagonalFill': '#3d434b',
+    },
+  });
+
+  monaco.editor.defineTheme('cortex-frost', {
+    base: 'vs',
+    inherit: true,
+    rules: [
+      { token: 'comment', foreground: '94a3b8', fontStyle: 'italic' },
+      { token: 'keyword', foreground: '6366f1' },
+      { token: 'string', foreground: '0d9488' },
+      { token: 'number', foreground: 'e879a0' },
+      { token: 'type', foreground: '8b5cf6' },
+      { token: 'variable', foreground: '0284c7' },
+      { token: 'function', foreground: '4f46e5' },
+      { token: 'delimiter', foreground: '94a3b8' },
+      { token: 'tag', foreground: 'e879a0' },
+      { token: 'attribute.name', foreground: '8b5cf6' },
+      { token: 'attribute.value', foreground: '0d9488' },
+      { token: 'operator', foreground: '64748b' },
+      { token: 'regexp', foreground: 'e879a0' },
+    ],
+    colors: {
+      'editor.background': '#f0f7ff',
+      'editor.foreground': '#1e293b',
+      'editor.lineHighlightBackground': '#e8f1fc',
+      'editor.selectionBackground': '#c7d2fe',
+      'editorLineNumber.foreground': '#94a3b8',
+      'editorLineNumber.activeForeground': '#475569',
+      'editor.inactiveSelectionBackground': '#c7d2fe60',
+      'editorCursor.foreground': '#4f46e5',
+      'editorGutter.background': '#f0f7ff',
+      'editorWidget.background': '#f8fafc',
+      'editorWidget.border': '#cbd5e1',
+      'input.background': '#ffffff',
+      'input.border': '#cbd5e1',
+      'focusBorder': '#6366f1',
+      'minimap.background': '#f0f7ff',
+      'scrollbarSlider.background': '#94a3b840',
+      'scrollbarSlider.hoverBackground': '#64748b40',
+      'editorBracketMatch.background': '#e0e7ff',
+      'editorBracketMatch.border': '#a5b4fc',
+      'diffEditor.insertedTextBackground': '#dcfce766',
+      'diffEditor.insertedLineBackground': '#dcfce740',
+      'diffEditor.removedTextBackground': '#dbeafe88',
+      'diffEditor.removedLineBackground': '#dbeafe55',
+      'diffEditor.diagonalFill': '#f0f7ff',
+    },
+  });
+}

--- a/src/components/desktop/o8-panel/O8SpecPane.tsx
+++ b/src/components/desktop/o8-panel/O8SpecPane.tsx
@@ -7,6 +7,7 @@ import { cleanupOrphanedRoughdraftAnnotations } from '@/lib/o8md/cleanup';
 import { O8SpecEditor } from './O8SpecEditor';
 import { O8SpecTargetPicker, useO8SpecTarget } from './O8SpecTargetPicker';
 import { TitleBarButton } from '../title-bar/TitleBarButton';
+import { SaveConflictStrip, type SaveConflict } from '../SaveConflictStrip';
 
 interface O8SpecPaneProps {
   repoPath?: string | null;
@@ -95,6 +96,7 @@ export function O8SpecPane({ repoPath: defaultRepoPath, toolbarSlot, embedded, a
   const [savePending, setSavePending] = useState(false);
   const [savedAt, setSavedAt] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [saveConflict, setSaveConflict] = useState<SaveConflict | null>(null);
   const [now, setNow] = useState(0);
   // Per-user note styling for the o8.md rail. customColor=null → brand orange;
   // else any CSS color string (a rainbow hue OR a neutral swatch incl. black).
@@ -114,6 +116,7 @@ export function O8SpecPane({ repoPath: defaultRepoPath, toolbarSlot, embedded, a
   // orchestrator's annotations without a manual reload — and never clobber the
   // operator's unsaved edits (we only swap when local === last-saved).
   const serverContentRef = useRef('');
+  const contentHashRef = useRef<string | null>(null);
   const prewarmedReposRef = useRef(new Set<string>());
 
   // Sparkle → headless one-shot review. An LLM turn server-side annotates o8.md
@@ -140,6 +143,9 @@ export function O8SpecPane({ repoPath: defaultRepoPath, toolbarSlot, embedded, a
       const fresh = await fetch(`/api/repo-spec?repoPath=${encodeURIComponent(repoPath)}`).then((r) => r.json()).catch(() => null);
       if (fresh?.ok && typeof fresh.content === 'string' && content === serverContentRef.current) {
         serverContentRef.current = fresh.content;
+        contentHashRef.current = fresh.exists !== false && typeof fresh.contentHash === 'string'
+          ? fresh.contentHash
+          : null;
         setContent(fresh.content);
         setLoadedContent(fresh.content);
       }
@@ -192,12 +198,16 @@ export function O8SpecPane({ repoPath: defaultRepoPath, toolbarSlot, embedded, a
       setLoadedContent('');
       setLoading(false);
       setSavePending(false);
+      setSaveConflict(null);
+      contentHashRef.current = null;
       setError('Select a repo to edit o8.md.');
       return;
     }
     let cancelled = false;
     setLoading(true);
     setError(null);
+    setSaveConflict(null);
+    contentHashRef.current = null;
     setSavedAt(null);
     fetch(`/api/repo-spec?repoPath=${encodeURIComponent(repoPath)}`)
       .then((res) => res.json())
@@ -207,6 +217,9 @@ export function O8SpecPane({ repoPath: defaultRepoPath, toolbarSlot, embedded, a
           setContent(data.content);
           setLoadedContent(data.content);
           serverContentRef.current = data.content;
+          contentHashRef.current = data.exists !== false && typeof data.contentHash === 'string'
+            ? data.contentHash
+            : null;
         } else {
           setLoadedContent('');
           setError(data?.error || 'Failed to load notes');
@@ -221,22 +234,37 @@ export function O8SpecPane({ repoPath: defaultRepoPath, toolbarSlot, embedded, a
     return () => { cancelled = true; };
   }, [repoPath]);
 
-  const persist = useCallback((next: string) => {
-    if (!repoPath) return;
+  const persist = useCallback((next: string, force = false) => {
+    if (!repoPath || (saveConflict && !force)) return;
     setSavePending(true);
     setError(null);
     fetch(`/api/repo-spec?repoPath=${encodeURIComponent(repoPath)}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ content: next }),
+      body: JSON.stringify({
+        content: next,
+        ...(contentHashRef.current ? { expectedHash: contentHashRef.current } : {}),
+        ...(force ? { force: true } : {}),
+      }),
     })
-      .then((res) => res.json())
-      .then((data) => {
-        if (data?.ok) {
+      .then(async (res) => ({ res, data: await res.json().catch(() => ({})) }))
+      .then(({ res, data }) => {
+        if (res.ok && data?.ok) {
           const saved = typeof data.content === 'string' ? data.content : next;
           setSavedAt(Date.now());
           serverContentRef.current = saved;
+          contentHashRef.current = typeof data.contentHash === 'string' ? data.contentHash : null;
+          setSaveConflict(null);
           if (saved !== next) setContent(saved);
+        } else if (res.status === 409 && data?.error === 'changed-on-disk') {
+          if (debounceRef.current) {
+            window.clearTimeout(debounceRef.current);
+            debounceRef.current = null;
+          }
+          setSaveConflict({
+            content: typeof data.content === 'string' ? data.content : null,
+            contentHash: typeof data.contentHash === 'string' ? data.contentHash : null,
+          });
         } else setError(data?.error || 'Save failed');
       })
       .catch((err) => {
@@ -245,17 +273,42 @@ export function O8SpecPane({ repoPath: defaultRepoPath, toolbarSlot, embedded, a
       .finally(() => {
         setSavePending(false);
       });
-  }, [repoPath]);
+  }, [repoPath, saveConflict]);
 
   const handleChange = useCallback((next: string) => {
     const cleaned = cleanupOrphanedRoughdraftAnnotations(next).content;
     setContent(cleaned);
+    if (saveConflict) {
+      setSavePending(false);
+      if (debounceRef.current) {
+        window.clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+      return;
+    }
     setSavePending(true);
     if (debounceRef.current) window.clearTimeout(debounceRef.current);
     debounceRef.current = window.setTimeout(() => {
       persist(cleaned);
     }, SAVE_DEBOUNCE_MS) as unknown as number;
-  }, [persist]);
+  }, [persist, saveConflict]);
+
+  const reloadConflict = useCallback(() => {
+    if (!saveConflict) return;
+    if (debounceRef.current) {
+      window.clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    const diskContent = saveConflict.content ?? '';
+    serverContentRef.current = diskContent;
+    contentHashRef.current = saveConflict.contentHash;
+    setContent(diskContent);
+    setLoadedContent(diskContent);
+    setSaveConflict(null);
+    setSavePending(false);
+    setSavedAt(null);
+    setError(null);
+  }, [saveConflict]);
 
   // Per-note server actions write immediately. Adopt their authoritative
   // content without scheduling a second autosave or leaving the poller's
@@ -271,7 +324,20 @@ export function O8SpecPane({ repoPath: defaultRepoPath, toolbarSlot, embedded, a
     setSavePending(false);
     setSavedAt(Date.now());
     setError(null);
-  }, []);
+    setSaveConflict(null);
+    if (repoPath) {
+      void fetch(`/api/repo-spec?repoPath=${encodeURIComponent(repoPath)}`)
+        .then((res) => res.json())
+        .then((data) => {
+          if (data?.ok && data.content === next) {
+            contentHashRef.current = data.exists !== false && typeof data.contentHash === 'string'
+              ? data.contentHash
+              : null;
+          }
+        })
+        .catch(() => { /* the next guarded save will detect drift */ });
+    }
+  }, [repoPath]);
 
   // Adopt external writes to o8.md (the orchestrator's annotations) without a
   // manual reload. Read-only against the server — never writes back — and only
@@ -292,10 +358,19 @@ export function O8SpecPane({ repoPath: defaultRepoPath, toolbarSlot, embedded, a
       .then((res) => res.json())
       .then((data) => {
         const next = data?.ok && typeof data.content === 'string' ? data.content : null;
-        if (next == null || next === serverContentRef.current) return;
+        if (next == null) return;
+        if (next === serverContentRef.current) {
+          contentHashRef.current = data.exists !== false && typeof data.contentHash === 'string'
+            ? data.contentHash
+            : null;
+          return;
+        }
         const cur = pollStateRef.current;
         if (cur.savePending || cur.content !== serverContentRef.current) return; // raced a local edit
         serverContentRef.current = next;
+        contentHashRef.current = data.exists !== false && typeof data.contentHash === 'string'
+          ? data.contentHash
+          : null;
         setContent(next);
         setLoadedContent(next);
       })
@@ -535,6 +610,13 @@ export function O8SpecPane({ repoPath: defaultRepoPath, toolbarSlot, embedded, a
           ) : null}
         </div>
       </div>
+      {saveConflict ? (
+        <SaveConflictStrip
+          busy={savePending}
+          onReload={reloadConflict}
+          onOverwrite={() => persist(content, true)}
+        />
+      ) : null}
       <div style={{ display: 'flex', flex: 1, minHeight: 0, overflow: 'hidden', paddingTop: embedded ? 0 : 14, paddingRight: embedded ? 0 : 14, paddingBottom: embedded ? 0 : 14, paddingLeft: embedded ? 0 : 14 }}>
         <div style={{
           display: 'flex',

--- a/tests/file-save-conflict-real-path.test.ts
+++ b/tests/file-save-conflict-real-path.test.ts
@@ -1,0 +1,177 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { NextRequest } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { contentHash } from '@/lib/markdown/transport';
+
+const ORIGINAL_REPO_ROOT = process.env.CORTEX_IDE_REVIEW_REPO_ROOT;
+
+let repoPath = '';
+
+function request(url: string, method = 'GET', body?: Record<string, unknown>) {
+  return new NextRequest(url, {
+    method,
+    ...(body ? {
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    } : {}),
+  });
+}
+
+describe('content-hash file-save conflicts through the real routes', () => {
+  beforeEach(() => {
+    repoPath = mkdtempSync(join(tmpdir(), 'o8-file-save-conflict-'));
+    process.env.CORTEX_IDE_REVIEW_REPO_ROOT = repoPath;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_REPO_ROOT === undefined) delete process.env.CORTEX_IDE_REVIEW_REPO_ROOT;
+    else process.env.CORTEX_IDE_REVIEW_REPO_ROOT = ORIGINAL_REPO_ROOT;
+    rmSync(repoPath, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  it('hashes the full file-content read even when the response is truncated', async () => {
+    const smallContent = 'small file\n';
+    const largeContent = `${'x'.repeat(100001)}\nfull-file-tail`;
+    writeFileSync(join(repoPath, 'small.md'), smallContent, 'utf-8');
+    writeFileSync(join(repoPath, 'large.md'), largeContent, 'utf-8');
+    const { GET } = await import('@/app/api/panel/file-content/route');
+
+    const small = await GET(request('http://localhost/api/panel/file-content?path=small.md'));
+    const smallBody = await small.json();
+    expect(small.status).toBe(200);
+    expect(smallBody.content).toBe(smallContent);
+    expect(smallBody.contentHash).toBe(await contentHash(smallContent));
+
+    const large = await GET(request('http://localhost/api/panel/file-content?path=large.md'));
+    const largeBody = await large.json();
+    expect(large.status).toBe(200);
+    expect(largeBody.truncated).toBe(true);
+    expect(largeBody.content).toBe(`${largeContent.slice(0, 100000)}\n\n... (truncated at 100KB)`);
+    expect(largeBody.contentHash).toBe(await contentHash(largeContent));
+    expect(largeBody.contentHash).not.toBe(await contentHash(largeBody.content));
+  });
+
+  it('guards v2 file saves while preserving force and legacy writes', async () => {
+    const filePath = join(repoPath, 'note.md');
+    writeFileSync(filePath, 'v2 before\n', 'utf-8');
+    const { GET, POST } = await import('@/app/api/v2/files/route');
+
+    const loaded = await GET(request('http://localhost/api/v2/files?path=note.md'));
+    const loadedBody = await loaded.json();
+    const h1 = loadedBody.contentHash as string;
+    expect(loaded.status).toBe(200);
+    expect(loadedBody.content).toBe('v2 before\n');
+    expect(h1).toBe(await contentHash('v2 before\n'));
+
+    const guarded = await POST(request('http://localhost/api/v2/files', 'POST', {
+      path: 'note.md',
+      content: 'v2 guarded\n',
+      expectedHash: h1,
+    }));
+    const guardedBody = await guarded.json();
+    const h2 = guardedBody.contentHash as string;
+    expect(guarded.status).toBe(200);
+    expect(h2).toBe(await contentHash('v2 guarded\n'));
+    expect(h2).not.toBe(h1);
+    expect(readFileSync(filePath, 'utf-8')).toBe('v2 guarded\n');
+
+    writeFileSync(filePath, 'v2 external\n', 'utf-8');
+    const stale = await POST(request('http://localhost/api/v2/files', 'POST', {
+      path: 'note.md',
+      content: 'v2 stale\n',
+      expectedHash: h2,
+    }));
+    const staleBody = await stale.json();
+    expect(stale.status).toBe(409);
+    expect(staleBody).toMatchObject({
+      error: 'changed-on-disk',
+      content: 'v2 external\n',
+    });
+    expect(staleBody.contentHash).toBe(await contentHash('v2 external\n'));
+    expect(staleBody.contentHash).not.toBe(h2);
+    expect(readFileSync(filePath, 'utf-8')).toBe('v2 external\n');
+
+    const forced = await POST(request('http://localhost/api/v2/files', 'POST', {
+      path: 'note.md',
+      content: 'v2 forced\n',
+      expectedHash: h2,
+      force: true,
+    }));
+    const forcedBody = await forced.json();
+    expect(forced.status).toBe(200);
+    expect(forcedBody.contentHash).toBe(await contentHash('v2 forced\n'));
+    expect(readFileSync(filePath, 'utf-8')).toBe('v2 forced\n');
+
+    const legacy = await POST(request('http://localhost/api/v2/files', 'POST', {
+      path: 'note.md',
+      content: 'v2 legacy\n',
+    }));
+    const legacyBody = await legacy.json();
+    expect(legacy.status).toBe(200);
+    expect(legacyBody.contentHash).toBe(await contentHash('v2 legacy\n'));
+    expect(readFileSync(filePath, 'utf-8')).toBe('v2 legacy\n');
+  });
+
+  it('guards repo-spec saves while preserving force and legacy writes', async () => {
+    const specPath = join(repoPath, 'o8.md');
+    const routeUrl = `http://localhost/api/repo-spec?repoPath=${encodeURIComponent(repoPath)}`;
+    writeFileSync(specPath, 'spec before\n', 'utf-8');
+    const { GET, PUT } = await import('@/app/api/repo-spec/route');
+
+    const loaded = await GET(request(routeUrl));
+    const loadedBody = await loaded.json();
+    const h1 = loadedBody.contentHash as string;
+    expect(loaded.status).toBe(200);
+    expect(loadedBody.content).toBe('spec before\n');
+    expect(h1).toBe(await contentHash('spec before\n'));
+
+    const guarded = await PUT(request(routeUrl, 'PUT', {
+      content: 'spec guarded\n',
+      expectedHash: h1,
+    }));
+    const guardedBody = await guarded.json();
+    const h2 = guardedBody.contentHash as string;
+    expect(guarded.status).toBe(200);
+    expect(h2).toBe(await contentHash('spec guarded\n'));
+    expect(h2).not.toBe(h1);
+    expect(readFileSync(specPath, 'utf-8')).toBe('spec guarded\n');
+
+    writeFileSync(specPath, 'spec external\n', 'utf-8');
+    const stale = await PUT(request(routeUrl, 'PUT', {
+      content: 'spec stale\n',
+      expectedHash: h2,
+    }));
+    const staleBody = await stale.json();
+    expect(stale.status).toBe(409);
+    expect(staleBody).toMatchObject({
+      error: 'changed-on-disk',
+      content: 'spec external\n',
+    });
+    expect(staleBody.contentHash).toBe(await contentHash('spec external\n'));
+    expect(staleBody.contentHash).not.toBe(h2);
+    expect(readFileSync(specPath, 'utf-8')).toBe('spec external\n');
+
+    const forced = await PUT(request(routeUrl, 'PUT', {
+      content: 'spec forced\n',
+      expectedHash: h2,
+      force: true,
+    }));
+    const forcedBody = await forced.json();
+    expect(forced.status).toBe(200);
+    expect(forcedBody.contentHash).toBe(await contentHash('spec forced\n'));
+    expect(readFileSync(specPath, 'utf-8')).toBe('spec forced\n');
+
+    const legacy = await PUT(request(routeUrl, 'PUT', {
+      content: 'spec legacy\n',
+    }));
+    const legacyBody = await legacy.json();
+    expect(legacy.status).toBe(200);
+    expect(legacyBody.contentHash).toBe(await contentHash('spec legacy\n'));
+    expect(readFileSync(specPath, 'utf-8')).toBe('spec legacy\n');
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1301,6 +1301,12 @@
       ]
     },
     {
+      "path": "tests/file-save-conflict-real-path.test.ts",
+      "reasons": [
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/fixed-reports-range.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
Closes #1921. Refs #1696.

## What

Optimistic content-hash conflict detection on the two repo-scoped file save paths. A save that lands on a file someone else changed in the meantime now returns **409** instead of overwriting.

- Reads carry a hash: `GET /api/panel/file-content`, `GET /api/v2/files`, and `GET /api/repo-spec` return `contentHash` (SHA-256 of the full file, via the transport layer's `contentHash` from #1947). `file-content` hashes the full file even when it truncates the returned text at 100 KB, so a stale save on a truncated load is still detected.
- Writes compare: `POST /api/v2/files` and `PUT /api/repo-spec` accept optional `expectedHash` and `force`. With `expectedHash` and no `force`, the route hashes the current on-disk content (a missing file hashes as `null`); on mismatch it responds `409 { error: 'changed-on-disk', contentHash, content }` and writes nothing. On match, or with `force`, it writes and returns the new `contentHash`. Without `expectedHash` the routes behave exactly as before, so the LLM-chat "Apply to File" path is unchanged.
- Clients: `FileViewer` and `O8SpecPane` keep the hash from their last load or save and send it as `expectedHash`. On 409 they show an inline `SaveConflictStrip` ("Changed on disk while you were editing") with **Reload** (adopt the on-disk content and hash) and **Overwrite** (resend with `force`). Nothing is written until the operator picks one; ⌘S and the o8.md autosave debounce hold while the strip is up. The o8.md poller and per-note server actions refresh the tracked hash when they adopt server content.
- `panel/file-io` keeps its existing mtime guard; no new routes, so no middleware manifest change.

## Proof

`tests/file-save-conflict-real-path.test.ts` drives the real route handlers with `NextRequest` against a temp repo: load → hash H1; guarded write with H1 → 200 and a new hash; external on-disk change → guarded write returns 409 with the on-disk content and hash, file untouched; the same write with `force` → 200; a write with no `expectedHash` → 200 (legacy). Both `v2/files` and `repo-spec`. Plus `file-content` GET: a small file hashes its content; a >100 KB file returns `truncated: true` and the hash of the full file.

## Gates

tsc · 13 route tests · lint ratchet (no new warnings) · classification check · full suite green.
