### PR TITLE
fix: align orchestrator shortcut labels

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4507,7 +4507,7 @@ function DashboardInner() {
 
   // ── Power-user chrome shortcuts ──
   // macOS / VS Code conventions, each mapped to a real existing action:
-  //   ⌘T new tab · ⌘, settings · ⌘B left sidebar · ⌘⌥B right panel
+  //   ⌘T new orchestrator tab · ⌘, settings · ⌘B left sidebar · ⌘⌥B right panel
   //   ⌘J bottom terminal · ⌘⇧J Terminal Mode
   // Allowed even while typing — these are app-chrome toggles, none emit text,
   // and power users expect them to fire mid-compose (matches VS Code). Placed

--- a/src/components/desktop/KeyboardShortcutsOverlay.test.ts
+++ b/src/components/desktop/KeyboardShortcutsOverlay.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createDashboardChromeKeydownHandler,
+  type DashboardChromeShortcutActions,
+} from '@/app/dashboard/dashboard-chrome-shortcuts';
+import { KEYBOARD_SHORTCUT_SECTIONS } from './KeyboardShortcutsOverlay';
+
+const listeners: Array<(event: KeyboardEvent) => void> = [];
+
+afterEach(() => {
+  for (const listener of listeners.splice(0)) window.removeEventListener('keydown', listener);
+});
+
+function overlayLabelForChord(keys: string[]): string | undefined {
+  for (const section of KEYBOARD_SHORTCUT_SECTIONS) {
+    for (const row of section.rows) {
+      if (row.chords.some((chord) => chord.length === keys.length && chord.every((key, i) => key === keys[i]))) {
+        return row.label;
+      }
+    }
+  }
+  return undefined;
+}
+
+function installHandler() {
+  const actions: DashboardChromeShortcutActions = {
+    openCanvas: vi.fn(),
+    openSettings: vi.fn(),
+    spawnOrchestrator: vi.fn(),
+    toggleBottomPanel: vi.fn(),
+    toggleRightPanel: vi.fn(),
+    toggleSidebar: vi.fn(),
+    toggleTerminalMode: vi.fn(),
+  };
+  const handler = createDashboardChromeKeydownHandler(actions);
+  window.addEventListener('keydown', handler);
+  listeners.push(handler);
+  return actions;
+}
+
+describe('⌘T overlay label vs chrome handler', () => {
+  it('labels ⌘T as a new orchestrator tab and routes the chord to spawnOrchestrator', () => {
+    expect(overlayLabelForChord(['⌘', 'T'])).toBe('New orchestrator tab');
+
+    const actions = installHandler();
+    window.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 't',
+      metaKey: true,
+      cancelable: true,
+    }));
+
+    expect(actions.spawnOrchestrator).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/desktop/KeyboardShortcutsOverlay.tsx
+++ b/src/components/desktop/KeyboardShortcutsOverlay.tsx
@@ -41,7 +41,7 @@ interface ShortcutSection {
   rows: ShortcutRow[];
 }
 
-const SECTIONS: ShortcutSection[] = [
+export const KEYBOARD_SHORTCUT_SECTIONS: ShortcutSection[] = [
   {
     title: 'Navigation',
     rows: [
@@ -54,7 +54,7 @@ const SECTIONS: ShortcutSection[] = [
   {
     title: 'Tabs',
     rows: [
-      { label: 'New tab', chords: [['⌘', 'T']] },
+      { label: 'New orchestrator tab', chords: [['⌘', 'T']] },
       { label: 'Close active tab', chords: [['⌘', 'W']] },
     ],
   },
@@ -174,7 +174,7 @@ export function KeyboardShortcutsOverlay({ open, onClose }: KeyboardShortcutsOve
             paddingBottom: 10,
           }}
         >
-          {SECTIONS.map((section) => (
+          {KEYBOARD_SHORTCUT_SECTIONS.map((section) => (
             <div key={section.title}>
               <div style={sectionHeaderStyle}>{section.title}</div>
               {section.rows.map((row) => (

--- a/src/components/desktop/shell/HeaderPlayButton.tsx
+++ b/src/components/desktop/shell/HeaderPlayButton.tsx
@@ -86,7 +86,7 @@ export function HeaderPlayButton({
         aria-haspopup="menu"
         aria-expanded={open}
         aria-controls={menuId}
-        title="New tab (⌘T)"
+        title="New orchestrator tab (⌘T)"
         style={{
           display: 'inline-flex',
           alignItems: 'center',


### PR DESCRIPTION
> **Author-review gate:** This pull request remains draft. The submitting contributor must understand and be able to explain the complete diff before marking it ready; independent AI-assisted review does not replace that responsibility.

## What changed

- Relabel Cmd/Ctrl+T as “New orchestrator tab” in the rendered shortcuts catalog and header tooltip.
- Align the dashboard shortcut comment with the production `spawnOrchestrator` action.
- Add a regression that traverses the exported rendered catalog and dispatches a real keyboard event through the production keydown handler.

## Why

The shortcut overlay described Cmd/Ctrl+T as “New tab,” but the production handler opens an Orchestrator tab. The label and bound action now agree, and the test pins that pairing against future drift.

Closes #1972

## Verification

- [x] `npx tsc --noEmit`
- [ ] `npm test`
- [ ] `npm run lint`
- [x] Other relevant checks are listed below, or skipped checks are explained.

Verified on Node v22.23.2:

- Focused regression: 2 files, 3 tests passed.
- RED: the new regression failed on the baseline because the rendered shortcut catalog was not exported for the production-pairing assertion.
- GREEN: the focused regression passed after the minimal label/catalog change.
- Sabotage: restoring the old “New tab” label produced the expected label mismatch; restoring the fix returned the focused suite to green.
- `npx eslint` on all four touched files passed.
- `npm run rule-check -- --base=29cecb558020395d489d9b9e18945ed0a9dac545` passed on the three changed production files.
- `npm run test:classification:check` and the repository diff check passed.
- The full `npm test` run reached 3,720 passed and 3 skipped tests, with one unrelated environment-sensitive `cli-locate` failure because the production scan found the installed `/usr/bin/gemini` before the test's injected fake nvm path. The full-suite checkbox therefore remains unchecked.
- Repo-wide `npm run lint` was not run; the required touched-file ESLint gate passed.

## Scope and risk

- Copy and test only; no styling, dependency, lockfile, persistence, authorization, or runtime-selection changes.
- The current-main terminal visibility changes from #1983 are retained; the dashboard page change is limited to the shortcut comment.

## Author review

- [x] I reviewed and understand the complete diff, including any AI-generated code.

This pull request was developed with AI assistance. I reviewed the complete diff and the verification evidence, and I am responsible for the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the ⌘T shortcut opens a new orchestrator tab.

* **UI Improvements**
  * Updated keyboard shortcut overlay and button labels to use “New orchestrator tab.”
  * Added coverage verifying the shortcut label and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->