### PR TITLE
feat: steer the warm design-mode packet on follow-up UI edits

### DIFF
--- a/src/app/api/orchestrator/create-mission/route.ts
+++ b/src/app/api/orchestrator/create-mission/route.ts
@@ -128,6 +128,9 @@ export async function POST(request: NextRequest) {
   if (!repoPath) {
     return operatorError('invalid_request', 'repoPath is required.', 400);
   }
+  if (record.origin !== undefined && record.origin !== 'design-mode') {
+    return operatorError('invalid_request', 'origin must be "design-mode" when provided.', 400);
+  }
   const launchContext = normalizeWorkerLaunchContext(record.launchContext);
   if (record.launchContext !== undefined && !launchContext) {
     return operatorError('invalid_request', 'launchContext must name a valid source, presentation, and repoContext.', 400);
@@ -262,6 +265,7 @@ export async function POST(request: NextRequest) {
   if (qualitySearch && taskContract === 'off') {
     return operatorError('invalid_request', 'qualitySearch already uses a sealed contract and cannot be combined with taskContract: "off".', 400);
   }
+  const origin = record.origin === 'design-mode' ? 'design-mode' as const : undefined;
 
   const createInput = {
       issues,
@@ -275,6 +279,7 @@ export async function POST(request: NextRequest) {
       ...(hasClaudeCodePacket && claudeCodeCarrier ? { claudeCodeCarrier } : {}),
       requestedEffort,
       constraints: typeof record.constraints === 'string' ? record.constraints : '',
+      ...(origin ? { origin } : {}),
       sequential: record.sequential === true,
       existingBranchPolicy,
       ...(typeof record.useBrain === 'boolean' ? { useBrain: record.useBrain } : {}),

--- a/src/app/api/orchestrator/ui-loop/route.ts
+++ b/src/app/api/orchestrator/ui-loop/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest } from 'next/server';
+import { findWarmUiLoopPacket } from '@/lib/orchestrator/ui-loop';
+import { operatorError, operatorSuccess } from '../_utils';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const repoPath = request.nextUrl.searchParams.get('repo')?.trim() ?? '';
+  if (!repoPath) {
+    return operatorError('invalid_request', 'repo query parameter is required.', 400);
+  }
+
+  try {
+    return operatorSuccess(findWarmUiLoopPacket(repoPath));
+  } catch (error) {
+    return operatorError(
+      'ui_loop_lookup_failed',
+      error instanceof Error ? error.message : 'Unable to resolve a warm Design Mode packet.',
+      500,
+      error,
+    );
+  }
+}

--- a/src/app/api/orchestrator/ui-loop/steer/route.ts
+++ b/src/app/api/orchestrator/ui-loop/steer/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest } from 'next/server';
+import { SteerPacketUnavailableError } from '@/lib/orchestrator/operator-mission-service/steer';
+import { steerWarmUiLoop } from '@/lib/orchestrator/ui-loop';
+import { asRecord, operatorError, operatorSuccess, parseJsonBody } from '../../_utils';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  const record = asRecord(await parseJsonBody(request));
+  if (!record) {
+    return operatorError('invalid_request', 'Invalid JSON body.', 400);
+  }
+  const repoPath = typeof record.repo === 'string' ? record.repo.trim() : '';
+  const text = typeof record.text === 'string' ? record.text.trim() : '';
+  if (!repoPath || !text) {
+    return operatorError('invalid_request', 'repo and text are required.', 400);
+  }
+  const previewImageDataUri = typeof record.previewImageDataUri === 'string'
+    ? record.previewImageDataUri
+    : undefined;
+
+  try {
+    return operatorSuccess(await steerWarmUiLoop({ repoPath, text, previewImageDataUri }));
+  } catch (error) {
+    return operatorError(
+      'ui_loop_steer_failed',
+      error instanceof Error ? error.message : 'Unable to steer the warm Design Mode packet.',
+      error instanceof SteerPacketUnavailableError ? 409 : 500,
+      error,
+    );
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -149,6 +149,7 @@ import { handleRepoWorkspaceFocusEvent } from './hooks/focusRepoWorkspace';
 import { useDesignMode } from '@/hooks/useDesignMode';
 import type { GrabbedElement } from '@/lib/browser/grab';
 import { cropRegionBase64 } from '@/lib/browser/region-crop';
+import { routeUiLoopEdit } from '@/components/desktop/design-mode/ui-loop-edit';
 import { createTileRegistry } from './tileRegistry';
 import type { TerminalTabHandle } from '@/components/desktop/workspace-terminal/types';
 import type { SavedChatRepoContext } from '@/lib/llm/chat-history';
@@ -4882,14 +4883,21 @@ function DashboardInner() {
             <LazyO8ElementPanel
               element={grabbedElement}
               onClose={() => setGrabbedElement(null)}
-              onEditWithAI={(context) => {
-                injectPayloadIntoRepoChat({
-                  reason: 'element-edit',
-                  text: context.text,
-                  previewImageDataUri: context.previewImageDataUri,
-                }, null);
-                setGrabbedElement(null);
+              onEditWithAI={async (context, { forceFresh }) => {
+                const outcome = await routeUiLoopEdit({
+                  repoPath: globalRepoEntry?.localPath,
+                  context,
+                  forceFresh,
+                  injectFallback: () => injectPayloadIntoRepoChat({
+                    reason: 'element-edit',
+                    text: context.text,
+                    previewImageDataUri: context.previewImageDataUri,
+                  }, null),
+                });
+                if (outcome.kind === 'fallback') setGrabbedElement(null);
+                return outcome;
               }}
+              onFocusPacket={(packet) => handlePaletteSelectPacket(packet.packetId, packet.laneId, undefined, packet.label)}
             />
           </Suspense>
         </div>

--- a/src/components/desktop/O8ElementPanel.tsx
+++ b/src/components/desktop/O8ElementPanel.tsx
@@ -3,11 +3,16 @@
 import { useEffect, useState } from 'react';
 import { buildEditContext, buildTextEditContext, type ElementEditContext } from '@/lib/browser/edit-context';
 import type { GrabbedElement } from '@/lib/browser/grab';
+import type { UiLoopEditOutcome, WarmUiLoopPacket } from './design-mode/ui-loop-edit';
 
 interface O8ElementPanelProps {
   element: GrabbedElement;
   onClose: () => void;
-  onEditWithAI?: (context: ElementEditContext) => void;
+  onEditWithAI?: (
+    context: ElementEditContext,
+    options: { forceFresh: boolean },
+  ) => UiLoopEditOutcome | Promise<UiLoopEditOutcome> | void;
+  onFocusPacket?: (packet: WarmUiLoopPacket) => void;
 }
 
 type DescriptorPart = {
@@ -77,14 +82,19 @@ function isInteractiveValue(value: string) {
   return value && value !== 'transparent' && value !== 'rgba(0, 0, 0, 0)';
 }
 
-export function O8ElementPanel({ element, onClose, onEditWithAI }: O8ElementPanelProps) {
+export function O8ElementPanel({ element, onClose, onEditWithAI, onFocusPacket }: O8ElementPanelProps) {
   const [draftText, setDraftText] = useState(element.textContent);
   const [isVisible, setIsVisible] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [receipt, setReceipt] = useState<WarmUiLoopPacket | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const descriptorParts = truncateDescriptorParts(buildDescriptorParts(element), 60);
   const descriptorTitle = buildPlainDescriptor(element);
 
   useEffect(() => {
     setDraftText(element.textContent);
+    setReceipt(null);
+    setError(null);
   }, [element]);
 
   useEffect(() => {
@@ -93,12 +103,20 @@ export function O8ElementPanel({ element, onClose, onEditWithAI }: O8ElementPane
     return () => cancelAnimationFrame(frame);
   }, [element]);
 
-  const handleTextSubmit = () => {
-    if (!onEditWithAI) {
-      return;
+  const submitEdit = async (context: ElementEditContext, forceFresh: boolean) => {
+    if (!onEditWithAI || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const outcome = await onEditWithAI(context, { forceFresh });
+      if (outcome?.kind === 'steered') setReceipt(outcome.packet);
+      if (outcome?.kind === 'error') setError(outcome.message);
+    } finally {
+      setBusy(false);
     }
-    onEditWithAI(buildTextEditContext(element, draftText));
   };
+
+  const handleTextSubmit = () => void submitEdit(buildTextEditContext(element, draftText), false);
 
   return (
     <div
@@ -277,23 +295,97 @@ export function O8ElementPanel({ element, onClose, onEditWithAI }: O8ElementPane
           </div>
         </div>
 
+        {receipt ? (
+          <div
+            role="status"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 4,
+              minHeight: 44,
+              paddingTop: 0,
+              paddingRight: 10,
+              paddingBottom: 0,
+              paddingLeft: 12,
+              border: '1px solid var(--t-success-border)',
+              borderRadius: 10,
+              background: 'var(--t-success-soft)',
+              color: 'var(--t-text)',
+              fontFamily: 'var(--font-sans-system)',
+              fontSize: 11,
+              fontWeight: 300,
+              letterSpacing: '-0.1px',
+            }}
+          >
+            <span>Steered the running packet ·</span>
+            <button
+              type="button"
+              onClick={() => onFocusPacket?.(receipt)}
+              style={{
+                minHeight: 44,
+                border: 'none',
+                background: 'transparent',
+                color: 'var(--t-accent)',
+                paddingTop: 0,
+                paddingRight: 2,
+                paddingBottom: 0,
+                paddingLeft: 2,
+                fontFamily: 'var(--font-sans-system)',
+                fontSize: 11,
+                fontWeight: 300,
+                textDecoration: 'underline',
+                textUnderlineOffset: 2,
+                cursor: onFocusPacket ? 'pointer' : 'default',
+              }}
+            >
+              {receipt.label}
+            </button>
+          </div>
+        ) : error ? (
+          <div
+            role="alert"
+            style={{
+              paddingTop: 10,
+              paddingRight: 12,
+              paddingBottom: 10,
+              paddingLeft: 12,
+              border: '1px solid var(--t-danger-border)',
+              borderRadius: 10,
+              background: 'var(--t-danger-soft)',
+              color: 'var(--t-text)',
+              fontFamily: 'var(--font-sans-system)',
+              fontSize: 11,
+              fontWeight: 300,
+              lineHeight: 1.35,
+            }}
+          >
+            {error}
+          </div>
+        ) : null}
+
         <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
           <button
             type="button"
-            onClick={() => onEditWithAI?.(buildEditContext(element, draftText))}
+            disabled={!onEditWithAI || busy}
+            title="Steer the warm Design Mode packet. Hold ⌥ while clicking to start a new orchestrator turn."
+            onClick={(event) => void submitEdit(buildEditContext(element, draftText), event.altKey)}
             style={{
-              height: 28,
+              minHeight: 44,
               border: 'none',
               borderRadius: 8,
               background: 'var(--t-accent)',
               color: '#ffffff',
-              padding: '0 12px',
+              paddingTop: 0,
+              paddingRight: 12,
+              paddingBottom: 0,
+              paddingLeft: 12,
               fontSize: 12,
-              fontWeight: 600,
-              cursor: onEditWithAI ? 'pointer' : 'default',
+              fontWeight: 300,
+              cursor: onEditWithAI && !busy ? 'pointer' : 'default',
+              opacity: busy ? 0.7 : 1,
             }}
           >
-            Edit with AI
+            {busy ? 'Steering packet…' : 'Edit with AI'}
           </button>
         </div>
       </div>

--- a/src/components/desktop/design-mode/ui-loop-edit.test.ts
+++ b/src/components/desktop/design-mode/ui-loop-edit.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { routeUiLoopEdit } from './ui-loop-edit';
+
+const context = {
+  text: 'Edit the selected browser element.\nSelector: #save',
+  previewImageDataUri: 'data:image/png;base64,element-crop',
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('routeUiLoopEdit', () => {
+  it('steers the resolved warm packet without invoking the composer fallback', async () => {
+    const injectFallback = vi.fn();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(Response.json({
+        ok: true,
+        result: {
+          packetId: 'pkt-warm',
+          laneId: 'lane-warm',
+          lastActivityAt: '2026-08-28T08:00:00.000Z',
+          label: '#1905',
+        },
+      }))
+      .mockResolvedValueOnce(Response.json({
+        ok: true,
+        result: {
+          kind: 'steered',
+          packet: {
+            packetId: 'pkt-warm',
+            laneId: 'lane-warm',
+            lastActivityAt: '2026-08-28T08:00:00.000Z',
+            label: '#1905',
+          },
+        },
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(routeUiLoopEdit({
+      repoPath: '/repo/o8',
+      context,
+      forceFresh: false,
+      injectFallback,
+    })).resolves.toMatchObject({
+      kind: 'steered',
+      packet: { packetId: 'pkt-warm', laneId: 'lane-warm' },
+    });
+    expect(injectFallback).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/orchestrator/ui-loop?repo=%2Frepo%2Fo8');
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body))).toMatchObject({
+      repo: '/repo/o8',
+      text: context.text,
+      previewImageDataUri: context.previewImageDataUri,
+    });
+  });
+
+  it('uses the existing composer path immediately when Option forces a fresh turn', async () => {
+    const injectFallback = vi.fn();
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(routeUiLoopEdit({
+      repoPath: '/repo/o8',
+      context,
+      forceFresh: true,
+      injectFallback,
+    })).resolves.toEqual({ kind: 'fallback', reason: 'FORCED_FRESH' });
+    expect(injectFallback).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('uses the existing composer path when no warm packet exists', async () => {
+    const injectFallback = vi.fn();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json({ ok: true, result: null })));
+
+    await expect(routeUiLoopEdit({
+      repoPath: '/repo/o8',
+      context,
+      forceFresh: false,
+      injectFallback,
+    })).resolves.toEqual({ kind: 'fallback', reason: 'NO_WARM_UI_LOOP_PACKET' });
+    expect(injectFallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not dispatch a fallback turn when the steer response is lost', async () => {
+    const injectFallback = vi.fn();
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(Response.json({
+        ok: true,
+        result: {
+          packetId: 'pkt-warm',
+          laneId: 'lane-warm',
+          lastActivityAt: '2026-08-28T08:00:00.000Z',
+          label: '#1905',
+        },
+      }))
+      .mockRejectedValueOnce(new Error('connection closed')));
+
+    await expect(routeUiLoopEdit({
+      repoPath: '/repo/o8',
+      context,
+      forceFresh: false,
+      injectFallback,
+    })).resolves.toMatchObject({
+      kind: 'error',
+      message: expect.stringContaining('Check the running packet before retrying'),
+    });
+    expect(injectFallback).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/desktop/design-mode/ui-loop-edit.ts
+++ b/src/components/desktop/design-mode/ui-loop-edit.ts
@@ -1,0 +1,81 @@
+'use client';
+
+import type { ElementEditContext } from '@/lib/browser/edit-context';
+
+export interface WarmUiLoopPacket {
+  packetId: string;
+  laneId: string;
+  lastActivityAt: string;
+  label: string;
+}
+
+export type UiLoopEditOutcome =
+  | { kind: 'steered'; packet: WarmUiLoopPacket }
+  | { kind: 'fallback'; reason: string }
+  | { kind: 'error'; message: string };
+
+interface OperatorEnvelope<T> {
+  ok?: boolean;
+  result?: T;
+  error?: { message?: string } | string;
+}
+
+function fallback(reason: string, injectFallback: () => void): UiLoopEditOutcome {
+  injectFallback();
+  return { kind: 'fallback', reason };
+}
+
+function errorMessage(payload: OperatorEnvelope<unknown> | null): string {
+  if (typeof payload?.error === 'string') return payload.error;
+  return payload?.error?.message ?? 'The warm packet could not accept this edit.';
+}
+
+export async function routeUiLoopEdit(input: {
+  repoPath?: string | null;
+  context: ElementEditContext;
+  forceFresh: boolean;
+  injectFallback: () => void;
+}): Promise<UiLoopEditOutcome> {
+  const repoPath = input.repoPath?.trim() ?? '';
+  if (input.forceFresh || !repoPath) {
+    return fallback(input.forceFresh ? 'FORCED_FRESH' : 'NO_REPO', input.injectFallback);
+  }
+
+  let lookupResponse: Response;
+  try {
+    lookupResponse = await fetch(`/api/orchestrator/ui-loop?repo=${encodeURIComponent(repoPath)}`);
+  } catch {
+    return fallback('LOOKUP_UNAVAILABLE', input.injectFallback);
+  }
+  const lookup = await lookupResponse.json().catch(() => null) as OperatorEnvelope<WarmUiLoopPacket | null> | null;
+  if (!lookupResponse.ok || !lookup?.result) {
+    return fallback(lookupResponse.ok ? 'NO_WARM_UI_LOOP_PACKET' : 'LOOKUP_FAILED', input.injectFallback);
+  }
+
+  let steerResponse: Response;
+  try {
+    steerResponse = await fetch('/api/orchestrator/ui-loop/steer', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        repo: repoPath,
+        text: input.context.text,
+        previewImageDataUri: input.context.previewImageDataUri,
+      }),
+    });
+  } catch {
+    return { kind: 'error', message: 'The steer response was lost. Check the running packet before retrying.' };
+  }
+  const payload = await steerResponse.json().catch(() => null) as OperatorEnvelope<{
+    kind?: string;
+    packet?: WarmUiLoopPacket;
+    reason?: string;
+  }> | null;
+  if (steerResponse.ok && payload?.result?.kind === 'steered' && payload.result.packet) {
+    return { kind: 'steered', packet: payload.result.packet };
+  }
+  if (steerResponse.ok && payload?.result?.kind === 'fallback') {
+    return fallback(payload.result.reason ?? 'NO_STEERABLE_SESSION', input.injectFallback);
+  }
+  return { kind: 'error', message: errorMessage(payload) };
+}

--- a/src/lib/lane/orchestrator.md
+++ b/src/lib/lane/orchestrator.md
@@ -216,6 +216,7 @@ Dispatched agents (codex in isolated worktrees) have **the `o8` CLI on PATH** �
 - `o8 lane touches --path <file>` — agent self-detects parallel-edit conflicts before writing
 - `o8 cortex observe --kind gotcha --text "..."` — agent writes lessons learned back to Cortex memory mid-run
 - `o8 ask "<question>"` — agent queries the Engineering Brain (answer + titled citations, auto-scoped to its repo). Whether the packet prompt TEACHES the agent about this is governed by the operator's "Workers use the Brain" setting (auto = non-frontier models only); pass `useBrain: true` on `create_mission` to force it for a mission — do this when the worker model is weak or the task is conventions/history-heavy. Each ask lands as a `brain_consulted` lane event you can see in `o8_lane_events`.
+- When the operator's message carries the `element-edit` payload, pass `origin: 'design-mode'` to `create_mission`.
 - `o8 run <cmd>` — agent runs servers / backtests / long jobs in an o8-owned terminal the operator can watch live. Launch every server or daemon with `o8 run --detach -- <cmd>`, and use `o8 run -- <cmd>` for finite long jobs. Never combine Bash `run_in_background` with a shell `exec`: replacing Claude Code's tracked shell can produce a false failure notification while the replacement process remains healthy.
 
 You DO NOT need to read these files for the agent. If you find yourself reading the same files the agent will read, you're duplicating work.

--- a/src/lib/lane/types.ts
+++ b/src/lib/lane/types.ts
@@ -438,6 +438,8 @@ export type LaneEventVerb =
   | 'rules_applied'
   // Packet steer injected into an existing warm session. Payload: { packetId, source, message }
   | 'steered_packet'
+  // Design Mode follow-up reused the packet's warm lane. Payload: { packetId, elementSummary }
+  | 'ui_loop_steered'
   // Packet steer failed before a worker turn could start. Payload: { packetId, source, message, note, stderrHead? }
   | 'steer_failed'
   // Operator stop could not kill the live worker. Payload: { packetId?, sessionKey, note, pid?, tmuxSession?, steps }

--- a/src/lib/mcp/operator-handlers/mission-task-contract.test.ts
+++ b/src/lib/mcp/operator-handlers/mission-task-contract.test.ts
@@ -55,6 +55,7 @@ function stubRealMissionService() {
 
 async function createPacket(input: {
   runtime: OrchestratorRuntime;
+  origin?: 'design-mode';
   taskContract?: 'off';
   qualitySearch?: { taskContract: PacketTaskContract };
 }) {
@@ -63,6 +64,7 @@ async function createPacket(input: {
     repoPath,
     issues_inline: [{ title: `${input.runtime} contract ${Date.now()}` }],
     runtime: input.runtime,
+    origin: input.origin,
     taskContract: input.taskContract,
     qualitySearch: input.qualitySearch,
     dispatch: false,
@@ -80,6 +82,7 @@ describe('create_mission task contract default', () => {
     expect(schema).toMatchObject({
       type: 'object',
       properties: {
+        origin: { type: 'string', enum: ['design-mode'] },
         taskContract: { type: 'string', enum: ['off'] },
       },
       required: ['repoPath'],
@@ -87,6 +90,12 @@ describe('create_mission task contract default', () => {
     expect(schema).not.toHaveProperty('oneOf');
     expect(schema).not.toHaveProperty('anyOf');
     expect(schema).not.toHaveProperty('allOf');
+  });
+
+  it('stamps the Design Mode origin through the real MCP handler onto the persisted packet', async () => {
+    expect(await createPacket({ runtime: 'codex', origin: 'design-mode' })).toMatchObject({
+      origin: 'design-mode',
+    });
   });
 
   it.each(['claude-code', 'codex'] as const)('arms %s through the real handler and persisted packet', async (runtime) => {

--- a/src/lib/mcp/operator-handlers/mission.ts
+++ b/src/lib/mcp/operator-handlers/mission.ts
@@ -71,10 +71,8 @@ export const MISSION_TOOLS: McpTool[] = [
           },
           description: 'Ad-hoc inline tasks — no GitHub issue required. Each becomes its own packet.',
         },
-        repoPath: {
-          type: 'string',
-          description: 'Absolute local path to the repository.',
-        },
+        repoPath: { type: 'string', description: 'Absolute local path to the repository.' },
+        origin: { type: 'string', enum: ['design-mode'], description: 'Set to design-mode when the mission comes from an element-edit payload so follow-up edits can reuse its warm packet lane.' },
         runtime: {
           type: 'string',
           enum: listDispatchableRuntimes(),
@@ -800,6 +798,8 @@ export async function handleCreateMission(args: Record<string, unknown>): Promis
     }
     const shouldDispatch = args.dispatch !== false;
     const sequential = args.sequential === true;
+    if (args.origin !== undefined && args.origin !== 'design-mode') return textResult('origin must be `design-mode` when provided.', true);
+    const origin = args.origin === 'design-mode' ? 'design-mode' as const : undefined;
     const existingBranchPolicy = parseExistingBranchPolicy(args.existingBranchPolicy);
     const useBrain = typeof args.useBrain === 'boolean' ? args.useBrain : undefined;
     const huddle = typeof args.huddle === 'boolean' ? args.huddle : undefined;
@@ -825,7 +825,7 @@ export async function handleCreateMission(args: Record<string, unknown>): Promis
       const createResult = await createMissionInline({
         issues_inline: parsed,
         repoPath,
-        runtime,
+        runtime, origin,
         workerIntent,
         requestedProvider,
         requestedRuntime: runtime,
@@ -860,7 +860,7 @@ export async function handleCreateMission(args: Record<string, unknown>): Promis
     const createResult = await createMission({
       issues: parseIssueList(args.issues),
       repoPath,
-      runtime,
+      runtime, origin,
       workerIntent,
       requestedProvider,
       requestedRuntime: runtime,

--- a/src/lib/mcp/operator-mission-tools.ts
+++ b/src/lib/mcp/operator-mission-tools.ts
@@ -105,6 +105,7 @@ interface CreateMissionInput {
   issues: string[];
   repoPath: string;
   runtime: OrchestratorRuntime;
+  origin?: 'design-mode';
   workerIntent?: WorkerIntent;
   requestedProvider?: WorkerProvider | null;
   requestedRuntime?: OrchestratorRuntime | null;
@@ -136,6 +137,7 @@ interface CreateMissionInlineInput {
   issues_inline: InlineIssue[];
   repoPath: string;
   runtime: OrchestratorRuntime;
+  origin?: 'design-mode';
   workerIntent?: WorkerIntent;
   requestedProvider?: WorkerProvider | null;
   requestedRuntime?: OrchestratorRuntime | null;
@@ -395,6 +397,7 @@ export async function createMission(input: CreateMissionInput) {
           issues: loadedIssues,
           repoPath,
           runtime: input.runtime,
+          origin: input.origin,
           workerIntent: input.workerIntent,
           requestedProvider: input.requestedProvider,
           requestedRuntime: input.requestedRuntime,
@@ -442,6 +445,7 @@ export async function createMissionInline(input: CreateMissionInlineInput) {
           issues: loadedIssues,
           repoPath,
           runtime: input.runtime,
+          origin: input.origin,
           workerIntent: input.workerIntent,
           requestedProvider: input.requestedProvider,
           requestedRuntime: input.requestedRuntime,

--- a/src/lib/orchestrator/operator-mission-service/mission.ts
+++ b/src/lib/orchestrator/operator-mission-service/mission.ts
@@ -214,6 +214,7 @@ export async function createMission(input: CreateMissionInput) {
       referenceLabel: referenceLabels[index]!,
       title: issue.title,
       summary: packetSummary,
+      ...(input.origin === 'design-mode' ? { origin: input.origin } : {}),
       workspaceTargetPath: repoPath,
       branchTarget,
       runtime: packetRouting.selectedRuntime,

--- a/src/lib/orchestrator/operator-mission-service/steer.ts
+++ b/src/lib/orchestrator/operator-mission-service/steer.ts
@@ -15,6 +15,7 @@
  */
 
 import { findLaneByPacket, setLaneStatus } from '@/lib/lane/registry';
+import type { Lane } from '@/lib/lane/types';
 import { recordLaneEvent } from '@/lib/lane/events';
 import { rebindLaneSessionIfChanged } from '@/lib/lane/session-rebind';
 import { findMissionRegistryEntryByPacketId } from '@/lib/orchestrator/mission-registry';
@@ -35,7 +36,7 @@ export interface SteerPacketResult {
   note: string;
 }
 
-const NO_STEERABLE_SESSION = 'Packet has no steerable session — use rerun_with_feedback instead.';
+export const NO_STEERABLE_SESSION = 'Packet has no steerable session — use rerun_with_feedback instead.';
 const STARTUP_FAILURE_PROBE_MS = 2_000;
 
 export type SteerPacketFailurePhase = 'pre_effect' | 'terminal' | 'outcome_unknown';
@@ -53,6 +54,15 @@ export class SteerPacketUnavailableError extends Error {
 
 export function isPostEffectSteerFailure(error: unknown): error is SteerPacketUnavailableError {
   return error instanceof SteerPacketUnavailableError && error.phase !== 'pre_effect';
+}
+
+export function findSteerablePacketLane(packetId: string): (Lane & { sessionKey: string }) | null {
+  const lane = findLaneByPacket(packetId);
+  return lane?.sessionKey ? lane as Lane & { sessionKey: string } : null;
+}
+
+export function isNoSteerableSessionError(error: unknown): boolean {
+  return error instanceof SteerPacketUnavailableError && error.message === NO_STEERABLE_SESSION;
 }
 
 function outcomeUnknownSteerError(error: unknown): SteerPacketUnavailableError {
@@ -122,8 +132,8 @@ export async function steerPacket({
   source,
   clientMutationId,
 }: SteerPacketInput): Promise<SteerPacketResult> {
-  const lane = findLaneByPacket(packetId);
-  if (!lane?.sessionKey) {
+  const lane = findSteerablePacketLane(packetId);
+  if (!lane) {
     const current = currentMissionState();
     const packetExists = current.packets.some((packet) => packet.id === packetId)
       || Boolean(findMissionRegistryEntryByPacketId(packetId, {

--- a/src/lib/orchestrator/operator-mission-service/types.ts
+++ b/src/lib/orchestrator/operator-mission-service/types.ts
@@ -31,6 +31,8 @@ export interface CreateMissionInput {
   issues: LoadedIssue[];
   repoPath: string;
   runtime: OrchestratorRuntime;
+  /** Durable packet origin for Design Mode follow-up routing. */
+  origin?: 'design-mode';
   workerIntent?: WorkerIntent;
   requestedProvider?: WorkerProvider | null;
   requestedRuntime?: OrchestratorRuntime | null;

--- a/src/lib/orchestrator/store.ts
+++ b/src/lib/orchestrator/store.ts
@@ -321,7 +321,7 @@ function normalizePacket(raw: unknown, index: number, existing: Array<Pick<Orche
     id: typeof packet.id === 'string' && packet.id.trim() ? packet.id.trim() : `pkt-${Date.now()}-${index + 1}`,
     referenceLabel,
     title: typeof packet.title === 'string' && packet.title.trim() ? packet.title : `Packet ${index + 1}`,
-    summary: typeof packet.summary === 'string' ? packet.summary : '',
+    summary: typeof packet.summary === 'string' ? packet.summary : '', origin: packet.origin === 'design-mode' ? 'design-mode' : undefined,
     workspaceTargetPath: typeof packet.workspaceTargetPath === 'string' && packet.workspaceTargetPath.trim() ? packet.workspaceTargetPath : null,
     branchTarget: branchTarget || (queueState === 'draft' ? '' : 'main'),
     runtime: workerRouting.selectedRuntime, model: typeof packet.model === 'string' && packet.model.trim() ? packet.model.trim() : null,

--- a/src/lib/orchestrator/types.ts
+++ b/src/lib/orchestrator/types.ts
@@ -270,6 +270,8 @@ export interface OrchestratorPacket {
   referenceLabel: string;
   title: string;
   summary: string;
+  /** Packet was created from the Design Mode element-edit loop. */
+  origin?: 'design-mode';
   workspaceTargetPath: string | null;
   branchTarget: string;
   runtime: OrchestratorRuntime;

--- a/src/lib/orchestrator/ui-loop.ts
+++ b/src/lib/orchestrator/ui-loop.ts
@@ -1,0 +1,136 @@
+import 'server-only';
+
+import { resolve } from 'node:path';
+import { recordLaneEvent } from '@/lib/lane/events';
+import { listMissionRegistryEntries } from '@/lib/orchestrator/mission-registry';
+import { packetTerminalState } from '@/lib/orchestrator/packet-state';
+import type { OrchestratorMissionState, OrchestratorPacket } from '@/lib/orchestrator/types';
+import {
+  findSteerablePacketLane,
+  isNoSteerableSessionError,
+  steerPacket,
+} from '@/lib/orchestrator/operator-mission-service/steer';
+import { currentMissionState } from '@/lib/orchestrator/operator-mission-service/shared';
+
+export interface WarmUiLoopPacket {
+  packetId: string;
+  laneId: string;
+  lastActivityAt: string;
+  label: string;
+}
+
+export type UiLoopSteerResult =
+  | {
+      kind: 'steered';
+      packet: WarmUiLoopPacket;
+      imageForwarded: boolean;
+    }
+  | {
+      kind: 'fallback';
+      reason: 'NO_WARM_UI_LOOP_PACKET' | 'NO_STEERABLE_SESSION';
+    };
+
+function normalizeRepoPath(repoPath: string): string {
+  return resolve(repoPath.trim());
+}
+
+function activityAt(
+  mission: OrchestratorMissionState,
+  packet: OrchestratorPacket,
+  lane: NonNullable<ReturnType<typeof findSteerablePacketLane>>,
+): string {
+  const candidates = [lane.lastEventAt, lane.updatedAt, packet.lastEventAt, mission.updatedAt]
+    .filter((value): value is string => Boolean(value))
+    .map((value) => ({ value, time: Date.parse(value) }))
+    .filter((candidate) => Number.isFinite(candidate.time))
+    .sort((left, right) => right.time - left.time);
+  return candidates[0]?.value ?? new Date(0).toISOString();
+}
+
+function packetLabel(packet: OrchestratorPacket, laneLabel: string): string {
+  const issueNumber = packet.issue?.url && typeof packet.issue.number === 'number'
+    ? packet.issue.number
+    : null;
+  return issueNumber ? `#${issueNumber}` : laneLabel.trim() || packet.referenceLabel || packet.id;
+}
+
+function elementSummary(text: string): string {
+  const lines = text.split('\n').map((line) => line.trim()).filter(Boolean);
+  const element = lines.find((line) => line.startsWith('Element:'));
+  const selector = lines.find((line) => line.startsWith('Selector:'));
+  return [element, selector].filter(Boolean).join(' · ').slice(0, 300)
+    || lines[0]?.slice(0, 300)
+    || 'Design Mode element edit';
+}
+
+export function findWarmUiLoopPacket(repoPath: string): WarmUiLoopPacket | null {
+  const targetRepoPath = normalizeRepoPath(repoPath);
+  const current = currentMissionState();
+  const missions = [
+    current,
+    ...listMissionRegistryEntries({
+      includeArchived: false,
+      excludeMissionId: current.missionId,
+    }).map((entry) => entry.mission),
+  ];
+  const candidates = new Map<string, WarmUiLoopPacket>();
+
+  for (const mission of missions) {
+    for (const packet of mission.packets) {
+      const packetRepoPath = packet.workspaceTargetPath ?? mission.repoPath;
+      if (!packetRepoPath || normalizeRepoPath(packetRepoPath) !== targetRepoPath) continue;
+      if (packet.origin !== 'design-mode' || packetTerminalState(packet)) continue;
+      const lane = findSteerablePacketLane(packet.id);
+      if (!lane) continue;
+      const candidate = {
+        packetId: packet.id,
+        laneId: lane.id,
+        lastActivityAt: activityAt(mission, packet, lane),
+        label: packetLabel(packet, lane.label),
+      } satisfies WarmUiLoopPacket;
+      const previous = candidates.get(packet.id);
+      if (!previous || Date.parse(candidate.lastActivityAt) > Date.parse(previous.lastActivityAt)) {
+        candidates.set(packet.id, candidate);
+      }
+    }
+  }
+
+  return Array.from(candidates.values())
+    .sort((left, right) => Date.parse(right.lastActivityAt) - Date.parse(left.lastActivityAt))[0]
+    ?? null;
+}
+
+export async function steerWarmUiLoop(input: {
+  repoPath: string;
+  text: string;
+  previewImageDataUri?: string;
+}): Promise<UiLoopSteerResult> {
+  const packet = findWarmUiLoopPacket(input.repoPath);
+  if (!packet) return { kind: 'fallback', reason: 'NO_WARM_UI_LOOP_PACKET' };
+
+  const text = input.text.trim();
+  const message = input.previewImageDataUri
+    ? `${text}\n\nScreenshot note: warm-session steer cannot attach the element crop, so use the element, selector, accessibility, and style context above.`
+    : text;
+  try {
+    const result = await steerPacket({
+      packetId: packet.packetId,
+      message,
+      source: 'operator',
+    });
+    recordLaneEvent(result.laneId, 'ui_loop_steered', 'orchestrator', {
+      packetId: result.packetId,
+      elementSummary: elementSummary(text),
+    });
+    return {
+      kind: 'steered',
+      packet: { ...packet, laneId: result.laneId },
+      imageForwarded: false,
+    };
+  } catch (error) {
+    if (isNoSteerableSessionError(error)) {
+      return { kind: 'fallback', reason: 'NO_STEERABLE_SESSION' };
+    }
+    throw error;
+  }
+}

--- a/tests/middleware-gate.test.ts
+++ b/tests/middleware-gate.test.ts
@@ -255,6 +255,19 @@ describe('panelGateMiddleware — loopback trust', () => {
     expect(res.status).toBe(401);
   });
 
+  it.each([
+    ['/api/orchestrator/ui-loop', 'GET'],
+    ['/api/orchestrator/ui-loop/steer', 'POST'],
+  ])('gates the Design Mode warm-loop route against LAN: %s', (pathname, method) => {
+    const res = panelGateMiddleware(
+      gatedRequest(`http://192.168.1.50:3001${pathname}`, {
+        method,
+        headers: { host: '192.168.1.50:3001' },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
   it('gates /api/voice/realtime/session (mints OpenAI realtime tokens on the operator key) against LAN', () => {
     const res = panelGateMiddleware(
       gatedRequest('http://192.168.1.50:3001/api/voice/realtime/session', {

--- a/tests/packet-control-fields-survive-normalize.test.ts
+++ b/tests/packet-control-fields-survive-normalize.test.ts
@@ -26,6 +26,7 @@ function fullPacketFixture() {
     referenceLabel: 'P1',
     title: 'Control-field packet',
     summary: 'Full normalize fixture',
+    origin: 'design-mode',
     workspaceTargetPath: '/repo/o8',
     branchTarget: 'inline/full-normalize',
     runtime: 'codex',

--- a/tests/route-coverage.test.ts
+++ b/tests/route-coverage.test.ts
@@ -281,6 +281,7 @@ const EXPLICIT_GATED = [
   /^\/api\/prompt-library(\/|$)/,
   /^\/api\/mcp\/?$/,
   /^\/api\/leases\/?$/,
+  /^\/api\/orchestrator\/ui-loop(?:\/steer)?\/?$/,
   /^\/api\/broadcast\/tokens\/?$/,
   /^\/api\/broadcast\/post\/?$/,
   /^\/api\/broadcast\/say\/?$/,

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2261,6 +2261,12 @@
       ]
     },
     {
+      "path": "tests/ui-loop-warm-lane-real-path.test.ts",
+      "reasons": [
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/validate-qa-cases.test.ts",
       "reasons": [
         "child-process",

--- a/tests/ui-loop-warm-lane-real-path.test.ts
+++ b/tests/ui-loop-warm-lane-real-path.test.ts
@@ -1,0 +1,230 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { NextRequest } from 'next/server';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+
+const h = vi.hoisted(() => ({
+  perform: vi.fn(),
+}));
+
+vi.mock('@/lib/runtime/actions', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/runtime/actions')>(),
+  performRuntimeAction: h.perform,
+}));
+
+const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-ui-loop-real-path-'));
+const repoPath = mkdtempSync(join(os.tmpdir(), 'o8-ui-loop-repo-'));
+const otherRepoPath = mkdtempSync(join(os.tmpdir(), 'o8-ui-loop-other-repo-'));
+process.env.O8_DATA_DIR = dataDir;
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+
+const lookupRoute = await import('@/app/api/orchestrator/ui-loop/route');
+const steerRoute = await import('@/app/api/orchestrator/ui-loop/steer/route');
+const { closeDb } = await import('@/lib/db');
+const {
+  createLane,
+  deleteLane,
+  getLaneEvents,
+} = await import('@/lib/lane/registry');
+const {
+  readOrchestratorControlPlaneState,
+  writeOrchestratorControlPlaneState,
+} = await import('@/lib/orchestrator/control-plane');
+const {
+  createEmptyOrchestratorMissionState,
+  normalizeOrchestratorMissionState,
+} = await import('@/lib/orchestrator/store');
+
+const createdLaneIds: string[] = [];
+
+function packetFixture(input: {
+  id: string;
+  repoPath: string;
+  origin?: 'design-mode';
+  terminal?: boolean;
+}): OrchestratorPacket {
+  return {
+    id: input.id,
+    referenceLabel: 'P1',
+    title: 'Edit the selected element',
+    summary: 'Apply the Design Mode element edit.',
+    ...(input.origin ? { origin: input.origin } : {}),
+    workspaceTargetPath: input.repoPath,
+    branchTarget: `feat/${input.id}`,
+    runtime: 'codex',
+    dependencyLabels: [],
+    dependencyPacketIds: [],
+    queueState: input.terminal ? 'held' : 'queued',
+    releaseState: 'pending',
+    status: input.terminal ? 'archived' : 'running',
+    blockedReason: null,
+    lastEventAt: '2026-08-28T08:00:00.000Z',
+    lastEventLabel: input.terminal ? 'archived' : 'running',
+    archivedAt: input.terminal ? '2026-08-28T08:01:00.000Z' : null,
+    review: null,
+    lane: null,
+    issue: { number: 1905, url: 'https://example.invalid/issues/1905' },
+  };
+}
+
+function persistPackets(packets: OrchestratorPacket[]) {
+  writeOrchestratorControlPlaneState({
+    ...createEmptyOrchestratorMissionState(),
+    missionId: 'mission-ui-loop-real-path',
+    repoPath,
+    packets,
+    updatedAt: '2026-08-28T08:02:00.000Z',
+  });
+}
+
+function createWarmLane(packet: OrchestratorPacket) {
+  const lane = createLane({
+    repoPath: packet.workspaceTargetPath ?? repoPath,
+    branch: packet.branchTarget,
+    runtime: 'codex',
+    packetId: packet.id,
+    sessionKey: `test-owned:${packet.id}`,
+    label: `warm-${packet.id}`,
+  });
+  createdLaneIds.push(lane.id);
+  return lane;
+}
+
+function getRequest(targetRepoPath: string) {
+  return new NextRequest(`http://localhost:3001/api/orchestrator/ui-loop?repo=${encodeURIComponent(targetRepoPath)}`);
+}
+
+function postRequest(targetRepoPath: string, text: string, previewImageDataUri?: string) {
+  return new NextRequest('http://localhost:3001/api/orchestrator/ui-loop/steer', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ repo: targetRepoPath, text, previewImageDataUri }),
+  });
+}
+
+beforeEach(() => {
+  h.perform.mockReset();
+  h.perform.mockImplementation(async (input: { surfaceId: string }) => ({
+    ok: true,
+    action: 'steer',
+    surfaceId: input.surfaceId,
+    sessionKey: input.surfaceId,
+    runtime: 'codex',
+    status: 'completed',
+    note: 'steered',
+  }));
+  persistPackets([]);
+});
+
+afterEach(() => {
+  for (const laneId of createdLaneIds.splice(0)) deleteLane(laneId);
+});
+
+afterAll(() => {
+  closeDb();
+  rmSync(dataDir, { recursive: true, force: true });
+  rmSync(repoPath, { recursive: true, force: true });
+  rmSync(otherRepoPath, { recursive: true, force: true });
+});
+
+describe('Design Mode warm packet lane real path', () => {
+  it('finds the persisted packet, steers through the real service, and records the audit event', async () => {
+    const packet = packetFixture({ id: 'pkt-design-warm', repoPath, origin: 'design-mode' });
+    persistPackets([packet]);
+    const lane = createWarmLane(packet);
+    const editText = 'Edit the selected browser element.\nElement: <button.primary>\nSelector: #save';
+
+    const lookup = await lookupRoute.GET(getRequest(repoPath));
+    expect(lookup.status).toBe(200);
+    await expect(lookup.json()).resolves.toMatchObject({
+      ok: true,
+      result: { packetId: packet.id, laneId: lane.id, label: '#1905' },
+    });
+
+    const response = await steerRoute.POST(postRequest(
+      repoPath,
+      editText,
+      'data:image/png;base64,element-crop',
+    ));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      result: {
+        kind: 'steered',
+        packet: { packetId: packet.id, laneId: lane.id },
+        imageForwarded: false,
+      },
+    });
+    expect(h.perform).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'steer',
+      surfaceId: lane.sessionKey,
+      message: expect.stringContaining(editText),
+    }));
+    expect(h.perform.mock.calls[0]?.[0]?.message).toContain('cannot attach the element crop');
+    expect(getLaneEvents(lane.id)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        verb: 'ui_loop_steered',
+        payload: {
+          packetId: packet.id,
+          elementSummary: 'Element: <button.primary> · Selector: #save',
+        },
+      }),
+    ]));
+  });
+
+  it('returns fallback for a terminal packet and does not steer it', async () => {
+    const packet = packetFixture({ id: 'pkt-design-terminal', repoPath, origin: 'design-mode', terminal: true });
+    persistPackets([packet]);
+    createWarmLane(packet);
+
+    await expect((await lookupRoute.GET(getRequest(repoPath))).json()).resolves.toMatchObject({
+      ok: true,
+      result: null,
+    });
+    await expect((await steerRoute.POST(postRequest(repoPath, 'Edit the terminal packet.'))).json())
+      .resolves.toMatchObject({
+        ok: true,
+        result: { kind: 'fallback', reason: 'NO_WARM_UI_LOOP_PACKET' },
+      });
+    expect(h.perform).not.toHaveBeenCalled();
+  });
+
+  it('never chooses a Design Mode packet from another repo', async () => {
+    const packet = packetFixture({ id: 'pkt-design-other-repo', repoPath: otherRepoPath, origin: 'design-mode' });
+    persistPackets([packet]);
+    createWarmLane(packet);
+
+    await expect((await lookupRoute.GET(getRequest(repoPath))).json()).resolves.toMatchObject({
+      ok: true,
+      result: null,
+    });
+  });
+
+  it('never chooses an untagged packet even when its lane is warm', async () => {
+    const packet = packetFixture({ id: 'pkt-untagged-warm', repoPath });
+    persistPackets([packet]);
+    createWarmLane(packet);
+
+    await expect((await lookupRoute.GET(getRequest(repoPath))).json()).resolves.toMatchObject({
+      ok: true,
+      result: null,
+    });
+  });
+
+  it('round-trips the Design Mode origin through packet normalization and persistence', () => {
+    const packet = packetFixture({ id: 'pkt-origin-round-trip', repoPath, origin: 'design-mode' });
+    const normalized = normalizeOrchestratorMissionState({
+      ...createEmptyOrchestratorMissionState(),
+      missionId: 'mission-origin-round-trip',
+      repoPath,
+      packets: [packet],
+    });
+    expect(normalized.packets[0]?.origin).toBe('design-mode');
+
+    writeOrchestratorControlPlaneState(normalized);
+    expect(readOrchestratorControlPlaneState().packets[0]?.origin).toBe('design-mode');
+  });
+});


### PR DESCRIPTION
Closes #1905. Refs #1695.

## What

A follow-up "Edit with AI" from Design Mode now steers the packet that is already working on that repo instead of composing a fresh orchestrator turn that dispatches a fresh worker.

- **Packets carry an origin.** `create_mission` (MCP tool, HTTP route, and the service input) accepts `origin: 'design-mode'`; it persists on the packet (`OrchestratorPacket.origin`, round-tripped through `normalizePacket`). The orchestrator prompt gains one sentence: when the operator's message carries the `element-edit` payload, pass `origin: 'design-mode'`.
- **Warm-lane resolver.** `src/lib/orchestrator/ui-loop.ts` — `findWarmUiLoopPacket(repoPath)` scans the live mission and the registry for the newest non-terminal `design-mode` packet in that repo whose lane has a steerable session (the same lookup `steerPacket` uses, now exported as `findSteerablePacketLane`). `steerWarmUiLoop({ repoPath, text, previewImageDataUri })` calls the real `steerPacket` and records `ui_loop_steered { packetId, elementSummary }` (new `LaneEventVerb`); a `NO_STEERABLE_SESSION` becomes a `fallback` result, anything else propagates.
- **Routes** (gated; manifest + middleware cases added): `GET /api/orchestrator/ui-loop?repo=` and `POST /api/orchestrator/ui-loop/steer { repo, text, previewImageDataUri? }`. Both are thin.
- **Client.** `design-mode/ui-loop-edit.ts` `routeUiLoopEdit` does lookup → steer; on no warm packet, no steerable session, or a lookup failure it falls back to today's `injectPayloadIntoRepoChat`; on a lost steer response it reports an error and does **not** fall back, so an edit is never dispatched twice. Holding ⌥ while clicking Edit with AI forces the old path. On success the element panel shows an inline receipt ("Steered the running packet · <label>") with a link that focuses that packet; errors show inline. `page.tsx` +15 lines.
- Warm steering is text-only for now: when the edit context carries an element crop, the message says so and points the worker at the element, selector, accessibility, and style context it already includes.

## Proof

- `tests/ui-loop-warm-lane-real-path.test.ts` — a persisted `design-mode` packet with a steerable lane resolves through `GET`; `POST …/steer` invokes the real `steerPacket` (session continuation stubbed at the process boundary) with a message containing the edit text, and the `ui_loop_steered` event exists; a terminal packet returns `null` / `fallback` and nothing is steered; a `design-mode` packet in another repo is never chosen; an untagged packet is never chosen even with a warm lane; `origin` survives normalization and persistence.
- `design-mode/ui-loop-edit.test.ts` — steers without invoking the fallback; ⌥ forces the composer path immediately; no warm packet → composer path; a lost steer response → error, no fallback turn.
- `tests/middleware-gate.test.ts` / `tests/route-coverage.test.ts` cover the two routes.

## Gates

tsc · 479 focused tests · lint ratchet · classification check · full suite green.
