### PR TITLE
fix: keep tmux CSI S out of dashboard scrollback

### DIFF
--- a/src/lib/ws-server/dash-terminal-persistence.test.ts
+++ b/src/lib/ws-server/dash-terminal-persistence.test.ts
@@ -78,14 +78,20 @@ describe('dashboard terminal persistence real fallback path', () => {
       execFileSync: exec,
       recordHealth,
     })).toBe(false);
-    expect(exec.mock.calls[3]?.[1]).toEqual(['kill-session', '-t', 'cortex-dash-test']);
+    expect(exec.mock.calls[3]?.[1]).toEqual([
+      '-L', 'o8-dashboard', 'kill-session', '-t', 'cortex-dash-test',
+    ]);
     expect(recordHealth).toHaveBeenCalledWith('degraded', 'session_create_failed');
   });
 
-  it('receipts a real backing session after all required options land', () => {
+  it('creates dashboard sessions on the isolated tmux server with only indn disabled', () => {
     const recordHealth = vi.fn();
     const exec = vi.fn()
       .mockImplementationOnce(() => { throw new Error('no existing session'); })
+      .mockReturnValueOnce(Buffer.from(''))
+      .mockReturnValueOnce(Buffer.from(''))
+      .mockReturnValueOnce(Buffer.from(''))
+      .mockReturnValueOnce(Buffer.from('xterm*:XT'))
       .mockReturnValue(Buffer.from(''));
     vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -94,8 +100,33 @@ describe('dashboard terminal persistence real fallback path', () => {
       execFileSync: exec,
       recordHealth,
     })).toBe(true);
-    expect(exec).toHaveBeenCalledTimes(4);
+    expect(exec.mock.calls.map((call) => call[1])).toEqual([
+      ['-L', 'o8-dashboard', 'has-session', '-t', 'cortex-dash-test'],
+      ['-L', 'o8-dashboard', 'new-session', '-d', '-s', 'cortex-dash-test', '-x', '120', '-y', '30', '/bin/zsh', '-l'],
+      ['-L', 'o8-dashboard', 'set-option', '-t', 'cortex-dash-test', 'history-limit', '50000'],
+      ['-L', 'o8-dashboard', 'set-option', '-t', 'cortex-dash-test', 'status', 'off'],
+      ['-L', 'o8-dashboard', 'show-options', '-gv', 'terminal-overrides'],
+      ['-L', 'o8-dashboard', 'set-option', '-ga', 'terminal-overrides', ',xterm*:indn@'],
+    ]);
     expect(recordHealth).toHaveBeenCalledWith('ready', 'session_created');
+  });
+
+  it('does not grow terminal-overrides when a second dashboard session reuses the server', () => {
+    const recordHealth = vi.fn();
+    const exec = vi.fn()
+      .mockReturnValueOnce(Buffer.from(''))
+      .mockReturnValueOnce(Buffer.from('xterm*:XT,xterm*:indn@'));
+
+    expect(createDashTmuxSessionSync(input(), {
+      resolveTmuxBinary: () => '/usr/bin/tmux',
+      execFileSync: exec,
+      recordHealth,
+    })).toBe(true);
+    expect(exec.mock.calls.map((call) => call[1])).toEqual([
+      ['-L', 'o8-dashboard', 'has-session', '-t', 'cortex-dash-test'],
+      ['-L', 'o8-dashboard', 'show-options', '-gv', 'terminal-overrides'],
+    ]);
+    expect(recordHealth).toHaveBeenCalledWith('ready', 'session_reused');
   });
 });
 

--- a/src/lib/ws-server/dash-terminal-persistence.ts
+++ b/src/lib/ws-server/dash-terminal-persistence.ts
@@ -4,6 +4,29 @@ import { recordPersistentTerminalHealth } from '@/lib/terminal/persistence-healt
 import { resolveTmuxBinary } from '@/lib/ws-server/pty-support';
 
 const DASH_TERMINAL_OWNER_KEY_MAX_LENGTH = 512;
+export function dashTmuxServerName(): string {
+  return process.env.O8_DASH_TMUX_SERVER_NAME?.trim() || 'o8-dashboard';
+}
+const DASH_TERMINAL_OVERRIDE = 'xterm*:indn@';
+
+export function dashTmuxArgs(...args: string[]): string[] {
+  return ['-L', dashTmuxServerName(), ...args];
+}
+
+function ensureDashTerminalOverride(
+  tmuxBin: string,
+  dependencies: CreateDashTmuxSessionDependencies,
+) {
+  const configured = String(dependencies.execFileSync(
+    tmuxBin,
+    dashTmuxArgs('show-options', '-gv', 'terminal-overrides'),
+    { windowsHide: true, timeout: 3000, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+  ));
+  if (configured.split(/[\n,]/u).includes(DASH_TERMINAL_OVERRIDE)) return;
+  dependencies.execFileSync(tmuxBin, dashTmuxArgs(
+    'set-option', '-ga', 'terminal-overrides', `,${DASH_TERMINAL_OVERRIDE}`,
+  ), { windowsHide: true, timeout: 3000, stdio: 'ignore' });
+}
 
 /**
  * Give a durable workspace tab the same tmux identity on every launch.
@@ -77,34 +100,41 @@ export function createDashTmuxSessionSync(
   let created = false;
   try {
     try {
-      dependencies.execFileSync(tmuxBin, ['has-session', '-t', input.sessionName], {
+      dependencies.execFileSync(tmuxBin, dashTmuxArgs('has-session', '-t', input.sessionName), {
         windowsHide: true,
         timeout: 3000,
         stdio: 'ignore',
       });
+      // Reused sessions may predate #1979. The dedicated dashboard server keeps
+      // this server option away from the operator's personal tmux, and the read
+      // before append prevents duplicate entries across create/reuse cycles.
+      ensureDashTerminalOverride(tmuxBin, dependencies);
       recordHealthSafely(dependencies, 'ready', 'session_reused');
       return true;
     } catch { /* not present, create it below */ }
 
-    dependencies.execFileSync(tmuxBin, [
+    dependencies.execFileSync(tmuxBin, dashTmuxArgs(
       'new-session', '-d', '-s', input.sessionName,
       '-x', String(input.cols), '-y', String(input.rows),
       input.shell, '-l',
-    ], { windowsHide: true, cwd: input.cwd, timeout: 8000, env: input.env });
+    ), { windowsHide: true, cwd: input.cwd, timeout: 8000, env: input.env });
     created = true;
-    dependencies.execFileSync(tmuxBin, [
+    dependencies.execFileSync(tmuxBin, dashTmuxArgs(
       'set-option', '-t', input.sessionName, 'history-limit', '50000',
-    ], { windowsHide: true, timeout: 3000, stdio: 'ignore' });
-    dependencies.execFileSync(tmuxBin, [
+    ), { windowsHide: true, timeout: 3000, stdio: 'ignore' });
+    dependencies.execFileSync(tmuxBin, dashTmuxArgs(
       'set-option', '-t', input.sessionName, 'status', 'off',
-    ], { windowsHide: true, timeout: 3000, stdio: 'ignore' });
+    ), { windowsHide: true, timeout: 3000, stdio: 'ignore' });
+    // #1979 — disable only tmux `indn` (CSI n S), preserving alternate-screen
+    // entry/exit while making full-screen scrolling use line feeds xterm keeps.
+    ensureDashTerminalOverride(tmuxBin, dependencies);
     recordHealthSafely(dependencies, 'ready', 'session_created');
     console.log(`[persistent-terminals] created backing session: ${input.sessionName}`);
     return true;
   } catch (error) {
     if (created) {
       try {
-        dependencies.execFileSync(tmuxBin, ['kill-session', '-t', input.sessionName], {
+        dependencies.execFileSync(tmuxBin, dashTmuxArgs('kill-session', '-t', input.sessionName), {
           windowsHide: true,
           timeout: 3000,
           stdio: 'ignore',

--- a/src/lib/ws-server/pty-support.ts
+++ b/src/lib/ws-server/pty-support.ts
@@ -65,12 +65,12 @@ export function resolveTmuxBinary(): string {
   }
 }
 
-export function tmuxSessionExists(sessionName: string): boolean {
+export function tmuxSessionExists(sessionName: string, serverArgs: readonly string[] = []): boolean {
   const target = sessionName.trim();
   if (!target) return false;
 
   try {
-    execFileSync(resolveTmuxBinary(), ['has-session', '-t', target], {
+    execFileSync(resolveTmuxBinary(), [...serverArgs, 'has-session', '-t', target], {
       windowsHide: true,
       timeout: 2000,
       stdio: 'ignore',

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -284,6 +284,8 @@ import {
 import {
   createDashTmuxSessionSync,
   dashSessionNameForOwnerKey,
+  dashTmuxArgs,
+  dashTmuxServerName,
 } from './lib/ws-server/dash-terminal-persistence';
 import { parseGitWorktreeList, shortHome } from './lib/ws-server/git-worktrees';
 import {
@@ -1607,7 +1609,7 @@ function listDashTmuxSessionsWithAge(): DashSessionInfo[] {
   try {
     const out = execFileSync(
       resolveTmuxBinary(),
-      ['list-sessions', '-F', '#{session_name} #{session_created}'],
+      dashTmuxArgs('list-sessions', '-F', '#{session_name} #{session_created}'),
       { windowsHide: true, timeout: 4000, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], env: sanitizePtyEnv() as NodeJS.ProcessEnv },
     );
     const rows: DashSessionInfo[] = [];
@@ -1638,7 +1640,7 @@ function captureTmuxPaneResult(sessionName: string): { ok: boolean; data: string
       ok: true,
       data: execFileSync(
       resolveTmuxBinary(),
-      ['capture-pane', '-p', '-e', '-S', `-${TERMINAL_SCROLLBACK_LINES}`, '-t', sessionName],
+      dashTmuxArgs('capture-pane', '-p', '-e', '-S', `-${TERMINAL_SCROLLBACK_LINES}`, '-t', sessionName),
       {
         windowsHide: true,
         timeout: 4000,
@@ -1697,7 +1699,7 @@ function reapOrphanDashSessions() {
       terminalAttachments.delete(name);
     }
     try {
-      execFileSync(tmuxBin, ['kill-session', '-t', name], { windowsHide: true, timeout: 3000, stdio: 'ignore', env: sanitizePtyEnv() as NodeJS.ProcessEnv });
+      execFileSync(tmuxBin, dashTmuxArgs('kill-session', '-t', name), { windowsHide: true, timeout: 3000, stdio: 'ignore', env: sanitizePtyEnv() as NodeJS.ProcessEnv });
     } catch { /* already gone */ }
   }
   console.log(`[ws-server] [persistent-terminals] GC reaped ${toKill.length} orphan dash tmux session(s)`);
@@ -2003,12 +2005,17 @@ function spawnTmuxAttachPty(
   const tmuxBin = resolveTmuxBinary();
   const env = sanitizePtyEnv();
   const cwd = process.env.HOME ?? homedir() ?? '/tmp';
+  const dashboardSession = isDashTerminalSession(sessionName);
+  const attachArgs = dashboardSession
+    ? dashTmuxArgs('attach-session', '-t', sessionName)
+    : ['attach-session', '-t', sessionName];
+  const serverDescription = dashboardSession ? ` -L ${dashTmuxServerName()}` : '';
 
   try {
-    console.log(`[ws-server] Spawning terminal directly: ${tmuxBin} attach-session -t ${sessionName}`);
+    console.log(`[ws-server] Spawning terminal directly: ${tmuxBin}${serverDescription} attach-session -t ${sessionName}`);
     return terminalHost.spawn({
       file: tmuxBin,
-      args: ['attach-session', '-t', sessionName],
+      args: attachArgs,
       name: 'xterm-256color',
       cols,
       rows,
@@ -2017,7 +2024,9 @@ function spawnTmuxAttachPty(
     });
   } catch (directError) {
     const shell = resolvePreferredShell();
-    const shellCmd = `exec "${tmuxBin}" attach-session -t ${sessionName}`;
+    const shellCmd = dashboardSession
+      ? `exec "${tmuxBin}" -L "${dashTmuxServerName()}" attach-session -t "${sessionName}"`
+      : `exec "${tmuxBin}" attach-session -t "${sessionName}"`;
     console.warn(`[ws-server] Direct tmux PTY spawn failed, falling back to shell wrapper: ${directError instanceof Error ? directError.message : String(directError)}`);
     console.log(`[ws-server] Spawning terminal via shell: ${shellCmd}`);
     return terminalHost.spawn({
@@ -6655,7 +6664,7 @@ function handleTerminalCreate(client: ClientState, msg: Record<string, unknown>)
     && (
       pendingDashSessions.has(ownerSessionName)
       || terminalAttachments.has(ownerSessionName)
-      || (dashPersistentTerminalsEnabled() && tmuxSessionExists(ownerSessionName))
+      || (dashPersistentTerminalsEnabled() && tmuxSessionExists(ownerSessionName, dashTmuxArgs()))
     )
   ) {
     console.log(`[ws-server] Reusing owned dashboard PTY session: ${ownerSessionName}`);
@@ -6740,7 +6749,7 @@ function handleTerminalAttach(client: ClientState, msg: Record<string, unknown>)
   if (
     isDashTerminalSession(sessionName)
     && dashPersistentTerminalsEnabled()
-    && tmuxSessionExists(sessionName)
+    && tmuxSessionExists(sessionName, dashTmuxArgs())
   ) {
     try {
       const ptyProcess = spawnTmuxAttachPty(sessionName, cols, rows);
@@ -6775,8 +6784,11 @@ function handleTerminalAttach(client: ClientState, msg: Record<string, unknown>)
       const history = captureTmuxPane(sessionName);
       if (history) {
         const lines = history.replace(/\n+$/, '').split('\n');
-        const keep = lines.length > rows ? lines.slice(0, lines.length - rows).join('\n') : '';
-        if (keep) appendScrollback(attachment, `${keep}\n`);
+        const keep = lines.length > rows ? lines.slice(0, lines.length - rows) : [];
+        // capture-pane is line-oriented (LF), while xterm's production write
+        // path does not enable convertEol. Replay CRLF so each captured row
+        // starts at column zero instead of wrapping away every screenful.
+        if (keep.length > 0) appendScrollback(attachment, `${keep.join('\r\n')}\r\n`);
       }
       sendTerminal(client, 'attached', { sessionName });
       sendTerminalScrollback(client, attachment);
@@ -7121,13 +7133,14 @@ function terminateTerminalSession(sessionName: string, signal: string = 'SIGTERM
   // 2. Try killing tmux session directly (if PTY already detached but tmux lives)
   try {
     const tmuxBin = resolveTmuxBinary();
-    execFileSync(tmuxBin, ['has-session', '-t', sessionName], {
+    const tmuxArgs = isDashTerminalSession(sessionName) ? dashTmuxArgs() : [];
+    execFileSync(tmuxBin, [...tmuxArgs, 'has-session', '-t', sessionName], {
       windowsHide: true,
       timeout: 2000,
       stdio: 'ignore',
       env: sanitizePtyEnv() as NodeJS.ProcessEnv,
     });
-    execFileSync(tmuxBin, ['kill-session', '-t', sessionName], {
+    execFileSync(tmuxBin, [...tmuxArgs, 'kill-session', '-t', sessionName], {
       windowsHide: true,
       timeout: 3000,
       stdio: 'ignore',

--- a/tests/dash-terminal-csi-s-scrollback-real-path.test.ts
+++ b/tests/dash-terminal-csi-s-scrollback-real-path.test.ts
@@ -1,0 +1,271 @@
+import { execFile, execFileSync, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+import { createServer, type Server } from 'node:http';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { WebSocket } from 'ws';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { dashSessionNameForOwnerKey } from '@/lib/ws-server/dash-terminal-persistence';
+import { renderTerminalBytes } from './helpers/headless-terminal';
+
+type WireFrame = {
+  channel?: string;
+  event?: string;
+  data?: { data?: string; requestId?: string; sessionName?: string };
+};
+
+const ESC = String.fromCharCode(27);
+const CSI_S = new RegExp(`${ESC}\\[[0-9]*S`);
+const COLS = 20;
+const ROWS = 5;
+const LINE_COUNT = 40;
+const dataDir = mkdtempSync(join(tmpdir(), 'o8-csi-s-ws-xterm-'));
+const token = `dash-terminal-csi-s-${process.pid}`;
+const dashboardServerName = `o8-dashboard-test-${process.pid}`;
+const dashboardTmuxArgs = (...args: string[]) => ['-L', dashboardServerName, ...args];
+const fixedOwner = `csi-s-fixed-${process.pid}`;
+const secondOwner = `csi-s-second-${process.pid}`;
+const fixedSession = dashSessionNameForOwnerKey(fixedOwner)!;
+const secondSession = dashSessionNameForOwnerKey(secondOwner)!;
+const sockets = new Set<WebSocket>();
+let apiServer: Server;
+let apiPort = 0;
+let wsPort = 0;
+let wsProcess: ChildProcess | null = null;
+let serverOutput = '';
+
+const tmuxAvailable = process.platform !== 'win32' && (() => {
+  try {
+    execFileSync('tmux', ['-V'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') return reject(new Error('missing test port'));
+      server.close((error) => error ? reject(error) : resolve(address.port));
+    });
+  });
+}
+
+async function waitFor(predicate: () => boolean | Promise<boolean>, description: string, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out waiting for ${description}. ${serverOutput.slice(-4_000)}`);
+}
+
+function defaultTmuxOverrides(): string | null {
+  try {
+    return execFileSync('tmux', ['show-options', '-gv', 'terminal-overrides'], { encoding: 'utf8' });
+  } catch {
+    return null;
+  }
+}
+
+function capturePane(sessionName: string) {
+  return execFileSync('tmux', dashboardTmuxArgs('capture-pane', '-p', '-S', '-', '-t', sessionName), { encoding: 'utf8' });
+}
+
+function numberedLines(text: string): string[] {
+  return [...text.matchAll(/\b(\d{3})\b/g)].map((match) => match[1]!);
+}
+
+async function renderPayload(payload: string) {
+  return numberedLines((await renderTerminalBytes(
+    [Buffer.from(payload, 'base64').toString('utf8')],
+    { cols: COLS, rows: ROWS, scrollback: 1_000 },
+  )).join('\n'));
+}
+
+async function startWsServer() {
+  serverOutput = '';
+  wsProcess = execFile(process.execPath, [
+    '--import=./scripts/register-server-only-stub.mjs',
+    '--import=tsx',
+    'src/ws-server.ts',
+  ], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      CORTEX_IDE_DATA_DIR: dataDir,
+      O8_API_PORT: String(apiPort),
+      O8_WS_PORT: String(wsPort),
+      O8_PERSISTENT_TERMINALS: '1',
+      O8_DASH_TMUX_SERVER_NAME: dashboardServerName,
+      NEXT_ORIGIN: `http://127.0.0.1:${apiPort}`,
+    },
+  });
+  wsProcess.stdout?.on('data', (chunk) => { serverOutput += String(chunk); });
+  wsProcess.stderr?.on('data', (chunk) => { serverOutput += String(chunk); });
+  await waitFor(async () => {
+    try { return (await fetch(`http://127.0.0.1:${wsPort}/health`)).ok; } catch { return false; }
+  }, 'ws server health', 30_000);
+}
+
+async function stopWsServer() {
+  const running = wsProcess;
+  wsProcess = null;
+  if (!running || running.exitCode !== null) return;
+  running.kill('SIGTERM');
+  await Promise.race([once(running, 'exit'), new Promise((resolve) => setTimeout(resolve, 5_000))]);
+}
+
+async function connectRenderedClient() {
+  const frames: WireFrame[] = [];
+  const decodedChunks: string[] = [];
+  const socket = new WebSocket(`ws://127.0.0.1:${wsPort}/ws?token=${encodeURIComponent(token)}`);
+  sockets.add(socket);
+  socket.on('message', (raw) => {
+    const frame = JSON.parse(String(raw)) as WireFrame;
+    frames.push(frame);
+    if (frame.channel !== 'terminal' || frame.event !== 'data' || typeof frame.data?.data !== 'string') return;
+    decodedChunks.push(Buffer.from(frame.data.data, 'base64').toString('utf8'));
+  });
+  socket.on('close', () => sockets.delete(socket));
+  await once(socket, 'open');
+  await waitFor(
+    () => frames.some((frame) => frame.channel === 'system' && frame.event === 'connected'),
+    'authenticated WebSocket connection',
+  );
+  return {
+    socket,
+    frames,
+    raw: () => decodedChunks.join(''),
+    renderedRows: () => renderTerminalBytes(decodedChunks, { cols: COLS, rows: ROWS, scrollback: 1_000 }),
+  };
+}
+
+async function createAndFill(ownerKey: string, sessionName: string) {
+  const client = await connectRenderedClient();
+  client.socket.send(JSON.stringify({
+    type: 'terminal-create',
+    cols: COLS,
+    rows: ROWS,
+    requestId: ownerKey,
+    ownerKey,
+  }));
+  await waitFor(
+    () => client.frames.some((frame) => frame.event === 'created' && frame.data?.sessionName === sessionName),
+    `${ownerKey} creation`,
+  );
+  client.socket.send(JSON.stringify({ type: 'terminal-attach', sessionName, cols: COLS, rows: ROWS }));
+  await waitFor(
+    () => client.frames.some((frame) => frame.event === 'attached' && frame.data?.sessionName === sessionName),
+    `${ownerKey} attachment`,
+  );
+  client.socket.send(JSON.stringify({
+    type: 'terminal-input',
+    sessionName,
+    data: `python3 -c 'for i in range(${LINE_COUNT}): print(f"{i:03d}")'\n`,
+  }));
+  const expected = Array.from({ length: LINE_COUNT }, (_, index) => String(index).padStart(3, '0'));
+  await waitFor(
+    () => expected.every((line) => numberedLines(capturePane(sessionName)).includes(line)),
+    `${ownerKey} pane history`,
+  );
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  return { client, expected };
+}
+
+beforeAll(async () => {
+  if (!tmuxAvailable) return;
+  mkdirSync(dataDir, { recursive: true });
+  writeFileSync(join(dataDir, 'ws-token'), `${token}\n`, { mode: 0o600 });
+  apiPort = await freePort();
+  wsPort = await freePort();
+  apiServer = createServer((_request, response) => {
+    response.writeHead(200, { 'Content-Type': 'application/json' });
+    response.end('{}');
+  });
+  apiServer.listen(apiPort, '127.0.0.1');
+  await once(apiServer, 'listening');
+  await startWsServer();
+}, 40_000);
+
+afterAll(async () => {
+  for (const socket of sockets) socket.close();
+  await stopWsServer();
+  if (apiServer?.listening) await new Promise<void>((resolve) => apiServer.close(() => resolve()));
+  try { execFileSync('tmux', dashboardTmuxArgs('kill-server'), { stdio: 'ignore' }); } catch { /* */ }
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe.runIf(tmuxAvailable)('dashboard terminal CSI S through WebSocket and xterm (#1979)', () => {
+  it('keeps dashboard overrides isolated, idempotent, and alternate-screen safe', async () => {
+    const beforeDefaultOverrides = defaultTmuxOverrides();
+
+    const fixed = await createAndFill(fixedOwner, fixedSession);
+    expect(CSI_S.test(fixed.client.raw())).toBe(false);
+    const firstOverrides = execFileSync('tmux', dashboardTmuxArgs(
+      'show-options', '-gv', 'terminal-overrides',
+    ), { encoding: 'utf8' });
+    expect(firstOverrides.split(/[\n,]/u).map((entry) => entry.trim())
+      .filter((entry) => entry === 'xterm*:indn@')).toHaveLength(1);
+    expect(firstOverrides).not.toContain('smcup@');
+    expect(firstOverrides).not.toContain('rmcup@');
+
+    const second = await createAndFill(secondOwner, secondSession);
+    const secondOverrides = execFileSync('tmux', dashboardTmuxArgs(
+      'show-options', '-gv', 'terminal-overrides',
+    ), { encoding: 'utf8' });
+    expect(secondOverrides).toBe(firstOverrides);
+    expect(defaultTmuxOverrides()).toBe(beforeDefaultOverrides);
+    second.client.socket.close();
+
+    const alternateScreenRows = await renderTerminalBytes([
+      `PRIMARY${ESC}[?1049hALTERNATE${ESC}[?1049l`,
+    ], { cols: COLS, rows: ROWS, scrollback: 1_000 });
+    expect(alternateScreenRows.join('\n')).toContain('PRIMARY');
+    expect(alternateScreenRows.join('\n')).not.toContain('ALTERNATE');
+
+    const partialRegionRows = await renderPayload(Buffer.from(
+      `111\r\n222\r\n333\r\n444\r\n555${ESC}[2;4r${ESC}[4;1H777\n${ESC}[r`,
+    ).toString('base64'));
+    expect(partialRegionRows).toContain('777');
+    fixed.client.socket.close();
+    await once(fixed.client.socket, 'close');
+    await stopWsServer();
+    await startWsServer();
+    const restored = await connectRenderedClient();
+    restored.socket.send(JSON.stringify({
+      type: 'terminal-create',
+      cols: COLS,
+      rows: ROWS,
+      requestId: 'restored',
+      ownerKey: fixedOwner,
+    }));
+    await waitFor(
+      () => restored.frames.some((frame) => frame.event === 'created' && frame.data?.sessionName === fixedSession),
+      'cold restored reservation',
+    );
+    restored.socket.send(JSON.stringify({
+      type: 'terminal-attach', sessionName: fixedSession, cols: COLS, rows: ROWS,
+    }));
+    await waitFor(
+      () => restored.frames.some((frame) => frame.event === 'attached' && frame.data?.sessionName === fixedSession),
+      'cold restored attachment',
+    );
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    const captureRows = numberedLines(capturePane(fixedSession));
+    expect(captureRows).toEqual(expect.arrayContaining(fixed.expected));
+    const scrollbackFrame = restored.frames.find((frame) => {
+      if (frame.channel !== 'terminal' || frame.event !== 'data' || !frame.data?.data) return false;
+      return Buffer.from(frame.data.data, 'base64').toString('utf8').includes('000');
+    });
+    expect(scrollbackFrame?.data?.data).toBeTypeOf('string');
+    const replayRows = await renderPayload(scrollbackFrame!.data!.data!);
+    const visibleRows = numberedLines((await restored.renderedRows()).join('\n'));
+    expect([...replayRows, ...visibleRows.filter((row) => !replayRows.includes(row))]).toEqual(captureRows);
+  }, 60_000);
+});

--- a/tests/dash-terminal-indn-isolated-server.test.ts
+++ b/tests/dash-terminal-indn-isolated-server.test.ts
@@ -1,0 +1,84 @@
+process.env.O8_DASH_TMUX_SERVER_NAME = `o8-dashboard-indn-${process.pid}`;
+
+import { execFileSync } from 'node:child_process';
+import { afterAll, describe, expect, it } from 'vitest';
+import {
+  createDashTmuxSessionSync,
+  dashTmuxArgs,
+  dashTmuxServerName,
+} from '@/lib/ws-server/dash-terminal-persistence';
+import { resolveTmuxBinary } from '@/lib/ws-server/pty-support';
+import { renderTerminalBytes } from './helpers/headless-terminal';
+
+const ESC = String.fromCharCode(27);
+const tmuxAvailable = process.platform !== 'win32' && (() => {
+  try {
+    execFileSync('tmux', ['-V'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+function overrides(): string {
+  return String(execFileSync(resolveTmuxBinary(), dashTmuxArgs('show-options', '-gv', 'terminal-overrides'), {
+    encoding: 'utf8',
+    timeout: 3000,
+  }));
+}
+
+afterAll(() => {
+  try { execFileSync('tmux', dashTmuxArgs('kill-server'), { stdio: 'ignore', timeout: 3000 }); } catch { /* */ }
+});
+
+describe.runIf(tmuxAvailable)('isolated dashboard tmux server terminal-overrides (#1979)', () => {
+  it('sets xterm*:indn@ once per server and leaves alternate-screen capability intact', () => {
+    const first = createDashTmuxSessionSync({
+      enabled: true,
+      sessionName: 'cortex-dash-first',
+      cols: 40,
+      rows: 12,
+      cwd: '/tmp',
+      shell: '/bin/sh',
+      env: process.env,
+    });
+    expect(first).toBe(true);
+    const afterFirst = overrides();
+    expect(afterFirst.split(/[\n,]/u).map((entry) => entry.trim()).filter((entry) => entry === 'xterm*:indn@'))
+      .toHaveLength(1);
+    expect(afterFirst).not.toContain('smcup@');
+    expect(afterFirst).not.toContain('rmcup@');
+
+    const second = createDashTmuxSessionSync({
+      enabled: true,
+      sessionName: 'cortex-dash-second',
+      cols: 40,
+      rows: 12,
+      cwd: '/tmp',
+      shell: '/bin/sh',
+      env: process.env,
+    });
+    expect(second).toBe(true);
+    expect(overrides()).toBe(afterFirst);
+
+    const reused = createDashTmuxSessionSync({
+      enabled: true,
+      sessionName: 'cortex-dash-first',
+      cols: 40,
+      rows: 12,
+      cwd: '/tmp',
+      shell: '/bin/sh',
+      env: process.env,
+    });
+    expect(reused).toBe(true);
+    expect(overrides()).toBe(afterFirst);
+    expect(dashTmuxServerName()).toBe(process.env.O8_DASH_TMUX_SERVER_NAME);
+
+    return renderTerminalBytes([
+      `PRIMARY${ESC}[?1049hALTERNATE${ESC}[?1049l`,
+    ], { cols: 20, rows: 5, scrollback: 100 }).then((rows) => {
+      expect(rows.join('\n')).toContain('PRIMARY');
+      expect(rows.join('\n')).not.toContain('ALTERNATE');
+    });
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1257,6 +1257,23 @@
       ]
     },
     {
+      "path": "tests/dash-terminal-csi-s-scrollback-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "network-listener",
+        "process-signal",
+        "real-path",
+        "terminal-tool"
+      ]
+    },
+    {
+      "path": "tests/dash-terminal-indn-isolated-server.test.ts",
+      "reasons": [
+        "child-process",
+        "terminal-tool"
+      ]
+    },
+    {
       "path": "tests/dash-terminal-restart-real-path.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
## What changed

- Override tmux's `indn` capability for dashboard attach clients so full-screen scrolling falls back to line feeds that xterm preserves in scrollback.
- Normalize captured tmux history to CRLF before replay so each row starts at column zero.
- Add focused persistence coverage plus a production WS → PTY → base64 → xterm real-path regression for the numbered-scrollback failure.

## Why

Dashboard terminals advertise `xterm-256color`, so tmux can emit `CSI n S` (`indn`) when output scrolls. xterm removes those rows from the scroll region without adding them to scrollback, producing the gaps reported in #1979. Disabling only `indn` at the tmux attach boundary preserves all lines while leaving partial-region TUI scrolling intact.

Closes #1979

## Verification

Node `v22.23.2`:

- [x] `npx tsc --noEmit`
- [ ] `npm test` — ran; final summary was 627 passed and 3 skipped, with one unrelated existing hermetic failure in `src/lib/runtimes/shared/cli-locate.test.ts`.
- [ ] `npm run lint` — repo-wide lint was not run; touched-file ESLint completed with 0 errors and 3 pre-existing unused-variable warnings in `src/ws-server.ts`.
- [x] `npx vitest run src/lib/ws-server/dash-terminal-persistence.test.ts tests/dash-terminal-csi-s-scrollback-real-path.test.ts` — 11 passed.
- [x] `npm run rule-check -- --base=29cecb558020395d489d9b9e18945ed0a9dac545`
- [x] Test-classification check.

Real-path evidence: the regression traverses the production WebSocket server, tmux-backed PTY, base64 terminal frames, and headless xterm buffer. The RED witness reproduced missing numbered lines while `CSI S` was present. GREEN retained the complete scrollback. As a sabotage check, removing the `indn@` override made the oracle fail as expected because `CSI S` returned. The partial-region TUI case still rendered marker `777`.

Hotspots: `src/ws-server.ts` and `tests/test-classification.json`; this PR intentionally limits both edits to the #1979 behavior and its real-path classification.

## Author review

- [x] I reviewed and understand the complete diff, including any AI-generated code.

## AI disclosure

This change was developed with AI assistance. I reviewed the complete diff, reproduced the failure and fix through the production path, ran the listed gates, and independently checked the sabotage and partial-region cases.

## Operator note

Dashboard attach now uses a dedicated tmux server (`-L o8-dashboard`). Sessions named `o8-dash-*` left on the default server by earlier builds are no longer found by `has-session` and will linger until the operator kills them once.
