### PR TITLE
feat(bench): add the terminal workload fixture and baseline receipt

### DIFF
--- a/docs/internals/terminal-workload-baseline.md
+++ b/docs/internals/terminal-workload-baseline.md
@@ -1,0 +1,147 @@
+# Terminal Workload Baseline
+
+Phase 1 records the current hidden-terminal workload without changing terminal
+delivery, attachment, parsing, or rendering behavior. The only runtime changes
+are bench-gated counters and stable read-only selectors. Budgets in this report
+are **PROPOSED**, not accepted gates; the operator locks them before Phase 2.
+
+## Outcome
+
+The production fixture completed nine samples: three each at 1, 4, and 12 live
+terminal sessions. Each session received a deterministic 81,920-byte/second,
+10-second workload with a DECSET 1049 alternate-screen phase. Each seeded
+workspace restored all requested terminal chips plus exactly one Orchestrator
+chip, kept the first terminal active, and exposed exactly one visible terminal
+panel.
+
+The baseline host was Darwin 25.6.0 on x64 with 16 logical CPUs and 64 GiB of
+memory. CPU percentage uses process CPU-time deltas, where 100% is one logical
+core. Memory is physical footprint measured after each workload.
+
+### Interaction and residency baseline
+
+Values are p50 / p95 unless a range is shown.
+
+| Sessions | Mounted terminal panels | PTYs | Attached clients/session | Hidden write B/s/panel | Hidden writes/s/panel | Long-task ms/min | Reveal ms | First-correct-frame ms | Visible input ms |
+| ---: | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 1 | 1 | 1 | 0 / 0 | 0 / 0 | 0 / 0 | n/a | n/a | 43.1 / 56.4 |
+| 4 | 2–3 (p50 3) | 4 | 1–2 | 55,341 / 129,319 | 20.80 / 25.38 | 482 / 1,379 | 51.6 / 96.3 | 134.8 / 204.1 | 43.6 / 62.0 |
+| 12 | 3 | 12 | 1–2 | 53,453 / 71,366 | 19.98 / 20.08 | 362 / 1,300 | 165.5 / 195.9 | 263.4 / 290.2 | 54.2 / 138.2 |
+
+At 12 sessions, all three samples had exactly three mounted terminal panels and
+one visible panel. Nine terminals were initially unmounted. Resident-set churn
+during reveal later mounted 2–3 of those terminals, leaving 6–7 that never
+mounted during the observation. The never-mounted terminals recorded zero
+browser write bytes while their PTYs produced 5.1–5.9 MiB of hidden server-side
+output. The session inventory endpoint reported all 12 PTYs.
+
+### Process resource baseline
+
+| Sessions | App server CPU % | App server MiB | Realtime server CPU % | Realtime server MiB | Browser renderer CPU % | Browser renderer MiB |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 15.03 / 17.18 | 235 / 267 | 7.22 / 7.52 | 138 / 154 | 19.16 / 20.74 | 174 / 177 |
+| 4 | 18.24 / 23.74 | 256 / 368 | 13.74 / 14.61 | 152 / 171 | 27.67 / 31.33 | 214 / 249 |
+| 12 | 9.96 / 18.04 | 438 / 440 | 25.23 / 38.11 | 191 / 193 | 33.86 / 41.12 | 259 / 261 |
+
+The app-server CPU result is not monotonic and includes dashboard restoration
+and Orchestrator background work. The realtime-server and renderer trends are
+the cleaner workload-scaling signals.
+
+## Evidence
+
+- Receipt: `tests/bench/results/terminal-workload-baseline.json`
+- Receipt schema: `o8/terminal-workload/v1`
+- Raw artifacts: `tests/bench/latest/terminal-workload-2026-08-28`
+- Samples: 9, production build, fixture `terminal-ansi-alt-screen-v1`
+- Measured tree base commit: `0609729bd5e286e1aa2ac33a0fde89486d0b9e6b`
+- The receipt records `dirty: true` and a tree fingerprint because the fixture
+  and its instrumentation had to exist before their baseline could be run.
+
+The committed receipt is 68,622 bytes. Full per-session counters remain in the
+ignored raw directory; each raw sample is below 200 KiB.
+
+### Attribution
+
+These p50 totals cover one approximately 11-second observation. Write-completion
+time is elapsed time from `term.write` call to its callback and therefore
+includes xterm queue/parse/buffer work; it is not additive with every other
+column.
+
+| Sessions | WS JSON parse ms | Base64 decode ms | Direct `term.write` call ms | Write completion ms | xterm render events | Server fan-out deliveries |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 4.4 | 69.8 | 6.0 | 152.5 | 319 | 635 |
+| 4 | 9.9 | 190.1 | 9.5 | 497.1 | 307 | 2,047 |
+| 12 | 15.0 | 223.8 | 11.9 | 547.6 | 308 | 5,066 |
+
+The numbers locate the hidden browser cost in base64 decode plus xterm
+parse/buffer completion, not proportional painting. Direct `term.write` calls
+are cheap, while callback completion is the largest measured browser-side
+terminal interval. Render events stay essentially flat from 319 at one session
+to 308 at twelve, even as renderer p50 CPU rises from 19.16% to 33.86% and
+occasional long-task bursts appear. JSON parsing is a small fraction of the
+measured terminal work.
+
+Server fan-out is a separate scaling cost. Its p50 deliveries rise from 635 to
+5,066 and realtime-server p50 CPU rises from 7.22% to 25.23%. The auxiliary
+workload clients are intentional parts of the fixture, so browser attachments
+plus fixture attachments produce the recorded 1–2 clients per session.
+
+### Replay correctness evidence
+
+The 512 KiB per-session scrollback ring overflowed even at one session: the p50
+run removed 326,015 bytes. At twelve sessions the p50 run removed 3,930,373
+bytes across the rings and recorded four lossy backpressure drops. The p50
+alternate-screen result observed nine enter/exit phases; all nine enter markers
+had aged out of retained scrollback, while exit markers remained in all twelve
+rings. Replay can therefore begin after an alternate-screen enter but still
+contain a later exit. Because PTY escape sequences may span the chunks trimmed
+from the front of the ring, an incomplete leading escape is an additional
+structural risk; the fixture directly observed the enter/exit asymmetry, not an
+incomplete leading escape in these nine samples.
+
+This favors **bounded hidden-write batching in `writeData`** for Phase 2. It can
+reduce roughly 20 hidden writes per second per mounted hidden panel while
+preserving the browser parser's continuous escape state. Detach-hidden plus
+ring replay would save more browser work, but the measured overflow and
+alternate-screen asymmetry make server-scrollback-only reconstruction unsafe
+without a full terminal snapshot/recovery protocol. No intervention is included
+in Phase 1.
+
+## Proposed budgets
+
+These thresholds are proposals derived from the baseline and include rounded
+headroom. They are deliberately not locked by this change.
+
+| Acceptance line | **PROPOSED** gate | Baseline used |
+| --- | --- | --- |
+| Hidden-session CPU | At N=12, browser-renderer p95 ≤35% and its p95 increase over N=1 ≤15 percentage points; realtime-server p95 ≤42% as a non-regression guard; main-thread long tasks p95 ≤750 ms/min. | Renderer p95 41.12%, +20.38 points over N=1; realtime p95 38.11%; long tasks p95 1,300 ms/min. The renderer and long-task targets require a material Phase 2 reduction. |
+| Memory | At N=12, p95 app server ≤512 MiB, realtime server ≤224 MiB, renderer ≤288 MiB, and renderer growth over N=1 ≤112 MiB. | p95 values are 440, 193, and 261 MiB; renderer growth is 84 MiB. |
+| Reveal | p95 visible-panel reveal ≤225 ms, p95 first-correct-frame ≤350 ms, with zero correctness failures or censored timeouts. | N=12 p95 values are 195.9 ms and 290.2 ms. |
+| Visible input | N=12 keystroke-to-paint p50 ≤75 ms and p95 ≤175 ms, with zero 10-second censored timeouts. | N=12 p50/p95 are 54.2/138.2 ms with zero timeouts. |
+
+For the separate “no proportional hidden rendering” acceptance line, the
+proposed diagnostic guard is N=12 xterm render events no more than 1.25× N=1.
+The baseline already meets it (308 versus 319); the CPU and long-task gates are
+what prevent a no-op result from passing Phase 2.
+
+## Residual
+
+- This is one host and three samples per cardinality. The proposed budgets need
+  operator lock and a stable machine lane before becoming gates.
+- The numbers are browser production-server measurements, not packaged native
+  shell measurements. The packaged footprint gate remains authoritative for
+  native-process CPU and memory.
+- A single reveal is exercised per N>1 sample. Rapid switching among all twelve
+  sessions, full snapshot recovery, and image/link/Unicode/mouse/paste/resize/
+  signal behavior remain Phase 2 acceptance coverage.
+- Ring overflow and replay risk are diagnosed but not recovered in Phase 1.
+- The auxiliary clients required by the workload contract contribute to server
+  fan-out CPU; browser attribution is separated by process and page counters.
+
+## Decision
+
+Hold the implementation at measurement only. Ask the operator to lock or amend
+the **PROPOSED** budgets, then pursue bounded hidden-write batching in Phase 2
+unless a full replay snapshot protocol is separately authorized. Keep the
+server behavior unchanged for the batching path and preserve ordered bytes,
+partial escape sequences, and an explicit overflow diagnostic.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "bench:speed": "node scripts/bench/run-speed.mjs",
     "bench:quick": "node scripts/bench/quick.mjs",
     "bench:memory": "node scripts/bench/run-memory.mjs",
+    "bench:terminal": "node scripts/bench/run-terminal-workload.mjs",
     "bench:governance": "node scripts/run.mjs NODE_OPTIONS=--import=./scripts/register-server-only-stub.mjs -- tsx scripts/bench/run-governance.ts && npm run bench:score",
     "bench:score": "node scripts/bench/score.mjs",
     "bench:all": "npm run bench:speed && npm run bench:memory && npm run bench:governance",

--- a/scripts/bench/measure-browser-boot.mjs
+++ b/scripts/bench/measure-browser-boot.mjs
@@ -30,7 +30,7 @@ function readPort() {
   }
 }
 
-function browserCandidates() {
+export function browserCandidates() {
   return [
     process.env.O8_BENCH_BROWSER_PATH,
     '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
@@ -48,7 +48,7 @@ function browserCandidates() {
   ].filter(Boolean);
 }
 
-function resolveBrowserPath() {
+export function resolveBrowserPath() {
   return browserCandidates().find((candidate) => fs.existsSync(candidate)) ?? null;
 }
 

--- a/scripts/bench/run-terminal-workload.mjs
+++ b/scripts/bench/run-terminal-workload.mjs
@@ -1,0 +1,644 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { chromium } from 'playwright-core';
+import { resolveBrowserPath } from './measure-browser-boot.mjs';
+import { snapshotProcesses } from '../lib/footprint-budget.mjs';
+import {
+  cleanupTmuxSessions,
+  measureProcessGroups,
+  resolveProcessGroups,
+  seedFixtureState,
+  sleep,
+  startIsolatedStack,
+} from './terminal-workload/runtime.mjs';
+import { connectTerminalClients } from './terminal-workload/ws-client.mjs';
+import { summarizeSamples } from './terminal-workload/statistics.mjs';
+
+const ROOT = process.cwd();
+
+function option(name, fallback) {
+  const prefix = `--${name}=`;
+  const inline = process.argv.find((value) => value.startsWith(prefix));
+  if (inline) return inline.slice(prefix.length);
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : fallback;
+}
+
+function config() {
+  const sessionCounts = String(option('sessions', '1,4,12'))
+    .split(',')
+    .map(Number)
+    .filter((value) => Number.isInteger(value) && value > 0);
+  const samples = Math.max(3, Number(option('samples', 3)) || 3);
+  const durationMs = Math.max(1000, Number(option('duration-ms', 10000)) || 10000);
+  const bytesPerSecond = Math.max(1024, Number(option('bytes-per-second', 81920)) || 81920);
+  const chunkMs = Math.max(8, Number(option('chunk-ms', 32)) || 32);
+  const seed = Number(option('seed', 1721)) || 1721;
+  const runId = new Date().toISOString().replaceAll(':', '-').replaceAll('.', '-');
+  return {
+    sessionCounts: sessionCounts.length > 0 ? sessionCounts : [1, 4, 12],
+    samples,
+    durationMs,
+    bytesPerSecond,
+    chunkMs,
+    seed,
+    requestedBuildMode: String(option('build-mode', 'auto')),
+    rawDir: path.resolve(option('output-dir', path.join(ROOT, 'tests/bench/latest/terminal-workload', runId))),
+    receiptPath: path.resolve(option('receipt', path.join(ROOT, 'tests/bench/results/terminal-workload-baseline.json'))),
+  };
+}
+
+function round(value, digits = 2) {
+  return Number.isFinite(value) ? Number(value.toFixed(digits)) : null;
+}
+
+function gitInfo() {
+  const commit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: ROOT, encoding: 'utf8' }).trim();
+  const status = execFileSync('git', ['status', '--porcelain=v1', '--untracked-files=all'], { cwd: ROOT, encoding: 'utf8' });
+  const hash = createHash('sha256').update(status);
+  for (const line of status.split('\n').filter(Boolean)) {
+    const relative = line.slice(3).replace(/^.* -> /, '');
+    const absolute = path.join(ROOT, relative);
+    if (fs.existsSync(absolute) && fs.statSync(absolute).isFile()) hash.update(fs.readFileSync(absolute));
+  }
+  return { commit, dirty: status.trim().length > 0, treeFingerprint: hash.digest('hex') };
+}
+
+function machineClass() {
+  return {
+    hardware: {
+      arch: os.arch(),
+      cpuModel: os.cpus()[0]?.model ?? 'unknown',
+      logicalCpuCount: os.cpus().length,
+      totalMemoryBytes: os.totalmem(),
+    },
+    os: { platform: os.platform(), release: os.release() },
+  };
+}
+
+function browserInitScript() {
+  window.__o8TerminalBenchEnabled = true;
+  window.__o8TerminalBenchTabs = null;
+  window.__o8TerminalPerf = { startedAt: performance.now(), frames: 0, longTasks: [], longTaskSupported: false };
+  window.addEventListener('o8:workspace-active-label', (event) => {
+    const detail = event.detail;
+    if (detail?.activeWorkspaceSurface && Array.isArray(detail.tabs)) window.__o8TerminalBenchTabs = detail;
+  });
+  window.__o8TerminalPerf.longTaskSupported = PerformanceObserver.supportedEntryTypes?.includes('longtask') ?? false;
+  if (window.__o8TerminalPerf.longTaskSupported) {
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        window.__o8TerminalPerf.longTasks.push({ startTime: entry.startTime, duration: entry.duration });
+      }
+    });
+    observer.observe({ type: 'longtask', buffered: true });
+  }
+  const frame = () => {
+    window.__o8TerminalPerf.frames += 1;
+    requestAnimationFrame(frame);
+  };
+  requestAnimationFrame(frame);
+}
+
+async function dashboardDiagnostic(page) {
+  return page.evaluate(() => {
+    const workspace = document.querySelector('[data-o8-workspace]');
+    const rect = workspace instanceof HTMLElement ? workspace.getBoundingClientRect() : null;
+    return {
+      hydrated: document.documentElement.getAttribute('data-o8-dashboard-hydrated'),
+      workspaceCount: document.querySelectorAll('[data-o8-workspace]').length,
+      workspaceRect: rect ? { width: rect.width, height: rect.height } : null,
+      tabs: window.__o8TerminalBenchTabs?.tabs ?? null,
+      activeTabId: window.__o8TerminalBenchTabs?.tabId ?? null,
+      chipIds: Array.from(document.querySelectorAll('[data-o8-workspace-tab]')).map((element) => element.getAttribute('data-o8-workspace-tab')),
+      panelSessions: Array.from(document.querySelectorAll('[data-o8-term-panel]')).map((element) => ({
+        sessionName: element.getAttribute('data-o8-term-panel'),
+        display: getComputedStyle(element).display,
+      })),
+      bodyText: document.body.innerText.slice(0, 1200),
+    };
+  });
+}
+
+async function waitForSeededDashboard(page, baseUrl, seeded) {
+  const response = await page.goto(`${baseUrl}/dashboard`, { waitUntil: 'domcontentloaded', timeout: 90000 });
+  if (!response?.ok()) throw new Error(`/dashboard returned ${response?.status() ?? 'no response'}`);
+  try {
+    await page.waitForFunction(() => {
+      const workspace = document.querySelector('[data-o8-workspace]');
+      if (!(workspace instanceof HTMLElement)) return false;
+      const rect = workspace.getBoundingClientRect();
+      return document.documentElement.getAttribute('data-o8-dashboard-hydrated') === '1'
+        && rect.width > 0 && rect.height > 0;
+    }, undefined, { timeout: 90000 });
+    await page.waitForFunction(({ terminalIds, activeTabId }) => {
+      const tabs = window.__o8TerminalBenchTabs?.tabs;
+      if (!Array.isArray(tabs)) return false;
+      const terminalTabs = tabs.filter((tab) => terminalIds.includes(tab.id));
+      const orchestrators = tabs.filter((tab) => tab.kind === 'orchestrator');
+      const chipIds = Array.from(document.querySelectorAll('[data-o8-workspace-tab]'))
+        .map((element) => element.getAttribute('data-o8-workspace-tab'));
+      return terminalTabs.length === terminalIds.length
+        && orchestrators.length === 1
+        && chipIds.filter((id) => terminalIds.includes(id)).length === terminalIds.length
+        && chipIds.filter((id) => id?.startsWith('orchestrator-')).length === 1
+        && window.__o8TerminalBenchTabs.tabId === activeTabId;
+    }, { terminalIds: seeded.tabs.map((tab) => tab.id), activeTabId: seeded.tabs[0].id }, { timeout: 45000 });
+  } catch (error) {
+    throw new Error(`seeded dashboard contract failed: ${JSON.stringify(await dashboardDiagnostic(page))}`, { cause: error });
+  }
+  return page.evaluate(() => ({
+    activeTabId: window.__o8TerminalBenchTabs.tabId,
+    workspaceId: window.__o8TerminalBenchTabs.workspaceId,
+    tabs: window.__o8TerminalBenchTabs.tabs,
+  }));
+}
+
+async function waitForPanelContract(page, activeSessionName) {
+  const deadline = Date.now() + 45000;
+  let previous = null;
+  while (Date.now() < deadline) {
+    const inventory = await page.evaluate((expectedVisible) => {
+      const panels = Array.from(document.querySelectorAll('[data-o8-term-panel]'));
+      const visible = panels.filter((panel) => getComputedStyle(panel).display !== 'none');
+      return {
+        valid: panels.length >= 1
+          && visible.length === 1
+          && visible[0]?.getAttribute('data-o8-term-panel') === expectedVisible,
+        mountedTerminalPanelCount: panels.length,
+        visibleTerminalPanelCount: visible.length,
+        mountedSessionNames: panels.map((panel) => panel.getAttribute('data-o8-term-panel')).filter(Boolean),
+      };
+    }, activeSessionName);
+    const signature = JSON.stringify(inventory);
+    if (inventory.valid && signature === previous) {
+      return {
+        mountedTerminalPanelCount: inventory.mountedTerminalPanelCount,
+        visibleTerminalPanelCount: inventory.visibleTerminalPanelCount,
+        mountedSessionNames: inventory.mountedSessionNames,
+      };
+    }
+    previous = inventory.valid ? signature : null;
+    await sleep(350);
+  }
+  throw new Error(`terminal panel contract did not stabilize: ${JSON.stringify(await dashboardDiagnostic(page))}`);
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+function generatorCommand(generatorPath, sessionName, runConfig, sampleSeed) {
+  return [
+    shellQuote(process.execPath), shellQuote(generatorPath),
+    '--session', shellQuote(sessionName),
+    '--bytes-per-second', String(runConfig.bytesPerSecond),
+    '--duration-ms', String(runConfig.durationMs),
+    '--chunk-ms', String(runConfig.chunkMs),
+    '--seed', String(sampleSeed),
+  ].join(' ');
+}
+
+async function fetchPtyInventory(stack) {
+  const response = await fetch(`http://127.0.0.1:${stack.apiPort}/api/panel/terminal-sessions`, {
+    headers: { Authorization: `Bearer ${stack.token}` },
+  });
+  if (!response.ok) throw new Error(`terminal session inventory returned ${response.status}`);
+  const payload = await response.json();
+  return Array.isArray(payload.sessions) ? payload.sessions : [];
+}
+
+async function prepareShell(client, sessionName, seed) {
+  const marker = `O8_SHELL_READY_${sessionName}_${seed}`;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    client.send({
+      type: 'terminal-input',
+      sessionName,
+      data: `\x03printf '${marker}\\n'\r`,
+    });
+    try {
+      await client.waitForText(sessionName, marker, 5000);
+      return;
+    } catch (error) {
+      if (attempt === 3) throw error;
+    }
+  }
+}
+
+async function resetPageMeasurement(page) {
+  await page.evaluate(() => {
+    window.__o8TerminalWriteStats?.reset();
+    window.__o8TerminalPerf.startedAt = performance.now();
+    window.__o8TerminalPerf.frames = 0;
+    window.__o8TerminalPerf.longTasks = [];
+  });
+}
+
+async function readPageStats(page) {
+  return page.evaluate(() => {
+    const stats = window.__o8TerminalWriteStats;
+    if (!stats) throw new Error('terminal write instrumentation was not installed');
+    const at = performance.now();
+    const sessions = Object.fromEntries(Object.entries(stats.sessions).map(([sessionName, session]) => {
+      const elapsed = Math.max(0, at - session.visibilityChangedAt);
+      return [sessionName, {
+        mountCount: session.mountCount,
+        unmountCount: session.unmountCount,
+        mounted: session.mounted,
+        visible: session.visible,
+        visibleMs: session.visibleMs + (session.visible ? elapsed : 0),
+        hiddenMs: session.hiddenMs + (session.visible ? 0 : elapsed),
+        visibleWork: { ...session.visibleWork },
+        hiddenWork: { ...session.hiddenWork },
+      }];
+    }));
+    return {
+      schema: stats.schema,
+      observationMs: at - stats.startedAt,
+      sessions,
+      transport: { ...stats.transport },
+    };
+  });
+}
+
+async function readPerformance(page, observationMs) {
+  return page.evaluate((elapsedMs) => {
+    const perf = window.__o8TerminalPerf;
+    const longTaskMs = perf.longTasks.reduce((sum, task) => sum + task.duration, 0);
+    return {
+      longTaskSupported: perf.longTaskSupported,
+      longTaskCount: perf.longTasks.length,
+      longTaskMs,
+      longTaskMsPerMinute: elapsedMs > 0 ? longTaskMs * 60000 / elapsedMs : null,
+      frameCount: perf.frames,
+      framesPerSecond: elapsedMs > 0 ? perf.frames * 1000 / elapsedMs : null,
+      longTasks: perf.longTasks,
+    };
+  }, observationMs);
+}
+
+async function measureKeystrokeToPaint(page, sessionName, marker) {
+  const input = page.locator(`[data-o8-term-panel="${sessionName}"] .xterm-helper-textarea`);
+  await input.focus();
+  await page.waitForFunction((expectedSession) => {
+    const panel = document.querySelector(`[data-o8-term-panel="${CSS.escape(expectedSession)}"]`);
+    return panel?.contains(document.activeElement) === true
+      && document.activeElement?.classList.contains('xterm-helper-textarea') === true;
+  }, sessionName, { timeout: 5000 });
+  const startedAt = await page.evaluate(() => performance.now());
+  await page.keyboard.type(marker);
+  await page.keyboard.press('Enter');
+  try {
+    await page.waitForFunction(({ targetSession, targetMarker }) => {
+      const session = window.__o8TerminalWriteStats?.sessions[targetSession];
+      return session?.readText(80).includes(targetMarker) === true;
+    }, { targetSession: sessionName, targetMarker: marker }, { polling: 'raf', timeout: 10000 });
+    const paintedAt = await page.evaluate(() => performance.now());
+    return { elapsedMs: paintedAt - startedAt, timedOut: false };
+  } catch (error) {
+    if (!(error instanceof Error) || !error.message.includes('Timeout')) throw error;
+    return { elapsedMs: 10000, timedOut: true };
+  }
+}
+
+async function selectTabAndMeasure(page, tab, marker) {
+  const startedAt = await page.evaluate(() => performance.now());
+  await page.locator(`[data-o8-workspace-tab="${tab.id}"]`).click();
+  await page.waitForFunction(({ sessionName, tabId }) => {
+    const panel = document.querySelector(`[data-o8-term-panel="${CSS.escape(sessionName)}"]`);
+    return panel && getComputedStyle(panel).display !== 'none' && window.__o8TerminalBenchTabs?.tabId === tabId;
+  }, { sessionName: tab.sessionName, tabId: tab.id }, { polling: 'raf', timeout: 10000 });
+  const visibleAt = await page.evaluate(() => performance.now());
+  await page.waitForFunction(({ sessionName, markerText }) => (
+    window.__o8TerminalWriteStats?.sessions[sessionName]?.readText(100).includes(markerText) === true
+  ), { sessionName: tab.sessionName, markerText: marker }, { polling: 'raf', timeout: 10000 });
+  const correctAt = await page.evaluate(() => performance.now());
+  return { revealMs: visibleAt - startedAt, firstCorrectFrameMs: correctAt - startedAt };
+}
+
+function deriveBrowser(raw, expectedSessions, initiallyMountedSessionNames) {
+  const sessions = expectedSessions.map((session) => ({ ...session, stats: raw.sessions[session.sessionName] ?? null }));
+  const hiddenRates = sessions
+    .filter((entry) => initiallyMountedSessionNames.includes(entry.sessionName)
+      && entry.stats && entry.stats.hiddenMs > 0 && entry.stats.hiddenWork.calls > 0)
+    .map((entry) => ({
+      bytes: entry.stats.hiddenWork.decodedBytes / (entry.stats.hiddenMs / 1000),
+      calls: entry.stats.hiddenWork.calls / (entry.stats.hiddenMs / 1000),
+    }));
+  const sum = (selector) => sessions.reduce((total, entry) => total + (entry.stats ? selector(entry.stats) : 0), 0);
+  const initiallyUnmounted = sessions.filter((entry) => !initiallyMountedSessionNames.includes(entry.sessionName));
+  const neverMounted = sessions.filter((entry) => !entry.stats || entry.stats.mountCount === 0);
+  return {
+    hiddenWriteBytesPerSecondPerPanel: hiddenRates.length > 0 ? round(hiddenRates.reduce((sumValue, rate) => sumValue + rate.bytes, 0) / hiddenRates.length) : 0,
+    hiddenWriteCallsPerSecondPerPanel: hiddenRates.length > 0 ? round(hiddenRates.reduce((sumValue, rate) => sumValue + rate.calls, 0) / hiddenRates.length) : 0,
+    totalVisibleWriteBytes: sum((stats) => stats.visibleWork.decodedBytes),
+    totalHiddenWriteBytes: sum((stats) => stats.hiddenWork.decodedBytes),
+    totalWriteCalls: sum((stats) => stats.visibleWork.calls + stats.hiddenWork.calls),
+    totalDecodeMs: round(sum((stats) => stats.visibleWork.decodeMs + stats.hiddenWork.decodeMs)),
+    totalWriteCallMs: round(sum((stats) => stats.visibleWork.writeCallMs + stats.hiddenWork.writeCallMs)),
+    totalWriteCompletionMs: round(sum((stats) => stats.visibleWork.writeCompletionMs + stats.hiddenWork.writeCompletionMs)),
+    totalRenderEvents: sum((stats) => stats.visibleWork.renderEvents + stats.hiddenWork.renderEvents),
+    totalRenderRows: sum((stats) => stats.visibleWork.renderRows + stats.hiddenWork.renderRows),
+    initiallyUnmountedSessionNames: initiallyUnmounted.map((entry) => entry.sessionName),
+    neverMountedSessionNames: neverMounted.map((entry) => entry.sessionName),
+    residencyChurnSessionNames: initiallyUnmounted
+      .filter((entry) => entry.stats && entry.stats.mountCount > 0)
+      .map((entry) => entry.sessionName),
+    endMountedSessionNames: sessions.filter((entry) => entry.stats?.mounted).map((entry) => entry.sessionName),
+    initiallyUnmountedWriteBytes: initiallyUnmounted.reduce((total, entry) => total + (entry.stats?.visibleWork.decodedBytes ?? 0) + (entry.stats?.hiddenWork.decodedBytes ?? 0), 0),
+    unmountedWriteBytes: neverMounted.reduce((total, entry) => total + (entry.stats?.visibleWork.decodedBytes ?? 0) + (entry.stats?.hiddenWork.decodedBytes ?? 0), 0),
+    transport: raw.transport,
+    sessions: raw.sessions,
+  };
+}
+
+function deriveServer(snapshot, expectedSessions, unmountedSessionNames) {
+  const sessions = expectedSessions.map((session) => snapshot.sessions[session.sessionName]).filter(Boolean);
+  const sum = (selector) => sessions.reduce((total, session) => total + selector(session), 0);
+  return {
+    visiblePtyChunks: sum((session) => session.pty.visible.chunks),
+    visiblePtyBytes: sum((session) => session.pty.visible.bytes),
+    hiddenPtyChunks: sum((session) => session.pty.hidden.chunks),
+    hiddenPtyBytes: sum((session) => session.pty.hidden.bytes),
+    attachEvents: sum((session) => session.attachEvents),
+    detachEvents: sum((session) => session.detachEvents),
+    bufferEvents: sum((session) => session.buffer.events),
+    replayEvents: sum((session) => session.replay.events),
+    overflowEvents: sum((session) => session.overflow.events),
+    overflowBytes: sum((session) => session.overflow.bytes),
+    backpressureDropEvents: sum((session) => session.backpressureDrops.events),
+    backpressureDropBytes: sum((session) => session.backpressureDrops.bytes),
+    fanoutClientDeliveries: sum((session) => session.fanout.clientDeliveries),
+    unmountedHiddenBytes: unmountedSessionNames.reduce((total, sessionName) => total + (snapshot.sessions[sessionName]?.pty.hidden.bytes ?? 0), 0),
+    sessions: snapshot.sessions,
+  };
+}
+
+async function runSample({ browser, browserPid, runConfig, sessionCount, sampleIndex }) {
+  const sampleSeed = runConfig.seed + sessionCount * 100 + sampleIndex;
+  const runPrefix = `tw${Date.now().toString(36)}n${sessionCount}s${sampleIndex}`;
+  const seeded = seedFixtureState(sessionCount, runPrefix);
+  const expectedSessionNames = seeded.tabs.map((tab) => tab.sessionName);
+  let stack;
+  let context;
+  let page;
+  let clients = [];
+  try {
+    stack = await startIsolatedStack(ROOT, seeded, runConfig.requestedBuildMode);
+    context = await browser.newContext({ viewport: { width: 1000, height: 800 } });
+    page = await context.newPage();
+    await page.addInitScript(browserInitScript);
+    const ui = await waitForSeededDashboard(page, `http://127.0.0.1:${stack.apiPort}`, seeded);
+    const panelInventory = await waitForPanelContract(page, seeded.tabs[0].sessionName);
+
+    const wsUrl = `ws://127.0.0.1:${stack.wsPort}/ws?token=${encodeURIComponent(stack.token)}`;
+    clients = await connectTerminalClients(wsUrl, sessionCount);
+    await Promise.all(seeded.tabs.map((tab, index) => clients[index].createAndAttach({
+      ownerKey: `workspace:${tab.id}`,
+      requestId: `bench-${runPrefix}-${index + 1}`,
+      sessionName: tab.sessionName,
+      cwd: seeded.repoDir,
+    })));
+    await Promise.all(seeded.tabs.map((tab, index) => (
+      prepareShell(clients[index], tab.sessionName, sampleSeed)
+    )));
+    await clients[0].request('terminal-bench-reset');
+    await clients[0].request('terminal-bench-visibility', {
+      sessions: seeded.tabs.map((tab, index) => ({ sessionName: tab.sessionName, visible: index === 0 })),
+    });
+    const attachmentSnapshot = (await clients[0].request('terminal-bench-stats')).data.snapshot;
+    const attachedClientsPerSession = Object.fromEntries(seeded.tabs.map((tab) => [
+      tab.sessionName,
+      attachmentSnapshot.sessions[tab.sessionName]?.attachedClientCount ?? null,
+    ]));
+    const ptySessions = await fetchPtyInventory(stack);
+    await resetPageMeasurement(page);
+
+    const before = snapshotProcesses();
+    const groups = resolveProcessGroups(before, stack, browserPid);
+    const observationStartedAt = Date.now();
+    const generatorPath = path.join(ROOT, 'scripts/bench/terminal-workload/generator.mjs');
+    for (const [index, tab] of seeded.tabs.entries()) {
+      clients[index].send({
+        type: 'terminal-input',
+        sessionName: tab.sessionName,
+        data: `${generatorCommand(generatorPath, tab.sessionName, runConfig, sampleSeed)}\r`,
+      });
+    }
+    await Promise.all(seeded.tabs.map((tab, index) => clients[index].waitForText(
+      tab.sessionName,
+      `O8_WORKLOAD_READY_${tab.sessionName}_${sampleSeed}`,
+      30000,
+    )));
+
+    await sleep(700);
+    const keystrokeToPaint = [];
+    for (let index = 0; index < 3; index += 1) {
+      const marker = `O8K_${sampleSeed}_${index}`;
+      keystrokeToPaint.push(await measureKeystrokeToPaint(page, seeded.tabs[0].sessionName, marker));
+      await sleep(100);
+    }
+
+    const revealMs = [];
+    const firstCorrectFrameMs = [];
+    let revealAvailability = 'not-applicable-single-terminal';
+    const mountedHidden = seeded.tabs.find((tab) => (
+      panelInventory.mountedSessionNames.includes(tab.sessionName) && tab.sessionName !== seeded.tabs[0].sessionName
+    ));
+    const revealTarget = mountedHidden ?? seeded.tabs.find((tab) => tab.sessionName !== seeded.tabs[0].sessionName);
+    const revealAt = Math.floor(runConfig.durationMs * 0.55);
+    const elapsedBeforeReveal = Date.now() - observationStartedAt;
+    if (elapsedBeforeReveal < revealAt) await sleep(revealAt - elapsedBeforeReveal);
+    if (revealTarget) {
+      revealAvailability = mountedHidden ? 'hidden-mounted-terminal' : 'hidden-unmounted-terminal';
+      const targetIndex = seeded.tabs.findIndex((tab) => tab.id === revealTarget.id);
+      const marker = `O8_REVEAL_${sampleSeed}_${targetIndex}`;
+      clients[targetIndex].send({ type: 'terminal-input', sessionName: revealTarget.sessionName, data: `O8_BENCH_REVEAL:${marker}\r` });
+      await clients[targetIndex].waitForText(revealTarget.sessionName, marker, 10000);
+      const markerSnapshot = (await clients[0].request('terminal-bench-stats')).data.snapshot;
+      if (!markerSnapshot.sessions[revealTarget.sessionName]?.lastOutputTail.includes(marker)) {
+        throw new Error(`server output tail did not contain paused reveal marker ${marker}`);
+      }
+      const reveal = await selectTabAndMeasure(page, revealTarget, marker);
+      revealMs.push(round(reveal.revealMs));
+      firstCorrectFrameMs.push(round(reveal.firstCorrectFrameMs));
+      await clients[0].request('terminal-bench-visibility', {
+        sessions: seeded.tabs.map((tab) => ({ sessionName: tab.sessionName, visible: tab.id === revealTarget.id })),
+      });
+      clients[targetIndex].send({ type: 'terminal-input', sessionName: revealTarget.sessionName, data: 'O8_BENCH_RESUME\r' });
+    }
+
+    await Promise.all(seeded.tabs.map((tab, index) => clients[index].waitForText(
+      tab.sessionName,
+      `O8_WORKLOAD_DONE_${tab.sessionName}_${sampleSeed}`,
+      runConfig.durationMs + 30000,
+    )));
+    const observationMs = Date.now() - observationStartedAt;
+    const after = snapshotProcesses();
+    const processes = measureProcessGroups(before, after, groups, observationMs);
+    const rawBrowser = await readPageStats(page);
+    const performance = await readPerformance(page, observationMs);
+    await context.close();
+    context = null;
+    await sleep(200);
+    const rawServer = (await clients[0].request('terminal-bench-stats')).data.snapshot;
+    const browserSummary = deriveBrowser(rawBrowser, seeded.tabs, panelInventory.mountedSessionNames);
+    const serverSummary = deriveServer(rawServer, seeded.tabs, browserSummary.neverMountedSessionNames);
+    const replayRisk = {
+      sessionsWithObservedAltScreen: seeded.tabs.filter((tab) => {
+        const alt = rawServer.sessions[tab.sessionName]?.alternateScreen;
+        return alt?.observedEnter && alt?.observedExit;
+      }).map((tab) => tab.sessionName),
+      sessionsMissingRetainedAltEnter: seeded.tabs.filter((tab) => {
+        const alt = rawServer.sessions[tab.sessionName]?.alternateScreen;
+        return alt?.observedEnter && alt?.observedExit && !alt?.retainedEnter;
+      }).map((tab) => tab.sessionName),
+      sessionsWithRetainedAltExit: seeded.tabs.filter((tab) => rawServer.sessions[tab.sessionName]?.alternateScreen?.retainedExit).map((tab) => tab.sessionName),
+    };
+    return {
+      schema: 'o8/terminal-workload-sample/v1',
+      sessionCount,
+      sampleIndex,
+      seed: sampleSeed,
+      buildMode: stack.buildMode,
+      devModeCpuWarning: stack.devModeCpuWarning,
+      observationMs,
+      inventory: {
+        terminalChipCount: seeded.tabs.length,
+        orchestratorChipCount: ui.tabs.filter((tab) => tab.kind === 'orchestrator').length,
+        activeTabId: ui.activeTabId,
+        ptyCount: ptySessions.length,
+        ptySessions,
+        ...panelInventory,
+        attachedClientsPerSession,
+      },
+      latency: {
+        revealAvailability,
+        revealMs,
+        firstCorrectFrameMs,
+        keystrokeToPaintMs: keystrokeToPaint.map((result) => round(result.elapsedMs)),
+        keystrokeToPaintTimedOut: keystrokeToPaint.map((result) => result.timedOut),
+        keystrokeToPaintTimeoutMs: 10000,
+      },
+      browser: browserSummary,
+      server: serverSummary,
+      performance: {
+        ...performance,
+        longTaskMs: round(performance.longTaskMs),
+        longTaskMsPerMinute: round(performance.longTaskMsPerMinute),
+        framesPerSecond: round(performance.framesPerSecond),
+      },
+      processes,
+      replayRisk,
+      raw: { browser: rawBrowser, server: rawServer, ui },
+    };
+  } catch (error) {
+    const failure = {
+      sessionCount,
+      sampleIndex,
+      runPrefix,
+      error: error instanceof Error ? { message: error.message, stack: error.stack } : String(error),
+      dashboard: page && !page.isClosed() ? await dashboardDiagnostic(page).catch(() => null) : null,
+      nextLog: stack?.logs.next() ?? null,
+      wsLog: stack?.logs.ws() ?? null,
+    };
+    fs.mkdirSync(runConfig.rawDir, { recursive: true });
+    fs.writeFileSync(path.join(runConfig.rawDir, `failure-n${sessionCount}-sample-${sampleIndex}.json`), JSON.stringify(failure, null, 2));
+    throw error;
+  } finally {
+    if (context) await context.close().catch(() => undefined);
+    await Promise.all(clients.map((client) => client.close().catch(() => undefined)));
+    if (stack) await stack.close().catch(() => undefined);
+    else fs.rmSync(seeded.dataDir, { recursive: true, force: true });
+    cleanupTmuxSessions(expectedSessionNames);
+  }
+}
+
+async function main() {
+  const runConfig = config();
+  const browserPath = resolveBrowserPath();
+  if (!browserPath) throw new Error('Chrome or Chromium is unavailable');
+  fs.mkdirSync(runConfig.rawDir, { recursive: true });
+  const browserTag = `o8-terminal-workload-${process.pid}-${Date.now()}`;
+  const browser = await chromium.launch({
+    executablePath: browserPath,
+    headless: true,
+    args: [
+      '--disable-background-networking',
+      '--disable-background-timer-throttling',
+      '--disable-renderer-backgrounding',
+      `--o8-terminal-bench-id=${browserTag}`,
+    ],
+  });
+  const browserProcesses = [...snapshotProcesses().values()].filter((process) => (
+    process.command.includes(`--o8-terminal-bench-id=${browserTag}`)
+  ));
+  if (browserProcesses.length !== 1) {
+    await browser.close();
+    throw new Error(`unable to identify Chromium root process for ${browserTag}`);
+  }
+  const browserPid = browserProcesses[0].pid;
+  const samples = [];
+  try {
+    for (const sessionCount of runConfig.sessionCounts) {
+      for (let sampleIndex = 1; sampleIndex <= runConfig.samples; sampleIndex += 1) {
+        process.stdout.write(`[bench:terminal] N=${sessionCount} sample=${sampleIndex}/${runConfig.samples}\n`);
+        const sample = await runSample({ browser, browserPid, runConfig, sessionCount, sampleIndex });
+        const samplePath = path.join(runConfig.rawDir, `n${sessionCount}-sample-${sampleIndex}.json`);
+        fs.writeFileSync(samplePath, JSON.stringify(sample, null, 2));
+        const { sessions: _browserSessions, ...browserSummary } = sample.browser;
+        const { sessions: _serverSessions, ...serverSummary } = sample.server;
+        void _browserSessions;
+        void _serverSessions;
+        samples.push({
+          ...sample,
+          browser: browserSummary,
+          server: serverSummary,
+          raw: undefined,
+          artifact: path.relative(ROOT, samplePath).split(path.sep).join('/'),
+        });
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+  const buildModes = [...new Set(samples.map((sample) => sample.buildMode))];
+  const receipt = {
+    schema: 'o8/terminal-workload/v1',
+    generatedAt: new Date().toISOString(),
+    ...gitInfo(),
+    buildMode: buildModes.length === 1 ? buildModes[0] : 'mixed',
+    devModeCpuWarning: samples.some((sample) => sample.devModeCpuWarning),
+    ...machineClass(),
+    fixture: {
+      id: 'terminal-ansi-alt-screen-v1',
+      sessionCounts: runConfig.sessionCounts,
+      samplesPerSessionCount: runConfig.samples,
+      bytesPerSecondPerSession: runConfig.bytesPerSecond,
+      durationMs: runConfig.durationMs,
+      chunkMs: runConfig.chunkMs,
+      seed: runConfig.seed,
+      alternateScreen: { enterAtFraction: 0.25, exitAtFraction: 0.8, decset: 1049 },
+    },
+    sampleCount: samples.length,
+    rawArtifactDirectory: path.relative(ROOT, runConfig.rawDir).split(path.sep).join('/'),
+    summary: summarizeSamples(samples),
+    samples,
+  };
+  fs.mkdirSync(path.dirname(runConfig.receiptPath), { recursive: true });
+  fs.writeFileSync(runConfig.receiptPath, JSON.stringify(receipt, null, 2));
+  process.stdout.write(`[bench:terminal] receipt ${path.relative(ROOT, runConfig.receiptPath)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    process.stderr.write(`[bench:terminal] failed: ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/bench/terminal-workload/generator.mjs
+++ b/scripts/bench/terminal-workload/generator.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+function option(name, fallback) {
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : fallback;
+}
+
+const session = String(option('session', 'session'));
+const bytesPerSecond = Math.max(1024, Number(option('bytes-per-second', 81920)) || 81920);
+const durationMs = Math.max(1000, Number(option('duration-ms', 10000)) || 10000);
+const chunkMs = Math.max(8, Number(option('chunk-ms', 32)) || 32);
+const seed = Number(option('seed', 1721)) || 1721;
+const totalTicks = Math.max(1, Math.ceil(durationMs / chunkMs));
+const bytesPerTick = Math.max(32, Math.floor(bytesPerSecond * chunkMs / 1000));
+const altEnterTick = Math.floor(totalTicks * 0.25);
+const altExitTick = Math.floor(totalTicks * 0.8);
+
+let state = seed >>> 0;
+let tick = 0;
+let paused = false;
+let alternateScreen = false;
+let inputBuffer = '';
+
+function randomWord(length) {
+  let output = '';
+  while (output.length < length) {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    output += (state >>> 0).toString(36);
+  }
+  return output.slice(0, length);
+}
+
+function writeLine(value) {
+  process.stdout.write(`\r\n${value}\r\n`);
+}
+
+function fixedChunk(index) {
+  const prefix = `\x1b[${31 + (index % 6)}m${session} tick=${String(index).padStart(5, '0')} seed=${seed} `;
+  const suffix = '\x1b[0m';
+  const fillLength = Math.max(0, bytesPerTick - Buffer.byteLength(prefix) - Buffer.byteLength(suffix));
+  return `${prefix}${randomWord(fillLength)}${suffix}`;
+}
+
+function handleInput(line) {
+  const value = line.replace(/\n/g, '').trim();
+  if (!value) return;
+  if (value.startsWith('O8_BENCH_REVEAL:')) {
+    paused = true;
+    writeLine(value.slice('O8_BENCH_REVEAL:'.length));
+    return;
+  }
+  if (value === 'O8_BENCH_RESUME') {
+    paused = false;
+    return;
+  }
+  paused = true;
+  writeLine(value);
+  setTimeout(() => { paused = false; }, 140).unref();
+}
+
+if (process.stdin.isTTY && typeof process.stdin.setRawMode === 'function') {
+  process.stdin.setRawMode(true);
+}
+process.stdin.setEncoding('utf8');
+process.stdin.resume();
+process.stdin.on('data', (chunk) => {
+  inputBuffer += chunk;
+  while (inputBuffer.includes('\r')) {
+    const separator = inputBuffer.indexOf('\r');
+    const line = inputBuffer.slice(0, separator);
+    inputBuffer = inputBuffer.slice(separator + 1);
+    handleInput(line);
+  }
+});
+
+writeLine(`O8_WORKLOAD_READY_${session}_${seed}`);
+
+const timer = setInterval(() => {
+  if (paused) return;
+  if (tick === altEnterTick) {
+    process.stdout.write(`\x1b[?1049h\x1b[2J\x1b[HO8_ALT_SCREEN_ENTER_${session}_${seed}\r\n`);
+    alternateScreen = true;
+  }
+  if (tick === altExitTick && alternateScreen) {
+    process.stdout.write(`\x1b[?1049l\r\nO8_ALT_SCREEN_EXIT_${session}_${seed}\r\n`);
+    alternateScreen = false;
+  }
+  process.stdout.write(alternateScreen ? `\x1b[H${fixedChunk(tick)}` : `\r\x1b[2K${fixedChunk(tick)}`);
+  tick += 1;
+  if (tick < totalTicks) return;
+  clearInterval(timer);
+  if (alternateScreen) process.stdout.write(`\x1b[?1049l\r\nO8_ALT_SCREEN_EXIT_${session}_${seed}\r\n`);
+  writeLine(`O8_WORKLOAD_DONE_${session}_${seed}`);
+  if (process.stdin.isTTY && typeof process.stdin.setRawMode === 'function') {
+    process.stdin.setRawMode(false);
+  }
+  setTimeout(() => process.exit(0), 40).unref();
+}, chunkMs);
+
+timer.unref?.();
+process.stdin.on('end', () => process.exit(0));

--- a/scripts/bench/terminal-workload/runtime.mjs
+++ b/scripts/bench/terminal-workload/runtime.mjs
@@ -1,0 +1,258 @@
+import { execFileSync, spawn } from 'node:child_process';
+import { createHash, randomBytes } from 'node:crypto';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  descendantPids,
+  measureProcessPhysicalBytes,
+} from '../../lib/footprint-budget.mjs';
+
+export const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function reservedPorts(root) {
+  const source = fs.readFileSync(path.join(root, 'src/lib/panel/port-constants.ts'), 'utf8');
+  return new Set(Array.from(source.matchAll(/\b(\d{5})\b/g), (match) => Number(match[1])));
+}
+
+async function freePort(root) {
+  const reserved = reservedPorts(root);
+  while (true) {
+    const port = await new Promise((resolve, reject) => {
+      const server = net.createServer();
+      server.unref();
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address();
+        const selected = typeof address === 'object' && address ? address.port : 0;
+        server.close(() => resolve(selected));
+      });
+    });
+    if (port > 0 && !reserved.has(port)) return port;
+  }
+}
+
+export function sessionNameForTabId(tabId) {
+  const digest = createHash('sha256').update(`workspace:${tabId}`).digest('hex').slice(0, 32);
+  return `cortex-dash-${digest}`;
+}
+
+function repoEntry(repoDir, now) {
+  return {
+    id: 'terminal-workload-fixture',
+    name: 'terminal-workload-fixture',
+    localPath: repoDir,
+    remoteUrl: null,
+    defaultBranch: 'main',
+    isGitRepo: true,
+    addedAt: now,
+    lastOpenedAt: now,
+    storagePressureParkingDisabled: false,
+    setup: {
+      envMode: 'copy',
+      envFiles: ['.env', '.env.local'],
+      installCommand: null,
+      installOnCreateWorkspace: false,
+      buildCommand: null,
+      runBuildOnCreateWorkspace: false,
+      devCommand: null,
+      defaultPort: null,
+      workspaceIsolationPreference: 'auto',
+    },
+  };
+}
+
+export function seedFixtureState(sessionCount, runPrefix) {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), `o8-terminal-workload-${runPrefix}-`));
+  const repoDir = path.join(dataDir, 'fixture-repo');
+  fs.mkdirSync(repoDir, { recursive: true });
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repoDir, stdio: 'ignore' });
+  fs.writeFileSync(path.join(repoDir, 'fixture.txt'), 'terminal workload fixture\n');
+  execFileSync('git', ['add', 'fixture.txt'], { cwd: repoDir, stdio: 'ignore' });
+  execFileSync('git', ['-c', 'user.name=o8 fixture', '-c', 'user.email=fixture@invalid', 'commit', '-qm', 'fixture'], { cwd: repoDir, stdio: 'ignore' });
+  const now = new Date().toISOString();
+  const tabs = Array.from({ length: sessionCount }, (_, index) => {
+    const id = `term-${runPrefix}-${index + 1}`;
+    return {
+      id,
+      label: `Terminal ${index + 1}`,
+      kind: 'terminal',
+      cliAgent: 'shell',
+      repoName: 'terminal-workload-fixture',
+      repoPath: repoDir,
+      sessionName: sessionNameForTabId(id),
+    };
+  });
+  fs.mkdirSync(path.join(dataDir, 'terminal-states'), { recursive: true });
+  fs.writeFileSync(path.join(dataDir, 'setup.json'), JSON.stringify({ setupComplete: true, skippedSteps: [] }));
+  fs.writeFileSync(path.join(dataDir, 'settings.toml'), [
+    '[telemetry]',
+    'consent_answered = true',
+    'product_enabled = false',
+    'sentry_enabled = false',
+    'crash_log_opt_in = false',
+    '',
+  ].join('\n'));
+  fs.writeFileSync(path.join(dataDir, 'repos.json'), JSON.stringify({ version: 1, repos: [repoEntry(repoDir, now)] }));
+  fs.writeFileSync(path.join(dataDir, 'terminal-states', 'tile-root.json'), JSON.stringify({
+    version: 1,
+    activeTabId: tabs[0].id,
+    tabs: tabs.map((tab) => ({
+      id: tab.id,
+      label: tab.label,
+      kind: tab.kind,
+      cliAgent: tab.cliAgent,
+      repoName: tab.repoName,
+      repoPath: tab.repoPath,
+    })),
+    savedAt: now,
+  }));
+  return { dataDir, repoDir, tabs };
+}
+
+function processLog(child) {
+  let output = '';
+  for (const stream of [child.stdout, child.stderr]) {
+    stream?.setEncoding('utf8');
+    stream?.on('data', (chunk) => { output = `${output}${chunk}`.slice(-30000); });
+  }
+  return () => output;
+}
+
+async function waitForUrl(url, child, log, timeoutMs = 90000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`${url} server exited ${child.exitCode}\n${log()}`);
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(2000) });
+      if (response.ok) return;
+    } catch { /* booting */ }
+    await sleep(250);
+  }
+  throw new Error(`timed out waiting for ${url}\n${log()}`);
+}
+
+function signalProcessGroup(child, signal) {
+  if (!child || child.exitCode !== null) return;
+  try { process.kill(-child.pid, signal); } catch { /* already stopped */ }
+}
+
+async function stopProcessGroup(child) {
+  signalProcessGroup(child, 'SIGTERM');
+  const deadline = Date.now() + 2500;
+  while (child?.exitCode === null && Date.now() < deadline) await sleep(50);
+  signalProcessGroup(child, 'SIGKILL');
+}
+
+export function cleanupTmuxSessions(sessionNames) {
+  const cleaned = [];
+  for (const sessionName of new Set(sessionNames)) {
+    if (!/^cortex-dash-[a-f0-9]{32}$/.test(sessionName)) continue;
+    try {
+      execFileSync('tmux', ['kill-session', '-t', sessionName], { stdio: 'ignore' });
+      cleaned.push(sessionName);
+    } catch { /* absent */ }
+  }
+  return cleaned;
+}
+
+export async function startIsolatedStack(root, seeded, requestedBuildMode = 'auto') {
+  const apiPort = await freePort(root);
+  let wsPort = await freePort(root);
+  while (wsPort === apiPort) wsPort = await freePort(root);
+  const productionAvailable = fs.existsSync(path.join(root, '.next', 'BUILD_ID'));
+  const buildMode = requestedBuildMode === 'next-dev' || !productionAvailable ? 'next-dev' : 'production';
+  const token = randomBytes(32).toString('hex');
+  fs.writeFileSync(path.join(seeded.dataDir, 'ws-token'), token, { mode: 0o600 });
+  const env = {
+    ...process.env,
+    NODE_ENV: buildMode === 'production' ? 'production' : 'development',
+    PORT: String(apiPort),
+    O8_API_PORT: String(apiPort),
+    WS_PORT: String(wsPort),
+    O8_WS_PORT: String(wsPort),
+    O8_DATA_DIR: seeded.dataDir,
+    CORTEX_IDE_DATA_DIR: seeded.dataDir,
+    CORTEX_IDE_REPO_ROOT: seeded.repoDir,
+    WS_TOKEN: token,
+    O8_TERMINAL_BENCH: '1',
+    O8_PERSISTENT_TERMINALS: '1',
+  };
+  delete env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+  delete env.CLERK_PUBLISHABLE_KEY;
+
+  const nextArgs = buildMode === 'production' ? ['scripts/start.mjs'] : ['scripts/dev.mjs', 'next'];
+  const next = spawn(process.execPath, nextArgs, { cwd: root, env, detached: true, stdio: ['ignore', 'pipe', 'pipe'] });
+  const stubUrl = pathToFileURL(path.join(root, 'scripts/register-server-only-stub.mjs')).href;
+  const ws = spawn(process.execPath, [path.join(root, 'node_modules/tsx/dist/cli.mjs'), 'src/ws-server.ts'], {
+    cwd: root,
+    env: { ...env, NODE_OPTIONS: [env.NODE_OPTIONS, `--import=${stubUrl}`].filter(Boolean).join(' ') },
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const nextLog = processLog(next);
+  const wsLog = processLog(ws);
+  try {
+    await Promise.all([
+      waitForUrl(`http://127.0.0.1:${apiPort}/api/panel/status`, next, nextLog),
+      waitForUrl(`http://127.0.0.1:${wsPort}/health`, ws, wsLog),
+    ]);
+  } catch (error) {
+    await Promise.all([stopProcessGroup(next), stopProcessGroup(ws)]);
+    throw error;
+  }
+  return {
+    apiPort,
+    wsPort,
+    token,
+    buildMode,
+    devModeCpuWarning: buildMode === 'next-dev',
+    nextPid: next.pid,
+    wsPid: ws.pid,
+    logs: { next: nextLog, ws: wsLog },
+    close: async () => {
+      await Promise.all([stopProcessGroup(next), stopProcessGroup(ws)]);
+      fs.rmSync(seeded.dataDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function processGroup(processes, rootPid) {
+  return [...descendantPids(processes, rootPid)].filter((pid) => processes.has(pid));
+}
+
+export function resolveProcessGroups(processes, stack, browserPid) {
+  const browserTree = processGroup(processes, browserPid);
+  return {
+    applicationServer: processGroup(processes, stack.nextPid),
+    realtimeServer: processGroup(processes, stack.wsPid),
+    chromiumRenderer: browserTree.filter((pid) => processes.get(pid)?.command.includes('--type=renderer')),
+  };
+}
+
+export function measureProcessGroups(before, after, groups, observationMs) {
+  const seconds = observationMs / 1000;
+  return Object.fromEntries(Object.entries(groups).map(([name, pids]) => {
+    let cpuSeconds = 0;
+    let physicalBytes = 0;
+    const physicalUnavailable = [];
+    for (const pid of pids) {
+      const beforeProcess = before.get(pid);
+      const afterProcess = after.get(pid);
+      if (beforeProcess && afterProcess) {
+        cpuSeconds += Math.max(0, afterProcess.cpuTimeSeconds - beforeProcess.cpuTimeSeconds);
+      }
+      if (!afterProcess) continue;
+      try { physicalBytes += measureProcessPhysicalBytes(pid); }
+      catch (error) { physicalUnavailable.push({ pid, reason: error instanceof Error ? error.message : String(error) }); }
+    }
+    return [name, {
+      processCount: pids.filter((pid) => after.has(pid)).length,
+      cpuPercent: seconds > 0 ? Number(((cpuSeconds / seconds) * 100).toFixed(2)) : null,
+      physicalBytes: physicalUnavailable.length === 0 ? physicalBytes : null,
+      physicalUnavailable,
+    }];
+  }));
+}

--- a/scripts/bench/terminal-workload/statistics.mjs
+++ b/scripts/bench/terminal-workload/statistics.mjs
@@ -1,0 +1,67 @@
+export function percentile(values, quantile) {
+  const sorted = values.filter(Number.isFinite).sort((left, right) => left - right);
+  if (sorted.length === 0) return null;
+  const index = Math.max(0, Math.ceil(sorted.length * quantile) - 1);
+  return Number(sorted[index].toFixed(2));
+}
+
+export function distribution(values) {
+  const finite = values.filter(Number.isFinite);
+  return {
+    samples: finite.length,
+    min: finite.length > 0 ? Number(Math.min(...finite).toFixed(2)) : null,
+    p50: percentile(finite, 0.5),
+    p95: percentile(finite, 0.95),
+    max: finite.length > 0 ? Number(Math.max(...finite).toFixed(2)) : null,
+  };
+}
+
+export function summarizeSamples(samples) {
+  const output = {};
+  for (const sessionCount of [...new Set(samples.map((sample) => sample.sessionCount))].sort((a, b) => a - b)) {
+    const group = samples.filter((sample) => sample.sessionCount === sessionCount);
+    const processMetric = (processName, field) => distribution(group.map((sample) => sample.processes[processName]?.[field]));
+    output[sessionCount] = {
+      sampleCount: group.length,
+      mountedTerminalPanels: distribution(group.map((sample) => sample.inventory.mountedTerminalPanelCount)),
+      visibleTerminalPanels: distribution(group.map((sample) => sample.inventory.visibleTerminalPanelCount)),
+      ptyCount: distribution(group.map((sample) => sample.inventory.ptyCount)),
+      hiddenWriteBytesPerSecondPerPanel: distribution(group.map((sample) => sample.browser.hiddenWriteBytesPerSecondPerPanel)),
+      hiddenWriteCallsPerSecondPerPanel: distribution(group.map((sample) => sample.browser.hiddenWriteCallsPerSecondPerPanel)),
+      longTaskMsPerMinute: distribution(group.map((sample) => sample.performance.longTaskMsPerMinute)),
+      revealMs: distribution(group.flatMap((sample) => sample.latency.revealMs)),
+      firstCorrectFrameMs: distribution(group.flatMap((sample) => sample.latency.firstCorrectFrameMs)),
+      keystrokeToPaintMs: distribution(group.flatMap((sample) => sample.latency.keystrokeToPaintMs)),
+      keystrokeToPaintTimeouts: group.reduce((total, sample) => (
+        total + sample.latency.keystrokeToPaintTimedOut.filter(Boolean).length
+      ), 0),
+      processCpuPercent: {
+        applicationServer: processMetric('applicationServer', 'cpuPercent'),
+        realtimeServer: processMetric('realtimeServer', 'cpuPercent'),
+        chromiumRenderer: processMetric('chromiumRenderer', 'cpuPercent'),
+      },
+      processPhysicalBytes: {
+        applicationServer: processMetric('applicationServer', 'physicalBytes'),
+        realtimeServer: processMetric('realtimeServer', 'physicalBytes'),
+        chromiumRenderer: processMetric('chromiumRenderer', 'physicalBytes'),
+      },
+      attachedClientsPerSession: group.map((sample) => sample.inventory.attachedClientsPerSession),
+      initiallyUnmountedBrowserWriteBytes: distribution(group.map((sample) => sample.browser.initiallyUnmountedWriteBytes)),
+      residencyChurnCount: distribution(group.map((sample) => sample.browser.residencyChurnSessionNames.length)),
+      neverMountedSessionCount: distribution(group.map((sample) => sample.browser.neverMountedSessionNames.length)),
+      unmountedBrowserWriteBytes: distribution(group.map((sample) => sample.browser.unmountedWriteBytes)),
+      unmountedServerHiddenBytes: distribution(group.map((sample) => sample.server.unmountedHiddenBytes)),
+      attribution: {
+        transportJsonParseMs: distribution(group.map((sample) => sample.browser.transport.jsonParseMs)),
+        base64DecodeMs: distribution(group.map((sample) => sample.browser.totalDecodeMs)),
+        termWriteCallMs: distribution(group.map((sample) => sample.browser.totalWriteCallMs)),
+        termWriteCompletionMs: distribution(group.map((sample) => sample.browser.totalWriteCompletionMs)),
+        renderEvents: distribution(group.map((sample) => sample.browser.totalRenderEvents)),
+        fanoutClientDeliveries: distribution(group.map((sample) => sample.server.fanoutClientDeliveries)),
+      },
+      overflowEvents: distribution(group.map((sample) => sample.server.overflowEvents)),
+      backpressureDropEvents: distribution(group.map((sample) => sample.server.backpressureDropEvents)),
+    };
+  }
+  return output;
+}

--- a/scripts/bench/terminal-workload/ws-client.mjs
+++ b/scripts/bench/terminal-workload/ws-client.mjs
@@ -1,0 +1,109 @@
+import WebSocket from 'ws';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export class TerminalWorkloadClient {
+  constructor(url) {
+    this.url = url;
+    this.socket = null;
+    this.frames = [];
+    this.textBySession = new Map();
+  }
+
+  async connect() {
+    this.socket = new WebSocket(this.url);
+    this.socket.on('message', (raw) => {
+      let frame;
+      try { frame = JSON.parse(raw.toString('utf8')); } catch { return; }
+      this.frames.push(frame);
+      if (this.frames.length > 4000) this.frames.splice(0, 2000);
+      if (frame.channel === 'terminal' && frame.event === 'data') {
+        const sessionName = frame.data?.sessionName;
+        const encoded = frame.data?.data;
+        if (typeof sessionName === 'string' && typeof encoded === 'string') {
+          const next = `${this.textBySession.get(sessionName) ?? ''}${Buffer.from(encoded, 'base64').toString('utf8')}`;
+          this.textBySession.set(sessionName, next.slice(-131072));
+        }
+      }
+    });
+    await new Promise((resolve, reject) => {
+      this.socket.once('open', resolve);
+      this.socket.once('error', reject);
+    });
+    await this.waitForFrame((frame) => frame.channel === 'system' && frame.event === 'connected', 10000);
+    return this;
+  }
+
+  send(message) {
+    if (this.socket?.readyState !== WebSocket.OPEN) throw new Error('terminal workload socket is not open');
+    this.socket.send(JSON.stringify(message));
+  }
+
+  async waitForFrame(predicate, timeoutMs = 10000, startIndex = 0) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const match = this.frames.slice(startIndex).find(predicate);
+      if (match) return match;
+      if (this.socket?.readyState === WebSocket.CLOSED) throw new Error('terminal workload socket closed');
+      await sleep(20);
+    }
+    throw new Error(`timed out waiting for terminal workload frame after ${timeoutMs}ms`);
+  }
+
+  async request(type, message = {}, timeoutMs = 10000) {
+    const requestId = `${type}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const startIndex = this.frames.length;
+    this.send({ type, requestId, ...message });
+    return this.waitForFrame(
+      (frame) => frame.channel === 'terminal-bench' && frame.data?.requestId === requestId,
+      timeoutMs,
+      startIndex,
+    );
+  }
+
+  async createAndAttach({ ownerKey, requestId, sessionName, cwd }) {
+    let startIndex = this.frames.length;
+    this.send({ type: 'terminal-create', ownerKey, requestId, cwd, cols: 120, rows: 30 });
+    const created = await this.waitForFrame(
+      (frame) => frame.channel === 'terminal' && frame.event === 'created' && frame.data?.requestId === requestId,
+      15000,
+      startIndex,
+    );
+    if (created.data?.sessionName !== sessionName) {
+      throw new Error(`owner key resolved to ${created.data?.sessionName ?? 'no session'}, expected ${sessionName}`);
+    }
+    startIndex = this.frames.length;
+    this.send({ type: 'terminal-attach', sessionName, cols: 120, rows: 30 });
+    await this.waitForFrame(
+      (frame) => frame.channel === 'terminal' && frame.event === 'attached' && frame.data?.sessionName === sessionName,
+      15000,
+      startIndex,
+    );
+  }
+
+  async waitForText(sessionName, marker, timeoutMs = 30000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if ((this.textBySession.get(sessionName) ?? '').includes(marker)) return;
+      await sleep(20);
+    }
+    throw new Error(`timed out waiting for ${marker} on ${sessionName}`);
+  }
+
+  async close() {
+    if (!this.socket || this.socket.readyState === WebSocket.CLOSED) return;
+    await new Promise((resolve) => {
+      this.socket.once('close', resolve);
+      this.socket.close();
+      setTimeout(resolve, 1000).unref();
+    });
+  }
+}
+
+export async function connectTerminalClients(url, count) {
+  const clients = [];
+  for (let index = 0; index < count; index += 1) {
+    clients.push(await new TerminalWorkloadClient(url).connect());
+  }
+  return clients;
+}

--- a/scripts/lib/footprint-budget.d.mts
+++ b/scripts/lib/footprint-budget.d.mts
@@ -36,6 +36,7 @@ export function parseProcessTable(output: string): Map<number, FootprintProcess>
 export function snapshotProcesses(run?: typeof import('node:child_process').execFileSync): Map<number, FootprintProcess>;
 export function descendantPids(processes: Map<number, FootprintProcess>, rootPid: number): Set<number>;
 export function webkitPids(processes: Map<number, FootprintProcess>): Set<number>;
+export function measureProcessPhysicalBytes(pid: number, run?: typeof import('node:child_process').execFileSync): number;
 export function evaluateFootprintBudget(metrics: FootprintMetrics, budget?: typeof FOOTPRINT_BUDGET): {
   pass: boolean;
   checks: Array<{ metric: string; actual: number; ceiling: number; pass: boolean }>;

--- a/scripts/lib/footprint-budget.mjs
+++ b/scripts/lib/footprint-budget.mjs
@@ -130,7 +130,7 @@ function measureDiskBytes(target, run = execFileSync) {
   return kib * 1024;
 }
 
-function measurePhysicalBytes(pid, run = execFileSync) {
+export function measureProcessPhysicalBytes(pid, run = execFileSync) {
   const output = run('footprint', ['-p', String(pid)], { encoding: 'utf8' });
   return parseFootprintBytes(output);
 }
@@ -223,7 +223,7 @@ export function collectFootprintReceipt({
     const process = after.get(pid);
     if (!process) continue;
     const key = classifyProcess(process, rootPid);
-    const bytes = measurePhysicalBytes(pid, run);
+    const bytes = measureProcessPhysicalBytes(pid, run);
     const component = components[key] ?? {
       processCount: 0,
       bytes: 0,

--- a/src/components/desktop/hooks/DesktopWebSocketContext.tsx
+++ b/src/components/desktop/hooks/DesktopWebSocketContext.tsx
@@ -31,6 +31,10 @@ import type {
 import { getBrowserWsPort } from '@/lib/panel/ws-port-client';
 import { openSurfaceWebSocket } from '@/lib/connect/open-surface-websocket';
 import { TranscriptSessionSubscriptionProvider } from '@/lib/transcripts/useTranscript';
+import {
+  recordTerminalBenchTransport,
+  terminalBenchEnabled,
+} from '@/components/desktop/workspace-terminal/terminal-bench-instrumentation';
 
 export type WsConnectionState = 'connecting' | 'connected' | 'reconnecting' | 'disconnected';
 
@@ -286,7 +290,24 @@ export function DesktopWebSocketProvider({ children }: { children: ReactNode }) 
 
     function handleMessage(event: MessageEvent) {
       let msg: Record<string, unknown>;
-      try { msg = JSON.parse(typeof event.data === 'string' ? event.data : ''); } catch { return; }
+      if (terminalBenchEnabled()) {
+        const raw = typeof event.data === 'string' ? event.data : '';
+        const parseStartedAt = performance.now();
+        try { msg = JSON.parse(raw); } catch { return; }
+
+        const channel = msg.channel as string;
+        const eventType = msg.event as string;
+        const data = msg.data as Record<string, unknown> | undefined;
+        if (channel === 'terminal' && eventType === 'data' && typeof data?.data === 'string') {
+          recordTerminalBenchTransport({
+            rawBytes: raw.length,
+            encodedBytes: data.data.length,
+            jsonParseMs: performance.now() - parseStartedAt,
+          });
+        }
+      } else {
+        try { msg = JSON.parse(typeof event.data === 'string' ? event.data : ''); } catch { return; }
+      }
 
       const channel = msg.channel as string;
       const eventType = msg.event as string;

--- a/src/components/desktop/shell/WorkspaceHeaderStrip.tsx
+++ b/src/components/desktop/shell/WorkspaceHeaderStrip.tsx
@@ -530,6 +530,7 @@ function HeaderPill({
   return (
     <div
       data-no-drag
+      data-o8-workspace-tab={tab.id}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       onContextMenu={(event) => {

--- a/src/components/desktop/workspace-terminal/XtermPanel.bench.test.ts
+++ b/src/components/desktop/workspace-terminal/XtermPanel.bench.test.ts
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+
+import { act, createElement, createRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { XtermPanelHandle, XtermPanelProps } from './XtermPanel';
+
+const xtermMock = vi.hoisted(() => ({
+  writes: [] as Uint8Array[],
+  writeCallbacks: [] as Array<(() => void) | undefined>,
+  onRenderCalls: 0,
+}));
+
+class MockDisposable {
+  dispose() {}
+}
+
+class MockAddon {
+  fit() {}
+}
+
+class MockTerminal {
+  cols = 120;
+  rows = 30;
+  options: { theme?: Record<string, string> } = {};
+  unicode = { activeVersion: '' };
+  buffer = {
+    active: {
+      length: 1,
+      getLine: () => ({ translateToString: () => 'fixture terminal' }),
+    },
+  };
+
+  loadAddon() {}
+  open() {}
+  focus() {}
+  reset() {}
+  dispose() {}
+  getSelection() { return ''; }
+  onData() { return new MockDisposable(); }
+  onSelectionChange() { return new MockDisposable(); }
+  onRender() {
+    xtermMock.onRenderCalls += 1;
+    return new MockDisposable();
+  }
+  write(data: Uint8Array | string, callback?: () => void) {
+    if (data instanceof Uint8Array) xtermMock.writes.push(data);
+    xtermMock.writeCallbacks.push(callback);
+    callback?.();
+  }
+}
+
+vi.mock('@xterm/xterm', () => ({ Terminal: MockTerminal }));
+vi.mock('@xterm/addon-fit', () => ({ FitAddon: MockAddon }));
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: MockAddon }));
+vi.mock('@xterm/addon-search', () => ({ SearchAddon: MockAddon }));
+vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: MockAddon }));
+vi.mock('@xterm/addon-image', () => ({ ImageAddon: MockAddon }));
+vi.mock('@/lib/theme/context', () => ({ useTheme: () => ({ themeId: 'dark-solid' }) }));
+vi.mock('@/components/desktop/workspace-terminal/constants', () => ({ buildXtermTheme: () => ({}) }));
+vi.mock('@/components/desktop/workspace-terminal/xterm-selection-registry', () => ({
+  recordXtermSelectionSnapshot: vi.fn(),
+  registerXtermSelectionSource: () => () => {},
+}));
+
+import { XtermPanel } from './XtermPanel';
+
+function panelProps(visible: boolean): XtermPanelProps {
+  return {
+    tmuxSession: 'cortex-dash-bench-fixture',
+    visible,
+    sendTerminalAttach: vi.fn(),
+    sendTerminalInput: vi.fn(),
+    sendTerminalResize: vi.fn(),
+    sendTerminalDetach: vi.fn(),
+  };
+}
+
+describe('XtermPanel terminal workload instrumentation', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    xtermMock.writes.length = 0;
+    xtermMock.writeCallbacks.length = 0;
+    xtermMock.onRenderCalls = 0;
+    delete window.__o8TerminalBenchEnabled;
+    delete window.__o8TerminalWriteStats;
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      configurable: true,
+      value: class ResizeObserver {
+        observe() {}
+        disconnect() {}
+      },
+    });
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(performance.now());
+      return 1;
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    document.getElementById('xterm-css')?.remove();
+    delete window.__o8TerminalBenchEnabled;
+    delete window.__o8TerminalWriteStats;
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('does not allocate counters when the bench flag is unset', async () => {
+    const panelRef = createRef<XtermPanelHandle>();
+    await act(async () => {
+      root.render(createElement(XtermPanel, { ...panelProps(false), ref: panelRef }));
+      await Promise.resolve();
+    });
+
+    await act(async () => panelRef.current?.writeData(btoa('hidden')));
+
+    expect(xtermMock.writes).toHaveLength(1);
+    expect(window.__o8TerminalWriteStats).toBeUndefined();
+  });
+
+  it('does not install render or write-completion instrumentation when the bench flag is unset', async () => {
+    const panelRef = createRef<XtermPanelHandle>();
+    await act(async () => {
+      root.render(createElement(XtermPanel, { ...panelProps(false), ref: panelRef }));
+      await Promise.resolve();
+    });
+
+    await act(async () => panelRef.current?.writeData(btoa('plain')));
+
+    expect(xtermMock.onRenderCalls).toBe(0);
+    expect(xtermMock.writes).toHaveLength(1);
+    expect(xtermMock.writeCallbacks).toEqual([undefined]);
+  });
+
+  it('resizes a visible terminal after its session name arrives', async () => {
+    vi.useFakeTimers();
+    const sendTerminalResize = vi.fn();
+    const pendingProps = {
+      ...panelProps(true),
+      tmuxSession: null as unknown as string,
+      sendTerminalResize,
+    };
+    await act(async () => {
+      root.render(createElement(XtermPanel, pendingProps));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(75);
+    });
+    sendTerminalResize.mockClear();
+
+    await act(async () => {
+      root.render(createElement(XtermPanel, {
+        ...pendingProps,
+        tmuxSession: 'cortex-dash-session-ready',
+      }));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(75);
+    });
+
+    expect(sendTerminalResize).toHaveBeenCalledWith('cortex-dash-session-ready', 120, 30);
+    vi.useRealTimers();
+  });
+
+  it('counts writes through the real hidden and visible writeData path', async () => {
+    window.__o8TerminalBenchEnabled = true;
+    const panelRef = createRef<XtermPanelHandle>();
+    const hiddenProps = panelProps(false);
+    await act(async () => {
+      root.render(createElement(XtermPanel, { ...hiddenProps, ref: panelRef }));
+      await Promise.resolve();
+    });
+
+    await act(async () => panelRef.current?.writeData(btoa('hidden')));
+    await act(async () => root.render(createElement(XtermPanel, {
+      ...hiddenProps,
+      visible: true,
+      ref: panelRef,
+    })));
+    await act(async () => panelRef.current?.writeData(btoa('shown')));
+
+    const session = window.__o8TerminalWriteStats?.sessions['cortex-dash-bench-fixture'];
+    expect(session?.hiddenWork).toMatchObject({ calls: 1, decodedBytes: 6 });
+    expect(session?.visibleWork).toMatchObject({ calls: 1, decodedBytes: 5 });
+    expect(xtermMock.writes).toHaveLength(2);
+  });
+});

--- a/src/components/desktop/workspace-terminal/XtermPanel.tsx
+++ b/src/components/desktop/workspace-terminal/XtermPanel.tsx
@@ -7,6 +7,26 @@ import { buildXtermTheme } from '@/components/desktop/workspace-terminal/constan
 import { startSpawnReveal } from '@/components/desktop/workspace-terminal/spawn-reveal';
 import { recordXtermSelectionSnapshot, registerXtermSelectionSource } from '@/components/desktop/workspace-terminal/xterm-selection-registry';
 import { retainInlineTerminalImages, TERMINAL_SCROLLBACK_LINES } from '@/lib/terminal/client-retention';
+import {
+  recordTerminalBenchRender,
+  recordTerminalBenchVisibility,
+  recordTerminalBenchWrite,
+  recordTerminalBenchWriteCompletion,
+  registerTerminalBenchPanel,
+  terminalBenchEnabled,
+} from '@/components/desktop/workspace-terminal/terminal-bench-instrumentation';
+
+function readTerminalText(term: { buffer?: { active?: { length?: number; getLine: (index: number) => { translateToString: (trimRight: boolean) => string } | undefined } } } | null, lines = 40): string {
+  if (!term?.buffer?.active) return '';
+  const active = term.buffer.active;
+  const length = active.length ?? 0;
+  const start = Math.max(0, length - Math.max(1, Math.floor(lines)));
+  const out: string[] = [];
+  for (let index = start; index < length; index += 1) {
+    out.push(active.getLine(index)?.translateToString(true) ?? '');
+  }
+  return out.join('\n').replace(/\s+$/g, '');
+}
 
 export interface InlineImage {
   id: string;
@@ -73,6 +93,8 @@ export const XtermPanel = forwardRef<XtermPanelHandle, XtermPanelProps>(function
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const fitAddonRef = useRef<any>(null);
   const observerRef = useRef<ResizeObserver | null>(null);
+  const tmuxSessionRef = useRef(tmuxSession);
+  tmuxSessionRef.current = tmuxSession;
   const visibleRef = useRef(visible);
   visibleRef.current = visible;
   const revealCancelRef = useRef<((resetTerm: boolean) => void) | null>(null);
@@ -118,8 +140,31 @@ export const XtermPanel = forwardRef<XtermPanelHandle, XtermPanelProps>(function
       }
       cancelReveal(true);
       try {
+        if (!terminalBenchEnabled()) {
+          const bytes = Uint8Array.from(atob(data), (char) => char.charCodeAt(0));
+          termRef.current.write(bytes);
+          return;
+        }
+        const decodeStartedAt = performance.now();
         const bytes = Uint8Array.from(atob(data), (char) => char.charCodeAt(0));
-        termRef.current.write(bytes);
+        const decodeMs = performance.now() - decodeStartedAt;
+        const visibleAtWrite = visibleRef.current;
+        const sessionNameAtWrite = tmuxSessionRef.current;
+        const completionStartedAt = performance.now();
+        const writeStartedAt = performance.now();
+        termRef.current.write(bytes, () => {
+          recordTerminalBenchWriteCompletion(
+            sessionNameAtWrite,
+            visibleAtWrite,
+            performance.now() - completionStartedAt,
+          );
+        });
+        recordTerminalBenchWrite(sessionNameAtWrite, visibleAtWrite, {
+          encodedBytes: data.length,
+          decodedBytes: bytes.byteLength,
+          decodeMs,
+          writeCallMs: performance.now() - writeStartedAt,
+        });
       } catch {
         return;
       }
@@ -154,20 +199,23 @@ export const XtermPanel = forwardRef<XtermPanelHandle, XtermPanelProps>(function
       }
     },
     readText: (lines = 40) => {
-      const term = termRef.current;
-      if (!term?.buffer?.active) return '';
-      const active = term.buffer.active;
-      const length = active.length ?? 0;
-      const start = Math.max(0, length - Math.max(1, Math.floor(lines)));
-      const out: string[] = [];
-      for (let index = start; index < length; index += 1) {
-        out.push(active.getLine(index)?.translateToString(true) ?? '');
-      }
-      return out.join('\n').replace(/\s+$/g, '');
+      return readTerminalText(termRef.current, lines);
     },
     setError: (nextError: string) => setError(nextError),
     setExited: () => setExited(true),
   }), [fitTerminal]);
+
+  useEffect(() => (
+    registerTerminalBenchPanel(
+      tmuxSession,
+      visibleRef.current,
+      (lines) => readTerminalText(termRef.current, lines),
+    ) ?? undefined
+  ), [tmuxSession]);
+
+  useEffect(() => {
+    recordTerminalBenchVisibility(tmuxSession, visible);
+  }, [tmuxSession, visible]);
 
   useEffect(() => {
     if (visible) {
@@ -245,6 +293,11 @@ export const XtermPanel = forwardRef<XtermPanelHandle, XtermPanelProps>(function
         term.open(containerRef.current);
         termRef.current = term;
         fitAddonRef.current = fitAddon;
+        const renderDisposable = terminalBenchEnabled()
+          ? term.onRender(({ start, end }: { start: number; end: number }) => {
+            recordTerminalBenchRender(tmuxSession, visibleRef.current, start, end);
+          })
+          : null;
         term.onData((data) => {
           sendTerminalInput(tmuxSession, data);
         });
@@ -296,6 +349,7 @@ export const XtermPanel = forwardRef<XtermPanelHandle, XtermPanelProps>(function
           sendTerminalAttach(tmuxSession, liveTerm.cols, liveTerm.rows);
         }));
         return () => {
+          renderDisposable?.dispose();
           observerRef.current?.disconnect();
           observerRef.current = null;
         };
@@ -406,6 +460,7 @@ export const XtermPanel = forwardRef<XtermPanelHandle, XtermPanelProps>(function
 
   return (
     <div
+      data-o8-term-panel={tmuxSession}
       style={{
         flex: 1,
         width: '100%',

--- a/src/components/desktop/workspace-terminal/terminal-bench-instrumentation.ts
+++ b/src/components/desktop/workspace-terminal/terminal-bench-instrumentation.ts
@@ -1,0 +1,212 @@
+'use client';
+
+export type TerminalBenchVisibilityCounters = {
+  calls: number;
+  encodedBytes: number;
+  decodedBytes: number;
+  decodeMs: number;
+  writeCallMs: number;
+  writeCompletionMs: number;
+  renderEvents: number;
+  renderRows: number;
+};
+
+export type TerminalBenchSessionStats = {
+  mountCount: number;
+  unmountCount: number;
+  mounted: boolean;
+  visible: boolean;
+  visibleMs: number;
+  hiddenMs: number;
+  visibilityChangedAt: number;
+  visibleWork: TerminalBenchVisibilityCounters;
+  hiddenWork: TerminalBenchVisibilityCounters;
+  readText: (lines?: number) => string;
+};
+
+export type TerminalBenchWriteStats = {
+  schema: 'o8/terminal-write-stats/v1';
+  startedAt: number;
+  sessions: Record<string, TerminalBenchSessionStats>;
+  transport: {
+    terminalMessages: number;
+    rawBytes: number;
+    encodedBytes: number;
+    jsonParseMs: number;
+  };
+  reset: () => void;
+};
+
+declare global {
+  interface Window {
+    __o8TerminalBenchEnabled?: boolean;
+    __o8TerminalWriteStats?: TerminalBenchWriteStats;
+  }
+}
+
+function now(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
+
+function emptyCounters(): TerminalBenchVisibilityCounters {
+  return {
+    calls: 0,
+    encodedBytes: 0,
+    decodedBytes: 0,
+    decodeMs: 0,
+    writeCallMs: 0,
+    writeCompletionMs: 0,
+    renderEvents: 0,
+    renderRows: 0,
+  };
+}
+
+export function terminalBenchEnabled(): boolean {
+  return typeof window !== 'undefined' && window.__o8TerminalBenchEnabled === true;
+}
+
+function resetStats(stats: TerminalBenchWriteStats): void {
+  const resetAt = now();
+  stats.startedAt = resetAt;
+  stats.transport = { terminalMessages: 0, rawBytes: 0, encodedBytes: 0, jsonParseMs: 0 };
+  for (const session of Object.values(stats.sessions)) {
+    session.mountCount = session.mounted ? 1 : 0;
+    session.unmountCount = 0;
+    session.visibleMs = 0;
+    session.hiddenMs = 0;
+    session.visibilityChangedAt = resetAt;
+    session.visibleWork = emptyCounters();
+    session.hiddenWork = emptyCounters();
+  }
+}
+
+function ensureStats(): TerminalBenchWriteStats | null {
+  if (!terminalBenchEnabled()) return null;
+  if (window.__o8TerminalWriteStats) return window.__o8TerminalWriteStats;
+  const stats: TerminalBenchWriteStats = {
+    schema: 'o8/terminal-write-stats/v1',
+    startedAt: now(),
+    sessions: {},
+    transport: { terminalMessages: 0, rawBytes: 0, encodedBytes: 0, jsonParseMs: 0 },
+    reset: () => resetStats(stats),
+  };
+  window.__o8TerminalWriteStats = stats;
+  return stats;
+}
+
+function settleVisibility(session: TerminalBenchSessionStats, at = now()): void {
+  const elapsed = Math.max(0, at - session.visibilityChangedAt);
+  if (session.visible) session.visibleMs += elapsed;
+  else session.hiddenMs += elapsed;
+  session.visibilityChangedAt = at;
+}
+
+function sessionStats(sessionName: string): TerminalBenchSessionStats | null {
+  return ensureStats()?.sessions[sessionName] ?? null;
+}
+
+function counters(sessionName: string, visible: boolean): TerminalBenchVisibilityCounters | null {
+  const session = sessionStats(sessionName);
+  if (!session) return null;
+  return visible ? session.visibleWork : session.hiddenWork;
+}
+
+export function registerTerminalBenchPanel(
+  sessionName: string,
+  visible: boolean,
+  readText: (lines?: number) => string,
+): (() => void) | null {
+  const stats = ensureStats();
+  if (!stats) return null;
+  const at = now();
+  const existing = stats.sessions[sessionName];
+  if (existing) {
+    settleVisibility(existing, at);
+    existing.mountCount += 1;
+    existing.mounted = true;
+    existing.visible = visible;
+    existing.readText = readText;
+  } else {
+    stats.sessions[sessionName] = {
+      mountCount: 1,
+      unmountCount: 0,
+      mounted: true,
+      visible,
+      visibleMs: 0,
+      hiddenMs: 0,
+      visibilityChangedAt: at,
+      visibleWork: emptyCounters(),
+      hiddenWork: emptyCounters(),
+      readText,
+    };
+  }
+  return () => {
+    const session = sessionStats(sessionName);
+    if (!session) return;
+    settleVisibility(session);
+    session.unmountCount += 1;
+    session.mounted = false;
+  };
+}
+
+export function recordTerminalBenchVisibility(sessionName: string, visible: boolean): void {
+  const session = sessionStats(sessionName);
+  if (!session || session.visible === visible) return;
+  settleVisibility(session);
+  session.visible = visible;
+}
+
+export function recordTerminalBenchWrite(
+  sessionName: string,
+  visible: boolean,
+  values: { encodedBytes: number; decodedBytes: number; decodeMs: number; writeCallMs: number },
+): void {
+  const target = counters(sessionName, visible);
+  if (!target) return;
+  target.calls += 1;
+  target.encodedBytes += values.encodedBytes;
+  target.decodedBytes += values.decodedBytes;
+  target.decodeMs += values.decodeMs;
+  target.writeCallMs += values.writeCallMs;
+}
+
+export function recordTerminalBenchWriteCompletion(
+  sessionName: string,
+  visible: boolean,
+  elapsedMs: number,
+): void {
+  const target = counters(sessionName, visible);
+  if (target) target.writeCompletionMs += elapsedMs;
+}
+
+export function recordTerminalBenchRender(
+  sessionName: string,
+  visible: boolean,
+  start: number,
+  end: number,
+): void {
+  const target = counters(sessionName, visible);
+  if (!target) return;
+  target.renderEvents += 1;
+  target.renderRows += Math.max(0, end - start + 1);
+}
+
+export function recordTerminalBenchTransport(values: {
+  rawBytes: number;
+  encodedBytes: number;
+  jsonParseMs: number;
+}): void {
+  const stats = ensureStats();
+  if (!stats) return;
+  stats.transport.terminalMessages += 1;
+  stats.transport.rawBytes += values.rawBytes;
+  stats.transport.encodedBytes += values.encodedBytes;
+  stats.transport.jsonParseMs += values.jsonParseMs;
+}
+
+export function settleTerminalBenchStats(): void {
+  const stats = ensureStats();
+  if (!stats) return;
+  const at = now();
+  for (const session of Object.values(stats.sessions)) settleVisibility(session, at);
+}

--- a/src/lib/ws-server/terminal-workload-stats.ts
+++ b/src/lib/ws-server/terminal-workload-stats.ts
@@ -1,0 +1,158 @@
+export type TerminalWorkloadSessionSnapshot = {
+  visible: boolean;
+  attachedClientCount: number;
+  peakAttachedClientCount: number;
+  attachEvents: number;
+  detachEvents: number;
+  pty: {
+    visible: { chunks: number; bytes: number };
+    hidden: { chunks: number; bytes: number };
+  };
+  buffer: { events: number; bytesAppended: number; retainedBytes: number };
+  replay: { events: number; bytes: number };
+  overflow: { events: number; bytes: number };
+  backpressureDrops: { events: number; bytes: number };
+  fanout: { events: number; sourceBytes: number; clientDeliveries: number };
+  alternateScreen: {
+    observedEnter: boolean;
+    observedExit: boolean;
+    retainedEnter: boolean;
+    retainedExit: boolean;
+  };
+  lastOutputTail: string;
+};
+
+type MutableSession = TerminalWorkloadSessionSnapshot & { clients: Set<string>; escapeTail: string };
+
+function emptySession(): MutableSession {
+  return {
+    visible: false,
+    attachedClientCount: 0,
+    peakAttachedClientCount: 0,
+    attachEvents: 0,
+    detachEvents: 0,
+    pty: {
+      visible: { chunks: 0, bytes: 0 },
+      hidden: { chunks: 0, bytes: 0 },
+    },
+    buffer: { events: 0, bytesAppended: 0, retainedBytes: 0 },
+    replay: { events: 0, bytes: 0 },
+    overflow: { events: 0, bytes: 0 },
+    backpressureDrops: { events: 0, bytes: 0 },
+    fanout: { events: 0, sourceBytes: 0, clientDeliveries: 0 },
+    alternateScreen: { observedEnter: false, observedExit: false, retainedEnter: false, retainedExit: false },
+    lastOutputTail: '',
+    clients: new Set(),
+    escapeTail: '',
+  };
+}
+
+export class TerminalWorkloadStats {
+  private sessions = new Map<string, MutableSession>();
+
+  private session(sessionName: string): MutableSession {
+    let session = this.sessions.get(sessionName);
+    if (!session) {
+      session = emptySession();
+      this.sessions.set(sessionName, session);
+    }
+    return session;
+  }
+
+  reset(attachments: Iterable<{ sessionName: string; clientIds: Set<string>; scrollbackBytes: number }>): void {
+    this.sessions.clear();
+    for (const attachment of attachments) {
+      const session = this.session(attachment.sessionName);
+      session.clients = new Set(attachment.clientIds);
+      session.attachedClientCount = session.clients.size;
+      session.peakAttachedClientCount = session.clients.size;
+      session.buffer.retainedBytes = attachment.scrollbackBytes;
+    }
+  }
+
+  setVisibility(sessionName: string, visible: boolean): void {
+    this.session(sessionName).visible = visible;
+  }
+
+  recordAttach(sessionName: string, clientId: string): void {
+    const session = this.session(sessionName);
+    if (session.clients.has(clientId)) return;
+    session.clients.add(clientId);
+    session.attachedClientCount = session.clients.size;
+    session.peakAttachedClientCount = Math.max(session.peakAttachedClientCount, session.clients.size);
+    session.attachEvents += 1;
+  }
+
+  recordDetach(sessionName: string, clientId: string): void {
+    const session = this.session(sessionName);
+    if (!session.clients.delete(clientId)) return;
+    session.attachedClientCount = session.clients.size;
+    session.detachEvents += 1;
+  }
+
+  recordPty(sessionName: string, data: string): void {
+    const session = this.session(sessionName);
+    const target = session.visible ? session.pty.visible : session.pty.hidden;
+    const bytes = Buffer.byteLength(data, 'utf8');
+    target.chunks += 1;
+    target.bytes += bytes;
+    const scanned = `${session.escapeTail}${data}`;
+    if (scanned.includes('\x1b[?1049h') || scanned.includes('O8_ALT_SCREEN_ENTER_')) {
+      session.alternateScreen.observedEnter = true;
+    }
+    if (scanned.includes('\x1b[?1049l') || scanned.includes('O8_ALT_SCREEN_EXIT_')) {
+      session.alternateScreen.observedExit = true;
+    }
+    session.escapeTail = scanned.slice(-32);
+    session.lastOutputTail = `${session.lastOutputTail}${data}`.slice(-4096);
+  }
+
+  recordBuffer(sessionName: string, appendedBytes: number, retainedBytes: number): void {
+    const buffer = this.session(sessionName).buffer;
+    buffer.events += 1;
+    buffer.bytesAppended += appendedBytes;
+    buffer.retainedBytes = retainedBytes;
+  }
+
+  recordOverflow(sessionName: string, bytes: number): void {
+    const overflow = this.session(sessionName).overflow;
+    overflow.events += 1;
+    overflow.bytes += bytes;
+  }
+
+  recordReplay(sessionName: string, bytes: number): void {
+    const replay = this.session(sessionName).replay;
+    replay.events += 1;
+    replay.bytes += bytes;
+  }
+
+  recordBackpressureDrop(sessionName: string, bytes: number): void {
+    const drops = this.session(sessionName).backpressureDrops;
+    drops.events += 1;
+    drops.bytes += bytes;
+  }
+
+  recordFanout(sessionName: string, sourceBytes: number, clientDeliveries: number): void {
+    const fanout = this.session(sessionName).fanout;
+    fanout.events += 1;
+    fanout.sourceBytes += sourceBytes;
+    fanout.clientDeliveries += clientDeliveries;
+  }
+
+  recordRetainedEscapeState(sessionName: string, retained: string): void {
+    const alternate = this.session(sessionName).alternateScreen;
+    alternate.retainedEnter = retained.includes('\x1b[?1049h') || retained.includes('O8_ALT_SCREEN_ENTER_');
+    alternate.retainedExit = retained.includes('\x1b[?1049l') || retained.includes('O8_ALT_SCREEN_EXIT_');
+  }
+
+  snapshot(): { schema: 'o8/terminal-server-stats/v1'; sessions: Record<string, TerminalWorkloadSessionSnapshot> } {
+    const sessions: Record<string, TerminalWorkloadSessionSnapshot> = {};
+    for (const [sessionName, session] of this.sessions) {
+      const { clients: _clients, escapeTail: _escapeTail, ...snapshot } = session;
+      void _clients;
+      void _escapeTail;
+      sessions[sessionName] = structuredClone(snapshot);
+    }
+    return { schema: 'o8/terminal-server-stats/v1', sessions };
+  }
+}

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -51,6 +51,7 @@ import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
 import { homedir } from 'node:os';
 import { promisify } from 'node:util';
 import { getDataDir, migrateDataDirOnce } from '@/lib/data-dir-migration';
+import { TerminalWorkloadStats } from '@/lib/ws-server/terminal-workload-stats';
 
 migrateDataDirOnce();
 
@@ -1037,6 +1038,9 @@ interface InternalTerminalSignalPayload {
 }
 
 const terminalAttachments = new Map<string, TerminalAttachment>();
+const terminalWorkloadStats = process.env.O8_TERMINAL_BENCH === '1'
+  ? new TerminalWorkloadStats()
+  : null;
 const TERMINAL_BATCH_MS = 16; // batch PTY output every 16ms (60fps)
 const DASH_SESSION_ORPHAN_TTL_MS = 30 * 60 * 1000;
 const TERMINAL_SCROLLBACK_MAX_BYTES = 512 * 1024;
@@ -1716,21 +1720,26 @@ function spawnManagedCommandPty(
 function trimScrollback(att: TerminalAttachment) {
   while (att.scrollbackBytes > TERMINAL_SCROLLBACK_MAX_BYTES && att.scrollbackChunks.length > 0) {
     const removed = att.scrollbackChunks.shift() ?? '';
-    att.scrollbackBytes -= Buffer.byteLength(removed, 'utf-8');
+    const removedBytes = Buffer.byteLength(removed, 'utf-8');
+    att.scrollbackBytes -= removedBytes;
+    terminalWorkloadStats?.recordOverflow(att.sessionName, removedBytes);
   }
 }
 
 function appendScrollback(att: TerminalAttachment, data: string) {
   if (!data) return;
   att.scrollbackChunks.push(data);
-  att.scrollbackBytes += Buffer.byteLength(data, 'utf-8');
+  const appendedBytes = Buffer.byteLength(data, 'utf-8');
+  att.scrollbackBytes += appendedBytes;
   trimScrollback(att);
+  terminalWorkloadStats?.recordBuffer(att.sessionName, appendedBytes, att.scrollbackBytes);
 }
 
 function sendTerminalScrollback(client: ClientState, attachment: TerminalAttachment) {
   if (attachment.scrollbackChunks.length === 0) return;
   const scrollback = attachment.scrollbackChunks.join('');
   if (!scrollback) return;
+  terminalWorkloadStats?.recordReplay(attachment.sessionName, Buffer.byteLength(scrollback, 'utf8'));
   const encoded = Buffer.from(scrollback, 'utf-8').toString('base64');
   sendRaw(client, JSON.stringify({
     channel: 'terminal',
@@ -1742,11 +1751,16 @@ function sendTerminalScrollback(client: ClientState, attachment: TerminalAttachm
 function registerTerminalAttachment(attachment: TerminalAttachment) {
   const { sessionName, ptyProcess } = attachment;
 
+  for (const clientId of attachment.clientIds) {
+    terminalWorkloadStats?.recordAttach(sessionName, clientId);
+  }
+
   ptyProcess.onData((data: string) => {
     const att = terminalAttachments.get(sessionName);
     if (!att) return;
 
     att.lastOutputAt = Date.now();
+    terminalWorkloadStats?.recordPty(sessionName, data);
     appendScrollback(att, data);
     att.batchBuffer += data;
 
@@ -1765,10 +1779,19 @@ function registerTerminalAttachment(attachment: TerminalAttachment) {
           data: { sessionName, data: encoded },
         });
 
+        let clientDeliveries = 0;
         for (const cid of att.clientIds) {
           const c = clients.get(cid);
-          if (c) sendRaw(c, msg);
+          if (c) {
+            clientDeliveries += 1;
+            sendRaw(c, msg);
+          }
         }
+        terminalWorkloadStats?.recordFanout(
+          sessionName,
+          Buffer.byteLength(buffered, 'utf8'),
+          clientDeliveries,
+        );
       }, TERMINAL_BATCH_MS);
     }
   });
@@ -2065,7 +2088,10 @@ function sendRaw(client: ClientState, preStringified: string) {
   // per-client encrypted frame for an E2EE client, or the plaintext otherwise.
   const wire = wireForClient(client, preStringified);
   if (client.ws.bufferedAmount > BACKPRESSURE_LIMIT) {
-    if (isLossyMessage(preStringified)) return; // safe to drop
+    if (isLossyMessage(preStringified)) {
+      recordTerminalBenchDrop(preStringified);
+      return;
+    }
     if (client.backpressureQueue.length >= BACKPRESSURE_QUEUE_LIMIT) {
       client.backpressureQueue.shift();
     }
@@ -2076,7 +2102,10 @@ function sendRaw(client: ClientState, preStringified: string) {
   if (client.backpressureQueue.length > 0) {
     flushBackpressureQueue(client);
     if (client.backpressureQueue.length > 0) {
-      if (isLossyMessage(preStringified)) return;
+      if (isLossyMessage(preStringified)) {
+        recordTerminalBenchDrop(preStringified);
+        return;
+      }
       if (client.backpressureQueue.length >= BACKPRESSURE_QUEUE_LIMIT) {
         client.backpressureQueue.shift();
       }
@@ -2086,6 +2115,24 @@ function sendRaw(client: ClientState, preStringified: string) {
     }
   }
   client.ws.send(wire);
+}
+
+function recordTerminalBenchDrop(preStringified: string) {
+  if (!terminalWorkloadStats || !preStringified.includes('"channel":"terminal"')) return;
+  try {
+    const message = JSON.parse(preStringified) as {
+      channel?: string;
+      event?: string;
+      data?: { sessionName?: string; data?: string };
+    };
+    if (message.channel !== 'terminal' || message.event !== 'data') return;
+    const sessionName = message.data?.sessionName;
+    const encoded = message.data?.data;
+    if (!sessionName || !encoded) return;
+    terminalWorkloadStats.recordBackpressureDrop(sessionName, Buffer.from(encoded, 'base64').byteLength);
+  } catch {
+    // Bench diagnostics never affect delivery.
+  }
 }
 
 function broadcast(msg: Record<string, unknown>, filter?: (c: ClientState) => boolean) {
@@ -3487,6 +3534,15 @@ function handleClientMessage(client: ClientState, raw: string) {
     }
 
     // ── Terminal commands ──
+    case 'terminal-bench-reset':
+      handleTerminalBenchReset(client, msg);
+      break;
+    case 'terminal-bench-visibility':
+      handleTerminalBenchVisibility(client, msg);
+      break;
+    case 'terminal-bench-stats':
+      handleTerminalBenchStats(client, msg);
+      break;
     case 'terminal-create':
       handleTerminalCreate(client, msg);
       break;
@@ -6146,6 +6202,52 @@ function sendTerminal(client: ClientState, event: string, payload: Record<string
   send(client, { channel: 'terminal', event, data: payload });
 }
 
+function sendTerminalBench(
+  client: ClientState,
+  event: string,
+  requestId: unknown,
+) {
+  if (!terminalWorkloadStats) return;
+  for (const attachment of terminalAttachments.values()) {
+    terminalWorkloadStats.recordRetainedEscapeState(
+      attachment.sessionName,
+      attachment.scrollbackChunks.join(''),
+    );
+  }
+  send(client, {
+    channel: 'terminal-bench',
+    event,
+    data: {
+      requestId: typeof requestId === 'string' ? requestId : null,
+      snapshot: terminalWorkloadStats.snapshot(),
+    },
+  });
+}
+
+function handleTerminalBenchReset(client: ClientState, msg: Record<string, unknown>) {
+  if (!terminalWorkloadStats) return;
+  terminalWorkloadStats.reset(terminalAttachments.values());
+  sendTerminalBench(client, 'reset', msg.requestId);
+}
+
+function handleTerminalBenchVisibility(client: ClientState, msg: Record<string, unknown>) {
+  if (!terminalWorkloadStats) return;
+  const sessions = Array.isArray(msg.sessions) ? msg.sessions : [];
+  for (const entry of sessions) {
+    if (!entry || typeof entry !== 'object') continue;
+    const sessionName = (entry as { sessionName?: unknown }).sessionName;
+    const visible = (entry as { visible?: unknown }).visible;
+    if (typeof sessionName === 'string' && typeof visible === 'boolean') {
+      terminalWorkloadStats.setVisibility(sessionName, visible);
+    }
+  }
+  sendTerminalBench(client, 'visibility', msg.requestId);
+}
+
+function handleTerminalBenchStats(client: ClientState, msg: Record<string, unknown>) {
+  sendTerminalBench(client, 'stats', msg.requestId);
+}
+
 function materializePendingDashSession(
   client: ClientState,
   sessionName: string,
@@ -6280,6 +6382,7 @@ function handleTerminalAttach(client: ClientState, msg: Record<string, unknown>)
       attachment.orphanTimer = null;
     }
     attachment.clientIds.add(client.id);
+    terminalWorkloadStats?.recordAttach(sessionName, client.id);
     client.terminalSessions.add(sessionName);
     sendTerminal(client, 'attached', { sessionName });
     if (attachment.kind === 'dash-shell') {
@@ -6512,6 +6615,7 @@ function removeClientFromTerminal(clientId: string, sessionName: string) {
   if (!attachment) return;
 
   attachment.clientIds.delete(clientId);
+  terminalWorkloadStats?.recordDetach(sessionName, clientId);
   const c = clients.get(clientId);
   if (c) c.terminalSessions.delete(sessionName);
 

--- a/tests/bench/results/terminal-workload-baseline.json
+++ b/tests/bench/results/terminal-workload-baseline.json
@@ -1,0 +1,2210 @@
+{
+  "schema": "o8/terminal-workload/v1",
+  "generatedAt": "2026-08-28T18:35:21.976Z",
+  "commit": "0609729bd5e286e1aa2ac33a0fde89486d0b9e6b",
+  "dirty": true,
+  "treeFingerprint": "7298ad7fa5f1b9cf47152ad4fdb861bb22a1a018ef25e08760e26c878dbfebd0",
+  "buildMode": "production",
+  "devModeCpuWarning": false,
+  "hardware": {
+    "arch": "x64",
+    "cpuModel": "Intel(R) Core(TM) i7-10700K CPU @ 3.80GHz",
+    "logicalCpuCount": 16,
+    "totalMemoryBytes": 68719476736
+  },
+  "os": {
+    "platform": "darwin",
+    "release": "25.6.0"
+  },
+  "fixture": {
+    "id": "terminal-ansi-alt-screen-v1",
+    "sessionCounts": [
+      1,
+      4,
+      12
+    ],
+    "samplesPerSessionCount": 3,
+    "bytesPerSecondPerSession": 81920,
+    "durationMs": 10000,
+    "chunkMs": 32,
+    "seed": 1721,
+    "alternateScreen": {
+      "enterAtFraction": 0.25,
+      "exitAtFraction": 0.8,
+      "decset": 1049
+    }
+  },
+  "sampleCount": 9,
+  "rawArtifactDirectory": "tests/bench/latest/terminal-workload-2026-08-28",
+  "summary": {
+    "1": {
+      "sampleCount": 3,
+      "mountedTerminalPanels": {
+        "samples": 3,
+        "min": 1,
+        "p50": 1,
+        "p95": 1,
+        "max": 1
+      },
+      "visibleTerminalPanels": {
+        "samples": 3,
+        "min": 1,
+        "p50": 1,
+        "p95": 1,
+        "max": 1
+      },
+      "ptyCount": {
+        "samples": 3,
+        "min": 1,
+        "p50": 1,
+        "p95": 1,
+        "max": 1
+      },
+      "hiddenWriteBytesPerSecondPerPanel": {
+        "samples": 3,
+        "min": 0,
+        "p50": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "hiddenWriteCallsPerSecondPerPanel": {
+        "samples": 3,
+        "min": 0,
+        "p50": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "longTaskMsPerMinute": {
+        "samples": 3,
+        "min": 0,
+        "p50": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "revealMs": {
+        "samples": 0,
+        "min": null,
+        "p50": null,
+        "p95": null,
+        "max": null
+      },
+      "firstCorrectFrameMs": {
+        "samples": 0,
+        "min": null,
+        "p50": null,
+        "p95": null,
+        "max": null
+      },
+      "keystrokeToPaintMs": {
+        "samples": 9,
+        "min": 41.4,
+        "p50": 43.1,
+        "p95": 56.4,
+        "max": 56.4
+      },
+      "keystrokeToPaintTimeouts": 0,
+      "processCpuPercent": {
+        "applicationServer": {
+          "samples": 3,
+          "min": 12.38,
+          "p50": 15.03,
+          "p95": 17.18,
+          "max": 17.18
+        },
+        "realtimeServer": {
+          "samples": 3,
+          "min": 6.05,
+          "p50": 7.22,
+          "p95": 7.52,
+          "max": 7.52
+        },
+        "chromiumRenderer": {
+          "samples": 3,
+          "min": 18.35,
+          "p50": 19.16,
+          "p95": 20.74,
+          "max": 20.74
+        }
+      },
+      "processPhysicalBytes": {
+        "applicationServer": {
+          "samples": 3,
+          "min": 242221056,
+          "p50": 246415360,
+          "p95": 279969792,
+          "max": 279969792
+        },
+        "realtimeServer": {
+          "samples": 3,
+          "min": 140754944,
+          "p50": 144924672,
+          "p95": 161669120,
+          "max": 161669120
+        },
+        "chromiumRenderer": {
+          "samples": 3,
+          "min": 182452224,
+          "p50": 182452224,
+          "p95": 185597952,
+          "max": 185597952
+        }
+      },
+      "attachedClientsPerSession": [
+        {
+          "cortex-dash-2224e39f7de5c59cc602d323d668d0a2": 1
+        },
+        {
+          "cortex-dash-8cb524ebd991386d90859eb9142055e6": 1
+        },
+        {
+          "cortex-dash-aecb6fa7024ff6d8eb8f02a5f82a5b79": 1
+        }
+      ],
+      "initiallyUnmountedBrowserWriteBytes": {
+        "samples": 3,
+        "min": 0,
+        "p50": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "residencyChurnCount": {
+        "samples": 3,
+        "min": 0,
+        "p50": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "neverMountedSessionCount": {
+        "samples": 3,
+        "min": 0,
+        "p50": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "unmountedBrowserWriteBytes": {
+        "samples": 3,
+        "min": 0,
+        "p50": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "unmountedServerHiddenBytes": {
+        "samples": 3,
+        "min": 0,
+        "p50": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "attribution": {
+        "transportJsonParseMs": {
+          "samples": 3,
+          "min": 4.2,
+          "p50": 4.4,
+          "p95": 4.8,
+          "max": 4.8
+        },
+        "base64DecodeMs": {
+          "samples": 3,
+          "min": 66.8,
+          "p50": 69.8,
+          "p95": 70.8,
+          "max": 70.8
+        },
+        "termWriteCallMs": {
+          "samples": 3,
+          "min": 4.2,
+          "p50": 6,
+          "p95": 6.4,
+          "max": 6.4
+        },
+        "termWriteCompletionMs": {
+          "samples": 3,
+          "min": 152.2,
+          "p50": 152.5,
+          "p95": 170.8,
+          "max": 170.8
+        },
+        "renderEvents": {
+          "samples": 3,
+          "min": 280,
+          "p50": 319,
+          "p95": 320,
+          "max": 320
+        },
+        "fanoutClientDeliveries": {
+          "samples": 3,
+          "min": 595,
+          "p50": 635,
+          "p95": 635,
+          "max": 635
+        }
+      },
+      "overflowEvents": {
+        "samples": 3,
+        "min": 595,
+        "p50": 661,
+        "p95": 705,
+        "max": 705
+      },
+      "backpressureDropEvents": {
+        "samples": 3,
+        "min": 0,
+        "p50": 0,
+        "p95": 0,
+        "max": 0
+      }
+    },
+    "4": {
+      "sampleCount": 3,
+      "mountedTerminalPanels": {
+        "samples": 3,
+        "min": 2,
+        "p50": 3,
+        "p95": 3,
+        "max": 3
+      },
+      "visibleTerminalPanels": {
+        "samples": 3,
+        "min": 1,
+        "p50": 1,
+        "p95": 1,
+        "max": 1
+      },
+      "ptyCount": {
+        "samples": 3,
+        "min": 4,
+        "p50": 4,
+        "p95": 4,
+        "max": 4
+      },
+      "hiddenWriteBytesPerSecondPerPanel": {
+        "samples": 3,
+        "min": 54155.24,
+        "p50": 55341.11,
+        "p95": 129319.32,
+        "max": 129319.32
+      },
+      "hiddenWriteCallsPerSecondPerPanel": {
+        "samples": 3,
+        "min": 20.36,
+        "p50": 20.8,
+        "p95": 25.38,
+        "max": 25.38
+      },
+      "longTaskMsPerMinute": {
+        "samples": 3,
+        "min": 373.93,
+        "p50": 482.19,
+        "p95": 1379.06,
+        "max": 1379.06
+      },
+      "revealMs": {
+        "samples": 3,
+        "min": 46.1,
+        "p50": 51.6,
+        "p95": 96.3,
+        "max": 96.3
+      },
+      "firstCorrectFrameMs": {
+        "samples": 3,
+        "min": 47.7,
+        "p50": 134.8,
+        "p95": 204.1,
+        "max": 204.1
+      },
+      "keystrokeToPaintMs": {
+        "samples": 9,
+        "min": 33.8,
+        "p50": 43.6,
+        "p95": 62,
+        "max": 62
+      },
+      "keystrokeToPaintTimeouts": 0,
+      "processCpuPercent": {
+        "applicationServer": {
+          "samples": 3,
+          "min": 14.19,
+          "p50": 18.24,
+          "p95": 23.74,
+          "max": 23.74
+        },
+        "realtimeServer": {
+          "samples": 3,
+          "min": 11.64,
+          "p50": 13.74,
+          "p95": 14.61,
+          "max": 14.61
+        },
+        "chromiumRenderer": {
+          "samples": 3,
+          "min": 24.2,
+          "p50": 27.67,
+          "p95": 31.33,
+          "max": 31.33
+        }
+      },
+      "processPhysicalBytes": {
+        "applicationServer": {
+          "samples": 3,
+          "min": 256901120,
+          "p50": 268435456,
+          "p95": 385875968,
+          "max": 385875968
+        },
+        "realtimeServer": {
+          "samples": 3,
+          "min": 148701184,
+          "p50": 159215616,
+          "p95": 179625984,
+          "max": 179625984
+        },
+        "chromiumRenderer": {
+          "samples": 3,
+          "min": 219152384,
+          "p50": 224395264,
+          "p95": 261095424,
+          "max": 261095424
+        }
+      },
+      "attachedClientsPerSession": [
+        {
+          "cortex-dash-26bea426ac404df4056c576268434e90": 2,
+          "cortex-dash-e562a83579f842da417f5b12f72a3d7b": 1,
+          "cortex-dash-1b36310fa314d8afe587a6dd9c583352": 2,
+          "cortex-dash-8ce6ae3eba45faa48f2923aa982ca506": 2
+        },
+        {
+          "cortex-dash-5f85079d2f8dcc286718f8638162af69": 2,
+          "cortex-dash-4e649ff503510bcab0a5e834b08a5298": 1,
+          "cortex-dash-0c97ec3fa0fa5570690fb4e58b1f0ca8": 2,
+          "cortex-dash-2d78a91a64ba30d3a921c49c0c46d72a": 2
+        },
+        {
+          "cortex-dash-d238ddea12d0f249293f29d7fcda26a0": 1,
+          "cortex-dash-220e4af968ca80152e18f5409c4201be": 1,
+          "cortex-dash-e2c8161ceddedf6b531dfa0a7f2da244": 1,
+          "cortex-dash-27884eb6692cf7f41962b355d06d0ae7": 1
+        }
+      ],
+      "initiallyUnmountedBrowserWriteBytes": {
+        "samples": 3,
+        "min": 79440,
+        "p50": 886924,
+        "p95": 889731,
+        "max": 889731
+      },
+      "residencyChurnCount": {
+        "samples": 3,
+        "min": 1,
+        "p50": 1,
+        "p95": 1,
+        "max": 1
+      },
+      "neverMountedSessionCount": {
+        "samples": 3,
+        "min": 0,
+        "p50": 0,
+        "p95": 1,
+        "max": 1
+      },
+      "unmountedBrowserWriteBytes": {
+        "samples": 3,
+        "min": 0,
+        "p50": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "unmountedServerHiddenBytes": {
+        "samples": 3,
+        "min": 0,
+        "p50": 0,
+        "p95": 844284,
+        "max": 844284
+      },
+      "attribution": {
+        "transportJsonParseMs": {
+          "samples": 3,
+          "min": 6.5,
+          "p50": 9.9,
+          "p95": 9.9,
+          "max": 9.9
+        },
+        "base64DecodeMs": {
+          "samples": 3,
+          "min": 177.8,
+          "p50": 190.1,
+          "p95": 224.9,
+          "max": 224.9
+        },
+        "termWriteCallMs": {
+          "samples": 3,
+          "min": 6.1,
+          "p50": 9.5,
+          "p95": 12.3,
+          "max": 12.3
+        },
+        "termWriteCompletionMs": {
+          "samples": 3,
+          "min": 432.5,
+          "p50": 497.1,
+          "p95": 556.7,
+          "max": 556.7
+        },
+        "renderEvents": {
+          "samples": 3,
+          "min": 182,
+          "p50": 307,
+          "p95": 308,
+          "max": 308
+        },
+        "fanoutClientDeliveries": {
+          "samples": 3,
+          "min": 1779,
+          "p50": 2047,
+          "p95": 2051,
+          "max": 2051
+        }
+      },
+      "overflowEvents": {
+        "samples": 3,
+        "min": 2095,
+        "p50": 2241,
+        "p95": 2307,
+        "max": 2307
+      },
+      "backpressureDropEvents": {
+        "samples": 3,
+        "min": 1,
+        "p50": 2,
+        "p95": 4,
+        "max": 4
+      }
+    },
+    "12": {
+      "sampleCount": 3,
+      "mountedTerminalPanels": {
+        "samples": 3,
+        "min": 3,
+        "p50": 3,
+        "p95": 3,
+        "max": 3
+      },
+      "visibleTerminalPanels": {
+        "samples": 3,
+        "min": 1,
+        "p50": 1,
+        "p95": 1,
+        "max": 1
+      },
+      "ptyCount": {
+        "samples": 3,
+        "min": 12,
+        "p50": 12,
+        "p95": 12,
+        "max": 12
+      },
+      "hiddenWriteBytesPerSecondPerPanel": {
+        "samples": 3,
+        "min": 53080.62,
+        "p50": 53452.84,
+        "p95": 71365.91,
+        "max": 71365.91
+      },
+      "hiddenWriteCallsPerSecondPerPanel": {
+        "samples": 3,
+        "min": 18.69,
+        "p50": 19.98,
+        "p95": 20.08,
+        "max": 20.08
+      },
+      "longTaskMsPerMinute": {
+        "samples": 3,
+        "min": 360.89,
+        "p50": 362,
+        "p95": 1299.85,
+        "max": 1299.85
+      },
+      "revealMs": {
+        "samples": 3,
+        "min": 106.8,
+        "p50": 165.5,
+        "p95": 195.9,
+        "max": 195.9
+      },
+      "firstCorrectFrameMs": {
+        "samples": 3,
+        "min": 159.1,
+        "p50": 263.4,
+        "p95": 290.2,
+        "max": 290.2
+      },
+      "keystrokeToPaintMs": {
+        "samples": 9,
+        "min": 39.2,
+        "p50": 54.2,
+        "p95": 138.2,
+        "max": 138.2
+      },
+      "keystrokeToPaintTimeouts": 0,
+      "processCpuPercent": {
+        "applicationServer": {
+          "samples": 3,
+          "min": 7.83,
+          "p50": 9.96,
+          "p95": 18.04,
+          "max": 18.04
+        },
+        "realtimeServer": {
+          "samples": 3,
+          "min": 23.14,
+          "p50": 25.23,
+          "p95": 38.11,
+          "max": 38.11
+        },
+        "chromiumRenderer": {
+          "samples": 3,
+          "min": 27.83,
+          "p50": 33.86,
+          "p95": 41.12,
+          "max": 41.12
+        }
+      },
+      "processPhysicalBytes": {
+        "applicationServer": {
+          "samples": 3,
+          "min": 277872640,
+          "p50": 459276288,
+          "p95": 461373440,
+          "max": 461373440
+        },
+        "realtimeServer": {
+          "samples": 3,
+          "min": 199946240,
+          "p50": 200200192,
+          "p95": 202252288,
+          "max": 202252288
+        },
+        "chromiumRenderer": {
+          "samples": 3,
+          "min": 240123904,
+          "p50": 271581184,
+          "p95": 273678336,
+          "max": 273678336
+        }
+      },
+      "attachedClientsPerSession": [
+        {
+          "cortex-dash-5cbacb7becbbc7aa48abb0202cc727e7": 1,
+          "cortex-dash-cc0db5ce485c5b75d01e596f2cac4c25": 2,
+          "cortex-dash-c75696b3f2b02ff0ba17ffd40aa214ff": 1,
+          "cortex-dash-b4ea18d2954e916c9d823374485b29d2": 1,
+          "cortex-dash-a42e86836d1301e3ade778d8a69bf4f5": 1,
+          "cortex-dash-085b51301ec0a3c83be2bd21f169d496": 1,
+          "cortex-dash-e3d036ed499c7562913c838815aa92e5": 1,
+          "cortex-dash-2ac285cb69116c07db886278b6a45695": 1,
+          "cortex-dash-f21a0f3fe64785f43193123249dfb85b": 1,
+          "cortex-dash-0440c3abace6f3a9299387e91e3c43d8": 1,
+          "cortex-dash-fa3beeeef4a8eed57f19864d81d226bc": 1,
+          "cortex-dash-ec86f63511fc6628d146bbfd77eed49e": 1
+        },
+        {
+          "cortex-dash-cfc79ba84319f459ea64e6a1dad3de3c": 1,
+          "cortex-dash-bac9806ec054f95837869a82fdf27c1f": 1,
+          "cortex-dash-a4ca531e12807707e88b8d6bfe2a537d": 1,
+          "cortex-dash-0f8f92b133c934c988577ac119277e36": 1,
+          "cortex-dash-b9d34fd562b407fca893f45297172349": 1,
+          "cortex-dash-231fb987cf01198f57d25453e17ef220": 1,
+          "cortex-dash-a0e24d62a2e930db4b0e4b277fedbf37": 1,
+          "cortex-dash-e3faaa7cbec585a11b8fb179b52f865f": 1,
+          "cortex-dash-9df1a366784053fd1fd65b9aa2dae2ec": 1,
+          "cortex-dash-c14676124c6d115733b503606952e8aa": 1,
+          "cortex-dash-f2dd6dd09f2ba982f97cb39bbf3d5521": 1,
+          "cortex-dash-ca585d1b88b5f24eff1a6545fbae9c19": 1
+        },
+        {
+          "cortex-dash-6b2ed455b841c1e5879b7f37b057c624": 2,
+          "cortex-dash-6e9ae50061caae2fd3d548a4d4c8cf24": 2,
+          "cortex-dash-5be5e2c0cc1b630fe594ad85e92802a6": 1,
+          "cortex-dash-87644e58c07343ee15831526813f5cc2": 1,
+          "cortex-dash-a6495330ac0f5211bd11d23e18b44697": 1,
+          "cortex-dash-76adfa16607292a4cd55280c4d4c35f9": 1,
+          "cortex-dash-726092e92fea636dbdd99b2827023d96": 1,
+          "cortex-dash-0fb35985c079ab378efe6b9fc2e0b697": 1,
+          "cortex-dash-5e95f53cc126f454abbcfb40323e41ff": 1,
+          "cortex-dash-f89c07d59d25ef8b0acc34914de5034b": 2,
+          "cortex-dash-cf1381a6bbddcd488485c2a2f2f4f0e2": 2,
+          "cortex-dash-116b1476efe9f420e3d467e98aab72ed": 1
+        }
+      ],
+      "initiallyUnmountedBrowserWriteBytes": {
+        "samples": 3,
+        "min": 450851,
+        "p50": 869110,
+        "p95": 1264869,
+        "max": 1264869
+      },
+      "residencyChurnCount": {
+        "samples": 3,
+        "min": 2,
+        "p50": 2,
+        "p95": 3,
+        "max": 3
+      },
+      "neverMountedSessionCount": {
+        "samples": 3,
+        "min": 6,
+        "p50": 7,
+        "p95": 7,
+        "max": 7
+      },
+      "unmountedBrowserWriteBytes": {
+        "samples": 3,
+        "min": 0,
+        "p50": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "unmountedServerHiddenBytes": {
+        "samples": 3,
+        "min": 5069660,
+        "p50": 5908069,
+        "p95": 5908168,
+        "max": 5908168
+      },
+      "attribution": {
+        "transportJsonParseMs": {
+          "samples": 3,
+          "min": 14.1,
+          "p50": 15,
+          "p95": 32.6,
+          "max": 32.6
+        },
+        "base64DecodeMs": {
+          "samples": 3,
+          "min": 206.8,
+          "p50": 223.8,
+          "p95": 253.7,
+          "max": 253.7
+        },
+        "termWriteCallMs": {
+          "samples": 3,
+          "min": 11.5,
+          "p50": 11.9,
+          "p95": 14.3,
+          "max": 14.3
+        },
+        "termWriteCompletionMs": {
+          "samples": 3,
+          "min": 478.8,
+          "p50": 547.6,
+          "p95": 898.8,
+          "max": 898.8
+        },
+        "renderEvents": {
+          "samples": 3,
+          "min": 305,
+          "p50": 308,
+          "p95": 312,
+          "max": 312
+        },
+        "fanoutClientDeliveries": {
+          "samples": 3,
+          "min": 4894,
+          "p50": 5066,
+          "p95": 6640,
+          "max": 6640
+        }
+      },
+      "overflowEvents": {
+        "samples": 3,
+        "min": 5746,
+        "p50": 7689,
+        "p95": 7859,
+        "max": 7859
+      },
+      "backpressureDropEvents": {
+        "samples": 3,
+        "min": 2,
+        "p50": 4,
+        "p95": 15,
+        "max": 15
+      }
+    }
+  },
+  "samples": [
+    {
+      "schema": "o8/terminal-workload-sample/v1",
+      "sessionCount": 1,
+      "sampleIndex": 1,
+      "seed": 1822,
+      "buildMode": "production",
+      "devModeCpuWarning": false,
+      "observationMs": 10909,
+      "inventory": {
+        "terminalChipCount": 1,
+        "orchestratorChipCount": 1,
+        "activeTabId": "term-twmtdag2lwn1s1-1",
+        "ptyCount": 1,
+        "ptySessions": [
+          "cortex-dash-2224e39f7de5c59cc602d323d668d0a2"
+        ],
+        "mountedTerminalPanelCount": 1,
+        "visibleTerminalPanelCount": 1,
+        "mountedSessionNames": [
+          "cortex-dash-2224e39f7de5c59cc602d323d668d0a2"
+        ],
+        "attachedClientsPerSession": {
+          "cortex-dash-2224e39f7de5c59cc602d323d668d0a2": 1
+        }
+      },
+      "latency": {
+        "revealAvailability": "not-applicable-single-terminal",
+        "revealMs": [],
+        "firstCorrectFrameMs": [],
+        "keystrokeToPaintMs": [
+          45.7,
+          43.1,
+          43.3
+        ],
+        "keystrokeToPaintTimedOut": [
+          false,
+          false,
+          false
+        ],
+        "keystrokeToPaintTimeoutMs": 10000
+      },
+      "browser": {
+        "hiddenWriteBytesPerSecondPerPanel": 0,
+        "hiddenWriteCallsPerSecondPerPanel": 0,
+        "totalVisibleWriteBytes": 850845,
+        "totalHiddenWriteBytes": 0,
+        "totalWriteCalls": 318,
+        "totalDecodeMs": 66.8,
+        "totalWriteCallMs": 6.4,
+        "totalWriteCompletionMs": 152.2,
+        "totalRenderEvents": 319,
+        "totalRenderRows": 7570,
+        "initiallyUnmountedSessionNames": [],
+        "neverMountedSessionNames": [],
+        "residencyChurnSessionNames": [],
+        "endMountedSessionNames": [
+          "cortex-dash-2224e39f7de5c59cc602d323d668d0a2"
+        ],
+        "initiallyUnmountedWriteBytes": 0,
+        "unmountedWriteBytes": 0,
+        "transport": {
+          "terminalMessages": 318,
+          "rawBytes": 1172262,
+          "encodedBytes": 1135056,
+          "jsonParseMs": 4.199997901916504
+        }
+      },
+      "server": {
+        "visiblePtyChunks": 1380,
+        "visiblePtyBytes": 848359,
+        "hiddenPtyChunks": 0,
+        "hiddenPtyBytes": 0,
+        "attachEvents": 1,
+        "detachEvents": 1,
+        "bufferEvents": 1380,
+        "replayEvents": 1,
+        "overflowEvents": 661,
+        "overflowBytes": 326015,
+        "backpressureDropEvents": 0,
+        "backpressureDropBytes": 0,
+        "fanoutClientDeliveries": 635,
+        "unmountedHiddenBytes": 0
+      },
+      "performance": {
+        "longTaskSupported": true,
+        "longTaskCount": 0,
+        "longTaskMs": 0,
+        "longTaskMsPerMinute": 0,
+        "frameCount": 715,
+        "framesPerSecond": 65.54,
+        "longTasks": []
+      },
+      "processes": {
+        "applicationServer": {
+          "processCount": 2,
+          "cpuPercent": 15.03,
+          "physicalBytes": 246415360,
+          "physicalUnavailable": []
+        },
+        "realtimeServer": {
+          "processCount": 3,
+          "cpuPercent": 7.52,
+          "physicalBytes": 144924672,
+          "physicalUnavailable": []
+        },
+        "chromiumRenderer": {
+          "processCount": 3,
+          "cpuPercent": 19.16,
+          "physicalBytes": 182452224,
+          "physicalUnavailable": []
+        }
+      },
+      "replayRisk": {
+        "sessionsWithObservedAltScreen": [
+          "cortex-dash-2224e39f7de5c59cc602d323d668d0a2"
+        ],
+        "sessionsMissingRetainedAltEnter": [
+          "cortex-dash-2224e39f7de5c59cc602d323d668d0a2"
+        ],
+        "sessionsWithRetainedAltExit": [
+          "cortex-dash-2224e39f7de5c59cc602d323d668d0a2"
+        ]
+      },
+      "artifact": "tests/bench/latest/terminal-workload-2026-08-28/n1-sample-1.json"
+    },
+    {
+      "schema": "o8/terminal-workload-sample/v1",
+      "sessionCount": 1,
+      "sampleIndex": 2,
+      "seed": 1823,
+      "buildMode": "production",
+      "devModeCpuWarning": false,
+      "observationMs": 10902,
+      "inventory": {
+        "terminalChipCount": 1,
+        "orchestratorChipCount": 1,
+        "activeTabId": "term-twmtdagkmon1s2-1",
+        "ptyCount": 1,
+        "ptySessions": [
+          "cortex-dash-8cb524ebd991386d90859eb9142055e6"
+        ],
+        "mountedTerminalPanelCount": 1,
+        "visibleTerminalPanelCount": 1,
+        "mountedSessionNames": [
+          "cortex-dash-8cb524ebd991386d90859eb9142055e6"
+        ],
+        "attachedClientsPerSession": {
+          "cortex-dash-8cb524ebd991386d90859eb9142055e6": 1
+        }
+      },
+      "latency": {
+        "revealAvailability": "not-applicable-single-terminal",
+        "revealMs": [],
+        "firstCorrectFrameMs": [],
+        "keystrokeToPaintMs": [
+          56.4,
+          42.4,
+          42.6
+        ],
+        "keystrokeToPaintTimedOut": [
+          false,
+          false,
+          false
+        ],
+        "keystrokeToPaintTimeoutMs": 10000
+      },
+      "browser": {
+        "hiddenWriteBytesPerSecondPerPanel": 0,
+        "hiddenWriteCallsPerSecondPerPanel": 0,
+        "totalVisibleWriteBytes": 857237,
+        "totalHiddenWriteBytes": 0,
+        "totalWriteCalls": 279,
+        "totalDecodeMs": 70.8,
+        "totalWriteCallMs": 6,
+        "totalWriteCompletionMs": 170.8,
+        "totalRenderEvents": 280,
+        "totalRenderRows": 6697,
+        "initiallyUnmountedSessionNames": [],
+        "neverMountedSessionNames": [],
+        "residencyChurnSessionNames": [],
+        "endMountedSessionNames": [
+          "cortex-dash-8cb524ebd991386d90859eb9142055e6"
+        ],
+        "initiallyUnmountedWriteBytes": 0,
+        "unmountedWriteBytes": 0,
+        "transport": {
+          "terminalMessages": 279,
+          "rawBytes": 1176123,
+          "encodedBytes": 1143480,
+          "jsonParseMs": 4.399999141693115
+        }
+      },
+      "server": {
+        "visiblePtyChunks": 1427,
+        "visiblePtyBytes": 852820,
+        "hiddenPtyChunks": 0,
+        "hiddenPtyBytes": 0,
+        "attachEvents": 1,
+        "detachEvents": 1,
+        "bufferEvents": 1427,
+        "replayEvents": 1,
+        "overflowEvents": 705,
+        "overflowBytes": 330458,
+        "backpressureDropEvents": 0,
+        "backpressureDropBytes": 0,
+        "fanoutClientDeliveries": 595,
+        "unmountedHiddenBytes": 0
+      },
+      "performance": {
+        "longTaskSupported": true,
+        "longTaskCount": 0,
+        "longTaskMs": 0,
+        "longTaskMsPerMinute": 0,
+        "frameCount": 714,
+        "framesPerSecond": 65.49,
+        "longTasks": []
+      },
+      "processes": {
+        "applicationServer": {
+          "processCount": 2,
+          "cpuPercent": 12.38,
+          "physicalBytes": 242221056,
+          "physicalUnavailable": []
+        },
+        "realtimeServer": {
+          "processCount": 3,
+          "cpuPercent": 6.05,
+          "physicalBytes": 161669120,
+          "physicalUnavailable": []
+        },
+        "chromiumRenderer": {
+          "processCount": 3,
+          "cpuPercent": 18.35,
+          "physicalBytes": 185597952,
+          "physicalUnavailable": []
+        }
+      },
+      "replayRisk": {
+        "sessionsWithObservedAltScreen": [
+          "cortex-dash-8cb524ebd991386d90859eb9142055e6"
+        ],
+        "sessionsMissingRetainedAltEnter": [
+          "cortex-dash-8cb524ebd991386d90859eb9142055e6"
+        ],
+        "sessionsWithRetainedAltExit": [
+          "cortex-dash-8cb524ebd991386d90859eb9142055e6"
+        ]
+      },
+      "artifact": "tests/bench/latest/terminal-workload-2026-08-28/n1-sample-2.json"
+    },
+    {
+      "schema": "o8/terminal-workload-sample/v1",
+      "sessionCount": 1,
+      "sampleIndex": 3,
+      "seed": 1824,
+      "buildMode": "production",
+      "devModeCpuWarning": false,
+      "observationMs": 10945,
+      "inventory": {
+        "terminalChipCount": 1,
+        "orchestratorChipCount": 1,
+        "activeTabId": "term-twmtdah1z4n1s3-1",
+        "ptyCount": 1,
+        "ptySessions": [
+          "cortex-dash-aecb6fa7024ff6d8eb8f02a5f82a5b79"
+        ],
+        "mountedTerminalPanelCount": 1,
+        "visibleTerminalPanelCount": 1,
+        "mountedSessionNames": [
+          "cortex-dash-aecb6fa7024ff6d8eb8f02a5f82a5b79"
+        ],
+        "attachedClientsPerSession": {
+          "cortex-dash-aecb6fa7024ff6d8eb8f02a5f82a5b79": 1
+        }
+      },
+      "latency": {
+        "revealAvailability": "not-applicable-single-terminal",
+        "revealMs": [],
+        "firstCorrectFrameMs": [],
+        "keystrokeToPaintMs": [
+          48.9,
+          41.4,
+          41.5
+        ],
+        "keystrokeToPaintTimedOut": [
+          false,
+          false,
+          false
+        ],
+        "keystrokeToPaintTimeoutMs": 10000
+      },
+      "browser": {
+        "hiddenWriteBytesPerSecondPerPanel": 0,
+        "hiddenWriteCallsPerSecondPerPanel": 0,
+        "totalVisibleWriteBytes": 850076,
+        "totalHiddenWriteBytes": 0,
+        "totalWriteCalls": 318,
+        "totalDecodeMs": 69.8,
+        "totalWriteCallMs": 4.2,
+        "totalWriteCompletionMs": 152.5,
+        "totalRenderEvents": 320,
+        "totalRenderRows": 7594,
+        "initiallyUnmountedSessionNames": [],
+        "neverMountedSessionNames": [],
+        "residencyChurnSessionNames": [],
+        "endMountedSessionNames": [
+          "cortex-dash-aecb6fa7024ff6d8eb8f02a5f82a5b79"
+        ],
+        "initiallyUnmountedWriteBytes": 0,
+        "unmountedWriteBytes": 0,
+        "transport": {
+          "terminalMessages": 318,
+          "rawBytes": 1171234,
+          "encodedBytes": 1134028,
+          "jsonParseMs": 4.8000006675720215
+        }
+      },
+      "server": {
+        "visiblePtyChunks": 1320,
+        "visiblePtyBytes": 848368,
+        "hiddenPtyChunks": 0,
+        "hiddenPtyBytes": 0,
+        "attachEvents": 1,
+        "detachEvents": 1,
+        "bufferEvents": 1320,
+        "replayEvents": 1,
+        "overflowEvents": 595,
+        "overflowBytes": 326002,
+        "backpressureDropEvents": 0,
+        "backpressureDropBytes": 0,
+        "fanoutClientDeliveries": 635,
+        "unmountedHiddenBytes": 0
+      },
+      "performance": {
+        "longTaskSupported": true,
+        "longTaskCount": 0,
+        "longTaskMs": 0,
+        "longTaskMsPerMinute": 0,
+        "frameCount": 733,
+        "framesPerSecond": 66.97,
+        "longTasks": []
+      },
+      "processes": {
+        "applicationServer": {
+          "processCount": 2,
+          "cpuPercent": 17.18,
+          "physicalBytes": 279969792,
+          "physicalUnavailable": []
+        },
+        "realtimeServer": {
+          "processCount": 3,
+          "cpuPercent": 7.22,
+          "physicalBytes": 140754944,
+          "physicalUnavailable": []
+        },
+        "chromiumRenderer": {
+          "processCount": 3,
+          "cpuPercent": 20.74,
+          "physicalBytes": 182452224,
+          "physicalUnavailable": []
+        }
+      },
+      "replayRisk": {
+        "sessionsWithObservedAltScreen": [
+          "cortex-dash-aecb6fa7024ff6d8eb8f02a5f82a5b79"
+        ],
+        "sessionsMissingRetainedAltEnter": [
+          "cortex-dash-aecb6fa7024ff6d8eb8f02a5f82a5b79"
+        ],
+        "sessionsWithRetainedAltExit": [
+          "cortex-dash-aecb6fa7024ff6d8eb8f02a5f82a5b79"
+        ]
+      },
+      "artifact": "tests/bench/latest/terminal-workload-2026-08-28/n1-sample-3.json"
+    },
+    {
+      "schema": "o8/terminal-workload-sample/v1",
+      "sessionCount": 4,
+      "sampleIndex": 1,
+      "seed": 2122,
+      "buildMode": "production",
+      "devModeCpuWarning": false,
+      "observationMs": 10911,
+      "inventory": {
+        "terminalChipCount": 4,
+        "orchestratorChipCount": 1,
+        "activeTabId": "term-twmtdahkv5n4s1-1",
+        "ptyCount": 4,
+        "ptySessions": [
+          "cortex-dash-26bea426ac404df4056c576268434e90",
+          "cortex-dash-e562a83579f842da417f5b12f72a3d7b",
+          "cortex-dash-1b36310fa314d8afe587a6dd9c583352",
+          "cortex-dash-8ce6ae3eba45faa48f2923aa982ca506"
+        ],
+        "mountedTerminalPanelCount": 3,
+        "visibleTerminalPanelCount": 1,
+        "mountedSessionNames": [
+          "cortex-dash-26bea426ac404df4056c576268434e90",
+          "cortex-dash-1b36310fa314d8afe587a6dd9c583352",
+          "cortex-dash-8ce6ae3eba45faa48f2923aa982ca506"
+        ],
+        "attachedClientsPerSession": {
+          "cortex-dash-26bea426ac404df4056c576268434e90": 2,
+          "cortex-dash-e562a83579f842da417f5b12f72a3d7b": 1,
+          "cortex-dash-1b36310fa314d8afe587a6dd9c583352": 2,
+          "cortex-dash-8ce6ae3eba45faa48f2923aa982ca506": 2
+        }
+      },
+      "latency": {
+        "revealAvailability": "hidden-mounted-terminal",
+        "revealMs": [
+          46.1
+        ],
+        "firstCorrectFrameMs": [
+          47.7
+        ],
+        "keystrokeToPaintMs": [
+          40.7,
+          33.8,
+          43.6
+        ],
+        "keystrokeToPaintTimedOut": [
+          false,
+          false,
+          false
+        ],
+        "keystrokeToPaintTimeoutMs": 10000
+      },
+      "browser": {
+        "hiddenWriteBytesPerSecondPerPanel": 55341.11,
+        "hiddenWriteCallsPerSecondPerPanel": 20.8,
+        "totalVisibleWriteBytes": 823043,
+        "totalHiddenWriteBytes": 1760765,
+        "totalWriteCalls": 784,
+        "totalDecodeMs": 190.1,
+        "totalWriteCallMs": 9.5,
+        "totalWriteCompletionMs": 432.5,
+        "totalRenderEvents": 307,
+        "totalRenderRows": 7305,
+        "initiallyUnmountedSessionNames": [
+          "cortex-dash-e562a83579f842da417f5b12f72a3d7b"
+        ],
+        "neverMountedSessionNames": [],
+        "residencyChurnSessionNames": [
+          "cortex-dash-e562a83579f842da417f5b12f72a3d7b"
+        ],
+        "endMountedSessionNames": [
+          "cortex-dash-e562a83579f842da417f5b12f72a3d7b",
+          "cortex-dash-1b36310fa314d8afe587a6dd9c583352"
+        ],
+        "initiallyUnmountedWriteBytes": 889731,
+        "unmountedWriteBytes": 0,
+        "transport": {
+          "terminalMessages": 787,
+          "rawBytes": 3549475,
+          "encodedBytes": 3457396,
+          "jsonParseMs": 9.900002002716064
+        }
+      },
+      "server": {
+        "visiblePtyChunks": 1256,
+        "visiblePtyBytes": 824137,
+        "hiddenPtyChunks": 3884,
+        "hiddenPtyBytes": 2604854,
+        "attachEvents": 1,
+        "detachEvents": 4,
+        "bufferEvents": 5140,
+        "replayEvents": 1,
+        "overflowEvents": 2241,
+        "overflowBytes": 1344524,
+        "backpressureDropEvents": 1,
+        "backpressureDropBytes": 1094,
+        "fanoutClientDeliveries": 2051,
+        "unmountedHiddenBytes": 0
+      },
+      "performance": {
+        "longTaskSupported": true,
+        "longTaskCount": 1,
+        "longTaskMs": 68,
+        "longTaskMsPerMinute": 373.93,
+        "frameCount": 733,
+        "framesPerSecond": 67.18,
+        "longTasks": [
+          {
+            "startTime": 14805.800000190735,
+            "duration": 68
+          }
+        ]
+      },
+      "processes": {
+        "applicationServer": {
+          "processCount": 2,
+          "cpuPercent": 18.24,
+          "physicalBytes": 268435456,
+          "physicalUnavailable": []
+        },
+        "realtimeServer": {
+          "processCount": 6,
+          "cpuPercent": 11.64,
+          "physicalBytes": 159215616,
+          "physicalUnavailable": []
+        },
+        "chromiumRenderer": {
+          "processCount": 3,
+          "cpuPercent": 24.2,
+          "physicalBytes": 224395264,
+          "physicalUnavailable": []
+        }
+      },
+      "replayRisk": {
+        "sessionsWithObservedAltScreen": [
+          "cortex-dash-26bea426ac404df4056c576268434e90",
+          "cortex-dash-e562a83579f842da417f5b12f72a3d7b",
+          "cortex-dash-1b36310fa314d8afe587a6dd9c583352",
+          "cortex-dash-8ce6ae3eba45faa48f2923aa982ca506"
+        ],
+        "sessionsMissingRetainedAltEnter": [
+          "cortex-dash-26bea426ac404df4056c576268434e90",
+          "cortex-dash-e562a83579f842da417f5b12f72a3d7b",
+          "cortex-dash-1b36310fa314d8afe587a6dd9c583352",
+          "cortex-dash-8ce6ae3eba45faa48f2923aa982ca506"
+        ],
+        "sessionsWithRetainedAltExit": [
+          "cortex-dash-26bea426ac404df4056c576268434e90",
+          "cortex-dash-e562a83579f842da417f5b12f72a3d7b",
+          "cortex-dash-1b36310fa314d8afe587a6dd9c583352",
+          "cortex-dash-8ce6ae3eba45faa48f2923aa982ca506"
+        ]
+      },
+      "artifact": "tests/bench/latest/terminal-workload-2026-08-28/n4-sample-1.json"
+    },
+    {
+      "schema": "o8/terminal-workload-sample/v1",
+      "sessionCount": 4,
+      "sampleIndex": 2,
+      "seed": 2123,
+      "buildMode": "production",
+      "devModeCpuWarning": false,
+      "observationMs": 10950,
+      "inventory": {
+        "terminalChipCount": 4,
+        "orchestratorChipCount": 1,
+        "activeTabId": "term-twmtdai42cn4s2-1",
+        "ptyCount": 4,
+        "ptySessions": [
+          "cortex-dash-5f85079d2f8dcc286718f8638162af69",
+          "cortex-dash-4e649ff503510bcab0a5e834b08a5298",
+          "cortex-dash-0c97ec3fa0fa5570690fb4e58b1f0ca8",
+          "cortex-dash-2d78a91a64ba30d3a921c49c0c46d72a"
+        ],
+        "mountedTerminalPanelCount": 3,
+        "visibleTerminalPanelCount": 1,
+        "mountedSessionNames": [
+          "cortex-dash-5f85079d2f8dcc286718f8638162af69",
+          "cortex-dash-0c97ec3fa0fa5570690fb4e58b1f0ca8",
+          "cortex-dash-2d78a91a64ba30d3a921c49c0c46d72a"
+        ],
+        "attachedClientsPerSession": {
+          "cortex-dash-5f85079d2f8dcc286718f8638162af69": 2,
+          "cortex-dash-4e649ff503510bcab0a5e834b08a5298": 1,
+          "cortex-dash-0c97ec3fa0fa5570690fb4e58b1f0ca8": 2,
+          "cortex-dash-2d78a91a64ba30d3a921c49c0c46d72a": 2
+        }
+      },
+      "latency": {
+        "revealAvailability": "hidden-mounted-terminal",
+        "revealMs": [
+          51.6
+        ],
+        "firstCorrectFrameMs": [
+          134.8
+        ],
+        "keystrokeToPaintMs": [
+          40.8,
+          49.3,
+          41.2
+        ],
+        "keystrokeToPaintTimedOut": [
+          false,
+          false,
+          false
+        ],
+        "keystrokeToPaintTimeoutMs": 10000
+      },
+      "browser": {
+        "hiddenWriteBytesPerSecondPerPanel": 54155.24,
+        "hiddenWriteCallsPerSecondPerPanel": 20.36,
+        "totalVisibleWriteBytes": 831953,
+        "totalHiddenWriteBytes": 1749852,
+        "totalWriteCalls": 781,
+        "totalDecodeMs": 224.9,
+        "totalWriteCallMs": 12.3,
+        "totalWriteCompletionMs": 497.1,
+        "totalRenderEvents": 308,
+        "totalRenderRows": 7306,
+        "initiallyUnmountedSessionNames": [
+          "cortex-dash-4e649ff503510bcab0a5e834b08a5298"
+        ],
+        "neverMountedSessionNames": [],
+        "residencyChurnSessionNames": [
+          "cortex-dash-4e649ff503510bcab0a5e834b08a5298"
+        ],
+        "endMountedSessionNames": [
+          "cortex-dash-4e649ff503510bcab0a5e834b08a5298",
+          "cortex-dash-0c97ec3fa0fa5570690fb4e58b1f0ca8"
+        ],
+        "initiallyUnmountedWriteBytes": 886924,
+        "unmountedWriteBytes": 0,
+        "transport": {
+          "terminalMessages": 785,
+          "rawBytes": 3550145,
+          "encodedBytes": 3458300,
+          "jsonParseMs": 9.900002002716064
+        }
+      },
+      "server": {
+        "visiblePtyChunks": 1482,
+        "visiblePtyBytes": 837879,
+        "hiddenPtyChunks": 3752,
+        "hiddenPtyBytes": 2596148,
+        "attachEvents": 1,
+        "detachEvents": 4,
+        "bufferEvents": 5234,
+        "replayEvents": 1,
+        "overflowEvents": 2307,
+        "overflowBytes": 1350877,
+        "backpressureDropEvents": 2,
+        "backpressureDropBytes": 2718,
+        "fanoutClientDeliveries": 2047,
+        "unmountedHiddenBytes": 0
+      },
+      "performance": {
+        "longTaskSupported": true,
+        "longTaskCount": 1,
+        "longTaskMs": 88,
+        "longTaskMsPerMinute": 482.19,
+        "frameCount": 737,
+        "framesPerSecond": 67.31,
+        "longTasks": [
+          {
+            "startTime": 15514.199999809265,
+            "duration": 88
+          }
+        ]
+      },
+      "processes": {
+        "applicationServer": {
+          "processCount": 2,
+          "cpuPercent": 23.74,
+          "physicalBytes": 256901120,
+          "physicalUnavailable": []
+        },
+        "realtimeServer": {
+          "processCount": 6,
+          "cpuPercent": 14.61,
+          "physicalBytes": 148701184,
+          "physicalUnavailable": []
+        },
+        "chromiumRenderer": {
+          "processCount": 3,
+          "cpuPercent": 27.67,
+          "physicalBytes": 219152384,
+          "physicalUnavailable": []
+        }
+      },
+      "replayRisk": {
+        "sessionsWithObservedAltScreen": [
+          "cortex-dash-5f85079d2f8dcc286718f8638162af69",
+          "cortex-dash-0c97ec3fa0fa5570690fb4e58b1f0ca8",
+          "cortex-dash-2d78a91a64ba30d3a921c49c0c46d72a"
+        ],
+        "sessionsMissingRetainedAltEnter": [
+          "cortex-dash-5f85079d2f8dcc286718f8638162af69",
+          "cortex-dash-0c97ec3fa0fa5570690fb4e58b1f0ca8",
+          "cortex-dash-2d78a91a64ba30d3a921c49c0c46d72a"
+        ],
+        "sessionsWithRetainedAltExit": [
+          "cortex-dash-5f85079d2f8dcc286718f8638162af69",
+          "cortex-dash-4e649ff503510bcab0a5e834b08a5298",
+          "cortex-dash-0c97ec3fa0fa5570690fb4e58b1f0ca8",
+          "cortex-dash-2d78a91a64ba30d3a921c49c0c46d72a"
+        ]
+      },
+      "artifact": "tests/bench/latest/terminal-workload-2026-08-28/n4-sample-2.json"
+    },
+    {
+      "schema": "o8/terminal-workload-sample/v1",
+      "sessionCount": 4,
+      "sampleIndex": 3,
+      "seed": 2124,
+      "buildMode": "production",
+      "devModeCpuWarning": false,
+      "observationMs": 11138,
+      "inventory": {
+        "terminalChipCount": 4,
+        "orchestratorChipCount": 1,
+        "activeTabId": "term-twmtdainupn4s3-1",
+        "ptyCount": 4,
+        "ptySessions": [
+          "cortex-dash-d238ddea12d0f249293f29d7fcda26a0",
+          "cortex-dash-220e4af968ca80152e18f5409c4201be",
+          "cortex-dash-e2c8161ceddedf6b531dfa0a7f2da244",
+          "cortex-dash-27884eb6692cf7f41962b355d06d0ae7"
+        ],
+        "mountedTerminalPanelCount": 2,
+        "visibleTerminalPanelCount": 1,
+        "mountedSessionNames": [
+          "cortex-dash-d238ddea12d0f249293f29d7fcda26a0",
+          "cortex-dash-27884eb6692cf7f41962b355d06d0ae7"
+        ],
+        "attachedClientsPerSession": {
+          "cortex-dash-d238ddea12d0f249293f29d7fcda26a0": 1,
+          "cortex-dash-220e4af968ca80152e18f5409c4201be": 1,
+          "cortex-dash-e2c8161ceddedf6b531dfa0a7f2da244": 1,
+          "cortex-dash-27884eb6692cf7f41962b355d06d0ae7": 1
+        }
+      },
+      "latency": {
+        "revealAvailability": "hidden-mounted-terminal",
+        "revealMs": [
+          96.3
+        ],
+        "firstCorrectFrameMs": [
+          204.1
+        ],
+        "keystrokeToPaintMs": [
+          62,
+          61.7,
+          51.4
+        ],
+        "keystrokeToPaintTimedOut": [
+          false,
+          false,
+          false
+        ],
+        "keystrokeToPaintTimeoutMs": 10000
+      },
+      "browser": {
+        "hiddenWriteBytesPerSecondPerPanel": 129319.32,
+        "hiddenWriteCallsPerSecondPerPanel": 25.38,
+        "totalVisibleWriteBytes": 1242339,
+        "totalHiddenWriteBytes": 930193,
+        "totalWriteCalls": 376,
+        "totalDecodeMs": 177.8,
+        "totalWriteCallMs": 6.1,
+        "totalWriteCompletionMs": 556.7,
+        "totalRenderEvents": 182,
+        "totalRenderRows": 4322,
+        "initiallyUnmountedSessionNames": [
+          "cortex-dash-220e4af968ca80152e18f5409c4201be",
+          "cortex-dash-e2c8161ceddedf6b531dfa0a7f2da244"
+        ],
+        "neverMountedSessionNames": [
+          "cortex-dash-e2c8161ceddedf6b531dfa0a7f2da244"
+        ],
+        "residencyChurnSessionNames": [
+          "cortex-dash-220e4af968ca80152e18f5409c4201be"
+        ],
+        "endMountedSessionNames": [
+          "cortex-dash-d238ddea12d0f249293f29d7fcda26a0",
+          "cortex-dash-27884eb6692cf7f41962b355d06d0ae7"
+        ],
+        "initiallyUnmountedWriteBytes": 79440,
+        "unmountedWriteBytes": 0,
+        "transport": {
+          "terminalMessages": 505,
+          "rawBytes": 3419545,
+          "encodedBytes": 3360460,
+          "jsonParseMs": 6.499999523162842
+        }
+      },
+      "server": {
+        "visiblePtyChunks": 1256,
+        "visiblePtyBytes": 833359,
+        "hiddenPtyChunks": 3584,
+        "hiddenPtyBytes": 2553174,
+        "attachEvents": 6,
+        "detachEvents": 6,
+        "bufferEvents": 4840,
+        "replayEvents": 7,
+        "overflowEvents": 2095,
+        "overflowBytes": 1295604,
+        "backpressureDropEvents": 4,
+        "backpressureDropBytes": 360872,
+        "fanoutClientDeliveries": 1779,
+        "unmountedHiddenBytes": 844284
+      },
+      "performance": {
+        "longTaskSupported": true,
+        "longTaskCount": 4,
+        "longTaskMs": 256,
+        "longTaskMsPerMinute": 1379.06,
+        "frameCount": 729,
+        "framesPerSecond": 65.45,
+        "longTasks": [
+          {
+            "startTime": 9949.099999904633,
+            "duration": 53
+          },
+          {
+            "startTime": 10052.099999904633,
+            "duration": 65
+          },
+          {
+            "startTime": 11051.799999713898,
+            "duration": 71
+          },
+          {
+            "startTime": 11162.299999713898,
+            "duration": 67
+          }
+        ]
+      },
+      "processes": {
+        "applicationServer": {
+          "processCount": 2,
+          "cpuPercent": 14.19,
+          "physicalBytes": 385875968,
+          "physicalUnavailable": []
+        },
+        "realtimeServer": {
+          "processCount": 6,
+          "cpuPercent": 13.74,
+          "physicalBytes": 179625984,
+          "physicalUnavailable": []
+        },
+        "chromiumRenderer": {
+          "processCount": 3,
+          "cpuPercent": 31.33,
+          "physicalBytes": 261095424,
+          "physicalUnavailable": []
+        }
+      },
+      "replayRisk": {
+        "sessionsWithObservedAltScreen": [
+          "cortex-dash-d238ddea12d0f249293f29d7fcda26a0",
+          "cortex-dash-220e4af968ca80152e18f5409c4201be",
+          "cortex-dash-e2c8161ceddedf6b531dfa0a7f2da244",
+          "cortex-dash-27884eb6692cf7f41962b355d06d0ae7"
+        ],
+        "sessionsMissingRetainedAltEnter": [
+          "cortex-dash-d238ddea12d0f249293f29d7fcda26a0",
+          "cortex-dash-220e4af968ca80152e18f5409c4201be",
+          "cortex-dash-e2c8161ceddedf6b531dfa0a7f2da244",
+          "cortex-dash-27884eb6692cf7f41962b355d06d0ae7"
+        ],
+        "sessionsWithRetainedAltExit": [
+          "cortex-dash-d238ddea12d0f249293f29d7fcda26a0",
+          "cortex-dash-220e4af968ca80152e18f5409c4201be",
+          "cortex-dash-e2c8161ceddedf6b531dfa0a7f2da244",
+          "cortex-dash-27884eb6692cf7f41962b355d06d0ae7"
+        ]
+      },
+      "artifact": "tests/bench/latest/terminal-workload-2026-08-28/n4-sample-3.json"
+    },
+    {
+      "schema": "o8/terminal-workload-sample/v1",
+      "sessionCount": 12,
+      "sampleIndex": 1,
+      "seed": 2922,
+      "buildMode": "production",
+      "devModeCpuWarning": false,
+      "observationMs": 11105,
+      "inventory": {
+        "terminalChipCount": 12,
+        "orchestratorChipCount": 1,
+        "activeTabId": "term-twmtdaj42ln12s1-1",
+        "ptyCount": 12,
+        "ptySessions": [
+          "cortex-dash-5cbacb7becbbc7aa48abb0202cc727e7",
+          "cortex-dash-cc0db5ce485c5b75d01e596f2cac4c25",
+          "cortex-dash-c75696b3f2b02ff0ba17ffd40aa214ff",
+          "cortex-dash-a42e86836d1301e3ade778d8a69bf4f5",
+          "cortex-dash-b4ea18d2954e916c9d823374485b29d2",
+          "cortex-dash-085b51301ec0a3c83be2bd21f169d496",
+          "cortex-dash-e3d036ed499c7562913c838815aa92e5",
+          "cortex-dash-2ac285cb69116c07db886278b6a45695",
+          "cortex-dash-f21a0f3fe64785f43193123249dfb85b",
+          "cortex-dash-0440c3abace6f3a9299387e91e3c43d8",
+          "cortex-dash-fa3beeeef4a8eed57f19864d81d226bc",
+          "cortex-dash-ec86f63511fc6628d146bbfd77eed49e"
+        ],
+        "mountedTerminalPanelCount": 3,
+        "visibleTerminalPanelCount": 1,
+        "mountedSessionNames": [
+          "cortex-dash-5cbacb7becbbc7aa48abb0202cc727e7",
+          "cortex-dash-f21a0f3fe64785f43193123249dfb85b",
+          "cortex-dash-ec86f63511fc6628d146bbfd77eed49e"
+        ],
+        "attachedClientsPerSession": {
+          "cortex-dash-5cbacb7becbbc7aa48abb0202cc727e7": 1,
+          "cortex-dash-cc0db5ce485c5b75d01e596f2cac4c25": 2,
+          "cortex-dash-c75696b3f2b02ff0ba17ffd40aa214ff": 1,
+          "cortex-dash-b4ea18d2954e916c9d823374485b29d2": 1,
+          "cortex-dash-a42e86836d1301e3ade778d8a69bf4f5": 1,
+          "cortex-dash-085b51301ec0a3c83be2bd21f169d496": 1,
+          "cortex-dash-e3d036ed499c7562913c838815aa92e5": 1,
+          "cortex-dash-2ac285cb69116c07db886278b6a45695": 1,
+          "cortex-dash-f21a0f3fe64785f43193123249dfb85b": 1,
+          "cortex-dash-0440c3abace6f3a9299387e91e3c43d8": 1,
+          "cortex-dash-fa3beeeef4a8eed57f19864d81d226bc": 1,
+          "cortex-dash-ec86f63511fc6628d146bbfd77eed49e": 1
+        }
+      },
+      "latency": {
+        "revealAvailability": "hidden-mounted-terminal",
+        "revealMs": [
+          106.8
+        ],
+        "firstCorrectFrameMs": [
+          159.1
+        ],
+        "keystrokeToPaintMs": [
+          58.1,
+          42.4,
+          42.1
+        ],
+        "keystrokeToPaintTimedOut": [
+          false,
+          false,
+          false
+        ],
+        "keystrokeToPaintTimeoutMs": 10000
+      },
+      "browser": {
+        "hiddenWriteBytesPerSecondPerPanel": 53080.62,
+        "hiddenWriteCallsPerSecondPerPanel": 20.08,
+        "totalVisibleWriteBytes": 815997,
+        "totalHiddenWriteBytes": 2116912,
+        "totalWriteCalls": 930,
+        "totalDecodeMs": 223.8,
+        "totalWriteCallMs": 11.9,
+        "totalWriteCompletionMs": 547.6,
+        "totalRenderEvents": 308,
+        "totalRenderRows": 7306,
+        "initiallyUnmountedSessionNames": [
+          "cortex-dash-cc0db5ce485c5b75d01e596f2cac4c25",
+          "cortex-dash-c75696b3f2b02ff0ba17ffd40aa214ff",
+          "cortex-dash-b4ea18d2954e916c9d823374485b29d2",
+          "cortex-dash-a42e86836d1301e3ade778d8a69bf4f5",
+          "cortex-dash-085b51301ec0a3c83be2bd21f169d496",
+          "cortex-dash-e3d036ed499c7562913c838815aa92e5",
+          "cortex-dash-2ac285cb69116c07db886278b6a45695",
+          "cortex-dash-0440c3abace6f3a9299387e91e3c43d8",
+          "cortex-dash-fa3beeeef4a8eed57f19864d81d226bc"
+        ],
+        "neverMountedSessionNames": [
+          "cortex-dash-cc0db5ce485c5b75d01e596f2cac4c25",
+          "cortex-dash-c75696b3f2b02ff0ba17ffd40aa214ff",
+          "cortex-dash-b4ea18d2954e916c9d823374485b29d2",
+          "cortex-dash-a42e86836d1301e3ade778d8a69bf4f5",
+          "cortex-dash-085b51301ec0a3c83be2bd21f169d496",
+          "cortex-dash-e3d036ed499c7562913c838815aa92e5"
+        ],
+        "residencyChurnSessionNames": [
+          "cortex-dash-2ac285cb69116c07db886278b6a45695",
+          "cortex-dash-0440c3abace6f3a9299387e91e3c43d8",
+          "cortex-dash-fa3beeeef4a8eed57f19864d81d226bc"
+        ],
+        "endMountedSessionNames": [
+          "cortex-dash-f21a0f3fe64785f43193123249dfb85b",
+          "cortex-dash-0440c3abace6f3a9299387e91e3c43d8",
+          "cortex-dash-fa3beeeef4a8eed57f19864d81d226bc"
+        ],
+        "initiallyUnmountedWriteBytes": 1264869,
+        "unmountedWriteBytes": 0,
+        "transport": {
+          "terminalMessages": 1247,
+          "rawBytes": 5767979,
+          "encodedBytes": 5622080,
+          "jsonParseMs": 15.000001430511475
+        }
+      },
+      "server": {
+        "visiblePtyChunks": 1245,
+        "visiblePtyBytes": 828674,
+        "hiddenPtyChunks": 12659,
+        "hiddenPtyBytes": 9336234,
+        "attachEvents": 6,
+        "detachEvents": 7,
+        "bufferEvents": 13904,
+        "replayEvents": 6,
+        "overflowEvents": 5746,
+        "overflowBytes": 3900604,
+        "backpressureDropEvents": 4,
+        "backpressureDropBytes": 447327,
+        "fanoutClientDeliveries": 5066,
+        "unmountedHiddenBytes": 5069660
+      },
+      "performance": {
+        "longTaskSupported": true,
+        "longTaskCount": 1,
+        "longTaskMs": 67,
+        "longTaskMsPerMinute": 362,
+        "frameCount": 761,
+        "framesPerSecond": 68.53,
+        "longTasks": [
+          {
+            "startTime": 15519.60000038147,
+            "duration": 67
+          }
+        ]
+      },
+      "processes": {
+        "applicationServer": {
+          "processCount": 2,
+          "cpuPercent": 7.83,
+          "physicalBytes": 459276288,
+          "physicalUnavailable": []
+        },
+        "realtimeServer": {
+          "processCount": 14,
+          "cpuPercent": 23.14,
+          "physicalBytes": 199946240,
+          "physicalUnavailable": []
+        },
+        "chromiumRenderer": {
+          "processCount": 3,
+          "cpuPercent": 33.86,
+          "physicalBytes": 273678336,
+          "physicalUnavailable": []
+        }
+      },
+      "replayRisk": {
+        "sessionsWithObservedAltScreen": [
+          "cortex-dash-5cbacb7becbbc7aa48abb0202cc727e7",
+          "cortex-dash-cc0db5ce485c5b75d01e596f2cac4c25",
+          "cortex-dash-c75696b3f2b02ff0ba17ffd40aa214ff",
+          "cortex-dash-b4ea18d2954e916c9d823374485b29d2",
+          "cortex-dash-a42e86836d1301e3ade778d8a69bf4f5",
+          "cortex-dash-e3d036ed499c7562913c838815aa92e5",
+          "cortex-dash-2ac285cb69116c07db886278b6a45695",
+          "cortex-dash-0440c3abace6f3a9299387e91e3c43d8",
+          "cortex-dash-fa3beeeef4a8eed57f19864d81d226bc"
+        ],
+        "sessionsMissingRetainedAltEnter": [
+          "cortex-dash-5cbacb7becbbc7aa48abb0202cc727e7",
+          "cortex-dash-cc0db5ce485c5b75d01e596f2cac4c25",
+          "cortex-dash-c75696b3f2b02ff0ba17ffd40aa214ff",
+          "cortex-dash-b4ea18d2954e916c9d823374485b29d2",
+          "cortex-dash-a42e86836d1301e3ade778d8a69bf4f5",
+          "cortex-dash-e3d036ed499c7562913c838815aa92e5",
+          "cortex-dash-2ac285cb69116c07db886278b6a45695",
+          "cortex-dash-0440c3abace6f3a9299387e91e3c43d8",
+          "cortex-dash-fa3beeeef4a8eed57f19864d81d226bc"
+        ],
+        "sessionsWithRetainedAltExit": [
+          "cortex-dash-5cbacb7becbbc7aa48abb0202cc727e7",
+          "cortex-dash-cc0db5ce485c5b75d01e596f2cac4c25",
+          "cortex-dash-c75696b3f2b02ff0ba17ffd40aa214ff",
+          "cortex-dash-b4ea18d2954e916c9d823374485b29d2",
+          "cortex-dash-a42e86836d1301e3ade778d8a69bf4f5",
+          "cortex-dash-085b51301ec0a3c83be2bd21f169d496",
+          "cortex-dash-e3d036ed499c7562913c838815aa92e5",
+          "cortex-dash-2ac285cb69116c07db886278b6a45695",
+          "cortex-dash-0440c3abace6f3a9299387e91e3c43d8",
+          "cortex-dash-fa3beeeef4a8eed57f19864d81d226bc",
+          "cortex-dash-ec86f63511fc6628d146bbfd77eed49e"
+        ]
+      },
+      "artifact": "tests/bench/latest/terminal-workload-2026-08-28/n12-sample-1.json"
+    },
+    {
+      "schema": "o8/terminal-workload-sample/v1",
+      "sessionCount": 12,
+      "sampleIndex": 2,
+      "seed": 2923,
+      "buildMode": "production",
+      "devModeCpuWarning": false,
+      "observationMs": 11309,
+      "inventory": {
+        "terminalChipCount": 12,
+        "orchestratorChipCount": 1,
+        "activeTabId": "term-twmtdajnysn12s2-1",
+        "ptyCount": 12,
+        "ptySessions": [
+          "cortex-dash-cfc79ba84319f459ea64e6a1dad3de3c",
+          "cortex-dash-a4ca531e12807707e88b8d6bfe2a537d",
+          "cortex-dash-0f8f92b133c934c988577ac119277e36",
+          "cortex-dash-bac9806ec054f95837869a82fdf27c1f",
+          "cortex-dash-b9d34fd562b407fca893f45297172349",
+          "cortex-dash-e3faaa7cbec585a11b8fb179b52f865f",
+          "cortex-dash-231fb987cf01198f57d25453e17ef220",
+          "cortex-dash-a0e24d62a2e930db4b0e4b277fedbf37",
+          "cortex-dash-9df1a366784053fd1fd65b9aa2dae2ec",
+          "cortex-dash-c14676124c6d115733b503606952e8aa",
+          "cortex-dash-f2dd6dd09f2ba982f97cb39bbf3d5521",
+          "cortex-dash-ca585d1b88b5f24eff1a6545fbae9c19"
+        ],
+        "mountedTerminalPanelCount": 3,
+        "visibleTerminalPanelCount": 1,
+        "mountedSessionNames": [
+          "cortex-dash-cfc79ba84319f459ea64e6a1dad3de3c",
+          "cortex-dash-f2dd6dd09f2ba982f97cb39bbf3d5521",
+          "cortex-dash-ca585d1b88b5f24eff1a6545fbae9c19"
+        ],
+        "attachedClientsPerSession": {
+          "cortex-dash-cfc79ba84319f459ea64e6a1dad3de3c": 1,
+          "cortex-dash-bac9806ec054f95837869a82fdf27c1f": 1,
+          "cortex-dash-a4ca531e12807707e88b8d6bfe2a537d": 1,
+          "cortex-dash-0f8f92b133c934c988577ac119277e36": 1,
+          "cortex-dash-b9d34fd562b407fca893f45297172349": 1,
+          "cortex-dash-231fb987cf01198f57d25453e17ef220": 1,
+          "cortex-dash-a0e24d62a2e930db4b0e4b277fedbf37": 1,
+          "cortex-dash-e3faaa7cbec585a11b8fb179b52f865f": 1,
+          "cortex-dash-9df1a366784053fd1fd65b9aa2dae2ec": 1,
+          "cortex-dash-c14676124c6d115733b503606952e8aa": 1,
+          "cortex-dash-f2dd6dd09f2ba982f97cb39bbf3d5521": 1,
+          "cortex-dash-ca585d1b88b5f24eff1a6545fbae9c19": 1
+        }
+      },
+      "latency": {
+        "revealAvailability": "hidden-mounted-terminal",
+        "revealMs": [
+          195.9
+        ],
+        "firstCorrectFrameMs": [
+          263.4
+        ],
+        "keystrokeToPaintMs": [
+          58.6,
+          138.2,
+          54.2
+        ],
+        "keystrokeToPaintTimedOut": [
+          false,
+          false,
+          false
+        ],
+        "keystrokeToPaintTimeoutMs": 10000
+      },
+      "browser": {
+        "hiddenWriteBytesPerSecondPerPanel": 71365.91,
+        "hiddenWriteCallsPerSecondPerPanel": 18.69,
+        "totalVisibleWriteBytes": 848120,
+        "totalHiddenWriteBytes": 1786104,
+        "totalWriteCalls": 762,
+        "totalDecodeMs": 253.7,
+        "totalWriteCallMs": 14.3,
+        "totalWriteCompletionMs": 898.8,
+        "totalRenderEvents": 305,
+        "totalRenderRows": 7274,
+        "initiallyUnmountedSessionNames": [
+          "cortex-dash-bac9806ec054f95837869a82fdf27c1f",
+          "cortex-dash-a4ca531e12807707e88b8d6bfe2a537d",
+          "cortex-dash-0f8f92b133c934c988577ac119277e36",
+          "cortex-dash-b9d34fd562b407fca893f45297172349",
+          "cortex-dash-231fb987cf01198f57d25453e17ef220",
+          "cortex-dash-a0e24d62a2e930db4b0e4b277fedbf37",
+          "cortex-dash-e3faaa7cbec585a11b8fb179b52f865f",
+          "cortex-dash-9df1a366784053fd1fd65b9aa2dae2ec",
+          "cortex-dash-c14676124c6d115733b503606952e8aa"
+        ],
+        "neverMountedSessionNames": [
+          "cortex-dash-bac9806ec054f95837869a82fdf27c1f",
+          "cortex-dash-a4ca531e12807707e88b8d6bfe2a537d",
+          "cortex-dash-0f8f92b133c934c988577ac119277e36",
+          "cortex-dash-b9d34fd562b407fca893f45297172349",
+          "cortex-dash-231fb987cf01198f57d25453e17ef220",
+          "cortex-dash-a0e24d62a2e930db4b0e4b277fedbf37",
+          "cortex-dash-e3faaa7cbec585a11b8fb179b52f865f"
+        ],
+        "residencyChurnSessionNames": [
+          "cortex-dash-9df1a366784053fd1fd65b9aa2dae2ec",
+          "cortex-dash-c14676124c6d115733b503606952e8aa"
+        ],
+        "endMountedSessionNames": [
+          "cortex-dash-f2dd6dd09f2ba982f97cb39bbf3d5521",
+          "cortex-dash-ca585d1b88b5f24eff1a6545fbae9c19"
+        ],
+        "initiallyUnmountedWriteBytes": 450851,
+        "unmountedWriteBytes": 0,
+        "transport": {
+          "terminalMessages": 2815,
+          "rawBytes": 11674091,
+          "encodedBytes": 11344736,
+          "jsonParseMs": 32.60000038146973
+        }
+      },
+      "server": {
+        "visiblePtyChunks": 3232,
+        "visiblePtyBytes": 851631,
+        "hiddenPtyChunks": 12821,
+        "hiddenPtyBytes": 9441300,
+        "attachEvents": 14,
+        "detachEvents": 14,
+        "bufferEvents": 16053,
+        "replayEvents": 16,
+        "overflowEvents": 7859,
+        "overflowBytes": 4030645,
+        "backpressureDropEvents": 15,
+        "backpressureDropBytes": 79983,
+        "fanoutClientDeliveries": 6640,
+        "unmountedHiddenBytes": 5908168
+      },
+      "performance": {
+        "longTaskSupported": true,
+        "longTaskCount": 3,
+        "longTaskMs": 245,
+        "longTaskMsPerMinute": 1299.85,
+        "frameCount": 789,
+        "framesPerSecond": 69.77,
+        "longTasks": [
+          {
+            "startTime": 6570.5,
+            "duration": 80
+          },
+          {
+            "startTime": 6654.099999904633,
+            "duration": 78
+          },
+          {
+            "startTime": 11999.200000286102,
+            "duration": 87
+          }
+        ]
+      },
+      "processes": {
+        "applicationServer": {
+          "processCount": 2,
+          "cpuPercent": 18.04,
+          "physicalBytes": 277872640,
+          "physicalUnavailable": []
+        },
+        "realtimeServer": {
+          "processCount": 14,
+          "cpuPercent": 38.11,
+          "physicalBytes": 200200192,
+          "physicalUnavailable": []
+        },
+        "chromiumRenderer": {
+          "processCount": 3,
+          "cpuPercent": 41.12,
+          "physicalBytes": 271581184,
+          "physicalUnavailable": []
+        }
+      },
+      "replayRisk": {
+        "sessionsWithObservedAltScreen": [
+          "cortex-dash-bac9806ec054f95837869a82fdf27c1f",
+          "cortex-dash-a4ca531e12807707e88b8d6bfe2a537d",
+          "cortex-dash-a0e24d62a2e930db4b0e4b277fedbf37",
+          "cortex-dash-e3faaa7cbec585a11b8fb179b52f865f"
+        ],
+        "sessionsMissingRetainedAltEnter": [
+          "cortex-dash-bac9806ec054f95837869a82fdf27c1f",
+          "cortex-dash-a4ca531e12807707e88b8d6bfe2a537d",
+          "cortex-dash-a0e24d62a2e930db4b0e4b277fedbf37",
+          "cortex-dash-e3faaa7cbec585a11b8fb179b52f865f"
+        ],
+        "sessionsWithRetainedAltExit": [
+          "cortex-dash-cfc79ba84319f459ea64e6a1dad3de3c",
+          "cortex-dash-bac9806ec054f95837869a82fdf27c1f",
+          "cortex-dash-a4ca531e12807707e88b8d6bfe2a537d",
+          "cortex-dash-0f8f92b133c934c988577ac119277e36",
+          "cortex-dash-b9d34fd562b407fca893f45297172349",
+          "cortex-dash-231fb987cf01198f57d25453e17ef220",
+          "cortex-dash-a0e24d62a2e930db4b0e4b277fedbf37",
+          "cortex-dash-e3faaa7cbec585a11b8fb179b52f865f",
+          "cortex-dash-9df1a366784053fd1fd65b9aa2dae2ec",
+          "cortex-dash-c14676124c6d115733b503606952e8aa",
+          "cortex-dash-f2dd6dd09f2ba982f97cb39bbf3d5521",
+          "cortex-dash-ca585d1b88b5f24eff1a6545fbae9c19"
+        ]
+      },
+      "artifact": "tests/bench/latest/terminal-workload-2026-08-28/n12-sample-2.json"
+    },
+    {
+      "schema": "o8/terminal-workload-sample/v1",
+      "sessionCount": 12,
+      "sampleIndex": 3,
+      "seed": 2924,
+      "buildMode": "production",
+      "devModeCpuWarning": false,
+      "observationMs": 11139,
+      "inventory": {
+        "terminalChipCount": 12,
+        "orchestratorChipCount": 1,
+        "activeTabId": "term-twmtdak5zun12s3-1",
+        "ptyCount": 12,
+        "ptySessions": [
+          "cortex-dash-6b2ed455b841c1e5879b7f37b057c624",
+          "cortex-dash-6e9ae50061caae2fd3d548a4d4c8cf24",
+          "cortex-dash-f89c07d59d25ef8b0acc34914de5034b",
+          "cortex-dash-cf1381a6bbddcd488485c2a2f2f4f0e2",
+          "cortex-dash-87644e58c07343ee15831526813f5cc2",
+          "cortex-dash-5be5e2c0cc1b630fe594ad85e92802a6",
+          "cortex-dash-726092e92fea636dbdd99b2827023d96",
+          "cortex-dash-76adfa16607292a4cd55280c4d4c35f9",
+          "cortex-dash-a6495330ac0f5211bd11d23e18b44697",
+          "cortex-dash-0fb35985c079ab378efe6b9fc2e0b697",
+          "cortex-dash-5e95f53cc126f454abbcfb40323e41ff",
+          "cortex-dash-116b1476efe9f420e3d467e98aab72ed"
+        ],
+        "mountedTerminalPanelCount": 3,
+        "visibleTerminalPanelCount": 1,
+        "mountedSessionNames": [
+          "cortex-dash-6b2ed455b841c1e5879b7f37b057c624",
+          "cortex-dash-f89c07d59d25ef8b0acc34914de5034b",
+          "cortex-dash-cf1381a6bbddcd488485c2a2f2f4f0e2"
+        ],
+        "attachedClientsPerSession": {
+          "cortex-dash-6b2ed455b841c1e5879b7f37b057c624": 2,
+          "cortex-dash-6e9ae50061caae2fd3d548a4d4c8cf24": 2,
+          "cortex-dash-5be5e2c0cc1b630fe594ad85e92802a6": 1,
+          "cortex-dash-87644e58c07343ee15831526813f5cc2": 1,
+          "cortex-dash-a6495330ac0f5211bd11d23e18b44697": 1,
+          "cortex-dash-76adfa16607292a4cd55280c4d4c35f9": 1,
+          "cortex-dash-726092e92fea636dbdd99b2827023d96": 1,
+          "cortex-dash-0fb35985c079ab378efe6b9fc2e0b697": 1,
+          "cortex-dash-5e95f53cc126f454abbcfb40323e41ff": 1,
+          "cortex-dash-f89c07d59d25ef8b0acc34914de5034b": 2,
+          "cortex-dash-cf1381a6bbddcd488485c2a2f2f4f0e2": 2,
+          "cortex-dash-116b1476efe9f420e3d467e98aab72ed": 1
+        }
+      },
+      "latency": {
+        "revealAvailability": "hidden-mounted-terminal",
+        "revealMs": [
+          165.5
+        ],
+        "firstCorrectFrameMs": [
+          290.2
+        ],
+        "keystrokeToPaintMs": [
+          128.4,
+          43.5,
+          39.2
+        ],
+        "keystrokeToPaintTimedOut": [
+          false,
+          false,
+          false
+        ],
+        "keystrokeToPaintTimeoutMs": 10000
+      },
+      "browser": {
+        "hiddenWriteBytesPerSecondPerPanel": 53452.84,
+        "hiddenWriteCallsPerSecondPerPanel": 19.98,
+        "totalVisibleWriteBytes": 837754,
+        "totalHiddenWriteBytes": 1730193,
+        "totalWriteCalls": 783,
+        "totalDecodeMs": 206.8,
+        "totalWriteCallMs": 11.5,
+        "totalWriteCompletionMs": 478.8,
+        "totalRenderEvents": 312,
+        "totalRenderRows": 7402,
+        "initiallyUnmountedSessionNames": [
+          "cortex-dash-6e9ae50061caae2fd3d548a4d4c8cf24",
+          "cortex-dash-5be5e2c0cc1b630fe594ad85e92802a6",
+          "cortex-dash-87644e58c07343ee15831526813f5cc2",
+          "cortex-dash-a6495330ac0f5211bd11d23e18b44697",
+          "cortex-dash-76adfa16607292a4cd55280c4d4c35f9",
+          "cortex-dash-726092e92fea636dbdd99b2827023d96",
+          "cortex-dash-0fb35985c079ab378efe6b9fc2e0b697",
+          "cortex-dash-5e95f53cc126f454abbcfb40323e41ff",
+          "cortex-dash-116b1476efe9f420e3d467e98aab72ed"
+        ],
+        "neverMountedSessionNames": [
+          "cortex-dash-6e9ae50061caae2fd3d548a4d4c8cf24",
+          "cortex-dash-5be5e2c0cc1b630fe594ad85e92802a6",
+          "cortex-dash-87644e58c07343ee15831526813f5cc2",
+          "cortex-dash-a6495330ac0f5211bd11d23e18b44697",
+          "cortex-dash-76adfa16607292a4cd55280c4d4c35f9",
+          "cortex-dash-726092e92fea636dbdd99b2827023d96",
+          "cortex-dash-0fb35985c079ab378efe6b9fc2e0b697"
+        ],
+        "residencyChurnSessionNames": [
+          "cortex-dash-5e95f53cc126f454abbcfb40323e41ff",
+          "cortex-dash-116b1476efe9f420e3d467e98aab72ed"
+        ],
+        "endMountedSessionNames": [
+          "cortex-dash-f89c07d59d25ef8b0acc34914de5034b",
+          "cortex-dash-116b1476efe9f420e3d467e98aab72ed"
+        ],
+        "initiallyUnmountedWriteBytes": 869110,
+        "unmountedWriteBytes": 0,
+        "transport": {
+          "terminalMessages": 1101,
+          "rawBytes": 5268801,
+          "encodedBytes": 5139984,
+          "jsonParseMs": 14.099998950958252
+        }
+      },
+      "server": {
+        "visiblePtyChunks": 3222,
+        "visiblePtyBytes": 856945,
+        "hiddenPtyChunks": 12625,
+        "hiddenPtyBytes": 9334502,
+        "attachEvents": 2,
+        "detachEvents": 6,
+        "bufferEvents": 15847,
+        "replayEvents": 2,
+        "overflowEvents": 7689,
+        "overflowBytes": 3930373,
+        "backpressureDropEvents": 2,
+        "backpressureDropBytes": 5296,
+        "fanoutClientDeliveries": 4894,
+        "unmountedHiddenBytes": 5908069
+      },
+      "performance": {
+        "longTaskSupported": true,
+        "longTaskCount": 1,
+        "longTaskMs": 67,
+        "longTaskMsPerMinute": 360.89,
+        "frameCount": 804,
+        "framesPerSecond": 72.18,
+        "longTasks": [
+          {
+            "startTime": 14304.199999809265,
+            "duration": 67
+          }
+        ]
+      },
+      "processes": {
+        "applicationServer": {
+          "processCount": 2,
+          "cpuPercent": 9.96,
+          "physicalBytes": 461373440,
+          "physicalUnavailable": []
+        },
+        "realtimeServer": {
+          "processCount": 14,
+          "cpuPercent": 25.23,
+          "physicalBytes": 202252288,
+          "physicalUnavailable": []
+        },
+        "chromiumRenderer": {
+          "processCount": 3,
+          "cpuPercent": 27.83,
+          "physicalBytes": 240123904,
+          "physicalUnavailable": []
+        }
+      },
+      "replayRisk": {
+        "sessionsWithObservedAltScreen": [
+          "cortex-dash-6b2ed455b841c1e5879b7f37b057c624",
+          "cortex-dash-5be5e2c0cc1b630fe594ad85e92802a6",
+          "cortex-dash-87644e58c07343ee15831526813f5cc2",
+          "cortex-dash-a6495330ac0f5211bd11d23e18b44697",
+          "cortex-dash-726092e92fea636dbdd99b2827023d96",
+          "cortex-dash-0fb35985c079ab378efe6b9fc2e0b697",
+          "cortex-dash-5e95f53cc126f454abbcfb40323e41ff",
+          "cortex-dash-f89c07d59d25ef8b0acc34914de5034b",
+          "cortex-dash-cf1381a6bbddcd488485c2a2f2f4f0e2"
+        ],
+        "sessionsMissingRetainedAltEnter": [
+          "cortex-dash-6b2ed455b841c1e5879b7f37b057c624",
+          "cortex-dash-5be5e2c0cc1b630fe594ad85e92802a6",
+          "cortex-dash-87644e58c07343ee15831526813f5cc2",
+          "cortex-dash-a6495330ac0f5211bd11d23e18b44697",
+          "cortex-dash-726092e92fea636dbdd99b2827023d96",
+          "cortex-dash-0fb35985c079ab378efe6b9fc2e0b697",
+          "cortex-dash-5e95f53cc126f454abbcfb40323e41ff",
+          "cortex-dash-f89c07d59d25ef8b0acc34914de5034b",
+          "cortex-dash-cf1381a6bbddcd488485c2a2f2f4f0e2"
+        ],
+        "sessionsWithRetainedAltExit": [
+          "cortex-dash-6b2ed455b841c1e5879b7f37b057c624",
+          "cortex-dash-6e9ae50061caae2fd3d548a4d4c8cf24",
+          "cortex-dash-5be5e2c0cc1b630fe594ad85e92802a6",
+          "cortex-dash-87644e58c07343ee15831526813f5cc2",
+          "cortex-dash-a6495330ac0f5211bd11d23e18b44697",
+          "cortex-dash-76adfa16607292a4cd55280c4d4c35f9",
+          "cortex-dash-726092e92fea636dbdd99b2827023d96",
+          "cortex-dash-0fb35985c079ab378efe6b9fc2e0b697",
+          "cortex-dash-5e95f53cc126f454abbcfb40323e41ff",
+          "cortex-dash-f89c07d59d25ef8b0acc34914de5034b",
+          "cortex-dash-cf1381a6bbddcd488485c2a2f2f4f0e2",
+          "cortex-dash-116b1476efe9f420e3d467e98aab72ed"
+        ]
+      },
+      "artifact": "tests/bench/latest/terminal-workload-2026-08-28/n12-sample-3.json"
+    }
+  ]
+}


### PR DESCRIPTION
Refs #1721, #1697 (phase 1 of 2: measurement only).

Adds the terminal workload fixture the #1721 contract requires before an intervention is chosen, records the baseline, and proposes budgets. Terminal attachment, delivery, parsing, and rendering behaviour are unchanged; every counter is behind a bench flag and the non-bench path is byte-for-byte the previous code (no render listener, the original `JSON.parse` line, the original write path).

**Fixture** (`npm run bench:terminal`, `scripts/bench/run-terminal-workload.mjs` + `scripts/bench/terminal-workload/`): boots an isolated app server + realtime server on free ports with a seeded data dir (setup complete, one registered repo, N persisted terminal tabs), drives the real dashboard in headless chromium with exactly one terminal visible, runs a deterministic busy generator with an alternate-screen phase in every session, and records per session: PTY chunks and bytes, browser writes and decode/write/completion time, render events, long tasks, attach/detach/buffer/replay/overflow/backpressure-drop counts, reveal and first-correct-frame latency, keystroke-to-paint latency, and per-process CPU and memory using the same method as the packaged footprint gate. Emits `o8/terminal-workload/v1` (`tests/bench/results/terminal-workload-baseline.json`, 9 samples, production server) with the narrative in `docs/internals/terminal-workload-baseline.md`.

**Baseline (p50, N = 1 / 4 / 12 sessions, one visible)**: hidden panels each take ~54 KB/s and ~20 writes/s; long tasks 0 / 482 / 362 ms per minute; reveal — / 52 / 166 ms; first correct frame — / 135 / 263 ms; keystroke-to-paint 43 / 44 / 54 ms; realtime-server CPU 7 / 14 / 25 % as fan-out deliveries grow 635 → 5,066. Only three panels are ever mounted (resident cap), so at N = 12 nine sessions cost the browser nothing while their PTYs still produce 5–6 MiB each server-side.

**What the numbers say**: hidden browser cost is base64 decode plus xterm write completion, not painting (render events flat, 319 vs 308). The 512 KB scrollback ring overflowed in every configuration (326 KB at N = 1, 3.9 MB at N = 12) and alternate-screen enter markers had aged out while exit markers remained, so a detach-hidden + replay-on-reveal design is unsafe with the current ring. Bounded hidden-write batching is the design the baseline favours, with the server-side fan-out as the other cost centre.

**Proposed budgets** (proposals until the operator locks them; listed in the baseline doc): N = 12 renderer p95 ≤ 35 % and ≤ +15 points over N = 1; realtime p95 ≤ 42 %; long tasks p95 ≤ 750 ms/min; app ≤ 512 MiB, realtime ≤ 224 MiB, renderer ≤ 288 MiB (growth ≤ 112 MiB); reveal p95 ≤ 225 ms; first correct frame p95 ≤ 350 ms; input p50 ≤ 75 ms / p95 ≤ 175 ms; hidden render events ≤ 1.25 × N = 1.

**Other changes**: stable read-only markup hooks (`data-o8-workspace-tab`, `data-o8-term-panel`); `scripts/lib/footprint-budget.mjs` exports its per-process memory helper (renamed from a private function; no logic change); `src/lib/ws-server/terminal-workload-stats.ts` is instantiated only when `O8_TERMINAL_BENCH=1`; three bench-only socket message types. Tests: `XtermPanel.bench.test.ts` covers the counters with the flag on and proves the flag-off path has no listener and no completion callback.

**Residual**: one machine, three samples per N, production browser server rather than the native shell; rapid twelve-tab switching and the full image/link/Unicode/input matrix are phase-2 coverage.

**Gates**: tsc, workspace-terminal + realtime-server suites, lint (152 cap, zero new), classification check, full unit suite — all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional terminal workload benchmarking tool for measuring performance across multiple active sessions.
  * Added detailed terminal telemetry covering latency, rendering, memory, CPU usage, replay behavior, buffering, and backpressure.
  * Added the `bench:terminal` command to run workload benchmarks.
* **Documentation**
  * Added Phase 1 terminal workload baseline results and proposed performance budgets.
* **Tests**
  * Added coverage for terminal instrumentation, visibility handling, rendering, and write tracking.
* **Chores**
  * Included baseline benchmark results for 1, 4, and 12 terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->