### PR TITLE
perf: keep canvas card moves from re-rendering every card

### DIFF
--- a/src/app/preview/canvas-glass/agent-card.tsx
+++ b/src/app/preview/canvas-glass/agent-card.tsx
@@ -17,7 +17,7 @@
  * locked CHROME vocabulary via GlassCardShell — never hand-rolled.
  */
 
-import { useEffect, useMemo, useRef, useState, type CSSProperties, type FormEvent } from 'react';
+import { memo, useEffect, useMemo, useRef, useState, type CSSProperties, type FormEvent } from 'react';
 import { CHROME, FONT, chatVocabularyRebind, scrollFadeY } from './ui';
 import { GlassCardShell, ShellAction } from './card-shell';
 import { runtimeColor } from '@/lib/agents/codename';
@@ -183,7 +183,7 @@ function SentLine({ message }: { message: SentMessage }) {
   );
 }
 
-export function AgentGlassCard({
+export const AgentGlassCard = memo(function AgentGlassCard({
   card,
   lane,
   onMove,
@@ -543,4 +543,4 @@ export function AgentGlassCard({
       )}
     </GlassCardShell>
   );
-}
+});

--- a/src/app/preview/canvas-glass/brain-card.tsx
+++ b/src/app/preview/canvas-glass/brain-card.tsx
@@ -13,7 +13,7 @@
  * geometry persists, the transcript doesn't.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { CHROME, FONT, scrollFadeY } from './ui';
 import { Citations, InlineMarkdown, SourcesLine } from './response-blocks';
 import { CardComposer } from './card-composer';
@@ -273,7 +273,7 @@ export function BrainConversation({
   );
 }
 
-export function BrainGlassCard({
+export const BrainGlassCard = memo(function BrainGlassCard({
   card,
   onMove,
   onResize,
@@ -307,4 +307,4 @@ export function BrainGlassCard({
       </div>
     </GlassCardShell>
   );
-}
+});

--- a/src/app/preview/canvas-glass/canvas-card-state.ts
+++ b/src/app/preview/canvas-glass/canvas-card-state.ts
@@ -1,0 +1,18 @@
+export interface PositionedCanvasCard {
+  id: number;
+  x: number;
+  y: number;
+}
+
+export function spawnCanvasCard<Card>(cards: Card[], card: Card): Card[] {
+  return [...cards, card];
+}
+
+export function moveCanvasCard<Card extends PositionedCanvasCard>(
+  cards: Card[],
+  id: number,
+  x: number,
+  y: number,
+): Card[] {
+  return cards.map((card) => (card.id === id ? { ...card, x, y } : card));
+}

--- a/src/app/preview/canvas-glass/cards.tsx
+++ b/src/app/preview/canvas-glass/cards.tsx
@@ -7,7 +7,7 @@
  * dragging, and a selection ring on click.
  */
 
-import { useRef, useState } from 'react';
+import { memo, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import { canvasZoom, CARD_WIDTH, FONT, TONE_DOT, glass, type MockCard } from './ui';
 import { dragBounds, resistAxis, settleInBounds } from './canvas-drag';
@@ -16,7 +16,7 @@ import { dragBounds, resistAxis, settleInBounds } from './canvas-drag';
  *  bottom drag boundary so they don't bury under the composer. */
 const CARD_NOMINAL_H = 130;
 
-export function CanvasCard({
+export const CanvasCard = memo(function CanvasCard({
   card,
   selected,
   onMove,
@@ -117,7 +117,7 @@ export function CanvasCard({
       </motion.div>
     </motion.div>
   );
-}
+});
 
 function CardTitleBar({ card }: { card: MockCard }) {
   return (

--- a/src/app/preview/canvas-glass/chat-card.tsx
+++ b/src/app/preview/canvas-glass/chat-card.tsx
@@ -8,7 +8,7 @@
  * the thread — the next message continues that conversation).
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { SmoothCorners } from '@lisse/react';
 import { DockEntryView, DockTab } from './dock';
@@ -45,7 +45,7 @@ const CHAT_MIN_H = 140;
  *  bottom drag boundary clears the composer by the card's TRUE height. */
 const CHAT_CHROME_H = 63;
 
-export function ChatGlassCard({
+export const ChatGlassCard = memo(function ChatGlassCard({
   card,
   liveEntries,
   sendDefaults,
@@ -328,4 +328,4 @@ export function ChatGlassCard({
       <CornerResize card={card} minW={CHAT_MIN_W} minH={CHAT_MIN_H} onMove={onMove} onResize={onResize} onResizingChange={setResizing} />
     </motion.div>
   );
-}
+});

--- a/src/app/preview/canvas-glass/diff-card.tsx
+++ b/src/app/preview/canvas-glass/diff-card.tsx
@@ -8,10 +8,11 @@
  * /api/orchestrator/merge (the identical path approve_and_merge uses).
  */
 
-import { useRef, useState } from 'react';
+import { memo, useRef, useState } from 'react';
 import { actionReceiptIsInProgress, correlatedActionIsUnsettled, fetchCorrelatedActionReceipt } from '@/lib/orchestrator/action-receipt';
 import { CHROME, FONT, scrollFadeY } from './ui';
 import { GlassCardShell } from './card-shell';
+import { useCanvasRenderProbe } from './perf/render-probe';
 import { useScrollBlurFade } from './use-scroll-blur-fade';
 
 const MONO = '"SF Mono", ui-monospace, "Cascadia Code", Menlo, monospace';
@@ -51,7 +52,7 @@ function diffLineStyle(line: string): React.CSSProperties {
   return { color: 'var(--cnv-ink-muted)' };
 }
 
-export function DiffGlassCard({
+export const DiffGlassCard = memo(function DiffGlassCard({
   card,
   onMove,
   onResize,
@@ -67,6 +68,7 @@ export function DiffGlassCard({
   /** Hands the operator's words back to the composer, prefilled. */
   onRequestChanges: (card: DiffCard) => void;
 }) {
+  useCanvasRenderProbe('diff', card.id);
   const [merge, setMerge] = useState<MergeState>({ kind: 'idle' });
   const diffScrollRef = useRef<HTMLDivElement | null>(null);
   useScrollBlurFade(diffScrollRef);
@@ -224,4 +226,4 @@ export function DiffGlassCard({
         </div>
     </GlassCardShell>
   );
-}
+});

--- a/src/app/preview/canvas-glass/file-card.tsx
+++ b/src/app/preview/canvas-glass/file-card.tsx
@@ -18,11 +18,12 @@
  * agent-surfaced files) rides the regular-UI issue.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import { CanvasMarkdown } from './dock';
 import { CHROME, FONT, TERM_MIN_H, TERM_MIN_W } from './ui';
 import { GlassCardShell, ShellAction } from './card-shell';
+import { useCanvasRenderProbe } from './perf/render-probe';
 
 // NOTE: component (+ types) exports only — runtime const exports here would
 // break the Fast Refresh boundary and remount live cards on every edit.
@@ -106,7 +107,7 @@ function outdentSelection(value: string, start: number, end: number): { value: s
   };
 }
 
-export function FileGlassCard({
+export const FileGlassCard = memo(function FileGlassCard({
   card,
   termVeil,
   onMove,
@@ -122,6 +123,7 @@ export function FileGlassCard({
   onFocus: (id: number) => void;
   onClose: (id: number) => void;
 }) {
+  useCanvasRenderProbe('file', card.id);
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
   const [content, setContent] = useState('');
   const [savedContent, setSavedContent] = useState('');
@@ -452,4 +454,4 @@ export function FileGlassCard({
       </div>
     </GlassCardShell>
   );
-}
+});

--- a/src/app/preview/canvas-glass/image-card.tsx
+++ b/src/app/preview/canvas-glass/image-card.tsx
@@ -12,12 +12,13 @@
  * the bottom mask makes the lower corners moot.
  */
 
-import { useRef, useState, type CSSProperties } from 'react';
+import { memo, useRef, useState, type CSSProperties } from 'react';
 import { motion } from 'framer-motion';
 import { SmoothCorners } from '@lisse/react';
 import { canvasZoom, CHROME, chromeFloorScale, FONT, IMG_MIN_W, MEDIA_HEADER_H, MEDIA_RIM, glassMedia } from './ui';
 import { dragBounds, resistAxis, settleInBounds } from './canvas-drag';
 import { CornerResize } from './corner-resize';
+import { useCanvasRenderProbe } from './perf/render-probe';
 
 export interface ImageItem {
   src: string;
@@ -62,7 +63,7 @@ function navArrowStyle(side: 'left' | 'right'): CSSProperties {
   } as CSSProperties;
 }
 
-export function ImageGlassCard({
+export const ImageGlassCard = memo(function ImageGlassCard({
   card,
   isDropTarget,
   onMove,
@@ -93,6 +94,7 @@ export function ImageGlassCard({
   onSpread: (id: number) => void;
   onClose: (id: number) => void;
 }) {
+  useCanvasRenderProbe('image', card.id);
   const dragRef = useRef<{ pointerId: number; startX: number; startY: number; originX: number; originY: number; moved: boolean; lastX: number; lastY: number } | null>(null);
   const settleRef = useRef<{ stop: () => void } | null>(null);
   const [dragging, setDragging] = useState(false);
@@ -292,4 +294,4 @@ export function ImageGlassCard({
       <CornerResize card={card} minW={IMG_MIN_W} minH={90} aspect={card.aspect} edges={false} onMove={onMove} onResize={onResize} onResizingChange={setResizing} />
     </motion.div>
   );
-}
+});

--- a/src/app/preview/canvas-glass/markdown-card.tsx
+++ b/src/app/preview/canvas-glass/markdown-card.tsx
@@ -14,10 +14,11 @@
  * themed via the host's --cnv-* vars.
  */
 
-import { useRef, type ReactNode } from 'react';
+import { memo, useRef, type ReactNode } from 'react';
 import { CHROME, FONT, scrollFadeY } from './ui';
 import { InlineMarkdown } from './response-blocks';
 import { GlassCardShell } from './card-shell';
+import { useCanvasRenderProbe } from './perf/render-probe';
 import { useScrollBlurFade } from './use-scroll-blur-fade';
 
 export interface MarkdownCard {
@@ -147,7 +148,7 @@ function MarkdownBody({ md }: { md: string }) {
   return <div style={{ display: 'flex', flexDirection: 'column', gap: 9 }}>{blocks}</div>;
 }
 
-export function MarkdownGlassCard({
+export const MarkdownGlassCard = memo(function MarkdownGlassCard({
   card,
   onMove,
   onResize,
@@ -160,6 +161,7 @@ export function MarkdownGlassCard({
   onFocus: (id: number) => void;
   onClose: (id: number) => void;
 }) {
+  useCanvasRenderProbe('markdown', card.id);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   useScrollBlurFade(scrollRef);
 
@@ -195,4 +197,4 @@ export function MarkdownGlassCard({
       </div>
     </GlassCardShell>
   );
-}
+});

--- a/src/app/preview/canvas-glass/page.tsx
+++ b/src/app/preview/canvas-glass/page.tsx
@@ -51,6 +51,7 @@ import type { XtermPanelHandle } from '@/components/desktop/workspace-terminal/X
 import { DEFAULT_ORCHESTRATOR_MODEL } from '@/components/desktop/thoughts/use-orchestrator-stream/shared';
 import { THINKING_EFFORTS, isThinkingEffort, type ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import { usableCanvasArea } from './canvas-drag';
+import { moveCanvasCard, spawnCanvasCard } from './canvas-card-state';
 import { carveChrome, chromeRectsCanvas } from './chrome-rects';
 import { computeGrid, slotToCardGeom, type GridItem, type Slot } from './form-fit';
 import { NavigatorLoupe, type MinimapCard } from './navigator-loupe';
@@ -371,6 +372,7 @@ export default function CanvasGlassPreviewPage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [browserCards, setBrowserCards] = useState<BrowserCard[]>([]);
   const [chatCards, setChatCards] = useState<ChatCard[]>([]);
+  const chatSendDefaults = useMemo(() => ({ model: orchModel, thinkingEffort: orchEffort }), [orchEffort, orchModel]);
   const [topMenu, setTopMenu] = useState<'alerts' | 'agents' | 'profile' | null>(null);
   const [inboxItems, setInboxItems] = useState<InboxRow[]>([]);
   // Which alerts the operator has already clicked — dims the row + drops it
@@ -1749,7 +1751,7 @@ export default function CanvasGlassPreviewPage() {
     zPeakRef.current = Math.min(zPeakRef.current + 1, 39);
     const z = zPeakRef.current;
     const spot = at ?? findFreeSpot(560, 336);
-    setTermCards((previous) => [...previous, {
+    setTermCards((previous) => spawnCanvasCard(previous, {
       id,
       requestId,
       sessionName: null,
@@ -1764,7 +1766,7 @@ export default function CanvasGlassPreviewPage() {
       cwd,
       cwdLabel,
       agentCli: opts?.agentCli,
-    }]);
+    }));
     sendTerminalCreate(120, 30, requestId, cwd ?? undefined);
   }, [findFreeSpot, sendTerminalCreate]);
 
@@ -1811,42 +1813,23 @@ export default function CanvasGlassPreviewPage() {
   /** Clicked card comes forward. Terminals + files + images + browsers +
    *  chats share the 10–39 band — above mock cards (3), below chrome (40+). */
   const focusCard = useCallback((kind: 'term' | 'file' | 'image' | 'video' | 'browser' | 'chat' | 'diff' | 'spec' | 'brain' | 'markdown' | 'agent', id: number) => {
-    const current = kind === 'term'
-      ? termCards.find((card) => card.id === id)
-      : kind === 'file'
-        ? fileCards.find((card) => card.id === id)
-        : kind === 'image'
-          ? imageCards.find((card) => card.id === id)
-          : kind === 'video'
-            ? videoCards.find((card) => card.id === id)
-            : kind === 'browser'
-              ? browserCards.find((card) => card.id === id)
-              : kind === 'chat'
-                ? chatCards.find((card) => card.id === id)
-                : kind === 'diff'
-                  ? diffCards.find((card) => card.id === id)
-                  : kind === 'spec'
-                    ? specCards.find((card) => card.id === id)
-                    : kind === 'brain'
-                      ? brainCards.find((card) => card.id === id)
-                      : kind === 'markdown'
-                        ? markdownCards.find((card) => card.id === id)
-                        : agentCards.find((card) => card.id === id);
+    const canvasCards = canvasCardsRef.current;
+    const current = canvasCards[kind].find((card) => card.id === id);
     if (!current || current.z === zPeakRef.current) return;
     if (zPeakRef.current + 1 > 38) {
       // Renormalize the whole band, keeping order, with the target on top.
       const combined = [
-        ...termCards.map((card) => ({ kind: 'term' as const, id: card.id, z: card.z })),
-        ...fileCards.map((card) => ({ kind: 'file' as const, id: card.id, z: card.z })),
-        ...imageCards.map((card) => ({ kind: 'image' as const, id: card.id, z: card.z })),
-        ...videoCards.map((card) => ({ kind: 'video' as const, id: card.id, z: card.z })),
-        ...browserCards.map((card) => ({ kind: 'browser' as const, id: card.id, z: card.z })),
-        ...chatCards.map((card) => ({ kind: 'chat' as const, id: card.id, z: card.z })),
-        ...diffCards.map((card) => ({ kind: 'diff' as const, id: card.id, z: card.z })),
-        ...specCards.map((card) => ({ kind: 'spec' as const, id: card.id, z: card.z })),
-        ...brainCards.map((card) => ({ kind: 'brain' as const, id: card.id, z: card.z })),
-        ...markdownCards.map((card) => ({ kind: 'markdown' as const, id: card.id, z: card.z })),
-        ...agentCards.map((card) => ({ kind: 'agent' as const, id: card.id, z: card.z })),
+        ...canvasCards.term.map((card) => ({ kind: 'term' as const, id: card.id, z: card.z })),
+        ...canvasCards.file.map((card) => ({ kind: 'file' as const, id: card.id, z: card.z })),
+        ...canvasCards.image.map((card) => ({ kind: 'image' as const, id: card.id, z: card.z })),
+        ...canvasCards.video.map((card) => ({ kind: 'video' as const, id: card.id, z: card.z })),
+        ...canvasCards.browser.map((card) => ({ kind: 'browser' as const, id: card.id, z: card.z })),
+        ...canvasCards.chat.map((card) => ({ kind: 'chat' as const, id: card.id, z: card.z })),
+        ...canvasCards.diff.map((card) => ({ kind: 'diff' as const, id: card.id, z: card.z })),
+        ...canvasCards.spec.map((card) => ({ kind: 'spec' as const, id: card.id, z: card.z })),
+        ...canvasCards.brain.map((card) => ({ kind: 'brain' as const, id: card.id, z: card.z })),
+        ...canvasCards.markdown.map((card) => ({ kind: 'markdown' as const, id: card.id, z: card.z })),
+        ...canvasCards.agent.map((card) => ({ kind: 'agent' as const, id: card.id, z: card.z })),
       ].sort((a, b) => a.z - b.z);
       const remap = new Map(combined.map((entry, index) => [`${entry.kind}:${entry.id}`, 10 + index]));
       const top = 10 + combined.length;
@@ -1889,7 +1872,7 @@ export default function CanvasGlassPreviewPage() {
     } else {
       setAgentCards((previous) => previous.map((card) => (card.id === id ? { ...card, z } : card)));
     }
-  }, [agentCards, brainCards, markdownCards, browserCards, chatCards, diffCards, fileCards, imageCards, videoCards, specCards, termCards]);
+  }, []);
 
   const focusTermCard = useCallback((id: number) => focusCard('term', id), [focusCard]);
   const focusFileCard = useCallback((id: number) => focusCard('file', id), [focusCard]);
@@ -1902,6 +1885,26 @@ export default function CanvasGlassPreviewPage() {
   const focusBrainCard = useCallback((id: number) => focusCard('brain', id), [focusCard]);
   const focusMarkdownCard = useCallback((id: number) => focusCard('markdown', id), [focusCard]);
   const focusAgentCard = useCallback((id: number) => focusCard('agent', id), [focusCard]);
+  const moveDiffCard = useCallback((id: number, x: number, y: number) => setDiffCards((previous) => moveCanvasCard(previous, id, x, y)), []);
+  const resizeDiffCard = useCallback((id: number, w: number, h: number) => setDiffCards((previous) => previous.map((card) => (card.id === id ? { ...card, w, h } : card))), []);
+  const closeDiffCard = useCallback((id: number) => setDiffCards((previous) => previous.filter((card) => card.id !== id)), []);
+  const requestDiffCardChanges = useCallback((card: DiffCard) => {
+    setComposerValue(`Request changes on ${card.title}${card.branch ? ` (${card.branch})` : ''}: `);
+    composerInputRef.current?.focus();
+  }, []);
+  const moveAgentCard = useCallback((id: number, x: number, y: number) => setAgentCards((previous) => moveCanvasCard(previous, id, x, y)), []);
+  const resizeAgentCard = useCallback((id: number, w: number, h: number) => setAgentCards((previous) => previous.map((card) => (card.id === id ? { ...card, w, h } : card))), []);
+  const closeAgentCard = useCallback((id: number) => setAgentCards((previous) => previous.filter((card) => card.id !== id)), []);
+  const moveBrainCard = useCallback((id: number, x: number, y: number) => setBrainCards((previous) => moveCanvasCard(previous, id, x, y)), []);
+  const resizeBrainCard = useCallback((id: number, w: number, h: number) => setBrainCards((previous) => previous.map((card) => (card.id === id ? { ...card, w, h } : card))), []);
+  const closeBrainCard = useCallback((id: number) => setBrainCards((previous) => previous.filter((card) => card.id !== id)), []);
+  const moveMarkdownCard = useCallback((id: number, x: number, y: number) => setMarkdownCards((previous) => moveCanvasCard(previous, id, x, y)), []);
+  const resizeMarkdownCard = useCallback((id: number, w: number, h: number) => setMarkdownCards((previous) => previous.map((card) => (card.id === id ? { ...card, w, h } : card))), []);
+  const closeMarkdownCard = useCallback((id: number) => setMarkdownCards((previous) => previous.filter((card) => card.id !== id)), []);
+  const moveSpecCard = useCallback((id: number, x: number, y: number) => setSpecCards((previous) => moveCanvasCard(previous, id, x, y)), []);
+  const resizeSpecCard = useCallback((id: number, w: number, h: number) => setSpecCards((previous) => previous.map((card) => (card.id === id ? { ...card, w, h } : card))), []);
+  const closeSpecCard = useCallback((id: number) => setSpecCards((previous) => previous.filter((card) => card.id !== id)), []);
+  const specScreenMap = useMemo(() => ({ zoom: canvasZoomLevel, panX: pan.x, panY: pan.y }), [canvasZoomLevel, pan.x, pan.y]);
   /** Toggle an agent card compact ↔ full — snaps to that mode's preset size so
    *  the transcript+composer get room in full and the status tile stays tight in
    *  compact. The o8_canvas resize verb still resizes either mode afterward. */
@@ -2101,7 +2104,7 @@ export default function CanvasGlassPreviewPage() {
         nextIdRef.current += 1;
         zPeakRef.current = Math.min(zPeakRef.current + 1, 39);
         const spot = at ?? findFreeSpot(560, 356);
-        setDiffCards((previous) => [...previous, {
+        setDiffCards((previous) => spawnCanvasCard(previous, {
           id,
           x: spot.x,
           y: spot.y,
@@ -2115,10 +2118,15 @@ export default function CanvasGlassPreviewPage() {
           stat: data.stat ?? '',
           diff: data.diff ?? '',
           truncated: Boolean(data.truncated),
-        }]);
+        }));
       })
       .catch(() => {});
   }, [findFreeSpot]);
+
+  const reviewAgentCard = useCallback((laneId: string) => {
+    const lane = activeLanes.find((row) => row.id === laneId);
+    if (lane) void spawnDiffCard(lane);
+  }, [activeLanes, spawnDiffCard]);
 
   /** "What have I changed" — the active repo's WORKING-TREE diff in the
    *  same card the lane diffs use. laneId carries a worktree: prefix so
@@ -2307,7 +2315,7 @@ export default function CanvasGlassPreviewPage() {
     nextIdRef.current += 1;
     zPeakRef.current = Math.min(zPeakRef.current + 1, 39);
     const spot = findFreeSpot(380, 460);
-    setMarkdownCards((previous) => [...previous, {
+    setMarkdownCards((previous) => spawnCanvasCard(previous, {
       id,
       x: spot.x,
       y: spot.y,
@@ -2316,7 +2324,7 @@ export default function CanvasGlassPreviewPage() {
       h: 360,
       title: title.trim() || 'Note',
       markdown,
-    }]);
+    }));
   }, [findFreeSpot]);
 
   /** A REAL browser pane — defaults to the app's own dashboard. */
@@ -2397,7 +2405,7 @@ export default function CanvasGlassPreviewPage() {
     zPeakRef.current = Math.min(zPeakRef.current + 1, 39);
     const z = zPeakRef.current;
     const spot = at ?? findFreeSpot(620, 456);
-    setFileCards((previous) => [...previous, {
+    setFileCards((previous) => spawnCanvasCard(previous, {
       id,
       path,
       name: path.split('/').pop() || path,
@@ -2406,7 +2414,7 @@ export default function CanvasGlassPreviewPage() {
       w: at?.w ?? 620,
       h: at?.h ?? 420,
       z,
-    }]);
+    }));
   }, [findFreeSpot]);
 
   const showCanvasToast = useCallback((message: string, tone: CanvasToast['tone'] = 'error') => {
@@ -2893,9 +2901,7 @@ export default function CanvasGlassPreviewPage() {
   // ── Canvas control surface (agent parity) ────────────────────────────────
   // The intent bus's card verbs let an agent drive the canvas the way a human
   // can: SEE every card (list), then move / resize / focus / close one by id.
-  // focusCard + the per-kind close handlers (which own teardown — closeTerminal
-  // kills the PTY, closeImageCard revokes the object URL) already exist; these
-  // route to them so an agent's close behaves exactly like clicking the ✕.
+  // Existing focus/close handlers preserve each kind's teardown semantics.
   //
   // canvasCardsRef holds the latest card arrays so `list` + verb existence
   // checks read fresh state WITHOUT re-subscribing the intent listener on every
@@ -3390,7 +3396,7 @@ export default function CanvasGlassPreviewPage() {
               const id = nextIdRef.current;
               nextIdRef.current += 1;
               zPeakRef.current = Math.min(zPeakRef.current + 1, 39);
-              setImageCards((prev) => [...prev, { id, x: ax, y: ay, z: zPeakRef.current, w, h, aspect, items: [{ src, name }] }]);
+              setImageCards((prev) => spawnCanvasCard(prev, { id, x: ax, y: ay, z: zPeakRef.current, w, h, aspect, items: [{ src, name }] }));
             };
             probe.src = src;
             note = `adding image ${name}`;
@@ -3706,14 +3712,11 @@ export default function CanvasGlassPreviewPage() {
           <DiffGlassCard
             key={card.id}
             card={card}
-            onMove={(id, x, y) => setDiffCards((previous) => previous.map((c) => (c.id === id ? { ...c, x, y } : c)))}
-            onResize={(id, w, h) => setDiffCards((previous) => previous.map((c) => (c.id === id ? { ...c, w, h } : c)))}
+            onMove={moveDiffCard}
+            onResize={resizeDiffCard}
             onFocus={focusDiffCard}
-            onClose={(id) => setDiffCards((previous) => previous.filter((c) => c.id !== id))}
-            onRequestChanges={(diffCard) => {
-              setComposerValue(`Request changes on ${diffCard.title}${diffCard.branch ? ` (${diffCard.branch})` : ''}: `);
-              composerInputRef.current?.focus();
-            }}
+            onClose={closeDiffCard}
+            onRequestChanges={requestDiffCardChanges}
           />
         ))}
       </AnimatePresence>
@@ -3725,14 +3728,11 @@ export default function CanvasGlassPreviewPage() {
             key={card.id}
             card={card}
             lane={activeLanes.find((lane) => lane.id === card.laneId) ?? null}
-            onMove={(id, x, y) => setAgentCards((previous) => previous.map((c) => (c.id === id ? { ...c, x, y } : c)))}
-            onResize={(id, w, h) => setAgentCards((previous) => previous.map((c) => (c.id === id ? { ...c, w, h } : c)))}
+            onMove={moveAgentCard}
+            onResize={resizeAgentCard}
             onFocus={focusAgentCard}
-            onClose={(id) => setAgentCards((previous) => previous.filter((c) => c.id !== id))}
-            onReview={(laneId) => {
-              const lane = activeLanes.find((row) => row.id === laneId);
-              if (lane) void spawnDiffCard(lane);
-            }}
+            onClose={closeAgentCard}
+            onReview={reviewAgentCard}
             onToggleExpand={toggleAgentCardExpand}
           />
         ))}
@@ -3748,10 +3748,10 @@ export default function CanvasGlassPreviewPage() {
           <BrainGlassCard
             key={card.id}
             card={card}
-            onMove={(id, x, y) => setBrainCards((previous) => previous.map((c) => (c.id === id ? { ...c, x, y } : c)))}
-            onResize={(id, w, h) => setBrainCards((previous) => previous.map((c) => (c.id === id ? { ...c, w, h } : c)))}
+            onMove={moveBrainCard}
+            onResize={resizeBrainCard}
             onFocus={focusBrainCard}
-            onClose={(id) => setBrainCards((previous) => previous.filter((c) => c.id !== id))}
+            onClose={closeBrainCard}
           />
         ))}
       </AnimatePresence>
@@ -3762,10 +3762,10 @@ export default function CanvasGlassPreviewPage() {
           <MarkdownGlassCard
             key={card.id}
             card={card}
-            onMove={(id, x, y) => setMarkdownCards((previous) => previous.map((c) => (c.id === id ? { ...c, x, y } : c)))}
-            onResize={(id, w, h) => setMarkdownCards((previous) => previous.map((c) => (c.id === id ? { ...c, w, h } : c)))}
+            onMove={moveMarkdownCard}
+            onResize={resizeMarkdownCard}
             onFocus={focusMarkdownCard}
-            onClose={(id) => setMarkdownCards((previous) => previous.filter((c) => c.id !== id))}
+            onClose={closeMarkdownCard}
           />
         ))}
       </AnimatePresence>
@@ -3777,7 +3777,7 @@ export default function CanvasGlassPreviewPage() {
             key={card.id}
             card={card}
             liveEntries={convos[`thread:${card.threadId}`] ?? null}
-            sendDefaults={{ model: orchModel, thinkingEffort: orchEffort }}
+            sendDefaults={chatSendDefaults}
             onLiveEvent={handleOrchEvent}
             onUserSend={noteCardSend}
             onTruncate={truncateLane}
@@ -3807,11 +3807,11 @@ export default function CanvasGlassPreviewPage() {
             <SpecGlassCard
               key={card.id}
               card={card}
-              screenMap={{ zoom: canvasZoomLevel, panX: pan.x, panY: pan.y }}
-              onMove={(id, x, y) => setSpecCards((previous) => previous.map((c) => (c.id === id ? { ...c, x, y } : c)))}
-              onResize={(id, w, h) => setSpecCards((previous) => previous.map((c) => (c.id === id ? { ...c, w, h } : c)))}
+              screenMap={specScreenMap}
+              onMove={moveSpecCard}
+              onResize={resizeSpecCard}
               onFocus={focusSpecCard}
-              onClose={(id) => setSpecCards((previous) => previous.filter((c) => c.id !== id))}
+              onClose={closeSpecCard}
             />
           ))}
         </AnimatePresence>

--- a/src/app/preview/canvas-glass/perf/canvas-card-perf.test.ts
+++ b/src/app/preview/canvas-glass/perf/canvas-card-perf.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+
+import { act, createElement, createRef } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CANVAS_CARD_PERF_COUNTS,
+  CanvasCardPerfHarness,
+  createCanvasCardPerfFixture,
+  type CanvasCardPerfHandle,
+} from './canvas-card-perf';
+import { setCanvasRenderProbe } from './render-probe';
+
+vi.mock('@/components/desktop/workspace-terminal/XtermPanel', () => ({
+  XtermPanel: () => createElement('div', { 'data-perf-xterm': true }, 'fixed terminal content'),
+}));
+
+const ACT_ENV = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+ACT_ENV.IS_REACT_ACT_ENVIRONMENT = true;
+
+interface PerfResult {
+  initialRenderMs: number;
+  drag30FramesMs: number;
+  maxCardsRenderedPerFrame: number;
+  cardRendersPerFrame: number[];
+}
+
+async function measureCanvasCardPerf(): Promise<PerfResult> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const handle = createRef<CanvasCardPerfHandle>();
+  const renders: string[] = [];
+  const previousProbe = setCanvasRenderProbe((id) => renders.push(id));
+
+  try {
+    const initialStart = performance.now();
+    act(() => root.render(createElement(CanvasCardPerfHarness, { ref: handle })));
+    const initialRenderMs = performance.now() - initialStart;
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    renders.length = 0;
+
+    const cardRendersPerFrame: number[] = [];
+    const dragStart = performance.now();
+    for (let frame = 1; frame <= 30; frame += 1) {
+      const renderStart = renders.length;
+      act(() => handle.current?.moveFirstCard(frame));
+      cardRendersPerFrame.push(new Set(renders.slice(renderStart)).size);
+    }
+    const drag30FramesMs = performance.now() - dragStart;
+
+    return {
+      initialRenderMs,
+      drag30FramesMs,
+      maxCardsRenderedPerFrame: Math.max(...cardRendersPerFrame),
+      cardRendersPerFrame,
+    };
+  } finally {
+    setCanvasRenderProbe(previousProbe);
+    act(() => root.unmount());
+    container.remove();
+  }
+}
+
+describe('canvas card performance fixture', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        content: 'export const fixedFixture = true;\nexport const cardCount = 20;\n',
+        mtimeMs: 1,
+      }),
+    })));
+  });
+
+  afterEach(() => {
+    setCanvasRenderProbe(null);
+    vi.unstubAllGlobals();
+  });
+
+  it('spawns the fixed 20-card mixed fixture without network input', () => {
+    const fixture = createCanvasCardPerfFixture();
+    expect(fixture.termCards).toHaveLength(CANVAS_CARD_PERF_COUNTS.term);
+    expect(fixture.fileCards).toHaveLength(CANVAS_CARD_PERF_COUNTS.file);
+    expect(fixture.diffCards).toHaveLength(CANVAS_CARD_PERF_COUNTS.diff);
+    expect(fixture.markdownCards).toHaveLength(CANVAS_CARD_PERF_COUNTS.markdown);
+    expect(fixture.imageCards).toHaveLength(CANVAS_CARD_PERF_COUNTS.image);
+    expect(Object.values(fixture).flat()).toHaveLength(CANVAS_CARD_PERF_COUNTS.total);
+  });
+
+  it('records the 20-card initial render and 30-frame drag profile', async () => {
+    const result = await measureCanvasCardPerf();
+    if (process.env.CANVAS_PERF_REPORT === '1') {
+      console.info(`CANVAS_PERF ${JSON.stringify(result)}`);
+    }
+    expect(result.cardRendersPerFrame).toHaveLength(30);
+    expect(result.initialRenderMs).toBeGreaterThan(0);
+    expect(result.drag30FramesMs).toBeGreaterThan(0);
+  });
+
+  it('keeps a single-card move to at most two card renders', async () => {
+    const result = await measureCanvasCardPerf();
+    expect(result.maxCardsRenderedPerFrame).toBeLessThanOrEqual(2);
+  });
+});

--- a/src/app/preview/canvas-glass/perf/canvas-card-perf.tsx
+++ b/src/app/preview/canvas-glass/perf/canvas-card-perf.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useState,
+} from 'react';
+import { moveCanvasCard, spawnCanvasCard } from '../canvas-card-state';
+import { DiffGlassCard, type DiffCard } from '../diff-card';
+import { FileGlassCard, type FileCard } from '../file-card';
+import { ImageGlassCard, type ImageCard } from '../image-card';
+import { MarkdownGlassCard, type MarkdownCard } from '../markdown-card';
+import { TerminalGlassCard, type TermCard } from '../terminal-card';
+
+export interface CanvasCardPerfFixture {
+  termCards: TermCard[];
+  fileCards: FileCard[];
+  diffCards: DiffCard[];
+  markdownCards: MarkdownCard[];
+  imageCards: ImageCard[];
+}
+
+export interface CanvasCardPerfHandle {
+  moveFirstCard: (frame: number) => void;
+}
+
+const FIXED_MARKDOWN = [
+  '# Canvas performance fixture',
+  '',
+  'This card uses fixed content so every measurement renders the same tree.',
+  '',
+  '- terminal cards: 6',
+  '- file cards: 6',
+  '- diff cards: 3',
+  '- markdown cards: 3',
+  '- image cards: 2',
+].join('\n');
+
+const FIXED_DIFF = [
+  'diff --git a/src/canvas.ts b/src/canvas.ts',
+  'index 1111111..2222222 100644',
+  '--- a/src/canvas.ts',
+  '+++ b/src/canvas.ts',
+  '@@ -1,3 +1,4 @@',
+  ' export const cards = 20;',
+  '+export const frameBudget = 16.67;',
+  ' export const network = false;',
+].join('\n');
+
+const FIXED_IMAGE = 'data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%22640%22 height=%22360%22 viewBox=%220 0 640 360%22%3E%3Crect width=%22640%22 height=%22360%22 fill=%22%23242a34%22/%3E%3Cpath d=%22M0 280L180 120l110 100 110-80 240 220H0z%22 fill=%22%23586170%22/%3E%3C/svg%3E';
+
+export const CANVAS_CARD_PERF_COUNTS = {
+  term: 6,
+  file: 6,
+  diff: 3,
+  markdown: 3,
+  image: 2,
+  total: 20,
+} as const;
+
+export function createCanvasCardPerfFixture(): CanvasCardPerfFixture {
+  const fixture: CanvasCardPerfFixture = {
+    termCards: [],
+    fileCards: [],
+    diffCards: [],
+    markdownCards: [],
+    imageCards: [],
+  };
+  let id = 1;
+  let z = 10;
+
+  for (let index = 0; index < CANVAS_CARD_PERF_COUNTS.term; index += 1) {
+    fixture.termCards = spawnCanvasCard(fixture.termCards, {
+      id: id++,
+      requestId: `perf-terminal-${index + 1}`,
+      sessionName: `perf-terminal-${index + 1}`,
+      exited: false,
+      live: true,
+      revealHold: false,
+      x: 40 + index * 36,
+      y: 60 + index * 28,
+      w: 560,
+      h: 300,
+      z: z++,
+      cwd: '/fixture/repo',
+      cwdLabel: 'fixture',
+    });
+  }
+
+  for (let index = 0; index < CANVAS_CARD_PERF_COUNTS.file; index += 1) {
+    fixture.fileCards = spawnCanvasCard(fixture.fileCards, {
+      id: id++,
+      path: `/fixture/repo/src/file-${index + 1}.ts`,
+      name: `file-${index + 1}.ts`,
+      x: 280 + index * 34,
+      y: 120 + index * 26,
+      w: 620,
+      h: 420,
+      z: z++,
+    });
+  }
+
+  for (let index = 0; index < CANVAS_CARD_PERF_COUNTS.diff; index += 1) {
+    fixture.diffCards = spawnCanvasCard(fixture.diffCards, {
+      id: id++,
+      x: 520 + index * 38,
+      y: 180 + index * 30,
+      w: 560,
+      h: 320,
+      z: z++,
+      laneId: `perf-lane-${index + 1}`,
+      packetId: `perf-packet-${index + 1}`,
+      title: `Fixture diff ${index + 1}`,
+      branch: `perf/fixture-${index + 1}`,
+      stat: '1 file changed, 1 insertion(+)',
+      diff: FIXED_DIFF,
+      truncated: false,
+    });
+  }
+
+  for (let index = 0; index < CANVAS_CARD_PERF_COUNTS.markdown; index += 1) {
+    fixture.markdownCards = spawnCanvasCard(fixture.markdownCards, {
+      id: id++,
+      x: 700 + index * 42,
+      y: 240 + index * 32,
+      w: 380,
+      h: 360,
+      z: z++,
+      title: `Fixture note ${index + 1}`,
+      markdown: FIXED_MARKDOWN,
+    });
+  }
+
+  for (let index = 0; index < CANVAS_CARD_PERF_COUNTS.image; index += 1) {
+    fixture.imageCards = spawnCanvasCard(fixture.imageCards, {
+      id: id++,
+      x: 860 + index * 46,
+      y: 300 + index * 34,
+      w: 400,
+      h: 225,
+      z: z++,
+      aspect: 16 / 9,
+      items: [{ src: FIXED_IMAGE, name: `fixture-${index + 1}.svg` }],
+    });
+  }
+
+  return fixture;
+}
+
+const ignore = (): void => {};
+
+export const CanvasCardPerfHarness = forwardRef<CanvasCardPerfHandle>(function CanvasCardPerfHarness(_props, ref) {
+  const [fixture] = useState(createCanvasCardPerfFixture);
+  const [termCards, setTermCards] = useState(fixture.termCards);
+  const [fileCards] = useState(fixture.fileCards);
+  const [diffCards] = useState(fixture.diffCards);
+  const [markdownCards] = useState(fixture.markdownCards);
+  const [imageCards] = useState(fixture.imageCards);
+
+  const moveTermCard = useCallback((cardId: number, x: number, y: number) => {
+    setTermCards((previous) => moveCanvasCard(previous, cardId, x, y));
+  }, []);
+
+  useImperativeHandle(ref, () => ({
+    moveFirstCard(frame) {
+      moveTermCard(termCards[0]!.id, 40 + frame * 3, 60 + frame * 2);
+    },
+  }), [moveTermCard, termCards]);
+
+  return (
+    <div>
+      {termCards.map((card) => (
+        <TerminalGlassCard
+          key={`term:${card.id}`}
+          card={card}
+          termVeil={0.52}
+          connectionEpoch={0}
+          onMove={moveTermCard}
+          onResize={ignore}
+          onFocus={ignore}
+          onClose={ignore}
+          onTermVeilChange={ignore}
+          registerHandle={ignore}
+          sendTerminalAttach={ignore}
+          sendTerminalInput={ignore}
+          sendTerminalResize={ignore}
+          sendTerminalDetach={ignore}
+        />
+      ))}
+      {fileCards.map((card) => (
+        <FileGlassCard key={`file:${card.id}`} card={card} termVeil={0.52} onMove={ignore} onResize={ignore} onFocus={ignore} onClose={ignore} />
+      ))}
+      {diffCards.map((card) => (
+        <DiffGlassCard key={`diff:${card.id}`} card={card} onMove={ignore} onResize={ignore} onFocus={ignore} onClose={ignore} onRequestChanges={ignore} />
+      ))}
+      {markdownCards.map((card) => (
+        <MarkdownGlassCard key={`markdown:${card.id}`} card={card} onMove={ignore} onResize={ignore} onFocus={ignore} onClose={ignore} />
+      ))}
+      {imageCards.map((card) => (
+        <ImageGlassCard
+          key={`image:${card.id}`}
+          card={card}
+          isDropTarget={false}
+          onMove={ignore}
+          onResize={ignore}
+          onFocus={ignore}
+          onDrop={ignore}
+          onTap={ignore}
+          onCycle={ignore}
+          onSpread={ignore}
+          onClose={ignore}
+        />
+      ))}
+    </div>
+  );
+});

--- a/src/app/preview/canvas-glass/perf/render-probe.ts
+++ b/src/app/preview/canvas-glass/perf/render-probe.ts
@@ -1,0 +1,13 @@
+type CanvasRenderProbe = (id: string) => void;
+
+let probe: CanvasRenderProbe | null = null;
+
+export function setCanvasRenderProbe(next: CanvasRenderProbe | null): CanvasRenderProbe | null {
+  const previous = probe;
+  probe = next;
+  return previous;
+}
+
+export function useCanvasRenderProbe(kind: string, id: number): void {
+  probe?.(`${kind}:${id}`);
+}

--- a/src/app/preview/canvas-glass/spec-card.tsx
+++ b/src/app/preview/canvas-glass/spec-card.tsx
@@ -12,6 +12,7 @@
  * operator's saved palette either way.
  */
 
+import { memo } from 'react';
 import { ThemeProvider } from '@/lib/theme/context';
 import { O8SpecPane } from '@/components/desktop/o8-panel/O8SpecPane';
 import { CHROME } from './ui';
@@ -44,7 +45,7 @@ const SPEC_PANE_BASE_PX = 13.5;
 // notes keep their own knob (--o8ed-note-scale in O8SpecPane).
 export const SPEC_TEXT_BOOST = CHROME.bodySize / SPEC_PANE_BASE_PX;
 
-export function SpecGlassCard({
+export const SpecGlassCard = memo(function SpecGlassCard({
   card,
   onMove,
   onResize,
@@ -128,4 +129,4 @@ export function SpecGlassCard({
       </div>
     </GlassCardShell>
   );
-}
+});

--- a/src/app/preview/canvas-glass/terminal-card.tsx
+++ b/src/app/preview/canvas-glass/terminal-card.tsx
@@ -13,12 +13,13 @@
  * so the session dies instead of leaking into the dashboard's session list).
  */
 
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { XtermPanel, type XtermPanelHandle } from '@/components/desktop/workspace-terminal/XtermPanel';
 import { CANVAS_GLASS_CHANGED_EVENT } from '@/lib/canvas-mode/glass-settings';
 import { CHROME, DEV_TERM_GLASS_TUNER, FONT, TERM_FONT_PX, TERM_MIN_H, TERM_MIN_W } from './ui';
 import { GlassCardShell } from './card-shell';
+import { useCanvasRenderProbe } from './perf/render-probe';
 
 // NOTE: this module must export ONLY the component (+ types) — runtime
 // const exports here would break the Fast Refresh boundary and remount
@@ -96,7 +97,7 @@ function ConnectingVerb() {
   );
 }
 
-export function TerminalGlassCard({
+export const TerminalGlassCard = memo(function TerminalGlassCard({
   card,
   termVeil,
   connectionEpoch,
@@ -127,6 +128,7 @@ export function TerminalGlassCard({
   sendTerminalResize: (sessionName: string, cols: number, rows: number) => void;
   sendTerminalDetach: (sessionName: string) => void;
 }) {
+  useCanvasRenderProbe('term', card.id);
   // The shell inks with the CANVAS vocabulary — one text color across the
   // whole theme (Q, 2026-06-12). buildXtermTheme reads --t-terminal-* off
   // the root, which the o8.md card's ThemeProvider stamps with dashboard
@@ -248,4 +250,4 @@ export function TerminalGlassCard({
       </div>
     </GlassCardShell>
   );
-}
+});

--- a/src/app/preview/canvas-glass/video-card.tsx
+++ b/src/app/preview/canvas-glass/video-card.tsx
@@ -13,7 +13,7 @@
  * page minted for it.
  */
 
-import { useRef, useState } from 'react';
+import { memo, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import { SmoothCorners } from '@lisse/react';
 import { canvasZoom, CHROME, chromeFloorScale, FONT, IMG_MIN_W, MEDIA_HEADER_H, MEDIA_RIM, glassMedia } from './ui';
@@ -40,7 +40,7 @@ export interface VideoCard {
 
 const MONO = '"SF Mono", ui-monospace, "Cascadia Code", Menlo, monospace';
 
-export function VideoGlassCard({
+export const VideoGlassCard = memo(function VideoGlassCard({
   card,
   onMove,
   onResize,
@@ -213,4 +213,4 @@ export function VideoGlassCard({
       <CornerResize card={card} minW={IMG_MIN_W} minH={90} aspect={card.aspect} edges={false} onMove={onMove} onResize={onResize} onResizingChange={setResizing} />
     </motion.div>
   );
-}
+});


### PR DESCRIPTION
Closes #1917. Refs #1664.

## What

A canvas move no longer re-renders every card.

- Card components (`cards.tsx`, terminal, file, diff, markdown, image, chat, brain, spec, video, agent) are `memo`-wrapped on their own props.
- The page passes stable callbacks to every card kind (the diff / agent / brain / markdown / spec kinds had inline lambdas that changed identity on every parent render) and memoizes the two object props that were rebuilt per render (`sendDefaults`, `screenMap`).
- `focusCard` reads the latest card arrays from `canvasCardsRef` instead of closing over eleven state arrays, so its identity is stable and the per-kind focus handlers stop churning.
- `canvas-card-state.ts` holds the shared `spawnCanvasCard` / `moveCanvasCard` helpers. `page.tsx` stays at 5,465 lines (no net additions).

Visual output is unchanged; no paint properties were touched.

## Measurement

`src/app/preview/canvas-glass/perf/` — a deterministic 20-card fixture (term ×6, file ×6, diff ×3, markdown ×3, image ×2) with fixed content and stubbed local I/O, rendered with createRoot + act in jsdom. Renders are counted by a perf-only probe hook (`useCanvasRenderProbe`) called inside each card's memo boundary; the probe is null in production. An outer `Profiler` wrapper was tried first and rejected — it fires whenever its boundary participates in the parent commit even when the memoized child bails out, so it cannot tell a memo hit from a miss.

| Measurement | Value |
|---|---:|
| Initial render, 20 cards | 915.5 ms |
| Dragging one card, 30 frames | 120.7 ms |
| Card renders per frame | 1 |

Falsification: with `memo` removed from the terminal card only, the same fixture renders 6 cards per frame and the test fails; restored, 1 and it passes. Before this change none of the 20 card components were memoized and the page's handlers changed identity on every move, so every visible card rendered per frame.

The regression test asserts ≤ 2 card renders on a single-card move. Initial-render cost is recorded, not bounded: memoization removes repeated update work but not the first mount of 20 subtrees; deferred mounting or virtualization would change first-paint behaviour and is out of scope here.

## Gates

tsc · canvas tests 51 · lint ratchet · classification check · full suite green.
