### PR TITLE
chore: clear the no-unused-vars lint warnings

### DIFF
--- a/e2e/diag2.spec.ts
+++ b/e2e/diag2.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 
 test('diagnostic: click split button and trace', async ({ page }) => {
   await page.addInitScript(() => {

--- a/scripts/bundle-node.mjs
+++ b/scripts/bundle-node.mjs
@@ -13,7 +13,6 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import { pipeline } from 'stream/promises';
-import { createGunzip } from 'zlib';
 import { Readable } from 'stream';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/scripts/distill-commit.ts
+++ b/scripts/distill-commit.ts
@@ -26,7 +26,7 @@ import { readFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
-import { execFile, execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { buildCommitFactExtractionPromptV1 } from '../src/lib/prompts/v1/fact-extraction';
 
@@ -101,36 +101,6 @@ async function resolveCodexBin(): Promise<string | null> {
     }
   }
   return null;
-}
-
-/**
- * Extract the final assistant text from a codex `exec --json` stream. Codex
- * emits the reply as either `item.completed` with `item.type='agent_message'`
- * and `item.text` (codex-cli 0.130.0+), or `event_msg` with
- * `payload.type='agent_message'` and `payload.message` (legacy). Both shapes
- * accepted — mirrors the parser in src/lib/lane/codex-orchestrator-session.ts.
- */
-function extractResultText(output: string): string {
-  const lines = output.split('\n').filter(Boolean);
-  let last = '';
-  for (const line of lines) {
-    try {
-      const evt = JSON.parse(line) as Record<string, unknown>;
-      const item = evt.item as Record<string, unknown> | undefined;
-      if (evt.type === 'item.completed' && item?.type === 'agent_message' && typeof item.text === 'string') {
-        last = item.text;
-        continue;
-      }
-      const payload = evt.payload as Record<string, unknown> | undefined;
-      if (evt.type === 'event_msg' && payload?.type === 'agent_message' && typeof payload.message === 'string') {
-        last = payload.message;
-        continue;
-      }
-    } catch {
-      // not JSON / partial line
-    }
-  }
-  return last;
 }
 
 async function callCodexCli(codexBin: string, prompt: string): Promise<string> {

--- a/scripts/fable-succession-eval.mjs
+++ b/scripts/fable-succession-eval.mjs
@@ -23,7 +23,7 @@
  */
 
 import { execFileSync, spawn } from 'node:child_process';
-import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/scripts/smoke-warm-repl.ts
+++ b/scripts/smoke-warm-repl.ts
@@ -1,5 +1,5 @@
 /** Live smoke for the warm REPL pool — cold vs warm timing + streaming. */
-import { askClaudeWarm, prewarmClaudeRepl, resetWarmReplPool } from '../src/lib/claude-code/warm-repl-pool';
+import { askClaudeWarm, resetWarmReplPool } from '../src/lib/claude-code/warm-repl-pool';
 import { REPL_HEALTH_PROMPTS_V1 } from '../src/lib/prompts/v1/health';
 
 const BIN = process.env.CLAUDE_BIN || `${process.env.HOME}/.claude/local/claude`;

--- a/src/app/api/panel/timeline/route.ts
+++ b/src/app/api/panel/timeline/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { execSync } from 'child_process';
 import os from 'node:os';
 import { listRepos } from '@/lib/repos/registry';
@@ -272,47 +272,6 @@ async function collectTimelineMilestones(todayStart: Date, windowMinutes: number
     .slice(-12);
 }
 
-/** Classify chat-style JSONL messages */
-function classifyMessage(role: string, content: string, type: string): SegmentKind {
-  const lc = content.toLowerCase();
-
-  // Tool results are direct evidence of coding activity
-  if (role === 'toolResult' || role === 'tool') {
-    if (looksLikeRealError(content)) {
-      return 'error';
-    }
-    if (looksLikeTesting(content)) {
-      return 'testing';
-    }
-    // All other tool results = coding
-    return 'coding';
-  }
-
-  // Assistant messages with tool calls = coding
-  if (role === 'assistant') {
-    // Look for coding indicators in the message
-    if (lc.includes('commit') || lc.includes('shipped') || lc.includes('pushed') || lc.includes('git push') ||
-        lc.includes('let me fix') || lc.includes('let me build') || lc.includes('let me add') || lc.includes('let me create') ||
-        lc.includes('let me rewrite') || lc.includes('let me update') || lc.includes('now wire') || lc.includes('now add') ||
-        lc.includes('successfully replaced') || lc.includes('successfully wrote') || lc.includes('i need to check') ||
-        lc.includes('the fix is') || lc.includes('two fixes') || lc.includes('three things')) {
-      return 'coding';
-    }
-    // Short assistant messages between tool calls = still coding (narration)
-    if (content.length < 150) return 'coding';
-    // Longer messages = thinking/planning
-    return 'thinking';
-  }
-
-  // User messages = thinking (giving direction)
-  if (role === 'user') return 'thinking';
-
-  // Compaction / custom events
-  if (type === 'compaction') return 'idle';
-
-  return 'thinking';
-}
-
 /** Classify Claude Code JSONL messages — content blocks include tool_use / tool_result */
 function classifyClaudeCode(entry: any): SegmentKind {
   const type = entry.type || '';
@@ -487,7 +446,7 @@ function accumulateSegments(
   return segments;
 }
 
-export async function GET(req: NextRequest) {
+export async function GET() {
   try {
     const now = new Date();
     // True 24h rolling window: right edge = now, left edge = now − 24h.

--- a/src/app/api/panel/workspaces/route.ts
+++ b/src/app/api/panel/workspaces/route.ts
@@ -24,8 +24,6 @@ const branchCache = new Map<string, { branch: string; ts: number }>();
 const BRANCH_CACHE_TTL = 10_000;
 const diffCache = new Map<string, { data: { additions: number; deletions: number; changedFiles: number } | null; ts: number }>();
 const DIFF_CACHE_TTL = 30_000;
-const STALE_WORKSPACE_AGE_MS = 2 * 60 * 60 * 1000; // 2 hours
-
 interface PRData {
   number: number;
   title: string;
@@ -477,7 +475,7 @@ async function collectWorkspaceLifecycle() {
   };
 }
 
-export async function GET(req: Request) {
+export async function GET() {
   try {
     const result = await collectWorkspaceLifecycle();
     return NextResponse.json(result);

--- a/src/app/api/v2/proxy/cli/route.ts
+++ b/src/app/api/v2/proxy/cli/route.ts
@@ -49,13 +49,6 @@ function describeSilentExit(input: {
   return input.stderrTail.trim() ? `${head}\n${input.stderrTail.trim()}` : head;
 }
 
-/** Map CLI model id suffix to the --model flag value */
-const CLAUDE_MODEL_MAP: Record<string, string> = {
-  opus: 'opus',
-  sonnet: 'sonnet',
-  haiku: 'haiku',
-};
-
 const CODEX_MODEL_MAP: Record<string, string> = {
   'gpt-5.6-sol': 'gpt-5.6-sol',
   'gpt-5.6-terra': 'gpt-5.6-terra',
@@ -70,8 +63,6 @@ const GEMINI_MODEL_MAP: Record<string, string> = {
   'gemini-2.5-pro': 'gemini-2.5-pro',
   'gemini-2.5-flash': 'gemini-2.5-flash',
 };
-
-const VALID_EFFORTS = new Set<string>(['low', 'medium', 'high', 'max']);
 
 function extractModelKey(cliModelId: string): string {
   // cli:claude-code:opus → opus
@@ -112,7 +103,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'runtime, model, and messages are required' }, { status: 400 });
     }
 
-    const { runtime, model, messages, effort, repoPath } = body;
+    const { runtime, model, messages, repoPath } = body;
     const modelKey = extractModelKey(model);
     const prompt = buildPrompt(messages);
     if (!prompt) {

--- a/src/app/api/v2/proxy/llm/google-native-tools.ts
+++ b/src/app/api/v2/proxy/llm/google-native-tools.ts
@@ -372,7 +372,6 @@ export async function createGoogleToolResponseStream(options: GoogleStreamOption
   const encoder = new TextEncoder();
   let totalInputTokens = 0;
   let totalOutputTokens = 0;
-  let fullResponseText = '';
 
   const stream = new ReadableStream({
     async start(controller) {
@@ -400,7 +399,6 @@ export async function createGoogleToolResponseStream(options: GoogleStreamOption
               enqueue({ type: 'thinking', text: event.text });
               return;
             }
-            fullResponseText += event.text;
             enqueue({ type: 'content', text: event.text });
           });
 

--- a/src/app/point-overlay/page.tsx
+++ b/src/app/point-overlay/page.tsx
@@ -281,7 +281,7 @@ function Flight({ point, screenW, screenH }: { point: OverlayPoint; screenW: num
  * dot's glass+orange vocabulary, that "draw on" — the stroke reveals along its
  * own path, then the arrowhead/label settles. Coords arrive window-local (Rust
  * owns the screenshot→screen transform, same as points). */
-function DrawShape({ point, screenH }: { point: OverlayPoint; screenH: number }) {
+function DrawShape({ point }: { point: OverlayPoint; screenH: number }) {
   const [drawn, setDrawn] = useState(false);
   useEffect(() => {
     // Double-rAF so the dash-offset start commits before the transition runs.

--- a/src/app/preview/canvas-glass/dock.tsx
+++ b/src/app/preview/canvas-glass/dock.tsx
@@ -39,7 +39,6 @@ export function OrchestratorDock({
   entries,
   activeLane,
   activeLabel,
-  activeTone,
   onSelectLane,
   onSend,
   busy,
@@ -750,4 +749,3 @@ export function CanvasMarkdown({ text }: { text: string }) {
     </div>
   );
 }
-

--- a/src/app/preview/canvas-glass/tuner.tsx
+++ b/src/app/preview/canvas-glass/tuner.tsx
@@ -19,11 +19,9 @@ import {
   CANVAS_GLASS_MATERIALS,
   CANVAS_GLASS_PRESETS,
   CANVAS_GLASS_RANGES,
-  CANVAS_GLASS_TONES,
   canvasFreeLook,
   canvasFreeLookIdFor,
   CANVAS_FREE_LOOKS,
-  defaultTextShadeForTone,
   type CanvasGlassSettings,
 } from '@/lib/canvas-mode/glass-settings';
 import { FONT, glass } from './ui';

--- a/src/app/preview/effects/ascii-field.ts
+++ b/src/app/preview/effects/ascii-field.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, type MutableRefObject } from 'react';
+import { useEffect, type MutableRefObject } from 'react';
 
 // Shared ASCII-field engine. Handles the canvas, DPR, resize, RAF loop, cursor
 // tracking, and the density→glyph render. An effect only supplies an `update`

--- a/src/app/preview/motion/page.tsx
+++ b/src/app/preview/motion/page.tsx
@@ -1141,51 +1141,6 @@ function MockMissionCard() {
   );
 }
 
-function MockStatusBar() {
-  return (
-    <div
-      style={{
-        width: '100%',
-        maxWidth: 280,
-        display: 'flex',
-        alignItems: 'center',
-        gap: 10,
-        paddingTop: 5,
-        paddingBottom: 5,
-        paddingLeft: 12,
-        paddingRight: 10,
-        background: 'var(--t-panel, #ffffff)',
-        border: '1px solid var(--t-divider, #e5e7eb)',
-        borderRadius: 6,
-        fontFamily: FONT,
-      }}
-    >
-      <PulsingInfinityGlyph />
-      <span
-        style={{
-          fontSize: 11,
-          fontWeight: 300,
-          letterSpacing: '-0.1px',
-          color: 'var(--t-text-muted)',
-        }}
-      >
-        o8 v0.1.165
-      </span>
-      <span style={{ flex: 1 }} />
-      <span
-        style={{
-          fontSize: 9.5,
-          fontWeight: 260,
-          letterSpacing: '-0.4px',
-          color: 'var(--t-text-faint)',
-        }}
-      >
-        14 chats · 8 agents
-      </span>
-    </div>
-  );
-}
-
 // ── Pulse + ∞ variants ──────────────────────────────────────────────
 
 function O8DualPulse() {

--- a/src/app/voice-settings/tabs/AgentTab.tsx
+++ b/src/app/voice-settings/tabs/AgentTab.tsx
@@ -7,7 +7,7 @@
  * All toggles persist via voice_prefs_set.
  */
 import {
-  ICONS, TEXT_PRIMARY, TEXT_SECONDARY, TEXT_TERTIARY, GLASS_BORDER_SUBTLE, WARN_AMBER, SECTION_BG, SECTION_BORDER,
+  ICONS, TEXT_SECONDARY, GLASS_BORDER_SUBTLE, WARN_AMBER,
   INK_ON_GLASS_1, INK_ON_GLASS_3,
 } from '../tokens';
 import { SectionCard, SectionTitle, SectionHint, ToggleRow, Icon, PageHeader, ProPill } from '../primitives';

--- a/src/app/voice-settings/tabs/StatsTab.tsx
+++ b/src/app/voice-settings/tabs/StatsTab.tsx
@@ -10,7 +10,7 @@
 import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import { dictationHistoryGet, type DictationHistoryEntry } from '@/lib/tauri/bridge';
 import {
-  TEXT_PRIMARY, TEXT_SECONDARY, TEXT_TERTIARY, ACCENT_LIGHT, SECTION_BG, SECTION_BORDER,
+  TEXT_PRIMARY, TEXT_TERTIARY, ACCENT_LIGHT, SECTION_BG, SECTION_BORDER,
   INK_ON_GLASS_1, INK_ON_GLASS_2, INK_ON_GLASS_3,
 } from '../tokens';
 import { ICONS } from '../tokens';

--- a/src/components/NavigationBridge.tsx
+++ b/src/components/NavigationBridge.tsx
@@ -30,7 +30,7 @@ export default function NavigationBridge() {
       // to a full navigation as a safety net.
       try {
         router.push(path);
-      } catch (_err) {
+      } catch {
         window.location.assign(path);
       }
     };

--- a/src/components/desktop/AuditLogPanel.tsx
+++ b/src/components/desktop/AuditLogPanel.tsx
@@ -3,11 +3,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   AlertCircle,
-  CheckCircle2,
-  Clock,
   RefreshCw,
   ShieldCheck,
-  XCircle,
 } from './lucide-shims';
 import type { ApprovalAuditEvent, ApprovalRecord, ApprovalRisk, OrchestratorReviewFinding } from '@/lib/approvals/types';
 
@@ -211,21 +208,6 @@ function formatRelativeAge(timestamp: number) {
 
 function filterWindowForRange(range: TimeRangeOption) {
   return TIME_RANGE_WINDOWS[range];
-}
-
-function iconForEventType(type: ApprovalAuditEvent['type']) {
-  switch (type) {
-    case 'orchestrator_review':
-      return ShieldCheck;
-    case 'approved':
-    case 'resumed':
-      return CheckCircle2;
-    case 'rejected':
-    case 'resume_failed':
-      return XCircle;
-    default:
-      return Clock;
-  }
 }
 
 function formatFindingSeverity(severity: OrchestratorReviewFinding['severity']) {
@@ -830,7 +812,6 @@ export function AuditLogPanel() {
             {filteredTimeline.map((item, itemIndex) => {
               const eventTone = EVENT_TONES[item.type];
               const riskTone = RISK_TONES[item.risk];
-              const EventIcon = iconForEventType(item.type);
               const reviewVerdictTone = typeof item.approved === 'boolean'
                 ? item.approved
                   ? EVENT_TONES.approved

--- a/src/components/desktop/BlueGlassHoverCard.tsx
+++ b/src/components/desktop/BlueGlassHoverCard.tsx
@@ -49,7 +49,7 @@ export function BlueGlassHoverCard({
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
 }) {
-  const [inTauri, setInTauri] = useState(false);
+  const [, setInTauri] = useState(false);
   useEffect(() => { setInTauri(isTauri()); }, []);
 
   const content = (

--- a/src/components/desktop/ContextualPanel.tsx
+++ b/src/components/desktop/ContextualPanel.tsx
@@ -170,16 +170,6 @@ function PlusIcon({ size = 14 }: { size?: number }) {
   );
 }
 
-function SplitVerticalIcon({ size = 12 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
-      <path d="M12 4v16" />
-      <path d="M6 7v10" />
-      <path d="M18 7v10" />
-    </svg>
-  );
-}
-
 // ── Main Component ──
 
 interface BottomPanelSurface {
@@ -366,7 +356,6 @@ export const ContextualPanel = forwardRef<ContextualPanelHandle, ContextualPanel
       registeredRepos = [],
       previews = [],
       onRepoPathChange,
-      onSplitVertical,
       panelLabel = 'Bottom Panel',
       onClose,
     },

--- a/src/components/desktop/DesktopStatusBar.tsx
+++ b/src/components/desktop/DesktopStatusBar.tsx
@@ -64,7 +64,6 @@ function DesktopStatusBarBase({
   leftColumnWidth,
   rightColumnWidth,
   compact = false,
-  glassSurface = false,
   parkedLanes = [],
   onOpenReviewLane,
   onOpenAwaitingMerge,

--- a/src/components/desktop/LLMMarkdown.tsx
+++ b/src/components/desktop/LLMMarkdown.tsx
@@ -8,7 +8,7 @@
  * images, mermaid diagrams, horizontal rules, and strikethrough.
  */
 
-import React, { useState, useCallback, useEffect, useRef, useMemo, memo } from 'react';
+import React, { useState, useCallback, useEffect, useRef, memo } from 'react';
 import { Copy, Check, ChevronDown, ChevronRight, FileCode, PanelRight, Play } from './lucide-shims';
 import { DiffCard } from './DiffCard';
 import { sanitizeAgentHtml } from '@/lib/render/sanitize-html';

--- a/src/components/desktop/OrchestratorEmptyState.tsx
+++ b/src/components/desktop/OrchestratorEmptyState.tsx
@@ -16,7 +16,7 @@
  * first.
  */
 
-import { memo, useCallback, useEffect, useId, useMemo, useRef, useState, type ReactNode } from 'react';
+import { memo, useEffect, useId, useMemo, useRef, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import {
   Computer as IconoirComputer,

--- a/src/components/desktop/SessionTimeline.tsx
+++ b/src/components/desktop/SessionTimeline.tsx
@@ -39,7 +39,7 @@ import {
   timelinePrimarySession,
 } from './timeline/helpers';
 import { useTimelineData, useTimelineSessions } from './timeline/hooks';
-import { PlayIcon, ExpandIcon } from './timeline/icons';
+import { ExpandIcon } from './timeline/icons';
 import { TimelineButton } from './timeline/TimelineButton';
 import { TimelineEmptyState } from './timeline/TimelineEmptyState';
 

--- a/src/components/desktop/SessionVisualizer.tsx
+++ b/src/components/desktop/SessionVisualizer.tsx
@@ -47,13 +47,6 @@ export const STATUS_COLORS: Record<VisualStatus, string> = {
   error: '#ef4444',
 };
 
-const STATUS_LABELS: Record<VisualStatus, string> = {
-  running: 'Running',
-  waiting: 'Waiting',
-  idle: 'Idle',
-  error: 'Error',
-};
-
 export function classifyStatus(rawStatus: string | undefined): VisualStatus {
   const value = (rawStatus ?? '').toLowerCase();
   if (value.includes('error') || value.includes('fail')) return 'error';

--- a/src/components/desktop/agent-panel/shared.tsx
+++ b/src/components/desktop/agent-panel/shared.tsx
@@ -325,7 +325,6 @@ export function SidebarSection({
 export function ActivityDock({
   title,
   count,
-  summary,
   open,
   onToggle,
   children,

--- a/src/components/desktop/canvas/TimelineExpanded.tsx
+++ b/src/components/desktop/canvas/TimelineExpanded.tsx
@@ -8,8 +8,6 @@ import { formatAge } from '@/components/desktop/canvas-utils';
 import { ORCHESTRATOR_RUNTIMES } from '@/lib/orchestrator/runtime-capabilities';
 type ReplaySegment = { kind: string; startMin: number; durationMin: number; label?: string; agent?: string };
 const THEME_ACCENT = 'var(--t-accent, #2563eb)';
-const THEME_ACCENT_SOFT = 'var(--t-accent-soft, rgba(37, 99, 235, 0.08))';
-const THEME_ACCENT_BORDER = 'var(--t-accent-border, rgba(37, 99, 235, 0.22))';
 const REPLAY_CARD_BACKGROUND = 'linear-gradient(180deg, var(--t-panel-translucent) 0%, var(--t-bg-card, rgba(148, 163, 184, 0.08)) 100%)';
 function sessionReplayRuntimePalette(runtime?: string) {
   switch (runtime) {
@@ -256,11 +254,6 @@ export function TimelineExpanded() {
   const sectionPadding = isCompact ? 14 : isTight ? 16 : 20;
   const sectionRadius = isCompact ? 16 : 18;
   const titleSize = isCompact ? 18 : 20;
-  const introSize = isCompact ? 11 : 12;
-  const metricPillPaddingTop = isCompact ? 5 : 6;
-  const metricPillPaddingRight = isCompact ? 8 : 10;
-  const metricPillPaddingBottom = isCompact ? 5 : 6;
-  const metricPillPaddingLeft = isCompact ? 8 : 10;
   const summaryBarHeight = isCompact ? 32 : 40;
   const contentColumns = isTight ? '1fr' : '1.15fr 0.85fr';
 

--- a/src/components/desktop/llm-chat/ModelPicker.tsx
+++ b/src/components/desktop/llm-chat/ModelPicker.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useRef, useState } from 'react';
 import { Check, ChevronDown } from '../lucide-shims';
 import { createPortal } from 'react-dom';
 
-import { THEME_ACCENT, THEME_ACCENT_SOFT, THEME_PANEL_GLASS, type ModelOption } from './shared';
+import { THEME_ACCENT, THEME_ACCENT_SOFT, type ModelOption } from './shared';
 
 const RUNTIME_META: Record<string, { label: string; logo?: string; color: string }> = {
   'claude-code': { label: 'Claude Code', logo: '/logos/claude.png', color: '#e07a3a' },

--- a/src/components/desktop/o8-panel/O8HeaderTabs.tsx
+++ b/src/components/desktop/o8-panel/O8HeaderTabs.tsx
@@ -17,15 +17,6 @@ function IconWorkspace({ size = 16, color = 'currentColor' }: { size?: number; c
   );
 }
 
-function IconFiles({ size = 16, color = 'currentColor' }: { size?: number; color?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', width: size, height: size, minWidth: size, minHeight: size, flexShrink: 0 }}>
-      <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
-      <polyline points="14 2 14 8 20 8" />
-    </svg>
-  );
-}
-
 function IconActivity({ size = 16, color = 'currentColor' }: { size?: number; color?: string }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', width: size, height: size, minWidth: size, minHeight: size, flexShrink: 0 }}>

--- a/src/components/desktop/o8-panel/workspace-rail/ChangesList.tsx
+++ b/src/components/desktop/o8-panel/workspace-rail/ChangesList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react';
 import {
   File,
   FileCode,

--- a/src/components/desktop/orchestrator/QuickActionPalette.tsx
+++ b/src/components/desktop/orchestrator/QuickActionPalette.tsx
@@ -20,7 +20,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
-import { QUICK_ACTIONS, filterQuickActions, type QuickAction } from '@/lib/orchestrator/quick-actions';
+import { filterQuickActions, type QuickAction } from '@/lib/orchestrator/quick-actions';
 
 interface QuickActionPaletteProps {
   open: boolean;

--- a/src/components/desktop/pr-viewer/usePRData.ts
+++ b/src/components/desktop/pr-viewer/usePRData.ts
@@ -3,9 +3,7 @@ import type { AgentPanelChatInjectionPayload } from '@/lib/chat/injection';
 import { openExternalUrl } from '@/lib/desktop/open-external';
 import {
   formatCiCheckInjection,
-  formatCiCheckBatchInjection,
   formatReviewCommentInjection,
-  formatReviewCommentBatchInjection,
   formatReviewThreadInjection,
 } from '@/lib/chat/injection';
 import type { RepoRegistryEntry } from '@/lib/repos/types';

--- a/src/components/desktop/repo-registry/RepoBranchRow.tsx
+++ b/src/components/desktop/repo-registry/RepoBranchRow.tsx
@@ -13,8 +13,6 @@ import {
   THEME_ACCENT_BORDER,
   THEME_ACCENT_SOFT,
   THEME_SUCCESS_TEXT,
-  THEME_WORKTREE_BORDER,
-  THEME_WORKTREE_SOFT,
   THEME_WORKTREE_TEXT,
   Trash2,
   branchSessionLabel,
@@ -128,8 +126,6 @@ function RepoBranchRowBase({
   branchAgents,
   orchestratorPackets,
   allPacketBoundSessionKeys,
-  sessionDisclosureByBranch,
-  setSessionDisclosureByBranch,
   worktree,
   activeSessionKey = null,
   activeWorkspacePath = null,
@@ -253,7 +249,6 @@ function RepoBranchRowBase({
       return true;
     })
     .sort(compareBranchAgents);
-  const sessionsExpanded = sessionDisclosureByBranch[branch.name] ?? true;
   const isActiveWorktree = Boolean(activeWorkspacePath && worktree?.path === activeWorkspacePath);
   const isActiveRootBranch = Boolean(!branch.isWorktree && branch.current && activeWorkspacePath === repo.localPath);
   const isActiveScope = isActiveWorktree || isActiveRootBranch;
@@ -266,11 +261,6 @@ function RepoBranchRowBase({
     && branch.name !== repo.defaultBranch
     && branch.ahead > 0,
   );
-  const branchAgentLabel = branchAgents.length === 1
-    ? branchAgents[0]?.name ?? null
-    : branchAgents.length > 1
-      ? `${branchAgents.length} agents`
-      : null;
   const branchDiffAgent = branchAgents.find((agent) => ((agent.additions ?? 0) > 0 || (agent.deletions ?? 0) > 0)) ?? null;
   const branchBaseBackground = isActiveScope ? 'rgba(37, 99, 235, 0.08)' : 'transparent';
   const branchHoverBackground = 'var(--t-panel-hover)';

--- a/src/components/desktop/repo-registry/RepoCardHeader.tsx
+++ b/src/components/desktop/repo-registry/RepoCardHeader.tsx
@@ -41,11 +41,6 @@ interface RepoCardHeaderProps {
 function RepoCardHeaderBase({
   repo,
   agentsByBranch,
-  // activePorts, onSelectPR, and onReviewPR are intentionally unused here —
-  // the new repo hover no longer surfaces port pills or PR action buttons.
-  // We keep them on the prop type so parent components can pass them without
-  // churn when the card body is extended later.
-  activePorts: _activePorts,
   isActive,
   expanded = false,
   activeWorkspacePath = null,
@@ -53,8 +48,6 @@ function RepoCardHeaderBase({
   onSelectRepo,
   onLocate,
   onRemove,
-  onSelectPR: _onSelectPR,
-  onReviewPR: _onReviewPR,
   model,
 }: RepoCardHeaderProps) {
   const {

--- a/src/components/desktop/shell/SidebarTogglePill.tsx
+++ b/src/components/desktop/shell/SidebarTogglePill.tsx
@@ -43,8 +43,7 @@ interface SidebarTogglePillProps {
   onHoverLeave?: () => void;
 }
 
-export function SidebarTogglePill({ sidebarVisible = true, onClick, yNudge = 3.3, onHoverEnter, onHoverLeave }: SidebarTogglePillProps) {
-  const active = sidebarVisible;
+export function SidebarTogglePill({ onClick, yNudge = 3.3, onHoverEnter, onHoverLeave }: SidebarTogglePillProps) {
   return (
     <motion.button
       type="button"

--- a/src/components/desktop/shell/WorkspaceHeaderStrip.tsx
+++ b/src/components/desktop/shell/WorkspaceHeaderStrip.tsx
@@ -10,7 +10,7 @@
  * the dashboard gate compact mode / sidebar-collapsed state from the call site.
  */
 
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ColumnHeaderStrip } from './ColumnHeaderStrip';
 import { SidebarTogglePill } from './SidebarTogglePill';
@@ -50,7 +50,6 @@ export function WorkspaceHeaderStrip({
   onToggleSidebar,
   onSidebarHoverEnter,
   onSidebarHoverLeave,
-  bottomPanelVisible = true,
   onToggleBottomPanel,
   onSplitWorkspacePanel,
   rightPanelOpen = false,
@@ -63,14 +62,10 @@ export function WorkspaceHeaderStrip({
   terminalModeActive = false,
   headerActiveTabId,
   finishedTabCount = 0,
-  projectContextRailAvailable = false,
-  projectContextRailVisible = true,
-  onToggleProjectContextRail,
   splitHeaderWorkspaces,
 }: WorkspaceHeaderStripProps) {
   const showRightPanelFallbackToggle = !rightPanelOpen && Boolean(onToggleRightPanel);
   const showApprovalBadge = approvalCount > 0 && Boolean(onOpenInbox);
-  const showProjectContextToggle = projectContextRailAvailable && Boolean(onToggleProjectContextRail);
   const tabs = headerTabs ?? [];
   const isSplit = Boolean(splitHeaderWorkspaces && splitHeaderWorkspaces.length >= 2);
   // Split mode → side-by-side pill strips. Single 2+ tabs → pill strip.

--- a/src/components/desktop/workspace-terminal/OrchestratorTab.tsx
+++ b/src/components/desktop/workspace-terminal/OrchestratorTab.tsx
@@ -12,7 +12,7 @@
  * workspace shell does not prop-drill mission, agent, or packet state.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLaneArchivedView } from '@/app/dashboard/hooks/useLaneArchivedSet';
 import { ComparisonPicker } from '@/components/desktop/ComparisonPicker';
 import { useComparisonGroups } from '@/components/desktop/comparison/useComparisonGroups';
@@ -165,96 +165,6 @@ function persistCollide(tabId: string, enabled: boolean): void {
   } catch {
     // ignore
   }
-}
-
-const USERS_THREE_ICON_PATH = 'M244.8,150.4a8,8,0,0,1-11.2-1.6A51.6,51.6,0,0,0,192,128a8,8,0,0,1-7.37-4.89,8,8,0,0,1,0-6.22A8,8,0,0,1,192,112a24,24,0,1,0-23.24-30,8,8,0,1,1-15.5-4A40,40,0,1,1,219,117.51a67.94,67.94,0,0,1,27.43,21.68A8,8,0,0,1,244.8,150.4ZM190.92,212a8,8,0,1,1-13.84,8,57,57,0,0,0-98.16,0,8,8,0,1,1-13.84-8,72.06,72.06,0,0,1,33.74-29.92,48,48,0,1,1,58.36,0A72.06,72.06,0,0,1,190.92,212ZM128,176a32,32,0,1,0-32-32A32,32,0,0,0,128,176ZM72,120a8,8,0,0,0-8-8A24,24,0,1,1,87.24,82a8,8,0,1,0,15.5-4A40,40,0,1,0,37,117.51,67.94,67.94,0,0,0,9.6,139.19a8,8,0,1,0,12.8,9.61A51.6,51.6,0,0,1,64,128,8,8,0,0,0,72,120Z';
-
-function HeaderToggleButton({
-  active,
-  label,
-  title,
-  onClick,
-  children,
-}: {
-  active: boolean;
-  label: string;
-  title: string;
-  onClick: () => void;
-  children: ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={title}
-      style={{
-        height: 28,
-        paddingTop: 0,
-        paddingRight: 10,
-        paddingBottom: 0,
-        paddingLeft: 10,
-        borderRadius: 8,
-        borderWidth: 1,
-        borderStyle: 'solid',
-        borderColor: active ? 'var(--t-accent-border)' : 'var(--t-border)',
-        background: active ? 'var(--t-accent-soft)' : 'transparent',
-        color: active ? 'var(--t-accent)' : 'var(--t-text-muted)',
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 6,
-        cursor: 'pointer',
-        flexShrink: 0,
-        fontSize: 11.5,
-        fontWeight: 500,
-        letterSpacing: '-0.005em',
-        transition: 'background 180ms cubic-bezier(0.22, 1, 0.36, 1), border-color 180ms cubic-bezier(0.22, 1, 0.36, 1), color 180ms cubic-bezier(0.22, 1, 0.36, 1)',
-        fontFamily: 'var(--font-sans-system)',
-      }}
-      onMouseEnter={(event) => {
-        if (active) return;
-        event.currentTarget.style.background = 'var(--t-bg-card)';
-        event.currentTarget.style.borderColor = 'var(--t-border)';
-        event.currentTarget.style.color = 'var(--t-text)';
-      }}
-      onMouseLeave={(event) => {
-        if (active) return;
-        event.currentTarget.style.background = 'transparent';
-        event.currentTarget.style.borderColor = 'var(--t-border)';
-        event.currentTarget.style.color = 'var(--t-text-secondary)';
-      }}
-    >
-      {children}
-      <span>{label}</span>
-    </button>
-  );
-}
-
-function ClockIcon({ size = 14 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.1" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }} aria-hidden="true">
-      <circle cx="12" cy="12" r="9" />
-      <path d="M12 7v5l3 2" />
-    </svg>
-  );
-}
-
-function RocketIcon({ size = 14 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.1" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }} aria-hidden="true">
-      <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z" />
-      <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z" />
-      <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0" />
-      <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5" />
-    </svg>
-  );
-}
-
-function UsersThreeIcon({ size = 14 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 256 256" aria-hidden="true" style={{ display: 'block', flexShrink: 0 }}>
-      <path d={USERS_THREE_ICON_PATH} fill="currentColor" />
-    </svg>
-  );
 }
 
 export function OrchestratorTab(props: OrchestratorTabProps) {
@@ -1115,8 +1025,6 @@ function OrchestratorTabInner({
   const emptyOrShimmerNode = isRestoringThread
     ? (showRestoreLoader ? restoringShimmerNode : <></>)
     : emptyStateNode;
-
-  const hasMessages = chatChromeState.hasMessages;
 
   // The glass top-glow lives on the TAB ROOT (below), not the chat body:
   // when it sat on the body, the run strip / comparison row above rendered

--- a/src/components/desktop/workspace-terminal/WorkspaceTerminalRoot.tsx
+++ b/src/components/desktop/workspace-terminal/WorkspaceTerminalRoot.tsx
@@ -2,7 +2,6 @@
 
 
 import { forwardRef, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
-import { motion } from 'framer-motion';
 // RotateCcw shim removed with the in-workspace reconnect banner —
 // recovery now lives in the AgentPanel ConnectionPill.
 import { PreviewPane } from '@/components/desktop/workspace-terminal/PreviewPane';

--- a/src/components/mobile/ComposeBar.tsx
+++ b/src/components/mobile/ComposeBar.tsx
@@ -84,7 +84,6 @@ function CloseIcon({ size = 14, strokeWidth = 2.2 }: { size?: number; strokeWidt
 export const ComposeBar = memo(function ComposeBar(props: ComposeBarProps) {
   const { colors } = useTheme();
   const {
-    session,
     sessionKey,
     draft,
     attachments,
@@ -97,7 +96,6 @@ export const ComposeBar = memo(function ComposeBar(props: ComposeBarProps) {
     ownedReviewDisposition,
     ownedQueuedTurn,
     actionNote,
-    agentDisplayName,
     composeRef,
     fileInputRef,
     handlers,
@@ -296,13 +294,6 @@ export const ComposeBar = memo(function ComposeBar(props: ComposeBarProps) {
     fontFamily: SYSTEM_FONT,
     fontSize: 13,
     lineHeight: '18px',
-  };
-
-  const handleCommandShortcut = () => {
-    if (!draft.trim()) {
-      handlers.onDraftChange('/');
-    }
-    composeRef.current?.focus();
   };
 
   const renderSlashSuggestions = () => (

--- a/src/components/mobile/ContextMenu.tsx
+++ b/src/components/mobile/ContextMenu.tsx
@@ -6,7 +6,7 @@
  * Used on agent cards, notifications, PR cards.
  */
 
-import { useState, useEffect, useRef, memo, useCallback } from 'react';
+import { useEffect, useRef, memo, useCallback } from 'react';
 import { triggerHaptic } from '@/lib/mobile/haptic';
 
 export interface ContextMenuItem {

--- a/src/lib/claude-code/interactive-session.ts
+++ b/src/lib/claude-code/interactive-session.ts
@@ -4,7 +4,7 @@ import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import type { ChildProcessWithoutNullStreams } from 'node:child_process';
 import { homedir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 import {
   createClaudeCodeStreamJsonParser,
 } from './stream-json-parser';

--- a/src/lib/claude-code/one-shot-repl.ts
+++ b/src/lib/claude-code/one-shot-repl.ts
@@ -28,8 +28,6 @@ import 'server-only';
 import { resolveClaudeBinary } from '@/lib/runtimes/shared/cli-locate';
 
 import { spawn } from 'node:child_process';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
 import os from 'node:os';
 
 import {

--- a/src/lib/cortex/qa/contradictions.ts
+++ b/src/lib/cortex/qa/contradictions.ts
@@ -73,8 +73,6 @@ function buildCandidatePairs(rows: TypedRow[]): CandidatePair[] {
       const oOutcome = typeof oFields.outcome === 'string' ? oFields.outcome : '';
       const oSummary = typeof oFields.summary === 'string' ? oFields.summary : '';
       const oPlanText = typeof oFields.planText === 'string' ? oFields.planText : '';
-      const oPrNumber = typeof oFields.prNumber === 'number' ? oFields.prNumber : undefined;
-
       // Scope filter: directive must be scoped to the same repo as the outcome,
       // OR have no scope (global directive — applies everywhere).
       if (dScope && oRepoPath && !oRepoPath.includes(dScope) && !dScope.includes(oRepoPath)) {

--- a/src/lib/db/sessions.ts
+++ b/src/lib/db/sessions.ts
@@ -6,7 +6,7 @@
  * Middleware checks session exists before accepting a JWT.
  */
 
-import { eq, and, lt } from 'drizzle-orm';
+import { eq, lt } from 'drizzle-orm';
 import { getDb, sessions } from './index';
 import { randomUUID } from 'node:crypto';
 import { createHash } from 'node:crypto';

--- a/src/lib/github-app.ts
+++ b/src/lib/github-app.ts
@@ -6,7 +6,6 @@
  */
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
 import { createSign } from 'crypto';
 import { getDataDir } from '@/lib/data-dir-migration';
 

--- a/src/lib/lane/resource-attribution.ts
+++ b/src/lib/lane/resource-attribution.ts
@@ -18,7 +18,6 @@
 
 import { execFile } from 'node:child_process';
 import os from 'node:os';
-import path from 'node:path';
 import { promisify } from 'node:util';
 import { listActiveOrchestratorTurns } from '@/lib/lane/orchestrator-crash-survival';
 import { listActiveLanesWithSessions } from '@/lib/lane/registry';

--- a/src/lib/llm/mobile-chat-session.ts
+++ b/src/lib/llm/mobile-chat-session.ts
@@ -7,8 +7,6 @@ import {
 import { MODEL_IDS } from '@/lib/models';
 import { readIdeSurfaceState } from '@/lib/runtime/ide-surface-state';
 
-const DEFAULT_MOBILE_GEMINI_MODEL = MODEL_IDS.mobileGeminiDefault;
-const DEFAULT_MOBILE_OPENAI_MODEL = MODEL_IDS.mobileOpenAiDefault;
 const DEFAULT_MOBILE_CLI_MODEL = MODEL_IDS.mobileCliDefault;
 const DEFAULT_MOBILE_CHAT_TITLE = 'Assistant';
 

--- a/src/lib/llm/personalized-chat-ftux.ts
+++ b/src/lib/llm/personalized-chat-ftux.ts
@@ -13,11 +13,6 @@ const FTUX_CACHE_TTL_MS = 20_000;
 
 type PromptIconKey = 'tree' | 'search' | 'file' | 'diff' | 'rocket';
 
-interface TopicMatcher {
-  label: string;
-  patterns: RegExp[];
-}
-
 interface BaseRepoContext {
   name: string;
   localPath: string;
@@ -59,22 +54,6 @@ export interface PersonalizedChatFtuxPayload {
   profile: PersonalizedChatFtuxProfile;
   systemContext: string;
 }
-
-const TOPIC_MATCHERS: TopicMatcher[] = [
-  { label: 'React', patterns: [/\breact\b/i] },
-  { label: 'Next.js', patterns: [/\bnext(?:\.js)?\b/i, /\bapp router\b/i] },
-  { label: 'TypeScript', patterns: [/\btypescript\b/i, /\btype-safe\b/i] },
-  { label: 'Python', patterns: [/\bpython\b/i] },
-  { label: 'Go', patterns: [/\bgolang\b/i, /\bgo\.mod\b/i, /\bgo install\b/i] },
-  { label: 'Rust', patterns: [/\brust\b/i, /\bcargo\b/i] },
-  { label: 'Auth systems', patterns: [/\bauth(?:entication|orization)?\b/i, /\boauth\b/i, /\bsession\b/i, /\blogin\b/i] },
-  { label: 'UI systems', patterns: [/\bfrontend\b/i, /\bui\b/i, /\bux\b/i, /\bdesign system\b/i] },
-  { label: 'GitHub workflows', patterns: [/\bgithub\b/i, /\bpull request\b/i, /\bissue(?:s)?\b/i, /\bactions\b/i] },
-  { label: 'APIs', patterns: [/\bgraphql\b/i, /\brest\b/i, /\bapi(?:s)?\b/i, /\bendpoint(?:s)?\b/i] },
-  { label: 'Performance', patterns: [/\bperformance\b/i, /\boptimi(?:s|z)/i, /\blatency\b/i] },
-  { label: 'Testing', patterns: [/\btest(?:s|ing)?\b/i, /\bplaywright\b/i, /\bjest\b/i, /\bcypress\b/i] },
-  { label: 'Mobile', patterns: [/\bmobile\b/i, /\bios\b/i, /\bandroid\b/i] },
-];
 
 const RUNTIME_BINARIES = [
   { bin: 'codex', label: 'Codex' },
@@ -160,28 +139,6 @@ function resolveHeadline(name: string | null, now: Date) {
   const salutation = salutationForDate(now);
   const shortName = greetingName(name);
   return shortName ? `${salutation}, ${shortName}.` : `${salutation}.`;
-}
-
-function scoreTopics(corpus: string[]) {
-  const scores = new Map<string, number>();
-
-  for (const text of corpus) {
-    for (const matcher of TOPIC_MATCHERS) {
-      const hits = matcher.patterns.reduce((count, pattern) => (
-        count + (pattern.test(text) ? 1 : 0)
-      ), 0);
-      if (hits === 0) continue;
-      scores.set(matcher.label, (scores.get(matcher.label) ?? 0) + hits);
-    }
-  }
-
-  return [...scores.entries()]
-    .sort((left, right) => {
-      if (right[1] !== left[1]) return right[1] - left[1];
-      return left[0].localeCompare(right[0]);
-    })
-    .map(([label]) => label)
-    .slice(0, 3);
 }
 
 async function inferTopicsFromCortex() {

--- a/src/lib/pretext/hooks.ts
+++ b/src/lib/pretext/hooks.ts
@@ -12,9 +12,6 @@ import {
   measureHeight,
   measureLayout,
   getLines,
-  prepareText,
-  prepareTextWithSegments,
-  FONTS,
   LINE_HEIGHTS,
   type FontKey,
   type LayoutResult,
@@ -172,10 +169,6 @@ export function usePretextTruncation(
 
     const result = getLines(text, font, maxWidth, lineHeight);
     if (result.lines.length <= maxLines) return { truncated: text, isTruncated: false };
-
-    // Get the text up to the end of the last visible line
-    const lastLine = result.lines[maxLines - 1];
-    const truncatedText = lastLine.text;
 
     // Build the full truncated string from all visible lines
     const visibleText = result.lines

--- a/src/lib/skeleton/index.ts
+++ b/src/lib/skeleton/index.ts
@@ -8,7 +8,7 @@ import { basename } from 'node:path';
 import { hashFile } from './parser';
 import { parseFile } from './parser';
 import { renderSkeleton } from './renderer';
-import { getAllCached, getChunkStats, isCacheValid, isChunkCacheValid, pruneStale, pruneStaleChunks, upsert, upsertBatch, upsertChunks } from './store';
+import { getAllCached, getChunkStats, isCacheValid, isChunkCacheValid, pruneStale, pruneStaleChunks, upsertBatch, upsertChunks } from './store';
 import { walkRepo } from './walker';
 import type { FileSkeleton, RenderOptions, RenderedSkeleton, ScanOptions, SkeletonMap } from './types';
 
@@ -94,10 +94,9 @@ export async function scanRepo(options: ScanOptions): Promise<SkeletonMap> {
   }
 
   // Chunk uncached TS/TSX files (bodies — TS Compiler API)
-  let chunkedCount = 0;
   if (enableChunks && toChunk.length > 0) {
     try {
-      const { chunkFileAsync } = await import('./chunker');
+      await import('./chunker');
       // Warmup TS compiler on first chunk
       if (toChunk.length > 0) {
         const { warmup } = await import('./chunker');
@@ -110,7 +109,6 @@ export async function scanRepo(options: ScanOptions): Promise<SkeletonMap> {
           const fileChunks = chunkFile(wf.absolutePath, wf.relativePath, wf.language);
           if (fileChunks && fileChunks.chunks.length > 0) {
             upsertChunks(repoPath, fileChunks);
-            chunkedCount++;
           }
         } catch (err) {
           console.warn(`[skeleton] Failed to chunk ${wf.relativePath}:`, err);

--- a/src/lib/skeleton/parser.ts
+++ b/src/lib/skeleton/parser.ts
@@ -82,7 +82,7 @@ function truncateSignature(line: string): string {
   return sig;
 }
 
-function parseTypeScript(content: string, relativePath: string): { symbols: SkeletonSymbol[]; imports: string[] } {
+function parseTypeScript(content: string): { symbols: SkeletonSymbol[]; imports: string[] } {
   const lines = content.split('\n');
   const symbols: SkeletonSymbol[] = [];
   const imports: string[] = [];
@@ -303,7 +303,7 @@ export function parseFile(absolutePath: string, relativePath: string, language: 
   switch (language) {
     case 'typescript':
     case 'tsx':
-      result = parseTypeScript(content, relativePath);
+      result = parseTypeScript(content);
       break;
     case 'rust':
       result = parseRust(content);

--- a/src/lib/skeleton/walker.ts
+++ b/src/lib/skeleton/walker.ts
@@ -7,7 +7,7 @@
 
 import { execSync } from 'node:child_process';
 import { statSync } from 'node:fs';
-import { join, extname, basename } from 'node:path';
+import { join, extname } from 'node:path';
 import type { ScanOptions, SupportedLanguage } from './types';
 
 export interface WalkedFile {

--- a/src/lib/supervisor/agent-supervisor.ts
+++ b/src/lib/supervisor/agent-supervisor.ts
@@ -1108,10 +1108,6 @@ function applyTranscriptStatusSnapshot(
   watched.lastTranscriptMtimeMs = transcriptStatus.mtimeMs;
 }
 
-function dedupeStrings(values: string[]): string[] {
-  return [...new Set(values.filter(Boolean))];
-}
-
 // ── Helpers ──
 
 function formatDuration(seconds: number): string {

--- a/tests/managed-github-app.test.ts
+++ b/tests/managed-github-app.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 

--- a/tests/opencode-standalone-resume.test.ts
+++ b/tests/opencode-standalone-resume.test.ts
@@ -23,7 +23,6 @@
  */
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';

--- a/tests/voice-narration-bridge.test.ts
+++ b/tests/voice-narration-bridge.test.ts
@@ -16,7 +16,7 @@ import { mkdtempSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import { join } from 'node:path';
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { NextRequest } from 'next/server';
 
 const WS_TOKEN = 'vitest-voice-narration-token-0123456789';


### PR DESCRIPTION
Closes #1896. Refs #1670.

## What

Clears the `@typescript-eslint/no-unused-vars` warnings that can be removed without changing shape, arity, or behaviour. The lint ratchet (`--max-warnings 300`) was sitting at 299, so every feature had to land with zero new warnings; this buys 95 of headroom.

| Rule | Before | After |
|---|---:|---:|
| Total warnings | 299 | 204 |
| `@typescript-eslint/no-unused-vars` | 123 | 28 |
| every other rule | unchanged | unchanged |

- 56 files, 33 insertions, 414 deletions. Dead imports and locals removed; unused destructured values become array holes (`const [, setInTauri] = …`); unused request params dropped from two route handlers and one prop from a component signature (no caller passed it — tsc is the proof); dynamic imports kept for their side effects (`await import('./chunker')`).
- Whole unused private helpers removed where nothing referenced them: a JSON-lines result parser in `scripts/distill-commit.ts`, a role→phase classifier in the timeline route, a topic scorer in the chat FTUX, a mock status bar in the motion preview, and three icon components plus a header toggle left in `OrchestratorTab.tsx` from the retired NavRail launchers. Each name was referenced only in its own file.
- No `eslint-disable` comments added; no restructuring; no test edits beyond removing unused imports.

## Left in place (28)

The ESLint config has no `_`-prefix ignore pattern, so these stay: 13 object-rest omission bindings (`const { secret, ...rest } = row` shapes in the approvals, setup-config, db, openclaw, fingerprint, and ws-server modules) and 15 callback/public-signature bindings (arity the caller supplies). They are listed in the issue comment for a follow-up decision on the ignore pattern.

## Gates

tsc · lint (counts above, no other rule moved) · classification check · full suite green.
