### PR TITLE
feat: settle workspace manifest runs into lifecycle receipts

### DIFF
--- a/src/lib/lane/registry.ts
+++ b/src/lib/lane/registry.ts
@@ -12,11 +12,10 @@ import { reportMissingArchiveEnding, resolveArchiveEnding, type ArchiveEndingOve
 import { publishPacketTailEvent } from './packet-tail';
 import { publishLaneLifecycleEvent } from './lifecycle';
 import { extractLaneReviewScreenshot } from './review-screenshot';
-import { isRefusedTerminalTransition, isWorkerTerminal } from './terminal-states';
-import type {
-  Lane, LaneEvent, LaneEventActor, LaneEventVerb, LaneOwnership, LaneRuntime, LaneStatus,
-} from './types';
+import { isLaneTerminal, isRefusedTerminalTransition, isWorkerTerminal } from './terminal-states';
+import type { Lane, LaneEvent, LaneEventActor, LaneEventVerb, LaneOwnership, LaneRuntime, LaneStatus } from './types';
 import { scheduleTerminalLaneCleanup } from './terminal-lane-cleanup';
+import { settleWorkspaceManifestOnTerminal } from '@/lib/workspace/manifest/terminal-release';
 import { captureLaneStorageCleanup, laneOwnsWorktree, settleLaneStorageOnAssociationLoss, worktreeIsConfirmedAbsent } from './lane-storage-release';
 import { getDataDir } from '@/lib/data-dir-migration';
 import { resolveLaneCreationBaseCommit } from './creation-base';
@@ -58,9 +57,7 @@ const REVIEW_SCREENSHOT_DIR = join(
 );
 let reviewScreenshotClient: O8WebviewClient | null = null;
 
-function isWorktreeCleanupTerminalStatus(status: LaneStatus) {
-  return status === 'completed' || status === 'archived';
-}
+function isWorktreeCleanupTerminalStatus(status: LaneStatus) { return status === 'completed' || status === 'archived'; }
 
 function getLaneDb() {
   const db = getDb();
@@ -488,6 +485,8 @@ export function updateLane(
   if (statusChanged && previousStatus) {
     publishLaneLifecycleEvent(resolvedLane, previousStatus, lifecycleTimestamp ?? nowIso());
   }
+
+  if (statusChanged && isLaneTerminal(resolvedLane.status)) settleWorkspaceManifestOnTerminal(resolvedLane);
 
   if (
     statusChanged

--- a/src/lib/lane/terminal-lane-cleanup.ts
+++ b/src/lib/lane/terminal-lane-cleanup.ts
@@ -1,7 +1,7 @@
 import type { Lane } from './types';
 import { cleanupLaneWorktree } from './worktree-cleanup';
 import { releaseTerminalPacketStorageReservations } from '@/lib/orchestrator/terminal-storage-release';
-import { scheduleWorkspaceManifestLeaseRelease } from '@/lib/workspace/manifest/terminal-release';
+import { settleTerminalWorkspaceManifestAndLeases } from '@/lib/workspace/manifest/terminal-release';
 import { laneOwnsWorktree } from './lane-storage-release';
 
 type TerminalCleanupLane = Pick<Lane, 'id' | 'repoPath' | 'worktreePath' | 'packetId'>
@@ -23,19 +23,28 @@ function releaseWithoutWorktree(lane: TerminalCleanupLane): void {
 }
 
 export function scheduleTerminalLaneCleanup(lane: TerminalCleanupLane): void {
-  scheduleWorkspaceManifestLeaseRelease({ packetId: lane.packetId, laneId: lane.id });
-  if (!lane.worktreePath || !laneOwnsWorktree(lane)) {
-    releaseWithoutWorktree(lane);
-    if (lane.worktreePath) {
-      void import('./registry').then(({ getLane, updateLane }) => {
+  void (async () => {
+    try {
+      await settleTerminalWorkspaceManifestAndLeases({
+        worktreePath: lane.worktreePath,
+        packetId: lane.packetId,
+        laneId: lane.id,
+      });
+    } catch (error) {
+      console.error(
+        `[lane-worktree] Terminal manifest cleanup failed for ${lane.id}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    if (!lane.worktreePath || !laneOwnsWorktree(lane)) {
+      releaseWithoutWorktree(lane);
+      if (lane.worktreePath) {
+        const { getLane, updateLane } = await import('./registry');
         if (getLane(lane.id)?.worktreePath === lane.worktreePath) {
           updateLane(lane.id, { worktreePath: null }, 'system', { phase: 'terminal_cleanup' });
         }
-      });
+      }
+      return;
     }
-    return;
-  }
-  void (async () => {
     const removed = await cleanupLaneWorktree(lane, { terminal: true });
     const { appendEvent, getLane, updateLane } = await import('./registry');
     const current = getLane(lane.id);
@@ -55,7 +64,7 @@ export function scheduleTerminalLaneCleanup(lane: TerminalCleanupLane): void {
     }
   })().catch((error) => {
     console.error(
-      `[lane-worktree] Terminal cleanup failed for ${lane.id}: ${error instanceof Error ? error.message : String(error)}`,
+      `[lane-worktree] Terminal worktree cleanup failed for ${lane.id}: ${error instanceof Error ? error.message : String(error)}`,
     );
   });
 }

--- a/src/lib/lane/types.ts
+++ b/src/lib/lane/types.ts
@@ -317,13 +317,13 @@ export type LaneEventVerb =
   | 'worktree_refresh_failed'
   // A checked-in workspace manifest allocated service ports and completed its
   // setup and one-shot health probes. Payload:
-  // { services: [{ name, port }], preview?, durationMs }
+  // { services: [{ name, port }], preview?, durationMs, state: 'completed' }
   | 'workspace_manifest_applied'
   // Operator policy prevented a checked-in manifest from executing. Payload:
   // { policy, manifestHash, approvalId?, reason? }
   | 'workspace_manifest_skipped'
   // Workspace manifest application failed without blocking packet launch.
-  // Payload: { step, error }
+  // Payload: { step, commandId?, error, state }
   | 'workspace_manifest_failed'
   // Discard could not prove its preserved branch exists. Payload:
   // { code, reason, packetId, branch, ref, note, gcRisk }

--- a/src/lib/orchestrator/operator-mission-service/rerun-with-feedback.ts
+++ b/src/lib/orchestrator/operator-mission-service/rerun-with-feedback.ts
@@ -22,6 +22,7 @@ import { collectPacketLifecycleLanes } from '@/lib/orchestrator/packet-lifecycle
 import { cleanupResetPacketTargets, type ResetCleanupTarget } from './reset-cleanup';
 import { unregisterWatchedAgent } from '@/lib/supervisor/agent-supervisor';
 import { storageOwnerGenerationForLane } from '@/lib/orchestrator/terminal-storage-release';
+import { archiveWorkspaceManifestRunForReset } from '@/lib/workspace/manifest/lifecycle';
 
 /**
  * #662 — One-click rerun-with-feedback.
@@ -196,6 +197,11 @@ async function retireRerunGeneration(guard: PacketLifecycleGuard): Promise<boole
 
   for (const target of targets) {
     if (target.sessionKey?.trim()) unregisterWatchedAgent(target.sessionKey.trim());
+    await archiveWorkspaceManifestRunForReset({
+      worktreePath: target.worktreePath,
+      packetId: guard.packetId,
+      laneId: target.id,
+    });
   }
   const confirmedKills = new Set(kills
     .filter((outcome) => outcome.confirmed || outcome.alreadyDead)

--- a/src/lib/orchestrator/operator-mission-service/reset-lane-fallback.ts
+++ b/src/lib/orchestrator/operator-mission-service/reset-lane-fallback.ts
@@ -10,6 +10,7 @@ import { archiveResetLaneSessions, confirmedKilledLaneIds } from './reset-lifecy
 import { log } from './shared';
 import type { ResetPacketInput } from './types';
 import { storageOwnerGenerationForLane } from '@/lib/orchestrator/terminal-storage-release';
+import { archiveWorkspaceManifestRunForReset } from '@/lib/workspace/manifest/lifecycle';
 
 export interface ResetAuthoritativeBinding {
   packet: OrchestratorPacket;
@@ -40,6 +41,11 @@ export async function resetPacketViaLaneFallback(
 
   const bound: typeof allBound = [];
   for (const lane of allBound) {
+    await archiveWorkspaceManifestRunForReset({
+      worktreePath: lane.worktreePath,
+      packetId: input.packetId,
+      laneId: lane.id,
+    });
     if (lane.status !== 'archived' && lane.status !== 'completed') {
       bound.push(lane);
       continue;

--- a/src/lib/orchestrator/operator-mission-service/reset.ts
+++ b/src/lib/orchestrator/operator-mission-service/reset.ts
@@ -25,6 +25,7 @@ import {
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 import { advancePacketStorageAdmissionEpoch } from '@/lib/orchestrator/packet-storage-admission-normalize';
 import { managedPacketWorktreeId, resolveWorktreeRootLayout } from '@/lib/worktree/root-layout';
+import { archiveWorkspaceManifestRunForReset } from '@/lib/workspace/manifest/lifecycle';
 import { supersedeDurableApprovedReviews } from '@/lib/lane/durable-review-approval';
 import {
   withMissionHandoffBarrier,
@@ -436,6 +437,11 @@ async function resetPacketUnlocked(input: ResetPacketInput) {
       if (lane.sessionKey?.trim()) unregisterWatchedAgent(lane.sessionKey.trim());
     }
     for (const lane of bound) {
+      await archiveWorkspaceManifestRunForReset({
+        worktreePath: lane.worktreePath,
+        packetId: packet.id,
+        laneId: lane.id,
+      });
       // #1215 — terminal lanes get unbound below like the rest but are never
       // re-archived and never donate a worktreePath (mirrors
       // archiveLanesForPacket, #1214).

--- a/src/lib/workspace/dependency-install.ts
+++ b/src/lib/workspace/dependency-install.ts
@@ -38,6 +38,7 @@ export interface DependencyInstallInvocation {
   cwd: string;
   timeoutMs: number;
   env: NodeJS.ProcessEnv;
+  signal?: AbortSignal;
 }
 
 export interface DependencyInstallRecipe {

--- a/src/lib/workspace/manifest/apply.ts
+++ b/src/lib/workspace/manifest/apply.ts
@@ -7,6 +7,17 @@ import path from 'node:path';
 import { recordLaneEvent } from '@/lib/lane/events';
 import { getOperatorDefaults } from '@/lib/operator/defaults';
 import { runRepoSetupCommand } from '@/lib/workspace/repo-setup';
+import {
+  beginWorkspaceManifestRun,
+  finishWorkspaceManifestRun,
+  settleWorkspaceManifestRun,
+  updateWorkspaceManifestRun,
+  type WorkspaceManifestHealthReceipt,
+  type WorkspaceManifestLifecycleRun,
+  type WorkspaceManifestServiceReceipt,
+  type WorkspaceManifestSetupReceipt,
+  type WorkspaceManifestState,
+} from './lifecycle';
 import { loadWorkspaceManifestSource } from './loader';
 import {
   findWorkspaceManifestApproval,
@@ -19,33 +30,15 @@ import type {
   WorkspaceManifestServiceHealth,
 } from './types';
 
-const SETUP_TIMEOUT_MS = 45 * 60_000;
+const DEFAULT_SETUP_TIMEOUT_MS = 45 * 60_000;
 const DEFAULT_HEALTH_TIMEOUT_MS = 5_000;
+let setupTimeoutOverrideForTest: number | null = null;
 
-export interface WorkspaceManifestHealthReceipt {
-  kind: 'http' | 'tcp';
-  target: string;
-  ok: boolean;
-  durationMs: number;
-  checkedAt: string;
-  error?: string;
-}
-
-export interface WorkspaceManifestSetupReceipt {
-  index: number;
-  commandId: string;
-  durationMs: number;
-  completedAt: string;
-}
-
-export interface WorkspaceManifestServiceReceipt {
-  name: string;
-  commandId: string;
-  cwd: string;
-  port: number | null;
-  environment: NodeJS.ProcessEnv;
-  health: WorkspaceManifestHealthReceipt | null;
-}
+export type {
+  WorkspaceManifestHealthReceipt,
+  WorkspaceManifestServiceReceipt,
+  WorkspaceManifestSetupReceipt,
+} from './lifecycle';
 
 export interface WorkspaceManifestApplyResult {
   ports: Record<string, number>;
@@ -57,7 +50,32 @@ export interface WorkspaceManifestApplyResult {
   };
 }
 
-type ApplyStep = 'load' | 'policy' | 'ports' | 'preview' | `setup:${number}`;
+type ApplyStep = 'load' | 'policy' | 'ports' | 'services' | 'preview' | `setup:${number}`;
+
+class WorkspaceManifestSetupTimeoutError extends Error {
+  constructor(
+    readonly step: `setup:${number}`,
+    readonly commandId: string,
+    timeoutMs: number,
+  ) {
+    super(`Workspace manifest ${step} (${commandId}) timed out after ${timeoutMs}ms.`);
+    this.name = 'WorkspaceManifestSetupTimeoutError';
+  }
+}
+
+class WorkspaceManifestCancelledError extends Error {
+  constructor() {
+    super('Workspace manifest cancelled because its lane became terminal.');
+    this.name = 'WorkspaceManifestCancelledError';
+  }
+}
+
+export function setWorkspaceManifestSetupTimeoutForTest(timeoutMs: number | null): void {
+  if (timeoutMs !== null && (!Number.isFinite(timeoutMs) || timeoutMs <= 0)) {
+    throw new Error('Workspace manifest setup timeout must be a positive number.');
+  }
+  setupTimeoutOverrideForTest = timeoutMs;
+}
 
 function commandId(command: string): string {
   return createHash('sha256').update(command).digest('hex');
@@ -200,9 +218,11 @@ async function applyLoadedManifest(input: {
   worktreePath: string;
   packetId: string;
   laneId: string;
-  setStep: (step: ApplyStep) => void;
+  lifecycle: WorkspaceManifestLifecycleRun;
+  setupTimeoutMs: number;
+  setStep: (step: ApplyStep, commandId?: string) => Promise<void>;
 }): Promise<WorkspaceManifestApplyResult> {
-  input.setStep('ports');
+  await input.setStep('ports');
   const services = input.manifest.services ?? [];
   const ports = await allocateWorkspaceServicePorts({
     packetId: input.packetId,
@@ -211,28 +231,57 @@ async function applyLoadedManifest(input: {
       ? [{ name: service.name, preferred: service.port.preferred }]
       : []),
   });
+  await updateWorkspaceManifestRun(input.lifecycle, (receipt) => ({ ...receipt, ports }));
   const allocatedEnvironment = portEnvironment(input.manifest, ports);
   const setupEnvironment = { ...process.env, ...allocatedEnvironment };
   const setupReceipts: WorkspaceManifestSetupReceipt[] = [];
   for (const [index, setupCommand] of (input.manifest.setup ?? []).entries()) {
-    input.setStep(`setup:${index + 1}`);
+    const step = `setup:${index + 1}` as const;
+    const setupCommandId = commandId(setupCommand);
+    await input.setStep(step, setupCommandId);
     const startedAt = Date.now();
     const shell = setupShell(setupCommand);
-    await runRepoSetupCommand({
-      ...shell,
-      cwd: input.worktreePath,
-      timeoutMs: SETUP_TIMEOUT_MS,
-      env: setupEnvironment,
-    });
-    setupReceipts.push({
+    const timeoutController = new AbortController();
+    const timeoutError = new WorkspaceManifestSetupTimeoutError(
+      step,
+      setupCommandId,
+      input.setupTimeoutMs,
+    );
+    const timer = setTimeout(() => timeoutController.abort(timeoutError), input.setupTimeoutMs);
+    timer.unref?.();
+    try {
+      await runRepoSetupCommand({
+        ...shell,
+        cwd: input.worktreePath,
+        timeoutMs: input.setupTimeoutMs,
+        env: setupEnvironment,
+        signal: AbortSignal.any([input.lifecycle.signal, timeoutController.signal]),
+      });
+    } catch (error) {
+      if (input.lifecycle.signal.aborted) throw new WorkspaceManifestCancelledError();
+      if (timeoutController.signal.aborted) throw timeoutError;
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+    if (input.lifecycle.signal.aborted) throw new WorkspaceManifestCancelledError();
+    const setupReceipt: WorkspaceManifestSetupReceipt = {
       index,
-      commandId: commandId(setupCommand),
+      commandId: setupCommandId,
       durationMs: Date.now() - startedAt,
       completedAt: new Date().toISOString(),
+    };
+    setupReceipts.push(setupReceipt);
+    await updateWorkspaceManifestRun(input.lifecycle, (receipt) => {
+      const next = { ...receipt, setup: [...receipt.setup, setupReceipt] };
+      delete next.commandId;
+      return next;
     });
   }
   const serviceReceipts: WorkspaceManifestServiceReceipt[] = [];
+  await input.setStep('services');
   for (const service of services) {
+    if (input.lifecycle.signal.aborted) throw new WorkspaceManifestCancelledError();
     const cwd = path.resolve(input.worktreePath, service.cwd ?? '.');
     if (!pathInside(cwd, input.worktreePath)) {
       throw new Error(`Service ${service.name} cwd escapes the packet worktree.`);
@@ -240,16 +289,21 @@ async function applyLoadedManifest(input: {
     const health = service.health
       ? await probeHealth({ health: service.health, service, ports })
       : null;
-    serviceReceipts.push({
+    const serviceReceipt: WorkspaceManifestServiceReceipt = {
       name: service.name,
       commandId: commandId(service.command),
       cwd,
       port: ports[service.name] ?? null,
       environment: { ...service.env, ...allocatedEnvironment },
       health,
-    });
+    };
+    serviceReceipts.push(serviceReceipt);
+    await updateWorkspaceManifestRun(input.lifecycle, (receipt) => ({
+      ...receipt,
+      services: [...receipt.services, serviceReceipt],
+    }));
   }
-  input.setStep('preview');
+  await input.setStep('preview');
   const firstPort = services.map((service) => ports[service.name]).find((port) => port !== undefined);
   const preview = input.manifest.preview
     ? resolveTemplate(input.manifest.preview.url, ports, firstPort)
@@ -285,6 +339,7 @@ export async function applyWorkspaceManifest(input: {
 }): Promise<WorkspaceManifestApplyResult | null> {
   const startedAt = Date.now();
   let step: ApplyStep = 'load';
+  let lifecycle: WorkspaceManifestLifecycleRun | null = null;
   try {
     const loaded = await loadWorkspaceManifestSource(input.worktreePath);
     if (!loaded) return null;
@@ -307,25 +362,68 @@ export async function applyWorkspaceManifest(input: {
       });
       return null;
     }
+    lifecycle = await beginWorkspaceManifestRun({
+      worktreePath: path.resolve(input.worktreePath),
+      packetId: input.packetId,
+      laneId: input.laneId,
+      manifestHash: decision.manifestHash,
+    });
     const result = await applyLoadedManifest({
       manifest: loaded.manifest,
       worktreePath: path.resolve(input.worktreePath),
       packetId: input.packetId,
       laneId: input.laneId,
-      setStep: (next) => { step = next; },
+      lifecycle,
+      setupTimeoutMs: setupTimeoutOverrideForTest ?? DEFAULT_SETUP_TIMEOUT_MS,
+      setStep: async (next, setupCommandId) => {
+        step = next;
+        await updateWorkspaceManifestRun(lifecycle!, (receipt) => {
+          const updated = { ...receipt, step: next };
+          if (setupCommandId) updated.commandId = setupCommandId;
+          else delete updated.commandId;
+          return updated;
+        });
+      },
     });
-    recordEventSafely(input.laneId, 'workspace_manifest_applied', {
-      services: Object.entries(result.ports).map(([name, port]) => ({ name, port })),
-      ...(result.preview ? { preview: result.preview } : {}),
-      durationMs: Date.now() - startedAt,
-    });
-    return result;
+    if (lifecycle.signal.aborted) throw new WorkspaceManifestCancelledError();
+    const settlement = await settleWorkspaceManifestRun(lifecycle, { state: 'completed' });
+    if (settlement.changed) {
+      recordEventSafely(input.laneId, 'workspace_manifest_applied', {
+        services: Object.entries(result.ports).map(([name, port]) => ({ name, port })),
+        ...(result.preview ? { preview: result.preview } : {}),
+        durationMs: Date.now() - startedAt,
+        state: 'completed',
+      });
+      return result;
+    }
+    return null;
   } catch (error) {
     const message = formatError(error);
+    const state: Exclude<WorkspaceManifestState, 'running' | 'completed' | 'crashed'> =
+      error instanceof WorkspaceManifestSetupTimeoutError
+        ? 'timed_out'
+        : error instanceof WorkspaceManifestCancelledError || lifecycle?.signal.aborted
+          ? 'cancelled'
+          : 'failed';
+    const commandId = error instanceof WorkspaceManifestSetupTimeoutError
+      ? error.commandId
+      : undefined;
     console.warn(
       `[workspace-manifest] Apply failed for packet ${input.packetId} in ${path.resolve(input.repoPath)} at ${step}: ${message}`,
     );
-    recordEventSafely(input.laneId, 'workspace_manifest_failed', { step, error: message });
+    const settlement = lifecycle
+      ? await settleWorkspaceManifestRun(lifecycle, { state, step, commandId, error: message })
+      : { receipt: null, changed: true };
+    if (settlement.changed) {
+      recordEventSafely(input.laneId, 'workspace_manifest_failed', {
+        step,
+        ...(commandId ? { commandId } : {}),
+        error: message,
+        state,
+      });
+    }
     return null;
+  } finally {
+    if (lifecycle) finishWorkspaceManifestRun(lifecycle);
   }
 }

--- a/src/lib/workspace/manifest/index.ts
+++ b/src/lib/workspace/manifest/index.ts
@@ -6,6 +6,14 @@ export {
 } from './loader';
 export { applyWorkspaceManifest } from './apply';
 export {
+  readWorkspaceManifestReceipt,
+  workspaceManifestReceiptPath,
+} from './lifecycle';
+export type {
+  WorkspaceManifestReceipt,
+  WorkspaceManifestState,
+} from './lifecycle';
+export {
   findWorkspaceManifestApproval,
   resolveWorkspaceManifestExecution,
   type WorkspaceManifestExecutionDecision,

--- a/src/lib/workspace/manifest/lifecycle.ts
+++ b/src/lib/workspace/manifest/lifecycle.ts
@@ -1,0 +1,589 @@
+import 'server-only';
+
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  chmod,
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  unlink,
+  writeFile,
+} from 'node:fs/promises';
+import path from 'node:path';
+
+import { getDataDir } from '@/lib/data-dir-migration';
+import { recordLaneEvent } from '@/lib/lane/events';
+import { probeMetadataLockProcessIdentity } from '@/lib/worktree/metadata-lock-process-identity';
+import { releaseWorkspacePortLeases } from './port-leases';
+
+const RECEIPT_VERSION = 1 as const;
+const RECEIPT_DIRECTORY = '.o8';
+const RECEIPT_FILENAME = 'workspace-manifest-receipt.json';
+const ARCHIVE_PREFIX = 'workspace-manifest-receipt.';
+const ARCHIVE_LIMIT = 3;
+const RESET_HANDOFF_DIRECTORY = 'workspace-manifest-reset-receipts';
+
+export type WorkspaceManifestState =
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'timed_out'
+  | 'cancelled'
+  | 'crashed';
+
+export interface WorkspaceManifestHealthReceipt {
+  kind: 'http' | 'tcp';
+  target: string;
+  ok: boolean;
+  durationMs: number;
+  checkedAt: string;
+  error?: string;
+}
+
+export interface WorkspaceManifestSetupReceipt {
+  index: number;
+  commandId: string;
+  durationMs: number;
+  completedAt: string;
+}
+
+export interface WorkspaceManifestServiceReceipt {
+  name: string;
+  commandId: string;
+  cwd: string;
+  port: number | null;
+  environment: NodeJS.ProcessEnv;
+  health: WorkspaceManifestHealthReceipt | null;
+}
+
+export interface WorkspaceManifestReceipt {
+  version: typeof RECEIPT_VERSION;
+  packetId: string;
+  laneId: string;
+  manifestHash: string;
+  state: WorkspaceManifestState;
+  pid: number;
+  startedAt: string;
+  finishedAt?: string;
+  step?: string;
+  commandId?: string;
+  ports: Record<string, number>;
+  setup: WorkspaceManifestSetupReceipt[];
+  services: WorkspaceManifestServiceReceipt[];
+  error?: string;
+}
+
+export interface WorkspaceManifestLifecycleRun {
+  readonly packetId: string;
+  readonly laneId: string;
+  readonly worktreePath: string;
+  readonly startedAt: string;
+  readonly pid: number;
+  readonly signal: AbortSignal;
+}
+
+interface ActiveWorkspaceManifestRun extends WorkspaceManifestLifecycleRun {
+  controller: AbortController;
+  receiptPath: string;
+}
+
+export interface WorkspaceManifestSettlement {
+  receipt: WorkspaceManifestReceipt | null;
+  changed: boolean;
+}
+
+const activeRuns = new Map<string, ActiveWorkspaceManifestRun>();
+const receiptMutations = new Map<string, Promise<unknown>>();
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isManifestState(value: unknown): value is WorkspaceManifestState {
+  return value === 'running'
+    || value === 'completed'
+    || value === 'failed'
+    || value === 'timed_out'
+    || value === 'cancelled'
+    || value === 'crashed';
+}
+
+function validateReceipt(value: unknown): WorkspaceManifestReceipt {
+  if (!isRecord(value)
+    || value.version !== RECEIPT_VERSION
+    || typeof value.packetId !== 'string'
+    || !value.packetId
+    || typeof value.laneId !== 'string'
+    || !value.laneId
+    || typeof value.manifestHash !== 'string'
+    || !/^[a-f0-9]{64}$/.test(value.manifestHash)
+    || !isManifestState(value.state)
+    || !Number.isInteger(value.pid)
+    || Number(value.pid) <= 0
+    || typeof value.startedAt !== 'string'
+    || !Number.isFinite(Date.parse(value.startedAt))
+    || !isRecord(value.ports)
+    || !Object.values(value.ports).every((port) => Number.isInteger(port))
+    || !Array.isArray(value.setup)
+    || !Array.isArray(value.services)) {
+    throw new Error('Workspace manifest receipt has an unsupported shape.');
+  }
+  if (value.finishedAt !== undefined
+    && (typeof value.finishedAt !== 'string' || !Number.isFinite(Date.parse(value.finishedAt)))) {
+    throw new Error('Workspace manifest receipt has an invalid finishedAt value.');
+  }
+  if (value.step !== undefined && typeof value.step !== 'string') {
+    throw new Error('Workspace manifest receipt has an invalid step value.');
+  }
+  if (value.commandId !== undefined
+    && (typeof value.commandId !== 'string' || !/^[a-f0-9]{64}$/.test(value.commandId))) {
+    throw new Error('Workspace manifest receipt has an invalid commandId value.');
+  }
+  if (value.error !== undefined && typeof value.error !== 'string') {
+    throw new Error('Workspace manifest receipt has an invalid error value.');
+  }
+  return value as unknown as WorkspaceManifestReceipt;
+}
+
+export function workspaceManifestReceiptPath(worktreePath: string): string {
+  return path.join(path.resolve(worktreePath), RECEIPT_DIRECTORY, RECEIPT_FILENAME);
+}
+
+function stateDirectory(worktreePath: string): string {
+  return path.dirname(workspaceManifestReceiptPath(worktreePath));
+}
+
+async function ensureStateDirectory(worktreePath: string): Promise<string> {
+  const directory = stateDirectory(worktreePath);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const entry = await lstat(directory);
+  if (!entry.isDirectory() || entry.isSymbolicLink()) {
+    throw new Error('Workspace manifest receipt directory is not an exact directory.');
+  }
+  return directory;
+}
+
+async function readReceiptFile(receiptPath: string): Promise<WorkspaceManifestReceipt | null> {
+  try {
+    return validateReceipt(JSON.parse(await readFile(receiptPath, 'utf8')) as unknown);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+async function writeReceiptFile(
+  worktreePath: string,
+  receiptPath: string,
+  receipt: WorkspaceManifestReceipt,
+): Promise<void> {
+  const directory = await ensureStateDirectory(worktreePath);
+  if (path.dirname(receiptPath) !== directory) {
+    throw new Error('Workspace manifest receipt path escaped its state directory.');
+  }
+  const temporaryPath = path.join(directory, `${path.basename(receiptPath)}.${process.pid}.${randomUUID()}.tmp`);
+  try {
+    await writeFile(temporaryPath, `${JSON.stringify(receipt, null, 2)}\n`, {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+    await rename(temporaryPath, receiptPath);
+    await chmod(receiptPath, 0o600).catch(() => {});
+  } catch (error) {
+    await unlink(temporaryPath).catch(() => {});
+    throw error;
+  }
+}
+
+async function writePrivateJsonFile(
+  directory: string,
+  filePath: string,
+  receipt: WorkspaceManifestReceipt,
+): Promise<void> {
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const temporaryPath = path.join(directory, `${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`);
+  try {
+    await writeFile(temporaryPath, `${JSON.stringify(receipt, null, 2)}\n`, {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+    await rename(temporaryPath, filePath);
+    await chmod(filePath, 0o600).catch(() => {});
+  } catch (error) {
+    await unlink(temporaryPath).catch(() => {});
+    throw error;
+  }
+}
+
+async function withReceiptMutation<T>(
+  worktreePath: string,
+  operation: (receiptPath: string) => Promise<T>,
+): Promise<T> {
+  const receiptPath = workspaceManifestReceiptPath(worktreePath);
+  const prior = receiptMutations.get(receiptPath) ?? Promise.resolve();
+  const current = prior.catch(() => {}).then(() => operation(receiptPath));
+  receiptMutations.set(receiptPath, current);
+  try {
+    return await current;
+  } finally {
+    if (receiptMutations.get(receiptPath) === current) receiptMutations.delete(receiptPath);
+  }
+}
+
+function archiveTimestamp(startedAt: string): string {
+  return startedAt.replace(/[:]/g, '-');
+}
+
+function resetHandoffDirectory(packetId: string): string {
+  const packetKey = createHash('sha256').update(packetId).digest('hex');
+  return path.join(getDataDir(), RESET_HANDOFF_DIRECTORY, packetKey);
+}
+
+async function trimArchives(directory: string): Promise<void> {
+  const archives = (await readdir(directory))
+    .filter((name) => name.startsWith(ARCHIVE_PREFIX) && name.endsWith('.json'))
+    .sort()
+    .reverse();
+  await Promise.all(archives.slice(ARCHIVE_LIMIT).map((name) => (
+    unlink(path.join(directory, name)).catch(() => {})
+  )));
+}
+
+async function archiveReceipt(
+  worktreePath: string,
+  receipt: WorkspaceManifestReceipt,
+): Promise<string> {
+  const directory = await ensureStateDirectory(worktreePath);
+  const archivePath = path.join(
+    directory,
+    `${ARCHIVE_PREFIX}${archiveTimestamp(receipt.startedAt)}.json`,
+  );
+  await writeReceiptFile(worktreePath, archivePath, receipt);
+  await trimArchives(directory);
+  return archivePath;
+}
+
+async function stageResetArchives(worktreePath: string, packetId: string): Promise<void> {
+  const sourceDirectory = stateDirectory(worktreePath);
+  const names = (await readdir(sourceDirectory))
+    .filter((name) => name.startsWith(ARCHIVE_PREFIX) && name.endsWith('.json'))
+    .sort()
+    .reverse()
+    .slice(0, ARCHIVE_LIMIT);
+  const handoffDirectory = resetHandoffDirectory(packetId);
+  for (const name of names) {
+    const receipt = await readReceiptFile(path.join(sourceDirectory, name));
+    if (!receipt || receipt.packetId !== packetId) continue;
+    await writePrivateJsonFile(handoffDirectory, path.join(handoffDirectory, name), receipt);
+  }
+  await trimArchives(handoffDirectory);
+}
+
+async function restoreResetArchives(worktreePath: string, packetId: string): Promise<void> {
+  const handoffDirectory = resetHandoffDirectory(packetId);
+  let names: string[];
+  try {
+    names = (await readdir(handoffDirectory))
+      .filter((name) => name.startsWith(ARCHIVE_PREFIX) && name.endsWith('.json'));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw error;
+  }
+  for (const name of names) {
+    const receipt = await readReceiptFile(path.join(handoffDirectory, name));
+    if (!receipt || receipt.packetId !== packetId) continue;
+    await writeReceiptFile(worktreePath, path.join(stateDirectory(worktreePath), name), receipt);
+  }
+  await trimArchives(await ensureStateDirectory(worktreePath));
+  await rm(handoffDirectory, { recursive: true, force: true });
+}
+
+function sameAttempt(
+  receipt: WorkspaceManifestReceipt,
+  run: WorkspaceManifestLifecycleRun,
+): boolean {
+  return receipt.packetId === run.packetId
+    && receipt.laneId === run.laneId
+    && receipt.startedAt === run.startedAt
+    && receipt.pid === run.pid;
+}
+
+function findActiveRun(input: {
+  worktreePath?: string | null;
+  packetId: string;
+  laneId: string;
+}): ActiveWorkspaceManifestRun | null {
+  if (input.worktreePath) {
+    const exact = activeRuns.get(workspaceManifestReceiptPath(input.worktreePath));
+    if (exact?.packetId === input.packetId && exact.laneId === input.laneId) return exact;
+  }
+  return [...activeRuns.values()].find((run) => (
+    run.packetId === input.packetId && run.laneId === input.laneId
+  )) ?? null;
+}
+
+function recordFailureSafely(receipt: WorkspaceManifestReceipt): void {
+  try {
+    recordLaneEvent(receipt.laneId, 'workspace_manifest_failed', 'system', {
+      ...(receipt.step ? { step: receipt.step } : {}),
+      ...(receipt.commandId ? { commandId: receipt.commandId } : {}),
+      error: receipt.error ?? `Workspace manifest settled as ${receipt.state}.`,
+      state: receipt.state,
+    });
+  } catch (error) {
+    console.warn(
+      `[workspace-manifest] Could not record workspace_manifest_failed for ${receipt.laneId}: ${formatError(error)}`,
+    );
+  }
+}
+
+async function settleReceiptDirectly(input: {
+  worktreePath: string;
+  packetId: string;
+  laneId: string;
+  state: Exclude<WorkspaceManifestState, 'running' | 'completed'>;
+  error: string;
+}): Promise<WorkspaceManifestSettlement> {
+  return withReceiptMutation(input.worktreePath, async (receiptPath) => {
+    const receipt = await readReceiptFile(receiptPath);
+    if (!receipt
+      || receipt.state !== 'running'
+      || receipt.packetId !== input.packetId
+      || receipt.laneId !== input.laneId) {
+      return { receipt, changed: false };
+    }
+    const settled: WorkspaceManifestReceipt = {
+      ...receipt,
+      state: input.state,
+      finishedAt: new Date().toISOString(),
+      error: input.error,
+    };
+    await writeReceiptFile(input.worktreePath, receiptPath, settled);
+    return { receipt: settled, changed: true };
+  });
+}
+
+export async function readWorkspaceManifestReceipt(
+  worktreePath: string,
+): Promise<WorkspaceManifestReceipt | null> {
+  return readReceiptFile(workspaceManifestReceiptPath(worktreePath));
+}
+
+export async function beginWorkspaceManifestRun(input: {
+  worktreePath: string;
+  packetId: string;
+  laneId: string;
+  manifestHash: string;
+}): Promise<WorkspaceManifestLifecycleRun> {
+  const worktreePath = path.resolve(input.worktreePath);
+  const startedAt = new Date().toISOString();
+  const controller = new AbortController();
+  const active: ActiveWorkspaceManifestRun = {
+    packetId: input.packetId,
+    laneId: input.laneId,
+    worktreePath,
+    startedAt,
+    pid: process.pid,
+    signal: controller.signal,
+    controller,
+    receiptPath: workspaceManifestReceiptPath(worktreePath),
+  };
+  let crashed: WorkspaceManifestReceipt | null = null;
+
+  await withReceiptMutation(worktreePath, async (receiptPath) => {
+    if (activeRuns.has(receiptPath)) {
+      throw new Error(`Workspace manifest setup is already running for ${worktreePath}.`);
+    }
+    await restoreResetArchives(worktreePath, input.packetId);
+    let previous = await readReceiptFile(receiptPath);
+    if (previous?.state === 'running') {
+      if (previous.pid === process.pid) {
+        throw new Error('Workspace manifest receipt belongs to an unsettled run in this process.');
+      }
+      const owner = await probeMetadataLockProcessIdentity(previous.pid);
+      if (owner.state !== 'absent') {
+        throw new Error(
+          owner.state === 'live'
+            ? `Workspace manifest setup is still owned by process ${previous.pid}.`
+            : `Workspace manifest setup owner ${previous.pid} could not be verified: ${owner.detail}`,
+        );
+      }
+      previous = {
+        ...previous,
+        state: 'crashed',
+        finishedAt: new Date().toISOString(),
+        error: `Workspace manifest owner process ${previous.pid} exited before setup settled.`,
+      };
+      await writeReceiptFile(worktreePath, receiptPath, previous);
+      crashed = previous;
+    }
+    if (previous) {
+      await releaseWorkspacePortLeases({
+        packetId: previous.packetId,
+        laneId: previous.laneId,
+      });
+      await archiveReceipt(worktreePath, previous);
+    }
+    const running: WorkspaceManifestReceipt = {
+      version: RECEIPT_VERSION,
+      packetId: input.packetId,
+      laneId: input.laneId,
+      manifestHash: input.manifestHash,
+      state: 'running',
+      pid: process.pid,
+      startedAt,
+      ports: {},
+      setup: [],
+      services: [],
+    };
+    await writeReceiptFile(worktreePath, receiptPath, running);
+    activeRuns.set(receiptPath, active);
+  });
+
+  if (crashed) recordFailureSafely(crashed);
+  return active;
+}
+
+export async function updateWorkspaceManifestRun(
+  run: WorkspaceManifestLifecycleRun,
+  update: (receipt: WorkspaceManifestReceipt) => WorkspaceManifestReceipt,
+): Promise<WorkspaceManifestReceipt | null> {
+  return withReceiptMutation(run.worktreePath, async (receiptPath) => {
+    const receipt = await readReceiptFile(receiptPath);
+    if (!receipt || receipt.state !== 'running' || !sameAttempt(receipt, run)) return receipt;
+    const next = update(receipt);
+    await writeReceiptFile(run.worktreePath, receiptPath, next);
+    return next;
+  });
+}
+
+export async function settleWorkspaceManifestRun(
+  run: WorkspaceManifestLifecycleRun,
+  input: {
+    state: Exclude<WorkspaceManifestState, 'running' | 'crashed'>;
+    step?: string;
+    commandId?: string;
+    error?: string;
+  },
+): Promise<WorkspaceManifestSettlement> {
+  return withReceiptMutation(run.worktreePath, async (receiptPath) => {
+    const receipt = await readReceiptFile(receiptPath);
+    if (!receipt || receipt.state !== 'running' || !sameAttempt(receipt, run)) {
+      return { receipt, changed: false };
+    }
+    const settled: WorkspaceManifestReceipt = {
+      ...receipt,
+      state: input.state,
+      finishedAt: new Date().toISOString(),
+      ...(input.step ? { step: input.step } : {}),
+      ...(input.commandId ? { commandId: input.commandId } : {}),
+      ...(input.error ? { error: input.error } : {}),
+    };
+    if (input.state === 'completed') {
+      delete settled.step;
+      delete settled.commandId;
+      delete settled.error;
+    }
+    await writeReceiptFile(run.worktreePath, receiptPath, settled);
+    return { receipt: settled, changed: true };
+  });
+}
+
+export function finishWorkspaceManifestRun(run: WorkspaceManifestLifecycleRun): void {
+  const receiptPath = workspaceManifestReceiptPath(run.worktreePath);
+  const active = activeRuns.get(receiptPath);
+  if (active
+    && active.packetId === run.packetId
+    && active.laneId === run.laneId
+    && active.pid === run.pid
+    && active.startedAt === run.startedAt) {
+    activeRuns.delete(receiptPath);
+  }
+}
+
+export function settleTerminalWorkspaceManifest(input: {
+  worktreePath?: string | null;
+  packetId: string;
+  laneId: string;
+}): Promise<void> {
+  const active = findActiveRun(input);
+  active?.controller.abort(new Error('Workspace manifest cancelled because its lane became terminal.'));
+  const worktreePath = active?.worktreePath ?? input.worktreePath;
+  return (async () => {
+    try {
+      let settlement: WorkspaceManifestSettlement = { receipt: null, changed: false };
+      if (active) {
+        settlement = await settleWorkspaceManifestRun(active, {
+          state: 'cancelled',
+          error: 'Workspace manifest cancelled because its lane became terminal.',
+        });
+      } else if (worktreePath) {
+        settlement = await settleReceiptDirectly({
+          worktreePath,
+          packetId: input.packetId,
+          laneId: input.laneId,
+          state: 'cancelled',
+          error: 'Workspace manifest cancelled because its lane became terminal.',
+        });
+      }
+      if (settlement.changed && settlement.receipt) recordFailureSafely(settlement.receipt);
+    } finally {
+      await releaseWorkspacePortLeases({ packetId: input.packetId, laneId: input.laneId });
+    }
+  })();
+}
+
+export function archiveWorkspaceManifestRunForReset(input: {
+  worktreePath?: string | null;
+  packetId: string;
+  laneId: string;
+}): Promise<string | null> {
+  const active = findActiveRun(input);
+  active?.controller.abort(new Error('Workspace manifest cancelled by packet reset.'));
+  const worktreePath = active?.worktreePath ?? input.worktreePath;
+  return (async () => {
+    await releaseWorkspacePortLeases({ packetId: input.packetId, laneId: input.laneId });
+    if (!worktreePath) {
+      return null;
+    }
+    return withReceiptMutation(worktreePath, async (receiptPath) => {
+      let receipt = await readReceiptFile(receiptPath);
+      if (receipt
+        && receipt.packetId === input.packetId
+        && receipt.laneId === input.laneId
+        && receipt.state === 'running') {
+        const owner = receipt.pid === process.pid
+          ? null
+          : await probeMetadataLockProcessIdentity(receipt.pid);
+        const crashed = owner?.state === 'absent';
+        receipt = {
+          ...receipt,
+          state: crashed ? 'crashed' : 'cancelled',
+          finishedAt: new Date().toISOString(),
+          error: crashed
+            ? `Workspace manifest owner process ${receipt.pid} exited before packet reset.`
+            : 'Workspace manifest cancelled by packet reset.',
+        };
+        await writeReceiptFile(worktreePath, receiptPath, receipt);
+        recordFailureSafely(receipt);
+      }
+      if (!receipt
+        || receipt.packetId !== input.packetId
+        || receipt.laneId !== input.laneId) return null;
+      const archived = await archiveReceipt(worktreePath, receipt);
+      await stageResetArchives(worktreePath, input.packetId);
+      await unlink(receiptPath).catch((error) => {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      });
+      activeRuns.delete(receiptPath);
+      return archived;
+    });
+  })();
+}

--- a/src/lib/workspace/manifest/terminal-release.ts
+++ b/src/lib/workspace/manifest/terminal-release.ts
@@ -1,14 +1,30 @@
 import 'server-only';
 
-import { releaseWorkspacePortLeases } from './port-leases';
+import type { Lane } from '@/lib/lane/types';
+import { settleTerminalWorkspaceManifest } from './lifecycle';
 
-export function scheduleWorkspaceManifestLeaseRelease(input: {
+export function settleTerminalWorkspaceManifestAndLeases(input: {
+  worktreePath?: string | null;
   packetId?: string | null;
   laneId: string;
-}): void {
-  void releaseWorkspacePortLeases(input).catch((error) => {
+}): Promise<void> {
+  return settleTerminalWorkspaceManifest({
+    worktreePath: input.worktreePath,
+    packetId: input.packetId?.trim() || `lane:${input.laneId}`,
+    laneId: input.laneId,
+  });
+}
+
+export function settleWorkspaceManifestOnTerminal(
+  lane: Pick<Lane, 'id' | 'worktreePath' | 'packetId'>,
+): void {
+  void settleTerminalWorkspaceManifestAndLeases({
+    worktreePath: lane.worktreePath,
+    packetId: lane.packetId,
+    laneId: lane.id,
+  }).catch((error) => {
     console.error(
-      `[workspace-manifest] Terminal port lease release failed for ${input.laneId}: ${error instanceof Error ? error.message : String(error)}`,
+      `[workspace-manifest] Terminal settlement failed for ${lane.id}: ${error instanceof Error ? error.message : String(error)}`,
     );
   });
 }

--- a/src/lib/workspace/repo-setup.ts
+++ b/src/lib/workspace/repo-setup.ts
@@ -37,6 +37,7 @@ export async function runRepoSetupCommand(
     maxBuffer: 8 * 1024 * 1024,
     windowsHide: true,
     env: invocation.env,
+    signal: invocation.signal,
   });
 }
 

--- a/src/lib/worktree/materialization-execution.ts
+++ b/src/lib/worktree/materialization-execution.ts
@@ -1,4 +1,4 @@
-import { execFile, type ExecFileOptions } from 'node:child_process';
+import { execFile, type ChildProcess, type ExecFileOptions } from 'node:child_process';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import path from 'node:path';
 
@@ -71,7 +71,24 @@ export function materializationAwareExecFile(
   const identity = cwd ? materializationContext.getStore()?.get(cwd) ?? null : null;
   const invocation = guardedWorkspaceInvocation(command, [...args], identity);
   return new Promise((resolve, reject) => {
-    execFile(invocation.command, invocation.args, options, (error, stdout, stderr) => {
+    const { signal, ...execOptions } = options;
+    let child: ChildProcess | null = null;
+    let settled = false;
+    const cleanup = () => signal?.removeEventListener('abort', abort);
+    const abort = () => {
+      if (settled) return;
+      child?.kill();
+      settled = true;
+      cleanup();
+      const error = new Error('The operation was aborted.', { cause: signal?.reason });
+      error.name = 'AbortError';
+      Object.assign(error, { code: 'ABORT_ERR' });
+      reject(error);
+    };
+    child = execFile(invocation.command, invocation.args, execOptions, (error, stdout, stderr) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
       const stdoutText = Buffer.isBuffer(stdout) ? stdout.toString('utf8') : stdout;
       const stderrText = Buffer.isBuffer(stderr) ? stderr.toString('utf8') : stderr;
       if (error) {
@@ -81,5 +98,7 @@ export function materializationAwareExecFile(
         resolve({ stdout: stdoutText, stderr: stderrText });
       }
     });
+    if (signal?.aborted) abort();
+    else signal?.addEventListener('abort', abort, { once: true });
   });
 }

--- a/src/lib/worktree/safety-hooks.ts
+++ b/src/lib/worktree/safety-hooks.ts
@@ -170,7 +170,7 @@ async function ensureSafetyHookGitExclusion(
     gitAdmin.commonPath,
     gitAdmin.commonIdentity,
     excludeName,
-    `${MANAGED_WORKSPACE_SAFETY_SETTINGS}\n`,
+    `${MANAGED_WORKSPACE_SAFETY_SETTINGS}\n.o8/\n`,
   );
   await withWorktreeMaterializationExecution(
     gitAdmin.commonPath,

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2339,6 +2339,15 @@
       ]
     },
     {
+      "path": "tests/workspace-manifest-lifecycle-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path",
+        "worktree-api"
+      ]
+    },
+    {
       "path": "tests/workspace-manifest-policy-real-path.test.ts",
       "reasons": [
         "child-process",

--- a/tests/workspace-manifest-lifecycle-real-path.test.ts
+++ b/tests/workspace-manifest-lifecycle-real-path.test.ts
@@ -1,0 +1,580 @@
+import { createHash } from 'node:crypto';
+import type { ExecFileOptions } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+
+type SetupMode = 'complete' | 'timeout' | 'cancel' | 'block_once';
+
+const execution = vi.hoisted(() => ({
+  mode: 'complete' as SetupMode,
+  blockedOnce: false,
+  invocations: [] as Array<{ command: string; cwd: string }>,
+  children: [] as Array<{
+    command: string;
+    killed: boolean;
+    release: (() => void) | null;
+  }>,
+  crashSeed: null as null | {
+    packetId: string;
+    laneId: string;
+    manifestHash: string;
+    port: number;
+  },
+}));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  const execFile = (
+    file: string,
+    args: string[] = [],
+    options: ExecFileOptions = {},
+    callback?: (error: Error | null, stdout: string, stderr: string) => void,
+  ) => {
+    const cwd = String(options.cwd ?? '');
+    seedCrashedReceiptAtProcessBoundary(cwd);
+    const setupCommand = ['manifest-step-one', 'manifest-step-two']
+      .find((candidate) => args.includes(candidate));
+    if (!setupCommand) return actual.execFile(file, args, options, callback as never);
+
+    execution.invocations.push({ command: setupCommand, cwd });
+    const child = {
+      command: setupCommand,
+      killed: false,
+      release: null as (() => void) | null,
+    };
+    const finish = () => queueMicrotask(() => callback?.(null, '', ''));
+    if (execution.mode === 'complete') {
+      finish();
+    } else if (execution.mode === 'block_once' && !execution.blockedOnce) {
+      execution.blockedOnce = true;
+      child.release = finish;
+    } else if (execution.mode === 'block_once') {
+      finish();
+    }
+    execution.children.push(child);
+    return {
+      kill: () => {
+        child.killed = true;
+        child.release = null;
+        return true;
+      },
+    } as never;
+  };
+  const promisifySymbol = Symbol.for('nodejs.util.promisify.custom');
+  Object.defineProperty(execFile, promisifySymbol, {
+    value: (actual.execFile as unknown as Record<symbol, unknown>)[promisifySymbol],
+  });
+  return { ...actual, execFile };
+});
+
+const tempRoot = realpathSync(mkdtempSync(path.join(os.homedir(), '.tmp-o8-manifest-lifecycle-')));
+const dataDir = path.join(tempRoot, 'data');
+const repoPath = path.join(tempRoot, 'repo');
+const worktreeRoot = path.join(tempRoot, 'worktrees');
+const manifestPath = path.join(repoPath, 'o8.workspace.json');
+const preferredPort = 44_100;
+const controlledEnvKeys = [
+  'CORTEX_IDE_DATA_DIR',
+  'O8_DATA_DIR',
+  'O8_WORKTREE_ROOT',
+  'O8_SKIP_PRELAUNCH_TYPECHECK',
+] as const;
+const priorEnv: Record<string, string | undefined> = {};
+let launchSequence = 0;
+
+function seedCrashedReceiptAtProcessBoundary(cwd: string): void {
+  const seed = execution.crashSeed;
+  if (!seed
+    || !cwd.startsWith(worktreeRoot)
+    || !existsSync(path.join(cwd, 'o8.workspace.json'))) return;
+  const receiptPath = path.join(cwd, '.o8', 'workspace-manifest-receipt.json');
+  if (existsSync(receiptPath)) return;
+  mkdirSync(path.dirname(receiptPath), { recursive: true });
+  writeFileSync(receiptPath, `${JSON.stringify({
+    version: 1,
+    packetId: seed.packetId,
+    laneId: seed.laneId,
+    manifestHash: seed.manifestHash,
+    state: 'running',
+    pid: 2_147_483_647,
+    startedAt: '2026-08-28T04:00:00.000Z',
+    step: 'setup:1',
+    ports: { app: seed.port },
+    setup: [],
+    services: [],
+  }, null, 2)}\n`);
+  execution.crashSeed = null;
+}
+
+function resetExecution(mode: SetupMode): void {
+  execution.mode = mode;
+  execution.blockedOnce = false;
+  execution.invocations.length = 0;
+  execution.children.length = 0;
+  execution.crashSeed = null;
+}
+
+function setupChild(command = 'manifest-step-one') {
+  return execution.children.find((child) => child.command === command) ?? null;
+}
+
+async function launchPacket(input: {
+  packetId: string;
+  branch?: string;
+  bindWorktree?: boolean;
+}) {
+  launchSequence += 1;
+  const branch = input.branch ?? `issue/1910-lifecycle-${launchSequence}`;
+  const { createLane, updateLane } = await import('@/lib/lane/registry');
+  const { prepareLaunchWorktree } = await import('@/lib/worktree/launch');
+  const lane = createLane({
+    repoPath,
+    branch,
+    baseBranch: 'main',
+    runtime: 'codex',
+    label: `${input.packetId}-${launchSequence}`,
+    packetId: input.packetId,
+  });
+  const prepared = await prepareLaunchWorktree({
+    repoRoot: repoPath,
+    agentType: 'codex',
+    taskName: input.packetId,
+    branchName: branch,
+    baseBranch: 'main',
+    isolate: true,
+    skipSetup: true,
+    packetId: input.packetId,
+    laneId: lane.id,
+  });
+  if (!prepared) throw new Error(`Worktree launch returned no workspace for ${input.packetId}.`);
+  if (input.bindWorktree !== false) {
+    updateLane(lane.id, { worktreePath: prepared.cwd }, 'system');
+  }
+  return { lane, prepared };
+}
+
+async function waitForNoLaneLeases(laneId: string): Promise<void> {
+  const { readWorkspacePortLeases } = await import('@/lib/workspace/manifest/port-leases');
+  await vi.waitFor(async () => {
+    expect(Object.values(await readWorkspacePortLeases()).some(
+      (lease) => lease.laneId === laneId,
+    )).toBe(false);
+  }, { timeout: 30_000 });
+}
+
+async function terminalCleanup(laneId: string): Promise<void> {
+  const { getLane, setLaneStatus } = await import('@/lib/lane/registry');
+  if (getLane(laneId)?.status !== 'failed') {
+    setLaneStatus(laneId, 'failed', 'system', 'test cleanup');
+  }
+  await waitForNoLaneLeases(laneId);
+}
+
+async function archivedReceipts(worktreePath: string) {
+  const directory = path.join(worktreePath, '.o8');
+  return readdirSync(directory)
+    .filter((name) => name.startsWith('workspace-manifest-receipt.') && name.endsWith('.json'))
+    .map((name) => JSON.parse(readFileSync(path.join(directory, name), 'utf8')) as {
+      state: string;
+      laneId: string;
+    });
+}
+
+describe.sequential('workspace manifest lifecycle through packet launch', () => {
+  beforeAll(async () => {
+    for (const key of controlledEnvKeys) priorEnv[key] = process.env[key];
+    mkdirSync(dataDir, { recursive: true });
+    execFileSync('git', ['init', '-q', '-b', 'main', repoPath]);
+    writeFileSync(path.join(repoPath, 'README.md'), 'workspace manifest lifecycle fixture\n');
+    writeFileSync(path.join(repoPath, '.gitignore'), '.o8/\n');
+    writeFileSync(manifestPath, `${JSON.stringify({
+      version: 1,
+      setup: ['manifest-step-one', 'manifest-step-two'],
+      services: [{
+        name: 'app',
+        command: 'run-app',
+        port: { preferred: preferredPort, env: 'APP_PORT' },
+      }],
+    }, null, 2)}\n`);
+    execFileSync('git', ['add', 'README.md', '.gitignore', 'o8.workspace.json'], { cwd: repoPath });
+    execFileSync('git', [
+      '-c', 'user.email=test@o8.test',
+      '-c', 'user.name=o8-test',
+      'commit', '-qm', 'fixture',
+    ], { cwd: repoPath });
+    execFileSync('git', ['remote', 'add', 'origin', repoPath], { cwd: repoPath });
+
+    process.env.CORTEX_IDE_DATA_DIR = dataDir;
+    process.env.O8_DATA_DIR = dataDir;
+    process.env.O8_WORKTREE_ROOT = worktreeRoot;
+    process.env.O8_SKIP_PRELAUNCH_TYPECHECK = '1';
+    const { updateOperatorDefaults } = await import('@/lib/operator/defaults');
+    await updateOperatorDefaults({
+      productTelemetryEnabled: false,
+      storageReserveRatio: 0.0001,
+      storageReserveFloorGb: 0.001,
+      workspaceManifestPolicy: 'auto',
+    });
+  });
+
+  afterAll(async () => {
+    const { setWorkspaceManifestSetupTimeoutForTest } = await import(
+      '@/lib/workspace/manifest/apply'
+    );
+    setWorkspaceManifestSetupTimeoutForTest(null);
+    const { closeDb } = await import('@/lib/db');
+    closeDb();
+    for (const key of controlledEnvKeys) {
+      const prior = priorEnv[key];
+      if (prior === undefined) delete process.env[key];
+      else process.env[key] = prior;
+    }
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('persists a completed receipt with every setup command', async () => {
+    resetExecution('complete');
+    const { getLaneEvents } = await import('@/lib/lane/registry');
+    const { readWorkspaceManifestReceipt } = await import('@/lib/workspace/manifest');
+    const launch = await launchPacket({ packetId: 'packet-manifest-completed' });
+
+    const receipt = await readWorkspaceManifestReceipt(launch.prepared.cwd);
+    expect(receipt).toMatchObject({
+      packetId: 'packet-manifest-completed',
+      laneId: launch.lane.id,
+      state: 'completed',
+      ports: { app: preferredPort },
+    });
+    expect(receipt?.setup).toHaveLength(2);
+    expect(receipt?.setup.map((entry) => entry.index)).toEqual([0, 1]);
+    expect(receipt?.services).toHaveLength(1);
+    expect(getLaneEvents(launch.lane.id, 100).find(
+      (event) => event.verb === 'workspace_manifest_applied',
+    )?.payload).toMatchObject({ state: 'completed' });
+    expect(execFileSync('git', ['check-ignore', '.o8/workspace-manifest-receipt.json'], {
+      cwd: launch.prepared.cwd,
+      encoding: 'utf8',
+    }).trim()).toBe('.o8/workspace-manifest-receipt.json');
+
+    await terminalCleanup(launch.lane.id);
+  }, 90_000);
+
+  it('settles a timed-out setup step and releases its lease on terminal cleanup', async () => {
+    resetExecution('timeout');
+    const { getLaneEvents } = await import('@/lib/lane/registry');
+    const {
+      setWorkspaceManifestSetupTimeoutForTest,
+    } = await import('@/lib/workspace/manifest/apply');
+    const { readWorkspaceManifestReceipt } = await import('@/lib/workspace/manifest');
+    setWorkspaceManifestSetupTimeoutForTest(40);
+    const launch = await launchPacket({ packetId: 'packet-manifest-timeout' });
+    setWorkspaceManifestSetupTimeoutForTest(null);
+
+    const receipt = await readWorkspaceManifestReceipt(launch.prepared.cwd);
+    expect(receipt).toMatchObject({
+      state: 'timed_out',
+      step: 'setup:1',
+      commandId: expect.stringMatching(/^[a-f0-9]{64}$/),
+      error: expect.stringContaining('timed out after 40ms'),
+    });
+    expect(setupChild()?.killed).toBe(true);
+    expect(getLaneEvents(launch.lane.id, 100).find(
+      (event) => event.verb === 'workspace_manifest_failed',
+    )?.payload).toMatchObject({
+      state: 'timed_out',
+      step: 'setup:1',
+      commandId: receipt?.commandId,
+    });
+
+    await terminalCleanup(launch.lane.id);
+  }, 90_000);
+
+  it('aborts a blocked setup command and settles cancellation before releasing leases', async () => {
+    resetExecution('cancel');
+    const {
+      createLane,
+      getLane,
+      getLaneEvents,
+      setLaneStatus,
+      updateLane,
+    } = await import('@/lib/lane/registry');
+    const { prepareLaunchWorktree, getWorktreeManager } = await import('@/lib/worktree/launch');
+    const { readWorkspaceManifestReceipt } = await import('@/lib/workspace/manifest');
+    const packetId = 'packet-manifest-cancel';
+    const branch = 'issue/1910-lifecycle-cancel';
+    const lane = createLane({
+      repoPath,
+      branch,
+      baseBranch: 'main',
+      runtime: 'codex',
+      label: packetId,
+      packetId,
+    });
+    const launchPromise = prepareLaunchWorktree({
+      repoRoot: repoPath,
+      agentType: 'codex',
+      taskName: packetId,
+      branchName: branch,
+      baseBranch: 'main',
+      isolate: true,
+      skipSetup: true,
+      packetId,
+      laneId: lane.id,
+    });
+    let worktreePath = '';
+    await vi.waitFor(async () => {
+      const setupWorktree = (await getWorktreeManager(repoPath).list())
+        .find((worktree) => worktree.branch === branch && worktree.status === 'setup');
+      worktreePath = setupWorktree?.path ?? '';
+      expect((await readWorkspaceManifestReceipt(worktreePath))?.state).toBe('running');
+      expect((await readWorkspaceManifestReceipt(worktreePath))?.step).toBe('setup:1');
+    }, { timeout: 30_000 });
+
+    updateLane(lane.id, { worktreePath }, 'system');
+    setLaneStatus(lane.id, 'failed', 'system', 'cancel manifest setup');
+    const prepared = await launchPromise;
+    expect(prepared?.cwd).toBe(worktreePath);
+    expect(setupChild()?.killed).toBe(true);
+    expect(await readWorkspaceManifestReceipt(worktreePath)).toMatchObject({
+      state: 'cancelled',
+      step: 'setup:1',
+    });
+    expect(getLaneEvents(lane.id, 100).find(
+      (event) => event.verb === 'workspace_manifest_failed',
+    )?.payload).toMatchObject({ state: 'cancelled', step: 'setup:1' });
+    await waitForNoLaneLeases(lane.id);
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    expect(existsSync(worktreePath)).toBe(true);
+    expect(getLane(lane.id)?.worktreePath).toBe(worktreePath);
+    expect(getLaneEvents(lane.id, 100).some((event) => (
+      event.payload.phase === 'terminal_cleanup'
+      || event.payload.reason === 'terminal_worktree_cleanup'
+    ))).toBe(false);
+  }, 90_000);
+
+  it('settles a completed transition before removing its worktree', async () => {
+    resetExecution('cancel');
+    const {
+      createLane,
+      getLane,
+      getLaneEvents,
+      setLaneStatus,
+      updateLane,
+    } = await import('@/lib/lane/registry');
+    const { prepareLaunchWorktree, getWorktreeManager } = await import('@/lib/worktree/launch');
+    const { readWorkspaceManifestReceipt } = await import('@/lib/workspace/manifest');
+    const packetId = 'packet-manifest-completed-cleanup';
+    const branch = 'issue/1910-lifecycle-completed-cleanup';
+    const lane = createLane({
+      repoPath,
+      branch,
+      baseBranch: 'main',
+      runtime: 'codex',
+      label: packetId,
+      packetId,
+    });
+    const launchPromise = prepareLaunchWorktree({
+      repoRoot: repoPath,
+      agentType: 'codex',
+      taskName: packetId,
+      branchName: branch,
+      baseBranch: 'main',
+      isolate: true,
+      skipSetup: true,
+      packetId,
+      laneId: lane.id,
+    });
+    let worktreePath = '';
+    await vi.waitFor(async () => {
+      const setupWorktree = (await getWorktreeManager(repoPath).list())
+        .find((worktree) => worktree.branch === branch && worktree.status === 'setup');
+      worktreePath = setupWorktree?.path ?? '';
+      expect((await readWorkspaceManifestReceipt(worktreePath))?.state).toBe('running');
+      expect((await readWorkspaceManifestReceipt(worktreePath))?.step).toBe('setup:1');
+    }, { timeout: 30_000 });
+
+    updateLane(lane.id, { worktreePath }, 'system');
+    setLaneStatus(lane.id, 'completed', 'system', 'completed');
+    const prepared = await launchPromise;
+    expect(prepared?.cwd).toBe(worktreePath);
+    expect(setupChild()?.killed).toBe(true);
+    expect(getLaneEvents(lane.id, 100).find(
+      (event) => event.verb === 'workspace_manifest_failed',
+    )?.payload).toMatchObject({ state: 'cancelled', step: 'setup:1' });
+    await waitForNoLaneLeases(lane.id);
+    await vi.waitFor(() => {
+      expect(existsSync(worktreePath)).toBe(false);
+      expect(getLane(lane.id)?.worktreePath).toBeNull();
+      expect(getLaneEvents(lane.id, 100).some((event) => (
+        event.payload.phase === 'terminal_cleanup'
+        && event.payload.worktreeRemoved === true
+      ))).toBe(true);
+    }, { timeout: 30_000 });
+  }, 90_000);
+
+  it('rewrites a dead owner as crashed, releases stale leases, and starts a fresh attempt', async () => {
+    resetExecution('complete');
+    const { createLane, getLaneEvents } = await import('@/lib/lane/registry');
+    const {
+      allocateWorkspaceServicePorts,
+      readWorkspacePortLeases,
+    } = await import('@/lib/workspace/manifest/port-leases');
+    const { readWorkspaceManifestReceipt } = await import('@/lib/workspace/manifest');
+    const packetId = 'packet-manifest-crash';
+    const oldLane = createLane({
+      repoPath,
+      branch: 'issue/1910-lifecycle-crash-old',
+      baseBranch: 'main',
+      runtime: 'codex',
+      label: `${packetId}-old`,
+      packetId,
+    });
+    await allocateWorkspaceServicePorts({
+      packetId,
+      laneId: oldLane.id,
+      services: [{ name: 'app', preferred: preferredPort }],
+    });
+    execution.crashSeed = {
+      packetId,
+      laneId: oldLane.id,
+      manifestHash: createHash('sha256').update(readFileSync(manifestPath)).digest('hex'),
+      port: preferredPort,
+    };
+
+    const launch = await launchPacket({
+      packetId,
+      branch: 'issue/1910-lifecycle-crash-new',
+    });
+    expect(await readWorkspaceManifestReceipt(launch.prepared.cwd)).toMatchObject({
+      laneId: launch.lane.id,
+      state: 'completed',
+      ports: { app: preferredPort },
+    });
+    expect(await archivedReceipts(launch.prepared.cwd)).toContainEqual(expect.objectContaining({
+      laneId: oldLane.id,
+      state: 'crashed',
+    }));
+    expect(getLaneEvents(oldLane.id, 100).find(
+      (event) => event.verb === 'workspace_manifest_failed',
+    )?.payload).toMatchObject({ state: 'crashed', step: 'setup:1' });
+    const leases = Object.values(await readWorkspacePortLeases());
+    expect(leases.some((lease) => lease.laneId === oldLane.id)).toBe(false);
+    expect(leases.some((lease) => lease.laneId === launch.lane.id)).toBe(true);
+
+    await terminalCleanup(launch.lane.id);
+  }, 90_000);
+
+  it('archives a reset attempt and restores it beside the fresh receipt', async () => {
+    resetExecution('complete');
+    const { getLaneEvents } = await import('@/lib/lane/registry');
+    const { resetPacket } = await import('@/lib/orchestrator/operator-mission-service/reset');
+    const { getWorktreeManager, prepareLaunchWorktree } = await import('@/lib/worktree/launch');
+    const { createLane, updateLane } = await import('@/lib/lane/registry');
+    const { readWorkspaceManifestReceipt } = await import('@/lib/workspace/manifest');
+    const packetId = 'packet-manifest-reset';
+    const branch = 'issue/1910-lifecycle-reset';
+    const first = await launchPacket({ packetId, branch });
+    const firstReceipt = await readWorkspaceManifestReceipt(first.prepared.cwd);
+    expect(firstReceipt?.state).toBe('completed');
+
+    const reset = await resetPacket({ packetId, clearWorktree: true, reason: 'lifecycle proof' });
+    expect(reset.reset).toBe(true);
+    expect(reset.worktreePruned).toBe(true);
+    await waitForNoLaneLeases(first.lane.id);
+
+    resetExecution('block_once');
+    const { getPacketStorageAdmissionCoordinator } = await import(
+      '@/lib/orchestrator/storage-admission'
+    );
+    const { recordLaneEvent } = await import('@/lib/lane/events');
+    const storagePacket = {
+      id: packetId,
+      referenceLabel: packetId,
+      title: packetId,
+      summary: packetId,
+      workspaceTargetPath: repoPath,
+      branchTarget: branch,
+      runtime: 'codex',
+      dependencyLabels: [],
+      dependencyPacketIds: [],
+      queueState: 'queued',
+      releaseState: 'pending',
+      status: 'queued',
+      launchAttempts: 0,
+      storageAdmissionEpoch: 1,
+    } as OrchestratorPacket;
+    const admission = getPacketStorageAdmissionCoordinator();
+    const storageLease = await admission.reserveForLaunch(storagePacket);
+    const lane = createLane({
+      repoPath,
+      branch,
+      baseBranch: 'main',
+      runtime: 'codex',
+      label: `${packetId}-replacement`,
+      packetId,
+    });
+    const launchPromise = prepareLaunchWorktree({
+      repoRoot: repoPath,
+      agentType: 'codex',
+      taskName: packetId,
+      branchName: branch,
+      baseBranch: 'main',
+      isolate: true,
+      skipSetup: true,
+      packetId,
+      laneId: lane.id,
+      storageAdmissionReservationId: storageLease.reservation.reservationId,
+    });
+    let worktreePath = '';
+    let runningStartedAt = '';
+    await vi.waitFor(async () => {
+      const setupWorktree = (await getWorktreeManager(repoPath).list())
+        .find((worktree) => worktree.branch === branch && worktree.status === 'setup');
+      worktreePath = setupWorktree?.path ?? '';
+      const receipt = await readWorkspaceManifestReceipt(worktreePath);
+      expect(receipt?.state).toBe('running');
+      runningStartedAt = receipt?.startedAt ?? '';
+      expect(await archivedReceipts(worktreePath)).toContainEqual(expect.objectContaining({
+        laneId: first.lane.id,
+        state: 'completed',
+      }));
+      expect(setupChild()?.release).toBeTypeOf('function');
+    }, { timeout: 30_000 });
+
+    const blocked = setupChild();
+    expect(blocked?.release).toBeTypeOf('function');
+    blocked?.release?.();
+    const prepared = await launchPromise;
+    if (!prepared) throw new Error('Reset launch returned no worktree.');
+    await admission.commitAfterLaunch(storageLease);
+    recordLaneEvent(lane.id, 'update', 'orchestrator', {
+      storageAdmissionOwnerGeneration: storageLease.receipt.ownerGeneration,
+      storageAdmissionReservationId: storageLease.reservation.reservationId,
+    });
+    updateLane(lane.id, { worktreePath: prepared.cwd }, 'system');
+    expect(await readWorkspaceManifestReceipt(prepared.cwd)).toMatchObject({
+      laneId: lane.id,
+      state: 'completed',
+      startedAt: runningStartedAt,
+    });
+    expect(getLaneEvents(lane.id, 100).find(
+      (event) => event.verb === 'workspace_manifest_applied',
+    )?.payload).toMatchObject({ state: 'completed' });
+
+    await terminalCleanup(lane.id);
+  }, 120_000);
+});


### PR DESCRIPTION
Closes #1910. Refs #1725.

## What

Every workspace manifest run now settles into a defined terminal state with a persisted receipt, so a crash, timeout, cancel, or reset during setup leaves evidence and no stranded port leases.

- `src/lib/workspace/manifest/lifecycle.ts` — a per-packet receipt at `<worktree>/.o8/workspace-manifest-receipt.json` (`.o8/` is added to the managed worktree's git exclude): `{ version: 1, packetId, laneId, manifestHash, state, pid, startedAt, finishedAt?, step?, commandId?, ports, setup[], services[], error? }`, `state ∈ running | completed | failed | timed_out | cancelled | crashed`. Written atomically (tmp + rename, 0600) before the first setup command, after each command, and once more with the terminal state.
- **Timeout** — the setup runner's timeout settles `timed_out` with the step and command id; the lane event `workspace_manifest_failed` now carries `state`.
- **Cancel** — an `AbortSignal` threads through `runRepoSetupCommand` → `materializationAwareExecFile` (the child is killed on abort). When a lane reaches any terminal status while a receipt is `running`, the run is aborted and settled `cancelled`, then leases release. Manifest settlement is hooked on every lane-terminal status via `settleWorkspaceManifestOnTerminal`; **worktree removal keeps its original trigger** (`completed` / `archived`) — a failed lane keeps its worktree for rerun-with-feedback and forensics.
- **Crash** — the next `beginWorkspaceManifestRun` for the same worktree finds a `running` receipt owned by a pid that is gone (probed with `probeMetadataLockProcessIdentity`; a live or unverifiable owner refuses to start), rewrites it `crashed`, releases that attempt's leases, archives it, and starts fresh.
- **Reset / rerun** — `reset_packet`, the lane-fallback reset, and rerun-with-feedback archive the previous receipt (`workspace-manifest-receipt.<startedAt>.json`, last three kept; handed across a worktree clear through the data dir and restored beside the fresh receipt) and release its leases before the new attempt.
- `readWorkspaceManifestReceipt(worktreePath)` is exported from the manifest index; `workspace_manifest_applied` payloads carry `state: 'completed'`. `manager.ts` unchanged at 2,782 lines.

## Proof

`tests/workspace-manifest-lifecycle-real-path.test.ts` launches packets through the real `prepareLaunchWorktree` path (policy `auto`, setup command stubbed at the process boundary) and asserts the receipt file, lane event, and lease state for each terminal condition: completed (every setup command receipted); timed out (step recorded, lease released on terminal cleanup); cancelled (a blocked command is aborted when the lane goes terminal, receipt `cancelled`, leases released — and the failed lane's worktree still exists); completed (settles, then the worktree is removed as before); crashed (a hand-written `running` receipt with a dead pid is rewritten `crashed`, its leases released, the new attempt completes); reset (the real `resetPacket` archives the receipt, the next launch runs `running` → `completed` beside the archive).

## Gates

tsc · focused manifest + lane tests · lint ratchet (touched files carry zero warnings) · classification check · full suite green.
