### PR TITLE
fix: guard rich markdown editor size

### DIFF
--- a/docs/markdown-rich-editor-size-threshold.md
+++ b/docs/markdown-rich-editor-size-threshold.md
@@ -1,0 +1,15 @@
+# Rich Markdown size threshold
+
+Markdown files whose UTF-8 size is **greater than** `RICH_MARKDOWN_MAX_SOURCE_BYTES`
+(`64 * 1024` = 65536 bytes) open in **source** mode only.
+
+The constant and byte-length helper live in
+`src/lib/markdown/editor/size-guard.ts`. Size is `TextEncoder#encode(source).byteLength`,
+not JavaScript string length, so a file that is 65536 code units but 65537 UTF-8
+bytes is still over the limit.
+
+- Just at or under 65536 UTF-8 bytes: existing rich-mode path (operator can open Rich).
+- Over 65536 UTF-8 bytes: source-only; the mode control explains that rich mode is
+  unavailable because of file size. ProseMirror is not initialized.
+
+This guard is independent of unsupported-construct handling.

--- a/src/components/desktop/FileViewer.tsx
+++ b/src/components/desktop/FileViewer.tsx
@@ -403,6 +403,7 @@ export const FileViewer = memo(function FileViewer({ filePath, workspace }: { fi
           <MarkdownModeToggle
             mode={richMarkdown.mode}
             onChange={richMarkdown.selectMode}
+            richUnavailableReason={richMarkdown.sizeUnavailableReason}
           />
         ) : null}
 

--- a/src/components/desktop/file-viewer/RichMarkdownEditor.test.tsx
+++ b/src/components/desktop/file-viewer/RichMarkdownEditor.test.tsx
@@ -6,6 +6,7 @@ import { TextSelection } from 'prosemirror-state';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FileViewer } from '../FileViewer';
 import { getRichMarkdownEditorView } from './RichMarkdownEditor';
+import { RICH_MARKDOWN_MAX_SOURCE_BYTES } from '@/lib/markdown/editor';
 
 vi.mock('next/dynamic', async () => {
   const { createElement: createReactElement } = await import('react');
@@ -233,5 +234,197 @@ describe('FileViewer rich Markdown editor', () => {
     expect(container.textContent).toContain('Rich mode unavailable: image at line 3');
     expect(container.querySelector('[data-rich-markdown-editor="true"]')).toBeNull();
     expect(container.querySelector<HTMLTextAreaElement>('[data-testid="monaco-editor"]')?.value).toBe(source);
+  });
+
+  function stubMarkdownFile(source: string): void {
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('/api/panel/file-content')) {
+        return reply({ content: source, contentHash: 'size-hash' });
+      }
+      if (url.includes('/api/panel/file-diff')) {
+        return reply({ diff: '', hasDiff: false });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }));
+  }
+
+  it('keeps the rich path for a file at the UTF-8 size threshold', async () => {
+    const source = `${'a'.repeat(RICH_MARKDOWN_MAX_SOURCE_BYTES - 1)}\n`;
+    stubMarkdownFile(source);
+
+    await act(async () => {
+      root.render(createElement(FileViewer, { filePath: '/notes/just-under.md' }));
+    });
+    await settle();
+
+    act(() => button(container, 'Rich').click());
+    expect(container.querySelector('[data-rich-markdown-editor="true"]')).not.toBeNull();
+    expect(container.textContent).not.toContain('file is');
+    expect(button(container, 'Rich').disabled).toBe(false);
+  });
+
+  it('opens over-threshold files source-only and explains why in the mode control', async () => {
+    const source = `${'a'.repeat(RICH_MARKDOWN_MAX_SOURCE_BYTES)}\n`;
+    stubMarkdownFile(source);
+
+    await act(async () => {
+      root.render(createElement(FileViewer, { filePath: '/notes/over-size.md' }));
+    });
+    await settle();
+
+    const rich = button(container, 'Rich');
+    expect(rich.disabled).toBe(true);
+    expect(container.textContent).toContain(
+      `file is ${RICH_MARKDOWN_MAX_SOURCE_BYTES + 1} bytes (limit ${RICH_MARKDOWN_MAX_SOURCE_BYTES})`,
+    );
+    act(() => rich.click());
+    expect(button(container, 'Source').getAttribute('aria-pressed')).toBe('true');
+    expect(container.querySelector('[data-rich-markdown-editor="true"]')).toBeNull();
+    expect(container.querySelector<HTMLTextAreaElement>('[data-testid="monaco-editor"]')?.value).toBe(source);
+  });
+
+  it('counts multibyte source through FileViewer and visibly opens it source-only', async () => {
+    const source = `${'a'.repeat(RICH_MARKDOWN_MAX_SOURCE_BYTES - 1)}é`;
+    expect(source.length).toBe(RICH_MARKDOWN_MAX_SOURCE_BYTES);
+    stubMarkdownFile(source);
+
+    await act(async () => {
+      root.render(createElement(FileViewer, { filePath: '/notes/multibyte.md' }));
+    });
+    await settle();
+
+    expect(button(container, 'Rich').disabled).toBe(true);
+    expect(button(container, 'Source').getAttribute('aria-pressed')).toBe('true');
+    expect(container.textContent).toContain(
+      `file is ${RICH_MARKDOWN_MAX_SOURCE_BYTES + 1} bytes (limit ${RICH_MARKDOWN_MAX_SOURCE_BYTES})`,
+    );
+    expect(container.querySelector('[data-rich-markdown-editor="true"]')).toBeNull();
+    expect(container.querySelector<HTMLTextAreaElement>('[data-testid="monaco-editor"]')?.value).toBe(source);
+  });
+
+  it('recomputes rich availability in both directions when the same file is reloaded', async () => {
+    const initial = '# Small\n';
+    const large = `${'a'.repeat(RICH_MARKDOWN_MAX_SOURCE_BYTES)}\n`;
+    const smallAgain = '# Small again\n';
+    let conflictContent = large;
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/api/panel/file-content')) {
+        return reply({ content: initial, contentHash: 'initial-hash' });
+      }
+      if (url.includes('/api/panel/file-diff')) {
+        return reply({ diff: '', hasDiff: false });
+      }
+      if (url === '/api/v2/files' && init?.method === 'POST') {
+        return reply({
+          error: 'changed-on-disk',
+          content: conflictContent,
+          contentHash: `hash-${conflictContent.length}`,
+        }, 409);
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }));
+
+    await act(async () => {
+      root.render(createElement(FileViewer, { filePath: '/notes/reloaded.md' }));
+    });
+    await settle();
+    act(() => button(container, 'Rich').click());
+    const mount = container.querySelector<HTMLElement>('[data-rich-markdown-editor="true"]');
+    const view = getRichMarkdownEditorView(mount!);
+    act(() => view!.dispatch(view!.state.tr.insertText(' changed', 2)));
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 's', metaKey: true }));
+      await Promise.resolve();
+    });
+    await settle();
+    act(() => button(container, 'Reload').click());
+
+    expect(button(container, 'Rich').disabled).toBe(true);
+    expect(button(container, 'Source').getAttribute('aria-pressed')).toBe('true');
+    expect(container.textContent).toContain(`limit ${RICH_MARKDOWN_MAX_SOURCE_BYTES}`);
+    expect(container.querySelector<HTMLTextAreaElement>('[data-testid="monaco-editor"]')?.value).toBe(large);
+
+    conflictContent = smallAgain;
+    const monaco = container.querySelector<HTMLTextAreaElement>('[data-testid="monaco-editor"]')!;
+    act(() => {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!;
+      valueSetter.call(monaco, `${large}changed`);
+      monaco.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 's', metaKey: true }));
+      await Promise.resolve();
+    });
+    await settle();
+    act(() => button(container, 'Reload').click());
+
+    expect(button(container, 'Rich').disabled).toBe(false);
+    expect(button(container, 'Rich').getAttribute('aria-pressed')).toBe('true');
+    expect(container.textContent).not.toContain(`limit ${RICH_MARKDOWN_MAX_SOURCE_BYTES}`);
+    expect(container.querySelector('[data-rich-markdown-editor="true"]')).not.toBeNull();
+  });
+
+  it('does not keep rich mode after switching to an over-threshold file', async () => {
+    stubMarkdownFile('# Small\n');
+    await act(async () => {
+      root.render(createElement(FileViewer, { filePath: '/notes/small.md' }));
+    });
+    await settle();
+    act(() => button(container, 'Rich').click());
+    expect(container.querySelector('[data-rich-markdown-editor="true"]')).not.toBeNull();
+
+    const large = `${'a'.repeat(RICH_MARKDOWN_MAX_SOURCE_BYTES)}\n`;
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('/api/panel/file-content')) {
+        return reply({ content: large, contentHash: 'large-hash' });
+      }
+      if (url.includes('/api/panel/file-diff')) {
+        return reply({ diff: '', hasDiff: false });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }));
+
+    await act(async () => {
+      root.render(createElement(FileViewer, { filePath: '/notes/large.md' }));
+    });
+    await settle();
+
+    expect(button(container, 'Source').getAttribute('aria-pressed')).toBe('true');
+    expect(container.querySelector('[data-rich-markdown-editor="true"]')).toBeNull();
+    expect(container.textContent).toContain(`limit ${RICH_MARKDOWN_MAX_SOURCE_BYTES}`);
+  });
+
+  it('re-enables rich after switching from an over-threshold file back to a small one', async () => {
+    const large = `${'a'.repeat(RICH_MARKDOWN_MAX_SOURCE_BYTES)}\n`;
+    stubMarkdownFile(large);
+    await act(async () => {
+      root.render(createElement(FileViewer, { filePath: '/notes/large-first.md' }));
+    });
+    await settle();
+    expect(button(container, 'Rich').disabled).toBe(true);
+
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('/api/panel/file-content')) {
+        return reply({ content: '# Back\n', contentHash: 'back-hash' });
+      }
+      if (url.includes('/api/panel/file-diff')) {
+        return reply({ diff: '', hasDiff: false });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }));
+
+    await act(async () => {
+      root.render(createElement(FileViewer, { filePath: '/notes/small-again.md' }));
+    });
+    await settle();
+
+    expect(button(container, 'Rich').disabled).toBe(false);
+    act(() => button(container, 'Rich').click());
+    expect(container.querySelector('[data-rich-markdown-editor="true"]')).not.toBeNull();
+    expect(container.textContent).not.toContain(`limit ${RICH_MARKDOWN_MAX_SOURCE_BYTES}`);
   });
 });

--- a/src/components/desktop/file-viewer/RichMarkdownEditor.tsx
+++ b/src/components/desktop/file-viewer/RichMarkdownEditor.tsx
@@ -28,6 +28,7 @@ import {
   applyRichDocument,
   openRichDocument,
   richMarkdownSchema,
+  richMarkdownSizeUnavailableReason,
   UnsupportedMarkdownError,
 } from '@/lib/markdown/editor';
 import type { OpenRichDocumentResult } from '@/lib/markdown/editor/document';
@@ -59,6 +60,7 @@ export interface RichMarkdownEditorController {
   mode: MarkdownEditorMode;
   document: OpenRichDocumentResult | null;
   unavailable: UnsupportedMarkdownError | null;
+  sizeUnavailableReason: string | null;
   selectMode: (mode: MarkdownEditorMode) => void;
   clearUnavailable: () => void;
   loadSource: (sourceKey: string, source: string) => void;
@@ -79,9 +81,21 @@ export function useRichMarkdownEditor(
   const [mode, setMode] = useState<MarkdownEditorMode>('source');
   const [document, setDocument] = useState<OpenRichDocumentResult | null>(null);
   const [unavailable, setUnavailable] = useState<UnsupportedMarkdownError | null>(null);
+  const [sizeUnavailableReason, setSizeUnavailableReason] = useState<string | null>(null);
   const openedFileRef = useRef<string | null>(null);
 
+  const applySizeGuard = useCallback((nextSource: string): boolean => {
+    const reason = richMarkdownSizeUnavailableReason(nextSource);
+    setSizeUnavailableReason(reason);
+    if (!reason) return false;
+    setDocument(null);
+    setUnavailable(null);
+    setMode('source');
+    return true;
+  }, []);
+
   const openSource = useCallback((nextSource: string): boolean => {
+    if (applySizeGuard(nextSource)) return false;
     try {
       setDocument(openRichDocument(nextSource));
       setUnavailable(null);
@@ -94,7 +108,7 @@ export function useRichMarkdownEditor(
       setMode('source');
       return false;
     }
-  }, []);
+  }, [applySizeGuard]);
 
   const selectMode = useCallback((nextMode: MarkdownEditorMode) => {
     if (!supported) return;
@@ -109,31 +123,34 @@ export function useRichMarkdownEditor(
   }, [openSource, source, supported]);
 
   const reloadSource = useCallback((nextSource: string) => {
-    if (supported && mode === 'rich') {
+    if (applySizeGuard(nextSource)) return;
+    if (supported && sessionMarkdownMode === 'rich') {
       openSource(nextSource);
     } else {
       setDocument(null);
       setUnavailable(null);
     }
-  }, [mode, openSource, supported]);
+  }, [applySizeGuard, openSource, supported]);
 
   const loadSource = useCallback((sourceKey: string, nextSource: string) => {
     if (openedFileRef.current === sourceKey) return;
     openedFileRef.current = sourceKey;
     setUnavailable(null);
     setDocument(null);
+    if (applySizeGuard(nextSource)) return;
     if (!supported || sessionMarkdownMode === 'source') {
       setMode('source');
       return;
     }
     openSource(nextSource);
-  }, [openSource, supported]);
+  }, [applySizeGuard, openSource, supported]);
 
   return {
     supported,
     mode,
     document,
     unavailable,
+    sizeUnavailableReason,
     selectMode,
     clearUnavailable: () => setUnavailable(null),
     loadSource,
@@ -160,9 +177,11 @@ const toggleButtonStyle = {
 export function MarkdownModeToggle({
   mode,
   onChange,
+  richUnavailableReason,
 }: {
   mode: MarkdownEditorMode;
   onChange: (mode: MarkdownEditorMode) => void;
+  richUnavailableReason?: string | null;
 }) {
   return (
     <div
@@ -172,29 +191,58 @@ export function MarkdownModeToggle({
         display: 'flex',
         alignItems: 'center',
         gap: 2,
-        padding: 2,
+        paddingTop: 2,
+        paddingRight: 2,
+        paddingBottom: 2,
+        paddingLeft: 2,
         borderRadius: 9,
         background: 'var(--t-panel)',
       }}
     >
       {(['rich', 'source'] as const).map((candidate) => {
         const active = mode === candidate;
+        const blocked = candidate === 'rich' && Boolean(richUnavailableReason);
         return (
           <button
             key={candidate}
             type="button"
             aria-pressed={active}
-            onClick={() => onChange(candidate)}
+            disabled={blocked}
+            title={blocked ? `Rich mode unavailable: ${richUnavailableReason}` : undefined}
+            onClick={() => {
+              if (!blocked) onChange(candidate);
+            }}
             style={{
               ...toggleButtonStyle,
               color: active ? 'var(--t-text)' : 'var(--t-text-muted)',
               background: active ? 'var(--t-input-bg)' : 'transparent',
+              cursor: blocked ? 'not-allowed' : 'pointer',
+              opacity: blocked ? 0.55 : 1,
             }}
           >
             {candidate === 'rich' ? 'Rich' : 'Source'}
           </button>
         );
       })}
+      {richUnavailableReason ? (
+        <span
+          style={{
+            paddingTop: 0,
+            paddingRight: 8,
+            paddingBottom: 0,
+            paddingLeft: 6,
+            fontFamily: 'var(--font-sans-system)',
+            fontSize: 11,
+            fontWeight: 300,
+            letterSpacing: '-0.1px',
+            lineHeight: 1.25,
+            color: 'var(--t-text-muted)',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          Rich mode unavailable: {richUnavailableReason}
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/src/lib/markdown/editor/index.ts
+++ b/src/lib/markdown/editor/index.ts
@@ -2,3 +2,9 @@ export { applyRichDocument, openRichDocument } from './document';
 export { blockToPmNode, UnsupportedMarkdownError } from './from-mdast';
 export { richMarkdownSchema } from './schema';
 export { pmNodeToBlock } from './to-mdast';
+export {
+  RICH_MARKDOWN_MAX_SOURCE_BYTES,
+  isMarkdownSourceOverRichThreshold,
+  markdownSourceUtf8Bytes,
+  richMarkdownSizeUnavailableReason,
+} from './size-guard';

--- a/src/lib/markdown/editor/size-guard.test.ts
+++ b/src/lib/markdown/editor/size-guard.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RICH_MARKDOWN_MAX_SOURCE_BYTES,
+  isMarkdownSourceOverRichThreshold,
+  markdownSourceUtf8Bytes,
+  richMarkdownSizeUnavailableReason,
+} from './size-guard';
+
+describe('markdown rich-mode size guard', () => {
+  it('treats exactly the threshold as under (rich path allowed)', () => {
+    const source = 'a'.repeat(RICH_MARKDOWN_MAX_SOURCE_BYTES);
+    expect(markdownSourceUtf8Bytes(source)).toBe(RICH_MARKDOWN_MAX_SOURCE_BYTES);
+    expect(isMarkdownSourceOverRichThreshold(source)).toBe(false);
+    expect(richMarkdownSizeUnavailableReason(source)).toBeNull();
+  });
+
+  it('treats one ASCII byte over the threshold as source-only', () => {
+    const source = 'a'.repeat(RICH_MARKDOWN_MAX_SOURCE_BYTES + 1);
+    expect(isMarkdownSourceOverRichThreshold(source)).toBe(true);
+    expect(richMarkdownSizeUnavailableReason(source)).toBe(
+      `file is ${RICH_MARKDOWN_MAX_SOURCE_BYTES + 1} bytes (limit ${RICH_MARKDOWN_MAX_SOURCE_BYTES})`,
+    );
+  });
+
+  it('counts multibyte code points as UTF-8 bytes, not JS string length', () => {
+    const source = `${'a'.repeat(RICH_MARKDOWN_MAX_SOURCE_BYTES - 1)}é`;
+    expect(source.length).toBe(RICH_MARKDOWN_MAX_SOURCE_BYTES);
+    expect(markdownSourceUtf8Bytes(source)).toBe(RICH_MARKDOWN_MAX_SOURCE_BYTES + 1);
+    expect(isMarkdownSourceOverRichThreshold(source)).toBe(true);
+  });
+});

--- a/src/lib/markdown/editor/size-guard.ts
+++ b/src/lib/markdown/editor/size-guard.ts
@@ -1,0 +1,23 @@
+/**
+ * Rich Markdown (ProseMirror) is skipped above this UTF-8 byte size.
+ * Equality is allowed: `bytes > RICH_MARKDOWN_MAX_SOURCE_BYTES` is source-only.
+ * Measured with TextEncoder so multibyte code points cannot sneak under a
+ * JavaScript string-length check.
+ */
+export const RICH_MARKDOWN_MAX_SOURCE_BYTES = 64 * 1024;
+
+const utf8 = new TextEncoder();
+
+export function markdownSourceUtf8Bytes(source: string): number {
+  return utf8.encode(source).byteLength;
+}
+
+export function isMarkdownSourceOverRichThreshold(source: string): boolean {
+  return markdownSourceUtf8Bytes(source) > RICH_MARKDOWN_MAX_SOURCE_BYTES;
+}
+
+export function richMarkdownSizeUnavailableReason(source: string): string | null {
+  const bytes = markdownSourceUtf8Bytes(source);
+  if (bytes <= RICH_MARKDOWN_MAX_SOURCE_BYTES) return null;
+  return `file is ${bytes} bytes (limit ${RICH_MARKDOWN_MAX_SOURCE_BYTES})`;
+}


### PR DESCRIPTION
## What changed

- Keep rich Markdown editing available through an inclusive 65,536 UTF-8-byte threshold.
- Open larger Markdown files in source-only mode and show the byte-limit reason in the mode control.
- Wire the guard through the production `FileViewer` / `useRichMarkdownEditor` seam and document the threshold.
- Cover boundary, multibyte, reload, and file-switch behavior.

Closes #1966

## Why

Large Markdown documents should remain responsive instead of initializing ProseMirror. Byte size is measured as UTF-8 rather than JavaScript string length, so multibyte content is guarded correctly. Files above 65,536 bytes stay editable in source mode, with the reason visible to the operator.

The production-path tests verify that same-file reloads transition rich → source-only → rich as content crosses the limit, and that file switches work in both small → large and large → small directions. They also pin the inclusive boundary and multibyte behavior and verify that over-threshold content does not initialize ProseMirror.

## Verification

- [x] `npx tsc --noEmit`
- [ ] `npm test`
- [ ] `npm run lint`
- [x] Other relevant checks are listed below, or skipped checks are explained.

Verified on Node `v22.23.2`:

- `npx vitest run src/components/desktop/file-viewer/RichMarkdownEditor.test.tsx src/lib/markdown/editor/size-guard.test.ts` — 2 files, 12 tests passed.
- `npx tsc --noEmit` — passed.
- `npx eslint src/components/desktop/FileViewer.tsx src/components/desktop/file-viewer/RichMarkdownEditor.test.tsx src/components/desktop/file-viewer/RichMarkdownEditor.tsx src/lib/markdown/editor/index.ts src/lib/markdown/editor/size-guard.test.ts src/lib/markdown/editor/size-guard.ts` — passed.
- `npm run rule-check -- --base=29cecb558020395d489d9b9e18945ed0a9dac545` — passed on four changed production files with zero violations.
- `git diff --check 29cecb558020395d489d9b9e18945ed0a9dac545..HEAD` — passed.
- Repo-wide `npm test` and `npm run lint` were not run; the focused behavioral suite, mandatory TypeScript gate, touched-file ESLint, and changed-line rule check passed.

## Scope and risk

- One commit and exactly seven changed paths: production seam, editor hook, size guard/export, focused tests, and threshold documentation.
- No dependency, lockfile, generated-file, persistence, authorization, or unrelated issue changes.
- Open PRs #1985, #1986, #1987, and #1988 have no changed-path overlap.

## Author review

- [x] I reviewed and understand the complete diff, including any AI-generated code.

This pull request was developed with AI assistance. I reviewed the complete diff, the production-path verification, the independent approval evidence, and the boundary/multibyte/reload sabotage results, and I am responsible for the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a size limit for rich Markdown editing.
  * Files exceeding the limit now open in source mode, with Rich mode disabled and an explanation shown.
  * Size checks accurately account for UTF-8 content, including multibyte characters.

* **Documentation**
  * Added documentation describing the rich Markdown size threshold and source-only behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->