### PR TITLE
fix: guard the release cache against the project node_modules and verify native modules after a ship

### DIFF
--- a/scripts/lib/release-build-cache.d.mts
+++ b/scripts/lib/release-build-cache.d.mts
@@ -25,6 +25,7 @@ export interface ReleaseBuildCacheAction {
 }
 
 export function resolveReleaseBuildCacheRoot(env?: NodeJS.ProcessEnv): string;
+export function isReleaseBuildCacheSafetyError(error: unknown): boolean;
 export function collectReleaseBuildCacheIdentity(
   root: string,
   phase: ReleaseBuildCachePhase,
@@ -65,9 +66,11 @@ export function finalizeReleaseBuildCacheReceipt(
     source: Record<string, unknown>;
     buildDurationMs: number;
   },
+  options?: { projectRoot?: string },
 ): { receipt: Record<string, unknown>; receiptPath: string };
 export const releaseBuildCacheInternals: {
   PHASE_CONFIG: Record<ReleaseBuildCachePhase, unknown>;
+  assertOutsideProjectNodeModules(target: string, projectRoot: string): void;
   collectWebEnvironmentFiles(root: string): Array<{ path: string; sha256: string }>;
   normalizeArchivePath(value: string): string | null;
   pathAllowed(candidate: string, targets: string[], excludes: string[]): boolean;

--- a/scripts/lib/release-build-cache.mjs
+++ b/scripts/lib/release-build-cache.mjs
@@ -9,13 +9,14 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   renameSync,
   rmSync,
   statSync,
   writeFileSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
-import { basename, dirname, join, normalize, relative, resolve, sep } from 'node:path';
+import { basename, dirname, isAbsolute, join, normalize, relative, resolve, sep } from 'node:path';
 
 export const RELEASE_BUILD_CACHE_SCHEMA = 'o8/release-build-cache-entry/v1';
 export const RELEASE_BUILD_CACHE_RECEIPT_SCHEMA = 'o8/release-build-cache-receipt/v1';
@@ -24,6 +25,7 @@ export const RELEASE_BUILD_CACHE_PHASES = Object.freeze(['web', 'speech', 'nativ
 const CACHE_VERSION_DIR = 'release-v1';
 const ENTRY_LIMIT = 1;
 const COMPATIBILITY_LIMIT = 2;
+const UNSAFE_PATH_ERROR_CODE = 'O8_RELEASE_CACHE_UNSAFE_PATH';
 const WEB_ENVIRONMENT_PATTERNS = [
   /^NEXT_PUBLIC_/,
   /^CLERK_PUBLISHABLE_KEY$/,
@@ -250,6 +252,55 @@ function pathInside(candidate, root) {
   return candidate === root || candidate.startsWith(`${root}/`);
 }
 
+function realpathWithMissingSegments(path) {
+  const segments = [];
+  let existing = resolve(path);
+  while (!existsSync(existing)) {
+    const parent = dirname(existing);
+    if (parent === existing) return resolve(path);
+    segments.unshift(basename(existing));
+    existing = parent;
+  }
+  return resolve(realpathSync(existing), ...segments);
+}
+
+function resolvedPathInside(candidate, boundary) {
+  const remainder = relative(boundary, candidate);
+  return remainder === ''
+    || (remainder !== '..' && !remainder.startsWith(`..${sep}`) && !isAbsolute(remainder));
+}
+
+function assertOutsideProjectNodeModules(target, projectRoot) {
+  const absoluteTarget = resolve(target);
+  const resolvedTarget = realpathWithMissingSegments(absoluteTarget);
+  const resolvedProjectRoot = realpathWithMissingSegments(projectRoot);
+  const resolvedNodeModules = realpathWithMissingSegments(join(projectRoot, 'node_modules'));
+  if (resolvedTarget !== resolvedProjectRoot
+    && !resolvedPathInside(resolvedTarget, resolvedNodeModules)) return;
+
+  const error = new Error(
+    `release cache refused unsafe destructive path: ${absoluteTarget}`
+    + ` (resolved to ${resolvedTarget}; project node_modules: ${resolvedNodeModules})`,
+  );
+  error.code = UNSAFE_PATH_ERROR_CODE;
+  throw error;
+}
+
+function removeCachePath(target, options, projectRoot) {
+  assertOutsideProjectNodeModules(target, projectRoot);
+  rmSync(target, options);
+}
+
+function renameCachePath(source, destination, projectRoot) {
+  assertOutsideProjectNodeModules(source, projectRoot);
+  assertOutsideProjectNodeModules(destination, projectRoot);
+  renameSync(source, destination);
+}
+
+export function isReleaseBuildCacheSafetyError(error) {
+  return error?.code === UNSAFE_PATH_ERROR_CODE;
+}
+
 function pathAllowed(candidate, targets, excludes) {
   return targets.some((target) => pathInside(candidate, target))
     && !excludes.some((excluded) => pathInside(candidate, excluded));
@@ -350,6 +401,7 @@ export async function restoreReleaseBuildCache(root, phase, options = {}) {
       lastReason = verified.reason;
       continue;
     }
+    assertOutsideProjectNodeModules(cacheRoot, root);
     const restoreRoot = mkdtempSync(join(cacheRoot, '.restore-'));
     try {
       execFileSync('tar', ['-xf', verified.archivePath, '-C', restoreRoot], {
@@ -365,9 +417,9 @@ export async function restoreReleaseBuildCache(root, phase, options = {}) {
       for (const target of verified.manifest.targets) {
         const extracted = join(restoreRoot, target);
         const destination = join(root, target);
-        rmSync(destination, { recursive: true, force: true });
+        removeCachePath(destination, { recursive: true, force: true }, root);
         mkdirSync(dirname(destination), { recursive: true });
-        renameSync(extracted, destination);
+        renameCachePath(extracted, destination, root);
       }
       return {
         phase,
@@ -380,9 +432,10 @@ export async function restoreReleaseBuildCache(root, phase, options = {}) {
         durationMs: Date.now() - started,
       };
     } catch (error) {
+      if (isReleaseBuildCacheSafetyError(error)) throw error;
       lastReason = `restore_failed:${error instanceof Error ? error.message : String(error)}`;
     } finally {
-      rmSync(restoreRoot, { recursive: true, force: true });
+      removeCachePath(restoreRoot, { recursive: true, force: true }, root);
     }
   }
   return { phase, status: 'miss', reason: lastReason, durationMs: Date.now() - started };
@@ -395,7 +448,8 @@ function tarArguments(root, config, archivePath) {
   return args;
 }
 
-function pruneEntries(directory, keepEntry) {
+function pruneEntries(directory, keepEntry, projectRoot) {
+  assertOutsideProjectNodeModules(directory, projectRoot);
   const manifests = readdirSync(directory)
     .filter((name) => name.endsWith('.json'))
     .map((name) => ({ name, mtimeMs: statSync(join(directory, name)).mtimeMs }))
@@ -410,14 +464,15 @@ function pruneEntries(directory, keepEntry) {
   for (const { name } of manifests) {
     const entry = basename(name, '.json');
     if (keep.has(entry)) continue;
-    rmSync(join(directory, name), { force: true });
-    rmSync(archivePathFor(directory, entry), { force: true });
+    removeCachePath(join(directory, name), { force: true }, projectRoot);
+    removeCachePath(archivePathFor(directory, entry), { force: true }, projectRoot);
   }
 }
 
-function pruneCompatibilityDirectories(cacheRoot, phase, keepCompatibility) {
+function pruneCompatibilityDirectories(cacheRoot, phase, keepCompatibility, projectRoot) {
   const phaseRoot = join(cacheRoot, 'entries', phase);
   if (!existsSync(phaseRoot)) return;
+  assertOutsideProjectNodeModules(phaseRoot, projectRoot);
   const directories = readdirSync(phaseRoot, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
     .map((entry) => ({
@@ -431,7 +486,9 @@ function pruneCompatibilityDirectories(cacheRoot, phase, keepCompatibility) {
   ];
   const keep = new Set(ordered.slice(0, COMPATIBILITY_LIMIT));
   for (const { name } of directories) {
-    if (!keep.has(name)) rmSync(join(phaseRoot, name), { recursive: true, force: true });
+    if (!keep.has(name)) {
+      removeCachePath(join(phaseRoot, name), { recursive: true, force: true }, projectRoot);
+    }
   }
 }
 
@@ -452,6 +509,7 @@ export async function captureReleaseBuildCache(root, phase, options = {}) {
   }
   for (const target of config.targets) assertTreeHasNoLinks(join(root, target));
   const directory = entriesDirectory(cacheRoot, identity);
+  assertOutsideProjectNodeModules(directory, root);
   ensurePrivateDirectory(directory);
   const finalManifestPath = manifestPathFor(directory, identity.entrySha256);
   const finalArchivePath = archivePathFor(directory, identity.entrySha256);
@@ -497,10 +555,10 @@ export async function captureReleaseBuildCache(root, phase, options = {}) {
       archive,
     };
     writeFileSync(temporaryManifest, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
-    renameSync(temporaryArchive, finalArchivePath);
-    renameSync(temporaryManifest, finalManifestPath);
-    pruneEntries(directory, identity.entrySha256);
-    pruneCompatibilityDirectories(cacheRoot, phase, identity.compatibilitySha256);
+    renameCachePath(temporaryArchive, finalArchivePath, root);
+    renameCachePath(temporaryManifest, finalManifestPath, root);
+    pruneEntries(directory, identity.entrySha256, root);
+    pruneCompatibilityDirectories(cacheRoot, phase, identity.compatibilitySha256, root);
     return {
       phase,
       status: 'captured',
@@ -510,8 +568,8 @@ export async function captureReleaseBuildCache(root, phase, options = {}) {
       durationMs: Date.now() - started,
     };
   } finally {
-    rmSync(temporaryArchive, { force: true });
-    rmSync(temporaryManifest, { force: true });
+    removeCachePath(temporaryArchive, { force: true }, root);
+    removeCachePath(temporaryManifest, { force: true }, root);
   }
 }
 
@@ -529,7 +587,8 @@ export function writeReleaseBuildCachePhaseReceipt(cacheRoot, runId, receipt) {
   writeFileSync(join(directory, `${receipt.phase}.json`), `${JSON.stringify(receipt, null, 2)}\n`, { mode: 0o600 });
 }
 
-export function finalizeReleaseBuildCacheReceipt(cacheRoot, runId, summary) {
+export function finalizeReleaseBuildCacheReceipt(cacheRoot, runId, summary, options = {}) {
+  const projectRoot = options.projectRoot ?? process.cwd();
   const directory = runDirectory(cacheRoot, runId);
   const phases = {};
   if (existsSync(directory)) {
@@ -560,12 +619,13 @@ export function finalizeReleaseBuildCacheReceipt(cacheRoot, runId, summary) {
   ensurePrivateDirectory(receiptsDirectory);
   const receiptPath = join(receiptsDirectory, `${runId}.json`);
   writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, { mode: 0o600 });
-  rmSync(directory, { recursive: true, force: true });
+  removeCachePath(directory, { recursive: true, force: true }, projectRoot);
   return { receipt, receiptPath };
 }
 
 export const releaseBuildCacheInternals = {
   PHASE_CONFIG,
+  assertOutsideProjectNodeModules,
   collectWebEnvironmentFiles,
   normalizeArchivePath,
   pathAllowed,

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -43,7 +43,26 @@ const PING_MIN_BULLETS = Number(process.env.O8_PING_MIN_BULLETS || 4);
 // A release nobody can skip pings regardless of size: security, a forced/breaking update, data loss.
 const PING_ALWAYS_RE = /\b(security|vulnerabilit|CVE|breaking change|breaking:|data loss|corrupt|hotfix|urgent|must update|required update)\b/i;
 const LSREGISTER = '/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister';
+const CHECKOUT_NATIVE_MODULES = ['better-sqlite3', 'node-pty'];
 const root = process.cwd();
+
+function runCheckoutNativeModuleGate(checkoutRoot) {
+  const script = `
+for (const moduleName of process.argv.slice(1)) {
+  try {
+    const resolved = require.resolve(moduleName);
+    require(moduleName);
+    console.log('[release] checkout native module ' + moduleName + ' resolved to ' + resolved);
+  } catch (error) {
+    console.error('[release] FATAL: checkout native module ' + moduleName + ' failed to resolve or load: ' + error.message);
+    process.exitCode = 1;
+  }
+}`;
+  execFileSync(process.execPath, ['-e', script, ...CHECKOUT_NATIVE_MODULES], {
+    cwd: checkoutRoot,
+    stdio: 'inherit',
+  });
+}
 
 function runNativeGate(serverRoot) {
   verifyNativeBundle(serverRoot);
@@ -61,6 +80,17 @@ if (process.argv[2] === '--verify-native-bundle') {
     process.exit(0);
   } catch (error) {
     console.error(`[release] FATAL: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[2] === '--verify-checkout-native-modules') {
+  const target = resolve(process.argv[3] || root);
+  try {
+    runCheckoutNativeModuleGate(target);
+    process.exit(0);
+  } catch {
+    console.error(`[release] FATAL: checkout native module verification failed in ${target}`);
     process.exit(1);
   }
 }
@@ -142,6 +172,14 @@ try {
 } catch (error) {
   console.error(`[release] FATAL: ${error.message}`);
   console.error('[release] Refusing to publish without Node 22 + 24, x64 + arm64 prebuilds for both native addons.');
+  process.exit(1);
+}
+
+try {
+  runCheckoutNativeModuleGate(root);
+} catch {
+  console.error(`[release] FATAL: checkout native module verification failed in ${root}`);
+  console.error('[release] Refusing to publish because the local ship changed the checkout dependency state.');
   process.exit(1);
 }
 

--- a/scripts/tauri-build.mjs
+++ b/scripts/tauri-build.mjs
@@ -8,6 +8,7 @@ import {
   collectReleaseBuildCacheIdentity,
   createReleaseBuildCacheRunId,
   finalizeReleaseBuildCacheReceipt,
+  isReleaseBuildCacheSafetyError,
   resolveReleaseBuildCacheRoot,
   restoreReleaseBuildCache,
   writeReleaseBuildCachePhaseReceipt,
@@ -31,6 +32,7 @@ try {
     buildOptions: nativeBuildOptions,
   });
 } catch (error) {
+  if (isReleaseBuildCacheSafetyError(error)) throw error;
   nativeRestore = {
     phase: 'native',
     status: 'miss',
@@ -73,6 +75,7 @@ if (!build.error && build.status === 0) {
       buildOptions: nativeBuildOptions,
     });
   } catch (error) {
+    if (isReleaseBuildCacheSafetyError(error)) throw error;
     nativeCapture = {
       phase: 'native',
       status: 'miss',
@@ -98,7 +101,7 @@ try {
     outcome: !build.error && build.status === 0 ? 'PASS' : 'FAIL',
     source: nativeIdentity?.source ?? { head: 'unavailable' },
     buildDurationMs,
-  });
+  }, { projectRoot: root });
   const totals = finalized.receipt.totals ?? {};
   console.log(
     `[release-cache] receipt ${finalized.receiptPath}`
@@ -106,6 +109,7 @@ try {
     + ` restored=${totals.archiveBytesRestored ?? 0} estimated-saved=${totals.estimatedSavedMs ?? 0}ms`,
   );
 } catch (error) {
+  if (isReleaseBuildCacheSafetyError(error)) throw error;
   console.warn(`[release-cache] receipt unavailable: ${error instanceof Error ? error.message : String(error)}`);
 }
 

--- a/scripts/tauri-prebuild.mjs
+++ b/scripts/tauri-prebuild.mjs
@@ -13,6 +13,7 @@ import {
   collectReleaseBuildCacheIdentity,
   createReleaseBuildCacheRunId,
   finalizeReleaseBuildCacheReceipt,
+  isReleaseBuildCacheSafetyError,
   resolveReleaseBuildCacheRoot,
   restoreReleaseBuildCache,
   writeReleaseBuildCachePhaseReceipt,
@@ -54,6 +55,7 @@ async function cachedPhase(cachePhase, label, command, args) {
     cacheSource = identity.source;
     restore = await restoreReleaseBuildCache(root, cachePhase, { cacheRoot, identity });
   } catch (error) {
+    if (isReleaseBuildCacheSafetyError(error)) throw error;
     restore = {
       phase: cachePhase,
       status: 'miss',
@@ -75,6 +77,7 @@ async function cachedPhase(cachePhase, label, command, args) {
       buildDurationMs,
     });
   } catch (error) {
+    if (isReleaseBuildCacheSafetyError(error)) throw error;
     capture = {
       phase: cachePhase,
       status: 'miss',
@@ -128,9 +131,10 @@ try {
         outcome: cacheOutcome,
         source: cacheSource,
         buildDurationMs: Date.now() - prebuildStartedAt,
-      });
+      }, { projectRoot: root });
       console.log(`[release-cache] receipt ${finalized.receiptPath}`);
     } catch (error) {
+      if (isReleaseBuildCacheSafetyError(error)) throw error;
       console.warn(`[release-cache] receipt unavailable: ${error instanceof Error ? error.message : String(error)}`);
     }
   }

--- a/tests/release-build-cache.test.ts
+++ b/tests/release-build-cache.test.ts
@@ -1,4 +1,13 @@
-import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -100,6 +109,89 @@ describe('shared release build cache', () => {
     });
     expect(readFileSync(join(root, '.next', 'cache', 'webpack', 'entry.bin'), 'utf8'))
       .toBe('compiled-source-a');
+  });
+
+  it('restores and prunes normal compiler output without touching project node_modules', async () => {
+    const { root, cacheRoot } = fixture();
+    const nativeModuleRoot = join(root, 'node_modules', 'better-sqlite3');
+    const nativeModuleMarker = join(nativeModuleRoot, 'binding.node');
+    mkdirSync(nativeModuleRoot, { recursive: true });
+    writeFileSync(nativeModuleMarker, 'must-survive');
+
+    expect(await captureReleaseBuildCache(root, 'web', {
+      cacheRoot,
+      identity: identity('a'),
+    })).toMatchObject({ status: 'captured' });
+    writeFileSync(join(root, '.next', 'cache', 'webpack', 'entry.bin'), 'compiled-source-b');
+    expect(await captureReleaseBuildCache(root, 'web', {
+      cacheRoot,
+      identity: identity('b'),
+    })).toMatchObject({ status: 'captured' });
+
+    const entryDirectory = join(cacheRoot, 'entries', 'web', 'compatibility-a');
+    expect(readdirSync(entryDirectory).sort()).toEqual(['entry-b.json', 'entry-b.tar']);
+    writeFileSync(join(root, '.next', 'cache', 'webpack', 'entry.bin'), 'stale-local-output');
+    expect(await restoreReleaseBuildCache(root, 'web', {
+      cacheRoot,
+      identity: identity('c'),
+    })).toMatchObject({ status: 'hit_compatible', producerSourceSha256: 'source-b' });
+    expect(readFileSync(join(root, '.next', 'cache', 'webpack', 'entry.bin'), 'utf8'))
+      .toBe('compiled-source-b');
+    expect(readFileSync(nativeModuleMarker, 'utf8')).toBe('must-survive');
+  });
+
+  it('refuses cache mutations inside project node_modules without removing anything', async () => {
+    const { root } = fixture();
+    const nativeModuleRoot = join(root, 'node_modules', 'better-sqlite3');
+    const nativeModuleMarker = join(nativeModuleRoot, 'binding.node');
+    const unsafeCacheRoot = join(nativeModuleRoot, 'release-cache');
+    mkdirSync(nativeModuleRoot, { recursive: true });
+    writeFileSync(nativeModuleMarker, 'must-survive');
+
+    await expect(captureReleaseBuildCache(root, 'web', {
+      cacheRoot: unsafeCacheRoot,
+      identity: identity('a'),
+    })).rejects.toThrow(join(root, 'node_modules', 'better-sqlite3'));
+    expect(readFileSync(nativeModuleMarker, 'utf8')).toBe('must-survive');
+    expect(existsSync(unsafeCacheRoot)).toBe(false);
+  });
+
+  it('refuses a restore destination redirected into project node_modules', async () => {
+    const { root, cacheRoot } = fixture();
+    expect(await captureReleaseBuildCache(root, 'web', {
+      cacheRoot,
+      identity: identity('a'),
+    })).toMatchObject({ status: 'captured' });
+
+    rmSync(join(root, '.next'), { recursive: true, force: true });
+    const redirectedDestination = join(root, 'node_modules', 'cache');
+    mkdirSync(redirectedDestination, { recursive: true });
+    const destinationMarker = join(redirectedDestination, 'must-survive.txt');
+    writeFileSync(destinationMarker, 'must-survive');
+    symlinkSync(join(root, 'node_modules'), join(root, '.next'), 'dir');
+
+    await expect(restoreReleaseBuildCache(root, 'web', {
+      cacheRoot,
+      identity: identity('b'),
+    })).rejects.toThrow(join(root, '.next', 'cache'));
+    expect(readFileSync(destinationMarker, 'utf8')).toBe('must-survive');
+  });
+
+  it('refuses project node_modules symlinked outside the checkout', async () => {
+    const { root } = fixture();
+    const externalNodeModules = mkdtempSync(join(tmpdir(), 'o8-release-cache-node-modules-'));
+    roots.push(externalNodeModules);
+    const nativeModuleRoot = join(externalNodeModules, 'better-sqlite3');
+    const nativeModuleMarker = join(nativeModuleRoot, 'binding.node');
+    mkdirSync(nativeModuleRoot, { recursive: true });
+    writeFileSync(nativeModuleMarker, 'must-survive');
+    symlinkSync(externalNodeModules, join(root, 'node_modules'), 'dir');
+
+    await expect(captureReleaseBuildCache(root, 'web', {
+      cacheRoot: join(root, 'node_modules', 'better-sqlite3', 'release-cache'),
+      identity: identity('a'),
+    })).rejects.toThrow(join(root, 'node_modules', 'better-sqlite3'));
+    expect(readFileSync(nativeModuleMarker, 'utf8')).toBe('must-survive');
   });
 
   it('rejects a corrupt cache without touching the cold-build destination', async () => {

--- a/tests/release-native-module-check.test.ts
+++ b/tests/release-native-module-check.test.ts
@@ -1,0 +1,59 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const releaseScript = join(process.cwd(), 'scripts', 'release.mjs');
+const roots: string[] = [];
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'o8-release-native-modules-'));
+  roots.push(root);
+  return root;
+}
+
+function stubModule(root: string, moduleName: string) {
+  const moduleRoot = join(root, 'node_modules', moduleName);
+  mkdirSync(moduleRoot, { recursive: true });
+  writeFileSync(join(moduleRoot, 'index.js'), `module.exports = ${JSON.stringify(moduleName)};\n`);
+  return join(moduleRoot, 'index.js');
+}
+
+function runCheck(root: string) {
+  return spawnSync(process.execPath, [releaseScript, '--verify-checkout-native-modules', root], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: { ...process.env, NODE_PATH: '' },
+  });
+}
+
+afterEach(() => {
+  while (roots.length > 0) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+describe('post-ship checkout native module check', () => {
+  it('prints both resolved paths when the native modules load', () => {
+    const root = fixture();
+    const sqlitePath = stubModule(root, 'better-sqlite3');
+    const ptyPath = stubModule(root, 'node-pty');
+
+    const result = runCheck(root);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain(`better-sqlite3 resolved to ${realpathSync(sqlitePath)}`);
+    expect(result.stdout).toContain(`node-pty resolved to ${realpathSync(ptyPath)}`);
+  });
+
+  it('fails with the missing module name', () => {
+    const root = fixture();
+    stubModule(root, 'node-pty');
+
+    const result = runCheck(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('checkout native module better-sqlite3 failed to resolve or load');
+    expect(result.stderr).toContain('checkout native module verification failed');
+    expect(result.stdout).toContain('checkout native module node-pty resolved to');
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1972,6 +1972,12 @@
       ]
     },
     {
+      "path": "tests/release-native-module-check.test.ts",
+      "reasons": [
+        "child-process"
+      ]
+    },
+    {
       "path": "tests/release-preflight.test.ts",
       "reasons": [
         "git-cli",


### PR DESCRIPTION
Closes #1888.

## What

During the v0.1.717 local ship, `node_modules/better-sqlite3` disappeared from the checkout while the lockfiles stayed untouched. The suspect was the release intermediate cache, whose restore and prune paths remove and rename directories. This change does two things regardless of the unproven root cause.

- **Guard.** `scripts/lib/release-build-cache.mjs` now routes every `rmSync` / `renameSync` / prune through `assertOutsideProjectNodeModules(target, projectRoot)`: it resolves symlinks (including missing trailing segments) and refuses — throwing `O8_RELEASE_CACHE_UNSAFE_PATH` with the offending and resolved paths — when a target is the project root or anything inside the project's real `node_modules`. Restore roots, capture directories, entry and compatibility prune roots, temporary archives, and receipt cleanup are all covered. Callers in `tauri-prebuild.mjs` and `tauri-build.mjs` rethrow safety errors instead of downgrading them to a cache miss, so the guard can never be swallowed.
- **Post-ship check.** `scripts/release.mjs` runs a child `node` that `require.resolve`s and loads `better-sqlite3` and `node-pty` from the checkout after the build and before publishing, printing the resolved paths; a failure aborts the ship naming the module. Also available standalone as `release.mjs --verify-checkout-native-modules [root]`.

## Audit

For a normal ship (cache root `~/.o8-build-cache/release-v1`): the three phases restore to `src-tauri/sidecars/speech-local/.build`, `.next/cache`, and `src-tauri/target/release`; entry and compatibility prune roots live under `<cache>/entries/<phase>`. Prune keep-sets come only from those cache directories, and phase targets are static relative to `process.cwd()`, not package paths. None enter the project `node_modules`, so the call graph does not prove the cache caused the 717 deletion; the guard closes the alias/configuration failure class and the ship check turns any recurrence into a loud failure at publish time instead of at the next test run.

## Proof

- `tests/release-build-cache.test.ts` — restore + prune of normal compiler output leaves a fixture `node_modules/better-sqlite3` untouched; a cache mutation inside `node_modules` is refused with nothing removed; a restore destination redirected into `node_modules` is refused; a `node_modules` symlinked outside the checkout is still refused; existing corrupt-cache / native-bundle / dirty-source cases stay green.
- `tests/release-native-module-check.test.ts` — the check prints both resolved paths when the modules load and fails naming the missing module when one does not.

## Gates

tsc · release-cache + native-check tests · lint ratchet (cap 152) · classification check · full suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--verify-checkout-native-modules` to validate required native modules before publishing.
  * Publishing now stops when checkout native-module dependencies cannot be resolved.

* **Bug Fixes**
  * Release build cache operations now prevent unsafe access to project dependencies and protected paths.
  * Safety-related cache errors are surfaced immediately instead of being treated as cache misses or warnings.
  * Improved handling of symlinked cache and build directories to avoid unintended file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->