### PR TITLE
chore(ci): drop the weekly scheduled run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-  schedule:
-    - cron: '17 9 * * 1'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
PR-triggered CI already covers every merge. The Monday cron ran the full suite against whatever main happened to be, failed the last two weeks on stale states, and produced no signal anyone read. Removing the `schedule` trigger; `workflow_dispatch` and the PR/push triggers are unchanged. The port-build workflow keeps its own weekly schedule.