### PR TITLE
feat: commit from the canvas diff card and refresh it against the working tree

### DIFF
--- a/src/app/preview/canvas-glass/canvas-persistence.ts
+++ b/src/app/preview/canvas-glass/canvas-persistence.ts
@@ -34,7 +34,7 @@ export interface CanvasSnapshotV1 {
   /** `sessionName` (#6) lets a surviving tmux-backed shell re-attach on restore
    *  instead of respawning fresh; absent on older snapshots / dead sessions. */
   term: Array<SnapGeometry & { cwd: string | null; cwdLabel: string | null; sessionName?: string | null }>;
-  file: Array<SnapGeometry & { path: string }>;
+  file: Array<SnapGeometry & { path: string; repoPath?: string | null }>;
   /** Optional — file tree cards arrived after v1 snapshots existed. */
   tree?: Array<SnapGeometry & { repoPath: string }>;
   image: Array<SnapGeometry & { aspect: number; items: Array<{ src: string; name: string }> }>;

--- a/src/app/preview/canvas-glass/diff-card.test.ts
+++ b/src/app/preview/canvas-glass/diff-card.test.ts
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+
+import { act, createElement, type ReactNode, useCallback, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DiffGlassCard, type DiffCard } from './diff-card';
+import { dispatchWorktreeChanged, fetchWorktreeDiff, worktreeRepoPath } from './worktree-diff';
+
+vi.mock('./card-shell', () => ({
+  GlassCardShell: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('./perf/render-probe', () => ({ useCanvasRenderProbe: vi.fn() }));
+vi.mock('./use-scroll-blur-fade', () => ({ useScrollBlurFade: vi.fn() }));
+
+const ACT_ENV = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+ACT_ENV.IS_REACT_ACT_ENVIRONMENT = true;
+const REPO_PATH = '/tmp/o8-canvas-repo';
+
+const callbacks = {
+  onMove: vi.fn(),
+  onResize: vi.fn(),
+  onFocus: vi.fn(),
+  onClose: vi.fn(),
+  onRequestChanges: vi.fn(),
+};
+
+function worktreeCard(overrides: Partial<DiffCard> = {}): DiffCard {
+  return {
+    id: 1,
+    x: 10,
+    y: 20,
+    z: 3,
+    w: 560,
+    h: 320,
+    laneId: `worktree:${REPO_PATH}`,
+    packetId: null,
+    title: 'Your changes',
+    branch: 'feat/test',
+    stat: '1 file changed',
+    diff: 'diff --git a/file.ts b/file.ts\n+initial content',
+    truncated: false,
+    ...overrides,
+  };
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  } as Response;
+}
+
+function CardHarness({ initialCard, onChanged }: { initialCard: DiffCard; onChanged: (cardId: number) => void }) {
+  const [card, setCard] = useState(initialCard);
+  const refresh = useCallback(async (cardId: number) => {
+    const repoPath = worktreeRepoPath(initialCard.laneId);
+    if (!repoPath) return;
+    const data = await fetchWorktreeDiff(repoPath);
+    if (!data) return;
+    setCard((current) => current.id === cardId
+      ? { ...current, stat: data.stat, diff: data.diff, truncated: data.truncated }
+      : current);
+  }, [initialCard.laneId]);
+  return createElement(DiffGlassCard, { card, ...callbacks, onRefresh: refresh, onChanged });
+}
+
+function buttonWithText(container: HTMLElement, label: string): HTMLButtonElement | null {
+  return [...container.querySelectorAll('button')].find((button) => button.textContent === label) ?? null;
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('DiffGlassCard worktree actions', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('refreshes the existing worktree card for matching change events only', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      ok: true,
+      branch: 'feat/test',
+      stat: '2 files changed',
+      diff: 'diff --git a/file.ts b/file.ts\n+refreshed content',
+      truncated: false,
+    }));
+    act(() => root.render(createElement(CardHarness, { initialCard: worktreeCard(), onChanged: vi.fn() })));
+    expect(container.textContent).toContain('initial content');
+
+    await act(async () => {
+      dispatchWorktreeChanged(REPO_PATH);
+      await flushAsyncWork();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(`/api/panel/worktree-diff?workspace=${encodeURIComponent(REPO_PATH)}&maxBytes=131072`);
+    expect(container.textContent).toContain('refreshed content');
+    act(() => dispatchWorktreeChanged('/tmp/different-repo'));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes on the interval only while the document is visible', async () => {
+    vi.useFakeTimers();
+    let visibility: DocumentVisibilityState = 'visible';
+    vi.spyOn(document, 'visibilityState', 'get').mockImplementation(() => visibility);
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true, branch: 'feat/test', stat: '', diff: '+interval refresh', truncated: false }));
+    act(() => root.render(createElement(CardHarness, { initialCard: worktreeCard(), onChanged: vi.fn() })));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+      await flushAsyncWork();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    visibility = 'hidden';
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+      await flushAsyncWork();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not request a commit for an empty or whitespace-only message', () => {
+    act(() => root.render(createElement(CardHarness, { initialCard: worktreeCard(), onChanged: vi.fn() })));
+    act(() => buttonWithText(container, 'Commit')?.click());
+    const form = container.querySelector('form');
+    const input = container.querySelector<HTMLInputElement>('input[aria-label="Commit message"]');
+    expect(form).not.toBeNull();
+    expect(input).not.toBeNull();
+
+    act(() => { form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true })); });
+    expect(fetchMock).not.toHaveBeenCalled();
+    act(() => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(input, '   ');
+      input?.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(buttonWithText(container, 'Commit')?.disabled).toBe(true);
+    act(() => { form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true })); });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('commits a non-empty message, reports the hash, and refreshes the card', async () => {
+    const onChanged = vi.fn();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ ok: true, hash: 'abc123456789', message: 'Commit canvas change' }))
+      .mockResolvedValueOnce(jsonResponse({ ok: true, branch: 'feat/test', stat: '', diff: '', truncated: false }));
+    act(() => root.render(createElement(CardHarness, { initialCard: worktreeCard(), onChanged })));
+
+    act(() => buttonWithText(container, 'Commit')?.click());
+    const input = container.querySelector<HTMLInputElement>('input[aria-label="Commit message"]');
+    const submit = buttonWithText(container, 'Commit');
+    expect(input).not.toBeNull();
+    expect(submit?.disabled).toBe(true);
+    act(() => submit?.click());
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    act(() => {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+      valueSetter?.call(input, 'Commit canvas change');
+      input?.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(buttonWithText(container, 'Commit')?.disabled).toBe(false);
+
+    await act(async () => {
+      buttonWithText(container, 'Commit')?.click();
+      await flushAsyncWork();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/review/commit');
+    expect(JSON.parse(String((fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.body))).toEqual({
+      message: 'Commit canvas change',
+      workspace: REPO_PATH,
+    });
+    expect(onChanged).toHaveBeenCalledOnce();
+    expect(onChanged).toHaveBeenCalledWith(1);
+    expect(container.textContent).toContain('Committed abc12345');
+    expect(container.textContent).toContain('No uncommitted changes');
+  });
+
+  it('keeps lane cards free of worktree controls and refresh listeners', async () => {
+    vi.useFakeTimers();
+    const addEventListener = vi.spyOn(window, 'addEventListener');
+    const onRefresh = vi.fn();
+    const laneCard = worktreeCard({ laneId: 'lane-123', packetId: 'packet-123' });
+    act(() => root.render(createElement(DiffGlassCard, {
+      card: laneCard,
+      ...callbacks,
+      onRefresh,
+      onChanged: vi.fn(),
+    })));
+
+    expect(buttonWithText(container, 'Commit')).toBeNull();
+    expect(addEventListener.mock.calls.map(([eventName]) => eventName)).not.toContain('o8:worktree-changed');
+    expect(addEventListener.mock.calls.map(([eventName]) => eventName)).not.toContain('o8:lifecycle-reconcile');
+    await act(async () => { await vi.advanceTimersByTimeAsync(60_000); });
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/preview/canvas-glass/diff-card.tsx
+++ b/src/app/preview/canvas-glass/diff-card.tsx
@@ -8,12 +8,13 @@
  * /api/orchestrator/merge (the identical path approve_and_merge uses).
  */
 
-import { memo, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { actionReceiptIsInProgress, correlatedActionIsUnsettled, fetchCorrelatedActionReceipt } from '@/lib/orchestrator/action-receipt';
 import { CHROME, FONT, scrollFadeY } from './ui';
 import { GlassCardShell } from './card-shell';
 import { useCanvasRenderProbe } from './perf/render-probe';
 import { useScrollBlurFade } from './use-scroll-blur-fade';
+import { dispatchWorktreeChanged, useWorktreeDiffRefresh, worktreeRepoPath } from './worktree-diff';
 
 const MONO = '"SF Mono", ui-monospace, "Cascadia Code", Menlo, monospace';
 export const DIFF_MIN_W = 380;
@@ -41,6 +42,57 @@ type MergeState =
   | { kind: 'merged' }
   | { kind: 'blocked'; note: string };
 
+type CommitState =
+  | { kind: 'closed' }
+  | { kind: 'editing'; note?: string }
+  | { kind: 'committing' }
+  | { kind: 'committed'; hash: string };
+
+function DiffActionButton({
+  label,
+  onClick,
+  disabled = false,
+  primary = false,
+  type = 'button',
+}: {
+  label: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  primary?: boolean;
+  type?: 'button' | 'submit';
+}) {
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        minHeight: 44,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderWidth: 1,
+        borderStyle: 'solid',
+        borderColor: primary ? 'var(--cnv-ink-muted)' : 'var(--cnv-edge)',
+        background: primary ? 'var(--cnv-tint)' : 'transparent',
+        borderRadius: 999,
+        paddingTop: 0,
+        paddingBottom: 0,
+        paddingLeft: 13,
+        paddingRight: 13,
+        fontSize: 10.5,
+        fontWeight: primary ? 500 : 300,
+        color: primary ? 'var(--cnv-ink)' : 'var(--cnv-ink-muted)',
+        cursor: disabled ? 'default' : 'pointer',
+        fontFamily: FONT,
+        opacity: disabled ? 0.6 : 1,
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
 /** One diff line — the default-side read, in glass tones. */
 function diffLineStyle(line: string): React.CSSProperties {
   if (line.startsWith('+++') || line.startsWith('---') || line.startsWith('diff --git')) {
@@ -59,6 +111,8 @@ export const DiffGlassCard = memo(function DiffGlassCard({
   onFocus,
   onClose,
   onRequestChanges,
+  onRefresh,
+  onChanged,
 }: {
   card: DiffCard;
   onMove: (id: number, x: number, y: number) => void;
@@ -67,11 +121,22 @@ export const DiffGlassCard = memo(function DiffGlassCard({
   onClose: (id: number) => void;
   /** Hands the operator's words back to the composer, prefilled. */
   onRequestChanges: (card: DiffCard) => void;
+  onRefresh: (cardId: number) => void | Promise<void>;
+  onChanged: (cardId: number) => void | Promise<void>;
 }) {
   useCanvasRenderProbe('diff', card.id);
   const [merge, setMerge] = useState<MergeState>({ kind: 'idle' });
+  const [commit, setCommit] = useState<CommitState>({ kind: 'closed' });
+  const [commitMessage, setCommitMessage] = useState('');
   const diffScrollRef = useRef<HTMLDivElement | null>(null);
+  const commitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const repoPath = worktreeRepoPath(card.laneId);
   useScrollBlurFade(diffScrollRef);
+  useWorktreeDiffRefresh({ cardId: card.id, repoPath, onRefresh });
+
+  useEffect(() => () => {
+    if (commitTimerRef.current) clearTimeout(commitTimerRef.current);
+  }, []);
 
   const approve = async () => {
     if (merge.kind === 'merging' || merge.kind === 'merged') return;
@@ -121,6 +186,48 @@ export const DiffGlassCard = memo(function DiffGlassCard({
     }
   };
 
+  const closeCommitStrip = () => {
+    if (commit.kind === 'committing') return;
+    if (commitTimerRef.current) clearTimeout(commitTimerRef.current);
+    commitTimerRef.current = null;
+    setCommitMessage('');
+    setCommit({ kind: 'closed' });
+  };
+
+  const commitChanges = async () => {
+    const message = commitMessage.trim();
+    if (!repoPath || !message || commit.kind === 'committing') return;
+    setCommit({ kind: 'committing' });
+    try {
+      const { response, payload: data } = await fetchCorrelatedActionReceipt<{
+        ok?: boolean;
+        hash?: string;
+        message?: string;
+        error?: { message?: string } | string;
+      }>('/api/review/commit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message, workspace: repoPath }),
+      });
+      if (response.ok && data?.ok && typeof data.hash === 'string') {
+        setCommit({ kind: 'committed', hash: data.hash.slice(0, 8) });
+        dispatchWorktreeChanged(repoPath);
+        void onChanged(card.id);
+        commitTimerRef.current = setTimeout(closeCommitStrip, 2000);
+        return;
+      }
+      const errorMessage = typeof data?.error === 'string' ? data.error : data?.error?.message;
+      setCommit({ kind: 'editing', note: errorMessage || `Commit failed (${response.status}).` });
+    } catch (error) {
+      setCommit({
+        kind: 'editing',
+        note: correlatedActionIsUnsettled(error)
+          ? 'Commit is still running. Refresh before retrying.'
+          : 'Commit request failed. Check the repository and try again.',
+      });
+    }
+  };
+
   return (
     <GlassCardShell
       card={card}
@@ -146,7 +253,7 @@ export const DiffGlassCard = memo(function DiffGlassCard({
         <div ref={diffScrollRef} style={{ ...scrollFadeY, height: card.h, overflowY: 'auto', overflowX: 'hidden', paddingTop: 2, paddingBottom: 8, paddingLeft: 16, paddingRight: 16, scrollbarWidth: 'thin' } as React.CSSProperties}>
           {card.diff.trim() === '' ? (
             <span style={{ fontSize: CHROME.bodySize, fontWeight: 300, color: 'var(--cnv-ink-muted)', fontFamily: FONT }}>
-              Clean worktree — nothing to review on this lane.
+              {repoPath ? 'No uncommitted changes' : 'No diff is available for this lane.'}
             </span>
           ) : (
             card.diff.split('\n').map((line, index) => (
@@ -157,73 +264,61 @@ export const DiffGlassCard = memo(function DiffGlassCard({
           )}
         </div>
 
-        {/* Governance row — approve or push back, right here. A worktree
-            diff is YOUR uncommitted work, not a lane — no merge actions. */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingTop: 6, paddingBottom: 14, paddingLeft: 16, paddingRight: 16, flexShrink: 0 }}>
-          {card.laneId.startsWith('worktree:') ? (
-            <span style={{ fontSize: CHROME.bodySize, fontWeight: 300, color: 'var(--cnv-ink-muted)', fontFamily: FONT }}>
-              Your uncommitted changes — commit from a terminal or the dashboard.
-            </span>
-          ) : merge.kind === 'merged' ? (
-            <span style={{ fontSize: CHROME.bodySize, fontWeight: 400, color: '#a78bfa', fontFamily: FONT }}>Merged — the lane is on main.</span>
-          ) : (
-            <>
-              <button
-                type="button"
-                onClick={() => { void approve(); }}
-                disabled={merge.kind === 'merging'}
-                style={{
-                  borderWidth: 1,
-                  borderStyle: 'solid',
-                  borderColor: 'var(--cnv-ink-muted)',
-                  background: 'rgba(255,255,255,0.1)',
-                  borderRadius: 999,
-                  paddingTop: 4,
-                  paddingBottom: 4,
-                  paddingLeft: 13,
-                  paddingRight: 13,
-                  fontSize: 10.5,
-                  fontWeight: 500,
-                  color: 'var(--cnv-ink)',
-                  cursor: merge.kind === 'merging' ? 'default' : 'pointer',
-                  fontFamily: FONT,
-                  opacity: merge.kind === 'merging' ? 0.6 : 1,
-                }}
-              >
-                {merge.kind === 'merging' ? 'Merging…' : 'Approve & merge'}
-              </button>
-              <button
-                type="button"
-                onClick={() => onRequestChanges(card)}
-                style={{
-                  borderWidth: 1,
-                  borderStyle: 'solid',
-                  borderColor: 'var(--cnv-edge)',
-                  background: 'transparent',
-                  borderRadius: 999,
-                  paddingTop: 4,
-                  paddingBottom: 4,
-                  paddingLeft: 13,
-                  paddingRight: 13,
-                  fontSize: 10.5,
-                  fontWeight: 300,
-                  color: 'var(--cnv-ink-muted)',
-                  cursor: 'pointer',
-                  fontFamily: FONT,
-                }}
-                onMouseEnter={(event) => { event.currentTarget.style.color = 'var(--cnv-ink)'; }}
-                onMouseLeave={(event) => { event.currentTarget.style.color = 'var(--cnv-ink-muted)'; }}
-              >
-                Request changes
-              </button>
-            </>
-          )}
-          {merge.kind === 'blocked' ? (
-            <span style={{ flex: 1, fontSize: CHROME.captionSize, fontWeight: 300, color: '#f8a5a5', fontFamily: FONT, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={merge.note}>
-              {merge.note}
-            </span>
-          ) : null}
-        </div>
+        {repoPath && commit.kind === 'closed' ? (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingTop: 6, paddingBottom: 14, paddingLeft: 16, paddingRight: 16, flexShrink: 0 }}>
+            <DiffActionButton label="Commit" primary onClick={() => setCommit({ kind: 'editing' })} />
+          </div>
+        ) : null}
+        {repoPath && commit.kind !== 'closed' ? (
+          <form
+            onSubmit={(event) => { event.preventDefault(); void commitChanges(); }}
+            style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 8, paddingTop: 8, paddingBottom: 14, paddingLeft: 16, paddingRight: 16, borderTopWidth: 1, borderTopStyle: 'solid', borderTopColor: 'var(--cnv-edge)', flexShrink: 0 }}
+          >
+            {commit.kind === 'committed' ? (
+              <span role="status" style={{ minHeight: 44, display: 'inline-flex', alignItems: 'center', fontSize: CHROME.bodySize, fontWeight: 400, color: 'var(--cnv-ink)', fontFamily: FONT }}>
+                Committed {commit.hash}
+              </span>
+            ) : (
+              <>
+                <input
+                  aria-label="Commit message"
+                  autoFocus
+                  type="text"
+                  maxLength={500}
+                  value={commitMessage}
+                  disabled={commit.kind === 'committing'}
+                  onChange={(event) => setCommitMessage(event.target.value)}
+                  placeholder="Commit message"
+                  style={{ flex: 1, minWidth: 140, height: 44, boxSizing: 'border-box', borderWidth: 1, borderStyle: 'solid', borderColor: 'var(--cnv-edge)', borderRadius: 10, outline: 'none', background: 'var(--cnv-tint)', color: 'var(--cnv-ink)', paddingTop: 0, paddingBottom: 0, paddingLeft: 12, paddingRight: 12, fontSize: CHROME.bodySize, fontWeight: 300, fontFamily: FONT, opacity: commit.kind === 'committing' ? 0.6 : 1 }}
+                />
+                <DiffActionButton label={commit.kind === 'committing' ? 'Committing…' : 'Commit'} primary type="submit" disabled={!commitMessage.trim() || commit.kind === 'committing'} />
+                <DiffActionButton label="Cancel" disabled={commit.kind === 'committing'} onClick={closeCommitStrip} />
+                {commit.kind === 'editing' && commit.note ? (
+                  <span role="alert" style={{ flexBasis: '100%', fontSize: CHROME.captionSize, fontWeight: 300, color: 'var(--t-danger)', fontFamily: FONT }}>
+                    {commit.note}
+                  </span>
+                ) : null}
+              </>
+            )}
+          </form>
+        ) : null}
+        {!repoPath ? (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingTop: 6, paddingBottom: 14, paddingLeft: 16, paddingRight: 16, flexShrink: 0 }}>
+            {merge.kind === 'merged' ? (
+              <span style={{ fontSize: CHROME.bodySize, fontWeight: 400, color: '#a78bfa', fontFamily: FONT }}>Merged — the lane is on main.</span>
+            ) : (
+              <>
+                <DiffActionButton label={merge.kind === 'merging' ? 'Merging…' : 'Approve & merge'} primary disabled={merge.kind === 'merging'} onClick={() => { void approve(); }} />
+                <DiffActionButton label="Request changes" onClick={() => onRequestChanges(card)} />
+              </>
+            )}
+            {merge.kind === 'blocked' ? (
+              <span style={{ flex: 1, fontSize: CHROME.captionSize, fontWeight: 300, color: '#f8a5a5', fontFamily: FONT, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={merge.note}>
+                {merge.note}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
     </GlassCardShell>
   );
 });

--- a/src/app/preview/canvas-glass/file-card.tsx
+++ b/src/app/preview/canvas-glass/file-card.tsx
@@ -24,6 +24,7 @@ import { CanvasMarkdown } from './dock';
 import { CHROME, FONT, TERM_MIN_H, TERM_MIN_W } from './ui';
 import { GlassCardShell, ShellAction } from './card-shell';
 import { useCanvasRenderProbe } from './perf/render-probe';
+import { dispatchWorktreeChanged } from './worktree-diff';
 
 // NOTE: component (+ types) exports only — runtime const exports here would
 // break the Fast Refresh boundary and remount live cards on every edit.
@@ -32,6 +33,7 @@ export interface FileCard {
   id: number;
   path: string;
   name: string;
+  repoPath?: string | null;
   x: number;
   y: number;
   w: number;
@@ -211,6 +213,7 @@ export const FileGlassCard = memo(function FileGlassCard({
       mtimeRef.current = typeof data.mtimeMs === 'number' ? data.mtimeMs : mtimeRef.current;
       setSavedContent(content);
       setConflict(false);
+      if (card.repoPath) dispatchWorktreeChanged(card.repoPath);
     } catch {
       setConflict(false);
       setError('Could not reach the file API');
@@ -218,7 +221,7 @@ export const FileGlassCard = memo(function FileGlassCard({
     } finally {
       setSaving(false);
     }
-  }, [card.path, conflict, content, saving, status]);
+  }, [card.path, card.repoPath, conflict, content, saving, status]);
 
   const applyEditorValue = useCallback((next: string, selectionStart?: number, selectionEnd?: number) => {
     setContent(next);

--- a/src/app/preview/canvas-glass/file-tree-card.test.ts
+++ b/src/app/preview/canvas-glass/file-tree-card.test.ts
@@ -96,6 +96,6 @@ describe('FileTreeGlassCard', () => {
       y: 80,
       w: 620,
       h: 420,
-    });
+    }, '/repo');
   });
 });

--- a/src/app/preview/canvas-glass/file-tree-card.tsx
+++ b/src/app/preview/canvas-glass/file-tree-card.tsx
@@ -130,7 +130,7 @@ export const FileTreeGlassCard = memo(function FileTreeGlassCard({
   fetchImpl,
 }: {
   card: FileTreeCard;
-  spawnFileCard: (path: string, at?: SnapGeometry) => void;
+  spawnFileCard: (path: string, at?: SnapGeometry, repoPath?: string) => void;
   onMove: (id: number, x: number, y: number) => void;
   onResize: (id: number, w: number, h: number) => void;
   onFocus: (id: number) => void;
@@ -193,7 +193,7 @@ export const FileTreeGlassCard = memo(function FileTreeGlassCard({
       y: card.y,
       w: 620,
       h: 420,
-    });
+    }, card.repoPath);
   }, [card.repoPath, card.w, card.x, card.y, spawnFileCard]);
 
   const repoName = card.repoPath.split('/').filter(Boolean).pop() ?? card.repoPath;
@@ -264,7 +264,7 @@ export const FileTreeCardLayer = memo(function FileTreeCardLayer({
   onClose,
 }: {
   cards: FileTreeCard[];
-  spawnFileCard: (path: string, at?: SnapGeometry) => void;
+  spawnFileCard: (path: string, at?: SnapGeometry, repoPath?: string) => void;
   onMove: (id: number, x: number, y: number) => void;
   onResize: (id: number, w: number, h: number) => void;
   onFocus: (id: number) => void;

--- a/src/app/preview/canvas-glass/page.tsx
+++ b/src/app/preview/canvas-glass/page.tsx
@@ -63,6 +63,7 @@ import { BrainGlassCard, type BrainCard } from './brain-card';
 import { MarkdownGlassCard, type MarkdownCard } from './markdown-card';
 import { loadCanvasSnapshot, saveCanvasSnapshot, type SnapGeometry } from './canvas-persistence';
 import { DiffGlassCard, type DiffCard } from './diff-card';
+import { fetchWorktreeDiff, findFileRepoPath, worktreeDiffCardFromData, worktreeRepoPath } from './worktree-diff';
 import { AgentGlassCard, AGENT_FULL_W, AGENT_FULL_H, AGENT_COMPACT_W, AGENT_COMPACT_H, type AgentCard } from './agent-card';
 import { codename } from '@/lib/agents/codename';
 import { ChatGlassCard, type ChatCard } from './chat-card';
@@ -2119,17 +2120,13 @@ export default function CanvasGlassPreviewPage() {
     if (lane) void spawnDiffCard(lane);
   }, [activeLanes, spawnDiffCard]);
 
-  /** "What have I changed" — the active repo's WORKING-TREE diff in the
-   *  same card the lane diffs use. laneId carries a worktree: prefix so
-   *  the restore path knows which fetch to replay. */
+  /** Active-repo working-tree diff; the worktree: prefix also drives restore. */
   const spawnWorktreeDiffCard = useCallback((at?: SnapGeometry, repoOverride?: string) => {
     const repoPath = repoOverride ?? activeRepoPath;
     if (!repoPath) return Promise.resolve();
-    const repoTail = repoPath.split('/').filter(Boolean).pop() ?? repoPath;
-    return fetch(`/api/panel/worktree-diff?workspace=${encodeURIComponent(repoPath)}&maxBytes=131072`)
-      .then((response) => (response.ok ? response.json() : null))
-      .then((data: { ok?: boolean; branch?: string | null; stat?: string; diff?: string; truncated?: boolean } | null) => {
-        if (!data?.ok) return;
+    return fetchWorktreeDiff(repoPath)
+      .then((data) => {
+        if (!data) return;
         const id = nextIdRef.current;
         nextIdRef.current += 1;
         zPeakRef.current = Math.min(zPeakRef.current + 1, 39);
@@ -2138,25 +2135,24 @@ export default function CanvasGlassPreviewPage() {
           // One working-tree card per repo — auto-show + the picker row both
           // route here, so a re-trigger must never stack a duplicate.
           if (previous.some((card) => card.laneId === `worktree:${repoPath}`)) return previous;
-          return [...previous, {
-            id,
-            x: spot.x,
-            y: spot.y,
-            z: zPeakRef.current,
-            w: at?.w ?? 560,
-            h: at?.h ?? 320,
-            laneId: `worktree:${repoPath}`,
-            packetId: null,
-            title: `Your changes — ${repoTail}`,
-            branch: data.branch ?? null,
-            stat: data.stat ?? '',
-            diff: data.diff?.trim() ? data.diff : 'Working tree clean — nothing uncommitted.',
-            truncated: Boolean(data.truncated),
-          }];
+          return [...previous, worktreeDiffCardFromData({ id, z: zPeakRef.current, spot, saved: at, repoPath, data })];
         });
       })
       .catch(() => {});
   }, [activeRepoPath, findFreeSpot]);
+
+  const refreshWorktreeDiffCard = useCallback((cardId: number): Promise<void> => {
+    const repoPath = worktreeRepoPath(canvasCardsRef.current.diff.find((card) => card.id === cardId)?.laneId ?? '');
+    if (!repoPath) return Promise.resolve();
+    return fetchWorktreeDiff(repoPath).then((data) => {
+      if (!data) return;
+      setDiffCards((previous) => previous.map((card) => (
+        card.id === cardId && worktreeRepoPath(card.laneId) === repoPath
+          ? { ...card, stat: data.stat, diff: data.diff, truncated: data.truncated }
+          : card
+      )));
+    }).catch(() => {});
+  }, []);
 
   /** The active review's PR diff as a glass card — what the Alerts
    *  "Review ready · PR #N" row resolves to. Distinct from the working-tree
@@ -2390,23 +2386,25 @@ export default function CanvasGlassPreviewPage() {
   }, []);
 
   /** Open ANY file on the machine as a glass card — view, edit, ⌘S. */
-  const spawnFileCard = useCallback((path: string, at?: SnapGeometry) => {
+  const spawnFileCard = useCallback((path: string, at?: SnapGeometry, repoOverride?: string) => {
     const id = nextIdRef.current;
     nextIdRef.current += 1;
     zPeakRef.current = Math.min(zPeakRef.current + 1, 39);
     const z = zPeakRef.current;
     const spot = at ?? findFreeSpot(620, 456);
+    const repoPath = findFileRepoPath(path, [repoOverride, activeRepoPath, ...(repos ?? []).map((repo) => repo.path)]);
     setFileCards((previous) => spawnCanvasCard(previous, {
       id,
       path,
       name: path.split('/').pop() || path,
+      repoPath,
       x: spot.x,
       y: spot.y,
       w: at?.w ?? 620,
       h: at?.h ?? 420,
       z,
     }));
-  }, [findFreeSpot]);
+  }, [activeRepoPath, findFreeSpot, repos]);
 
   const spawnFileTreeCard = useCallback((repoPath: string, at?: SnapGeometry) => {
     const id = nextIdRef.current;
@@ -2510,7 +2508,7 @@ export default function CanvasGlassPreviewPage() {
         return { id, x: saved.x, y: saved.y, z: zPeakRef.current, w: saved.w, h: saved.h, title: saved.title, markdown: saved.markdown };
       })]);
     }
-    snap.file.forEach((saved) => spawnFileCard(saved.path, saved));
+    snap.file.forEach((saved) => spawnFileCard(saved.path, saved, saved.repoPath ?? snap.activeRepoPath ?? undefined));
     snap.tree?.forEach((saved) => spawnFileTreeCard(saved.repoPath, saved));
     const videoRestores = (snap.video ?? []).map(async (saved) => {
       const blob = await getMedia(saved.mediaId);
@@ -2562,7 +2560,7 @@ export default function CanvasGlassPreviewPage() {
     activeRepoPath,
     dockOpen,
     term: termCards.map((card) => ({ x: Math.round(card.x), y: Math.round(card.y), w: card.w, h: card.h, cwd: card.cwd, cwdLabel: card.cwdLabel, sessionName: card.sessionName })),
-    file: fileCards.map((card) => ({ x: Math.round(card.x), y: Math.round(card.y), w: card.w, h: card.h, path: card.path })),
+    file: fileCards.map((card) => ({ x: Math.round(card.x), y: Math.round(card.y), w: card.w, h: card.h, path: card.path, repoPath: card.repoPath })),
     tree: treeCards.map((card) => ({ x: Math.round(card.x), y: Math.round(card.y), w: card.w, h: card.h, repoPath: card.repoPath })),
     image: imageCards.map((card) => ({ x: Math.round(card.x), y: Math.round(card.y), w: card.w, h: card.h, aspect: card.aspect, items: card.items })),
     video: videoCards.map((card) => ({ x: Math.round(card.x), y: Math.round(card.y), w: card.w, h: card.h, aspect: card.aspect, mediaId: card.mediaId, name: card.name })),
@@ -3715,6 +3713,8 @@ export default function CanvasGlassPreviewPage() {
             onFocus={focusDiffCard}
             onClose={closeDiffCard}
             onRequestChanges={requestDiffCardChanges}
+            onRefresh={refreshWorktreeDiffCard}
+            onChanged={refreshWorktreeDiffCard}
           />
         ))}
       </AnimatePresence>

--- a/src/app/preview/canvas-glass/perf/canvas-card-perf.test.ts
+++ b/src/app/preview/canvas-glass/perf/canvas-card-perf.test.ts
@@ -106,4 +106,25 @@ describe('canvas card performance fixture', () => {
     const result = await measureCanvasCardPerf();
     expect(result.maxCardsRenderedPerFrame).toBeLessThanOrEqual(2);
   });
+
+  it('does not re-render sibling diff cards when one diff changes', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const handle = createRef<CanvasCardPerfHandle>();
+    const renders: string[] = [];
+    const previousProbe = setCanvasRenderProbe((id) => renders.push(id));
+    const firstDiffId = createCanvasCardPerfFixture().diffCards[0]!.id;
+    try {
+      act(() => root.render(createElement(CanvasCardPerfHarness, { ref: handle })));
+      await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+      renders.length = 0;
+      act(() => handle.current?.updateFirstDiffCard());
+      expect(renders.filter((id) => id.startsWith('diff:'))).toEqual([`diff:${firstDiffId}`]);
+    } finally {
+      setCanvasRenderProbe(previousProbe);
+      act(() => root.unmount());
+      container.remove();
+    }
+  });
 });

--- a/src/app/preview/canvas-glass/perf/canvas-card-perf.tsx
+++ b/src/app/preview/canvas-glass/perf/canvas-card-perf.tsx
@@ -23,6 +23,7 @@ export interface CanvasCardPerfFixture {
 
 export interface CanvasCardPerfHandle {
   moveFirstCard: (frame: number) => void;
+  updateFirstDiffCard: () => void;
 }
 
 const FIXED_MARKDOWN = [
@@ -154,7 +155,7 @@ export const CanvasCardPerfHarness = forwardRef<CanvasCardPerfHandle>(function C
   const [fixture] = useState(createCanvasCardPerfFixture);
   const [termCards, setTermCards] = useState(fixture.termCards);
   const [fileCards] = useState(fixture.fileCards);
-  const [diffCards] = useState(fixture.diffCards);
+  const [diffCards, setDiffCards] = useState(fixture.diffCards);
   const [markdownCards] = useState(fixture.markdownCards);
   const [imageCards] = useState(fixture.imageCards);
 
@@ -165,6 +166,9 @@ export const CanvasCardPerfHarness = forwardRef<CanvasCardPerfHandle>(function C
   useImperativeHandle(ref, () => ({
     moveFirstCard(frame) {
       moveTermCard(termCards[0]!.id, 40 + frame * 3, 60 + frame * 2);
+    },
+    updateFirstDiffCard() {
+      setDiffCards((previous) => previous.map((card, index) => index === 0 ? { ...card, stat: '2 files changed' } : card));
     },
   }), [moveTermCard, termCards]);
 
@@ -192,7 +196,7 @@ export const CanvasCardPerfHarness = forwardRef<CanvasCardPerfHandle>(function C
         <FileGlassCard key={`file:${card.id}`} card={card} termVeil={0.52} onMove={ignore} onResize={ignore} onFocus={ignore} onClose={ignore} />
       ))}
       {diffCards.map((card) => (
-        <DiffGlassCard key={`diff:${card.id}`} card={card} onMove={ignore} onResize={ignore} onFocus={ignore} onClose={ignore} onRequestChanges={ignore} />
+        <DiffGlassCard key={`diff:${card.id}`} card={card} onMove={ignore} onResize={ignore} onFocus={ignore} onClose={ignore} onRequestChanges={ignore} onRefresh={ignore} onChanged={ignore} />
       ))}
       {markdownCards.map((card) => (
         <MarkdownGlassCard key={`markdown:${card.id}`} card={card} onMove={ignore} onResize={ignore} onFocus={ignore} onClose={ignore} />

--- a/src/app/preview/canvas-glass/worktree-diff.ts
+++ b/src/app/preview/canvas-glass/worktree-diff.ts
@@ -1,0 +1,125 @@
+'use client';
+
+import { useEffect } from 'react';
+import type { DiffCard } from './diff-card';
+import type { SnapGeometry } from './canvas-persistence';
+
+export const WORKTREE_DIFF_PREFIX = 'worktree:';
+const WORKTREE_DIFF_MAX_BYTES = 131_072;
+const worktreeDiffRequests = new Map<string, Promise<WorktreeDiffData | null>>();
+
+export interface WorktreeDiffData {
+  branch: string | null;
+  stat: string;
+  diff: string;
+  truncated: boolean;
+}
+
+interface WorktreeDiffResponse {
+  ok?: boolean;
+  branch?: string | null;
+  stat?: string;
+  diff?: string;
+  truncated?: boolean;
+}
+
+export function fetchWorktreeDiff(repoPath: string, fetchImpl: typeof fetch = fetch): Promise<WorktreeDiffData | null> {
+  const existing = fetchImpl === fetch ? worktreeDiffRequests.get(repoPath) : null;
+  if (existing) return existing;
+  const request = (async () => {
+    const query = `?workspace=${encodeURIComponent(repoPath)}&maxBytes=${WORKTREE_DIFF_MAX_BYTES}`;
+    const response = await fetchImpl(`/api/panel/worktree-diff${query}`, { cache: 'no-store' });
+    if (!response.ok) return null;
+    const data = await response.json() as WorktreeDiffResponse;
+    if (!data?.ok) return null;
+    return {
+      branch: typeof data.branch === 'string' ? data.branch : null,
+      stat: typeof data.stat === 'string' ? data.stat : '',
+      diff: typeof data.diff === 'string' ? data.diff : '',
+      truncated: Boolean(data.truncated),
+    };
+  })();
+  if (fetchImpl === fetch) {
+    worktreeDiffRequests.set(repoPath, request);
+    const clear = () => { if (worktreeDiffRequests.get(repoPath) === request) worktreeDiffRequests.delete(repoPath); };
+    void request.then(clear, clear);
+  }
+  return request;
+}
+
+export function worktreeDiffCardFromData({
+  id,
+  z,
+  spot,
+  saved,
+  repoPath,
+  data,
+}: {
+  id: number;
+  z: number;
+  spot: { x: number; y: number };
+  saved?: SnapGeometry;
+  repoPath: string;
+  data: WorktreeDiffData;
+}): DiffCard {
+  const repoName = repoPath.split('/').filter(Boolean).pop() ?? repoPath;
+  return {
+    id,
+    x: spot.x,
+    y: spot.y,
+    z,
+    w: saved?.w ?? 560,
+    h: saved?.h ?? 320,
+    laneId: `${WORKTREE_DIFF_PREFIX}${repoPath}`,
+    packetId: null,
+    title: `Your changes — ${repoName}`,
+    branch: data.branch,
+    stat: data.stat,
+    diff: data.diff,
+    truncated: data.truncated,
+  };
+}
+
+export function worktreeRepoPath(laneId: string): string | null {
+  return laneId.startsWith(WORKTREE_DIFF_PREFIX) ? laneId.slice(WORKTREE_DIFF_PREFIX.length) : null;
+}
+
+export function findFileRepoPath(filePath: string, repoPaths: Array<string | null | undefined>): string | null {
+  return [...new Set(repoPaths.filter((path): path is string => Boolean(path)))]
+    .map((path) => path.replace(/\/+$/, ''))
+    .filter((path) => filePath === path || filePath.startsWith(`${path}/`))
+    .sort((left, right) => right.length - left.length)[0] ?? null;
+}
+
+export function dispatchWorktreeChanged(repoPath: string): void {
+  window.dispatchEvent(new CustomEvent('o8:worktree-changed', { detail: { repoPath } }));
+}
+
+export function useWorktreeDiffRefresh({
+  cardId,
+  repoPath,
+  onRefresh,
+}: {
+  cardId: number;
+  repoPath: string | null;
+  onRefresh: (cardId: number) => void | Promise<void>;
+}): void {
+  useEffect(() => {
+    if (!repoPath) return;
+    const refresh = () => { void onRefresh(cardId); };
+    const onWorktreeChanged = (event: Event) => {
+      const detail = (event as CustomEvent<{ repoPath?: unknown }>).detail;
+      if (detail?.repoPath === repoPath) refresh();
+    };
+    window.addEventListener('o8:worktree-changed', onWorktreeChanged);
+    window.addEventListener('o8:lifecycle-reconcile', refresh);
+    const intervalId = window.setInterval(() => {
+      if (document.visibilityState === 'visible') refresh();
+    }, 60_000);
+    return () => {
+      window.removeEventListener('o8:worktree-changed', onWorktreeChanged);
+      window.removeEventListener('o8:lifecycle-reconcile', refresh);
+      window.clearInterval(intervalId);
+    };
+  }, [cardId, onRefresh, repoPath]);
+}


### PR DESCRIPTION
Closes #1915. Refs #1664.

## What

The canvas working-tree diff card can commit, and it refreshes against the working tree instead of freezing on its first fetch.

- `worktree-diff.ts` (new) — one `fetchWorktreeDiff(repoPath)` shared by the spawn and the refresh (in-flight requests are deduped per repo), `refreshWorktreeDiffCard(cardId)` updates `stat` / `diff` / `truncated` on the existing card in place (never re-spawns, never moves it), and an empty diff renders "No uncommitted changes" so a reverted edit cannot linger.
- Refresh triggers, installed only on `worktree:` cards: a `window` event `o8:worktree-changed { repoPath }` (dispatched by the canvas file card after a successful save — file cards now carry the `repoPath` they belong to, persisted in the snapshot — and by the commit action below), the existing `o8:lifecycle-reconcile` event, and a 60 s interval that only fires while the document is visible. Lane and PR diff cards get none of this.
- Commit affordance on the worktree card: **Commit** opens an inline strip with a single-line message input and Commit / Cancel; submit posts `{ message, workspace }` to `POST /api/review/commit` through `fetchCorrelatedActionReceipt` (the same receipt path the merge action uses), disables while in flight, shows the short hash for 2 s on success, dispatches `o8:worktree-changed`, and calls `onChanged`; errors show inline. An empty message never posts.
- `page.tsx` 5,463 → 5,463. No new routes.

## Proof

`diff-card.test.ts` (createRoot + act, fetch stubbed): a `o8:worktree-changed` event for the card's repo triggers exactly one refetch and the rendered diff changes; a different repo triggers none; the interval refetches after 60 s while visible and not while hidden (fake timers); Commit → strip → message → submit posts to `/api/review/commit` with `{ message, workspace }`, then `onChanged` fires and a refetch follows; an empty message never posts; a lane card shows no Commit control and installs no listeners.

## Gates

tsc · canvas tests · lint ratchet (touched files carry zero warnings) · classification check · full suite green.
