### PR TITLE
feat(cost): centralize the dated model rate table and capture packet capacity snapshots

### DIFF
--- a/src/lib/cortex/qa/llm/brain-spend.ts
+++ b/src/lib/cortex/qa/llm/brain-spend.ts
@@ -19,21 +19,12 @@
 
 import 'server-only';
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { modelRateTable, resolveRate } from '@/lib/cost/rate-table';
 import type { UsageRole } from '@/lib/db/usage';
-
-/** USD per token (input, output) for the models in our OpenRouter chain. */
-const MODEL_PRICING_PER_TOKEN: Record<string, { input: number; output: number }> = {
-  'google/gemini-2.5-flash-lite': { input: 0.10e-6, output: 0.40e-6 },
-  'openai/gpt-5.4-nano': { input: 0.20e-6, output: 1.25e-6 },
-  'x-ai/grok-4.3': { input: 1.25e-6, output: 2.50e-6 },
-};
-
-/** Fallback pricing when the served model isn't in the table — assume the
- * priciest entry so the cap errs toward under-spend. */
-const WORST_CASE_PRICING = { input: 1.25e-6, output: 2.50e-6 };
 
 const BRAIN_AGENT_NAME = 'cortex-qa';
 const DEFAULT_DAILY_CAP_USD = 0.5;
+const TOKENS_PER_MILLION = 1_000_000;
 
 function dailyCapUsd(): number {
   const raw = Number(process.env.O8_QA_OPENROUTER_DAILY_CAP_USD);
@@ -65,8 +56,11 @@ export function estimateBrainTokenCount(...values: string[]): number {
 
 export function estimateCostUsd(model: string, usage: OpenRouterUsage): number {
   if (typeof usage.cost === 'number' && usage.cost >= 0) return usage.cost;
-  const pricing = MODEL_PRICING_PER_TOKEN[model] ?? WORST_CASE_PRICING;
-  return (usage.prompt_tokens ?? 0) * pricing.input + (usage.completion_tokens ?? 0) * pricing.output;
+  const rate = resolveRate('brain', model)!;
+  return (
+    (usage.prompt_tokens ?? 0) * rate.inputUsdPerMillion
+    + (usage.completion_tokens ?? 0) * rate.outputUsdPerMillion
+  ) / TOKENS_PER_MILLION;
 }
 
 /**
@@ -90,6 +84,7 @@ function recordBrainSpend(
   void (async () => {
     try {
       const { logUsage } = await import('@/lib/db/usage');
+      const gatewayCost = typeof usage.cost === 'number' && usage.cost >= 0;
       logUsage({
         userId: null,
         model,
@@ -100,6 +95,9 @@ function recordBrainSpend(
         agentName: BRAIN_AGENT_NAME,
         requestType,
         role: 'retrieval' satisfies UsageRole,
+        metadata: gatewayCost
+          ? { costSource: 'gateway' }
+          : { costSource: 'estimate', rateTableVersion: modelRateTable.rateTableVersion },
       });
     } catch (err) {
       console.warn('[qa][brain-spend] ledger write failed:', err instanceof Error ? err.message : err);

--- a/src/lib/cost/rate-table.test.ts
+++ b/src/lib/cost/rate-table.test.ts
@@ -1,0 +1,147 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import { estimateCostUsd } from '@/lib/cortex/qa/llm/brain-spend';
+import { parseCodexSessionCost } from '@/lib/runtimes/codex-cost-parser';
+import { parseSessionCost } from '@/lib/runtimes/cost-parser';
+import { parseCursorSessionCost } from '@/lib/runtimes/cursor-cost-parser';
+import { parseGeminiSessionCost } from '@/lib/runtimes/gemini-cost-parser';
+import { parseOpencodeSessionCost } from '@/lib/runtimes/opencode-cost-parser';
+import { modelRateTable, resolveRate } from './rate-table';
+
+const fixtureRoot = mkdtempSync(join(tmpdir(), 'o8-rate-table-'));
+const TOKENS_PER_MILLION = 1_000_000;
+
+function fixture(name: string, row: Record<string, unknown>): string {
+  const filePath = join(fixtureRoot, name);
+  writeFileSync(filePath, `${JSON.stringify(row)}\n`);
+  return filePath;
+}
+
+function rounded(value: number): number {
+  return Number(value.toFixed(6));
+}
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    return entry.isDirectory() ? sourceFiles(path) : entry.isFile() ? [path] : [];
+  });
+}
+
+afterAll(() => {
+  rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+describe('dated model rate table reproducibility', () => {
+  it('reproduces each table-priced parser and the Brain estimator', async () => {
+    const claudeRate = resolveRate('claude-code', 'claude-sonnet-5')!;
+    const claude = await parseSessionCost(fixture('claude.jsonl', {
+      type: 'assistant',
+      requestId: 'claude-rate-fixture',
+      message: {
+        id: 'claude-rate-fixture',
+        model: 'claude-sonnet-5',
+        usage: {
+          input_tokens: 100_000,
+          output_tokens: 20_000,
+          cache_read_input_tokens: 10_000,
+          cache_creation_input_tokens: 6_000,
+          cache_creation: {
+            ephemeral_5m_input_tokens: 4_000,
+            ephemeral_1h_input_tokens: 2_000,
+          },
+        },
+      },
+    }));
+    expect(claude.totalCostUsd).toBe(rounded((
+      100_000 * claudeRate.inputUsdPerMillion
+      + 20_000 * claudeRate.outputUsdPerMillion
+      + 10_000 * claudeRate.cacheReadUsdPerMillion!
+      + 4_000 * claudeRate.cacheWriteUsdPerMillion!
+      + 2_000 * claudeRate.cacheWrite1hUsdPerMillion!
+    ) / TOKENS_PER_MILLION));
+
+    const codexRate = resolveRate('codex', 'gpt-5.5')!;
+    const codex = await parseCodexSessionCost(fixture('codex.jsonl', {
+      type: 'turn.completed',
+      model: 'gpt-5.5',
+      usage: {
+        input_tokens: 100_000,
+        cached_input_tokens: 20_000,
+        output_tokens: 10_000,
+        total_tokens: 110_000,
+      },
+    }), 'gpt-5.5');
+    expect(codex.totalCostUsd).toBe(rounded((
+      80_000 * codexRate.inputUsdPerMillion
+      + 20_000 * codexRate.cacheReadUsdPerMillion!
+      + 10_000 * codexRate.outputUsdPerMillion
+    ) / TOKENS_PER_MILLION));
+
+    const geminiRate = resolveRate('gemini', 'gemini-2.5-flash')!;
+    const gemini = await parseGeminiSessionCost(fixture('gemini.jsonl', {
+      type: 'result',
+      model: 'gemini-2.5-flash',
+      stats: { inputTokens: 100_000, outputTokens: 10_000, cachedInputTokens: 20_000 },
+    }));
+    expect(gemini.totalCostUsd).toBe(rounded((
+      80_000 * geminiRate.inputUsdPerMillion
+      + 20_000 * geminiRate.cacheReadUsdPerMillion!
+      + 10_000 * geminiRate.outputUsdPerMillion
+    ) / TOKENS_PER_MILLION));
+
+    const cursorRate = resolveRate('cursor', 'cursor-fast')!;
+    const cursor = await parseCursorSessionCost([fixture('cursor.jsonl', {
+      type: 'result',
+      model: 'cursor-fast',
+      usage: { inputTokens: 100_000, outputTokens: 10_000, cacheWriteTokens: 5_000 },
+    })]);
+    expect(cursor.totalCostUsd).toBe(rounded((
+      100_000 * cursorRate.inputUsdPerMillion
+      + 10_000 * cursorRate.outputUsdPerMillion
+      + 5_000 * cursorRate.cacheWriteUsdPerMillion!
+    ) / TOKENS_PER_MILLION));
+
+    const opencodeRate = resolveRate('opencode', 'opencode/gpt-5-nano')!;
+    const opencode = await parseOpencodeSessionCost([fixture('opencode.jsonl', {
+      type: 'result',
+      model: 'opencode/gpt-5-nano',
+      usage: { inputTokens: 100_000, outputTokens: 10_000 },
+    })]);
+    expect(opencode.totalCostUsd).toBe(rounded((
+      100_000 * opencodeRate.inputUsdPerMillion
+      + 10_000 * opencodeRate.outputUsdPerMillion
+    ) / TOKENS_PER_MILLION));
+
+    const brainRate = resolveRate('brain', 'google/gemini-2.5-flash-lite')!;
+    expect(estimateCostUsd('google/gemini-2.5-flash-lite', {
+      prompt_tokens: 100_000,
+      completion_tokens: 10_000,
+    })).toBe((
+      100_000 * brainRate.inputUsdPerMillion
+      + 10_000 * brainRate.outputUsdPerMillion
+    ) / TOKENS_PER_MILLION);
+
+    expect(modelRateTable).toMatchObject({
+      rateTableVersion: '2026-08-28.1',
+      observedOn: '2026-08-28',
+    });
+  });
+
+  it('keeps private price-literal markers out of runtime and Brain sources', () => {
+    const roots = [
+      join(process.cwd(), 'src/lib/runtimes'),
+      join(process.cwd(), 'src/lib/cortex'),
+    ];
+    const forbidden = /USD_PER_MILLION|per 1M|USD per token/;
+    const matches = roots.flatMap(sourceFiles).flatMap((filePath) => {
+      const lines = readFileSync(filePath, 'utf8').split(/\r?\n/);
+      return lines.flatMap((line, index) => forbidden.test(line)
+        ? [`${filePath.slice(process.cwd().length + 1)}:${index + 1}:${line.trim()}`]
+        : []);
+    });
+    expect(matches).toEqual([]);
+  });
+});

--- a/src/lib/cost/rate-table.ts
+++ b/src/lib/cost/rate-table.ts
@@ -1,0 +1,283 @@
+export interface ModelRate {
+  inputUsdPerMillion: number;
+  outputUsdPerMillion: number;
+  cacheReadUsdPerMillion?: number;
+  cacheWriteUsdPerMillion?: number;
+  cacheWrite1hUsdPerMillion?: number;
+}
+
+export interface ModelRateTable {
+  rateTableVersion: string;
+  observedOn: `${number}-${number}-${number}`;
+  rates: Record<string, ModelRate>;
+}
+
+/**
+ * The first dated snapshot centralizes the exact values that were already
+ * checked into the runtime parsers and Brain spend guard. `observedOn` is the
+ * consolidation date, not a claim that provider prices were refreshed.
+ */
+export const modelRateTable = {
+  rateTableVersion: '2026-08-28.1',
+  observedOn: '2026-08-28',
+  rates: {
+    'claude-opus-4-8': {
+      inputUsdPerMillion: 5,
+      outputUsdPerMillion: 25,
+      cacheReadUsdPerMillion: 0.5,
+      cacheWriteUsdPerMillion: 6.25,
+      cacheWrite1hUsdPerMillion: 10,
+    },
+    'claude-opus-4-8-fast': {
+      inputUsdPerMillion: 30,
+      outputUsdPerMillion: 150,
+      cacheReadUsdPerMillion: 3,
+      cacheWriteUsdPerMillion: 37.5,
+      cacheWrite1hUsdPerMillion: 60,
+    },
+    'claude-opus-4-7': {
+      inputUsdPerMillion: 5,
+      outputUsdPerMillion: 25,
+      cacheReadUsdPerMillion: 0.5,
+      cacheWriteUsdPerMillion: 6.25,
+      cacheWrite1hUsdPerMillion: 10,
+    },
+    'claude-opus-4-7-fast': {
+      inputUsdPerMillion: 30,
+      outputUsdPerMillion: 150,
+      cacheReadUsdPerMillion: 3,
+      cacheWriteUsdPerMillion: 37.5,
+      cacheWrite1hUsdPerMillion: 60,
+    },
+    'claude-opus-4-6': {
+      inputUsdPerMillion: 5,
+      outputUsdPerMillion: 25,
+      cacheReadUsdPerMillion: 0.5,
+      cacheWriteUsdPerMillion: 6.25,
+      cacheWrite1hUsdPerMillion: 10,
+    },
+    'claude-opus-4-6-fast': {
+      inputUsdPerMillion: 30,
+      outputUsdPerMillion: 150,
+      cacheReadUsdPerMillion: 3,
+      cacheWriteUsdPerMillion: 37.5,
+      cacheWrite1hUsdPerMillion: 60,
+    },
+    'claude-sonnet-5': {
+      inputUsdPerMillion: 3,
+      outputUsdPerMillion: 15,
+      cacheReadUsdPerMillion: 0.3,
+      cacheWriteUsdPerMillion: 3.75,
+      cacheWrite1hUsdPerMillion: 6,
+    },
+    'claude-sonnet-4-6': {
+      inputUsdPerMillion: 3,
+      outputUsdPerMillion: 15,
+      cacheReadUsdPerMillion: 0.3,
+      cacheWriteUsdPerMillion: 3.75,
+      cacheWrite1hUsdPerMillion: 6,
+    },
+    'claude-sonnet-4-5': {
+      inputUsdPerMillion: 3,
+      outputUsdPerMillion: 15,
+      cacheReadUsdPerMillion: 0.3,
+      cacheWriteUsdPerMillion: 3.75,
+      cacheWrite1hUsdPerMillion: 6,
+    },
+    'claude-haiku-4-5': {
+      inputUsdPerMillion: 0.8,
+      outputUsdPerMillion: 4,
+      cacheReadUsdPerMillion: 0.08,
+      cacheWriteUsdPerMillion: 1,
+      cacheWrite1hUsdPerMillion: 1.6,
+    },
+    'gpt-5.6-sol': {
+      inputUsdPerMillion: 5,
+      outputUsdPerMillion: 30,
+      cacheReadUsdPerMillion: 0.5,
+    },
+    'gpt-5.6-terra': {
+      inputUsdPerMillion: 2.5,
+      outputUsdPerMillion: 15,
+      cacheReadUsdPerMillion: 0.25,
+    },
+    'gpt-5.6-luna': {
+      inputUsdPerMillion: 1,
+      outputUsdPerMillion: 6,
+      cacheReadUsdPerMillion: 0.1,
+    },
+    'gpt-5.5': {
+      inputUsdPerMillion: 2.5,
+      outputUsdPerMillion: 15,
+      cacheReadUsdPerMillion: 0.25,
+    },
+    'gpt-5.4-mini': {
+      inputUsdPerMillion: 0.75,
+      outputUsdPerMillion: 4.5,
+      cacheReadUsdPerMillion: 0.075,
+    },
+    'gpt-5.4-nano': {
+      inputUsdPerMillion: 0.2,
+      outputUsdPerMillion: 1.25,
+      cacheReadUsdPerMillion: 0.02,
+    },
+    'gpt-5.4': {
+      inputUsdPerMillion: 2.5,
+      outputUsdPerMillion: 15,
+      cacheReadUsdPerMillion: 0.25,
+    },
+    'gpt-5.2-pro': {
+      inputUsdPerMillion: 21,
+      outputUsdPerMillion: 168,
+      cacheReadUsdPerMillion: 2.1,
+    },
+    'gpt-5.2-codex': {
+      inputUsdPerMillion: 1.5,
+      outputUsdPerMillion: 6,
+      cacheReadUsdPerMillion: 0.15,
+    },
+    'gpt-5.2': {
+      inputUsdPerMillion: 2,
+      outputUsdPerMillion: 8,
+      cacheReadUsdPerMillion: 0.2,
+    },
+    'gemini-3-pro': {
+      inputUsdPerMillion: 1.25,
+      outputUsdPerMillion: 10,
+      cacheReadUsdPerMillion: 0.3125,
+    },
+    'gemini-2-5-pro': {
+      inputUsdPerMillion: 1.25,
+      outputUsdPerMillion: 10,
+      cacheReadUsdPerMillion: 0.3125,
+    },
+    'gemini-2-5-flash': {
+      inputUsdPerMillion: 0.075,
+      outputUsdPerMillion: 0.30,
+      cacheReadUsdPerMillion: 0.019,
+    },
+    'gemini-1-5-flash': {
+      inputUsdPerMillion: 0.075,
+      outputUsdPerMillion: 0.30,
+      cacheReadUsdPerMillion: 0.019,
+    },
+    'cursor-agent': {
+      inputUsdPerMillion: 1.25,
+      outputUsdPerMillion: 10,
+      cacheWriteUsdPerMillion: 1.25,
+    },
+    'opencode/gpt-5-nano': { inputUsdPerMillion: 0.05, outputUsdPerMillion: 0.20 },
+    'opencode/gpt-5-mini': { inputUsdPerMillion: 0.15, outputUsdPerMillion: 0.60 },
+    'opencode/gpt-5': { inputUsdPerMillion: 1.0, outputUsdPerMillion: 4.0 },
+    'anthropic/claude-sonnet-4-20250514': { inputUsdPerMillion: 3, outputUsdPerMillion: 15 },
+    'anthropic/claude-haiku-4-20250514': { inputUsdPerMillion: 0.8, outputUsdPerMillion: 4 },
+    'anthropic/claude-opus-4-20250514': { inputUsdPerMillion: 15, outputUsdPerMillion: 75 },
+    'google/gemini-2.5-pro': { inputUsdPerMillion: 1.25, outputUsdPerMillion: 10 },
+    'google/gemini-2.5-flash': { inputUsdPerMillion: 0.075, outputUsdPerMillion: 0.30 },
+    'openai/gpt-4o': { inputUsdPerMillion: 2.5, outputUsdPerMillion: 10 },
+    'openai/gpt-4o-mini': { inputUsdPerMillion: 0.15, outputUsdPerMillion: 0.60 },
+    'openai/gpt-5-nano': { inputUsdPerMillion: 0.05, outputUsdPerMillion: 0.20 },
+    'openrouter/anthropic/claude-haiku': { inputUsdPerMillion: 0.8, outputUsdPerMillion: 4 },
+    'openrouter/anthropic/claude-sonnet': { inputUsdPerMillion: 3, outputUsdPerMillion: 15 },
+    'brain/google/gemini-2.5-flash-lite': { inputUsdPerMillion: 0.10, outputUsdPerMillion: 0.40 },
+    'brain/openai/gpt-5.4-nano': { inputUsdPerMillion: 0.20, outputUsdPerMillion: 1.25 },
+    'brain/x-ai/grok-4.3': { inputUsdPerMillion: 1.25, outputUsdPerMillion: 2.50 },
+  },
+} as const satisfies ModelRateTable;
+
+export type ResolvedRate = ModelRate & { modelKey: string };
+
+function resolved(modelKey: keyof typeof modelRateTable.rates): ResolvedRate {
+  return { modelKey, ...modelRateTable.rates[modelKey] };
+}
+
+function resolveAnthropicRate(model: string): ResolvedRate | null {
+  const normalized = model.trim().toLowerCase();
+  if (!normalized || normalized === '<synthetic>') return null;
+  const fast = normalized.includes('fast');
+  if (normalized.includes('opus-4-8')) return resolved(fast ? 'claude-opus-4-8-fast' : 'claude-opus-4-8');
+  if (normalized.includes('opus-4-7')) return resolved(fast ? 'claude-opus-4-7-fast' : 'claude-opus-4-7');
+  if (normalized.includes('opus-4-6')) return resolved(fast ? 'claude-opus-4-6-fast' : 'claude-opus-4-6');
+  if (normalized.includes('sonnet-5')) return resolved('claude-sonnet-5');
+  if (normalized.includes('sonnet-4-6')) return resolved('claude-sonnet-4-6');
+  if (normalized.includes('sonnet-4-5') || normalized.includes('sonnet-4')) return resolved('claude-sonnet-4-5');
+  if (normalized.includes('haiku-4-5') || normalized.includes('haiku')) return resolved('claude-haiku-4-5');
+  return null;
+}
+
+function resolveCodexRate(model: string): ResolvedRate | null {
+  const normalized = model.trim().toLowerCase();
+  if (normalized.includes('gpt-5.6-sol')) return resolved('gpt-5.6-sol');
+  if (normalized.includes('gpt-5.6-terra')) return resolved('gpt-5.6-terra');
+  if (normalized.includes('gpt-5.6-luna')) return resolved('gpt-5.6-luna');
+  if (normalized.includes('gpt-5.5')) return resolved('gpt-5.5');
+  if (normalized.includes('gpt-5.4-mini')) return resolved('gpt-5.4-mini');
+  if (normalized.includes('gpt-5.4-nano')) return resolved('gpt-5.4-nano');
+  if (normalized.includes('gpt-5.4')) return resolved('gpt-5.4');
+  if (normalized.includes('gpt-5.2-pro')) return resolved('gpt-5.2-pro');
+  if (normalized.includes('gpt-5.2-codex')) return resolved('gpt-5.2-codex');
+  if (normalized.includes('gpt-5.2')) return resolved('gpt-5.2');
+  return null;
+}
+
+function resolveGeminiRate(model: string): ResolvedRate {
+  const normalized = model.trim().toLowerCase();
+  if (/gemini-3(?:[.-]\d+)?-pro/i.test(normalized)) return resolved('gemini-3-pro');
+  if (/gemini-2[.-]5-pro/i.test(normalized)) return resolved('gemini-2-5-pro');
+  if (/gemini-2[.-]5-flash/i.test(normalized)) return resolved('gemini-2-5-flash');
+  if (/gemini-1[.-]5-flash/i.test(normalized)) return resolved('gemini-1-5-flash');
+  // This parser intentionally falls back to the pessimistic Pro rate.
+  return resolved('gemini-3-pro');
+}
+
+function resolveOpenCodeRate(model: string): ResolvedRate | null {
+  if (!Object.hasOwn(modelRateTable.rates, model) || model.startsWith('brain/')) return null;
+  const allowed = new Set([
+    'opencode/gpt-5-nano',
+    'opencode/gpt-5-mini',
+    'opencode/gpt-5',
+    'anthropic/claude-sonnet-4-20250514',
+    'anthropic/claude-haiku-4-20250514',
+    'anthropic/claude-opus-4-20250514',
+    'google/gemini-2.5-pro',
+    'google/gemini-2.5-flash',
+    'openai/gpt-4o',
+    'openai/gpt-4o-mini',
+    'openai/gpt-5-nano',
+    'openrouter/anthropic/claude-haiku',
+    'openrouter/anthropic/claude-sonnet',
+  ]);
+  return allowed.has(model) ? resolved(model as keyof typeof modelRateTable.rates) : null;
+}
+
+function resolveBrainRate(model: string): ResolvedRate {
+  const key = `brain/${model}`;
+  if (Object.hasOwn(modelRateTable.rates, key)) {
+    return resolved(key as keyof typeof modelRateTable.rates);
+  }
+  // The Brain intentionally falls back to the priciest seeded chain entry.
+  return resolved('brain/x-ai/grok-4.3');
+}
+
+/**
+ * Provider-specific lookup preserves each former parser fallback:
+ * Claude/Codex/OpenCode return null for unknown models, Gemini uses Pro,
+ * Cursor always uses its fixed estimate, and the Brain uses its worst case.
+ */
+export function resolveRate(provider: string, model: string | null | undefined): ResolvedRate | null {
+  const normalizedProvider = provider.trim().toLowerCase();
+  const normalizedModel = model ?? '';
+  if (normalizedProvider === 'anthropic' || normalizedProvider === 'claude-code') {
+    return resolveAnthropicRate(normalizedModel);
+  }
+  if (normalizedProvider === 'openai' || normalizedProvider === 'codex') {
+    return resolveCodexRate(normalizedModel);
+  }
+  if (normalizedProvider === 'google' || normalizedProvider === 'gemini') {
+    return resolveGeminiRate(normalizedModel);
+  }
+  if (normalizedProvider === 'cursor') return resolved('cursor-agent');
+  if (normalizedProvider === 'opencode') return resolveOpenCodeRate(normalizedModel);
+  if (normalizedProvider === 'brain' || normalizedProvider === 'openrouter') return resolveBrainRate(normalizedModel);
+  return null;
+}

--- a/src/lib/lane/codex-orchestrator-events.ts
+++ b/src/lib/lane/codex-orchestrator-events.ts
@@ -1,3 +1,4 @@
+import { resolveRate } from '@/lib/cost/rate-table';
 import type { OrchestratorEvent, OrchestratorTurnUsage } from './orchestrator-stream-events';
 import { planFromCodexTodoList, planFromToolInput, type OrchestratorPlanSnapshot } from './orchestrator-plan';
 
@@ -22,10 +23,6 @@ export interface CodexLineHandlerState {
   lastPlanJson?: string;
 }
 
-const GPT_5_5_INPUT_USD_PER_MILLION = 2.5;
-const GPT_5_5_CACHED_INPUT_USD_PER_MILLION = 0.25;
-const GPT_5_5_OUTPUT_USD_PER_MILLION = 15;
-
 function safeObject(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -46,13 +43,14 @@ function emitPlanOnce(
 
 function computeUsdCost(usage: ParsedCodexLine['usage']): number | null {
   if (!usage) return null;
+  const rate = resolveRate('codex', 'gpt-5.5')!;
   const inputTokens = Math.max(0, (usage.input_tokens ?? 0) - (usage.cached_input_tokens ?? 0));
   const cachedTokens = usage.cached_input_tokens ?? 0;
   const outputTokens = usage.output_tokens ?? 0;
   const total =
-    (inputTokens / 1_000_000) * GPT_5_5_INPUT_USD_PER_MILLION
-    + (cachedTokens / 1_000_000) * GPT_5_5_CACHED_INPUT_USD_PER_MILLION
-    + (outputTokens / 1_000_000) * GPT_5_5_OUTPUT_USD_PER_MILLION;
+    (inputTokens / 1_000_000) * rate.inputUsdPerMillion
+    + (cachedTokens / 1_000_000) * (rate.cacheReadUsdPerMillion ?? 0)
+    + (outputTokens / 1_000_000) * rate.outputUsdPerMillion;
   return Number.isFinite(total) && total > 0 ? total : null;
 }
 

--- a/src/lib/lane/commands-launch.ts
+++ b/src/lib/lane/commands-launch.ts
@@ -6,6 +6,7 @@ import { getLanePolicy } from '@/lib/lane/policy';
 import { appendEvent, attachSession, getLane, getLaneEvents, setLaneStatus, updateLane } from '@/lib/lane/registry';
 import { resolvePortInfo } from '@/lib/panel/api-port';
 import { getRuntimeCapability, listDispatchableRuntimes } from '@/lib/orchestrator/runtime-capabilities';
+import { capturePacketCapacitySnapshot } from '@/lib/orchestrator/capacity-snapshots';
 import { getOrCreateWsToken } from '@/lib/ws-auth';
 import type { LaneCommand, LaneCommandResult, LaneEventActor, LaneRuntime } from '@/lib/lane/types';
 import { scanForBinary } from '@/lib/runtimes/shared/cli-locate';
@@ -110,6 +111,8 @@ export async function launchSession(
       updateLane(command.laneId, { model: resolvedLaunchModel(command, lane.runtime) }, 'system');
       attachSession(command.laneId, recovered.surfaceId, actor);
       setLaneStatus(command.laneId, 'running', actor, 'session_launch_recovered');
+      const recoveredLane = getLane(command.laneId);
+      if (recoveredLane) await capturePacketCapacitySnapshot(recoveredLane, 'start');
       return {
         ok: true,
         laneId: command.laneId,
@@ -234,6 +237,8 @@ export async function launchSession(
       }
     }
 
+    const launchedLane = getLane(command.laneId);
+    if (launchedLane) await capturePacketCapacitySnapshot(launchedLane, 'start');
     const updated = getLane(command.laneId);
     return {
       ok: true,

--- a/src/lib/lane/types.ts
+++ b/src/lib/lane/types.ts
@@ -286,6 +286,7 @@ export type LaneEventVerb =
   | 'explainer_completed'
   | 'explainer_failed'
   | 'runtime_drift'
+  | 'capacity_snapshot'
   | 'pr_merged_reconciled'
   | 'merged_by_ancestry_reconciled'
   // The ancestry sweep proved a merge, then found the branch had advanced past

--- a/src/lib/orchestrator/capacity-snapshots.ts
+++ b/src/lib/orchestrator/capacity-snapshots.ts
@@ -1,0 +1,60 @@
+import { recordLaneEvent } from '@/lib/lane/events';
+import { getLaneEvents } from '@/lib/lane/registry';
+import type { Lane } from '@/lib/lane/types';
+import type { RuntimeCapacitySnapshot } from '@/lib/runtimes/types';
+
+export type PacketCapacitySnapshotPhase = 'start' | 'end';
+
+function unavailable(runtime: string, reason: string): RuntimeCapacitySnapshot {
+  return {
+    runtime,
+    identityId: null,
+    status: 'unavailable',
+    reason,
+    observedAt: null,
+    source: null,
+    confidence: null,
+    buckets: [],
+  };
+}
+
+export async function capturePacketCapacitySnapshot(
+  lane: Lane,
+  phase: PacketCapacitySnapshotPhase,
+): Promise<void> {
+  if (!lane.packetId) return;
+  const sessionKey = lane.sessionKey?.trim() || null;
+  const alreadyCaptured = getLaneEvents(lane.id, 10_000).some((event) => (
+    event.verb === 'capacity_snapshot'
+      && event.payload.phase === phase
+      && event.payload.sessionKey === sessionKey
+  ));
+  if (alreadyCaptured) return;
+
+  let capacity: RuntimeCapacitySnapshot;
+  try {
+    const { getRuntimeCapacityControlSnapshot } = await import('@/lib/runtime/capacity-service');
+    const control = await getRuntimeCapacityControlSnapshot({ fresh: true });
+    capacity = control.capacities.find((candidate) => (
+      candidate.runtime === lane.runtime && candidate.identityId === null
+    )) ?? control.capacities.find((candidate) => candidate.runtime === lane.runtime)
+      ?? unavailable(lane.runtime, 'adapter_observation_unavailable');
+  } catch {
+    capacity = unavailable(lane.runtime, 'capacity_service_failed');
+  }
+
+  try {
+    recordLaneEvent(lane.id, 'capacity_snapshot', 'system', {
+      phase,
+      packetId: lane.packetId,
+      sessionKey,
+      capturedAt: new Date().toISOString(),
+      ...capacity,
+    });
+  } catch (error) {
+    console.warn(
+      `[capacity-snapshot] failed to persist ${phase} snapshot for lane ${lane.id}:`,
+      error instanceof Error ? error.message : error,
+    );
+  }
+}

--- a/src/lib/orchestrator/context-relay.ts
+++ b/src/lib/orchestrator/context-relay.ts
@@ -34,6 +34,7 @@ import { getActiveProjectScopeForRepoSync } from '@/lib/repos/projects';
 import { truncateText } from '@/lib/util/text';
 import { syncTranscriptSearchDocument } from '@/lib/search/transcripts';
 import { derivePacketAttemptIndex } from '@/lib/orchestrator/cost-attribution';
+import { capturePacketCapacitySnapshot } from '@/lib/orchestrator/capacity-snapshots';
 import {
   isReviewFinding,
   readLatestPersistedReview,
@@ -620,6 +621,7 @@ async function persistSessionOutcome(
   // runs, customer runtimes) weren't going to feed any downstream brain
   // consumer anyway.
   if (!isLedgerRuntime(runtimeId) || !lane?.repoPath) return;
+  await capturePacketCapacitySnapshot(lane, 'end');
   const db = getDb();
   if (!db) return;
 

--- a/src/lib/orchestrator/cost-persistence.test.ts
+++ b/src/lib/orchestrator/cost-persistence.test.ts
@@ -89,5 +89,6 @@ describe('runtime cost persistence', () => {
 
     const row = getDb()?.select().from(usageLogs).all().find((entry) => entry.sessionKey === base.sessionKey);
     expect(row).toMatchObject({ provider: 'openrouter', costUsd: 0.09 });
+    expect(JSON.parse(row?.metadataJson ?? '{}')).toEqual({ costSource: 'gateway' });
   });
 });

--- a/src/lib/orchestrator/cost-persistence.ts
+++ b/src/lib/orchestrator/cost-persistence.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 import { and, asc, eq } from 'drizzle-orm';
+import { modelRateTable } from '@/lib/cost/rate-table';
 import { getDb, getSqlite, usageLogs } from '@/lib/db';
 import type { UsageRole } from '@/lib/db/usage';
 import { getRuntime } from '@/lib/runtimes';
@@ -59,6 +60,24 @@ function normalizeTokenCount(value: unknown) {
 
 function normalizeUsd(value: number) {
   return Number(finiteNumber(value).toFixed(6));
+}
+
+function metadataJsonForCostSource(
+  metadata: Record<string, unknown> | null | undefined,
+  costSource: PersistSessionCostInput['costSource'],
+): string | null {
+  const normalized = { ...(metadata ?? {}) };
+  if (costSource === 'gateway') {
+    normalized.costSource = 'gateway';
+    delete normalized.rateTableVersion;
+  } else if (costSource === 'estimate') {
+    normalized.costSource = 'estimate';
+    normalized.rateTableVersion = modelRateTable.rateTableVersion;
+  } else if (costSource === 'unknown') {
+    normalized.costSource = 'unknown';
+    delete normalized.rateTableVersion;
+  }
+  return Object.keys(normalized).length > 0 ? JSON.stringify(normalized) : null;
 }
 
 export function readPersistedSessionCosts(sessionKey: string): PersistedSessionCost[] {
@@ -237,10 +256,12 @@ export async function persistSessionCost(input: PersistSessionCostInput): Promis
     missionId: context.missionId,
     role: context.role,
     runId: context.runId,
-    metadataJson: input.metadata ? JSON.stringify(input.metadata) : null,
   };
 
   if (existing) {
+    const effectiveCostSource = existing.provider === 'openrouter' && input.costSource !== 'gateway'
+      ? 'gateway'
+      : input.costSource;
     db.update(usageLogs).set({
       model: input.model?.trim() || input.runtime,
       provider: existing.provider === 'openrouter' && input.costSource !== 'gateway' ? 'openrouter' : provider,
@@ -257,6 +278,7 @@ export async function persistSessionCost(input: PersistSessionCostInput): Promis
       agentName: agentNameForRuntime(input.runtime),
       billingPeriod: billingPeriodFor(),
       ...attribution,
+      metadataJson: metadataJsonForCostSource(input.metadata, effectiveCostSource),
     }).where(and(eq(usageLogs.sessionKey, sessionKey), eq(usageLogs.attempt, context.attempt))).run();
     return true;
   }
@@ -278,6 +300,7 @@ export async function persistSessionCost(input: PersistSessionCostInput): Promis
     requestType: 'completion',
     billingPeriod: billingPeriodFor(),
     ...attribution,
+    metadataJson: metadataJsonForCostSource(input.metadata, input.costSource),
   }).run();
 
   console.log(`${LOG_PREFIX} Persisted ${sessionKey} attempt ${context.attempt}.`);
@@ -323,6 +346,13 @@ export async function persistRuntimeSessionCost(input: {
       missionId: input.missionId,
       role: input.role ?? 'worker',
       runId: input.runId,
+      metadata: telemetry.costSource === 'gateway'
+        ? { costSource: 'gateway' }
+        : telemetry.costSource === 'estimate'
+          ? { costSource: 'estimate', rateTableVersion: modelRateTable.rateTableVersion }
+          : telemetry.costSource === 'unknown'
+            ? { costSource: 'unknown' }
+            : undefined,
     });
     if (persisted) {
       const { getLaneEvents, listLanes } = await import('@/lib/lane/registry');

--- a/src/lib/runtimes/codex-cost-parser.ts
+++ b/src/lib/runtimes/codex-cost-parser.ts
@@ -3,6 +3,7 @@ import { access, readFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { createInterface } from 'node:readline';
+import { resolveRate, type ResolvedRate } from '@/lib/cost/rate-table';
 import type { SessionCostData } from '@/lib/runtimes/shared/cost-parser-registry';
 import { registerCostParser } from '@/lib/runtimes/shared/cost-parser-registry';
 export type { SessionCostData } from '@/lib/runtimes/shared/cost-parser-registry';
@@ -14,13 +15,7 @@ const LONG_CONTEXT_OUTPUT_MULTIPLIER = 1.5;
 const CODEX_HOME = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
 const CODEX_CONFIG_PATH = path.join(CODEX_HOME, 'config.toml');
 
-type CodexPricingModel = {
-  canonicalModel: string;
-  inputUsdPerMillion: number;
-  cachedInputUsdPerMillion: number;
-  outputUsdPerMillion: number;
-  longContextEligible?: boolean;
-};
+type CodexPricingModel = ResolvedRate & { longContextEligible: boolean };
 
 type NormalizedUsage = {
   inputTokens: number;
@@ -96,112 +91,20 @@ function diffUsage(next: NormalizedUsage, previous: NormalizedUsage | null): Nor
 }
 
 function detectPricingModel(rawModel: string | null | undefined): CodexPricingModel | null {
-  const normalizedModel = rawModel?.trim().toLowerCase();
-  if (!normalizedModel) {
-    return null;
-  }
-
-  // GPT-5.6 generation (per xAI/OpenAI pricing 2026-07-09, cache reads -90%).
-  if (normalizedModel.includes('gpt-5.6-sol')) {
-    return {
-      canonicalModel: 'gpt-5.6-sol',
-      inputUsdPerMillion: 5,
-      cachedInputUsdPerMillion: 0.5,
-      outputUsdPerMillion: 30,
-      longContextEligible: true,
-    };
-  }
-
-  if (normalizedModel.includes('gpt-5.6-terra')) {
-    return {
-      canonicalModel: 'gpt-5.6-terra',
-      inputUsdPerMillion: 2.5,
-      cachedInputUsdPerMillion: 0.25,
-      outputUsdPerMillion: 15,
-      longContextEligible: true,
-    };
-  }
-
-  if (normalizedModel.includes('gpt-5.6-luna')) {
-    return {
-      canonicalModel: 'gpt-5.6-luna',
-      inputUsdPerMillion: 1,
-      cachedInputUsdPerMillion: 0.1,
-      outputUsdPerMillion: 6,
-    };
-  }
-
-  if (normalizedModel.includes('gpt-5.5')) {
-    return {
-      canonicalModel: 'gpt-5.5',
-      inputUsdPerMillion: 2.5,
-      cachedInputUsdPerMillion: 0.25,
-      outputUsdPerMillion: 15,
-      longContextEligible: true,
-    };
-  }
-
-  if (normalizedModel.includes('gpt-5.4-mini')) {
-    return {
-      canonicalModel: 'gpt-5.4-mini',
-      inputUsdPerMillion: 0.75,
-      cachedInputUsdPerMillion: 0.075,
-      outputUsdPerMillion: 4.5,
-    };
-  }
-
-  if (normalizedModel.includes('gpt-5.4-nano')) {
-    return {
-      canonicalModel: 'gpt-5.4-nano',
-      inputUsdPerMillion: 0.2,
-      cachedInputUsdPerMillion: 0.02,
-      outputUsdPerMillion: 1.25,
-    };
-  }
-
-  if (normalizedModel.includes('gpt-5.4')) {
-    return {
-      canonicalModel: 'gpt-5.4',
-      inputUsdPerMillion: 2.5,
-      cachedInputUsdPerMillion: 0.25,
-      outputUsdPerMillion: 15,
-      longContextEligible: true,
-    };
-  }
-
-  if (normalizedModel.includes('gpt-5.2-pro')) {
-    return {
-      canonicalModel: 'gpt-5.2-pro',
-      inputUsdPerMillion: 21,
-      cachedInputUsdPerMillion: 2.1,
-      outputUsdPerMillion: 168,
-    };
-  }
-
-  if (normalizedModel.includes('gpt-5.2-codex')) {
-    return {
-      canonicalModel: 'gpt-5.2-codex',
-      inputUsdPerMillion: 1.5,
-      cachedInputUsdPerMillion: 0.15,
-      outputUsdPerMillion: 6,
-    };
-  }
-
-  if (normalizedModel.includes('gpt-5.2')) {
-    return {
-      canonicalModel: 'gpt-5.2',
-      inputUsdPerMillion: 2,
-      cachedInputUsdPerMillion: 0.2,
-      outputUsdPerMillion: 8,
-    };
-  }
-
-  return null;
+  const rate = resolveRate('codex', rawModel);
+  if (!rate) return null;
+  return {
+    ...rate,
+    longContextEligible: rate.modelKey === 'gpt-5.6-sol'
+      || rate.modelKey === 'gpt-5.6-terra'
+      || rate.modelKey === 'gpt-5.5'
+      || rate.modelKey === 'gpt-5.4',
+  };
 }
 
 function buildParsedUsageEntry(usage: NormalizedUsage, rawModel: string | null | undefined): ParsedUsageEntry {
   const pricing = detectPricingModel(rawModel);
-  const model = pricing?.canonicalModel ?? rawModel?.trim() ?? null;
+  const model = pricing?.modelKey ?? rawModel?.trim() ?? null;
   const uncachedInputTokens = Math.max(0, usage.inputTokens - usage.cachedInputTokens);
   const inputMultiplier = pricing?.longContextEligible && usage.inputTokens > LONG_CONTEXT_THRESHOLD
     ? LONG_CONTEXT_INPUT_MULTIPLIER
@@ -212,7 +115,7 @@ function buildParsedUsageEntry(usage: NormalizedUsage, rawModel: string | null |
   const totalCostUsd = pricing
     ? (
       (uncachedInputTokens * pricing.inputUsdPerMillion * inputMultiplier)
-      + (usage.cachedInputTokens * pricing.cachedInputUsdPerMillion * inputMultiplier)
+      + (usage.cachedInputTokens * (pricing.cacheReadUsdPerMillion ?? 0) * inputMultiplier)
       + (usage.outputTokens * pricing.outputUsdPerMillion * outputMultiplier)
     ) / TOKENS_PER_MILLION
     : 0;
@@ -373,6 +276,7 @@ export async function parseCodexSessionCost(
 
   totals.totalCostUsd = Number(totals.totalCostUsd.toFixed(6));
   totals.model = models.size === 1 ? [...models][0] : models.size > 1 ? 'mixed' : fallbackModel;
+  if (totals.totalCostUsd > 0) totals.costSource = 'estimate';
 
   return totals;
 }

--- a/src/lib/runtimes/codex.ts
+++ b/src/lib/runtimes/codex.ts
@@ -517,6 +517,7 @@ export const codexRuntime: AgentRuntime = {
         outputTokens: sessionCost.outputTokens,
         cacheReadTokens: sessionCost.cacheReadTokens,
         cacheWriteTokens: sessionCost.cacheWriteTokens,
+        costSource: sessionCost.costSource ?? 'unknown',
         model: sessionCost.model ?? undefined,
       };
     }
@@ -540,6 +541,7 @@ export const codexRuntime: AgentRuntime = {
       outputTokens: sessionCost.outputTokens,
       cacheReadTokens: sessionCost.cacheReadTokens,
       cacheWriteTokens: sessionCost.cacheWriteTokens,
+      costSource: sessionCost.costSource ?? 'unknown',
       model: sessionCost.model ?? undefined,
     };
   },

--- a/src/lib/runtimes/cost-parser.ts
+++ b/src/lib/runtimes/cost-parser.ts
@@ -2,15 +2,13 @@ import { createReadStream } from 'node:fs';
 import { readdir, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { createInterface } from 'node:readline';
+import { resolveRate, type ResolvedRate } from '@/lib/cost/rate-table';
 import { registerCostParser } from './shared/cost-parser-registry';
 
 export type { SessionCostData } from './shared/cost-parser-registry';
 import type { SessionCostData } from './shared/cost-parser-registry';
 
 const TOKENS_PER_MILLION = 1_000_000;
-const CACHE_READ_MULTIPLIER = 0.1;
-const CACHE_WRITE_5M_MULTIPLIER = 1.25;
-const CACHE_WRITE_1H_MULTIPLIER = 2;
 
 interface ClaudeUsagePayload {
   input_tokens?: number;
@@ -37,12 +35,6 @@ interface ClaudeJsonlEntry {
   };
 }
 
-interface PricingModel {
-  canonicalModel: string;
-  inputUsdPerMillion: number;
-  outputUsdPerMillion: number;
-}
-
 interface ParsedUsageEntry {
   cacheReadTokens: number;
   cacheWrite1hTokens: number;
@@ -60,7 +52,7 @@ function toTokenCount(value: unknown): number {
     : 0;
 }
 
-function detectPricingModel(rawModel: string | null | undefined, usage: ClaudeUsagePayload): PricingModel | null {
+function detectPricingModel(rawModel: string | null | undefined, usage: ClaudeUsagePayload): ResolvedRate | null {
   const normalizedModel = rawModel?.trim().toLowerCase();
   if (!normalizedModel || normalizedModel === '<synthetic>') {
     return null;
@@ -72,64 +64,10 @@ function detectPricingModel(rawModel: string | null | undefined, usage: ClaudeUs
     || normalizedTier === 'priority'
     || normalizedSpeed === 'fast'
     || normalizedModel.includes('fast');
-
-  if (normalizedModel.includes('opus-4-8')) {
-    return {
-      canonicalModel: isFastTier ? 'claude-opus-4-8-fast' : 'claude-opus-4-8',
-      inputUsdPerMillion: isFastTier ? 30 : 5,
-      outputUsdPerMillion: isFastTier ? 150 : 25,
-    };
-  }
-
-  if (normalizedModel.includes('opus-4-7')) {
-    return {
-      canonicalModel: isFastTier ? 'claude-opus-4-7-fast' : 'claude-opus-4-7',
-      inputUsdPerMillion: isFastTier ? 30 : 5,
-      outputUsdPerMillion: isFastTier ? 150 : 25,
-    };
-  }
-
-  if (normalizedModel.includes('opus-4-6')) {
-    return {
-      canonicalModel: isFastTier ? 'claude-opus-4-6-fast' : 'claude-opus-4-6',
-      inputUsdPerMillion: isFastTier ? 30 : 5,
-      outputUsdPerMillion: isFastTier ? 150 : 25,
-    };
-  }
-
-  if (normalizedModel.includes('sonnet-5')) {
-    return {
-      canonicalModel: 'claude-sonnet-5',
-      inputUsdPerMillion: 3,
-      outputUsdPerMillion: 15,
-    };
-  }
-
-  if (normalizedModel.includes('sonnet-4-6')) {
-    return {
-      canonicalModel: 'claude-sonnet-4-6',
-      inputUsdPerMillion: 3,
-      outputUsdPerMillion: 15,
-    };
-  }
-
-  if (normalizedModel.includes('sonnet-4-5') || normalizedModel.includes('sonnet-4')) {
-    return {
-      canonicalModel: 'claude-sonnet-4-5',
-      inputUsdPerMillion: 3,
-      outputUsdPerMillion: 15,
-    };
-  }
-
-  if (normalizedModel.includes('haiku-4-5') || normalizedModel.includes('haiku')) {
-    return {
-      canonicalModel: 'claude-haiku-4-5',
-      inputUsdPerMillion: 0.8,
-      outputUsdPerMillion: 4,
-    };
-  }
-
-  return null;
+  const lookupModel = isFastTier && !normalizedModel.includes('fast')
+    ? `${normalizedModel}-fast`
+    : normalizedModel;
+  return resolveRate('anthropic', lookupModel);
 }
 
 function buildParsedUsageEntry(
@@ -149,16 +87,14 @@ function buildParsedUsageEntry(
   const cacheWriteRemainder = Math.max(0, cacheWriteTokens - cacheWrite5mTokens - cacheWrite1hTokens);
   const normalizedCacheWrite5mTokens = cacheWrite5mTokens + cacheWriteRemainder;
   const pricing = detectPricingModel(rawModel, usage);
-  const model = pricing?.canonicalModel ?? fallbackModel ?? rawModel?.trim() ?? null;
-  const inputRate = pricing?.inputUsdPerMillion ?? 0;
-  const outputRate = pricing?.outputUsdPerMillion ?? 0;
+  const model = pricing?.modelKey ?? fallbackModel ?? rawModel?.trim() ?? null;
 
   const totalCostUsd = (
-    (inputTokens * inputRate)
-    + (outputTokens * outputRate)
-    + (cacheReadTokens * inputRate * CACHE_READ_MULTIPLIER)
-    + (normalizedCacheWrite5mTokens * inputRate * CACHE_WRITE_5M_MULTIPLIER)
-    + (cacheWrite1hTokens * inputRate * CACHE_WRITE_1H_MULTIPLIER)
+    (inputTokens * (pricing?.inputUsdPerMillion ?? 0))
+    + (outputTokens * (pricing?.outputUsdPerMillion ?? 0))
+    + (cacheReadTokens * (pricing?.cacheReadUsdPerMillion ?? 0))
+    + (normalizedCacheWrite5mTokens * (pricing?.cacheWriteUsdPerMillion ?? 0))
+    + (cacheWrite1hTokens * (pricing?.cacheWrite1hUsdPerMillion ?? 0))
   ) / TOKENS_PER_MILLION;
 
   return {
@@ -311,6 +247,7 @@ export async function parseSessionCost(
 
   totals.totalCostUsd = Number(totals.totalCostUsd.toFixed(6));
   totals.model = models.size === 1 ? [...models][0] : models.size > 1 ? 'mixed' : fallbackModel;
+  if (totals.totalCostUsd > 0) totals.costSource = 'estimate';
 
   return totals;
 }

--- a/src/lib/runtimes/cursor-cost-parser.ts
+++ b/src/lib/runtimes/cursor-cost-parser.ts
@@ -1,13 +1,12 @@
 import { createReadStream } from 'node:fs';
 import { access } from 'node:fs/promises';
 import { createInterface } from 'node:readline';
+import { resolveRate } from '@/lib/cost/rate-table';
 import { registerCostParser } from '@/lib/runtimes/shared/cost-parser-registry';
 import type { SessionCostData } from '@/lib/runtimes/shared/cost-parser-registry';
 
 const TOKENS_PER_MILLION = 1_000_000;
 const DEFAULT_MODEL = 'cursor-agent';
-const DEFAULT_INPUT_USD_PER_MILLION = 1.25;
-const DEFAULT_OUTPUT_USD_PER_MILLION = 10;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -41,8 +40,12 @@ function extractUsage(parsed: Record<string, unknown>): SessionCostData | null {
   const cacheWriteTokens = toNumber(source.cache_write_tokens ?? source.cacheWriteTokens);
   if (inputTokens === 0 && outputTokens === 0 && cacheReadTokens === 0 && cacheWriteTokens === 0) return null;
   const embeddedCost = toNumber(source.total_cost_usd ?? source.totalCostUsd ?? source.cost_usd ?? source.costUsd);
-  const computedCost = ((inputTokens + cacheWriteTokens) * DEFAULT_INPUT_USD_PER_MILLION
-    + outputTokens * DEFAULT_OUTPUT_USD_PER_MILLION) / TOKENS_PER_MILLION;
+  const rate = resolveRate('cursor', readModel(parsed, usage));
+  const computedCost = (
+    (inputTokens * (rate?.inputUsdPerMillion ?? 0))
+    + (cacheWriteTokens * (rate?.cacheWriteUsdPerMillion ?? 0))
+    + (outputTokens * (rate?.outputUsdPerMillion ?? 0))
+  ) / TOKENS_PER_MILLION;
   return {
     inputTokens,
     outputTokens,
@@ -50,6 +53,7 @@ function extractUsage(parsed: Record<string, unknown>): SessionCostData | null {
     cacheWriteTokens,
     totalCostUsd: Number((embeddedCost || computedCost).toFixed(6)),
     model: readModel(parsed, usage) ?? DEFAULT_MODEL,
+    costSource: embeddedCost > 0 ? 'gateway' : 'estimate',
   };
 }
 
@@ -83,6 +87,8 @@ export async function parseCursorSessionCost(paths: string[]): Promise<SessionCo
     model: null,
   };
   const models = new Set<string>();
+  let usedEstimate = false;
+  let usedGateway = false;
   for (const filePath of paths) {
     const parsed = await parseCursorCostFile(filePath);
     if (!parsed) continue;
@@ -91,10 +97,13 @@ export async function parseCursorSessionCost(paths: string[]): Promise<SessionCo
     totals.cacheReadTokens += parsed.cacheReadTokens;
     totals.cacheWriteTokens += parsed.cacheWriteTokens;
     totals.totalCostUsd += parsed.totalCostUsd;
+    usedEstimate ||= parsed.costSource === 'estimate';
+    usedGateway ||= parsed.costSource === 'gateway';
     if (parsed.model) models.add(parsed.model);
   }
   totals.totalCostUsd = Number(totals.totalCostUsd.toFixed(6));
   totals.model = models.size === 1 ? [...models][0] : models.size > 1 ? 'mixed' : DEFAULT_MODEL;
+  totals.costSource = usedEstimate ? 'estimate' : usedGateway ? 'gateway' : 'unknown';
   return totals;
 }
 

--- a/src/lib/runtimes/cursor.ts
+++ b/src/lib/runtimes/cursor.ts
@@ -232,6 +232,7 @@ export const cursorRuntime: AgentRuntime = {
       outputTokens: sessionCost.outputTokens,
       cacheReadTokens: sessionCost.cacheReadTokens,
       cacheWriteTokens: sessionCost.cacheWriteTokens,
+      costSource: sessionCost.costSource ?? 'unknown',
       model: sessionCost.model ?? undefined,
     };
   },

--- a/src/lib/runtimes/gemini-cost-parser.ts
+++ b/src/lib/runtimes/gemini-cost-parser.ts
@@ -17,70 +17,16 @@ import { access, readdir, readFile, stat } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { createInterface } from 'node:readline';
+import { resolveRate, type ResolvedRate } from '@/lib/cost/rate-table';
 import type { SessionCostData } from '@/lib/runtimes/shared/cost-parser-registry';
 import { registerCostParser } from '@/lib/runtimes/shared/cost-parser-registry';
 export type { SessionCostData } from '@/lib/runtimes/shared/cost-parser-registry';
 
 const TOKENS_PER_MILLION = 1_000_000;
 
-// Pricing snapshot for Gemini models (USD per 1M tokens).
-// TODO(pricing): verify against https://ai.google.dev/pricing at build time.
-// The shape mirrors codex-cost-parser.ts — per-model inline, no remote fetch.
-interface GeminiPricing {
-  canonicalModel: string;
-  inputUsdPerMillion: number;
-  outputUsdPerMillion: number;
-  cacheReadUsdPerMillion: number;
-}
-
-const GEMINI_PRICING: Array<{ match: RegExp; pricing: GeminiPricing }> = [
-  {
-    match: /gemini-3(?:[.-]\d+)?-pro/i,
-    pricing: {
-      canonicalModel: 'gemini-3-pro',
-      inputUsdPerMillion: 1.25,
-      outputUsdPerMillion: 10,
-      cacheReadUsdPerMillion: 0.3125,
-    },
-  },
-  {
-    match: /gemini-2[.-]5-pro/i,
-    pricing: {
-      canonicalModel: 'gemini-2-5-pro',
-      inputUsdPerMillion: 1.25,
-      outputUsdPerMillion: 10,
-      cacheReadUsdPerMillion: 0.3125,
-    },
-  },
-  {
-    match: /gemini-2[.-]5-flash/i,
-    pricing: {
-      canonicalModel: 'gemini-2-5-flash',
-      inputUsdPerMillion: 0.075,
-      outputUsdPerMillion: 0.30,
-      cacheReadUsdPerMillion: 0.019,
-    },
-  },
-  {
-    match: /gemini-1[.-]5-flash/i,
-    pricing: {
-      canonicalModel: 'gemini-1-5-flash',
-      inputUsdPerMillion: 0.075,
-      outputUsdPerMillion: 0.30,
-      cacheReadUsdPerMillion: 0.019,
-    },
-  },
-];
-
 // Fallback when the stream mentions a model we don't have pricing for — treat
 // it as Gemini 3 Pro. Pessimistic direction: slightly overestimates for flash
 // models, but only fires when model name is unknown, which should be rare.
-const DEFAULT_PRICING: GeminiPricing = {
-  canonicalModel: 'gemini-3-pro',
-  inputUsdPerMillion: 1.25,
-  outputUsdPerMillion: 10,
-  cacheReadUsdPerMillion: 0.3125,
-};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -92,13 +38,8 @@ function toTokenCount(value: unknown): number {
     : 0;
 }
 
-function detectPricing(rawModel: string | null | undefined): GeminiPricing {
-  const normalized = (rawModel ?? '').trim().toLowerCase();
-  if (!normalized) return DEFAULT_PRICING;
-  for (const entry of GEMINI_PRICING) {
-    if (entry.match.test(normalized)) return entry.pricing;
-  }
-  return DEFAULT_PRICING;
+function detectPricing(rawModel: string | null | undefined): ResolvedRate {
+  return resolveRate('gemini', rawModel)!;
 }
 
 interface AccumulatedUsage {
@@ -316,12 +257,13 @@ export async function parseGeminiSessionCost(
   totals.totalCostUsd = Number(
     (
       (uncachedInput * pricing.inputUsdPerMillion)
-      + (totals.cacheReadTokens * pricing.cacheReadUsdPerMillion)
+      + (totals.cacheReadTokens * (pricing.cacheReadUsdPerMillion ?? 0))
       + (totals.outputTokens * pricing.outputUsdPerMillion)
     ) / TOKENS_PER_MILLION,
   );
   totals.totalCostUsd = Number(totals.totalCostUsd.toFixed(6));
-  totals.model = resolvedModel ?? pricing.canonicalModel;
+  totals.model = resolvedModel ?? pricing.modelKey;
+  if (totals.totalCostUsd > 0) totals.costSource = 'estimate';
 
   return totals;
 }

--- a/src/lib/runtimes/gemini.ts
+++ b/src/lib/runtimes/gemini.ts
@@ -323,6 +323,7 @@ export const geminiRuntime: AgentRuntime = {
       outputTokens: sessionCost.outputTokens,
       cacheReadTokens: sessionCost.cacheReadTokens,
       cacheWriteTokens: sessionCost.cacheWriteTokens,
+      costSource: sessionCost.costSource ?? 'unknown',
       model: sessionCost.model ?? undefined,
     };
   },

--- a/src/lib/runtimes/grok.ts
+++ b/src/lib/runtimes/grok.ts
@@ -232,6 +232,7 @@ export const grokRuntime: AgentRuntime = {
       outputTokens: sessionCost.outputTokens,
       cacheReadTokens: sessionCost.cacheReadTokens,
       cacheWriteTokens: sessionCost.cacheWriteTokens,
+      costSource: sessionCost.totalCostUsd > 0 ? 'gateway' : 'unknown',
       model: sessionCost.model ?? undefined,
     };
   },

--- a/src/lib/runtimes/opencode-cost-parser.test.ts
+++ b/src/lib/runtimes/opencode-cost-parser.test.ts
@@ -47,6 +47,7 @@ describe('OpenCode 2 cost parser', () => {
       cacheWriteTokens: 10,
       totalCostUsd: 0.0035,
       model: 'opencode/deepseek-v4-flash-free',
+      costSource: 'gateway',
     });
   });
 
@@ -73,6 +74,7 @@ describe('OpenCode 2 cost parser', () => {
       cacheWriteTokens: 1,
       totalCostUsd: 0.00001,
       model: 'opencode/gpt-5-nano',
+      costSource: 'gateway',
     });
   });
 });

--- a/src/lib/runtimes/opencode-cost-parser.ts
+++ b/src/lib/runtimes/opencode-cost-parser.ts
@@ -7,57 +7,27 @@
  *   {"type":"step_finish","part":{"cost":X,"tokens":{"input":N,"output":N,"cache":{"read":N,"write":N}}}}
  *
  * When `totalCostUsd` is not present (e.g. offline models or older builds),
- * we fall back to a static per-model price table.  We prefer returning 0
- * cost to throwing — opencode's multi-provider surface makes a complete
- * pricing table impractical.
- *
- * TODO(pricing): Verify rates against openrouter.ai/models as models ship.
+ * we fall back to the dated per-model rate table. We prefer returning 0
+ * cost to throwing because the multi-provider surface cannot safely infer
+ * an unknown model's rate.
  */
 
 import { createReadStream } from 'node:fs';
 import { access } from 'node:fs/promises';
 import { createInterface } from 'node:readline';
+import { resolveRate } from '@/lib/cost/rate-table';
 import { registerCostParser } from '@/lib/runtimes/shared/cost-parser-registry';
 import type { SessionCostData } from '@/lib/runtimes/shared/cost-parser-registry';
 
-// ── Static price table ────────────────────────────────────────────────────────
-
-/**
- * Fallback price table keyed by model string (as returned by the session record).
- * All rates are $/1M tokens.
- */
-const OPENCODE_PRICING: Record<string, { input: number; output: number }> = {
-  // opencode built-in / proxied models
-  'opencode/gpt-5-nano': { input: 0.05, output: 0.20 },     // TODO(pricing): verify
-  'opencode/gpt-5-mini': { input: 0.15, output: 0.60 },     // TODO(pricing): verify
-  'opencode/gpt-5': { input: 1.0, output: 4.0 },             // TODO(pricing): verify
-
-  // Anthropic via openrouter
-  'anthropic/claude-sonnet-4-20250514': { input: 3, output: 15 },
-  'anthropic/claude-haiku-4-20250514': { input: 0.8, output: 4 },
-  'anthropic/claude-opus-4-20250514': { input: 15, output: 75 },
-
-  // Google via openrouter
-  'google/gemini-2.5-pro': { input: 1.25, output: 10 },
-  'google/gemini-2.5-flash': { input: 0.075, output: 0.30 },
-
-  // OpenAI via openrouter
-  'openai/gpt-4o': { input: 2.5, output: 10 },
-  'openai/gpt-4o-mini': { input: 0.15, output: 0.60 },
-  'openai/gpt-5-nano': { input: 0.05, output: 0.20 },       // TODO(pricing): verify
-
-  // OpenRouter generic passthrough
-  'openrouter/anthropic/claude-haiku': { input: 0.8, output: 4 },
-  'openrouter/anthropic/claude-sonnet': { input: 3, output: 15 },
-};
-
 const TOKENS_PER_MILLION = 1_000_000;
 
-function staticCost(inputTokens: number, outputTokens: number, model: string | null): number {
-  if (!model) return 0;
-  const pricing = OPENCODE_PRICING[model];
-  if (!pricing) return 0;
-  return (inputTokens * pricing.input + outputTokens * pricing.output) / TOKENS_PER_MILLION;
+function staticCost(inputTokens: number, outputTokens: number, model: string | null): { costUsd: number; priced: boolean } {
+  const rate = resolveRate('opencode', model);
+  if (!rate) return { costUsd: 0, priced: false };
+  return {
+    costUsd: (inputTokens * rate.inputUsdPerMillion + outputTokens * rate.outputUsdPerMillion) / TOKENS_PER_MILLION,
+    priced: true,
+  };
 }
 
 // ── JSONL parser ──────────────────────────────────────────────────────────────
@@ -195,6 +165,8 @@ export async function parseOpencodeSessionCost(
   };
   const models = new Set<string>();
   let fallbackModel = opts?.fallbackModel ?? null;
+  let usedEstimate = false;
+  let usedGateway = false;
 
   for (const filePath of paths) {
     const { results, detectedModel } = await parseOpencodeJSONLFile(filePath);
@@ -208,11 +180,14 @@ export async function parseOpencodeSessionCost(
       totals.cacheReadTokens += r.cacheReadTokens;
       totals.cacheWriteTokens += r.cacheWriteTokens;
 
-      // Use embedded cost if available; otherwise compute from static table.
+      // Use embedded cost if available; otherwise resolve the dated table.
       if (r.costUsd !== null) {
         totals.totalCostUsd += r.costUsd;
+        usedGateway = true;
       } else {
-        totals.totalCostUsd += staticCost(r.inputTokens, r.outputTokens, r.model ?? fallbackModel);
+        const estimated = staticCost(r.inputTokens, r.outputTokens, r.model ?? fallbackModel);
+        totals.totalCostUsd += estimated.costUsd;
+        usedEstimate ||= estimated.priced;
       }
 
       if (r.model) models.add(r.model);
@@ -225,6 +200,7 @@ export async function parseOpencodeSessionCost(
     : models.size > 1
       ? 'mixed'
       : fallbackModel;
+  totals.costSource = usedEstimate ? 'estimate' : usedGateway ? 'gateway' : 'unknown';
 
   return totals;
 }

--- a/src/lib/runtimes/opencode.ts
+++ b/src/lib/runtimes/opencode.ts
@@ -309,6 +309,7 @@ export const opencodeRuntime: AgentRuntime = {
       outputTokens: sessionCost.outputTokens,
       cacheReadTokens: sessionCost.cacheReadTokens,
       cacheWriteTokens: sessionCost.cacheWriteTokens,
+      costSource: sessionCost.costSource ?? 'unknown',
       model: sessionCost.model ?? undefined,
     };
   },

--- a/src/lib/runtimes/pi.ts
+++ b/src/lib/runtimes/pi.ts
@@ -163,6 +163,7 @@ export const piRuntime: AgentRuntime = {
       outputTokens: cost.outputTokens,
       cacheReadTokens: cost.cacheReadTokens,
       cacheWriteTokens: cost.cacheWriteTokens,
+      costSource: cost.totalCostUsd > 0 ? 'gateway' : 'unknown',
       model: cost.model ?? undefined,
     };
   },

--- a/src/lib/runtimes/prime-agent.ts
+++ b/src/lib/runtimes/prime-agent.ts
@@ -165,6 +165,7 @@ export const primeAgentRuntime: AgentRuntime = {
       outputTokens: sessionCost.outputTokens,
       cacheReadTokens: sessionCost.cacheReadTokens,
       cacheWriteTokens: sessionCost.cacheWriteTokens,
+      costSource: sessionCost.totalCostUsd > 0 ? 'gateway' : 'unknown',
       model: sessionCost.model ?? undefined,
     };
   },

--- a/src/lib/runtimes/shared/cost-parser-registry.ts
+++ b/src/lib/runtimes/shared/cost-parser-registry.ts
@@ -17,6 +17,7 @@ export interface SessionCostData {
   cacheWriteTokens: number;
   totalCostUsd: number;
   model: string | null;
+  costSource?: 'gateway' | 'estimate' | 'unknown';
 }
 
 export interface CostParser {

--- a/src/lib/runtimes/shared/declarative-agent-runtime.ts
+++ b/src/lib/runtimes/shared/declarative-agent-runtime.ts
@@ -153,6 +153,7 @@ export function createDeclarativeAgentRuntime(
         outputTokens: cost.outputTokens,
         cacheReadTokens: cost.cacheReadTokens,
         cacheWriteTokens: cost.cacheWriteTokens,
+        costSource: cost.costSource ?? 'unknown',
         model: cost.model ?? undefined,
       };
     };

--- a/tests/cost-ledger-real-path.test.ts
+++ b/tests/cost-ledger-real-path.test.ts
@@ -3,7 +3,24 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { NextRequest } from 'next/server';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
-import type { AgentRuntime, RuntimeTranscriptEntry } from '@/lib/runtimes/types';
+import type { AgentRuntime, RuntimeCapacitySnapshot, RuntimeTranscriptEntry } from '@/lib/runtimes/types';
+
+const launchRuntimeSurface = vi.hoisted(() => vi.fn(async (input: {
+  runtime: string;
+  existingLaneId?: string;
+  repoPath?: string;
+}) => ({
+  ok: true as const,
+  runtime: input.runtime,
+  surfaceId: `codex-owned:${input.existingLaneId ?? 'capacity-snapshot'}`,
+  note: 'launched capacity snapshot fixture',
+  cwd: input.repoPath ?? process.cwd(),
+  repoPath: input.repoPath ?? process.cwd(),
+  worktree: null,
+  laneId: input.existingLaneId ?? null,
+})));
+
+vi.mock('@/lib/runtime/actions', () => ({ launchRuntimeSurface }));
 
 const cacheRoot = join(process.cwd(), 'node_modules', '.cache');
 mkdirSync(cacheRoot, { recursive: true });
@@ -11,6 +28,9 @@ const dataDir = mkdtempSync(join(cacheRoot, 'o8-cost-ledger-real-path-'));
 const repoPath = join(dataDir, 'repo');
 process.env.CORTEX_IDE_DATA_DIR = dataDir;
 process.env.O8_DATA_DIR = dataDir;
+
+let testRuntime: AgentRuntime;
+let capacityObservation: RuntimeCapacitySnapshot;
 
 vi.mock('@/lib/panel/auth', () => ({ requirePanelAuth: () => null }));
 vi.mock('@/lib/runtime/inventory', () => ({ getRuntimeInventorySnapshot: async () => ({ agents: [] }) }));
@@ -40,7 +60,26 @@ beforeAll(async () => {
   git('add', 'README.md');
   git('-c', 'user.email=test@o8.test', '-c', 'user.name=o8-test', 'commit', '-m', 'init');
 
-  const runtime: AgentRuntime = {
+  capacityObservation = {
+    runtime: 'codex',
+    identityId: null,
+    status: 'available',
+    reason: null,
+    observedAt: '2026-08-28T16:00:00.000Z',
+    source: 'local-state',
+    confidence: 'exact',
+    buckets: [{
+      id: 'weekly',
+      label: 'Weekly',
+      usedRatio: null,
+      used: null,
+      unit: null,
+      remaining: null,
+      resetsAt: null,
+      expiresAt: null,
+    }],
+  };
+  testRuntime = {
     id: 'codex',
     displayName: 'Cost ledger test runtime',
     capabilities: {
@@ -52,6 +91,7 @@ beforeAll(async () => {
       reviewDiffs: true,
       costTelemetry: false,
       streaming: false,
+      capacity: { observe: true, identitySelection: false },
     },
     discoverSessions: async () => [],
     readTranscript: async () => transcript(),
@@ -59,9 +99,12 @@ beforeAll(async () => {
     resume: async () => ({ ok: false, note: 'not supported' }),
     interrupt: async () => ({ ok: false, note: 'not supported' }),
     getChangedFiles: async () => [],
+    getCapacity: async () => capacityObservation,
   };
-  const { registerRuntime } = await import('@/lib/runtimes/registry');
-  registerRuntime(runtime);
+  // Load the auto-registration barrel before installing the deterministic
+  // fixture so a later capacity-service import cannot overwrite it.
+  const { registerRuntime } = await import('@/lib/runtimes');
+  registerRuntime(testRuntime);
 });
 
 afterAll(() => {
@@ -69,6 +112,130 @@ afterAll(() => {
 });
 
 describe('cost ledger persisted real path', () => {
+  it('stamps table estimates and captures launch/completion capacity with explicit unavailable fallback', async () => {
+    const { modelRateTable, resolveRate } = await import('@/lib/cost/rate-table');
+    const rate = resolveRate('codex', 'gpt-5.5')!;
+    const sessionKey = 'codex-owned:rate-version-persistence';
+    const { createLane, getLaneEvents } = await import('@/lib/lane/registry');
+    const estimatedLane = createLane({
+      repoPath,
+      worktreePath: repoPath,
+      branch: 'fix/rate-version-persistence',
+      runtime: 'codex',
+      packetId: 'packet-rate-version-persistence',
+      sessionKey,
+    });
+    const { persistSessionCost } = await import('@/lib/orchestrator/cost-persistence');
+    await persistSessionCost({
+      sessionKey,
+      runtime: 'codex',
+      model: 'gpt-5.5',
+      inputTokens: 100_000,
+      outputTokens: 10_000,
+      costUsd: (100_000 * rate.inputUsdPerMillion + 10_000 * rate.outputUsdPerMillion) / 1_000_000,
+      repoPath,
+      laneId: estimatedLane.id,
+      packetId: estimatedLane.packetId,
+      costSource: 'estimate',
+    });
+    const { getSqlite } = await import('@/lib/db');
+    const estimatedRow = getSqlite().prepare(`
+      SELECT metadata_json FROM usage_logs WHERE session_key = ?
+    `).get(sessionKey) as { metadata_json: string };
+    expect(JSON.parse(estimatedRow.metadata_json)).toEqual({
+      costSource: 'estimate',
+      rateTableVersion: modelRateTable.rateTableVersion,
+    });
+
+    const { createMission } = await import('@/lib/orchestrator/operator-mission-service');
+    const mission = await createMission({
+      issues: [{
+        number: 1_974_001,
+        title: 'inline: verify packet capacity snapshots',
+        body: 'Launch and complete one packet through the lifecycle seams.',
+        url: '',
+      }],
+      repoPath,
+      runtime: 'codex',
+      constraints: 'Real-path capacity snapshot regression.',
+      taskContract: 'off',
+    });
+    const packetId = mission.packets[0]!.id;
+    const lane = createLane({
+      repoPath,
+      worktreePath: repoPath,
+      branch: 'fix/capacity-snapshot-real-path',
+      runtime: 'codex',
+      packetId,
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => new Response(null, { status: 200 })) as typeof fetch;
+    try {
+      const { dispatch } = await import('@/lib/lane/commands');
+      await expect(dispatch({
+        verb: 'launch_session',
+        laneId: lane.id,
+        prompt: 'Capture packet capacity.',
+        actor: 'orchestrator',
+      })).resolves.toMatchObject({ ok: true });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const startEvent = getLaneEvents(lane.id, 100).find((event) => (
+      event.verb === 'capacity_snapshot' && event.payload.phase === 'start'
+    ));
+    expect(startEvent?.payload).toMatchObject({
+      phase: 'start',
+      packetId,
+      runtime: 'codex',
+      status: 'available',
+      identityId: null,
+      reason: null,
+      source: 'local-state',
+      confidence: 'exact',
+      buckets: [expect.objectContaining({
+        id: 'weekly',
+        usedRatio: null,
+        used: null,
+        unit: null,
+        remaining: null,
+        resetsAt: null,
+        expiresAt: null,
+      })],
+    });
+    expect(startEvent?.payload.capturedAt).toEqual(expect.any(String));
+
+    testRuntime.capabilities.capacity = undefined;
+    testRuntime.getCapacity = undefined;
+    const launchedSessionKey = `codex-owned:${lane.id}`;
+    const { capturePacketCompletionContext } = await import('@/lib/orchestrator/context-relay');
+    try {
+      await capturePacketCompletionContext(packetId, launchedSessionKey);
+      await vi.waitFor(() => {
+        const capacityEvents = getLaneEvents(lane.id, 100).filter((event) => event.verb === 'capacity_snapshot');
+        expect(capacityEvents).toHaveLength(2);
+        expect(capacityEvents[1]?.payload).toMatchObject({
+          phase: 'end',
+          packetId,
+          sessionKey: launchedSessionKey,
+          runtime: 'codex',
+          status: 'unavailable',
+          reason: 'adapter_observation_unavailable',
+          identityId: null,
+          observedAt: null,
+          source: null,
+          confidence: null,
+          buckets: [],
+        });
+        expect(capacityEvents[1]?.payload.capturedAt).toEqual(expect.any(String));
+      });
+    } finally {
+      testRuntime.capabilities.capacity = { observe: true, identitySelection: false };
+      testRuntime.getCapacity = async () => capacityObservation;
+    }
+  });
+
   it('keeps retry attempts distinct and carries the same totals through outcomes and status', async () => {
     const { getSqlite } = await import('@/lib/db');
     const columns = getSqlite().prepare('PRAGMA table_info(usage_logs)').all() as Array<{ name: string }>;


### PR DESCRIPTION
Fixes #1974 (split out of #1791; follows #1976).

**Rate table.** Every model price the runtime parsers and the Brain spend guard carried as private literals now lives in one dated table, `src/lib/cost/rate-table.ts` (`rateTableVersion: 2026-08-28.1`, `observedOn: 2026-08-28`). The values are the ones that were already checked in, consolidated — not refreshed; cache tiers that parsers computed from multipliers (read × 0.1, write × 1.25, one-hour write × 2) are materialized as explicit per-million rates, and the Brain's per-token values are expressed per million. Parsers keep their provider-reported cost path (`costSource: 'gateway'`) and only price from the table when estimating.

**Provenance on every priced row.** Usage rows priced from the table stamp `{ costSource: 'estimate', rateTableVersion }` in `metadata_json`; provider-reported rows stamp `{ costSource: 'gateway' }` and no version; unknown sources say so. Cost for any stored row is reproducible from its tokens plus the named table version. The mission cost summary is unchanged because one mission can aggregate rows priced under different versions.

**Capacity snapshots.** At packet launch (including recovered launches) and at packet completion, the packet's runtime capacity is captured through the existing capacity service and recorded as a `capacity_snapshot` lane event (`phase: start | end`, raw snapshot, nulls preserved, explicit `unavailable` with a reason when the runtime exposes nothing). Never converted to dollars; no new table.

**Tests.** `rate-table.test.ts` prices a fixture through each real parser and the Brain estimator and asserts the result equals tokens × the table's rates for the seeded version; a source scan asserts no price-literal markers remain outside the table. The resource-owning real-path test (integration runner) drives a packet through launch and completion and checks both snapshot events and the metadata stamps on persisted rows.

**Not changed:** any price number, spend-cap thresholds, the Brain cascade order, UI.

**Gates:** tsc, runtimes/cost/cortex/orchestrator suites, integration runner, price-literal scan, lint (152 cap, zero new), classification check, full unit suite — all green.
