### PR TITLE
fix: bind team presence to the registering session and refuse foreign status writes

### DIFF
--- a/cli/src/commands/team.test.ts
+++ b/cli/src/commands/team.test.ts
@@ -1,0 +1,188 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { CliError, EXIT } from '../api';
+import { codename } from '../../../src/lib/agents/codename';
+import { resolveAgentIdentity, runTeam } from './team';
+
+const roots: string[] = [];
+const jsonMode = { human: false, verbose: false };
+
+function createRepo(): string {
+  const repo = mkdtempSync(path.join(os.tmpdir(), 'o8-team-presence-'));
+  roots.push(repo);
+  execFileSync('git', ['init', '--quiet', repo]);
+  return repo;
+}
+
+function presenceDir(repo: string): string {
+  return path.join(repo, '.git', 'agents', 'presence');
+}
+
+function presenceFile(repo: string, identity: string): string {
+  return path.join(presenceDir(repo), `${encodeURIComponent(identity)}.json`);
+}
+
+function options(repo: string, identity: string) {
+  return { cwd: repo, env: { O8_AGENT_ID: identity }, ppid: 300 };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('team CLI session identity', () => {
+  it('prefers explicit and packet bindings, ignores terminal ids, and walks stable ancestry', () => {
+    expect(resolveAgentIdentity({
+      env: {
+        O8_AGENT_ID: 'explicit-session',
+        O8_WORKER_PACKET_ID: 'packet-session',
+        CLAUDE_CODE_SESSION_ID: 'claude-session',
+      },
+    })).toBe('explicit-session');
+    expect(resolveAgentIdentity({
+      env: {
+        O8_WORKER_PACKET_ID: 'packet-session',
+        CLAUDE_CODE_SESSION_ID: 'claude-session',
+      },
+    })).toBe('packet-session');
+    expect(resolveAgentIdentity({
+      env: { CLAUDE_CODE_SESSION_ID: 'claude-session' },
+    })).toBe('claude-session');
+
+    const rows = new Map([
+      [300, { pid: 300, ppid: 200, command: '/bin/sh -lc o8 team status working' }],
+      [200, { pid: 200, ppid: 100, command: '/usr/local/bin/agent-runtime' }],
+    ]);
+    expect(resolveAgentIdentity({
+      env: { TERM_SESSION_ID: 'shared-terminal' },
+      ppid: 300,
+      readProcess: (pid) => rows.get(pid) ?? null,
+    })).toBe('pid-200');
+  });
+
+  it('keeps the first agent byte-unchanged when a second agent writes status in the same checkout', () => {
+    const repo = createRepo();
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+      stdout.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+      stderr.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write);
+
+    expect(runTeam(jsonMode, 'who', [], options(repo, 'session-one'))).toBe(EXIT.OK);
+    expect(runTeam(jsonMode, 'who', [], options(repo, 'session-two'))).toBe(EXIT.OK);
+    const firstBefore = readFileSync(presenceFile(repo, 'session-one'), 'utf8');
+
+    expect(runTeam(jsonMode, 'status', ['reviewing', 'identity'], options(repo, 'session-two'))).toBe(EXIT.OK);
+
+    expect(readFileSync(presenceFile(repo, 'session-one'), 'utf8')).toBe(firstBefore);
+    const second = JSON.parse(readFileSync(presenceFile(repo, 'session-two'), 'utf8')) as {
+      handle: string;
+      sessionKey: string;
+      status: string;
+    };
+    expect(second).toMatchObject({
+      handle: codename('session-two'),
+      sessionKey: 'session-two',
+      status: 'reviewing identity',
+    });
+    expect(stderr.join('')).toContain(`as @${codename('session-two')} · session-two`);
+    expect(JSON.parse(stdout.at(-1) ?? '{}')).toMatchObject({
+      handle: codename('session-two'),
+      sessionKey: 'session-two',
+    });
+  });
+
+  it('refuses a status write owned by another session and leaves the file unchanged', () => {
+    const repo = createRepo();
+    const file = presenceFile(repo, 'resolved-session');
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({
+      agentId: 'resolved-session',
+      sessionKey: 'owner-session',
+      handle: 'Owner',
+      runtime: 'cli',
+      pid: 200,
+      cwd: repo,
+      status: 'owner work',
+      startedAt: '2026-08-28T10:00:00.000Z',
+      lastSeen: '2026-08-28T10:00:00.000Z',
+    }, null, 2));
+    const before = readFileSync(file, 'utf8');
+
+    let caught: unknown;
+    try {
+      runTeam(jsonMode, 'status', ['intruding'], options(repo, 'resolved-session'));
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(CliError);
+    expect(caught).toMatchObject({
+      code: 'foreign_identity',
+      exit: EXIT.CONFLICT,
+      message: 'This status line is owned by @Owner (owner-session); your session is resolved-session.',
+    });
+    expect(readFileSync(file, 'utf8')).toBe(before);
+  });
+
+  it('fails closed without a stable identity and writes no presence file', () => {
+    const repo = createRepo();
+    let caught: unknown;
+    try {
+      runTeam(jsonMode, 'status', ['unresolved'], { cwd: repo, env: {}, ppid: 1 });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(CliError);
+    expect(caught).toMatchObject({ code: 'identity_unresolved', exit: EXIT.CONFLICT });
+    expect((caught as Error).message).toContain('Set O8_AGENT_ID');
+    expect(readdirSync(presenceDir(repo))).toEqual([]);
+  });
+
+  it('adopts a matching legacy file and stamps its session key once', () => {
+    const repo = createRepo();
+    const identity = 'legacy-session';
+    const file = presenceFile(repo, identity);
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({
+      agentId: identity,
+      handle: 'Legacy',
+      runtime: 'cli',
+      pid: 200,
+      cwd: repo,
+      status: 'legacy work',
+      startedAt: '2026-08-28T10:00:00.000Z',
+      lastSeen: new Date().toISOString(),
+    }, null, 2));
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    expect(runTeam(jsonMode, 'status', ['adopted'], options(repo, identity))).toBe(EXIT.OK);
+    const adopted = readFileSync(file, 'utf8');
+    expect(JSON.parse(adopted)).toMatchObject({
+      agentId: identity,
+      sessionKey: identity,
+      handle: 'Legacy',
+      status: 'adopted',
+      startedAt: '2026-08-28T10:00:00.000Z',
+    });
+    expect(adopted.match(/"sessionKey"/g)).toHaveLength(1);
+
+    expect(runTeam(jsonMode, 'status', ['still', 'owned'], options(repo, identity))).toBe(EXIT.OK);
+    const touchedAgain = readFileSync(file, 'utf8');
+    expect(JSON.parse(touchedAgain)).toMatchObject({ sessionKey: identity, status: 'still owned' });
+    expect(touchedAgain.match(/"sessionKey"/g)).toHaveLength(1);
+  });
+});

--- a/cli/src/commands/team.ts
+++ b/cli/src/commands/team.ts
@@ -18,8 +18,9 @@
  *                                       commands unless you hold the `ship` lease
  *   o8 team init                     — install the guard hook into .claude/settings.json
  *
- * Identity = CLAUDE_CODE_SESSION_ID (stable per session). Open-source extraction
- * tracked separately; this is the in-o8 build (`o8 team`).
+ * Identity comes from an explicit runtime/session binding or stable process
+ * ancestry. Open-source extraction tracked separately; this is the in-o8 build
+ * (`o8 team`).
  */
 
 import { execFileSync } from 'node:child_process';
@@ -29,6 +30,7 @@ import path from 'node:path';
 import { CliError, EXIT } from '../api.js';
 import { resolveCliDataDir } from '../config.js';
 import { printJson, type OutputMode } from '../output.js';
+import { resolveLeaseOwnerPid } from './lease.js';
 // PARITY: an agent's o8 team handle is the SAME canonical codename Symon speaks
 // (via o8_status) and the dashboard shows (SessionVisualizer / agent cards) —
 // one voice-friendly name follows the agent across every surface. Import the
@@ -47,6 +49,7 @@ const SHIP_COMMAND_PATTERNS = [
 ];
 interface Presence {
   agentId: string;
+  sessionKey?: string;
   handle: string;
   runtime: string;
   pid: number;
@@ -65,6 +68,22 @@ interface Lease {
   expiresAt: string;
 }
 
+interface AgentProcessRow {
+  pid: number;
+  ppid: number;
+  command: string;
+}
+
+export interface ResolveAgentIdentityOptions {
+  env?: NodeJS.ProcessEnv;
+  ppid?: number;
+  readProcess?: (pid: number) => AgentProcessRow | null;
+}
+
+interface TeamCommandOptions extends ResolveAgentIdentityOptions {
+  cwd?: string;
+}
+
 function nowIso() {
   return new Date().toISOString();
 }
@@ -77,9 +96,10 @@ function isFresh(iso: string | undefined, ttl = LIVE_TTL_MS): boolean {
 
 /** The shared room — the git common dir is the same for every worktree of a repo,
  *  and everything under it is git-ignored, so it never touches the tree. */
-function roomDir(): string {
+function roomDir(cwd = process.cwd()): string {
   try {
     const gitDir = execFileSync('git', ['rev-parse', '--absolute-git-dir'], {
+      cwd,
       windowsHide: true,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
@@ -91,8 +111,8 @@ function roomDir(): string {
   return path.join(resolveCliDataDir(), 'team', 'default');
 }
 
-function ensureRoom(): { room: string; presence: string; leases: string; mailbox: string } {
-  const room = roomDir();
+function ensureRoom(options: TeamCommandOptions = {}): { room: string; presence: string; leases: string; mailbox: string } {
+  const room = roomDir(options.cwd);
   const presence = path.join(room, 'presence');
   const leases = path.join(room, 'leases');
   const mailbox = path.join(room, 'mailbox');
@@ -146,11 +166,24 @@ function markRead(mailboxDir: string, handle: string, count: number): void {
   }
 }
 
-function agentId(): string {
-  return (
-    process.env.CLAUDE_CODE_SESSION_ID
-    || process.env.TERM_SESSION_ID
-    || `pid-${process.ppid || process.pid}`
+export function resolveAgentIdentity(options: ResolveAgentIdentityOptions = {}): string {
+  const env = options.env ?? process.env;
+  const explicit = env.O8_AGENT_ID?.trim();
+  if (explicit) return explicit;
+  const packetId = env.O8_WORKER_PACKET_ID?.trim();
+  if (packetId) return packetId;
+  const claudeSessionId = env.CLAUDE_CODE_SESSION_ID?.trim();
+  if (claudeSessionId) return claudeSessionId;
+  const ownerPid = resolveLeaseOwnerPid({
+    env,
+    ppid: options.ppid,
+    readProcess: options.readProcess,
+  });
+  if (ownerPid !== null) return `pid-${ownerPid}`;
+  throw new CliError(
+    'identity_unresolved',
+    'Unable to resolve a stable agent session identity. Set O8_AGENT_ID to a unique value for this session and retry.',
+    EXIT.CONFLICT,
   );
 }
 
@@ -192,10 +225,26 @@ function livePresences(presenceDir: string): Presence[] {
 }
 
 /** Touch my presence (heartbeat). Auto-assigns a friendly handle on first sight. */
-function touchPresence(presenceDir: string, status?: string): Presence {
-  const id = agentId();
+function touchPresence(
+  presenceDir: string,
+  status?: string,
+  options: TeamCommandOptions = {},
+  beforeWrite?: (presence: Presence) => void,
+): Presence {
+  const id = resolveAgentIdentity(options);
   const file = path.join(presenceDir, `${encodeURIComponent(id)}.json`);
   const existing = readJson<Presence>(file);
+  if (existing) {
+    const ownerSessionKey = existing.sessionKey ?? existing.agentId;
+    const canAdoptLegacy = existing.sessionKey === undefined && existing.agentId === id;
+    if (!canAdoptLegacy && ownerSessionKey !== id) {
+      throw new CliError(
+        'foreign_identity',
+        `This status line is owned by @${existing.handle} (${ownerSessionKey}); your session is ${id}.`,
+        EXIT.CONFLICT,
+      );
+    }
+  }
   let handle = existing?.handle;
   if (!handle) {
     // The canonical codename for this agent (parity with Symon + the UI). Suffix
@@ -212,14 +261,16 @@ function touchPresence(presenceDir: string, status?: string): Presence {
   }
   const presence: Presence = {
     agentId: id,
+    sessionKey: id,
     handle,
     runtime: existing?.runtime || runtimeLabel(),
-    pid: process.ppid || process.pid,
-    cwd: process.cwd(),
+    pid: options.ppid ?? (process.ppid || process.pid),
+    cwd: options.cwd ?? process.cwd(),
     status: status ?? existing?.status ?? 'working',
     startedAt: existing?.startedAt || nowIso(),
     lastSeen: nowIso(),
   };
+  beforeWrite?.(presence);
   writeJsonAtomic(file, presence);
   return presence;
 }
@@ -251,9 +302,9 @@ function leaseFor(leasesDir: string, name: string): Lease | null {
 
 // ── subcommands ─────────────────────────────────────────────────────────
 
-function cmdWho(mode: OutputMode): number {
-  const { presence, leases } = ensureRoom();
-  const me = touchPresence(presence);
+function cmdWho(mode: OutputMode, options: TeamCommandOptions): number {
+  const { presence, leases } = ensureRoom(options);
+  const me = touchPresence(presence, undefined, options);
   const peers = livePresences(presence);
   const held = liveLeases(leases);
   if (mode.human) {
@@ -272,13 +323,15 @@ function cmdWho(mode: OutputMode): number {
   return EXIT.OK;
 }
 
-function cmdStatus(mode: OutputMode, rest: string[]): number {
+function cmdStatus(mode: OutputMode, rest: string[], options: TeamCommandOptions): number {
   const text = rest.join(' ').trim();
   if (!text) throw new CliError('invalid_args', 'o8 team status requires text.', EXIT.INVALID_ARGS, 'Example: o8 team status "shipping 0.1.448"');
-  const { presence } = ensureRoom();
-  const me = touchPresence(presence, text);
+  const { presence } = ensureRoom(options);
+  const me = touchPresence(presence, text, options, (next) => {
+    process.stderr.write(`as @${next.handle} · ${next.sessionKey}\n`);
+  });
   if (mode.human) process.stdout.write(`@${me.handle}: ${me.status}\n`);
-  else printJson({ schema: 'o8/team.status/v1', handle: me.handle, status: me.status });
+  else printJson({ schema: 'o8/team.status/v1', handle: me.handle, sessionKey: me.sessionKey, status: me.status });
   return EXIT.OK;
 }
 
@@ -289,9 +342,9 @@ function flag(rest: string[], name: string): string | null {
   return eq ? eq.slice(name.length + 3) : null;
 }
 
-function cmdLease(mode: OutputMode, action: string | undefined, rest: string[]): number {
-  const { presence, leases } = ensureRoom();
-  const me = touchPresence(presence);
+function cmdLease(mode: OutputMode, action: string | undefined, rest: string[], options: TeamCommandOptions): number {
+  const { presence, leases } = ensureRoom(options);
+  const me = touchPresence(presence, undefined, options);
   if (action === 'list' || !action) {
     const held = liveLeases(leases);
     if (mode.human) {
@@ -339,9 +392,9 @@ function cmdLease(mode: OutputMode, action: string | undefined, rest: string[]):
   throw new CliError('invalid_args', `Unknown lease action: ${action}`, EXIT.INVALID_ARGS, 'Use: acquire | release | list');
 }
 
-function cmdTell(mode: OutputMode, rest: string[]): number {
-  const { presence, mailbox } = ensureRoom();
-  const me = touchPresence(presence);
+function cmdTell(mode: OutputMode, rest: string[], options: TeamCommandOptions): number {
+  const { presence, mailbox } = ensureRoom(options);
+  const me = touchPresence(presence, undefined, options);
   const target = rest.find((t) => t.startsWith('@'));
   if (!target) throw new CliError('invalid_args', 'o8 team tell requires a @handle.', EXIT.INVALID_ARGS, 'Example: o8 team tell @nova "hold your bump, I am mid-ship"');
   const toHandle = target.slice(1);
@@ -354,9 +407,9 @@ function cmdTell(mode: OutputMode, rest: string[]): number {
   return EXIT.OK;
 }
 
-function cmdInbox(mode: OutputMode, rest: string[]): number {
-  const { presence, mailbox } = ensureRoom();
-  const me = touchPresence(presence);
+function cmdInbox(mode: OutputMode, rest: string[], options: TeamCommandOptions): number {
+  const { presence, mailbox } = ensureRoom(options);
+  const me = touchPresence(presence, undefined, options);
   const box = readMailbox(mailbox, me.handle);
   const msgs = rest.includes('--all') ? box.all : box.all.slice(box.readCount);
   if (mode.human) {
@@ -370,9 +423,9 @@ function cmdInbox(mode: OutputMode, rest: string[]): number {
 /** PreToolUse hook: stamp heartbeat, surface unread peer messages as context,
  *  and block a ship/bump when the `ship` lease is held by another live agent.
  *  Reads Claude Code's hook JSON on stdin; exit 2 blocks + feeds stderr back. */
-function cmdGuard(): number {
-  const { presence, leases, mailbox } = ensureRoom();
-  const me = touchPresence(presence);
+function cmdGuard(options: TeamCommandOptions): number {
+  const { presence, leases, mailbox } = ensureRoom(options);
+  const me = touchPresence(presence, undefined, options);
   const box = readMailbox(mailbox, me.handle);
   const unread = box.all.slice(box.readCount);
 
@@ -415,8 +468,8 @@ const GUARD_HOOK = {
   hooks: [{ type: 'command', command: 'o8 team guard' }],
 };
 
-function cmdInit(mode: OutputMode): number {
-  const settingsPath = path.join(process.cwd(), '.claude', 'settings.json');
+function cmdInit(mode: OutputMode, options: TeamCommandOptions): number {
+  const settingsPath = path.join(options.cwd ?? process.cwd(), '.claude', 'settings.json');
   mkdirSync(path.dirname(settingsPath), { recursive: true });
   const settings = (readJson<Record<string, unknown>>(settingsPath)) ?? {};
   const hooks = (settings.hooks as Record<string, unknown>) ?? {};
@@ -425,8 +478,8 @@ function cmdInit(mode: OutputMode): number {
   if (!already) preToolUse.push(GUARD_HOOK);
   settings.hooks = { ...hooks, PreToolUse: preToolUse };
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
-  const { presence } = ensureRoom();
-  const me = touchPresence(presence);
+  const { presence } = ensureRoom(options);
+  const me = touchPresence(presence, undefined, options);
   if (mode.human) {
     process.stdout.write(`o8 team installed (you are @${me.handle}).\n`);
     process.stdout.write(`Guard hook ${already ? 'already present' : 'added'} in ${settingsPath}.\n`);
@@ -435,15 +488,20 @@ function cmdInit(mode: OutputMode): number {
   return EXIT.OK;
 }
 
-export function runTeam(mode: OutputMode, sub: string | undefined, rest: string[]): number {
+export function runTeam(
+  mode: OutputMode,
+  sub: string | undefined,
+  rest: string[],
+  options: TeamCommandOptions = {},
+): number {
   switch (sub) {
-    case 'who': return cmdWho(mode);
-    case 'status': return cmdStatus(mode, rest);
-    case 'lease': return cmdLease(mode, rest[0], rest.slice(1));
-    case 'tell': return cmdTell(mode, rest);
-    case 'inbox': return cmdInbox(mode, rest);
-    case 'guard': return cmdGuard();
-    case 'init': return cmdInit(mode);
+    case 'who': return cmdWho(mode, options);
+    case 'status': return cmdStatus(mode, rest, options);
+    case 'lease': return cmdLease(mode, rest[0], rest.slice(1), options);
+    case 'tell': return cmdTell(mode, rest, options);
+    case 'inbox': return cmdInbox(mode, rest, options);
+    case 'guard': return cmdGuard(options);
+    case 'init': return cmdInit(mode, options);
     default:
       throw new CliError(
         'unknown_team_subcommand',

--- a/src/app/api/agents/presence/route.ts
+++ b/src/app/api/agents/presence/route.ts
@@ -42,8 +42,9 @@ export async function POST(request: Request): Promise<Response> {
   try {
     const body = await request.json().catch(() => null);
     const agent = joinAgentPresence(body, resolveRequestPrincipalContext(request));
-    return Response.json({ schema: 'o8/agents.presence.join/v1', ok: true, agent }, {
-      status: 201,
+    const { adoptedLegacy, ...responseAgent } = agent;
+    return Response.json({ schema: 'o8/agents.presence.join/v1', ok: true, agent: responseAgent }, {
+      status: adoptedLegacy || agent.tookOverStale ? 200 : 201,
       headers: { 'Cache-Control': 'no-store, max-age=0' },
     });
   } catch (error) {

--- a/src/lib/agents/service.ts
+++ b/src/lib/agents/service.ts
@@ -22,8 +22,10 @@ import {
 } from './live-presence';
 import {
   AGENT_MESSAGE_TEXT_MAX_LENGTH,
+  AgentPresenceWriteConflictError,
   type AgentMessageRefs,
   type AgentPresence,
+  type AgentPresenceWriteResult,
   acknowledgeAgentInbox,
   claimAgentInboxWake,
   findAgentPresence,
@@ -265,7 +267,7 @@ export function joinAgentPresence(
   input: unknown,
   principal: RequestPrincipalContext,
   sqlite: Database.Database = getSqlite(),
-): AgentPresence {
+): AgentPresenceWriteResult {
   if (principal.role !== 'operator') {
     throw new AgentBusError('Presence join requires an operator credential.', 'agent_presence_join_forbidden', 403);
   }
@@ -276,17 +278,24 @@ export function joinAgentPresence(
   const name = automatic
     ? optionalString(body.name, 'name') ?? availableAutomaticAgentName(agentId, resolve(repo), sqlite)
     : requiredString(body.name, 'name');
-  return upsertAgentPresence({
-    agentId,
-    name,
-    repo,
-    worktreePath: optionalString(body.worktreePath, 'worktreePath', 2_000),
-    runtime: requiredString(body.runtime, 'runtime'),
-    sessionKey: optionalString(body.sessionKey, 'sessionKey', 500),
-    laneId: null,
-    packetId: null,
-    lastSeen: new Date().toISOString(),
-  }, sqlite);
+  try {
+    return upsertAgentPresence({
+      agentId,
+      name,
+      repo,
+      worktreePath: optionalString(body.worktreePath, 'worktreePath', 2_000),
+      runtime: requiredString(body.runtime, 'runtime'),
+      sessionKey: optionalString(body.sessionKey, 'sessionKey', 500),
+      laneId: null,
+      packetId: null,
+      lastSeen: new Date().toISOString(),
+    }, sqlite);
+  } catch (error) {
+    if (error instanceof AgentPresenceWriteConflictError) {
+      throw new AgentBusError(error.message, error.code, error.status);
+    }
+    throw error;
+  }
 }
 
 export async function readAgentPresence(

--- a/src/lib/agents/store.ts
+++ b/src/lib/agents/store.ts
@@ -15,6 +15,23 @@ export const AGENT_MESSAGE_TEXT_MAX_LENGTH = 4_000;
 export const AGENT_PRESENCE_TTL_MS = 6 * 60_000;
 export const AGENT_NATIVE_WAKE_TTL_MS = 15 * 60_000;
 
+export type AgentPresenceWriteResult = AgentPresence & {
+  adoptedLegacy?: true;
+  tookOverStale?: true;
+};
+
+export class AgentPresenceWriteConflictError extends Error {
+  readonly code = 'foreign_identity';
+  readonly status = 409;
+
+  constructor(readonly owner: AgentPresence, attemptedSessionKey: string | null) {
+    super(
+      `This status line is owned by @${owner.name} (${owner.sessionKey}); your session is ${attemptedSessionKey}.`,
+    );
+    this.name = 'AgentPresenceWriteConflictError';
+  }
+}
+
 interface PresenceRow {
   agent_id: string;
   name: string;
@@ -175,34 +192,55 @@ function mapMessage(row: MessageRow): AgentMessage {
 export function upsertAgentPresence(
   input: Omit<AgentPresence, 'repo'> & { repo: string },
   sqlite: Database.Database = getSqlite(),
-): AgentPresence {
+): AgentPresenceWriteResult {
   ensureAgentBusSchema(sqlite);
   const repo = normalizeRepoPath(input.repo);
-  sqlite.prepare(`
-    INSERT INTO agent_presence
-      (agent_id, name, repo_path, worktree_path, runtime, session_key, lane_id, packet_id, last_seen)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    ON CONFLICT(agent_id) DO UPDATE SET
-      name = excluded.name,
-      repo_path = excluded.repo_path,
-      worktree_path = excluded.worktree_path,
-      runtime = excluded.runtime,
-      session_key = excluded.session_key,
-      lane_id = excluded.lane_id,
-      packet_id = excluded.packet_id,
-      last_seen = excluded.last_seen
-  `).run(
-    input.agentId,
-    input.name,
+  let adoptedLegacy = false;
+  let tookOverStale = false;
+  sqlite.transaction(() => {
+    const existing = sqlite.prepare('SELECT * FROM agent_presence WHERE agent_id = ?')
+      .get(input.agentId) as PresenceRow | undefined;
+    if (existing && existing.session_key !== input.sessionKey) {
+      const owner = mapPresence(existing);
+      if (existing.session_key === null) {
+        adoptedLegacy = true;
+      } else if (!isPresenceLive(owner)) {
+        tookOverStale = true;
+      } else {
+        throw new AgentPresenceWriteConflictError(owner, input.sessionKey);
+      }
+    }
+    sqlite.prepare(`
+      INSERT INTO agent_presence
+        (agent_id, name, repo_path, worktree_path, runtime, session_key, lane_id, packet_id, last_seen)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(agent_id) DO UPDATE SET
+        name = excluded.name,
+        repo_path = excluded.repo_path,
+        worktree_path = excluded.worktree_path,
+        runtime = excluded.runtime,
+        session_key = excluded.session_key,
+        lane_id = excluded.lane_id,
+        packet_id = excluded.packet_id,
+        last_seen = excluded.last_seen
+    `).run(
+      input.agentId,
+      input.name,
+      repo,
+      input.worktreePath,
+      input.runtime,
+      input.sessionKey,
+      input.laneId,
+      input.packetId,
+      input.lastSeen,
+    );
+  })();
+  return {
+    ...input,
     repo,
-    input.worktreePath,
-    input.runtime,
-    input.sessionKey,
-    input.laneId,
-    input.packetId,
-    input.lastSeen,
-  );
-  return { ...input, repo };
+    ...(adoptedLegacy ? { adoptedLegacy: true as const } : {}),
+    ...(tookOverStale ? { tookOverStale: true as const } : {}),
+  };
 }
 
 export function findAgentPresence(

--- a/tests/agents-presence-foreign-write-real-path.test.ts
+++ b/tests/agents-presence-foreign-write-real-path.test.ts
@@ -1,0 +1,154 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const dataDir = mkdtempSync(path.join(os.tmpdir(), 'o8-presence-foreign-write-'));
+const operatorToken = 'presence-foreign-write-operator-token-0123456789';
+writeFileSync(path.join(dataDir, 'ws-token'), `${operatorToken}\n`, 'utf8');
+process.env.O8_DATA_DIR = dataDir;
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+
+const presenceRoute = await import('@/app/api/agents/presence/route');
+const { closeDb, getSqlite } = await import('@/lib/db');
+const { AGENT_PRESENCE_TTL_MS, findAgentPresence } = await import('@/lib/agents/store');
+
+function joinRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost:3001/api/agents/presence', {
+    method: 'POST',
+    headers: {
+      host: 'localhost:3001',
+      authorization: `Bearer ${operatorToken}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+afterAll(() => {
+  closeDb();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('agent presence foreign writes through the real route', () => {
+  it('returns 409 and preserves the owner row when an agent id arrives with another session key', async () => {
+    const agentId = 'shared-agent-id';
+    const first = await presenceRoute.POST(joinRequest({
+      agentId,
+      name: 'Owner',
+      repo: '/tmp/o8-presence-foreign-write-repo',
+      worktreePath: '/tmp/o8-presence-foreign-write-repo/owner',
+      runtime: 'codex',
+      sessionKey: 'owner-session-key',
+    }));
+    expect(first.status).toBe(201);
+    const before = findAgentPresence({ agentId });
+    expect(before).toMatchObject({ name: 'Owner', sessionKey: 'owner-session-key' });
+
+    const second = await presenceRoute.POST(joinRequest({
+      agentId,
+      name: 'Intruder',
+      repo: '/tmp/o8-presence-foreign-write-repo',
+      worktreePath: '/tmp/o8-presence-foreign-write-repo/intruder',
+      runtime: 'codex',
+      sessionKey: 'intruder-session-key',
+    }));
+
+    expect(second.status).toBe(409);
+    await expect(second.json()).resolves.toEqual({
+      schema: 'o8/agents.presence.error/v1',
+      ok: false,
+      error: {
+        code: 'foreign_identity',
+        message: 'This status line is owned by @Owner (owner-session-key); your session is intruder-session-key.',
+      },
+    });
+    expect(findAgentPresence({ agentId })).toEqual(before);
+  });
+
+  it('takes over an expired owner and records the new session key', async () => {
+    const agentId = 'stale-agent-id';
+    const first = await presenceRoute.POST(joinRequest({
+      agentId,
+      name: 'StaleOwner',
+      repo: '/tmp/o8-presence-foreign-write-repo',
+      worktreePath: '/tmp/o8-presence-foreign-write-repo/stale-owner',
+      runtime: 'codex',
+      sessionKey: 'stale-session-key',
+    }));
+    expect(first.status).toBe(201);
+    const staleLastSeen = new Date(Date.now() - AGENT_PRESENCE_TTL_MS - 1_000).toISOString();
+    getSqlite().prepare('UPDATE agent_presence SET last_seen = ? WHERE agent_id = ?')
+      .run(staleLastSeen, agentId);
+
+    const restarted = await presenceRoute.POST(joinRequest({
+      agentId,
+      name: 'RestartedWorker',
+      repo: '/tmp/o8-presence-foreign-write-repo',
+      worktreePath: '/tmp/o8-presence-foreign-write-repo/restarted-worker',
+      runtime: 'codex',
+      sessionKey: 'restarted-session-key',
+    }));
+
+    expect(restarted.status).toBe(200);
+    await expect(restarted.json()).resolves.toMatchObject({
+      ok: true,
+      agent: {
+        agentId,
+        name: 'RestartedWorker',
+        sessionKey: 'restarted-session-key',
+        tookOverStale: true,
+      },
+    });
+    expect(findAgentPresence({ agentId })).toMatchObject({
+      name: 'RestartedWorker',
+      sessionKey: 'restarted-session-key',
+    });
+  });
+
+  it('adopts a legacy null session key once', async () => {
+    const agentId = 'legacy-agent-id';
+    const first = await presenceRoute.POST(joinRequest({
+      agentId,
+      name: 'LegacyOwner',
+      repo: '/tmp/o8-presence-foreign-write-repo',
+      worktreePath: '/tmp/o8-presence-foreign-write-repo/legacy-owner',
+      runtime: 'codex',
+    }));
+    expect(first.status).toBe(201);
+    expect(findAgentPresence({ agentId })).toMatchObject({ sessionKey: null });
+
+    const adopted = await presenceRoute.POST(joinRequest({
+      agentId,
+      name: 'LegacyOwner',
+      repo: '/tmp/o8-presence-foreign-write-repo',
+      worktreePath: '/tmp/o8-presence-foreign-write-repo/legacy-owner',
+      runtime: 'codex',
+      sessionKey: 'adopted-session-key',
+    }));
+
+    expect(adopted.status).toBe(200);
+    await expect(adopted.json()).resolves.toMatchObject({
+      ok: true,
+      agent: {
+        agentId,
+        sessionKey: 'adopted-session-key',
+      },
+    });
+    const adoptedRow = findAgentPresence({ agentId });
+    expect(adoptedRow).toMatchObject({ sessionKey: 'adopted-session-key' });
+
+    const foreign = await presenceRoute.POST(joinRequest({
+      agentId,
+      name: 'LegacyOwner',
+      repo: '/tmp/o8-presence-foreign-write-repo',
+      worktreePath: '/tmp/o8-presence-foreign-write-repo/legacy-owner',
+      runtime: 'codex',
+      sessionKey: 'foreign-session-key',
+    }));
+    expect(foreign.status).toBe(409);
+    expect(findAgentPresence({ agentId })).toEqual(adoptedRow);
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -3,6 +3,13 @@
   "generatedBy": "node scripts/classify-tests.mjs --write",
   "resourceOwning": [
     {
+      "path": "cli/src/commands/team.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli"
+      ]
+    },
+    {
       "path": "src/app/api/leases/route.test.ts",
       "reasons": [
         "apfs-tool",
@@ -863,6 +870,12 @@
     },
     {
       "path": "tests/agent-message-bus-real-path.test.ts",
+      "reasons": [
+        "real-path"
+      ]
+    },
+    {
+      "path": "tests/agents-presence-foreign-write-real-path.test.ts",
       "reasons": [
         "real-path"
       ]


### PR DESCRIPTION
Fixes #1924.

## What

Team presence identity is bound to the registering session and fails closed, on both presence surfaces.

- **CLI (`o8 team …`)** — `agentId()` used to fall through `CLAUDE_CODE_SESSION_ID → TERM_SESSION_ID → pid-<ppid>`, so two agents in one checkout could resolve to the same identity and `o8 team status` would reuse the other agent's handle and overwrite its line. `resolveAgentIdentity()` now resolves explicit `O8_AGENT_ID` → `O8_WORKER_PACKET_ID` → `CLAUDE_CODE_SESSION_ID` → the lease command's stable ancestry pid, never the terminal id, and throws `identity_unresolved` (exit `CONFLICT`) with a fix-it message instead of guessing. Presence files carry `sessionKey`; a status write against a file owned by a different session is refused with `foreign_identity` naming the owner (`This status line is owned by @<handle> (<key>); your session is <key>`) and nothing is written. Legacy files without `sessionKey` are adopted once by the matching identity and stamped. `o8 team status` prints `as @<handle> · <identity>` on stderr before writing; `--json` includes `sessionKey`. Every subcommand takes injectable `env` / `ppid` / `readProcess` / `cwd` seams, like the lease command.
- **Agent bus (`POST /api/agents/presence`)** — `upsertAgentPresence` used to trust whatever `agentId` arrived. It now refuses a write whose `agentId` belongs to a **live** row (within `AGENT_PRESENCE_TTL_MS`) with a different session key (409, `foreign_identity`, owner named, row unchanged); a row past the TTL is taken over (packet workers reuse the packet id as `agentId` across restarts), and a legacy `NULL` session key is adopted and stamped.

## Proof

- `cli/src/commands/team.test.ts` (new): identity prefers explicit and packet bindings, ignores terminal ids, and walks stable ancestry; two agents joining the same checkout with different sessions — the second's status write leaves the first's file byte-unchanged and updates its own; a write whose identity maps to a file owned by another session is refused with the owner's handle and the file is unchanged; an unresolvable identity fails closed with no file written; a legacy file is adopted and stamped once.
- `tests/agents-presence-foreign-write-real-path.test.ts` (new): through the real route handler — a live row with another session key → 409 and the row is unchanged; a stale row → taken over; a `NULL`-key row → stamped.

## Gates

tsc · team + lease + presence tests · lint ratchet (cap 152, touched files add zero warnings) · classification check · full suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent sessions from overwriting another agent’s presence.
  * Added safe handling for stale and legacy presence records.
  * Improved error responses for identity conflicts and unresolved sessions.
  * Presence updates now report whether a stale record was taken over or a legacy record adopted.

* **Tests**
  * Added coverage for session identity resolution, presence ownership, stale takeover, and legacy adoption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->