### PR TITLE
feat: gate workspace manifest execution behind an operator policy

### DIFF
--- a/docs/internals/workspace-manifest.md
+++ b/docs/internals/workspace-manifest.md
@@ -2,6 +2,18 @@
 
 `o8.workspace.json` is a versioned repository workspace declaration. Keep it at the repository root, next to `o8.md`, and check it into the repository so clones receive the same contract. `~/.o8/repos.json` can cache the manifest version, path, service names, or a validation error, but the checked-in file is the source of truth.
 
+## Execution policy
+
+The operator setting `workspaceManifestPolicy` controls whether a packet launch may execute a checked-in manifest. The default is `disabled`, so a fresh installation does not run repository-declared commands.
+
+- `disabled` skips the manifest before allocating ports or running setup.
+- `one-approval` creates one operator approval for the repository path and the SHA-256 hash of the manifest bytes. Approval covers that exact manifest hash for later packet launches. Rejection keeps that hash blocked. Editing any manifest byte requires a new decision.
+- `auto` applies the manifest without a per-hash approval.
+
+The approval card lists the manifest commands verbatim and uses the existing operator inbox flow. An approval records the decision only. It does not apply the manifest to the packet that raised the card. A later packet launch reads the decision and applies the manifest through the normal launch path.
+
+Skipped launches record `workspace_manifest_skipped` with the policy and manifest hash. A pending or rejected one-approval decision also carries the approval ID. Policy evaluation completes before port leases, setup commands, service receipts, health probes, or preview resolution.
+
 ## Version 1 schema
 
 ```ts

--- a/src/app/api/panel/operator-defaults/route.ts
+++ b/src/app/api/panel/operator-defaults/route.ts
@@ -16,6 +16,7 @@ import {
   isRequireApproval,
   isReviewerBackendSetting,
   isSubscriptionProfile,
+  isWorkspaceManifestPolicy,
   OPERATOR_DEFAULTS_FALLBACK,
   updateOperatorDefaults,
   type OperatorDefaults,
@@ -387,6 +388,13 @@ function normalizeUpdate(body: Record<string, unknown>): Partial<OperatorDefault
       throw new Error('workersUseBrain must be one of "off", "auto", "all".');
     }
     update.workersUseBrain = raw;
+  }
+
+  if (body.workspaceManifestPolicy !== undefined) {
+    if (!isWorkspaceManifestPolicy(body.workspaceManifestPolicy)) {
+      throw new Error('workspaceManifestPolicy must be one of "disabled", "one-approval", "auto".');
+    }
+    update.workspaceManifestPolicy = body.workspaceManifestPolicy;
   }
 
   if (body.crossHouseWorkerFallback !== undefined) {

--- a/src/components/desktop/settings/DispatchFoundersSection.tsx
+++ b/src/components/desktop/settings/DispatchFoundersSection.tsx
@@ -32,6 +32,7 @@ import {
   type OperatorDefaultSources,
   type ThinkingEffort,
   type WorkersUseBrain,
+  type WorkspaceManifestPolicy,
 } from './dispatch-shared';
 
 // ── Minimal raw-SVG glyphs for row icon tiles ──
@@ -368,6 +369,23 @@ export function DispatchFoundersSection({
                   { value: 'off', label: 'Off' },
                   { value: 'auto', label: 'Auto' },
                   { value: 'all', label: 'All' },
+                ]}
+              />
+            }
+            divider
+          />
+          <SettingsRow
+            icon={<TargetIcon />}
+            label="Workspace manifest execution"
+            subtitle={lockedSub('workspaceManifestPolicy', 'Gate checked-in setup commands before packet launch')}
+            accessory={
+              <SettingsSegmented
+                value={values.workspaceManifestPolicy}
+                onChange={(next) => { updateField('workspaceManifestPolicy', next as WorkspaceManifestPolicy); }}
+                options={[
+                  { value: 'disabled', label: 'Disabled' },
+                  { value: 'one-approval', label: 'Approve once' },
+                  { value: 'auto', label: 'Auto' },
                 ]}
               />
             }

--- a/src/components/desktop/settings/dispatch-shared.tsx
+++ b/src/components/desktop/settings/dispatch-shared.tsx
@@ -37,6 +37,7 @@ export type SubscriptionProfile = 'both' | 'claude-only' | 'codex-only';
 export type DispatchRuntime = OrchestratorRuntime;
 export type ClassAComposer = 'auto' | 'haiku-cli' | 'sonnet-cli' | 'fastest';
 export type WorkersUseBrain = 'off' | 'auto' | 'all';
+export type WorkspaceManifestPolicy = 'disabled' | 'one-approval' | 'auto';
 // Was a hand-maintained copy that had drifted three backends behind
 // (missing fable, o8, opencode) — see lib/operator/backend-setting.ts.
 import type { OrchestratorBackendSetting } from '@/lib/operator/backend-setting';
@@ -94,6 +95,7 @@ export interface OperatorDefaults {
   inAppOrchestratorEnabled: boolean;
   brainUseClaudeCli: boolean;
   workersUseBrain: WorkersUseBrain;
+  workspaceManifestPolicy: WorkspaceManifestPolicy;
   crossHouseWorkerFallback: boolean;
   orchestratorBackend: OrchestratorBackendSetting;
   reviewerBackend: ReviewerBackendSetting;

--- a/src/components/desktop/settings/settings-search.ts
+++ b/src/components/desktop/settings/settings-search.ts
@@ -140,6 +140,7 @@ export const SETTINGS_SEARCH_REGISTRY: SettingsSearchEntry[] = [
   { tab: 'operator-defaults', tabLabel: 'Dispatch', group: "Brain routing", label: "Legacy orchestrator toggle", description: "What backend Auto follows: on = Claude REPL, off = Codex" },
   { tab: 'operator-defaults', tabLabel: 'Dispatch', group: "Brain routing", label: "Q&A composer", description: "Class A composer for Brain answers" },
   { tab: 'operator-defaults', tabLabel: 'Dispatch', group: "Brain routing", label: "Workers use the Brain", description: "Teach dispatched workers o8 ask for cited repo answers" },
+  { tab: 'operator-defaults', tabLabel: 'Dispatch', group: "Brain routing", label: "Workspace manifest execution", description: "Gate checked-in setup commands before packet launch", keywords: ['manifest', 'approval', 'setup', 'workspace'] },
   { tab: 'operator-defaults', tabLabel: 'Dispatch', group: "Dispatch runtime", label: "Claude worker effort", description: "Fallback effort for spawned Claude Code workers" },
   { tab: 'operator-defaults', tabLabel: 'Dispatch', group: "Dispatch runtime", label: "Codex worker effort", description: "Fallback effort for spawned Codex workers" },
   { tab: 'operator-defaults', tabLabel: 'Dispatch', group: "Dispatch runtime", label: "Default worker", description: "Codex by default \u2014 pick any installed dispatchable runtime to override (may be profile-pinned)" },

--- a/src/lib/lane/types.ts
+++ b/src/lib/lane/types.ts
@@ -319,6 +319,9 @@ export type LaneEventVerb =
   // setup and one-shot health probes. Payload:
   // { services: [{ name, port }], preview?, durationMs }
   | 'workspace_manifest_applied'
+  // Operator policy prevented a checked-in manifest from executing. Payload:
+  // { policy, manifestHash, approvalId?, reason? }
+  | 'workspace_manifest_skipped'
   // Workspace manifest application failed without blocking packet launch.
   // Payload: { step, error }
   | 'workspace_manifest_failed'

--- a/src/lib/mcp/operator-handlers/status.ts
+++ b/src/lib/mcp/operator-handlers/status.ts
@@ -270,6 +270,11 @@ export const STATUS_TOOLS: McpTool[] = [
           enum: ['off', 'auto', 'all'],
           description: 'Whether packet workers are taught to consult the Engineering Brain.',
         },
+        workspaceManifestPolicy: {
+          type: 'string',
+          enum: ['disabled', 'one-approval', 'auto'],
+          description: 'Whether checked-in workspace manifest commands are disabled, approved once per hash, or automatic.',
+        },
         brainUseClaudeCli: {
           type: 'boolean',
           description: 'Allow Engineering Brain to use the Claude subscription when the subscription profile permits it.',
@@ -325,6 +330,7 @@ const OPERATOR_DEFAULTS_KEYS = [
   'opencodeOrchestratorModel',
   'opencodeWorkerModel',
   'workersUseBrain',
+  'workspaceManifestPolicy',
   'brainUseClaudeCli',
   'crossHouseWorkerFallback',
   'healBotEnabled',

--- a/src/lib/operator/defaults-env.ts
+++ b/src/lib/operator/defaults-env.ts
@@ -51,6 +51,13 @@ export function isWorkersUseBrain(value: unknown): value is WorkersUseBrain {
   return value === 'off' || value === 'auto' || value === 'all';
 }
 
+/** Whether checked-in workspace manifest commands may run during packet launch. */
+export type WorkspaceManifestPolicy = 'disabled' | 'one-approval' | 'auto';
+
+export function isWorkspaceManifestPolicy(value: unknown): value is WorkspaceManifestPolicy {
+  return value === 'disabled' || value === 'one-approval' || value === 'auto';
+}
+
 /** Which backend drives the in-app Orchestrator. 'auto' = the legacy
  *  inAppOrchestratorEnabled derivation; a specific id forces that backend. */
 // Single source: the pure leaf, so client surfaces can share it without
@@ -260,6 +267,12 @@ export function envBrainUseClaudeCli(): boolean | null {
 export function envWorkersUseBrain(): WorkersUseBrain | null {
   const raw = process.env.O8_WORKERS_USE_BRAIN?.trim();
   if (raw && isWorkersUseBrain(raw)) return raw;
+  return null;
+}
+
+export function envWorkspaceManifestPolicy(): WorkspaceManifestPolicy | null {
+  const raw = process.env.O8_WORKSPACE_MANIFEST_POLICY?.trim();
+  if (raw && isWorkspaceManifestPolicy(raw)) return raw;
   return null;
 }
 

--- a/src/lib/operator/defaults-roundtrip.test.ts
+++ b/src/lib/operator/defaults-roundtrip.test.ts
@@ -52,6 +52,7 @@ const NON_DEFAULT_UPDATE = {
   inAppOrchestratorEnabled: false,
   brainUseClaudeCli: false,
   workersUseBrain: 'off',
+  workspaceManifestPolicy: 'auto',
   crossHouseWorkerFallback: true,
   orchestratorBackend: 'collide',
   reviewerBackend: 'codex',

--- a/src/lib/operator/defaults.ts
+++ b/src/lib/operator/defaults.ts
@@ -82,6 +82,7 @@ import { applyWorkspaceParkingUpdate, resolveStoredWorkspaceParking, resolveWork
 import { applyMeteredPacketCapUpdate, METERED_PACKET_CAP_FALLBACK, resolveMeteredPacketCapSettings, resolveStoredMeteredPacketCap, type MeteredPacketCapDefaults } from './metered-packet-cap-defaults';
 import { applyBroadcastCommentaryUpdate, BROADCAST_COMMENTARY_FALLBACK, broadcastCommentarySettingSources, resolveBroadcastCommentaryDefaults, resolveStoredBroadcastCommentary, type BroadcastCommentaryDefaults } from './broadcast-commentary-defaults';
 import { applyReviewContinuationUpdate, REVIEW_CONTINUATION_FALLBACK, resolveStoredReviewContinuation, type ReviewContinuationDefault } from './review-continuation-default';
+import { applyWorkspaceManifestPolicyUpdate, resolveStoredWorkspaceManifestPolicy, resolveWorkspaceManifestPolicySettings, WORKSPACE_MANIFEST_POLICY_FALLBACK, type WorkspaceManifestPolicyDefault } from './workspace-manifest-policy-default';
 import {
   applyOperatorDefaultsTomlWithLock,
   getOperatorDefaultsTomlState as readOperatorDefaultsTomlState,
@@ -94,16 +95,8 @@ import {
   type OperatorDefaultsTomlState,
 } from '@/lib/settings/operator-defaults-store';
 export { getOperatorDefaultsTomlPath } from '@/lib/settings/operator-defaults-store';
-export { isOrchestratorBackendSetting, isReviewerBackendSetting, isCollideAggregator, isPrLinkDestination } from './defaults-env';
-export type {
-  OverlapGateMode,
-  ClassAComposer,
-  WorkersUseBrain,
-  OrchestratorBackendSetting,
-  ReviewerBackendSetting,
-  CollideAggregator,
-  PrLinkDestination,
-} from './defaults-env';
+export { isOrchestratorBackendSetting, isReviewerBackendSetting, isCollideAggregator, isPrLinkDestination, isWorkspaceManifestPolicy } from './defaults-env';
+export type { OverlapGateMode, ClassAComposer, WorkersUseBrain, WorkspaceManifestPolicy, OrchestratorBackendSetting, ReviewerBackendSetting, CollideAggregator, PrLinkDestination } from './defaults-env';
 export { coerceStoredTier, isTargetingTier, mergeTier } from './targeting-tier';
 export type { TargetingTier } from './targeting-tier';
 export {
@@ -130,7 +123,7 @@ export type RequireApproval = 'high-risk' | 'surface' | 'always' | 'never';
 
 export function isRequireApproval(value: unknown): value is RequireApproval { return value === 'high-risk' || value === 'surface' || value === 'always' || value === 'never'; }
 
-export interface OperatorDefaults extends StorageReserveDefaults, WorkspaceParkingDefaults, ApfsDependencyImagesDefaults, MeteredPacketCapDefaults, BroadcastCommentaryDefaults, ReviewContinuationDefault {
+export interface OperatorDefaults extends StorageReserveDefaults, WorkspaceParkingDefaults, ApfsDependencyImagesDefaults, MeteredPacketCapDefaults, BroadcastCommentaryDefaults, ReviewContinuationDefault, WorkspaceManifestPolicyDefault {
   subscriptionProfile: SubscriptionProfile;
   parallelCap: number;
   overlapGate: OverlapGateMode;
@@ -369,6 +362,7 @@ export const OPERATOR_DEFAULTS_FALLBACK: OperatorDefaults = {
   // anyone with a Claude sub. Independent of the orchestrator toggle (2026-06-22).
   brainUseClaudeCli: true,
   workersUseBrain: 'auto',
+  ...WORKSPACE_MANIFEST_POLICY_FALLBACK,
   crossHouseWorkerFallback: false,
   // 'auto' → defer to inAppOrchestratorEnabled (legacy claude/codex derivation),
   // so the default is byte-identical to pre-setting behavior.
@@ -403,7 +397,7 @@ export const OPERATOR_DEFAULTS_FALLBACK: OperatorDefaults = {
   ...WORKSPACE_PARKING_FALLBACK,
   ...METERED_PACKET_CAP_FALLBACK,
 };
-interface StoredOperatorDefaults extends Partial<StorageReserveDefaults>, Partial<WorkspaceParkingDefaults>, Partial<ApfsDependencyImagesDefaults>, Partial<MeteredPacketCapDefaults>, Partial<BroadcastCommentaryDefaults>, Partial<ReviewContinuationDefault> {
+interface StoredOperatorDefaults extends Partial<StorageReserveDefaults>, Partial<WorkspaceParkingDefaults>, Partial<ApfsDependencyImagesDefaults>, Partial<MeteredPacketCapDefaults>, Partial<BroadcastCommentaryDefaults>, Partial<ReviewContinuationDefault>, Partial<WorkspaceManifestPolicyDefault> {
   subscriptionProfile?: SubscriptionProfile;
   parallelCap?: number;
   overlapGate?: OverlapGateMode;
@@ -568,6 +562,7 @@ function resolveFromFile(stored: StoredOperatorDefaults): FileOperatorDefaults {
   if (isWorkersUseBrain(stored.workersUseBrain)) {
     result.workersUseBrain = stored.workersUseBrain;
   }
+  Object.assign(result, resolveStoredWorkspaceManifestPolicy(stored));
   if (typeof stored.crossHouseWorkerFallback === 'boolean') {
     result.crossHouseWorkerFallback = stored.crossHouseWorkerFallback;
   }
@@ -656,6 +651,7 @@ function resolveDefaults(fileValues: FileOperatorDefaults): OperatorDefaultsWith
   const envInApp = envInAppOrchestratorEnabled();
   const envBrainCli = envBrainUseClaudeCli();
   const envBrain = envWorkersUseBrain();
+  const workspaceManifestPolicy = resolveWorkspaceManifestPolicySettings(fileValues);
   const envOrchBackend = envOrchestratorBackend();
   const envRevBackend = envReviewerBackend();
   const envExplainer = envPacketExplainerEnabled();
@@ -733,6 +729,7 @@ function resolveDefaults(fileValues: FileOperatorDefaults): OperatorDefaultsWith
     brainUseClaudeCli:
       envBrainCli ?? fileValues.brainUseClaudeCli ?? OPERATOR_DEFAULTS_FALLBACK.brainUseClaudeCli,
     workersUseBrain: envBrain ?? fileValues.workersUseBrain ?? OPERATOR_DEFAULTS_FALLBACK.workersUseBrain,
+    ...workspaceManifestPolicy.values,
     crossHouseWorkerFallback:
       fileValues.crossHouseWorkerFallback ?? OPERATOR_DEFAULTS_FALLBACK.crossHouseWorkerFallback,
     orchestratorBackend,
@@ -804,6 +801,7 @@ function resolveDefaults(fileValues: FileOperatorDefaults): OperatorDefaultsWith
     brainUseClaudeCli:
       envBrainCli !== null ? 'env' : fileValues.brainUseClaudeCli !== undefined ? 'file' : 'default',
     workersUseBrain: envBrain !== null ? 'env' : fileValues.workersUseBrain !== undefined ? 'file' : 'default',
+    ...workspaceManifestPolicy.sources,
     crossHouseWorkerFallback: fileValues.crossHouseWorkerFallback !== undefined ? 'file' : 'default',
     orchestratorBackend: profileDefaults ? 'profile' : envOrchBackend !== null ? 'env' : fileValues.orchestratorBackend !== undefined ? 'file' : 'default',
     reviewerBackend: profileDefaults ? 'profile' : envRevBackend !== null ? 'env' : fileValues.reviewerBackend !== undefined ? 'file' : 'default',
@@ -1024,6 +1022,7 @@ async function updateOperatorDefaultsOnce(update: Partial<OperatorDefaults>): Pr
     }
     stored.workersUseBrain = update.workersUseBrain;
   }
+  applyWorkspaceManifestPolicyUpdate(stored, update);
   if (update.crossHouseWorkerFallback !== undefined) {
     stored.crossHouseWorkerFallback = Boolean(update.crossHouseWorkerFallback);
   }

--- a/src/lib/operator/workspace-manifest-policy-default.ts
+++ b/src/lib/operator/workspace-manifest-policy-default.ts
@@ -1,0 +1,50 @@
+import 'server-only';
+
+import {
+  envWorkspaceManifestPolicy,
+  isWorkspaceManifestPolicy,
+  type WorkspaceManifestPolicy,
+} from './defaults-env';
+
+export interface WorkspaceManifestPolicyDefault {
+  workspaceManifestPolicy: WorkspaceManifestPolicy;
+}
+
+export const WORKSPACE_MANIFEST_POLICY_FALLBACK: WorkspaceManifestPolicyDefault = {
+  workspaceManifestPolicy: 'disabled',
+};
+
+export function resolveStoredWorkspaceManifestPolicy(
+  stored: Partial<WorkspaceManifestPolicyDefault>,
+): Partial<WorkspaceManifestPolicyDefault> {
+  return isWorkspaceManifestPolicy(stored.workspaceManifestPolicy)
+    ? { workspaceManifestPolicy: stored.workspaceManifestPolicy }
+    : {};
+}
+
+export function resolveWorkspaceManifestPolicySettings(
+  file: Partial<WorkspaceManifestPolicyDefault>,
+) {
+  const envPolicy = envWorkspaceManifestPolicy();
+  return {
+    values: {
+      workspaceManifestPolicy:
+        envPolicy ?? file.workspaceManifestPolicy ?? WORKSPACE_MANIFEST_POLICY_FALLBACK.workspaceManifestPolicy,
+    },
+    sources: {
+      workspaceManifestPolicy:
+        envPolicy !== null ? 'env' as const : file.workspaceManifestPolicy !== undefined ? 'file' as const : 'default' as const,
+    },
+  };
+}
+
+export function applyWorkspaceManifestPolicyUpdate(
+  stored: Partial<WorkspaceManifestPolicyDefault>,
+  update: Partial<WorkspaceManifestPolicyDefault>,
+): void {
+  if (update.workspaceManifestPolicy === undefined) return;
+  if (!isWorkspaceManifestPolicy(update.workspaceManifestPolicy)) {
+    throw new Error('workspaceManifestPolicy must be one of "disabled", "one-approval", "auto".');
+  }
+  stored.workspaceManifestPolicy = update.workspaceManifestPolicy;
+}

--- a/src/lib/settings/toml.ts
+++ b/src/lib/settings/toml.ts
@@ -21,6 +21,7 @@ import {
   isPrLinkDestination,
   isReviewerBackendSetting,
   isWorkersUseBrain,
+  isWorkspaceManifestPolicy,
   sanitizeBranchPrefix,
 } from '@/lib/operator/defaults-env';
 import { isSubscriptionProfile } from '@/lib/operator/subscription-profile';
@@ -236,6 +237,7 @@ export const OPERATOR_DEFAULTS_TOML_MAPPING = {
   inAppOrchestratorEnabled: booleanField('orchestrator', 'legacy_claude_enabled'),
   brainUseClaudeCli: booleanField('brain', 'use_claude_cli'),
   workersUseBrain: enumField('brain', 'workers_use_brain', 'one of "off", "auto", or "all"', isWorkersUseBrain),
+  workspaceManifestPolicy: enumField('operator', 'workspace_manifest_policy', 'one of "disabled", "one-approval", or "auto"', isWorkspaceManifestPolicy),
   crossHouseWorkerFallback: booleanField('models', 'cross_house_worker_fallback'),
   orchestratorBackend: enumField('orchestrator', 'backend', 'a supported orchestrator backend', isOrchestratorBackendSetting),
   reviewerBackend: enumField('review', 'backend', 'one of "follow", "codex", or "claude"', isReviewerBackendSetting),

--- a/src/lib/workspace/manifest/apply.ts
+++ b/src/lib/workspace/manifest/apply.ts
@@ -5,8 +5,13 @@ import { connect } from 'node:net';
 import path from 'node:path';
 
 import { recordLaneEvent } from '@/lib/lane/events';
+import { getOperatorDefaults } from '@/lib/operator/defaults';
 import { runRepoSetupCommand } from '@/lib/workspace/repo-setup';
-import { loadWorkspaceManifest } from './loader';
+import { loadWorkspaceManifestSource } from './loader';
+import {
+  findWorkspaceManifestApproval,
+  resolveWorkspaceManifestExecution,
+} from './policy';
 import { allocateWorkspaceServicePorts } from './port-leases';
 import type {
   WorkspaceManifest,
@@ -52,7 +57,7 @@ export interface WorkspaceManifestApplyResult {
   };
 }
 
-type ApplyStep = 'load' | 'ports' | 'preview' | `setup:${number}`;
+type ApplyStep = 'load' | 'policy' | 'ports' | 'preview' | `setup:${number}`;
 
 function commandId(command: string): string {
   return createHash('sha256').update(command).digest('hex');
@@ -262,7 +267,7 @@ async function applyLoadedManifest(input: {
 
 function recordEventSafely(
   laneId: string,
-  verb: 'workspace_manifest_applied' | 'workspace_manifest_failed',
+  verb: 'workspace_manifest_applied' | 'workspace_manifest_failed' | 'workspace_manifest_skipped',
   payload: Record<string, unknown>,
 ): void {
   try {
@@ -281,10 +286,29 @@ export async function applyWorkspaceManifest(input: {
   const startedAt = Date.now();
   let step: ApplyStep = 'load';
   try {
-    const manifest = await loadWorkspaceManifest(input.worktreePath);
-    if (!manifest) return null;
+    const loaded = await loadWorkspaceManifestSource(input.worktreePath);
+    if (!loaded) return null;
+    step = 'policy';
+    const policy = (await getOperatorDefaults()).values.workspaceManifestPolicy;
+    const decision = await resolveWorkspaceManifestExecution({
+      repoPath: input.repoPath,
+      manifestSource: loaded.source,
+      policy,
+    });
+    if (!decision.allowed) {
+      const approval = decision.reason === 'awaiting_approval' || decision.reason === 'rejected'
+        ? findWorkspaceManifestApproval(input.repoPath, decision.manifestHash)
+        : null;
+      recordEventSafely(input.laneId, 'workspace_manifest_skipped', {
+        policy,
+        manifestHash: decision.manifestHash,
+        ...(approval ? { approvalId: approval.id } : {}),
+        ...(decision.reason === 'rejected' ? { reason: 'rejected' } : {}),
+      });
+      return null;
+    }
     const result = await applyLoadedManifest({
-      manifest,
+      manifest: loaded.manifest,
       worktreePath: path.resolve(input.worktreePath),
       packetId: input.packetId,
       laneId: input.laneId,

--- a/src/lib/workspace/manifest/index.ts
+++ b/src/lib/workspace/manifest/index.ts
@@ -1,5 +1,15 @@
-export { loadWorkspaceManifest, workspaceManifestPath } from './loader';
+export {
+  loadWorkspaceManifest,
+  loadWorkspaceManifestSource,
+  workspaceManifestPath,
+  type WorkspaceManifestSource,
+} from './loader';
 export { applyWorkspaceManifest } from './apply';
+export {
+  findWorkspaceManifestApproval,
+  resolveWorkspaceManifestExecution,
+  type WorkspaceManifestExecutionDecision,
+} from './policy';
 export {
   allocateWorkspaceServicePorts,
   readWorkspacePortLeases,

--- a/src/lib/workspace/manifest/loader.ts
+++ b/src/lib/workspace/manifest/loader.ts
@@ -6,15 +6,22 @@ import path from 'node:path';
 import { parseWorkspaceManifest, WorkspaceManifestValidationError } from './schema';
 import { WORKSPACE_MANIFEST_FILENAME, type WorkspaceManifest } from './types';
 
+export interface WorkspaceManifestSource {
+  manifest: WorkspaceManifest;
+  source: Buffer;
+}
+
 export function workspaceManifestPath(repoPath: string): string {
   return path.join(path.resolve(repoPath), WORKSPACE_MANIFEST_FILENAME);
 }
 
-export async function loadWorkspaceManifest(repoPath: string): Promise<WorkspaceManifest | null> {
+export async function loadWorkspaceManifestSource(
+  repoPath: string,
+): Promise<WorkspaceManifestSource | null> {
   const manifestPath = workspaceManifestPath(repoPath);
-  let raw: string;
+  let source: Buffer;
   try {
-    raw = await readFile(manifestPath, 'utf8');
+    source = await readFile(manifestPath);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
     throw new WorkspaceManifestValidationError(
@@ -26,7 +33,7 @@ export async function loadWorkspaceManifest(repoPath: string): Promise<Workspace
 
   let parsed: unknown;
   try {
-    parsed = JSON.parse(raw);
+    parsed = JSON.parse(source.toString('utf8'));
   } catch (error) {
     throw new WorkspaceManifestValidationError(
       '$',
@@ -34,5 +41,9 @@ export async function loadWorkspaceManifest(repoPath: string): Promise<Workspace
       { cause: error },
     );
   }
-  return parseWorkspaceManifest(parsed);
+  return { manifest: parseWorkspaceManifest(parsed), source };
+}
+
+export async function loadWorkspaceManifest(repoPath: string): Promise<WorkspaceManifest | null> {
+  return (await loadWorkspaceManifestSource(repoPath))?.manifest ?? null;
 }

--- a/src/lib/workspace/manifest/policy.ts
+++ b/src/lib/workspace/manifest/policy.ts
@@ -1,0 +1,148 @@
+import 'server-only';
+
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+
+import { createApproval, listApprovals } from '@/lib/approvals/store';
+import type { ApprovalRecord } from '@/lib/approvals/types';
+import { getDataDir } from '@/lib/data-dir-migration';
+import type { WorkspaceManifestPolicy } from '@/lib/operator/defaults';
+import {
+  acquireMetadataTransactionLease,
+  releaseMetadataTransactionLease,
+} from '@/lib/worktree/metadata-transaction-lease';
+import { parseWorkspaceManifest } from './schema';
+
+const APPROVAL_ACTION = 'workspace_manifest_execution';
+const POLICY_RULE_ID = 'workspace-manifest-one-approval';
+
+export interface WorkspaceManifestExecutionDecision {
+  allowed: boolean;
+  reason: 'disabled' | 'approved' | 'auto' | 'awaiting_approval' | 'rejected';
+  manifestHash: string;
+}
+
+function manifestHash(source: Uint8Array): string {
+  return createHash('sha256').update(source).digest('hex');
+}
+
+function normalizedRepoPath(repoPath: string): string {
+  return path.resolve(repoPath);
+}
+
+function manifestSessionKey(repoPath: string, hash: string): string {
+  const repoIdentity = createHash('sha256').update(repoPath).digest('hex').slice(0, 12);
+  return `workspace-manifest:${repoIdentity}:${hash}`;
+}
+
+function isManifestApproval(
+  approval: ApprovalRecord,
+  repoPath: string,
+  hash: string,
+): boolean {
+  return approval.toolName === APPROVAL_ACTION
+    && approval.args?.kind === 'lane'
+    && approval.args?.action === APPROVAL_ACTION
+    && approval.args?.repoPath === repoPath
+    && approval.args?.manifestHash === hash;
+}
+
+export function findWorkspaceManifestApproval(
+  repoPath: string,
+  hash: string,
+): ApprovalRecord | null {
+  const normalized = normalizedRepoPath(repoPath);
+  return listApprovals({
+    status: 'all',
+    sessionKey: manifestSessionKey(normalized, hash),
+    projectId: null,
+  })
+    .find((approval) => isManifestApproval(approval, normalized, hash)) ?? null;
+}
+
+function codeFence(command: string): string {
+  const longestRun = Math.max(0, ...Array.from(command.matchAll(/`+/g), (match) => match[0].length));
+  const fence = '`'.repeat(Math.max(3, longestRun + 1));
+  return `${fence}\n${command}\n${fence}`;
+}
+
+function commandBody(source: Uint8Array): string {
+  const manifest = parseWorkspaceManifest(JSON.parse(Buffer.from(source).toString('utf8')) as unknown);
+  const sections: string[] = [];
+  if (manifest.setup?.length) {
+    sections.push('Setup commands:', ...manifest.setup.map(codeFence));
+  }
+  if (manifest.services?.length) {
+    sections.push(
+      'Service commands:',
+      ...manifest.services.flatMap((service) => [service.name, codeFence(service.command)]),
+    );
+  }
+  if (manifest.teardown?.length) {
+    sections.push('Teardown commands:', ...manifest.teardown.map(codeFence));
+  }
+  return sections.length > 0 ? sections.join('\n\n') : 'The manifest declares no commands.';
+}
+
+function createManifestApproval(repoPath: string, hash: string, source: Uint8Array): ApprovalRecord {
+  const repoName = path.basename(repoPath);
+  const reason = 'Run the checked-in workspace manifest commands after one operator approval.';
+  return createApproval({
+    source: 'runtime',
+    runtime: 'system',
+    agent: 'Workspace manifest policy',
+    sessionKey: manifestSessionKey(repoPath, hash),
+    title: `Run workspace manifest commands for ${repoName}`,
+    description: [
+      `Approve the checked-in o8.workspace.json commands for ${repoPath}.`,
+      'This approval remains valid only while the manifest bytes keep the same SHA-256 hash.',
+      commandBody(source),
+    ].join('\n\n'),
+    summary: `Approve workspace manifest execution for ${repoPath} at ${hash}.`,
+    toolName: APPROVAL_ACTION,
+    args: {
+      kind: 'lane',
+      action: APPROVAL_ACTION,
+      reason,
+      repoPath,
+      manifestHash: hash,
+    },
+    risk: 'high',
+    policyRuleId: POLICY_RULE_ID,
+    metadata: {
+      Repo: repoName,
+      RepoPath: repoPath,
+      'Manifest SHA-256': hash,
+    },
+  });
+}
+
+export async function resolveWorkspaceManifestExecution(input: {
+  repoPath: string;
+  manifestSource: Uint8Array;
+  policy: WorkspaceManifestPolicy;
+}): Promise<WorkspaceManifestExecutionDecision> {
+  const repoPath = normalizedRepoPath(input.repoPath);
+  const hash = manifestHash(input.manifestSource);
+  if (input.policy === 'disabled') {
+    return { allowed: false, reason: 'disabled', manifestHash: hash };
+  }
+  if (input.policy === 'auto') {
+    return { allowed: true, reason: 'auto', manifestHash: hash };
+  }
+
+  const lease = await acquireMetadataTransactionLease(getDataDir());
+  try {
+    const existing = findWorkspaceManifestApproval(repoPath, hash);
+    if (existing?.status === 'approved') {
+      return { allowed: true, reason: 'approved', manifestHash: hash };
+    }
+    if (existing?.status === 'rejected') {
+      return { allowed: false, reason: 'rejected', manifestHash: hash };
+    }
+    if (!existing) createManifestApproval(repoPath, hash, input.manifestSource);
+    return { allowed: false, reason: 'awaiting_approval', manifestHash: hash };
+  } finally {
+    releaseMetadataTransactionLease(lease);
+  }
+}

--- a/tests/operator-defaults-mcp-routing.test.ts
+++ b/tests/operator-defaults-mcp-routing.test.ts
@@ -313,6 +313,9 @@ describe('MCP operator defaults and dispatch routing', () => {
       meteredPacketCostCapUsd: expect.any(Object),
       meteredPacketInputTokenCap: expect.any(Object),
       workersUseBrain: expect.any(Object),
+      workspaceManifestPolicy: expect.objectContaining({
+        enum: ['disabled', 'one-approval', 'auto'],
+      }),
       crossHouseWorkerFallback: expect.any(Object),
       requireApproval: expect.objectContaining({
         enum: ['high-risk', 'surface', 'always', 'never'],

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2333,6 +2333,15 @@
       ]
     },
     {
+      "path": "tests/workspace-manifest-policy-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "network-listener",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/workspace-manifest-registry-real-path.test.ts",
       "reasons": [
         "child-process",

--- a/tests/workspace-manifest-launch-real-path.test.ts
+++ b/tests/workspace-manifest-launch-real-path.test.ts
@@ -114,6 +114,7 @@ describe.sequential('workspace manifest packet launch real path', () => {
       productTelemetryEnabled: false,
       storageReserveRatio: 0.0001,
       storageReserveFloorGb: 0.001,
+      workspaceManifestPolicy: 'auto',
     });
   });
 

--- a/tests/workspace-manifest-policy-real-path.test.ts
+++ b/tests/workspace-manifest-policy-real-path.test.ts
@@ -1,0 +1,302 @@
+import type { ExecFileOptions } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
+import { createServer, type Server, type Socket } from 'node:net';
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const setupInvocations = vi.hoisted(() => [] as Array<{
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}>);
+const setupServers = vi.hoisted(() => [] as Server[]);
+const setupSockets = vi.hoisted(() => [] as Socket[]);
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  const execFile = (
+    file: string,
+    args: string[] = [],
+    options: ExecFileOptions = {},
+    callback?: (error: Error | null, stdout: string, stderr: string) => void,
+  ) => {
+    if (!args.includes('prepare-workspace')) {
+      return actual.execFile(file, args, options, callback as never);
+    }
+    const cwd = String(options.cwd);
+    const env = options.env ?? process.env;
+    setupInvocations.push({ cwd, env });
+    const healthPort = Number(env.WEB_PORT);
+    const server = createServer((socket) => {
+      setupSockets.push(socket);
+      socket.end();
+    });
+    setupServers.push(server);
+    server.once('error', (error) => callback?.(error, '', error.message));
+    server.listen({ host: '127.0.0.1', port: healthPort }, () => callback?.(null, '', ''));
+    return server as never;
+  };
+  const promisifySymbol = Symbol.for('nodejs.util.promisify.custom');
+  Object.defineProperty(execFile, promisifySymbol, {
+    value: (actual.execFile as unknown as Record<symbol, unknown>)[promisifySymbol],
+  });
+  return {
+    ...actual,
+    execFile,
+  };
+});
+
+const tempRoot = realpathSync(mkdtempSync(path.join(os.homedir(), '.tmp-o8-manifest-policy-')));
+const dataDir = path.join(tempRoot, 'data');
+const repoPath = path.join(tempRoot, 'repo');
+const worktreeRoot = path.join(tempRoot, 'worktrees');
+const controlledEnvKeys = [
+  'CORTEX_IDE_DATA_DIR',
+  'O8_DATA_DIR',
+  'O8_WORKTREE_ROOT',
+  'O8_SKIP_PRELAUNCH_TYPECHECK',
+  'O8_WORKSPACE_MANIFEST_POLICY',
+] as const;
+const priorEnv: Record<string, string | undefined> = {};
+let launchSequence = 0;
+
+function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+function manifest(previewRevision: number) {
+  return {
+    version: 1,
+    setup: ['prepare-workspace'],
+    teardown: ['clean-workspace'],
+    services: [
+      {
+        name: 'api',
+        command: 'run-api',
+        port: { preferred: 43_400, env: 'API_PORT' },
+      },
+      {
+        name: 'web',
+        command: 'run-web',
+        port: { preferred: 43_400, env: 'WEB_PORT' },
+        health: { tcp: true, timeoutMs: 2_000 },
+      },
+    ],
+    preview: { url: `http://127.0.0.1:{{service:web}}/v${previewRevision}` },
+  };
+}
+
+function commitManifest(previewRevision: number): void {
+  writeFileSync(
+    path.join(repoPath, 'o8.workspace.json'),
+    `${JSON.stringify(manifest(previewRevision), null, 2)}\n`,
+  );
+  execFileSync('git', ['add', 'o8.workspace.json'], { cwd: repoPath });
+  execFileSync('git', [
+    '-c', 'user.email=test@o8.test',
+    '-c', 'user.name=o8-test',
+    'commit', '-qm', `manifest revision ${previewRevision}`,
+  ], { cwd: repoPath });
+}
+
+async function launchPacket(label: string) {
+  launchSequence += 1;
+  const packetId = `packet-manifest-policy-${launchSequence}-${label}`;
+  const branch = `test/manifest-policy-${launchSequence}-${label}`;
+  const { createLane, updateLane } = await import('@/lib/lane/registry');
+  const { prepareLaunchWorktree } = await import('@/lib/worktree/launch');
+  const lane = createLane({
+    repoPath,
+    branch,
+    baseBranch: 'main',
+    runtime: 'codex',
+    label: packetId,
+    packetId,
+  });
+  const prepared = await prepareLaunchWorktree({
+    repoRoot: repoPath,
+    agentType: 'codex',
+    taskName: packetId,
+    branchName: branch,
+    baseBranch: 'main',
+    isolate: true,
+    skipSetup: true,
+    packetId,
+    laneId: lane.id,
+  });
+  if (!prepared) throw new Error(`Worktree launch returned no workspace for ${packetId}.`);
+  updateLane(lane.id, { worktreePath: prepared.cwd }, 'system');
+  return { lane, prepared };
+}
+
+async function expectNoManifestSideEffects(launch: Awaited<ReturnType<typeof launchPacket>>) {
+  const { readWorkspacePortLeases } = await import('@/lib/workspace/manifest/port-leases');
+  expect(setupInvocations.some((invocation) => invocation.cwd === launch.prepared.cwd)).toBe(false);
+  expect(Object.values(await readWorkspacePortLeases()).some(
+    (lease) => lease.laneId === launch.lane.id,
+  )).toBe(false);
+}
+
+async function manifestApprovals() {
+  const { listApprovals } = await import('@/lib/approvals/store');
+  return listApprovals({ status: 'all', projectId: null })
+    .filter((approval) => approval.toolName === 'workspace_manifest_execution');
+}
+
+describe.sequential('workspace manifest execution policy through packet launch', () => {
+  beforeAll(() => {
+    for (const key of controlledEnvKeys) priorEnv[key] = process.env[key];
+    mkdirSync(dataDir, { recursive: true });
+    execFileSync('git', ['init', '-q', '-b', 'main', repoPath]);
+    writeFileSync(path.join(repoPath, 'README.md'), 'workspace manifest policy fixture\n');
+    writeFileSync(
+      path.join(repoPath, 'o8.workspace.json'),
+      `${JSON.stringify(manifest(1), null, 2)}\n`,
+    );
+    execFileSync('git', ['add', 'README.md', 'o8.workspace.json'], { cwd: repoPath });
+    execFileSync('git', [
+      '-c', 'user.email=test@o8.test',
+      '-c', 'user.name=o8-test',
+      'commit', '-qm', 'fixture',
+    ], { cwd: repoPath });
+    execFileSync('git', ['remote', 'add', 'origin', repoPath], { cwd: repoPath });
+
+    process.env.CORTEX_IDE_DATA_DIR = dataDir;
+    process.env.O8_DATA_DIR = dataDir;
+    process.env.O8_WORKTREE_ROOT = worktreeRoot;
+    process.env.O8_SKIP_PRELAUNCH_TYPECHECK = '1';
+    delete process.env.O8_WORKSPACE_MANIFEST_POLICY;
+    writeFileSync(
+      path.join(dataDir, 'settings.toml'),
+      '[git]\nstorage_reserve_ratio = 0.0001\nstorage_reserve_floor_gb = 0.001\n',
+    );
+  });
+
+  afterAll(async () => {
+    for (const socket of setupSockets) socket.destroy();
+    await Promise.all(setupServers.map(closeServer));
+    const { closeDb } = await import('@/lib/db');
+    closeDb();
+    for (const key of controlledEnvKeys) {
+      const prior = priorEnv[key];
+      if (prior === undefined) delete process.env[key];
+      else process.env[key] = prior;
+    }
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('fails closed by default before setup or port allocation', async () => {
+    const { getLaneEvents } = await import('@/lib/lane/registry');
+    const { getOperatorDefaults } = await import('@/lib/operator/defaults');
+    expect((await getOperatorDefaults()).values.workspaceManifestPolicy).toBe('disabled');
+
+    const launch = await launchPacket('default-disabled');
+    const event = getLaneEvents(launch.lane.id, 100).find(
+      (candidate) => candidate.verb === 'workspace_manifest_skipped',
+    );
+    expect(event?.payload).toMatchObject({
+      policy: 'disabled',
+      manifestHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+    await expectNoManifestSideEffects(launch);
+    expect(await manifestApprovals()).toHaveLength(0);
+  }, 60_000);
+
+  it('applies automatically only after the operator selects auto', async () => {
+    const { getLaneEvents } = await import('@/lib/lane/registry');
+    const { updateOperatorDefaults } = await import('@/lib/operator/defaults');
+    const { readWorkspacePortLeases } = await import('@/lib/workspace/manifest/port-leases');
+    await updateOperatorDefaults({ workspaceManifestPolicy: 'auto' });
+
+    const launch = await launchPacket('auto');
+    expect(getLaneEvents(launch.lane.id, 100).some(
+      (candidate) => candidate.verb === 'workspace_manifest_applied',
+    )).toBe(true);
+    expect(setupInvocations.some((invocation) => invocation.cwd === launch.prepared.cwd)).toBe(true);
+    expect(Object.values(await readWorkspacePortLeases()).some(
+      (lease) => lease.laneId === launch.lane.id,
+    )).toBe(true);
+  }, 60_000);
+
+  it('deduplicates one approval per hash and honors approval, rejection, and hash changes', async () => {
+    const { getLaneEvents } = await import('@/lib/lane/registry');
+    const { updateOperatorDefaults } = await import('@/lib/operator/defaults');
+    const { resolveApproval } = await import('@/lib/approvals/resolution');
+    await updateOperatorDefaults({ workspaceManifestPolicy: 'one-approval' });
+
+    const first = await launchPacket('approval-first');
+    const firstCards = await manifestApprovals();
+    expect(firstCards).toHaveLength(1);
+    expect(firstCards[0]).toMatchObject({
+      status: 'pending',
+      title: expect.stringContaining(path.basename(repoPath)),
+      args: {
+        kind: 'lane',
+        action: 'workspace_manifest_execution',
+        reason: expect.any(String),
+        repoPath,
+        manifestHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+      },
+    });
+    expect(firstCards[0].description).toContain('prepare-workspace');
+    expect(firstCards[0].description).toContain('run-api');
+    expect(firstCards[0].description).toContain('run-web');
+    expect(firstCards[0].description).toContain('clean-workspace');
+    expect(getLaneEvents(first.lane.id, 100).find(
+      (candidate) => candidate.verb === 'workspace_manifest_skipped',
+    )?.payload).toMatchObject({
+      policy: 'one-approval',
+      manifestHash: firstCards[0].args?.manifestHash,
+      approvalId: firstCards[0].id,
+    });
+    await expectNoManifestSideEffects(first);
+
+    const second = await launchPacket('approval-deduped');
+    expect(await manifestApprovals()).toHaveLength(1);
+    await expectNoManifestSideEffects(second);
+
+    resolveApproval(firstCards[0].id, 'approve', 'test', 'Approve the exact manifest hash.');
+    const approved = await launchPacket('approval-applied');
+    expect(getLaneEvents(approved.lane.id, 100).some(
+      (candidate) => candidate.verb === 'workspace_manifest_applied',
+    )).toBe(true);
+    expect(setupInvocations.some((invocation) => invocation.cwd === approved.prepared.cwd)).toBe(true);
+
+    commitManifest(2);
+    const changed = await launchPacket('changed-pending');
+    const changedCards = await manifestApprovals();
+    expect(changedCards).toHaveLength(2);
+    const pendingChanged = changedCards.find((approval) => approval.status === 'pending');
+    expect(pendingChanged?.args?.manifestHash).not.toBe(firstCards[0].args?.manifestHash);
+    await expectNoManifestSideEffects(changed);
+
+    resolveApproval(pendingChanged!.id, 'reject', 'test', 'Reject this manifest hash.');
+    const rejected = await launchPacket('changed-rejected');
+    expect(getLaneEvents(rejected.lane.id, 100).find(
+      (candidate) => candidate.verb === 'workspace_manifest_skipped',
+    )?.payload).toMatchObject({
+      policy: 'one-approval',
+      manifestHash: pendingChanged?.args?.manifestHash,
+      approvalId: pendingChanged?.id,
+      reason: 'rejected',
+    });
+    await expectNoManifestSideEffects(rejected);
+    expect(await manifestApprovals()).toHaveLength(2);
+
+    commitManifest(3);
+    const changedAgain = await launchPacket('changed-new-card');
+    const finalCards = await manifestApprovals();
+    expect(finalCards).toHaveLength(3);
+    expect(finalCards.filter((approval) => approval.status === 'pending')).toHaveLength(1);
+    await expectNoManifestSideEffects(changedAgain);
+  }, 120_000);
+});


### PR DESCRIPTION
Closes #1911. Refs #1725.

## What

An operator policy gate in front of workspace manifest execution (#1948). Repo-declared setup commands no longer run at packet launch unless the operator has opted in.

- Operator setting `workspaceManifestPolicy: 'disabled' | 'one-approval' | 'auto'`, **default `disabled`** — a fresh install never runs manifest commands. Declared, validated, persisted (TOML `[operator] workspace_manifest_policy`, env `O8_WORKSPACE_MANIFEST_POLICY`), and exposed through the operator-defaults API, the MCP `o8_operator_defaults` tool, and a Settings row, following the `workersUseBrain` pattern exactly.
- `src/lib/workspace/manifest/policy.ts` — `resolveWorkspaceManifestExecution({ repoPath, manifestSource, policy })` → `{ allowed, reason, manifestHash }` where `manifestHash` is the SHA-256 of the manifest bytes as checked out in the packet worktree.
  - `disabled` → skip. `auto` → run.
  - `one-approval` → look up an approval for (repo, hash). Approved → run. Rejected → skip. None → create **one** approval card (deduped under the metadata transaction lease, so two packets launching before a decision share a card) listing the setup, service, and teardown commands verbatim, and skip. A changed manifest is a new hash and needs its own decision. Approving records the decision; the next packet launch applies it through the normal path.
- `apply.ts` evaluates the policy after loading the manifest and before any port lease, setup command, health probe, or preview resolution. Skips record `workspace_manifest_skipped { policy, manifestHash, approvalId?, reason? }` (new `LaneEventVerb`). Approve/reject flows through the existing inbox (`o8_approve` / `o8_reject`); no new routes or UI beyond the setting.
- `manager.ts` unchanged in size (2,782). Docs: `docs/internals/workspace-manifest.md` "Execution policy".

## Proof

`tests/workspace-manifest-policy-real-path.test.ts` launches packets through the real `prepareLaunchWorktree` path with only the setup command stubbed at the process boundary, driving the real operator defaults and approvals store:

- default (nothing configured) → `workspace_manifest_skipped { policy: 'disabled' }`, no setup invocation, no port lease, no approval card;
- `auto` → applied (event, lease, setup invocation);
- `one-approval` → the first launch creates exactly one pending card whose body names every command; a second launch creates no second card; approving via the real resolver makes the next launch apply; editing the manifest raises a new card for the new hash; rejecting it makes later launches skip with `reason: 'rejected'`; a further edit raises a third card.

Existing manifest launch, port-lease, operator-defaults round-trip, and MCP routing tests stay green.

## Gates

tsc · focused manifest + defaults tests · lint ratchet (touched files carry zero warnings) · classification check · full suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace manifest execution policies: disabled, one approval, or automatic.
  * Added settings controls, environment configuration, TOML support, and operator tool support.
  * Workspace manifests now require approval when configured, with approvals tracked per repository and manifest version.
  * Added clear event tracking when manifest execution is skipped.

* **Documentation**
  * Documented policy options, approval behavior, and execution safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->