### PR TITLE
ci: make fork PR checks succeed without write tokens

### DIFF
--- a/.github/workflows/pr-author-triage.yml
+++ b/.github/workflows/pr-author-triage.yml
@@ -11,7 +11,9 @@ concurrency:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  # addLabels/removeLabel on a PR go through the issues endpoint but are
+  # permission-checked against the PR resource.
+  pull-requests: write
 
 jobs:
   label:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
   contents: read
@@ -75,13 +79,25 @@ jobs:
 
             body += `---\n*Automated review — [CI workflow](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions)*`;
 
-            // Post comment
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
-            });
+            const isFork = context.payload.pull_request.head.repo.full_name !==
+              `${context.repo.owner}/${context.repo.repo}`;
+
+            if (isFork) {
+              await core.summary.addRaw(body).write();
+              core.info('Fork pull request detected; wrote the report to the job summary.');
+            } else {
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+              } catch (error) {
+                if (error.status !== 403) throw error;
+                core.warning(`Could not post the PR review comment: ${error.message}`);
+              }
+            }
 
             // Also post inline review comments on large files
             const reviewComments = [];
@@ -93,7 +109,7 @@ jobs:
               });
             }
 
-            if (reviewComments.length > 0) {
+            if (!isFork && reviewComments.length > 0) {
               try {
                 await github.rest.pulls.createReview({
                   owner: context.repo.owner,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ Open an issue before starting any non-trivial change. An issue is not a promise 
 
 Keep each pull request to one concern. Explain the problem, why the change belongs in o8, and how you verified it. Include before-and-after images for visible UI changes and call out any test or gate you could not run.
 
+Pull requests from forks wait for maintainer approval before CI reports appear. After approval, the review bot writes its report to the workflow run summary instead of posting a pull request comment because fork workflow tokens are read-only.
+
 Before submitting, run:
 
 ```bash


### PR DESCRIPTION
Closes #1992.

Fork pull requests get a read-only job token no matter what `permissions:` declares, so the review bot's comment step failed on every external PR after its analysis had already run, and the author-triage labeler failed on the same PRs because label calls on a pull request are permission-checked against the PR resource (`pr-size.yml` already declared `pull-requests: write` for this reason and passed).

- `pr-review.yml`: detect a fork head; write the report to the job summary and skip write calls; keep the comment on same-repo PRs with a 403 treated as a warning. Event stays `pull_request` (never `pull_request_target` for a job that checks out the PR head). Adds `concurrency` with `cancel-in-progress`.
- `pr-author-triage.yml`: `pull-requests: write`, with the same note as `pr-size.yml`.
- `CONTRIBUTING.md`: fork runs wait for maintainer approval; the review bot's report lands in the run summary for fork PRs.

Verification: both workflows parse (`name, on, concurrency, permissions, jobs`), the embedded script passes a syntax check, no `pull_request_target` workflow checks out the PR head, `git diff --check` clean. The runtime proof is the next approved fork PR run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request review checks now cancel outdated runs when newer commits are submitted.
  * Review results for fork-based pull requests appear in the workflow summary.
  * Maintainers can approve fork-based checks before results are generated.

* **Bug Fixes**
  * Improved handling of permission failures when posting pull request review comments.
  * Updated workflow permissions to support pull request labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->