### PR TITLE
fix(cost): attribute usage rows by packet, role, and attempt; record cost on session outcomes

### DIFF
--- a/src/app/api/cortex/ask/answer/route.test.ts
+++ b/src/app/api/cortex/ask/answer/route.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
 const askCortexMock = vi.hoisted(() => vi.fn());
+const findLatestLaneByPacketMock = vi.hoisted(() => vi.fn());
+const findMissionRegistryEntryByPacketIdMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/cortex/qa/ask', () => ({
   askCortex: askCortexMock,
@@ -12,7 +14,11 @@ vi.mock('@/lib/lane/events', () => ({
 }));
 
 vi.mock('@/lib/lane/registry', () => ({
-  findLatestLaneByPacket: vi.fn(),
+  findLatestLaneByPacket: findLatestLaneByPacketMock,
+}));
+
+vi.mock('@/lib/orchestrator/mission-registry', () => ({
+  findMissionRegistryEntryByPacketId: findMissionRegistryEntryByPacketIdMock,
 }));
 
 const { POST } = await import('@/app/api/cortex/ask/answer/route');
@@ -28,6 +34,8 @@ function request(body: unknown): NextRequest {
 describe('/api/cortex/ask/answer terse flag', () => {
   beforeEach(() => {
     askCortexMock.mockReset();
+    findLatestLaneByPacketMock.mockReset();
+    findMissionRegistryEntryByPacketIdMock.mockReset();
     askCortexMock.mockResolvedValue({
       answer: 'Use the packet guide. [CITATION:directive-seed]',
       citations: [{ kind: 'directive', rowId: 'directive-seed', table: 'directives' }],
@@ -64,6 +72,28 @@ describe('/api/cortex/ask/answer terse flag', () => {
       bypassCache: false,
       projectId: null,
       terse: false,
+    });
+  });
+
+  it('passes usage attribution when the caller supplies a packet', async () => {
+    findLatestLaneByPacketMock.mockReturnValue({ id: 'lane-cost', repoPath: '/repo/o8' });
+    findMissionRegistryEntryByPacketIdMock.mockReturnValue({ id: 'mission-cost' });
+
+    const res = await POST(request({
+      question: 'What is the packet rule?',
+      packetId: 'packet-cost',
+    }));
+
+    expect(res.status).toBe(200);
+    expect(askCortexMock).toHaveBeenCalledWith('What is the packet rule?', '/repo/o8', {
+      bypassCache: false,
+      projectId: null,
+      terse: false,
+      usageContext: {
+        laneId: 'lane-cost',
+        packetId: 'packet-cost',
+        missionId: 'mission-cost',
+      },
     });
   });
 });

--- a/src/app/api/cortex/ask/answer/route.ts
+++ b/src/app/api/cortex/ask/answer/route.ts
@@ -23,6 +23,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { performance } from 'node:perf_hooks';
 
 import { askCortex, type AskCortexResult } from '@/lib/cortex/qa/ask';
+import { estimateBrainTokenCount } from '@/lib/cortex/qa/llm/brain-spend';
 import { recordLaneEvent } from '@/lib/lane/events';
 import { findLatestLaneByPacket } from '@/lib/lane/registry';
 import { resolveRequestPrincipalContext, workerPacketRefusal } from '@/lib/auth/principal';
@@ -36,7 +37,13 @@ interface AskAnswerBody {
   packetId?: unknown;
 }
 
-function recordBrainConsulted(packetId: string, laneId: string, question: string, result: AskCortexResult) {
+function recordBrainConsulted(
+  packetId: string,
+  laneId: string,
+  question: string,
+  result: AskCortexResult,
+  latencyMs: number,
+) {
   try {
     recordLaneEvent(laneId, 'brain_consulted', 'system', {
       packetId,
@@ -46,6 +53,8 @@ function recordBrainConsulted(packetId: string, laneId: string, question: string
       sourcesConsidered: result.sourcesConsidered,
       citedCount: result.citations.length,
       topTitles: result.citations.slice(0, 3).map((c) => c.title ?? c.excerpt?.slice(0, 80) ?? c.kind),
+      tokens: estimateBrainTokenCount(question, result.answer),
+      latencyMs,
     });
   } catch (err) {
     // The audit trail must never fail the ask itself.
@@ -94,8 +103,22 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const result = await askCortex(question, repoPath, { bypassCache, projectId, terse });
-    if (packetId && laneId) recordBrainConsulted(packetId, laneId, question, result);
+    let missionId: string | null = null;
+    if (packetId) {
+      const { findMissionRegistryEntryByPacketId } = await import('@/lib/orchestrator/mission-registry');
+      missionId = findMissionRegistryEntryByPacketId(packetId, { includeArchived: true })?.id ?? null;
+    }
+    const usageContext = laneId || packetId || missionId
+      ? { laneId, packetId, missionId }
+      : undefined;
+    const result = await askCortex(question, repoPath, {
+      bypassCache,
+      projectId,
+      terse,
+      ...(usageContext ? { usageContext } : {}),
+    });
+    const latencyMs = Math.max(0, performance.now() - startedAt);
+    if (packetId && laneId) recordBrainConsulted(packetId, laneId, question, result, latencyMs);
     return NextResponse.json({
       ok: true,
       answer: result.answer,

--- a/src/app/api/cortex/ask/route.ts
+++ b/src/app/api/cortex/ask/route.ts
@@ -30,6 +30,7 @@ export const dynamic = 'force-dynamic';
 import { NextRequest } from 'next/server';
 
 import { runAskPipeline } from '@/lib/cortex/qa/ask';
+import { withBrainRetrievalUsage } from '@/lib/cortex/qa/llm/brain-spend';
 
 interface AskBody {
   question?: unknown;
@@ -80,7 +81,17 @@ export async function POST(request: NextRequest) {
 
       try {
         emit('open', { ok: true });
-        await runAskPipeline(question, repoPath, emit, force, projectId, { terse });
+        let meteredAnswer = '';
+        const meteredEmit = (name: string, payload: unknown) => {
+          if (name === 'token') meteredAnswer += (payload as { text?: string }).text ?? '';
+          emit(name, payload);
+        };
+        await withBrainRetrievalUsage(
+          question,
+          { repoPath },
+          () => runAskPipeline(question, repoPath, meteredEmit, force, projectId, { terse }),
+          () => meteredAnswer,
+        );
       } catch (err) {
         const message = err instanceof Error ? err.message : 'pipeline error';
         console.error('[qa][ask-route] pipeline error:', message);

--- a/src/lib/cortex/qa/ask.ts
+++ b/src/lib/cortex/qa/ask.ts
@@ -28,6 +28,10 @@ import { buildGrepArmTopRows } from '@/lib/cortex/qa/grep-arm';
 import { embedQuestion } from '@/lib/cortex/qa/llm/gemini-embed';
 import { prewarmHaiku } from '@/lib/cortex/qa/llm/haiku-adapter';
 import { prewarmSonnetCli } from '@/lib/cortex/qa/llm/sonnet-adapter';
+import {
+  withBrainRetrievalUsage,
+  type BrainRetrievalUsageContext,
+} from '@/lib/cortex/qa/llm/brain-spend';
 import { detectLiteralLookup } from '@/lib/cortex/qa/literal-lookup';
 import { retrieveAll, unionMerge } from '@/lib/cortex/qa/retrieve';
 import {
@@ -227,7 +231,29 @@ function buildSourcesPayload(topRows: TypedRow[], retrievalMs: number): {
 export async function askCortex(
   question: string,
   repoPath: string | undefined,
-  options: { bypassCache?: boolean; projectId?: string | null; terse?: boolean } = {},
+  options: {
+    bypassCache?: boolean;
+    projectId?: string | null;
+    terse?: boolean;
+    usageContext?: BrainRetrievalUsageContext;
+  } = {},
+): Promise<AskCortexResult> {
+  return withBrainRetrievalUsage(
+    question,
+    { repoPath, ...options.usageContext },
+    () => askCortexUnmetered(question, repoPath, options),
+    (result) => result.answer,
+  );
+}
+
+async function askCortexUnmetered(
+  question: string,
+  repoPath: string | undefined,
+  options: {
+    bypassCache?: boolean;
+    projectId?: string | null;
+    terse?: boolean;
+  },
 ): Promise<AskCortexResult> {
   const { bypassCache = false, terse = false } = options;
   const projectId = options.projectId?.trim()

--- a/src/lib/cortex/qa/llm/brain-spend.test.ts
+++ b/src/lib/cortex/qa/llm/brain-spend.test.ts
@@ -3,9 +3,27 @@
  * 2026-06-11 brain perf pass).
  */
 
-import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
 
-import { estimateCostUsd } from '@/lib/cortex/qa/llm/brain-spend';
+const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-brain-spend-'));
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+
+const {
+  assertUnderBrainDailyCap,
+  estimateCostUsd,
+  resetBrainSpendCache,
+  withBrainRetrievalUsage,
+} = await import('@/lib/cortex/qa/llm/brain-spend');
+const { getSqlite } = await import('@/lib/db');
+const { logUsage } = await import('@/lib/db/usage');
+
+afterAll(() => {
+  delete process.env.O8_QA_OPENROUTER_DAILY_CAP_USD;
+  rmSync(dataDir, { recursive: true, force: true });
+});
 
 describe('estimateCostUsd', () => {
   it('prefers the exact cost OpenRouter returns', () => {
@@ -36,5 +54,51 @@ describe('estimateCostUsd', () => {
 
   it('treats missing token counts as zero', () => {
     expect(estimateCostUsd('google/gemini-2.5-flash-lite', {})).toBe(0);
+  });
+
+  it('records one zero-dollar subscription retrieval without changing the daily cap sum', async () => {
+    process.env.O8_QA_OPENROUTER_DAILY_CAP_USD = '0.5';
+    logUsage({
+      userId: null,
+      model: 'paid-brain-model',
+      provider: 'openrouter',
+      inputTokens: 100,
+      outputTokens: 10,
+      costUsd: 0.49,
+      agentName: 'cortex-qa',
+      role: 'retrieval',
+    });
+    const spendBefore = getSqlite().prepare(
+      "SELECT COALESCE(SUM(cost_usd), 0) AS total FROM usage_logs WHERE agent_name = 'cortex-qa'",
+    ).get() as { total: number };
+
+    resetBrainSpendCache();
+    await expect(assertUnderBrainDailyCap()).resolves.toBeUndefined();
+    await withBrainRetrievalUsage(
+      'Which migration owns the current schema?',
+      { packetId: 'packet-brain-spend' },
+      async () => ({ answer: 'Schema v57 owns cost attribution.' }),
+      (result) => result.answer,
+    );
+
+    const rows = getSqlite().prepare(`
+      SELECT role, packet_id, input_tokens, output_tokens, cost_usd, metadata_json
+      FROM usage_logs WHERE model = 'cortex-qa-request'
+    `).all() as Array<Record<string, unknown>>;
+    expect(rows).toEqual([expect.objectContaining({
+      role: 'retrieval',
+      packet_id: 'packet-brain-spend',
+      cost_usd: 0,
+    })]);
+    expect(JSON.parse(String(rows[0]?.metadata_json))).toMatchObject({
+      estimated: true,
+      source: 'chars_per_four',
+    });
+    const spendAfter = getSqlite().prepare(
+      "SELECT COALESCE(SUM(cost_usd), 0) AS total FROM usage_logs WHERE agent_name = 'cortex-qa'",
+    ).get() as { total: number };
+    expect(spendAfter.total).toBe(spendBefore.total);
+    resetBrainSpendCache();
+    await expect(assertUnderBrainDailyCap()).resolves.toBeUndefined();
   });
 });

--- a/src/lib/cortex/qa/llm/brain-spend.ts
+++ b/src/lib/cortex/qa/llm/brain-spend.ts
@@ -18,6 +18,8 @@
  */
 
 import 'server-only';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { UsageRole } from '@/lib/db/usage';
 
 /** USD per token (input, output) for the models in our OpenRouter chain. */
 const MODEL_PRICING_PER_TOKEN: Record<string, { input: number; output: number }> = {
@@ -47,6 +49,20 @@ export interface OpenRouterUsage {
 
 type BrainSpendProvider = 'google' | 'openrouter';
 
+type BrainAskMeter = { paidCallRecorded: boolean };
+const brainAskMeter = new AsyncLocalStorage<BrainAskMeter>();
+
+export interface BrainRetrievalUsageContext {
+  repoPath?: string | null;
+  laneId?: string | null;
+  packetId?: string | null;
+  missionId?: string | null;
+}
+
+export function estimateBrainTokenCount(...values: string[]): number {
+  return values.reduce((sum, value) => sum + Math.max(0, Math.ceil(value.length / 4)), 0);
+}
+
 export function estimateCostUsd(model: string, usage: OpenRouterUsage): number {
   if (typeof usage.cost === 'number' && usage.cost >= 0) return usage.cost;
   const pricing = MODEL_PRICING_PER_TOKEN[model] ?? WORST_CASE_PRICING;
@@ -63,6 +79,8 @@ function recordBrainSpend(
   usage: OpenRouterUsage,
   requestType: 'chat' | 'embedding',
 ): void {
+  const activeMeter = brainAskMeter.getStore();
+  if (activeMeter) activeMeter.paidCallRecorded = true;
   // Invalidate the cap memo SYNCHRONOUSLY, before the async ledger write —
   // resetting it inside the async block left a window where every concurrent
   // ask kept reading the stale (lower) memo and sailed past the cap check
@@ -81,11 +99,58 @@ function recordBrainSpend(
         costUsd: estimateCostUsd(model, usage),
         agentName: BRAIN_AGENT_NAME,
         requestType,
+        role: 'retrieval' satisfies UsageRole,
       });
     } catch (err) {
       console.warn('[qa][brain-spend] ledger write failed:', err instanceof Error ? err.message : err);
     }
   })();
+}
+
+/**
+ * Meter one complete Brain ask. Direct paid calls keep their provider receipt;
+ * subscription, proxy, local, heuristic, and cache paths receive one zero-dollar
+ * retrieval receipt with an explicit token estimate.
+ */
+export async function withBrainRetrievalUsage<T>(
+  inputText: string,
+  context: BrainRetrievalUsageContext,
+  run: () => Promise<T>,
+  outputText: (result: T) => string,
+): Promise<T> {
+  const startedAt = Date.now();
+  const meter: BrainAskMeter = { paidCallRecorded: false };
+  const result = await brainAskMeter.run(meter, run);
+  if (!meter.paidCallRecorded) {
+    try {
+      const output = outputText(result);
+      const { logUsage } = await import('@/lib/db/usage');
+      logUsage({
+        userId: null,
+        model: 'cortex-qa-request',
+        provider: 'runtime',
+        inputTokens: estimateBrainTokenCount(inputText),
+        outputTokens: estimateBrainTokenCount(output),
+        costUsd: 0,
+        sessionKey: `retrieval:${Date.now()}:${Math.random().toString(36).slice(2, 10)}`,
+        repoPath: context.repoPath ?? null,
+        laneId: context.laneId ?? null,
+        packetId: context.packetId ?? null,
+        missionId: context.missionId ?? null,
+        role: 'retrieval',
+        agentName: BRAIN_AGENT_NAME,
+        requestType: 'completion',
+        metadata: {
+          estimated: true,
+          source: 'chars_per_four',
+          latencyMs: Math.max(0, Date.now() - startedAt),
+        },
+      });
+    } catch (err) {
+      console.warn('[qa][brain-spend] retrieval ledger write failed:', err instanceof Error ? err.message : err);
+    }
+  }
+  return result;
 }
 
 export function recordBrainOpenRouterSpend(model: string, usage: OpenRouterUsage): void {

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -39,11 +39,10 @@ const DATA_DIR = getDataDir();
 // copy still points at the right file. Renaming the file would require a
 // second migration step with no user-facing benefit.
 const DB_PATH = process.env.CORTEX_IDE_DB_PATH || path.join(DATA_DIR, 'cortex-ide.db');
-const DB_SCHEMA_VERSION = 53;
+const DB_SCHEMA_VERSION = 57;
 function migrationMarkerPath(version: number): string {
   return path.join(DATA_DIR, `.db-migrated-v${version}`);
 }
-
 // Ensure data directory exists
 if (!existsSync(DATA_DIR)) {
   mkdirSync(DATA_DIR, { recursive: true });
@@ -536,6 +535,7 @@ function ensureTables(sqlite: Database.Database): void {
       cache_write_tokens INTEGER DEFAULT 0,
       cost_usd REAL NOT NULL DEFAULT 0,
       session_key TEXT,
+      lane_id TEXT, packet_id TEXT, mission_id TEXT, role TEXT, attempt INTEGER NOT NULL DEFAULT 1, run_id TEXT, metadata_json TEXT,
       repo_path TEXT,
       agent_name TEXT,
       request_type TEXT DEFAULT 'chat',

--- a/src/lib/db/latest-schema-migrations.ts
+++ b/src/lib/db/latest-schema-migrations.ts
@@ -20,6 +20,7 @@ import { ensureV53PromptLibrarySchema } from '@/lib/db/v53-prompt-library-migrat
 import { ensureV54WorkerMcpInjectionSchema } from '@/lib/db/v54-worker-mcp-injection-migration';
 import { ensureV55OutsiderAttentionSchema } from '@/lib/db/v55-outsider-attention-migration';
 import { ensureV56ManagedSymonMessagesSchema } from '@/lib/db/v56-managed-symon-messages-migration';
+import { ensureV57CostLedgerAttributionSchema } from '@/lib/db/v57-cost-ledger-attribution-migration';
 
 /**
  * Keep the current additive migrations behind one boot hook. `db/index.ts` is
@@ -51,4 +52,5 @@ export function ensurePostAutomationSchemas(sqlite: Database.Database): void {
   ensureV54WorkerMcpInjectionSchema(sqlite);
   ensureV55OutsiderAttentionSchema(sqlite);
   ensureV56ManagedSymonMessagesSchema(sqlite);
+  ensureV57CostLedgerAttributionSchema(sqlite);
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -100,6 +100,18 @@ export const usageLogs = sqliteTable('usage_logs', {
   costUsd: real('cost_usd').notNull().default(0),
   /** Associated agent session key */
   sessionKey: text('session_key'),
+  /** Durable orchestration context. Nullable for legacy and global rows. */
+  laneId: text('lane_id'),
+  packetId: text('packet_id'),
+  missionId: text('mission_id'),
+  /** Role played by this model call inside the orchestration pipeline. */
+  role: text('role', { enum: ['orchestrator', 'worker', 'reviewer', 'compaction', 'retrieval', 'other'] }),
+  /** One-based packet attempt index. */
+  attempt: integer('attempt').notNull().default(1),
+  /** Runtime-owned execution receipt when one exists. */
+  runId: text('run_id'),
+  /** Optional metering provenance, including whether token counts are estimated. */
+  metadataJson: text('metadata_json'),
   /** Repository where the session ran */
   repoPath: text('repo_path'),
   /** Agent name (for breakdown) */
@@ -110,7 +122,9 @@ export const usageLogs = sqliteTable('usage_logs', {
   billingPeriod: text('billing_period').notNull(),
   /** Timestamp */
   createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
-});
+}, (table) => ({
+  packetAttemptIdx: index('idx_usage_logs_packet_attempt').on(table.packetId, table.attempt),
+}));
 
 // ══════════════════════════════════════════════════════════════════
 //  Subscriptions — Stripe billing link

--- a/src/lib/db/usage-log-migration.ts
+++ b/src/lib/db/usage-log-migration.ts
@@ -44,6 +44,13 @@ export function ensureUsageLogSchema(sqlite: Database.Database): void {
           cache_write_tokens INTEGER DEFAULT 0,
           cost_usd REAL NOT NULL DEFAULT 0,
           session_key TEXT,
+          lane_id TEXT,
+          packet_id TEXT,
+          mission_id TEXT,
+          role TEXT,
+          attempt INTEGER NOT NULL DEFAULT 1,
+          run_id TEXT,
+          metadata_json TEXT,
           repo_path TEXT,
           agent_name TEXT,
           request_type TEXT DEFAULT 'chat',
@@ -104,5 +111,6 @@ export function ensureUsageLogIndexes(sqlite: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_usage_logs_user_period ON usage_logs(user_id, billing_period);
     CREATE INDEX IF NOT EXISTS idx_usage_logs_created ON usage_logs(created_at);
     CREATE INDEX IF NOT EXISTS idx_usage_logs_session_key ON usage_logs(session_key);
+    CREATE INDEX IF NOT EXISTS idx_usage_logs_packet_attempt ON usage_logs(packet_id, attempt);
   `);
 }

--- a/src/lib/db/usage.ts
+++ b/src/lib/db/usage.ts
@@ -11,7 +11,8 @@ import { randomUUID } from 'node:crypto';
 
 // ── Types ──
 
-export type Provider = 'anthropic' | 'openai' | 'google' | 'openrouter';
+export type Provider = 'anthropic' | 'openai' | 'google' | 'openrouter' | 'opencode' | 'runtime';
+export type UsageRole = 'orchestrator' | 'worker' | 'reviewer' | 'compaction' | 'retrieval' | 'other';
 
 export interface LogUsageInput {
   /** Null for operator-level local spend (house convention: such rows are
@@ -25,6 +26,14 @@ export interface LogUsageInput {
   cacheWriteTokens?: number;
   costUsd: number;
   sessionKey?: string;
+  repoPath?: string | null;
+  laneId?: string | null;
+  packetId?: string | null;
+  missionId?: string | null;
+  role?: UsageRole | null;
+  attempt?: number;
+  runId?: string | null;
+  metadata?: Record<string, unknown> | null;
   agentName?: string;
   requestType?: 'chat' | 'completion' | 'embedding';
 }
@@ -63,6 +72,14 @@ export function logUsage(input: LogUsageInput): void {
     cacheWriteTokens: input.cacheWriteTokens ?? 0,
     costUsd: input.costUsd,
     sessionKey: input.sessionKey ?? null,
+    repoPath: input.repoPath ?? null,
+    laneId: input.laneId ?? null,
+    packetId: input.packetId ?? null,
+    missionId: input.missionId ?? null,
+    role: input.role ?? null,
+    attempt: Math.max(1, Math.round(input.attempt ?? 1)),
+    runId: input.runId ?? null,
+    metadataJson: input.metadata ? JSON.stringify(input.metadata) : null,
     agentName: input.agentName ?? null,
     requestType: input.requestType ?? 'chat',
     billingPeriod: currentBillingPeriod(),

--- a/src/lib/db/v57-cost-ledger-attribution-migration.test.ts
+++ b/src/lib/db/v57-cost-ledger-attribution-migration.test.ts
@@ -1,0 +1,68 @@
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+import { ensureV57CostLedgerAttributionSchema } from './v57-cost-ledger-attribution-migration';
+
+function usageColumns(sqlite: Database.Database) {
+  return sqlite.prepare('PRAGMA table_info(usage_logs)').all() as Array<{
+    name: string;
+    notnull: number;
+    dflt_value: string | null;
+  }>;
+}
+
+describe('v57 cost ledger attribution migration', () => {
+  it('upgrades a previous-version table without inventing legacy attribution', () => {
+    const sqlite = new Database(':memory:');
+    try {
+      sqlite.exec(`
+        CREATE TABLE usage_logs (
+          id TEXT PRIMARY KEY,
+          model TEXT NOT NULL,
+          provider TEXT NOT NULL,
+          input_tokens INTEGER NOT NULL DEFAULT 0,
+          output_tokens INTEGER NOT NULL DEFAULT 0,
+          cost_usd REAL NOT NULL DEFAULT 0,
+          billing_period TEXT NOT NULL
+        );
+        INSERT INTO usage_logs (id, model, provider, billing_period)
+        VALUES ('legacy-row', 'legacy-model', 'runtime', '2026-08');
+      `);
+
+      ensureV57CostLedgerAttributionSchema(sqlite);
+      ensureV57CostLedgerAttributionSchema(sqlite);
+
+      const row = sqlite.prepare(`
+        SELECT lane_id, packet_id, mission_id, role, attempt, run_id, metadata_json
+        FROM usage_logs WHERE id = 'legacy-row'
+      `).get();
+      expect(row).toEqual({
+        lane_id: null,
+        packet_id: null,
+        mission_id: null,
+        role: null,
+        attempt: 1,
+        run_id: null,
+        metadata_json: null,
+      });
+      expect(usageColumns(sqlite).find((column) => column.name === 'attempt')).toMatchObject({
+        notnull: 1,
+        dflt_value: '1',
+      });
+      expect(sqlite.prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_usage_logs_packet_attempt'",
+      ).get()).toEqual({ name: 'idx_usage_logs_packet_attempt' });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it('creates no partial schema when the base table does not exist', () => {
+    const sqlite = new Database(':memory:');
+    try {
+      ensureV57CostLedgerAttributionSchema(sqlite);
+      expect(usageColumns(sqlite)).toEqual([]);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/src/lib/db/v57-cost-ledger-attribution-migration.ts
+++ b/src/lib/db/v57-cost-ledger-attribution-migration.ts
@@ -1,0 +1,41 @@
+import type Database from 'better-sqlite3';
+
+const USAGE_LOG_COLUMNS = [
+  ['lane_id', 'TEXT'],
+  ['packet_id', 'TEXT'],
+  ['mission_id', 'TEXT'],
+  ['role', 'TEXT'],
+  ['attempt', 'INTEGER NOT NULL DEFAULT 1'],
+  ['run_id', 'TEXT'],
+  ['metadata_json', 'TEXT'],
+] as const;
+
+function columnExists(sqlite: Database.Database, column: string): boolean {
+  const columns = sqlite.prepare('PRAGMA table_info(usage_logs)').all() as Array<{ name: string }>;
+  return columns.some((candidate) => candidate.name === column);
+}
+
+function addColumnTolerant(sqlite: Database.Database, column: string, definition: string): void {
+  if (columnExists(sqlite, column)) return;
+  try {
+    sqlite.exec(`ALTER TABLE usage_logs ADD COLUMN ${column} ${definition}`);
+  } catch (error) {
+    if (error instanceof Error && /duplicate column name/i.test(error.message)) return;
+    throw error;
+  }
+}
+
+/** Schema v57: packet, attempt, run, and role attribution for metered model calls. */
+export function ensureV57CostLedgerAttributionSchema(sqlite: Database.Database): void {
+  const table = sqlite.prepare(
+    "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'usage_logs'",
+  ).get() as { present: number } | undefined;
+  if (!table) return;
+
+  for (const [column, definition] of USAGE_LOG_COLUMNS) {
+    addColumnTolerant(sqlite, column, definition);
+  }
+  sqlite.exec(
+    'CREATE INDEX IF NOT EXISTS idx_usage_logs_packet_attempt ON usage_logs(packet_id, attempt)',
+  );
+}

--- a/src/lib/lane/reap-sessions.ts
+++ b/src/lib/lane/reap-sessions.ts
@@ -267,6 +267,8 @@ export async function archiveLaneSessions(lanes: Lane[]): Promise<LaneSessionArc
         repoPath: lanes.find((lane) => lane.id === target.laneId)?.worktreePath
           ?? lanes.find((lane) => lane.id === target.laneId)?.repoPath
           ?? process.cwd(),
+        laneId: target.laneId,
+        packetId: lanes.find((lane) => lane.id === target.laneId)?.packetId ?? null,
       });
       let result: { archived?: boolean } | null = null;
       const registeredLifecycle = getOwnedSessionLifecycle(target.sessionKey);

--- a/src/lib/orchestrator/auto-compact.test.ts
+++ b/src/lib/orchestrator/auto-compact.test.ts
@@ -1,0 +1,72 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+
+const testRoot = mkdtempSync(join(os.tmpdir(), 'o8-auto-compact-cost-'));
+const dataDir = join(testRoot, 'data');
+const repoPath = join(testRoot, 'repo');
+const fakeCodex = join(testRoot, 'fake-codex.mjs');
+const threadId = 'thoughts-auto-compact-cost';
+
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.O8_CODEX_BIN = fakeCodex;
+mkdirSync(join(dataDir, 'chat-history'), { recursive: true });
+mkdirSync(repoPath, { recursive: true });
+writeFileSync(fakeCodex, [
+  '#!/usr/bin/env node',
+  "console.log(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 321, output_tokens: 45 } }));",
+  "console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'Decisions made\\n- Keep the ledger complete.\\nFiles touched\\n- None.\\nOpen questions\\n- None.\\nCurrent mission state\\n- Continue.' } }));",
+].join('\n'));
+chmodSync(fakeCodex, 0o755);
+writeFileSync(join(dataDir, 'chat-history', `${threadId}.json`), JSON.stringify({
+  repoPath,
+  messages: Array.from({ length: 6 }, (_, index) => ({
+    id: `message-${index}`,
+    role: index % 2 === 0 ? 'user' : 'assistant',
+    content: `Message ${index}`,
+    timestamp: index + 1,
+  })),
+}));
+
+const { getSqlite } = await import('@/lib/db');
+const { autoCompactOrchestratorThread } = await import('./auto-compact');
+
+afterAll(() => {
+  delete process.env.O8_CODEX_BIN;
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+describe('auto compaction cost ledger', () => {
+  it('writes one compaction-role usage row from Codex telemetry', async () => {
+    const result = await autoCompactOrchestratorThread({
+      repoPath,
+      threadId,
+      keepTailCount: 2,
+      trigger: 'manual',
+      force: true,
+    });
+    expect(result.applied).toBe(true);
+
+    const rows = getSqlite().prepare(`
+      SELECT role, input_tokens, output_tokens, cost_usd, metadata_json
+      FROM usage_logs WHERE role = 'compaction'
+    `).all() as Array<{
+      role: string;
+      input_tokens: number;
+      output_tokens: number;
+      cost_usd: number;
+      metadata_json: string;
+    }>;
+    expect(rows).toEqual([expect.objectContaining({
+      role: 'compaction',
+      input_tokens: 321,
+      output_tokens: 45,
+      cost_usd: 0,
+    })]);
+    expect(JSON.parse(rows[0]!.metadata_json)).toEqual({
+      estimated: false,
+      source: 'codex_turn_completed',
+    });
+  });
+});

--- a/src/lib/orchestrator/auto-compact.ts
+++ b/src/lib/orchestrator/auto-compact.ts
@@ -8,6 +8,7 @@ import { MODEL_IDS } from '@/lib/models';
 import { getDataDir } from '@/lib/data-dir-migration';
 import { cliInvocation } from '@/lib/runtimes/shared/cli-spawn';
 import { getCanonicalChatHistoryPath, persistCanonicalChatHistoryRecord } from '@/lib/llm/chat-history-store';
+import { logUsage } from '@/lib/db/usage';
 const HISTORY_DIR = path.join(getDataDir(), 'chat-history');
 const ARCHIVE_DIR = path.join(getDataDir(), 'orchestrator-archives');
 const inFlight = new Map<string, Promise<AutoCompactResult>>();
@@ -147,7 +148,14 @@ function splitCompactionWindow(transcript: MobileTranscriptEntry[], compactedCou
  * `--skip-git-repo-check` so codex doesn't refuse on untrusted repos (the
  * summary doesn't need git context at all).
  */
-async function summarizeWithCodex(repoPath: string, prompt: string) {
+type CodexSummaryResult = {
+  text: string;
+  inputTokens: number;
+  outputTokens: number;
+  estimated: boolean;
+};
+
+async function summarizeWithCodex(repoPath: string, prompt: string): Promise<CodexSummaryResult> {
   const { resolveCli } = await import('@/lib/runtimes/shared/cli-resolver');
   const codexBin = (await resolveCli({
     runtimeId: 'codex',
@@ -162,7 +170,7 @@ async function summarizeWithCodex(repoPath: string, prompt: string) {
   // injection surface. Send it on stdin there instead — the same way the Brain's
   // codex adapter has always fed `codex exec`. POSIX keeps argv unchanged.
   const promptOnStdin = process.platform === 'win32';
-  return await new Promise<string>((resolve, reject) => {
+  return await new Promise<CodexSummaryResult>((resolve, reject) => {
     const launch = cliInvocation(codexBin, [
       'exec',
       '--json',
@@ -194,6 +202,8 @@ async function summarizeWithCodex(repoPath: string, prompt: string) {
     let buffer = '';
     let stderr = '';
     let result = '';
+    let inputTokens: number | null = null;
+    let outputTokens: number | null = null;
     // stdio[1]/stdio[2] are always 'pipe' above; only stdin varies by platform,
     // which is enough to cost the tuple its literal type.
     child.stdout!.on('data', (chunk: Buffer) => {
@@ -211,6 +221,10 @@ async function summarizeWithCodex(repoPath: string, prompt: string) {
           const item = parsed.item as Record<string, unknown> | undefined;
           if (parsed.type === 'item.completed' && item?.type === 'agent_message' && typeof item.text === 'string') {
             result = item.text;
+          } else if (parsed.type === 'turn.completed') {
+            const usage = parsed.usage as Record<string, unknown> | undefined;
+            if (typeof usage?.input_tokens === 'number') inputTokens = usage.input_tokens;
+            if (typeof usage?.output_tokens === 'number') outputTokens = usage.output_tokens;
           } else if (parsed.type === 'event_msg') {
             const payload = parsed.payload as Record<string, unknown> | undefined;
             if (payload?.type === 'agent_message' && typeof payload.message === 'string') {
@@ -226,10 +240,44 @@ async function summarizeWithCodex(repoPath: string, prompt: string) {
     child.once('error', reject);
     child.once('close', (code) => {
       const text = result.trim();
-      if (code === 0 && text) resolve(text);
+      if (code === 0 && text) resolve({
+        text,
+        inputTokens: inputTokens ?? approxTokens(prompt),
+        outputTokens: outputTokens ?? approxTokens(text),
+        estimated: inputTokens === null || outputTokens === null,
+      });
       else reject(new Error(stderr.trim() || `Codex compaction failed (${code ?? 'unknown'})`));
     });
   });
+}
+
+function recordCompactionUsage(
+  repoPath: string,
+  threadId: string | null,
+  result: CodexSummaryResult,
+  compactedAt: Date,
+): void {
+  try {
+    logUsage({
+      userId: null,
+      model: ORCHESTRATOR_COMPACTION_PROVENANCE.model,
+      provider: 'openai',
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+      costUsd: 0,
+      sessionKey: `compaction:${threadId ?? 'orchestrator'}:${compactedAt.getTime()}`,
+      repoPath,
+      agentName: 'orchestrator-compaction',
+      requestType: 'completion',
+      role: 'compaction',
+      metadata: {
+        estimated: result.estimated,
+        source: result.estimated ? 'chars_per_four' : 'codex_turn_completed',
+      },
+    });
+  } catch (error) {
+    console.warn('[auto-compact] usage ledger write failed:', error);
+  }
 }
 // ── digest() — Fable Slice 5 (2026-07-02) ────────────────────────────────────
 
@@ -260,7 +308,7 @@ export async function digest(text: string, repoPath: string): Promise<DigestResu
   const capped = truncatedInput
     ? `${trimmed.slice(0, DIGEST_INPUT_CHAR_CAP)}\n[... input truncated at ${DIGEST_INPUT_CHAR_CAP} chars ...]`
     : trimmed;
-  const summary = await summarizeWithCodex(repoPath, [
+  const summaryResult = await summarizeWithCodex(repoPath, [
     'Digest the following material into the smallest faithful summary a decision-maker can act on. Use exactly these sections with terse bullets:',
     'What this is',
     'Key facts / findings',
@@ -270,6 +318,7 @@ export async function digest(text: string, repoPath: string): Promise<DigestResu
     '',
     capped,
   ].join('\n'));
+  const summary = summaryResult.text;
   return {
     digest: summary,
     approxInputTokens: approxTokens(capped),
@@ -323,7 +372,9 @@ export async function autoCompactOrchestratorThread(input: {
     }
     const compactedAt = new Date();
     const compactedStamp = fmtStamp(compactedAt);
-    const summary = await summarizeWithCodex(repoPath, ['Summarize this orchestrator thread segment using exactly these sections and terse bullets:', 'Decisions made', 'Files touched', 'Open questions', 'Current mission state', 'Use file paths verbatim. If a section is empty, write "- None."', '', buildExcerpt(compactedTurns, 90_000)].join('\n'));
+    const summaryResult = await summarizeWithCodex(repoPath, ['Summarize this orchestrator thread segment using exactly these sections and terse bullets:', 'Decisions made', 'Files touched', 'Open questions', 'Current mission state', 'Use file paths verbatim. If a section is empty, write "- None."', '', buildExcerpt(compactedTurns, 90_000)].join('\n'));
+    const summary = summaryResult.text;
+    recordCompactionUsage(repoPath, thread?.tabId ?? input.threadId?.trim() ?? null, summaryResult, compactedAt);
     const displaySummary = `<compacted_context turns="${compactedTurns.length}" at="${compactedStamp}">\n${summary}\n</compacted_context>`;
     const compactionEntry: MobileTranscriptEntry = {
       id: `orch-compaction-${compactedAt.getTime()}`,

--- a/src/lib/orchestrator/context-relay-review.ts
+++ b/src/lib/orchestrator/context-relay-review.ts
@@ -1,0 +1,50 @@
+import { listApprovalsForContext } from '@/lib/approvals/store';
+import type { ApprovalRecord, OrchestratorReviewFinding } from '@/lib/approvals/types';
+import type { Lane } from '@/lib/lane/types';
+
+export function isReviewFinding(value: unknown): value is OrchestratorReviewFinding {
+  if (!value || typeof value !== 'object') return false;
+
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.file === 'string'
+    && typeof candidate.description === 'string'
+    && (candidate.line === undefined || (typeof candidate.line === 'number' && Number.isFinite(candidate.line)))
+    && (candidate.severity === 'bug' || candidate.severity === 'rule_violation' || candidate.severity === 'note')
+    && (candidate.resolution === 'fixed' || candidate.resolution === 'accepted' || candidate.resolution === 'deferred')
+    && (candidate.fixSuggestion === undefined || typeof candidate.fixSuggestion === 'string');
+}
+
+function reviewVerdictTimestamp(approval: ApprovalRecord): number {
+  for (let index = approval.audit.length - 1; index >= 0; index -= 1) {
+    const event = approval.audit[index];
+    if (event?.type === 'orchestrator_review') return event.timestamp;
+  }
+  return approval.resolvedAt ?? approval.updatedAt;
+}
+
+export function readLatestPersistedReview(
+  context: { packetId: string; sessionKey: string },
+  lane: Lane,
+): { approved: boolean; findings: OrchestratorReviewFinding[] } | null {
+  const approval = listApprovalsForContext({
+    packetId: context.packetId,
+    laneId: lane.id,
+    sessionKey: context.sessionKey,
+  }).filter((candidate) => (
+    candidate.toolName === 'orchestrator_review'
+    && candidate.args?.reviewSuperseded !== true
+    && typeof candidate.args?.approved === 'boolean'
+  )).sort((left, right) => (
+    reviewVerdictTimestamp(right) - reviewVerdictTimestamp(left)
+    || right.createdAt - left.createdAt
+    || right.id.localeCompare(left.id)
+  ))[0];
+  if (!approval || typeof approval.args?.approved !== 'boolean') return null;
+
+  return {
+    approved: approval.args.approved,
+    findings: Array.isArray(approval.args.findings)
+      ? approval.args.findings.filter(isReviewFinding)
+      : [],
+  };
+}

--- a/src/lib/orchestrator/context-relay.ts
+++ b/src/lib/orchestrator/context-relay.ts
@@ -1,7 +1,7 @@
 import { asc, eq, or } from 'drizzle-orm';
 import { listApprovalsForContext } from '@/lib/approvals/store';
 import type { ApprovalAuditEvent, OrchestratorReviewFinding } from '@/lib/approvals/types';
-import { getDb, laneEvents, sessionOutcomes } from '@/lib/db';
+import { getDb, laneEvents, sessionOutcomes, usageLogs } from '@/lib/db';
 import { getLaneSpokenDiffFacts } from '@/lib/lane/lane-diff-facts';
 import { findLaneByPacket } from '@/lib/lane/registry';
 import type { Lane } from '@/lib/lane/types';
@@ -33,6 +33,11 @@ import type { RuntimeId, RuntimeTranscriptEntry } from '@/lib/runtimes/types';
 import { getActiveProjectScopeForRepoSync } from '@/lib/repos/projects';
 import { truncateText } from '@/lib/util/text';
 import { syncTranscriptSearchDocument } from '@/lib/search/transcripts';
+import { derivePacketAttemptIndex } from '@/lib/orchestrator/cost-attribution';
+import {
+  isReviewFinding,
+  readLatestPersistedReview,
+} from '@/lib/orchestrator/context-relay-review';
 
 const TRANSCRIPT_CAPTURE_LIMIT = 5_000;
 const SUMMARY_LIMIT = 1_200;
@@ -220,20 +225,6 @@ function buildPacketSummary(input: {
 async function findAgentSummary(sessionKey: string): Promise<AgentSummary | null> {
   const snapshot = await getRuntimeInventorySnapshot({ fresh: true });
   return snapshot.agents.find((agent) => agent.sessionKey === sessionKey) ?? null;
-}
-
-function isReviewFinding(value: unknown): value is OrchestratorReviewFinding {
-  if (!value || typeof value !== 'object') {
-    return false;
-  }
-
-  const candidate = value as Record<string, unknown>;
-  return typeof candidate.file === 'string'
-    && typeof candidate.description === 'string'
-    && (candidate.line === undefined || (typeof candidate.line === 'number' && Number.isFinite(candidate.line)))
-    && (candidate.severity === 'bug' || candidate.severity === 'rule_violation' || candidate.severity === 'note')
-    && (candidate.resolution === 'fixed' || candidate.resolution === 'accepted' || candidate.resolution === 'deferred')
-    && (candidate.fixSuggestion === undefined || typeof candidate.fixSuggestion === 'string');
 }
 
 function toPacketReviewContext(review: {
@@ -645,6 +636,18 @@ async function persistSessionOutcome(
   // Outcome derivation remains coarse at capture time, but a present failed
   // receipt must not be promoted to success. Merge later stamps mergedClean.
   const outcome = outcomeFromPacketSelfReview(context.selfReview);
+  const usage = db.select({
+    inputTokens: usageLogs.inputTokens,
+    outputTokens: usageLogs.outputTokens,
+    costUsd: usageLogs.costUsd,
+  }).from(usageLogs).where(eq(usageLogs.packetId, context.packetId)).all();
+  const totalTokens = usage.reduce(
+    (sum, row) => sum + Math.max(0, row.inputTokens) + Math.max(0, row.outputTokens),
+    0,
+  );
+  const costUsd = Number(usage.reduce((sum, row) => sum + Math.max(0, row.costUsd), 0).toFixed(6));
+  const attempts = derivePacketAttemptIndex({ packetId: context.packetId, laneId: lane.id });
+  const latestReview = readLatestPersistedReview(context, lane) ?? context.review;
 
   try {
     await db.insert(sessionOutcomes).values({
@@ -663,10 +666,13 @@ async function persistSessionOutcome(
       startedAt: start.startedAt,
       completedAt,
       durationMs: start.durationMs,
-      // mergedClean / reviewApproved / reviewFindingsCount left at defaults;
-      // the merge handler stamps mergedClean via markOutcomeMerged() below
-      // when the packet's branch actually lands on main. Without that hop the
-      // routing recommender (#747) never sees a scoreable signal.
+      totalTokens,
+      costUsd,
+      attempts,
+      reviewApproved: latestReview?.approved ?? false,
+      reviewFindingsCount: latestReview?.findings.length ?? 0,
+      // mergedClean stays NULL until the merge handler stamps it via
+      // markOutcomeMerged() below when the packet branch lands on main.
     }).onConflictDoNothing();
     // New ledger row — cached "what shipped"-style Q&A answers are now stale.
     // Lazy import keeps the qa module out of this file's cold-start graph.

--- a/src/lib/orchestrator/cost-aggregator.test.ts
+++ b/src/lib/orchestrator/cost-aggregator.test.ts
@@ -84,4 +84,87 @@ describe('aggregateMissionCost', () => {
     });
     expect(result.totalCostUsd).toBe(0);
   });
+
+  it('uses newer live totals while retaining persisted per-role subtotals', async () => {
+    const sessionKey = 'codex:live-over-persisted';
+    const packet = stubPacket({
+      lane: {
+        tileId: 'live-tile',
+        tabId: 'live-tab',
+        repoPath: null,
+        runtime: 'codex',
+        sessionKey,
+      },
+    });
+    const [{ getRuntime }, { registerRuntime }, { logUsage }] = await Promise.all([
+      import('@/lib/runtimes'),
+      import('@/lib/runtimes/registry'),
+      import('@/lib/db/usage'),
+    ]);
+    const originalRuntime = getRuntime('codex');
+    logUsage({
+      userId: null,
+      model: 'persisted-model',
+      provider: 'openai',
+      inputTokens: 100,
+      outputTokens: 20,
+      costUsd: 0.1,
+      sessionKey,
+      packetId: packet.id,
+      role: 'worker',
+      attempt: 1,
+    });
+    logUsage({
+      userId: null,
+      model: 'persisted-model',
+      provider: 'openai',
+      inputTokens: 40,
+      outputTokens: 10,
+      costUsd: 0.05,
+      sessionKey,
+      packetId: packet.id,
+      role: 'reviewer',
+      attempt: 2,
+    });
+    registerRuntime({
+      ...originalRuntime!,
+      capabilities: { ...originalRuntime!.capabilities, costTelemetry: true },
+      getTelemetry: async () => ({
+        inputTokens: 500,
+        outputTokens: 100,
+        estimatedCostUsd: 1.5,
+        model: 'live-model',
+        costSource: 'gateway',
+      }),
+    });
+
+    try {
+      const result = await aggregateMissionCost(stubState(packet));
+
+      expect(result).toMatchObject({
+        totalCostUsd: 1.5,
+        packetCosts: [{
+          inputTokens: 500,
+          outputTokens: 100,
+          totalCostUsd: 1.5,
+          model: 'live-model',
+          costSource: 'gateway',
+        }],
+      });
+      expect(result.costByRole.worker).toEqual({
+        inputTokens: 100,
+        outputTokens: 20,
+        totalCostUsd: 0.1,
+        requestCount: 1,
+      });
+      expect(result.costByRole.reviewer).toEqual({
+        inputTokens: 40,
+        outputTokens: 10,
+        totalCostUsd: 0.05,
+        requestCount: 1,
+      });
+    } finally {
+      if (originalRuntime) registerRuntime(originalRuntime);
+    }
+  });
 });

--- a/src/lib/orchestrator/cost-aggregator.ts
+++ b/src/lib/orchestrator/cost-aggregator.ts
@@ -1,5 +1,6 @@
 import { getRuntime } from '@/lib/runtimes';
-import { readPersistedSessionCost } from '@/lib/orchestrator/cost-persistence';
+import { readPersistedSessionCosts } from '@/lib/orchestrator/cost-persistence';
+import type { UsageRole } from '@/lib/db/usage';
 import { resolveRuntimeSessionIdentityId } from '@/lib/runtime/session-identity';
 import { runtimeIdFromSessionKey } from '@/lib/runtime/transcript';
 import { isOrchestratorRuntime } from '@/lib/orchestrator/runtime-capabilities';
@@ -26,10 +27,18 @@ export interface RuntimeTokenSummary {
   packetCount: number;
 }
 
+export interface RoleCostSummary {
+  inputTokens: number;
+  outputTokens: number;
+  totalCostUsd: number;
+  requestCount: number;
+}
+
 export interface MissionCostSummary {
   totalCostUsd: number;
   packetCosts: PacketCostSummary[];
   tokensByRuntime: Record<OrchestratorRuntime, RuntimeTokenSummary>;
+  costByRole: Record<UsageRole, RoleCostSummary>;
   /** Usage from a session shared by multiple packets; never guessed onto one packet. */
   unattributed: {
     sessionCount: number;
@@ -64,6 +73,9 @@ type CachedTelemetrySummary = {
   model: string | null;
   hasTelemetry: boolean;
   costSource: PacketCostSource;
+  /** undefined means live telemetry may inherit packet context; null means a persisted row is explicitly unattributed. */
+  persistedPacketId?: string | null;
+  costByRole: Record<UsageRole, RoleCostSummary>;
 };
 
 type AttributedSessionCost = CachedTelemetrySummary & {
@@ -86,6 +98,21 @@ function emptyRuntimeTokenSummary(): RuntimeTokenSummary {
     outputTokens: 0,
     totalCostUsd: 0,
     packetCount: 0,
+  };
+}
+
+function emptyRoleCostSummary(): RoleCostSummary {
+  return { inputTokens: 0, outputTokens: 0, totalCostUsd: 0, requestCount: 0 };
+}
+
+function emptyCostByRole(): Record<UsageRole, RoleCostSummary> {
+  return {
+    orchestrator: emptyRoleCostSummary(),
+    worker: emptyRoleCostSummary(),
+    reviewer: emptyRoleCostSummary(),
+    compaction: emptyRoleCostSummary(),
+    retrieval: emptyRoleCostSummary(),
+    other: emptyRoleCostSummary(),
   };
 }
 
@@ -194,6 +221,15 @@ async function resolveSessionTelemetry(
           model: telemetry.model?.trim() || null,
           hasTelemetry: true,
           costSource: telemetry.costSource ?? 'estimate',
+          costByRole: {
+            ...emptyCostByRole(),
+            worker: {
+              inputTokens: toFiniteNumber(telemetry.inputTokens),
+              outputTokens: toFiniteNumber(telemetry.outputTokens),
+              totalCostUsd: roundUsd(toFiniteNumber(telemetry.estimatedCostUsd)),
+              requestCount: 1,
+            },
+          },
         };
       }
     } catch (error) {
@@ -201,10 +237,38 @@ async function resolveSessionTelemetry(
     }
   }
 
-  const persisted = resolved ? null : readPersistedSessionCost(sessionKey);
-  const next = resolved ?? (persisted
-    ? { ...persisted, identityId, hasTelemetry: true }
-    : {
+  const persistedRows = readPersistedSessionCosts(sessionKey);
+  if (persistedRows.length > 0) {
+    const costByRole = emptyCostByRole();
+    for (const row of persistedRows) {
+      const role = row.role ?? 'other';
+      const subtotal = costByRole[role];
+      subtotal.inputTokens += row.inputTokens;
+      subtotal.outputTokens += row.outputTokens;
+      subtotal.totalCostUsd = roundUsd(subtotal.totalCostUsd + row.totalCostUsd);
+      subtotal.requestCount += 1;
+    }
+    const packetIds = new Set(persistedRows.map((row) => row.packetId));
+    const persistedPacketId = packetIds.size === 1 ? [...packetIds][0] : null;
+    if (resolved) {
+      resolved = { ...resolved, persistedPacketId, costByRole };
+    } else {
+      const models = new Set(persistedRows.map((row) => row.model).filter((model): model is string => Boolean(model)));
+      resolved = {
+        identityId,
+        inputTokens: persistedRows.reduce((sum, row) => sum + row.inputTokens, 0),
+        outputTokens: persistedRows.reduce((sum, row) => sum + row.outputTokens, 0),
+        totalCostUsd: roundUsd(persistedRows.reduce((sum, row) => sum + row.totalCostUsd, 0)),
+        model: models.size === 1 ? [...models][0] : models.size > 1 ? 'mixed' : null,
+        hasTelemetry: true,
+        costSource: persistedRows.some((row) => row.costSource === 'gateway') ? 'gateway' : 'estimate',
+        persistedPacketId,
+        costByRole,
+      };
+    }
+  }
+
+  const next = resolved ?? {
         identityId,
         inputTokens: 0,
         outputTokens: 0,
@@ -212,7 +276,8 @@ async function resolveSessionTelemetry(
         model: null,
         hasTelemetry: false,
         costSource: 'unknown',
-      });
+        costByRole: emptyCostByRole(),
+      };
   cache.set(sessionKey, next);
   return next;
 }
@@ -257,7 +322,11 @@ async function resolvePacketTelemetry(
     claimedSessionKeys.add(sessionKey);
     const runtime = runtimeFromSessionKey(sessionKey) ?? candidate.runtime;
     const telemetry = await resolveSessionTelemetry(sessionKey, runtime, cache);
-    sessionCosts.push({ ...telemetry, packetId: packet.id, sessionKey, runtime });
+    const resolvedPacketId = telemetry.persistedPacketId === undefined
+      ? packet.id
+      : telemetry.persistedPacketId;
+    sessionCosts.push({ ...telemetry, packetId: resolvedPacketId, sessionKey, runtime });
+    if (resolvedPacketId !== packet.id) continue;
     inputTokens += telemetry.inputTokens;
     outputTokens += telemetry.outputTokens;
     totalCostUsd += telemetry.totalCostUsd;
@@ -334,6 +403,7 @@ export async function aggregateMissionCost(
         model: null,
         hasTelemetry: false,
         costSource: 'unknown',
+        costByRole: emptyCostByRole(),
         packetId: null,
         sessionKey,
         runtime,
@@ -373,10 +443,18 @@ export async function aggregateMissionCost(
     outputTokens: 0,
     totalCostUsd: 0,
   };
+  const costByRole = emptyCostByRole();
   const countedPacketRuntimes = new Set<string>();
 
   for (const sessionCost of attributedSessionCosts) {
     totalCostUsd += sessionCost.totalCostUsd;
+    for (const [role, subtotal] of Object.entries(sessionCost.costByRole) as Array<[UsageRole, RoleCostSummary]>) {
+      const roleTotal = costByRole[role];
+      roleTotal.inputTokens += subtotal.inputTokens;
+      roleTotal.outputTokens += subtotal.outputTokens;
+      roleTotal.totalCostUsd = roundUsd(roleTotal.totalCostUsd + subtotal.totalCostUsd);
+      roleTotal.requestCount += subtotal.requestCount;
+    }
 
     if (sessionCost.packetId === null) {
       unattributed.sessionCount += 1;
@@ -407,6 +485,7 @@ export async function aggregateMissionCost(
     totalCostUsd: roundUsd(totalCostUsd),
     packetCosts,
     tokensByRuntime,
+    costByRole,
     unattributed,
   };
 }

--- a/src/lib/orchestrator/cost-attribution.test.ts
+++ b/src/lib/orchestrator/cost-attribution.test.ts
@@ -1,0 +1,75 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+
+const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-cost-attribution-'));
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+
+const { appendEvent, attachSession, createLane, setLaneStatus } = await import('@/lib/lane/registry');
+const { derivePacketAttemptIndex } = await import('./cost-attribution');
+
+afterAll(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('derivePacketAttemptIndex', () => {
+  function recordSuccessfulLaunch(laneId: string, sessionKey: string) {
+    attachSession(laneId, sessionKey, 'system');
+    setLaneStatus(laneId, 'running', 'system', 'session_launched');
+  }
+
+  it('counts a rerun replacement launch once without counting the retry signal again', () => {
+    const packetId = 'packet-attempt-events';
+    const first = createLane({
+      repoPath: dataDir,
+      branch: 'fix/attempt-first',
+      runtime: 'codex',
+      packetId,
+    });
+    recordSuccessfulLaunch(first.id, 'codex-owned:attempt-first');
+    expect(derivePacketAttemptIndex({ packetId, laneId: first.id })).toBe(1);
+    appendEvent(first.id, 'typecheck_auto_retry', 'system', { packetId });
+
+    const rerun = createLane({
+      repoPath: dataDir,
+      branch: 'fix/attempt-rerun',
+      runtime: 'codex',
+      packetId,
+    });
+    recordSuccessfulLaunch(rerun.id, 'codex-owned:attempt-rerun');
+    expect(derivePacketAttemptIndex({ packetId, laneId: rerun.id })).toBe(2);
+  });
+
+  it('counts a warm-session steer as a separate attempt without a launch', () => {
+    const packetId = 'packet-steer-events';
+    const lane = createLane({
+      repoPath: dataDir,
+      branch: 'fix/attempt-steer',
+      runtime: 'codex',
+      packetId,
+    });
+    recordSuccessfulLaunch(lane.id, 'codex-owned:attempt-steer');
+    appendEvent(lane.id, 'steered_packet', 'orchestrator', { packetId, source: 'operator' });
+
+    expect(derivePacketAttemptIndex({ packetId, laneId: lane.id })).toBe(2);
+  });
+
+  it('deduplicates two launch receipts emitted in the same lane window', () => {
+    const packetId = 'packet-fallback-events';
+    const lane = createLane({
+      repoPath: dataDir,
+      branch: 'fix/attempt-fallback',
+      runtime: 'codex',
+      packetId,
+    });
+    attachSession(lane.id, 'codex-owned:attempt-fallback', 'system');
+    setLaneStatus(lane.id, 'running', 'system', 'worker_quota_fallback_launched');
+    appendEvent(lane.id, 'worker_fallback', 'system', {
+      packetId,
+      status: 'redispatched',
+    });
+
+    expect(derivePacketAttemptIndex({ packetId, laneId: lane.id })).toBe(1);
+  });
+});

--- a/src/lib/orchestrator/cost-attribution.ts
+++ b/src/lib/orchestrator/cost-attribution.ts
@@ -1,0 +1,73 @@
+import { getSqlite } from '@/lib/db';
+
+type AttemptContext = {
+  packetId?: string | null;
+  laneId?: string | null;
+};
+
+/**
+ * Derive the one-based packet attempt from durable lane events.
+ *
+ * A successful session launch starts an attempt. A warm-session steer starts
+ * another attempt without producing a new session key. Fresh reruns create a
+ * new lane whose open event keeps the packet id, so their launch is counted
+ * across the packet's full lane history.
+ */
+export function derivePacketAttemptIndex(context: AttemptContext): number {
+  const packetId = context.packetId?.trim() || null;
+  const laneId = context.laneId?.trim() || null;
+  if (!packetId && !laneId) return 1;
+
+  const sqlite = getSqlite();
+  const laneIds = new Set<string>(laneId ? [laneId] : []);
+  if (packetId) {
+    const openRows = sqlite.prepare(`
+      SELECT lane_id FROM lane_events
+      WHERE verb = 'open_lane'
+        AND json_extract(payload_json, '$.packetId') = ?
+    `).all(packetId) as Array<{ lane_id: string }>;
+    for (const row of openRows) laneIds.add(row.lane_id);
+    const currentRows = sqlite.prepare('SELECT id FROM lanes WHERE packet_id = ?').all(packetId) as Array<{ id: string }>;
+    for (const row of currentRows) laneIds.add(row.id);
+  }
+  if (laneIds.size === 0) return 1;
+
+  const placeholders = [...laneIds].map(() => '?').join(', ');
+  const row = sqlite.prepare(`
+    WITH relevant_events AS (
+      SELECT id, lane_id, verb, payload_json, timestamp
+      FROM lane_events
+      WHERE lane_id IN (${placeholders})
+        AND (
+          verb IN ('session_launched', 'steered_packet')
+          OR (verb = 'worker_fallback' AND json_extract(payload_json, '$.status') = 'redispatched')
+          OR (
+            verb = 'status_change'
+            AND json_extract(payload_json, '$.eventLabel') IN (
+              'session_launched',
+              'session_launch_recovered',
+              'worker_quota_fallback_launched'
+            )
+          )
+        )
+    ), ordered_launch_signals AS (
+      SELECT
+        lane_id,
+        julianday(timestamp) * 86400000 AS timestamp_ms,
+        LAG(julianday(timestamp) * 86400000) OVER (
+          PARTITION BY lane_id ORDER BY timestamp, id
+        ) AS previous_timestamp_ms
+      FROM relevant_events
+      WHERE verb != 'steered_packet'
+    ), launch_windows AS (
+      SELECT COUNT(*) AS launches
+      FROM ordered_launch_signals
+      WHERE previous_timestamp_ms IS NULL OR timestamp_ms - previous_timestamp_ms > 1000
+    )
+    SELECT
+      (SELECT launches FROM launch_windows)
+      + (SELECT COUNT(*) FROM relevant_events WHERE verb = 'steered_packet') AS attempts
+  `).get(...laneIds) as { attempts: number } | undefined;
+
+  return Math.max(1, row?.attempts ?? 0);
+}

--- a/src/lib/orchestrator/cost-persistence.ts
+++ b/src/lib/orchestrator/cost-persistence.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
-import { eq } from 'drizzle-orm';
-import { getDb, usageLogs } from '@/lib/db';
+import { and, asc, eq } from 'drizzle-orm';
+import { getDb, getSqlite, usageLogs } from '@/lib/db';
+import type { UsageRole } from '@/lib/db/usage';
 import { getRuntime } from '@/lib/runtimes';
 import { ORCHESTRATOR_RUNTIMES } from '@/lib/orchestrator/runtime-capabilities';
+import { derivePacketAttemptIndex } from '@/lib/orchestrator/cost-attribution';
 
 const LOG_PREFIX = '[cost-persistence]';
 
@@ -20,6 +22,12 @@ export interface PersistSessionCostInput {
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
   costSource?: 'gateway' | 'estimate' | 'unknown';
+  laneId?: string | null;
+  packetId?: string | null;
+  missionId?: string | null;
+  role?: UsageRole | null;
+  runId?: string | null;
+  metadata?: Record<string, unknown> | null;
 }
 
 export interface PersistedSessionCost {
@@ -28,6 +36,13 @@ export interface PersistedSessionCost {
   totalCostUsd: number;
   model: string | null;
   costSource: 'gateway' | 'estimate';
+  laneId: string | null;
+  packetId: string | null;
+  missionId: string | null;
+  role: UsageRole | null;
+  attempt: number;
+  runId: string | null;
+  metadataJson: string | null;
 }
 
 function billingPeriodFor(date = new Date()) {
@@ -46,30 +61,70 @@ function normalizeUsd(value: number) {
   return Number(finiteNumber(value).toFixed(6));
 }
 
-export function readPersistedSessionCost(sessionKey: string): PersistedSessionCost | null {
+export function readPersistedSessionCosts(sessionKey: string): PersistedSessionCost[] {
   const normalized = sessionKey.trim();
   const db = getDb();
-  if (!normalized || !db) return null;
+  if (!normalized || !db) return [];
 
-  const row = db
+  const rows = db
     .select({
       inputTokens: usageLogs.inputTokens,
       outputTokens: usageLogs.outputTokens,
       costUsd: usageLogs.costUsd,
       model: usageLogs.model,
       provider: usageLogs.provider,
+      laneId: usageLogs.laneId,
+      packetId: usageLogs.packetId,
+      missionId: usageLogs.missionId,
+      role: usageLogs.role,
+      attempt: usageLogs.attempt,
+      runId: usageLogs.runId,
+      metadataJson: usageLogs.metadataJson,
     })
     .from(usageLogs)
     .where(eq(usageLogs.sessionKey, normalized))
-    .get();
+    .orderBy(asc(usageLogs.attempt), asc(usageLogs.createdAt))
+    .all();
 
-  if (!row) return null;
-  return {
+  return rows.map((row) => ({
     inputTokens: normalizeTokenCount(row.inputTokens),
     outputTokens: normalizeTokenCount(row.outputTokens),
     totalCostUsd: normalizeUsd(row.costUsd),
     model: row.model?.trim() || null,
     costSource: row.provider === 'openrouter' ? 'gateway' : 'estimate',
+    laneId: row.laneId?.trim() || null,
+    packetId: row.packetId?.trim() || null,
+    missionId: row.missionId?.trim() || null,
+    role: row.role,
+    attempt: Math.max(1, normalizeTokenCount(row.attempt)),
+    runId: row.runId?.trim() || null,
+    metadataJson: row.metadataJson,
+  }));
+}
+
+/** Back-compatible aggregate for callers that only need the session total. */
+export function readPersistedSessionCost(sessionKey: string): PersistedSessionCost | null {
+  const rows = readPersistedSessionCosts(sessionKey);
+  if (rows.length === 0) return null;
+  const models = new Set(rows.map((row) => row.model).filter((model): model is string => Boolean(model)));
+  const packetIds = new Set(rows.map((row) => row.packetId));
+  const laneIds = new Set(rows.map((row) => row.laneId));
+  const missionIds = new Set(rows.map((row) => row.missionId));
+  const roles = new Set(rows.map((row) => row.role));
+  const runIds = new Set(rows.map((row) => row.runId));
+  return {
+    inputTokens: rows.reduce((sum, row) => sum + row.inputTokens, 0),
+    outputTokens: rows.reduce((sum, row) => sum + row.outputTokens, 0),
+    totalCostUsd: normalizeUsd(rows.reduce((sum, row) => sum + row.totalCostUsd, 0)),
+    model: models.size === 1 ? [...models][0] : models.size > 1 ? 'mixed' : null,
+    costSource: rows.some((row) => row.costSource === 'gateway') ? 'gateway' : 'estimate',
+    laneId: laneIds.size === 1 ? [...laneIds][0] : null,
+    packetId: packetIds.size === 1 ? [...packetIds][0] : null,
+    missionId: missionIds.size === 1 ? [...missionIds][0] : null,
+    role: roles.size === 1 ? [...roles][0] : null,
+    attempt: Math.max(...rows.map((row) => row.attempt)),
+    runId: runIds.size === 1 ? [...runIds][0] : null,
+    metadataJson: null,
   };
 }
 
@@ -99,6 +154,43 @@ function agentNameForRuntime(runtime: string) {
   return label ?? runtime;
 }
 
+async function resolvePersistenceContext(input: PersistSessionCostInput): Promise<{
+  laneId: string | null;
+  packetId: string | null;
+  missionId: string | null;
+  role: UsageRole;
+  runId: string | null;
+  attempt: number;
+}> {
+  const { getLane, findLaneBySession } = await import('@/lib/lane/registry');
+  const explicitLaneId = input.laneId?.trim() || null;
+  const lane = explicitLaneId
+    ? getLane(explicitLaneId)
+    : findLaneBySession(input.sessionKey.trim());
+  const laneId = explicitLaneId ?? lane?.id ?? null;
+  const packetId = input.packetId?.trim() || lane?.packetId?.trim() || null;
+  let missionId = input.missionId?.trim() || null;
+  if (!missionId && packetId) {
+    const { findMissionRegistryEntryByPacketId } = await import('@/lib/orchestrator/mission-registry');
+    missionId = findMissionRegistryEntryByPacketId(packetId, { includeArchived: true })?.id ?? null;
+  }
+  let runId = input.runId?.trim() || null;
+  if (!runId && laneId) {
+    const row = getSqlite().prepare(`
+      SELECT id FROM worker_runs WHERE lane_id = ? ORDER BY started_at DESC LIMIT 1
+    `).get(laneId) as { id: string } | undefined;
+    runId = row?.id ?? null;
+  }
+  return {
+    laneId,
+    packetId,
+    missionId,
+    role: input.role ?? (packetId || laneId ? 'worker' : 'other'),
+    runId,
+    attempt: derivePacketAttemptIndex({ packetId, laneId }),
+  };
+}
+
 export async function persistSessionCost(input: PersistSessionCostInput): Promise<boolean> {
   const db = getDb();
   if (!db) {
@@ -111,10 +203,12 @@ export async function persistSessionCost(input: PersistSessionCostInput): Promis
     return false;
   }
 
+  const context = await resolvePersistenceContext(input);
   const provider = providerForRuntime(input.runtime, input.costSource);
-  const existing = db
+  const sessionRows = db
     .select({
       id: usageLogs.id,
+      attempt: usageLogs.attempt,
       inputTokens: usageLogs.inputTokens,
       outputTokens: usageLogs.outputTokens,
       cacheReadTokens: usageLogs.cacheReadTokens,
@@ -124,25 +218,46 @@ export async function persistSessionCost(input: PersistSessionCostInput): Promis
     })
     .from(usageLogs)
     .where(eq(usageLogs.sessionKey, sessionKey))
-    .get();
+    .all();
+  const existing = sessionRows.find((row) => row.attempt === context.attempt);
+  const priorRows = sessionRows.filter((row) => row.attempt < context.attempt);
+  const priorInputTokens = priorRows.reduce((sum, row) => sum + normalizeTokenCount(row.inputTokens), 0);
+  const priorOutputTokens = priorRows.reduce((sum, row) => sum + normalizeTokenCount(row.outputTokens), 0);
+  const priorCacheReadTokens = priorRows.reduce((sum, row) => sum + normalizeTokenCount(row.cacheReadTokens), 0);
+  const priorCacheWriteTokens = priorRows.reduce((sum, row) => sum + normalizeTokenCount(row.cacheWriteTokens), 0);
+  const priorCostUsd = normalizeUsd(priorRows.reduce((sum, row) => sum + normalizeUsd(row.costUsd), 0));
+  const attemptInputTokens = Math.max(0, normalizeTokenCount(input.inputTokens) - priorInputTokens);
+  const attemptOutputTokens = Math.max(0, normalizeTokenCount(input.outputTokens) - priorOutputTokens);
+  const attemptCacheReadTokens = Math.max(0, normalizeTokenCount(input.cacheReadTokens) - priorCacheReadTokens);
+  const attemptCacheWriteTokens = Math.max(0, normalizeTokenCount(input.cacheWriteTokens) - priorCacheWriteTokens);
+  const attemptCostUsd = normalizeUsd(Math.max(0, normalizeUsd(input.costUsd) - priorCostUsd));
+  const attribution = {
+    laneId: context.laneId,
+    packetId: context.packetId,
+    missionId: context.missionId,
+    role: context.role,
+    runId: context.runId,
+    metadataJson: input.metadata ? JSON.stringify(input.metadata) : null,
+  };
 
   if (existing) {
     db.update(usageLogs).set({
       model: input.model?.trim() || input.runtime,
       provider: existing.provider === 'openrouter' && input.costSource !== 'gateway' ? 'openrouter' : provider,
-      inputTokens: Math.max(normalizeTokenCount(existing.inputTokens), normalizeTokenCount(input.inputTokens)),
-      outputTokens: Math.max(normalizeTokenCount(existing.outputTokens), normalizeTokenCount(input.outputTokens)),
-      cacheReadTokens: Math.max(normalizeTokenCount(existing.cacheReadTokens), normalizeTokenCount(input.cacheReadTokens)),
-      cacheWriteTokens: Math.max(normalizeTokenCount(existing.cacheWriteTokens), normalizeTokenCount(input.cacheWriteTokens)),
+      inputTokens: Math.max(normalizeTokenCount(existing.inputTokens), attemptInputTokens),
+      outputTokens: Math.max(normalizeTokenCount(existing.outputTokens), attemptOutputTokens),
+      cacheReadTokens: Math.max(normalizeTokenCount(existing.cacheReadTokens), attemptCacheReadTokens),
+      cacheWriteTokens: Math.max(normalizeTokenCount(existing.cacheWriteTokens), attemptCacheWriteTokens),
       costUsd: input.costSource === 'gateway'
-        ? normalizeUsd(input.costUsd)
+        ? attemptCostUsd
         : existing.provider === 'openrouter'
           ? normalizeUsd(existing.costUsd)
-          : Math.max(normalizeUsd(existing.costUsd), normalizeUsd(input.costUsd)),
+          : Math.max(normalizeUsd(existing.costUsd), attemptCostUsd),
       repoPath: resolve(input.repoPath),
       agentName: agentNameForRuntime(input.runtime),
       billingPeriod: billingPeriodFor(),
-    }).where(eq(usageLogs.id, existing.id)).run();
+      ...attribution,
+    }).where(and(eq(usageLogs.sessionKey, sessionKey), eq(usageLogs.attempt, context.attempt))).run();
     return true;
   }
 
@@ -151,19 +266,21 @@ export async function persistSessionCost(input: PersistSessionCostInput): Promis
     userId: null,
     model: input.model?.trim() || input.runtime,
     provider,
-    inputTokens: normalizeTokenCount(input.inputTokens),
-    outputTokens: normalizeTokenCount(input.outputTokens),
-    cacheReadTokens: normalizeTokenCount(input.cacheReadTokens),
-    cacheWriteTokens: normalizeTokenCount(input.cacheWriteTokens),
-    costUsd: normalizeUsd(input.costUsd),
+    inputTokens: attemptInputTokens,
+    outputTokens: attemptOutputTokens,
+    cacheReadTokens: attemptCacheReadTokens,
+    cacheWriteTokens: attemptCacheWriteTokens,
+    costUsd: attemptCostUsd,
     sessionKey,
+    attempt: context.attempt,
     repoPath: resolve(input.repoPath),
     agentName: agentNameForRuntime(input.runtime),
     requestType: 'completion',
     billingPeriod: billingPeriodFor(),
+    ...attribution,
   }).run();
 
-  console.log(`${LOG_PREFIX} Persisted ${sessionKey}.`);
+  console.log(`${LOG_PREFIX} Persisted ${sessionKey} attempt ${context.attempt}.`);
   return true;
 }
 
@@ -171,6 +288,11 @@ export async function persistRuntimeSessionCost(input: {
   sessionKey: string;
   runtime: string;
   repoPath: string;
+  laneId?: string | null;
+  packetId?: string | null;
+  missionId?: string | null;
+  role?: UsageRole;
+  runId?: string | null;
 }): Promise<boolean> {
   try {
     const adapter = getRuntime(input.runtime);
@@ -196,6 +318,11 @@ export async function persistRuntimeSessionCost(input: {
       cacheReadTokens: telemetry.cacheReadTokens,
       cacheWriteTokens: telemetry.cacheWriteTokens,
       costSource: telemetry.costSource,
+      laneId: input.laneId,
+      packetId: input.packetId,
+      missionId: input.missionId,
+      role: input.role ?? 'worker',
+      runId: input.runId,
     });
     if (persisted) {
       const { getLaneEvents, listLanes } = await import('@/lib/lane/registry');

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -8831,6 +8831,8 @@ async function bootstrapWsServer() {
               sessionKey: surfaceId,
               runtime: lane.runtime,
               repoPath: completionCwd,
+              laneId: lane.id,
+              packetId: lane.packetId,
             });
           } catch (error) {
             console.error('[cost-persistence] Failed to persist lane session cost:', error);

--- a/tests/cost-ledger-real-path.test.ts
+++ b/tests/cost-ledger-real-path.test.ts
@@ -1,0 +1,308 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { NextRequest } from 'next/server';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { AgentRuntime, RuntimeTranscriptEntry } from '@/lib/runtimes/types';
+
+const cacheRoot = join(process.cwd(), 'node_modules', '.cache');
+mkdirSync(cacheRoot, { recursive: true });
+const dataDir = mkdtempSync(join(cacheRoot, 'o8-cost-ledger-real-path-'));
+const repoPath = join(dataDir, 'repo');
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.O8_DATA_DIR = dataDir;
+
+vi.mock('@/lib/panel/auth', () => ({ requirePanelAuth: () => null }));
+vi.mock('@/lib/runtime/inventory', () => ({ getRuntimeInventorySnapshot: async () => ({ agents: [] }) }));
+vi.mock('@/lib/search/transcripts', () => ({ syncTranscriptSearchDocument: () => undefined }));
+vi.mock('@/lib/lane/lane-diff-facts', () => ({
+  getLaneDiffFacts: () => ({ changedFiles: 0, addedDiffLines: 0 }),
+  getLaneSpokenDiffFacts: () => undefined,
+}));
+
+function git(...args: string[]) {
+  return execFileSync('git', args, { cwd: repoPath, stdio: 'pipe' }).toString().trim();
+}
+
+function transcript(): RuntimeTranscriptEntry[] {
+  return [{
+    id: 'cost-ledger-completion',
+    role: 'assistant',
+    text: 'Implemented and verified the cost ledger.',
+    timestamp: new Date('2026-08-28T16:00:00.000Z'),
+  }];
+}
+
+beforeAll(async () => {
+  mkdirSync(repoPath, { recursive: true });
+  git('init', '--initial-branch=main');
+  writeFileSync(join(repoPath, 'README.md'), 'cost ledger real path\n');
+  git('add', 'README.md');
+  git('-c', 'user.email=test@o8.test', '-c', 'user.name=o8-test', 'commit', '-m', 'init');
+
+  const runtime: AgentRuntime = {
+    id: 'codex',
+    displayName: 'Cost ledger test runtime',
+    capabilities: {
+      discover: false,
+      readTranscript: true,
+      launch: false,
+      resume: false,
+      interrupt: false,
+      reviewDiffs: true,
+      costTelemetry: false,
+      streaming: false,
+    },
+    discoverSessions: async () => [],
+    readTranscript: async () => transcript(),
+    launch: async () => ({ ok: false, note: 'not supported' }),
+    resume: async () => ({ ok: false, note: 'not supported' }),
+    interrupt: async () => ({ ok: false, note: 'not supported' }),
+    getChangedFiles: async () => [],
+  };
+  const { registerRuntime } = await import('@/lib/runtimes/registry');
+  registerRuntime(runtime);
+});
+
+afterAll(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('cost ledger persisted real path', () => {
+  it('keeps retry attempts distinct and carries the same totals through outcomes and status', async () => {
+    const { getSqlite } = await import('@/lib/db');
+    const columns = getSqlite().prepare('PRAGMA table_info(usage_logs)').all() as Array<{ name: string }>;
+    expect(columns.map((column) => column.name)).toEqual(expect.arrayContaining([
+      'lane_id',
+      'packet_id',
+      'mission_id',
+      'role',
+      'attempt',
+      'run_id',
+      'metadata_json',
+    ]));
+
+    const { createMission } = await import('@/lib/orchestrator/operator-mission-service');
+    const mission = await createMission({
+      issues: [{
+        number: 1_973_001,
+        title: 'inline: verify retry cost attribution',
+        body: 'Persist two attempts and verify the outcome and status receipts.',
+        url: '',
+      }],
+      repoPath,
+      runtime: 'codex',
+      constraints: 'Real-path cost ledger regression.',
+      taskContract: 'off',
+    });
+    const packetId = mission.packets[0]!.id;
+    const sessionKey = 'codex-owned:cost-ledger-retry';
+    const { appendEvent, createLane, setLaneStatus } = await import('@/lib/lane/registry');
+    const lane = createLane({
+      repoPath,
+      worktreePath: repoPath,
+      branch: 'fix/cost-ledger-real-path',
+      runtime: 'codex',
+      packetId,
+      sessionKey,
+    });
+    setLaneStatus(lane.id, 'running', 'system', 'session_launched');
+
+    const { persistSessionCost } = await import('@/lib/orchestrator/cost-persistence');
+    await persistSessionCost({
+      sessionKey,
+      runtime: 'codex',
+      model: 'gpt-test',
+      inputTokens: 100,
+      outputTokens: 20,
+      costUsd: 0.1,
+      repoPath,
+      laneId: lane.id,
+      packetId,
+      role: 'worker',
+    });
+    appendEvent(lane.id, 'steered_packet', 'orchestrator', {
+      packetId,
+      source: 'operator',
+      message: 'Retry with the persisted correction.',
+    });
+    await persistSessionCost({
+      sessionKey,
+      runtime: 'codex',
+      model: 'gpt-test',
+      inputTokens: 250,
+      outputTokens: 70,
+      costUsd: 0.3,
+      repoPath,
+      laneId: lane.id,
+      packetId,
+      role: 'worker',
+    });
+
+    const usageRows = getSqlite().prepare(`
+      SELECT attempt, input_tokens, output_tokens, cost_usd, lane_id, packet_id, mission_id, role
+      FROM usage_logs WHERE session_key = ? ORDER BY attempt
+    `).all(sessionKey);
+    expect(usageRows).toEqual([
+      expect.objectContaining({ attempt: 1, input_tokens: 100, output_tokens: 20, cost_usd: 0.1 }),
+      expect.objectContaining({ attempt: 2, input_tokens: 150, output_tokens: 50, cost_usd: 0.2 }),
+    ]);
+    expect(usageRows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ lane_id: lane.id, packet_id: packetId, mission_id: mission.missionId, role: 'worker' }),
+    ]));
+
+    const reviewRoute = await import('@/app/api/orchestrator/review/route');
+    const reviewResponse = await reviewRoute.POST(new NextRequest(
+      'http://localhost/api/orchestrator/review',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          packetId,
+          clientMutationId: 'cost-ledger-real-path-review',
+          approved: true,
+          findings: [{
+            file: 'README.md',
+            line: 1,
+            severity: 'note',
+            description: 'The persisted receipt matches the requested path.',
+            status: 'accepted',
+          }, {
+            file: 'README.md',
+            line: 1,
+            severity: 'note',
+            description: 'The retry totals remain visible on the outcome.',
+            status: 'accepted',
+          }],
+          reviewedHeadSha: git('rev-parse', 'HEAD'),
+        }),
+      },
+    ));
+    expect(reviewResponse.status).toBe(200);
+    expect(await reviewResponse.json()).toMatchObject({
+      ok: true,
+      result: { recorded: true, findingsCount: 2 },
+    });
+
+    const { capturePacketCompletionContext } = await import('@/lib/orchestrator/context-relay');
+    await capturePacketCompletionContext(packetId, sessionKey);
+    await vi.waitFor(() => {
+      const outcome = getSqlite().prepare(`
+        SELECT attempts, total_tokens, cost_usd, review_approved, review_findings_count
+        FROM session_outcomes WHERE packet_id = ?
+      `).get(packetId);
+      expect(outcome).toEqual({
+        attempts: 2,
+        total_tokens: 320,
+        cost_usd: 0.3,
+        review_approved: 1,
+        review_findings_count: 2,
+      });
+    });
+
+    const statusRoute = await import('@/app/api/orchestrator/status/route');
+    const response = await statusRoute.GET(new NextRequest(
+      `http://localhost/api/orchestrator/status?missionId=${mission.missionId}&includeCost=true`,
+    ));
+    expect(response.status).toBe(200);
+    const payload = await response.json() as {
+      ok: boolean;
+      result: {
+        cost: {
+          totalCostUsd: number;
+          packetCosts: Array<{ packetId: string; inputTokens: number; outputTokens: number; totalCostUsd: number }>;
+          costByRole: Record<string, { inputTokens: number; outputTokens: number; totalCostUsd: number; requestCount: number }>;
+        };
+      };
+    };
+    expect(payload.ok).toBe(true);
+    expect(payload.result.cost.totalCostUsd).toBe(0.3);
+    expect(payload.result.cost.packetCosts).toContainEqual(expect.objectContaining({
+      packetId,
+      inputTokens: 250,
+      outputTokens: 70,
+      totalCostUsd: 0.3,
+    }));
+    expect(payload.result.cost.costByRole.worker).toEqual({
+      inputTokens: 250,
+      outputTokens: 70,
+      totalCostUsd: 0.3,
+      requestCount: 2,
+    });
+  });
+
+  it('preserves a rejected review verdict and its finding count on the outcome', async () => {
+    const { createMission } = await import('@/lib/orchestrator/operator-mission-service');
+    const mission = await createMission({
+      issues: [{
+        number: 1_973_002,
+        title: 'inline: verify rejected review attribution',
+        body: 'Persist the rejected review verdict on the session outcome.',
+        url: '',
+      }],
+      repoPath,
+      runtime: 'codex',
+      constraints: 'Real-path review ledger regression.',
+      taskContract: 'off',
+    });
+    const packetId = mission.packets[0]!.id;
+    const sessionKey = 'codex-owned:cost-ledger-rejected-review';
+    const { createLane, setLaneStatus } = await import('@/lib/lane/registry');
+    const lane = createLane({
+      repoPath,
+      worktreePath: repoPath,
+      branch: 'fix/cost-ledger-rejected-review',
+      runtime: 'codex',
+      packetId,
+      sessionKey,
+    });
+    setLaneStatus(lane.id, 'running', 'system', 'session_launched');
+
+    const reviewRoute = await import('@/app/api/orchestrator/review/route');
+    const reviewResponse = await reviewRoute.POST(new NextRequest(
+      'http://localhost/api/orchestrator/review',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          packetId,
+          clientMutationId: 'cost-ledger-rejected-review',
+          approved: false,
+          findings: [{
+            file: 'README.md',
+            line: 1,
+            severity: 'bug',
+            description: 'The first finding remains unresolved.',
+            status: 'deferred',
+          }, {
+            file: 'README.md',
+            line: 1,
+            severity: 'rule_violation',
+            description: 'The second finding requires another pass.',
+            status: 'deferred',
+          }],
+          reviewedHeadSha: git('rev-parse', 'HEAD'),
+        }),
+      },
+    ));
+    expect(reviewResponse.status).toBe(200);
+    expect(await reviewResponse.json()).toMatchObject({
+      ok: true,
+      result: { recorded: true, findingsCount: 2 },
+    });
+
+    const { capturePacketCompletionContext } = await import('@/lib/orchestrator/context-relay');
+    const { getSqlite } = await import('@/lib/db');
+    await capturePacketCompletionContext(packetId, sessionKey);
+    await vi.waitFor(() => {
+      const outcome = getSqlite().prepare(`
+        SELECT review_approved, review_findings_count
+        FROM session_outcomes WHERE packet_id = ?
+      `).get(packetId);
+      expect(outcome).toEqual({
+        review_approved: 0,
+        review_findings_count: 2,
+      });
+    });
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -335,6 +335,12 @@
       ]
     },
     {
+      "path": "src/lib/orchestrator/auto-compact.test.ts",
+      "reasons": [
+        "executable-fixture"
+      ]
+    },
+    {
       "path": "src/lib/orchestrator/backend-switch-carry.test.ts",
       "reasons": [
         "child-process",
@@ -1213,6 +1219,14 @@
     {
       "path": "tests/cortex-observation-worker-authz-real-path.test.ts",
       "reasons": [
+        "real-path"
+      ]
+    },
+    {
+      "path": "tests/cost-ledger-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
         "real-path"
       ]
     },


### PR DESCRIPTION
Fixes #1973 (split out of #1791).

The cost figures o8 shows were undercounted and misattributed. This makes the ledger a faithful record of what a packet cost, without changing any spend guardrail or price.

**What was invisible before**
- A retry inside one session overwrote the first attempt's `usage_logs` row, so retry tokens vanished.
- `session_outcomes` declared `attempts`, `totalTokens`, `costUsd`, `reviewApproved`, `reviewFindingsCount` but never received them.
- The auto-compact summarizer's model call and every subscription-tier Brain ask were unlogged.
- No usage row carried a lane, packet, mission, role, or attempt, so per-packet and per-role rollups were guesses.

**Changes**
- Schema v57 (additive, nullable, tolerant of re-runs): `usage_logs` gains `lane_id`, `packet_id`, `mission_id`, `role`, `attempt` (default 1), `run_id`, `metadata_json`, plus an index on `(packet_id, attempt)`. Old rows read back unchanged with `attempt = 1`.
- Persistence keys on session + attempt. The attempt index is derived from durable lane events (one per session launch, one per warm-session steer) in a single helper with its own test; per-attempt tokens are the delta over prior attempts because runtimes report cumulative session totals. Lane, packet, mission, and run ids are resolved from the lane registry and worker runs, never sliced from a session key.
- The outcome write now records totals from the packet's usage rows, the attempt count, and the latest durable review verdict (approved flag + findings count; false/0 when no review exists). `mergedClean` is stamped later by the merge handler exactly as before.
- Compaction logs one `compaction` row per summarizer call — real usage from the runtime's completion event when present, otherwise a marked estimate.
- Every Brain ask logs one `retrieval` row; paid fallback calls keep their existing priced row, subscription/local/cache paths get a zero-dollar row with an explicit token estimate and latency. Zero-dollar rows cannot move the daily spend cap (tested).
- The mission cost summary gains additive per-role subtotals (`orchestrator / worker / reviewer / compaction / retrieval / other`); rows without a packet stay in the existing `unattributed` bucket. Live adapter telemetry keeps precedence for totals; persisted rows are the fallback and the source of per-role subtotals.
- The Brain answer route accepts an optional usage context (lane/packet/mission) and only passes it when present; existing call shapes are unchanged.

**Real-path tests**
- `tests/cost-ledger-real-path.test.ts` (resource-owning, integration runner): a mission + packet through the real store and mission service, two attempts persisted through the real writer and retry path → two rows with attempts 1 and 2; the outcome row via the real relay path carries `attempts = 2` and the summed totals; a review submitted through the real handler yields `reviewApproved` as submitted and `reviewFindingsCount = 2` (approved and rejected cases); `GET /api/orchestrator/status?includeCost=true` reports the same totals and the per-role shape; a rerun advances the attempt index 1 → 2, not 1 → 3.
- Migration test: fresh DB and a previous-version DB both reach v57; legacy rows read with null ids and `attempt = 1`.
- Compaction, Brain retrieval (zero-dollar + cap unchanged), and aggregator precedence tests.

**Not in this change**: price constants and a dated rate table (#1974), extending child-agent token attribution to other runtimes, any UI beyond what the new fields required.

**Gates**: tsc, focused orchestrator/cortex/db/api suites, integration runner for the real-path test, lint (152 cap, zero new), classification check, full unit suite — all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detailed usage tracking for Cortex requests, including token estimates, latency, and retrieval activity.
  - Added attribution of usage and costs to lanes, packets, missions, roles, runs, and retry attempts.
  - Added role-based cost summaries and improved session outcome reporting.
  - Added usage tracking for automatic context compaction.
  - Added retrieval of the latest persisted review decision and findings.

- **Bug Fixes**
  - Improved cost aggregation when live telemetry and persisted records differ.
  - Preserved accurate attribution across retries and reruns.

- **Tests**
  - Added comprehensive coverage for usage tracking, migrations, cost attribution, aggregation, compaction, and review outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->