### PR TITLE
feat(status): one authority per terminal session state, with evidence on every surface

### DIFF
--- a/src/app/api/operator/status/route.ts
+++ b/src/app/api/operator/status/route.ts
@@ -3,6 +3,7 @@ import { getRuntimeInventorySnapshot } from '@/lib/runtime/inventory';
 import { listApprovals, listUnsettledApprovalContinuations } from '@/lib/approvals/store';
 import { getLaneEvents, listLanes } from '@/lib/lane/registry';
 import { buildOperatorStatusAgents, summarizeOperatorStatus } from '@/lib/orchestrator/operator-status-model';
+import { listTerminalReviewQueueEvidence } from '@/lib/terminal-status/store';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -11,18 +12,24 @@ export async function GET(request: NextRequest) {
   try {
     const sessionKeyFilter = request.nextUrl.searchParams.get('sessionKey') || undefined;
 
-    const [snapshot, pendingAll] = await Promise.all([
-      getRuntimeInventorySnapshot({ fresh: true }),
-      [
-        ...listApprovals({ status: 'pending' }),
-        ...listUnsettledApprovalContinuations(),
-      ],
-    ]);
+    const snapshot = await getRuntimeInventorySnapshot({ fresh: true });
+    const pendingApprovals = listApprovals({ status: 'pending' });
+    const pendingAll = [
+      ...pendingApprovals,
+      ...listUnsettledApprovalContinuations(),
+    ];
 
     // ── Agents ──
     const sessions = snapshot.agents ?? [];
     const lanes = listLanes();
-    const agents = buildOperatorStatusAgents(sessions, lanes, sessionKeyFilter);
+    const laneEventsByLaneId = new Map(
+      lanes.map((lane) => [lane.id, getLaneEvents(lane.id, 200)]),
+    );
+    const agents = buildOperatorStatusAgents(sessions, lanes, sessionKeyFilter, {
+      laneEventsByLaneId,
+      approvals: pendingApprovals,
+      reviewQueue: listTerminalReviewQueueEvidence(),
+    });
     const spendCapHits = lanes.flatMap((lane) => getLaneEvents(lane.id, 200)
       .filter((event) => event.verb === 'spend_cap_hit')
       .map((event) => ({

--- a/src/app/api/orchestrator/state/route.ts
+++ b/src/app/api/orchestrator/state/route.ts
@@ -65,13 +65,15 @@ function enrichMissionWithLanes(mission: OrchestratorMissionState): Orchestrator
 
 async function buildStateResponse(mission: OrchestratorMissionState): Promise<OrchestratorStateApiResponse> {
   const enriched = enrichMissionWithLanes(mission);
-  const snapshot = await getRuntimeInventorySnapshot({ fresh: true });
+  // Desktop, mobile, MCP, and CLI poll this route; reuse the inventory TTL and
+  // bound lane history to sessions the response actually carries.
+  const snapshot = await getRuntimeInventorySnapshot({ fresh: false });
   const lanes = listLanes();
   const inventorySessionKeys = new Set((snapshot.agents ?? []).map((agent) => agent.sessionKey));
   const laneEventsByLaneId = new Map(
     lanes
       .filter((lane) => lane.sessionKey && inventorySessionKeys.has(lane.sessionKey))
-      .map((lane) => [lane.id, getLaneEvents(lane.id, 200)]),
+      .map((lane) => [lane.id, getLaneEvents(lane.id, 50)]),
   );
   const agents = resolveAgentSummaryStatuses(snapshot.agents ?? [], lanes, {
     laneEventsByLaneId,

--- a/src/app/api/orchestrator/state/route.ts
+++ b/src/app/api/orchestrator/state/route.ts
@@ -7,9 +7,13 @@ import {
 } from '@/lib/orchestrator/control-plane';
 import { buildDagMetadata } from '@/lib/orchestrator/dag';
 import { currentLaneMergePolicy } from '@/lib/lane/dogfood-guard';
-import { findLaneByPacket } from '@/lib/lane/registry';
+import { getLaneEvents, findLaneByPacket, listLanes } from '@/lib/lane/registry';
+import { listApprovals } from '@/lib/approvals/store';
+import { getRuntimeInventorySnapshot } from '@/lib/runtime/inventory';
+import { resolveAgentSummaryStatuses } from '@/lib/orchestrator/operator-status-model';
 import { packetStatusWriteRejection } from '@/lib/orchestrator/packet-patch-policy';
 import { autoResolveMergedPacketVerificationIncidents } from '@/lib/supervisor/merged-incident-resolution';
+import { listTerminalReviewQueueEvidence } from '@/lib/terminal-status/store';
 import type {
   OrchestratorMissionState,
   OrchestratorPacket,
@@ -59,11 +63,25 @@ function enrichMissionWithLanes(mission: OrchestratorMissionState): Orchestrator
   return { ...mission, packets };
 }
 
-function buildStateResponse(mission: OrchestratorMissionState): OrchestratorStateApiResponse {
+async function buildStateResponse(mission: OrchestratorMissionState): Promise<OrchestratorStateApiResponse> {
   const enriched = enrichMissionWithLanes(mission);
+  const snapshot = await getRuntimeInventorySnapshot({ fresh: true });
+  const lanes = listLanes();
+  const inventorySessionKeys = new Set((snapshot.agents ?? []).map((agent) => agent.sessionKey));
+  const laneEventsByLaneId = new Map(
+    lanes
+      .filter((lane) => lane.sessionKey && inventorySessionKeys.has(lane.sessionKey))
+      .map((lane) => [lane.id, getLaneEvents(lane.id, 200)]),
+  );
+  const agents = resolveAgentSummaryStatuses(snapshot.agents ?? [], lanes, {
+    laneEventsByLaneId,
+    approvals: listApprovals({ status: 'pending' }),
+    reviewQueue: listTerminalReviewQueueEvidence(),
+  });
   return {
     mission: enriched,
     dag: buildDagMetadata(enriched.packets),
+    agents,
   };
 }
 
@@ -92,7 +110,7 @@ export async function GET(req: NextRequest) {
     // between our read and the lock acquisition. undefined → reconcile reads
     // fresh state inside the lock.
     const mission = await syncOrchestratorControlPlaneState();
-    return NextResponse.json(buildStateResponse(mission), {
+    return NextResponse.json(await buildStateResponse(mission), {
       headers: { 'Cache-Control': 'no-store, max-age=0' },
     });
   } catch (error) {
@@ -165,7 +183,7 @@ export async function POST(req: NextRequest) {
     if (!incoming) {
       // No payload — fall back to the existing "reconcile current" behavior.
       const mission = await syncOrchestratorControlPlaneState();
-      return NextResponse.json(buildStateResponse(mission), {
+      return NextResponse.json(await buildStateResponse(mission), {
         headers: { 'Cache-Control': 'no-store, max-age=0' },
       });
     }
@@ -185,7 +203,7 @@ export async function POST(req: NextRequest) {
       return { dropped: false } as const;
     });
 
-    return NextResponse.json(buildStateResponse(mission), {
+    return NextResponse.json(await buildStateResponse(mission), {
       headers: { 'Cache-Control': 'no-store, max-age=0' },
     });
   } catch (error) {
@@ -249,7 +267,7 @@ export async function PATCH(req: NextRequest) {
       autoResolveMergedPacketVerificationIncidents({ packetId, event: 'packet_archived' });
     }
 
-    return NextResponse.json(buildStateResponse(mission), {
+    return NextResponse.json(await buildStateResponse(mission), {
       headers: { 'Cache-Control': 'no-store, max-age=0' },
     });
   } catch (error) {

--- a/src/app/api/orchestrator/state/route.ts
+++ b/src/app/api/orchestrator/state/route.ts
@@ -14,6 +14,9 @@ import { resolveAgentSummaryStatuses } from '@/lib/orchestrator/operator-status-
 import { packetStatusWriteRejection } from '@/lib/orchestrator/packet-patch-policy';
 import { autoResolveMergedPacketVerificationIncidents } from '@/lib/supervisor/merged-incident-resolution';
 import { listTerminalReviewQueueEvidence } from '@/lib/terminal-status/store';
+import { resolveTerminalStatusEvidence } from '@/lib/terminal-status/resolve';
+import type { ApprovalRecord } from '@/lib/approvals/types';
+import type { Lane } from '@/lib/lane/types';
 import type {
   OrchestratorMissionState,
   OrchestratorPacket,
@@ -63,26 +66,57 @@ function enrichMissionWithLanes(mission: OrchestratorMissionState): Orchestrator
   return { ...mission, packets };
 }
 
+function approvalMatchesLane(approval: ApprovalRecord, lane: Lane): boolean {
+  if (lane.sessionKey && approval.sessionKey === lane.sessionKey) return true;
+  if (approval.continuation?.kind === 'lane' && approval.continuation.laneId === lane.id) return true;
+  return approval.metadata?.laneId === lane.id || approval.metadata?.LaneId === lane.id;
+}
+
 async function buildStateResponse(mission: OrchestratorMissionState): Promise<OrchestratorStateApiResponse> {
   const enriched = enrichMissionWithLanes(mission);
   // Desktop, mobile, MCP, and CLI poll this route; reuse the inventory TTL and
-  // bound lane history to sessions the response actually carries.
+  // read at most 50 events only for agent or packet lanes the response carries.
   const snapshot = await getRuntimeInventorySnapshot({ fresh: false });
   const lanes = listLanes();
+  const laneById = new Map(lanes.map((lane) => [lane.id, lane]));
+  const laneByPacketId = new Map(
+    lanes.flatMap((lane) => lane.packetId ? [[lane.packetId, lane] as const] : []),
+  );
   const inventorySessionKeys = new Set((snapshot.agents ?? []).map((agent) => agent.sessionKey));
+  const responsePacketLaneIds = new Set(
+    enriched.packets.flatMap((packet) => packet.lane?.laneId ? [packet.lane.laneId] : []),
+  );
   const laneEventsByLaneId = new Map(
     lanes
-      .filter((lane) => lane.sessionKey && inventorySessionKeys.has(lane.sessionKey))
+      .filter((lane) => responsePacketLaneIds.has(lane.id)
+        || Boolean(lane.sessionKey && inventorySessionKeys.has(lane.sessionKey)))
       .map((lane) => [lane.id, getLaneEvents(lane.id, 50)]),
   );
+  const approvals = listApprovals({ status: 'pending' });
+  const reviewQueue = listTerminalReviewQueueEvidence();
   const agents = resolveAgentSummaryStatuses(snapshot.agents ?? [], lanes, {
     laneEventsByLaneId,
-    approvals: listApprovals({ status: 'pending' }),
-    reviewQueue: listTerminalReviewQueueEvidence(),
+    approvals,
+    reviewQueue,
   });
+  const evidenceBySessionKey = new Map(agents.map((agent) => [agent.sessionKey, agent.statusEvidence]));
+  const packets = enriched.packets.map((packet) => {
+    const lane = (packet.lane?.laneId ? laneById.get(packet.lane.laneId) : undefined)
+      ?? laneByPacketId.get(packet.id);
+    if (!lane) return packet;
+    const agentEvidence = lane.sessionKey ? evidenceBySessionKey.get(lane.sessionKey) : undefined;
+    const statusEvidence = agentEvidence ?? resolveTerminalStatusEvidence({
+      lane,
+      laneEvents: laneEventsByLaneId.get(lane.id) ?? [],
+      approvals: approvals.filter((approval) => approvalMatchesLane(approval, lane)),
+      reviewQueue: reviewQueue.filter((review) => review.laneId === lane.id),
+    });
+    return { ...packet, statusEvidence };
+  });
+  const projectedMission = { ...enriched, packets };
   return {
-    mission: enriched,
-    dag: buildDagMetadata(enriched.packets),
+    mission: projectedMission,
+    dag: buildDagMetadata(projectedMission.packets),
     agents,
   };
 }
@@ -161,7 +195,13 @@ function mergeClientMissionUnderLock(
   // but pin identity fields to the server's values so a client that
   // synthesized partial state can't overwrite them to empty/different
   // strings. Packet-level updates flow through as-is.
-  const packets: OrchestratorPacket[] = Array.isArray(incoming.packets) ? incoming.packets : [];
+  const packets: OrchestratorPacket[] = Array.isArray(incoming.packets)
+    ? incoming.packets.map((packet) => {
+        const persisted = { ...packet };
+        delete persisted.statusEvidence;
+        return persisted;
+      })
+    : [];
   return {
     ...incoming,
     missionId: current.missionId || incoming.missionId,

--- a/src/app/dashboard/tileRegistry.tsx
+++ b/src/app/dashboard/tileRegistry.tsx
@@ -318,6 +318,7 @@ export function createTileRegistry({
                 sessionKey: agent.sessionKey,
                 tmuxSession,
                 label: agent.surfaceLabel ?? agent.name,
+                statusEvidence: agent.statusEvidence,
                 repo: repoPath ? {
                   name: repoPath.split('/').filter(Boolean).pop() ?? repoPath,
                   localPath: repoPath,

--- a/src/app/dashboard/types.ts
+++ b/src/app/dashboard/types.ts
@@ -5,6 +5,7 @@ import type { RepoReadiness } from '@/lib/repos/types';
 import type { WorktreeInfo } from '@/lib/worktree/types';
 import type { WorkspaceLifecycleRecordView, WorkspaceLifecycleSummaryView } from '@/lib/workspace/lifecycle-types';
 import type { WorkflowStageBadge } from '@/lib/workflows/status';
+import type { TerminalStatusEvidence } from '@/lib/terminal-status/resolve';
 
 // Retired NavRail's `NavSection` type — kept here so the dashboard hooks
 // that flip the section (useUIChrome, useGlobalRepoState,
@@ -56,6 +57,7 @@ export interface PaletteAgentSummary {
   lifecycleState?: string;
   workflowStage?: WorkflowStageBadge | null;
   runtime?: string;
+  statusEvidence?: TerminalStatusEvidence;
   localDiff?: {
     changedFiles?: number;
     additions?: number;

--- a/src/components/desktop/AgentPanel.tsx
+++ b/src/components/desktop/AgentPanel.tsx
@@ -482,7 +482,7 @@ export const AgentPanel = memo(function AgentPanel(props: AgentPanelProps = {}) 
             // Agents stay flat between Chats and Archived, never nested under a chat.
             agentsSection={(
               <>
-                <AgentPanelExtraAgents activeSessionKey={activeSessionKey} onSelectSession={onSelectSession} />
+                <AgentPanelExtraAgents activeSessionKey={activeSessionKey} onSelectSession={onSelectSession} packets={orchestratorMissionState?.packets ?? orchestratorPackets} />
                 <AgentMessageActivity repos={railReposForChats} />
               </>
             )}

--- a/src/components/desktop/AgentPanelExtraAgentRow.tsx
+++ b/src/components/desktop/AgentPanelExtraAgentRow.tsx
@@ -5,6 +5,7 @@ import { AgentStatusDot, type AgentDotState } from '@/components/desktop/AgentSt
 import { formatElapsedAgo } from './repo-focus/tabs/chats/helpers';
 import { attentionWashStyle } from './repo-focus/tabs/chats/HistoryRows';
 import { shouldRecede, type AttentionBand } from './repo-focus/tabs/chats/sections';
+import type { TerminalStatusEvidence } from '@/lib/terminal-status/resolve';
 
 export type AgentOrigin = 'CLI' | 'MCP' | 'Mobile' | 'Webhook' | 'Cloud';
 export type VisualStatus = 'running' | 'waiting' | 'idle' | 'error' | 'archived';
@@ -27,6 +28,7 @@ export interface ExtraAgentRow {
   outcome: 'no_changes' | 'merged' | 'discarded' | 'pr_opened' | 'asked' | null;
   outcomeNote: string | null;
   lastEventLabel: string | null;
+  statusEvidence?: TerminalStatusEvidence;
   /** Open PR for this lane, surfaced in the hover card (T3 keeps it in-row —
    *  too cramped; ours lives one hover away). */
   prNumber?: number | null;
@@ -203,7 +205,7 @@ export function ExtraAgentRowView({
         onOpenMenu?.(event, row);
       }}
       aria-current={active ? 'true' : undefined}
-      title={canFocus ? `Focus ${row.name}` : row.name}
+      title={row.statusEvidence?.summary ?? (canFocus ? `Focus ${row.name}` : row.name)}
       style={{
         width: '100%',
         minHeight: 31,

--- a/src/components/desktop/AgentPanelExtraAgents.test.ts
+++ b/src/components/desktop/AgentPanelExtraAgents.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { AgentSummary } from '@/lib/fleet/types';
 import {
   deriveSpawnedAgentRows,
   type LaneSummary,
@@ -56,6 +57,53 @@ describe('Agents rail derivation', () => {
       agents: [],
       archivedSessionKeys: new Set(['codex-owned:lane-running']),
     })).toEqual([]);
+  });
+
+  it('carries the fleet status evidence onto the matching lane row', () => {
+    const sessionKey = 'codex-owned:lane-evidence';
+    const statusEvidence = {
+      sessionId: sessionKey,
+      runtime: 'codex' as const,
+      state: 'blocked' as const,
+      authority: 'lane-state' as const,
+      observedAt: '2026-08-29T12:00:00.000Z',
+      summary: 'Lane is waiting for approval.',
+      evidence: [{ source: 'lane:lane-evidence.status', value: 'awaiting_human' }],
+    };
+    const lane: LaneSummary = {
+      id: 'lane-evidence',
+      label: 'Evidence worker',
+      repoPath: '/repos/project-repo',
+      branch: 'issue/evidence',
+      runtime: 'codex',
+      sessionKey,
+      packetId: 'pkt-evidence',
+      status: 'awaiting_human',
+      ownership: 'managed',
+      lastEventAt: statusEvidence.observedAt,
+      lastEventLabel: 'approval_requested',
+    };
+    const agent = {
+      id: 'agent-evidence',
+      name: 'Evidence worker',
+      squadId: 'default',
+      sessionKey,
+      runtime: 'codex',
+      model: 'gpt-5',
+      status: 'blocked',
+      currentTask: 'Waiting for approval',
+      workspace: lane.repoPath,
+      branch: lane.branch,
+      approvalStatus: 'pending',
+      lastEventAt: statusEvidence.observedAt,
+      context: { usedPercent: 0, trend: 'stable' },
+      alerts: 0,
+      statusEvidence,
+    } satisfies AgentSummary;
+
+    const [row] = deriveSpawnedAgentRows({ lanes: [lane], agents: [agent] });
+
+    expect(row?.statusEvidence).toEqual(statusEvidence);
   });
 
   it('hides an explicitly archived sessionless lane row', () => {

--- a/src/components/desktop/AgentPanelExtraAgents.tsx
+++ b/src/components/desktop/AgentPanelExtraAgents.tsx
@@ -41,6 +41,7 @@ import { SpawnedAgentHoverCard } from './SpawnedAgentHoverCard';
 import { callRetryPacket } from '@/lib/orchestrator/packet-actions';
 import { runtimeModelDisplayLabel } from '@/lib/orchestrator/display';
 import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+import type { AgentSummary } from '@/lib/fleet/types';
 import { archiveRuntimeTarget } from '@/lib/runtime/archive-client';
 import { SectionLabel } from './repo-focus/tabs/chats/shared';
 import {
@@ -73,20 +74,6 @@ export interface LaneSummary {
   lastEventAt: string | null;
   lastEventLabel: string | null;
   prNumber?: number | null;
-}
-
-type AgentStatus = 'idle' | 'running' | 'blocked' | 'waiting' | 'reviewing' | 'failed' | 'completed';
-
-export interface AgentSummary {
-  id: string;
-  name: string;
-  runtime: string;
-  status: AgentStatus;
-  sessionKey: string;
-  lastEventAt: string;
-  currentTask?: string;
-  model?: string;
-  workspace?: string;
 }
 
 export interface AgentPanelExtraAgentsProps {
@@ -140,6 +127,7 @@ function buildRows(
 ): ExtraAgentRow[] {
   const rows: ExtraAgentRow[] = [];
   const seenSessionKeys = new Set<string>();
+  const agentsBySessionKey = new Map(agents.map((agent) => [agent.sessionKey, agent]));
 
   for (const lane of lanes) {
     const origin = classifyOrigin(lane.runtime, lane.ownership);
@@ -149,6 +137,7 @@ function buildRows(
     // sitting in reviewing / awaiting_input, leaving the operator with
     // no way to see what got spawned. Surface them here too.
     const status = classifyStatus(lane.status);
+    const matchingAgent = lane.sessionKey ? agentsBySessionKey.get(lane.sessionKey) : undefined;
     if (lane.sessionKey) seenSessionKeys.add(lane.sessionKey);
     rows.push({
       key: `lane:${lane.id}`,
@@ -167,6 +156,7 @@ function buildRows(
       outcome: lane.outcome ?? null,
       outcomeNote: lane.outcomeNote ?? null,
       lastEventLabel: lane.lastEventLabel,
+      statusEvidence: matchingAgent?.statusEvidence,
       prNumber: lane.prNumber ?? null,
       rejected: lane.packetId ? rejectedPacketIds.has(lane.packetId) : false,
     });
@@ -194,6 +184,7 @@ function buildRows(
       outcome: null,
       outcomeNote: null,
       lastEventLabel: null,
+      statusEvidence: agent.statusEvidence,
     });
   }
 
@@ -364,8 +355,11 @@ function AgentPanelExtraAgentsBase({ activeSessionKey, onSelectSession }: AgentP
         setRejectedPacketIds(new Set(rejected.map((entry) => entry.packetId)));
       }
       if (snapshotRes.status === 'fulfilled' && snapshotRes.value.ok) {
-        const json = await snapshotRes.value.json() as { agents?: AgentSummary[] };
-        setAgents(json.agents ?? []);
+        const json = await snapshotRes.value.json() as {
+          agents?: AgentSummary[];
+          fleet?: { agents?: AgentSummary[] };
+        };
+        setAgents(json.fleet?.agents ?? json.agents ?? []);
       }
     } catch {
       // AbortError on teardown — silently ignore.

--- a/src/components/desktop/AgentPanelExtraAgents.tsx
+++ b/src/components/desktop/AgentPanelExtraAgents.tsx
@@ -40,7 +40,7 @@ import {
 import { SpawnedAgentHoverCard } from './SpawnedAgentHoverCard';
 import { callRetryPacket } from '@/lib/orchestrator/packet-actions';
 import { runtimeModelDisplayLabel } from '@/lib/orchestrator/display';
-import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+import type { OrchestratorPacket, OrchestratorRuntime } from '@/lib/orchestrator/types';
 import type { AgentSummary } from '@/lib/fleet/types';
 import { archiveRuntimeTarget } from '@/lib/runtime/archive-client';
 import { SectionLabel } from './repo-focus/tabs/chats/shared';
@@ -79,6 +79,7 @@ export interface LaneSummary {
 export interface AgentPanelExtraAgentsProps {
   activeSessionKey?: string | null;
   onSelectSession?: (sessionKey: string) => void;
+  packets?: OrchestratorPacket[];
 }
 
 // ── Constants ──
@@ -123,11 +124,13 @@ function normalizePath(value: string | null | undefined): string | null {
 function buildRows(
   lanes: LaneSummary[],
   agents: AgentSummary[],
+  packets: OrchestratorPacket[],
   rejectedPacketIds: ReadonlySet<string>,
 ): ExtraAgentRow[] {
   const rows: ExtraAgentRow[] = [];
   const seenSessionKeys = new Set<string>();
   const agentsBySessionKey = new Map(agents.map((agent) => [agent.sessionKey, agent]));
+  const packetsById = new Map(packets.map((packet) => [packet.id, packet]));
 
   for (const lane of lanes) {
     const origin = classifyOrigin(lane.runtime, lane.ownership);
@@ -138,6 +141,7 @@ function buildRows(
     // no way to see what got spawned. Surface them here too.
     const status = classifyStatus(lane.status);
     const matchingAgent = lane.sessionKey ? agentsBySessionKey.get(lane.sessionKey) : undefined;
+    const matchingPacket = lane.packetId ? packetsById.get(lane.packetId) : undefined;
     if (lane.sessionKey) seenSessionKeys.add(lane.sessionKey);
     rows.push({
       key: `lane:${lane.id}`,
@@ -156,7 +160,7 @@ function buildRows(
       outcome: lane.outcome ?? null,
       outcomeNote: lane.outcomeNote ?? null,
       lastEventLabel: lane.lastEventLabel,
-      statusEvidence: matchingAgent?.statusEvidence,
+      statusEvidence: matchingPacket?.statusEvidence ?? matchingAgent?.statusEvidence,
       prNumber: lane.prNumber ?? null,
       rejected: lane.packetId ? rejectedPacketIds.has(lane.packetId) : false,
     });
@@ -202,17 +206,19 @@ function isTerminalRow(row: ExtraAgentRow): boolean {
 export function deriveSpawnedAgentRows({
   lanes,
   agents,
+  packets = [],
   rejectedPacketIds = new Set<string>(),
   archivedSessionKeys = new Set<string>(),
   archivedRowKeys = new Set<string>(),
 }: {
   lanes: LaneSummary[];
   agents: AgentSummary[];
+  packets?: OrchestratorPacket[];
   rejectedPacketIds?: ReadonlySet<string>;
   archivedSessionKeys?: ReadonlySet<string>;
   archivedRowKeys?: ReadonlySet<string>;
 }): ExtraAgentRow[] {
-  const rows = buildRows(lanes, agents, rejectedPacketIds).filter((row) => (
+  const rows = buildRows(lanes, agents, packets, rejectedPacketIds).filter((row) => (
     !archivedRowKeys.has(row.key)
     && !(row.sessionKey && archivedSessionKeys.has(row.sessionKey))
   ));
@@ -228,7 +234,11 @@ export function deriveSpawnedAgentRows({
 
 const COLLAPSED_KEY = 'o8:agent-panel:spawned-agents-collapsed';
 
-function AgentPanelExtraAgentsBase({ activeSessionKey, onSelectSession }: AgentPanelExtraAgentsProps) {
+function AgentPanelExtraAgentsBase({
+  activeSessionKey,
+  onSelectSession,
+  packets = [],
+}: AgentPanelExtraAgentsProps) {
   const [lanes, setLanes] = useState<LaneSummary[]>([]);
   const [agents, setAgents] = useState<AgentSummary[]>([]);
   const [rejectedPacketIds, setRejectedPacketIds] = useState<Set<string>>(() => new Set());
@@ -414,9 +424,10 @@ function AgentPanelExtraAgentsBase({ activeSessionKey, onSelectSession }: AgentP
   const rows = useMemo(() => deriveSpawnedAgentRows({
     lanes,
     agents,
+    packets,
     rejectedPacketIds,
     archivedRowKeys,
-  }), [lanes, agents, rejectedPacketIds, archivedRowKeys]);
+  }), [lanes, agents, packets, rejectedPacketIds, archivedRowKeys]);
   const showRepoSuffix = deriveShowRepoSuffix(rows);
   const rankedRows = useMemo(() => {
     void readStateVersion;

--- a/src/components/desktop/SpawnedAgentHoverCard.test.ts
+++ b/src/components/desktop/SpawnedAgentHoverCard.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import type { TerminalStatusEvidence } from '@/lib/terminal-status/resolve';
+import {
+  deriveSpawnedAgentRows,
+  type LaneSummary,
+} from './AgentPanelExtraAgents';
+import { SpawnedAgentHoverCard } from './SpawnedAgentHoverCard';
+
+const ACT_ENV = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+ACT_ENV.IS_REACT_ACT_ENVIRONMENT = true;
+
+const anchorRect = {
+  x: 20,
+  y: 20,
+  top: 20,
+  right: 220,
+  bottom: 52,
+  left: 20,
+  width: 200,
+  height: 32,
+  toJSON: () => ({}),
+} as DOMRect;
+
+describe('SpawnedAgentHoverCard packet status evidence', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ events: [] }),
+    })));
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders packet evidence when the lane has no fleet agent', async () => {
+    const statusEvidence: TerminalStatusEvidence = {
+      sessionId: 'codex-owned:packet-only-hover',
+      runtime: 'codex',
+      state: 'blocked',
+      authority: 'lane-state',
+      observedAt: '2026-08-29T12:00:00.000Z',
+      summary: 'Lane packet-only worker is blocked: worktree_missing_unverified.',
+      evidence: [{
+        source: 'lane-event:worktree_missing_unverified',
+        value: 'awaiting_orchestrator',
+      }],
+    };
+    const packet = {
+      id: 'pkt-packet-only-hover',
+      statusEvidence,
+    } as OrchestratorPacket;
+    const lane: LaneSummary = {
+      id: 'lane-packet-only-hover',
+      label: 'Packet-only worker',
+      repoPath: '/repos/packet-only',
+      branch: 'issue/packet-only',
+      runtime: 'codex',
+      sessionKey: statusEvidence.sessionId,
+      packetId: packet.id,
+      status: 'awaiting_orchestrator',
+      ownership: 'managed',
+      lastEventAt: statusEvidence.observedAt,
+      lastEventLabel: 'worktree_missing_unverified',
+    };
+    const [row] = deriveSpawnedAgentRows({ lanes: [lane], agents: [], packets: [packet] });
+
+    expect(row?.statusEvidence).toEqual(statusEvidence);
+    await act(async () => {
+      root.render(createElement(SpawnedAgentHoverCard, {
+        row: row!,
+        anchorRect,
+        onMouseEnter: () => {},
+        onMouseLeave: () => {},
+      }));
+      await Promise.resolve();
+    });
+
+    const disclosure = document.body.querySelector(
+      `[data-terminal-status-evidence="${statusEvidence.sessionId}"]`,
+    );
+    expect(disclosure).not.toBeNull();
+    expect(disclosure?.textContent).toContain('blocked · lane');
+    expect(document.body.textContent).toContain(statusEvidence.summary);
+  });
+});

--- a/src/components/desktop/SpawnedAgentHoverCard.tsx
+++ b/src/components/desktop/SpawnedAgentHoverCard.tsx
@@ -6,6 +6,7 @@ import { deriveSpawnedAgentState, formatSpawnedAgentElapsed } from './spawned-ag
 import type { ExtraAgentRow } from './AgentPanelExtraAgentRow';
 import type { TranscriptEvent } from '@/lib/orchestrator/transcript-normalizer';
 import { runtimeModelDisplayLabel } from '@/lib/orchestrator/display';
+import { TerminalStatusEvidenceDisclosure } from './TerminalStatusEvidenceRows';
 
 interface SpawnedAgentHoverCardProps {
   row: ExtraAgentRow;
@@ -248,8 +249,15 @@ export function SpawnedAgentHoverCard({
           <MetaRow label="Repo" value={row.repoPath.split('/').filter(Boolean).at(-1) ?? row.repoPath} />
         ) : null}
         {row.prNumber ? <MetaRow label="PR" value={`#${row.prNumber}`} /> : null}
+        {row.statusEvidence ? <MetaRow label="Status" value={row.statusEvidence.summary} /> : null}
         {transcript.lastActivity ? <MetaRow label="Activity" value={transcript.lastActivity} /> : null}
       </div>
+
+      {row.statusEvidence ? (
+        <div style={{ marginTop: 12 }}>
+          <TerminalStatusEvidenceDisclosure evidence={row.statusEvidence} />
+        </div>
+      ) : null}
 
       <div
         style={{

--- a/src/components/desktop/TerminalStatusEvidenceRows.test.ts
+++ b/src/components/desktop/TerminalStatusEvidenceRows.test.ts
@@ -2,7 +2,7 @@
 
 import { act, createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TerminalStatusEvidence } from '@/lib/terminal-status/resolve';
 import { TerminalStatusEvidenceDisclosure } from './TerminalStatusEvidenceRows';
 
@@ -28,6 +28,8 @@ describe('TerminalStatusEvidenceDisclosure', () => {
   let root: Root;
 
   beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime('2026-08-29T12:03:00.000Z');
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -36,6 +38,7 @@ describe('TerminalStatusEvidenceDisclosure', () => {
   afterEach(async () => {
     await act(async () => root.unmount());
     container.remove();
+    vi.useRealTimers();
   });
 
   it('renders the state and selected authority caption with evidence rows', async () => {
@@ -47,9 +50,82 @@ describe('TerminalStatusEvidenceDisclosure', () => {
     });
 
     expect(container.textContent).toContain('blocked · lane');
-    expect(container.textContent).toContain('lane:lane-evidence.status');
+    expect(container.textContent).toContain('Lane status');
     expect(container.textContent).toContain('awaiting_human');
-    expect(container.textContent).toContain('2026-08-29T12:00:00.000Z');
+    expect(container.textContent).toContain('3 min ago');
+  });
+
+  it('renders relative observation time with the ISO value available on hover', async () => {
+    vi.setSystemTime('2026-08-29T12:00:41.000Z');
+    await act(async () => {
+      root.render(createElement(TerminalStatusEvidenceDisclosure, {
+        evidence: fixture,
+        defaultExpanded: true,
+      }));
+    });
+
+    const observed = container.querySelector('[data-terminal-status-evidence-row="observed"]');
+    expect(observed?.textContent).toContain('41 s ago');
+    expect(observed?.querySelectorAll('[title]')[1]?.getAttribute('title')).toBe(fixture.observedAt);
+  });
+
+  it('maps known evidence sources to readable labels', async () => {
+    await act(async () => {
+      root.render(createElement(TerminalStatusEvidenceDisclosure, {
+        evidence: {
+          ...fixture,
+          evidence: [
+            { source: 'runtime-session.status', value: 'running' },
+            { source: 'owned-run:run-1', value: 'finished' },
+            { source: 'lane:lane-1.status', value: 'reviewing' },
+            { source: 'lane-event:review_ready', value: 'ready' },
+            { source: 'approval:approval-1', value: 'pending' },
+            { source: 'review_queue:review-1', value: 'pending review' },
+            { source: 'raw-terminal.lifecycle', value: 'active' },
+            { source: 'custom.signal', value: 'custom' },
+          ],
+        },
+        defaultExpanded: true,
+      }));
+    });
+
+    for (const label of [
+      'Runtime status',
+      'Run',
+      'Lane status',
+      'Lane event · review ready',
+      'Approval',
+      'Review queue',
+      'Terminal',
+      'custom.signal',
+    ]) {
+      expect(container.textContent).toContain(label);
+    }
+  });
+
+  it('collapses consecutive equal values from one authority and keeps every source on hover', async () => {
+    await act(async () => {
+      root.render(createElement(TerminalStatusEvidenceDisclosure, {
+        evidence: {
+          ...fixture,
+          authority: 'runtime-event',
+          evidence: [
+            { source: 'runtime-session.status', value: 'running' },
+            { source: 'runtime-session.lifecycle', value: 'running' },
+            { source: 'raw-terminal.lifecycle', value: 'running' },
+          ],
+        },
+        defaultExpanded: true,
+      }));
+    });
+
+    const runtimeRow = container.querySelector('[data-terminal-status-evidence-row="Runtime status"]');
+    expect(runtimeRow?.querySelector('span')?.getAttribute('title')).toBe(
+      'runtime-session.status\nruntime-session.lifecycle',
+    );
+    expect(container.querySelector('[data-terminal-status-evidence-row="Runtime lifecycle"]')).toBeNull();
+    expect(container.querySelector('[data-terminal-status-evidence-row="Terminal"]')).not.toBeNull();
+    expect(runtimeRow?.querySelectorAll('span')[1]?.style.lineHeight).toBe('1.25');
   });
 
   it('shows fallback reason only when the record carries one', async () => {

--- a/src/components/desktop/TerminalStatusEvidenceRows.test.ts
+++ b/src/components/desktop/TerminalStatusEvidenceRows.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { TerminalStatusEvidence } from '@/lib/terminal-status/resolve';
+import { TerminalStatusEvidenceDisclosure } from './TerminalStatusEvidenceRows';
+
+const ACT_ENV = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+ACT_ENV.IS_REACT_ACT_ENVIRONMENT = true;
+
+const fixture: TerminalStatusEvidence = {
+  sessionId: 'codex-owned:evidence-rows',
+  runtime: 'codex',
+  state: 'blocked',
+  authority: 'lane-state',
+  observedAt: '2026-08-29T12:00:00.000Z',
+  summary: 'Approval pending: continue the governed run.',
+  evidence: [
+    { source: 'lane:lane-evidence.status', value: 'awaiting_human' },
+    { source: 'approval:approval-evidence', value: 'pending · Continue the run.' },
+  ],
+  fallbackReason: 'No runtime event evidence was available, so lane state is the next available authority.',
+};
+
+describe('TerminalStatusEvidenceDisclosure', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it('renders the state and selected authority caption with evidence rows', async () => {
+    await act(async () => {
+      root.render(createElement(TerminalStatusEvidenceDisclosure, {
+        evidence: fixture,
+        defaultExpanded: true,
+      }));
+    });
+
+    expect(container.textContent).toContain('blocked · lane');
+    expect(container.textContent).toContain('lane:lane-evidence.status');
+    expect(container.textContent).toContain('awaiting_human');
+    expect(container.textContent).toContain('2026-08-29T12:00:00.000Z');
+  });
+
+  it('shows fallback reason only when the record carries one', async () => {
+    await act(async () => {
+      root.render(createElement(TerminalStatusEvidenceDisclosure, {
+        evidence: fixture,
+        defaultExpanded: true,
+      }));
+    });
+    expect(container.textContent).toContain(fixture.fallbackReason);
+
+    await act(async () => {
+      root.render(createElement(TerminalStatusEvidenceDisclosure, {
+        evidence: { ...fixture, fallbackReason: undefined },
+        defaultExpanded: true,
+      }));
+    });
+    expect(container.textContent).not.toContain('No runtime event evidence was available');
+    expect(container.querySelector('[data-terminal-status-evidence-row="fallback"]')).toBeNull();
+  });
+});

--- a/src/components/desktop/TerminalStatusEvidenceRows.tsx
+++ b/src/components/desktop/TerminalStatusEvidenceRows.tsx
@@ -13,17 +13,93 @@ const AUTHORITY_CAPTION: Record<TerminalStatusAuthority, string> = {
   'raw-terminal': 'terminal',
 };
 
+const EVIDENCE_LABEL_COLUMN_WIDTH = 144;
+
+interface DisplayEvidenceRow {
+  authority: TerminalStatusAuthority;
+  sources: string[];
+  value: string;
+}
+
 export function terminalStatusCaption(evidence: TerminalStatusEvidence): string {
   return `${evidence.state} · ${AUTHORITY_CAPTION[evidence.authority]}`;
 }
 
-function EvidenceRow({ source, value }: { source: string; value: string }) {
+export function terminalEvidenceSourceLabel(source: string): string {
+  if (source === 'runtime-session.status') return 'Runtime status';
+  if (source === 'runtime-session.lifecycle') return 'Runtime lifecycle';
+  if (source.startsWith('owned-run:')) return 'Run';
+  if (/^lane:.*\.status$/.test(source)) return 'Lane status';
+  if (source.startsWith('lane-event:')) {
+    const verb = source.slice('lane-event:'.length).replace(/[_-]+/g, ' ').trim();
+    return verb ? `Lane event · ${verb}` : 'Lane event';
+  }
+  if (source.startsWith('approval:')) return 'Approval';
+  if (source.startsWith('review_queue:')) return 'Review queue';
+  if (source === 'raw-terminal.lifecycle') return 'Terminal';
+  return source;
+}
+
+function sourceAuthority(
+  source: string,
+  fallback: TerminalStatusAuthority,
+): TerminalStatusAuthority {
+  if (source.startsWith('runtime-session.') || source.startsWith('owned-run:')) {
+    return 'runtime-event';
+  }
+  if (/^lane:.*\.status$/.test(source)
+    || source.startsWith('lane-event:')
+    || source.startsWith('approval:')
+    || source.startsWith('review_queue:')) {
+    return 'lane-state';
+  }
+  if (source.startsWith('known-screen-adapter')) return 'known-screen-adapter';
+  if (source.startsWith('raw-terminal.')) return 'raw-terminal';
+  return fallback;
+}
+
+function displayEvidenceRows(evidence: TerminalStatusEvidence): DisplayEvidenceRow[] {
+  return evidence.evidence.reduce<DisplayEvidenceRow[]>((rows, item) => {
+    const authority = sourceAuthority(item.source, evidence.authority);
+    const previous = rows.at(-1);
+    if (previous?.value === item.value && previous.authority === authority) {
+      previous.sources.push(item.source);
+      return rows;
+    }
+    rows.push({ authority, sources: [item.source], value: item.value });
+    return rows;
+  }, []);
+}
+
+export function relativeObservationTime(observedAt: string, now = Date.now()): string {
+  const observed = Date.parse(observedAt);
+  if (!Number.isFinite(observed)) return observedAt;
+  const seconds = Math.max(0, Math.round((now - observed) / 1_000));
+  if (seconds < 60) return `${seconds} s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours} h ago`;
+  return `${Math.round(hours / 24)} d ago`;
+}
+
+function EvidenceRow({
+  source,
+  sourceTitle = source,
+  value,
+  valueTitle,
+}: {
+  source: string;
+  sourceTitle?: string;
+  value: string;
+  valueTitle?: string;
+}) {
   return (
     <div
       data-terminal-status-evidence-row={source}
       style={{
         display: 'grid',
-        gridTemplateColumns: '88px minmax(0, 1fr)',
+        gridTemplateColumns: `${EVIDENCE_LABEL_COLUMN_WIDTH}px minmax(0, 1fr)`,
         gap: 10,
         minHeight: 36,
         alignItems: 'center',
@@ -45,11 +121,9 @@ function EvidenceRow({ source, value }: { source: string; value: string }) {
           letterSpacing: '0.04em',
           lineHeight: '14px',
           textTransform: 'uppercase',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
+          overflowWrap: 'anywhere',
         }}
-        title={source}
+        title={sourceTitle}
       >
         {source}
       </span>
@@ -60,9 +134,10 @@ function EvidenceRow({ source, value }: { source: string; value: string }) {
           fontSize: 11.5,
           fontWeight: 300,
           letterSpacing: '-0.1px',
-          lineHeight: 1.4,
+          lineHeight: 1.25,
           overflowWrap: 'anywhere',
         }}
+        title={valueTitle}
       >
         {value}
       </span>
@@ -79,6 +154,7 @@ export function TerminalStatusEvidenceDisclosure({
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const caption = terminalStatusCaption(evidence);
+  const evidenceRows = displayEvidenceRows(evidence);
 
   return (
     <div
@@ -180,11 +256,16 @@ export function TerminalStatusEvidenceDisclosure({
       {expanded ? (
         <div role="group" aria-label="Session status diagnostics">
           <EvidenceRow source="authority" value={evidence.authority} />
-          <EvidenceRow source="observed" value={evidence.observedAt} />
-          {evidence.evidence.map((item, index) => (
+          <EvidenceRow
+            source="observed"
+            value={relativeObservationTime(evidence.observedAt)}
+            valueTitle={evidence.observedAt}
+          />
+          {evidenceRows.map((item, index) => (
             <EvidenceRow
-              key={`${item.source}:${item.value}:${index}`}
-              source={item.source}
+              key={`${item.sources.join(':')}:${item.value}:${index}`}
+              source={terminalEvidenceSourceLabel(item.sources[0])}
+              sourceTitle={item.sources.join('\n')}
               value={item.value}
             />
           ))}

--- a/src/components/desktop/TerminalStatusEvidenceRows.tsx
+++ b/src/components/desktop/TerminalStatusEvidenceRows.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useState } from 'react';
+import type {
+  TerminalStatusAuthority,
+  TerminalStatusEvidence,
+} from '@/lib/terminal-status/resolve';
+
+const AUTHORITY_CAPTION: Record<TerminalStatusAuthority, string> = {
+  'runtime-event': 'runtime',
+  'lane-state': 'lane',
+  'known-screen-adapter': 'adapter',
+  'raw-terminal': 'terminal',
+};
+
+export function terminalStatusCaption(evidence: TerminalStatusEvidence): string {
+  return `${evidence.state} · ${AUTHORITY_CAPTION[evidence.authority]}`;
+}
+
+function EvidenceRow({ source, value }: { source: string; value: string }) {
+  return (
+    <div
+      data-terminal-status-evidence-row={source}
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '88px minmax(0, 1fr)',
+        gap: 10,
+        minHeight: 36,
+        alignItems: 'center',
+        paddingTop: 6,
+        paddingRight: 10,
+        paddingBottom: 6,
+        paddingLeft: 10,
+        borderTopWidth: 1,
+        borderTopStyle: 'solid',
+        borderTopColor: 'var(--t-divider-subtle)',
+      }}
+    >
+      <span
+        style={{
+          minWidth: 0,
+          color: 'var(--t-text-faint)',
+          fontSize: 9,
+          fontWeight: 300,
+          letterSpacing: '0.04em',
+          lineHeight: '14px',
+          textTransform: 'uppercase',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+        title={source}
+      >
+        {source}
+      </span>
+      <span
+        style={{
+          minWidth: 0,
+          color: 'var(--t-text-muted)',
+          fontSize: 11.5,
+          fontWeight: 300,
+          letterSpacing: '-0.1px',
+          lineHeight: 1.4,
+          overflowWrap: 'anywhere',
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+export function TerminalStatusEvidenceDisclosure({
+  evidence,
+  defaultExpanded = false,
+}: {
+  evidence: TerminalStatusEvidence;
+  defaultExpanded?: boolean;
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const caption = terminalStatusCaption(evidence);
+
+  return (
+    <div
+      data-terminal-status-evidence={evidence.sessionId}
+      style={{
+        width: '100%',
+        minWidth: 0,
+        borderBottomWidth: 1,
+        borderBottomStyle: 'solid',
+        borderBottomColor: 'var(--t-divider-subtle)',
+        background: 'var(--t-panel)',
+        color: 'var(--t-text)',
+        fontFamily: 'var(--font-sans-system)',
+      }}
+    >
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-label={`${expanded ? 'Hide' : 'Show'} status evidence for ${evidence.sessionId}`}
+        title={evidence.summary}
+        onClick={() => setExpanded((current) => !current)}
+        style={{
+          width: '100%',
+          minHeight: 44,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          paddingTop: 5,
+          paddingRight: 10,
+          paddingBottom: 5,
+          paddingLeft: 10,
+          borderWidth: 0,
+          background: 'transparent',
+          color: 'var(--t-text)',
+          cursor: 'pointer',
+          textAlign: 'left',
+          fontFamily: 'var(--font-sans-system)',
+        }}
+        onMouseEnter={(event) => {
+          event.currentTarget.style.background = 'var(--t-hover)';
+        }}
+        onMouseLeave={(event) => {
+          event.currentTarget.style.background = 'transparent';
+        }}
+      >
+        <span style={{ flex: 1, minWidth: 0 }}>
+          <span
+            data-terminal-status-caption
+            style={{
+              display: 'block',
+              color: 'var(--t-text)',
+              fontSize: 11,
+              fontWeight: 300,
+              letterSpacing: '-0.1px',
+              lineHeight: 1.25,
+              textTransform: 'lowercase',
+            }}
+          >
+            {caption}
+          </span>
+          <span
+            style={{
+              display: 'block',
+              marginTop: 4,
+              color: 'var(--t-text-faint)',
+              fontSize: 9.5,
+              fontWeight: 260,
+              letterSpacing: '-0.4px',
+              lineHeight: 1.25,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {evidence.summary}
+          </span>
+        </span>
+        <svg
+          aria-hidden
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.4"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          style={{
+            flexShrink: 0,
+            color: 'var(--t-text-faint)',
+            transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+            transition: 'transform 150ms cubic-bezier(0.22, 1, 0.36, 1)',
+          }}
+        >
+          <path d="M2.5 4.5 6 8l3.5-3.5" />
+        </svg>
+      </button>
+
+      {expanded ? (
+        <div role="group" aria-label="Session status diagnostics">
+          <EvidenceRow source="authority" value={evidence.authority} />
+          <EvidenceRow source="observed" value={evidence.observedAt} />
+          {evidence.evidence.map((item, index) => (
+            <EvidenceRow
+              key={`${item.source}:${item.value}:${index}`}
+              source={item.source}
+              value={item.value}
+            />
+          ))}
+          {evidence.fallbackReason ? (
+            <EvidenceRow source="fallback" value={evidence.fallbackReason} />
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/desktop/agent-panel/shared.tsx
+++ b/src/components/desktop/agent-panel/shared.tsx
@@ -31,7 +31,10 @@ export function arraysMatchBy<T>(a: T[], b: T[], key: (item: T) => string | numb
 }
 
 export function agentFp(agent: AgentDetail): string {
-  return `${agent.id}|${agent.status}|${agent.currentTask}|${agent.lastEventAt}|${agent.alerts}|${agent.branch ?? ''}|${agent.workspaceStatus ?? ''}|${agent.lifecycleState ?? ''}|${agent.runtimeSurface?.reviewContext?.repoSlug ?? ''}|${agent.runtimeSurface?.cwd ?? ''}`;
+  const statusEvidenceFp = agent.statusEvidence
+    ? `${agent.statusEvidence.state}:${agent.statusEvidence.authority}:${agent.statusEvidence.observedAt}:${agent.statusEvidence.summary}:${agent.statusEvidence.fallbackReason ?? ''}:${agent.statusEvidence.evidence.map((item) => `${item.source}=${item.value}`).join(',')}`
+    : '';
+  return `${agent.id}|${agent.status}|${agent.currentTask}|${agent.lastEventAt}|${agent.alerts}|${agent.branch ?? ''}|${agent.workspaceStatus ?? ''}|${agent.lifecycleState ?? ''}|${agent.runtimeSurface?.reviewContext?.repoSlug ?? ''}|${agent.runtimeSurface?.cwd ?? ''}|${statusEvidenceFp}`;
 }
 
 export function eventFp(event: EventEntry): string {

--- a/src/components/desktop/agent-panel/types.ts
+++ b/src/components/desktop/agent-panel/types.ts
@@ -1,4 +1,5 @@
 import type { RuntimeSurfaceSummary } from '@/lib/fleet/types';
+import type { TerminalStatusEvidence } from '@/lib/terminal-status/resolve';
 import type { SavedChatRepoContext } from '@/lib/llm/chat-history';
 import type { MobileInboxSnapshot } from '@/lib/mobile/types';
 import type { OrchestratorMissionState, OrchestratorPacket, OrchestratorRuntime } from '@/lib/orchestrator/types';
@@ -45,6 +46,7 @@ export interface AgentDetail {
   lifecycleState?: 'active' | 'completed' | 'failed' | 'killed' | 'stalled';
   exitCode?: number;
   lifecycleTs?: number;
+  statusEvidence?: TerminalStatusEvidence;
   repoReadiness?: RepoReadiness;
 }
 

--- a/src/components/desktop/repo-focus/tabs/AgentRows.tsx
+++ b/src/components/desktop/repo-focus/tabs/AgentRows.tsx
@@ -4,6 +4,7 @@ import { ClaudeIcon, CodexIcon, GeminiIcon, OpenCodeIcon } from '@/components/de
 import { AgentStatusDot, agentStatusToDotState } from '@/components/desktop/AgentStatusDot';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 import { packetRuntimeModelDisplayLabel } from '@/lib/orchestrator/display';
+import { terminalStatusCaption } from '@/components/desktop/TerminalStatusEvidenceRows';
 import type { IdeWorkspaceSession } from '../types';
 import {
   formatElapsed,
@@ -110,9 +111,11 @@ export function PacketRow({
   onSelectSession?: (sessionKey: string) => void;
 }) {
   const sessionKey = packet.lane?.sessionKey ?? null;
+  const statusEvidence = packet.statusEvidence;
   return (
     <button
       type="button"
+      title={statusEvidence?.summary}
       onClick={() => {
         if (sessionKey) onSelectSession?.(sessionKey);
       }}
@@ -144,7 +147,10 @@ export function PacketRow({
           {packetRuntimeModelDisplayLabel(packet)} · {packetTimeLabel(packet)}
         </span>
       </span>
-      <StatusPill label={packetStatusLabel(packet)} color={packetStatusColor(packet)} />
+      <StatusPill
+        label={statusEvidence ? terminalStatusCaption(statusEvidence) : packetStatusLabel(packet)}
+        color={packetStatusColor(packet)}
+      />
     </button>
   );
 }

--- a/src/components/desktop/thoughts/PacketDetailsPopover.tsx
+++ b/src/components/desktop/thoughts/PacketDetailsPopover.tsx
@@ -169,10 +169,11 @@ export function PacketDetailsPopover({ packet, anchorRect, onClose }: PacketDeta
   const issueNumber = packet.issue?.number ?? null;
   const hasIssueSection = Boolean(issueBody || issueUrl || issueNumber);
   const statusEvidence = useMemo(() => {
+    if (packet.statusEvidence) return packet.statusEvidence;
     const sessionKey = packet.lane?.sessionKey;
     if (!sessionKey) return undefined;
     return orchestratorData?.agents.find((agent) => agent.sessionKey === sessionKey)?.statusEvidence;
-  }, [orchestratorData?.agents, packet.lane?.sessionKey]);
+  }, [orchestratorData?.agents, packet.lane?.sessionKey, packet.statusEvidence]);
 
   if (!portalHost || !anchorRect || !position) return null;
 

--- a/src/components/desktop/thoughts/PacketDetailsPopover.tsx
+++ b/src/components/desktop/thoughts/PacketDetailsPopover.tsx
@@ -12,6 +12,8 @@
 
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { TerminalStatusEvidenceDisclosure } from '@/components/desktop/TerminalStatusEvidenceRows';
+import { useOrchestratorData } from '@/components/desktop/orchestrator-data-context';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 
 const FONT_BODY = 'var(--font-sans-system)';
@@ -87,6 +89,7 @@ function EmptyValue() {
 }
 
 export function PacketDetailsPopover({ packet, anchorRect, onClose }: PacketDetailsPopoverProps) {
+  const orchestratorData = useOrchestratorData();
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const [position, setPosition] = useState<PopoverPosition | null>(null);
   const [portalHost, setPortalHost] = useState<HTMLElement | null>(null);
@@ -165,6 +168,11 @@ export function PacketDetailsPopover({ packet, anchorRect, onClose }: PacketDeta
   const issueUrl = packet.issue?.url?.trim() ?? null;
   const issueNumber = packet.issue?.number ?? null;
   const hasIssueSection = Boolean(issueBody || issueUrl || issueNumber);
+  const statusEvidence = useMemo(() => {
+    const sessionKey = packet.lane?.sessionKey;
+    if (!sessionKey) return undefined;
+    return orchestratorData?.agents.find((agent) => agent.sessionKey === sessionKey)?.statusEvidence;
+  }, [orchestratorData?.agents, packet.lane?.sessionKey]);
 
   if (!portalHost || !anchorRect || !position) return null;
 
@@ -279,6 +287,12 @@ export function PacketDetailsPopover({ packet, anchorRect, onClose }: PacketDeta
           gap: 14,
         }}
       >
+        {statusEvidence ? (
+          <Section label="Status diagnostics">
+            <TerminalStatusEvidenceDisclosure evidence={statusEvidence} defaultExpanded />
+          </Section>
+        ) : null}
+
         <Section label="Prompt">
           {prompt ? (
             <pre

--- a/src/components/desktop/thoughts/types.ts
+++ b/src/components/desktop/thoughts/types.ts
@@ -1,4 +1,5 @@
 import type { ApprovalRecord } from '@/lib/approvals/types';
+import type { TerminalStatusEvidence } from '@/lib/terminal-status/resolve';
 import type {
   OrchestratorLaneBinding,
   OrchestratorMissionState,
@@ -24,6 +25,7 @@ export interface FleetAgent {
   runtime?: string;
   isCurrentSession?: boolean;
   workspace?: string;
+  statusEvidence?: TerminalStatusEvidence;
 }
 
 export interface AgentTarget {

--- a/src/components/desktop/workspace-terminal/AgentTilePane.tsx
+++ b/src/components/desktop/workspace-terminal/AgentTilePane.tsx
@@ -291,11 +291,12 @@ function AgentTilePaneBase({ sessionKey, agent, packet, focused, onClose, onFocu
     packet?.issue?.body ? { id: packet.id, text: packet.issue.body } : null,
   ), [entries, name, packet?.id, packet?.issue?.body]);
   const runtime = useMemo(() => inferRuntime(sessionKey, agent?.runtime), [agent?.runtime, sessionKey]);
+  const statusEvidence = packet?.statusEvidence ?? agent?.statusEvidence;
   const status = useMemo(
-    () => agent?.statusEvidence
-      ? visualStatusFromTerminalState(agent.statusEvidence.state)
+    () => statusEvidence
+      ? visualStatusFromTerminalState(statusEvidence.state)
       : resolveAgentTileStatus(agent?.status, packet?.status, packet?.blockedReason),
-    [agent?.status, agent?.statusEvidence, packet?.blockedReason, packet?.status],
+    [agent?.status, packet?.blockedReason, packet?.status, statusEvidence],
   );
   const canSteer = canSteerAgentState(agent, packet);
   const trimmedDraft = draft.trim();
@@ -467,7 +468,7 @@ function AgentTilePaneBase({ sessionKey, agent, packet, focused, onClose, onFocu
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
           <span
-            title={agent?.statusEvidence?.summary ?? STATUS_META[status].label}
+            title={statusEvidence?.summary ?? STATUS_META[status].label}
             style={{ display: 'inline-flex', alignItems: 'center', gap: 5, color: 'var(--t-text-secondary)', fontSize: 10, fontWeight: 300 }}
           >
             <span
@@ -475,8 +476,8 @@ function AgentTilePaneBase({ sessionKey, agent, packet, focused, onClose, onFocu
                 width: 5, height: 5, borderRadius: 999, background: STATUS_META[status].color, flexShrink: 0,
               }}
             />
-            {agent?.statusEvidence
-              ? terminalStatusCaption(agent.statusEvidence)
+            {statusEvidence
+              ? terminalStatusCaption(statusEvidence)
               : STATUS_META[status].label}
           </span>
           <SessionTransformMenu runtimeId={runtime} sessionKey={sessionKey} />
@@ -507,8 +508,8 @@ function AgentTilePaneBase({ sessionKey, agent, packet, focused, onClose, onFocu
         </div>
       </div>
 
-      {agent?.statusEvidence ? (
-        <TerminalStatusEvidenceDisclosure evidence={agent.statusEvidence} />
+      {statusEvidence ? (
+        <TerminalStatusEvidenceDisclosure evidence={statusEvidence} />
       ) : null}
 
       <div

--- a/src/components/desktop/workspace-terminal/AgentTilePane.tsx
+++ b/src/components/desktop/workspace-terminal/AgentTilePane.tsx
@@ -13,6 +13,10 @@ import {
   type UIEvent as ReactUIEvent,
 } from 'react';
 import type { FleetAgent } from '@/components/desktop/thoughts/types';
+import {
+  TerminalStatusEvidenceDisclosure,
+  terminalStatusCaption,
+} from '@/components/desktop/TerminalStatusEvidenceRows';
 import { mergeAdjacentToolOnlyEntries } from '@/components/desktop/thoughts/chat-panel/ToolCallChipCluster';
 import { usePacketTranscriptPoll } from '@/components/desktop/workspace-terminal/use-packet-transcript-poll';
 import { WorkspaceTranscript } from '@/components/desktop/workspace-terminal/WorkspaceTranscript';
@@ -33,6 +37,7 @@ import { bootstrapTranscripts } from '@/lib/transcripts/bootstrap';
 import { transcriptStore } from '@/lib/transcripts/store';
 import { useTranscript } from '@/lib/transcripts/useTranscript';
 import { SessionTransformMenu } from './SessionTransformMenu';
+import type { TerminalStatusState } from '@/lib/terminal-status/resolve';
 
 interface AgentTilePaneProps {
   sessionKey: string;
@@ -82,6 +87,18 @@ export function resolveAgentTileStatus(
   if (states.includes('waiting')) return 'waiting';
   if (states.includes('running')) return 'running';
   return 'idle';
+}
+
+function visualStatusFromTerminalState(state: TerminalStatusState): VisualStatus {
+  switch (state) {
+    case 'working': return 'running';
+    case 'blocked': return 'waiting';
+    case 'review-ready':
+    case 'complete': return 'review';
+    case 'failed': return 'error';
+    case 'idle':
+    case 'unknown': return 'idle';
+  }
 }
 
 function inferRuntime(sessionKey: string, rawRuntime?: string): OrchestratorRuntime {
@@ -275,8 +292,10 @@ function AgentTilePaneBase({ sessionKey, agent, packet, focused, onClose, onFocu
   ), [entries, name, packet?.id, packet?.issue?.body]);
   const runtime = useMemo(() => inferRuntime(sessionKey, agent?.runtime), [agent?.runtime, sessionKey]);
   const status = useMemo(
-    () => resolveAgentTileStatus(agent?.status, packet?.status, packet?.blockedReason),
-    [agent?.status, packet?.blockedReason, packet?.status],
+    () => agent?.statusEvidence
+      ? visualStatusFromTerminalState(agent.statusEvidence.state)
+      : resolveAgentTileStatus(agent?.status, packet?.status, packet?.blockedReason),
+    [agent?.status, agent?.statusEvidence, packet?.blockedReason, packet?.status],
   );
   const canSteer = canSteerAgentState(agent, packet);
   const trimmedDraft = draft.trim();
@@ -448,7 +467,7 @@ function AgentTilePaneBase({ sessionKey, agent, packet, focused, onClose, onFocu
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
           <span
-            title={STATUS_META[status].label}
+            title={agent?.statusEvidence?.summary ?? STATUS_META[status].label}
             style={{ display: 'inline-flex', alignItems: 'center', gap: 5, color: 'var(--t-text-secondary)', fontSize: 10, fontWeight: 300 }}
           >
             <span
@@ -456,7 +475,9 @@ function AgentTilePaneBase({ sessionKey, agent, packet, focused, onClose, onFocu
                 width: 5, height: 5, borderRadius: 999, background: STATUS_META[status].color, flexShrink: 0,
               }}
             />
-            {STATUS_META[status].label}
+            {agent?.statusEvidence
+              ? terminalStatusCaption(agent.statusEvidence)
+              : STATUS_META[status].label}
           </span>
           <SessionTransformMenu runtimeId={runtime} sessionKey={sessionKey} />
           <button
@@ -485,6 +506,10 @@ function AgentTilePaneBase({ sessionKey, agent, packet, focused, onClose, onFocu
           </button>
         </div>
       </div>
+
+      {agent?.statusEvidence ? (
+        <TerminalStatusEvidenceDisclosure evidence={agent.statusEvidence} />
+      ) : null}
 
       <div
         ref={scrollRef}

--- a/src/components/desktop/workspace-terminal/WorkspaceTerminalPanels.tsx
+++ b/src/components/desktop/workspace-terminal/WorkspaceTerminalPanels.tsx
@@ -3,6 +3,8 @@
 import { MutableRefObject, Suspense, memo, useEffect, useMemo, useRef, useState } from 'react';
 import { Terminal as TerminalIcon } from '../lucide-shims';
 import type { CanvasTab } from '@/components/desktop/Canvas';
+import { TerminalStatusEvidenceDisclosure } from '@/components/desktop/TerminalStatusEvidenceRows';
+import type { WorkspaceAttachedTerminalSession } from '@/components/desktop/workspace-terminal/terminal-mode';
 import { WorkspaceChatPane } from '@/components/desktop/workspace-terminal/WorkspaceChatPane';
 import type { RegisteredRepo, TerminalTab } from '@/components/desktop/workspace-terminal/types';
 import { repoSlugFromRemote, shortenPath } from '@/components/desktop/workspace-terminal/utils';
@@ -11,6 +13,7 @@ import { WorkspaceBootLoaderClaim } from '@/components/desktop/workspace-termina
 import { updateResidentTabIds } from '@/components/desktop/workspace-terminal/resident-tabs';
 import { retryingLazy } from '@/lib/react/retrying-lazy';
 import { OUTSIDE_WORKER_HOST_EMPTY_EVENT } from './use-session-tiles';
+import type { TerminalStatusEvidence } from '@/lib/terminal-status/resolve';
 
 // LazyLLMChat used to render the Assistant tab (kind='llm-chat'). The
 // chooser-spawn rewrite routes both orchestrator and llm-chat tabs
@@ -29,6 +32,8 @@ interface WorkspaceTerminalPanelsProps {
    *  would clobber (GQXEZD). */
   restoreSettled: boolean;
   effectiveActiveTabId: string;
+  attachedTerminalSessions?: WorkspaceAttachedTerminalSession[];
+  terminalModeStatusEvidence?: TerminalStatusEvidence;
   termWsConnected: boolean;
   panelRefs: MutableRefObject<Map<string, XtermPanelHandle>>;
   onCloseTab: (tabId: string) => void;
@@ -57,6 +62,8 @@ function WorkspaceTerminalPanelsBase({
   workspaceId,
   visibleTabs,
   effectiveActiveTabId,
+  attachedTerminalSessions = [],
+  terminalModeStatusEvidence,
   termWsConnected,
   panelRefs,
   onCloseTab,
@@ -115,6 +122,11 @@ function WorkspaceTerminalPanelsBase({
     )),
     [effectiveActiveTabId, residentTabIds, visibleTabIdsKey],
   );
+  const statusEvidenceByTmuxSession = useMemo(() => new Map(
+    attachedTerminalSessions.flatMap((session) => (
+      session.statusEvidence ? [[session.tmuxSession, session.statusEvidence] as const] : []
+    )),
+  ), [attachedTerminalSessions]);
   const effectiveActiveTerminalSession = visibleTabs.find((tab) => (
     tab.id === effectiveActiveTabId && tab.kind === 'terminal'
   ))?.tmuxSession ?? null;
@@ -210,6 +222,9 @@ function WorkspaceTerminalPanelsBase({
             sendTerminalResize={sendTerminalResize}
             sendTerminalVisibility={sendTerminalVisibility}
             sendTerminalDetach={sendTerminalDetach}
+            statusEvidence={tab.id === effectiveActiveTabId
+              ? terminalModeStatusEvidence ?? statusEvidenceByTmuxSession.get(tab.tmuxSession)
+              : statusEvidenceByTmuxSession.get(tab.tmuxSession)}
             active={tab.id === effectiveActiveTabId}
           />
         ) : (
@@ -474,6 +489,7 @@ const TerminalResidentPanel = memo(function TerminalResidentPanel({
   sendTerminalResize,
   sendTerminalVisibility,
   sendTerminalDetach,
+  statusEvidence,
   active,
 }: {
   tabId: string;
@@ -484,6 +500,7 @@ const TerminalResidentPanel = memo(function TerminalResidentPanel({
   sendTerminalResize: WorkspaceTerminalPanelsProps['sendTerminalResize'];
   sendTerminalVisibility: WorkspaceTerminalPanelsProps['sendTerminalVisibility'];
   sendTerminalDetach: WorkspaceTerminalPanelsProps['sendTerminalDetach'];
+  statusEvidence?: TerminalStatusEvidence;
   active: boolean;
 }) {
   useEffect(() => {
@@ -504,19 +521,37 @@ const TerminalResidentPanel = memo(function TerminalResidentPanel({
     };
   }, [tabId, tmuxSession]);
   return (
-    <XtermPanel
-      ref={(handle) => {
-        if (handle) panelRefs.current.set(tmuxSession, handle);
-        else panelRefs.current.delete(tmuxSession);
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        display: active ? 'flex' : 'none',
+        flexDirection: 'column',
+        minWidth: 0,
+        minHeight: 0,
+        background: 'var(--t-terminal-bg)',
       }}
-      tmuxSession={tmuxSession}
-      sendTerminalAttach={sendTerminalAttach}
-      sendTerminalInput={sendTerminalInput}
-      sendTerminalResize={sendTerminalResize}
-      sendTerminalVisibility={sendTerminalVisibility}
-      sendTerminalDetach={sendTerminalDetach}
-      visible={active}
-    />
+    >
+      {statusEvidence ? <TerminalStatusEvidenceDisclosure evidence={statusEvidence} /> : null}
+      <div style={{ flex: 1, minWidth: 0, minHeight: 0, position: 'relative' }}>
+        <XtermPanel
+          ref={(handle) => {
+            if (handle) panelRefs.current.set(tmuxSession, handle);
+            else panelRefs.current.delete(tmuxSession);
+          }}
+          tmuxSession={tmuxSession}
+          sendTerminalAttach={sendTerminalAttach}
+          sendTerminalInput={sendTerminalInput}
+          sendTerminalResize={sendTerminalResize}
+          sendTerminalVisibility={sendTerminalVisibility}
+          sendTerminalDetach={sendTerminalDetach}
+          visible={active}
+        />
+      </div>
+    </div>
   );
 });
 

--- a/src/components/desktop/workspace-terminal/WorkspaceTerminalRoot.tsx
+++ b/src/components/desktop/workspace-terminal/WorkspaceTerminalRoot.tsx
@@ -126,8 +126,8 @@ export const WorkspaceTerminalRoot = forwardRef<TerminalTabHandle, WorkspaceTerm
     // header strip (one workspace) or hide it on splits (more than one),
     // surface the multi-tab pill strip when 2+ tabs exist, and drive the
     // `…` / right-click menu actions when applicable.
-    const activeTabId = controller.activeTab?.id ?? null;
-    const activeTabKind = controller.activeTab?.kind ?? null;
+    const activeTabId = activeTab?.id ?? null;
+    const activeTabKind = activeTab?.kind ?? null;
     const projectContextRailAvailable = activeTabKind === 'orchestrator' || activeTabKind === 'llm-chat';
     const [projectContextRailVisible, setProjectContextRailVisible] = useState(true);
     const tabsForBroadcast = useMemo(() => (
@@ -361,6 +361,8 @@ export const WorkspaceTerminalRoot = forwardRef<TerminalTabHandle, WorkspaceTerm
         <WorkspaceTerminalPanels
           workspaceId={workspaceInstanceId}
           visibleTabs={controller.visibleTabs}
+          attachedTerminalSessions={props.attachedTerminalSessions}
+          terminalModeStatusEvidence={terminalMode.statusEvidence}
           restoreSettled={controller.primaryRestoreSettled}
           effectiveActiveTabId={terminalMode.effectiveActiveTabId}
           termWsConnected={controller.termWsConnected}

--- a/src/components/desktop/workspace-terminal/terminal-mode.test.ts
+++ b/src/components/desktop/workspace-terminal/terminal-mode.test.ts
@@ -50,6 +50,43 @@ describe('Terminal Mode state and resolution', () => {
     });
   });
 
+  it('preserves status evidence while resolving an attached coding session', () => {
+    const repo = { name: 'repo', localPath: '/repo' };
+    const activeTab = tab({
+      id: 'coding',
+      kind: 'chat',
+      chatRuntime: 'codex',
+      chatSessionKey: 'codex-owned:evidence',
+      repo,
+    });
+    const statusEvidence = {
+      sessionId: 'codex-owned:evidence',
+      runtime: 'codex' as const,
+      state: 'blocked' as const,
+      authority: 'lane-state' as const,
+      observedAt: '2026-08-29T12:00:00.000Z',
+      summary: 'Lane is waiting for approval.',
+      evidence: [{ source: 'lane:lane-evidence.status', value: 'awaiting_human' }],
+    };
+
+    const resolution = resolveTerminalModeEntry({
+      activeTab,
+      attachedSessions: [{
+        sessionKey: statusEvidence.sessionId,
+        tmuxSession: 'agent-session',
+        repo,
+        statusEvidence,
+      }],
+      preferredRepo: repo,
+      tabs: [activeTab],
+    });
+
+    expect(resolution).toMatchObject({
+      kind: 'attached-session',
+      session: { statusEvidence },
+    });
+  });
+
   it('uses an existing terminal tab for the active repo when no coding session is attached', () => {
     const repo = { name: 'repo', localPath: '/repo' };
     const shell = tab({ id: 'shell', kind: 'terminal', tmuxSession: 'shell-session', repo });

--- a/src/components/desktop/workspace-terminal/terminal-mode.ts
+++ b/src/components/desktop/workspace-terminal/terminal-mode.ts
@@ -1,11 +1,13 @@
 import type { RegisteredRepo, TerminalTab } from '@/components/desktop/workspace-terminal/types';
 import { normalizeWorkspaceChatSessionKey } from '@/components/desktop/workspace-terminal/utils';
+import type { TerminalStatusEvidence } from '@/lib/terminal-status/resolve';
 
 export interface WorkspaceAttachedTerminalSession {
   sessionKey: string;
   tmuxSession: string;
   label?: string;
   repo?: RegisteredRepo;
+  statusEvidence?: TerminalStatusEvidence;
 }
 
 export interface TerminalModeSnapshot {
@@ -18,13 +20,19 @@ export interface TerminalModePresentation {
   terminalTabId: string;
   tmuxSession: string | null;
   snapshot: TerminalModeSnapshot;
+  statusEvidence?: TerminalStatusEvidence;
 }
 
 export type TerminalModesByWorkspace = ReadonlyMap<string, TerminalModePresentation>;
 
 export type TerminalModeEntryResolution =
   | { kind: 'attached-session'; session: WorkspaceAttachedTerminalSession; repo: RegisteredRepo | null }
-  | { kind: 'existing-terminal'; tabId: string; tmuxSession: string | null }
+  | {
+      kind: 'existing-terminal';
+      tabId: string;
+      tmuxSession: string | null;
+      session?: WorkspaceAttachedTerminalSession;
+    }
   | { kind: 'new-shell'; repo: RegisteredRepo | null };
 
 export function captureTerminalModeSnapshot(
@@ -63,7 +71,12 @@ export function resolveTerminalModeEntry({
       tab.kind === 'terminal' && tab.tmuxSession === attachedSession.tmuxSession
     ));
     if (existing) {
-      return { kind: 'existing-terminal', tabId: existing.id, tmuxSession: existing.tmuxSession };
+      return {
+        kind: 'existing-terminal',
+        tabId: existing.id,
+        tmuxSession: existing.tmuxSession,
+        session: attachedSession,
+      };
     }
     return {
       kind: 'attached-session',

--- a/src/components/desktop/workspace-terminal/use-terminal-mode.ts
+++ b/src/components/desktop/workspace-terminal/use-terminal-mode.ts
@@ -64,12 +64,15 @@ export function useTerminalMode({
     const resolution = resolveTerminalModeEntry({ activeTab, attachedSessions, preferredRepo, tabs: tabsRef.current });
     let terminalTabId: string;
     let tmuxSession: string | null;
+    let statusEvidence: WorkspaceAttachedTerminalSession['statusEvidence'];
     if (resolution.kind === 'attached-session') {
       terminalTabId = attachTerminalSession(resolution.session, resolution.repo);
       tmuxSession = resolution.session.tmuxSession;
+      statusEvidence = resolution.session.statusEvidence;
     } else if (resolution.kind === 'existing-terminal') {
       terminalTabId = resolution.tabId;
       tmuxSession = resolution.tmuxSession;
+      statusEvidence = resolution.session?.statusEvidence;
     } else {
       terminalTabId = createShellTab(resolution.repo ?? undefined);
       tmuxSession = null;
@@ -80,6 +83,7 @@ export function useTerminalMode({
       terminalTabId,
       tmuxSession,
       snapshot,
+      statusEvidence,
     }));
   }, [activeTab, activeTabId, attachTerminalSession, attachedSessions, createShellTab, preferredRepo, workspaceId]);
 
@@ -103,6 +107,9 @@ export function useTerminalMode({
     [mode, tabs],
   );
   const terminalSession = terminalTab?.tmuxSession ?? mode?.tmuxSession ?? null;
+  const statusEvidence = attachedSessions.find((session) => (
+    terminalSession && session.tmuxSession === terminalSession
+  ))?.statusEvidence ?? mode?.statusEvidence;
   useEffect(() => {
     if (!mode || !terminalSession) return;
     const frame = window.requestAnimationFrame(() => {
@@ -128,6 +135,7 @@ export function useTerminalMode({
     active: Boolean(mode),
     effectiveActiveTabId: mode?.terminalTabId ?? activeTabId,
     terminalTab,
+    statusEvidence,
     toggle,
   };
 }

--- a/src/lib/db/missions-store.ts
+++ b/src/lib/db/missions-store.ts
@@ -16,6 +16,7 @@
 import 'server-only';
 import { getSqlite } from '@/lib/db';
 import { normalizeOrchestratorMissionState } from '@/lib/orchestrator/store';
+import { normalizeOrchestratorMissionStateForPersistence } from '@/lib/orchestrator/persisted-mission';
 import type { OrchestratorMissionState } from '@/lib/orchestrator/types';
 
 export interface MissionPacketMeta {
@@ -139,7 +140,9 @@ export function recordMission(input: RecordMissionInput): void {
     input.summary,
     input.constraints,
     JSON.stringify(input.packetMeta),
-    JSON.stringify(input.missionState ?? null),
+    JSON.stringify(input.missionState
+      ? normalizeOrchestratorMissionStateForPersistence(input.missionState)
+      : null),
     input.totalWaves,
     now,
     now,

--- a/src/lib/fleet/types.ts
+++ b/src/lib/fleet/types.ts
@@ -1,4 +1,5 @@
 import type { BrowserSurfaceSummary } from '@/lib/browser/types';
+import type { TerminalStatusEvidence } from '@/lib/terminal-status/resolve';
 
 export type AgentStatus =
   | 'idle'
@@ -93,6 +94,8 @@ export interface AgentSummary {
   primaryModel?: string;
   heartbeatModel?: string;
   status: AgentStatus;
+  /** Normalized terminal status explanation for orchestrator runtime sessions. */
+  statusEvidence?: TerminalStatusEvidence;
   currentTask: string;
   /** Worker-posted implementation plan while the lane is huddling. */
   huddlePlan?: string;

--- a/src/lib/orchestrator/control-plane.ts
+++ b/src/lib/orchestrator/control-plane.ts
@@ -6,6 +6,7 @@ import { getLaneEvents, listLanes } from '@/lib/lane/registry';
 import { recoveryInfoFromLaneEvents } from '@/lib/lane/recovery-info';
 import type { Lane, LaneEvent } from '@/lib/lane/types';
 import type { DomainLaneSummary } from '@/lib/orchestrator/domain-lane-summary';
+import { normalizeOrchestratorMissionStateForPersistence } from '@/lib/orchestrator/persisted-mission';
 import type { OrchestratorMissionState, OrchestratorRuntimeTruth } from '@/lib/orchestrator/types';
 import { packetContextObservationFromEvent } from '@/lib/orchestrator/packet-context-telemetry';
 import {
@@ -164,7 +165,7 @@ export function writeOrchestratorControlPlaneState(state: OrchestratorMissionSta
   ensureControlPlaneDir();
   const next: OrchestratorControlPlaneFile = {
     version: 1,
-    mission: normalizeOrchestratorMissionState(state),
+    mission: normalizeOrchestratorMissionStateForPersistence(state),
   };
   writeFileSync(ORCHESTRATOR_TMP_PATH, `${JSON.stringify(next, null, 2)}\n`, 'utf8');
   renameSync(ORCHESTRATOR_TMP_PATH, ORCHESTRATOR_PATH);

--- a/src/lib/orchestrator/mission-registry.ts
+++ b/src/lib/orchestrator/mission-registry.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import { getSqlite } from '@/lib/db';
 import { buildDependencyGraph } from '@/lib/orchestrator/dag';
 import { normalizeOrchestratorMissionState } from '@/lib/orchestrator/store';
+import { normalizeOrchestratorMissionStateForPersistence } from '@/lib/orchestrator/persisted-mission';
 import type { OrchestratorMissionState, OrchestratorPacket } from '@/lib/orchestrator/types';
 
 interface MissionStateRow {
@@ -169,7 +170,7 @@ export function hasRegistryPendingHeadlessWork(currentMissionId?: string | null)
 function writeMissionRegistryStateUnlocked(state: OrchestratorMissionState): OrchestratorMissionState | null {
   const missionId = state.missionId?.trim();
   if (!missionId) return null;
-  const normalized = normalizeOrchestratorMissionState(state);
+  const normalized = normalizeOrchestratorMissionStateForPersistence(state);
   const waves = buildDependencyGraph(normalized.packets).map((node) => node.wave);
   const archivedAt = missionIsTerminal(normalized) ? Date.now() : null;
   const version = nextRegistryVersion(missionId);

--- a/src/lib/orchestrator/operator-status-model.test.ts
+++ b/src/lib/orchestrator/operator-status-model.test.ts
@@ -65,12 +65,18 @@ function lane(overrides: Partial<Lane>): Lane {
 }
 
 describe('operator status model', () => {
-  it('uses lane truth to mask transient failed runtime status for active packets', () => {
+  it('keeps runtime failure authoritative when the lane still says running', () => {
     const agents = buildOperatorStatusAgents([agent({ status: 'failed' })], [lane({ status: 'running' })]);
 
     expect(agents).toHaveLength(1);
-    expect(agents[0].status).toBe('running');
-    expect(summarizeOperatorStatus({ agents, approvalCount: 0 })).toContain('1 agent running');
+    expect(agents[0].status).toBe('failed');
+    expect(agents[0].authority).toBe('runtime-event');
+    expect(agents[0].summary).toBe('codex runtime reports this session as failed.');
+    expect(agents[0].observedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(agents[0].statusEvidence.evidence).toContainEqual({
+      source: 'lane:lane-1.status',
+      value: 'running',
+    });
   });
 
   it('keeps summary honest when the returned agents include a real terminal failure', () => {
@@ -83,11 +89,12 @@ describe('operator status model', () => {
     expect(summary).toContain('Last: packet worker failed');
   });
 
-  it('surfaces reviewable lane status in the same array the summary counts', () => {
+  it('does not let a lower lane review state override a current runtime event', () => {
     const agents = buildOperatorStatusAgents([agent({ status: 'running' })], [lane({ status: 'reviewing' })]);
     const summary = summarizeOperatorStatus({ agents, approvalCount: 0 });
 
-    expect(agents[0].status).toBe('awaiting_review');
-    expect(summary).toContain('1 awaiting review');
+    expect(agents[0].status).toBe('running');
+    expect(agents[0].authority).toBe('runtime-event');
+    expect(summary).toContain('1 agent running');
   });
 });

--- a/src/lib/orchestrator/operator-status-model.test.ts
+++ b/src/lib/orchestrator/operator-status-model.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { buildOperatorStatusAgents, summarizeOperatorStatus } from './operator-status-model';
+import {
+  buildOperatorStatusAgents,
+  resolveAgentSummaryStatuses,
+  summarizeOperatorStatus,
+} from './operator-status-model';
 import type { AgentSummary } from '@/lib/fleet/types';
 import type { Lane } from '@/lib/lane/types';
 
@@ -96,5 +100,64 @@ describe('operator status model', () => {
     expect(agents[0].status).toBe('running');
     expect(agents[0].authority).toBe('runtime-event');
     expect(summary).toContain('1 agent running');
+  });
+
+  it('emits cloud and remote-customer sessions with status evidence', () => {
+    const sessions = ['cloud', 'remote-customer'].map((runtime) => agent({
+      id: `${runtime}-owned:1`,
+      name: `${runtime} worker`,
+      runtime,
+      sessionKey: `${runtime}-owned:1`,
+      status: 'running',
+    }));
+
+    const agents = buildOperatorStatusAgents(sessions, []);
+
+    expect(agents.map((candidate) => candidate.runtime)).toEqual(['cloud', 'remote-customer']);
+    expect(agents.map((candidate) => candidate.statusEvidence.runtime)).toEqual([
+      'cloud',
+      'remote-customer',
+    ]);
+    expect(agents.every((candidate) => candidate.authority === 'runtime-event')).toBe(true);
+  });
+
+  it('contains a per-session programming error in both status projections', () => {
+    const malformed = agent({
+      id: '',
+      runtime: 'remote-customer',
+      sessionKey: '',
+      lastEventAt: 'not-a-time',
+      lastActivityAt: null,
+    });
+    const healthy = agent({
+      id: 'cloud-owned:healthy',
+      runtime: 'cloud',
+      sessionKey: 'cloud-owned:healthy',
+      status: 'running',
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const summaries = resolveAgentSummaryStatuses([malformed, healthy], []);
+      const operators = buildOperatorStatusAgents([malformed, healthy], []);
+
+      expect(summaries).toHaveLength(2);
+      expect(operators).toHaveLength(2);
+      expect(summaries[0].statusEvidence).toMatchObject({
+        state: 'unknown',
+        authority: 'raw-terminal',
+        evidence: [],
+      });
+      expect(operators[0].statusEvidence).toMatchObject({
+        state: 'unknown',
+        authority: 'raw-terminal',
+        evidence: [],
+      });
+      expect(summaries[1].statusEvidence?.runtime).toBe('cloud');
+      expect(operators[1].statusEvidence.runtime).toBe('cloud');
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('[terminal-status]'));
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/src/lib/orchestrator/operator-status-model.test.ts
+++ b/src/lib/orchestrator/operator-status-model.test.ts
@@ -93,6 +93,34 @@ describe('operator status model', () => {
     expect(summary).toContain('Last: packet worker failed');
   });
 
+  it('keeps the selected runtime state, summary, and observation time coherent', () => {
+    const currentObservedAt = '2026-08-29T12:05:00.000Z';
+    const [resolved] = resolveAgentSummaryStatuses([agent({
+      status: 'completed',
+      lastActivityAt: Date.parse(currentObservedAt),
+      statusEvidence: {
+        sessionId: 'codex-owned:1',
+        runtime: 'codex',
+        state: 'review-ready',
+        authority: 'runtime-event',
+        observedAt: '2026-08-29T12:00:00.000Z',
+        summary: 'codex runtime reports this session as review-ready.',
+        evidence: [{ source: 'runtime-session.status', value: 'reviewing' }],
+      },
+    })], []);
+
+    expect(resolved.statusEvidence).toMatchObject({
+      state: 'complete',
+      authority: 'runtime-event',
+      observedAt: currentObservedAt,
+      summary: 'codex runtime reports this session as complete.',
+    });
+    expect(resolved.statusEvidence?.evidence).toEqual(expect.arrayContaining([
+      { source: 'runtime-session.status', value: 'reviewing' },
+      { source: 'runtime-session.status', value: 'completed' },
+    ]));
+  });
+
   it('does not let a lower lane review state override a current runtime event', () => {
     const agents = buildOperatorStatusAgents([agent({ status: 'running' })], [lane({ status: 'reviewing' })]);
     const summary = summarizeOperatorStatus({ agents, approvalCount: 0 });

--- a/src/lib/orchestrator/operator-status-model.ts
+++ b/src/lib/orchestrator/operator-status-model.ts
@@ -1,8 +1,7 @@
 import type { ApprovalRecord } from '@/lib/approvals/types';
 import type { AgentStatus, AgentSummary } from '@/lib/fleet/types';
 import type { Lane, LaneEvent } from '@/lib/lane/types';
-import { isOrchestratorRuntime } from '@/lib/orchestrator/runtime-capabilities';
-import type { RuntimeSessionStatus } from '@/lib/runtimes/types';
+import type { RuntimeId, RuntimeSessionStatus } from '@/lib/runtimes/types';
 import {
   agentStatusFromTerminalState,
   resolveTerminalStatusEvidence,
@@ -96,8 +95,7 @@ export function resolveAgentSummaryStatusEvidence(
   agent: AgentSummary,
   lane: Lane | undefined,
   context: OperatorStatusEvidenceContext = {},
-): TerminalStatusEvidence | undefined {
-  if (!isOrchestratorRuntime(agent.runtime)) return undefined;
+): TerminalStatusEvidence {
   const previous = agent.statusEvidence;
   const observedAt = observedAtForAgent(agent, lane);
   const laneEvents = lane ? context.laneEventsByLaneId?.get(lane.id) ?? [] : [];
@@ -110,7 +108,7 @@ export function resolveAgentSummaryStatusEvidence(
   const rawLifecycle = previous?.authority === 'raw-terminal'
     ? {
         sessionId: agent.sessionKey,
-        runtime: agent.runtime,
+        runtime: agent.runtime as RuntimeId,
         state: previous.state,
         observedAt: previous.observedAt,
       }
@@ -121,7 +119,7 @@ export function resolveAgentSummaryStatusEvidence(
     ? undefined
     : {
         sessionKey: agent.sessionKey,
-        runtimeId: agent.runtime,
+        runtimeId: agent.runtime as RuntimeId,
         status: runtimeStatusFromAgent(agent.status),
         observedAt,
         lifecycle: agent.runtimeSurface?.lifecycle,
@@ -153,7 +151,6 @@ export function resolveAgentSummaryStatuses(
       laneBySession.get(agent.sessionKey),
       context,
     );
-    if (!statusEvidence) return agent;
     return {
       ...agent,
       status: agentStatusFromTerminalState(statusEvidence.state, agent.status),
@@ -193,11 +190,10 @@ export function buildOperatorStatusAgents(
     ? sessions.filter((session) => session.sessionKey === sessionKeyFilter)
     : sessions;
 
-  return filtered.flatMap((session) => {
+  return filtered.map((session) => {
     const lane = laneBySession.get(session.sessionKey);
     const statusEvidence = resolveAgentSummaryStatusEvidence(session, lane, context);
-    if (!statusEvidence) return [];
-    return [{
+    return {
       name: session.name || session.sessionKey,
       repo: repoFromWorkspace(lane?.repoPath || session.workspace),
       runtime: session.runtime || 'unknown',
@@ -211,7 +207,7 @@ export function buildOperatorStatusAgents(
       summary: statusEvidence.summary,
       observedAt: statusEvidence.observedAt,
       statusEvidence,
-    }];
+    };
   });
 }
 

--- a/src/lib/orchestrator/operator-status-model.ts
+++ b/src/lib/orchestrator/operator-status-model.ts
@@ -57,11 +57,17 @@ function runtimeStatusFromAgent(status: AgentStatus): RuntimeSessionStatus {
 }
 
 function observedAtForAgent(agent: AgentSummary, lane: Lane | undefined): string {
-  if (agent.statusEvidence?.observedAt) return agent.statusEvidence.observedAt;
   if (typeof agent.lastActivityAt === 'number' && Number.isFinite(agent.lastActivityAt)) {
     return new Date(agent.lastActivityAt).toISOString();
   }
-  return agent.lastEventAt || lane?.lastEventAt || lane?.updatedAt || '';
+  for (const value of [agent.lastEventAt, lane?.lastEventAt, lane?.updatedAt]) {
+    if (value && Number.isFinite(Date.parse(value))) return new Date(value).toISOString();
+  }
+  return agent.statusEvidence?.observedAt
+    || agent.lastEventAt
+    || lane?.lastEventAt
+    || lane?.updatedAt
+    || '';
 }
 
 function approvalMatchesAgent(approval: ApprovalRecord, agent: AgentSummary, lane: Lane | undefined): boolean {
@@ -83,9 +89,6 @@ function mergeEvidence(
     seen.add(key);
     return true;
   });
-  if (resolved.authority === 'runtime-event' && previous.authority === 'runtime-event') {
-    return { ...resolved, observedAt: previous.observedAt, summary: previous.summary, evidence };
-  }
   return { ...resolved, evidence };
 }
 

--- a/src/lib/orchestrator/operator-status-model.ts
+++ b/src/lib/orchestrator/operator-status-model.ts
@@ -5,6 +5,7 @@ import type { RuntimeId, RuntimeSessionStatus } from '@/lib/runtimes/types';
 import {
   agentStatusFromTerminalState,
   resolveTerminalStatusEvidence,
+  unknownTerminalStatusEvidence,
   type TerminalReviewQueueEvidence,
   type TerminalStatusEvidence,
   type TerminalStatusState,
@@ -13,7 +14,7 @@ import {
 export interface OperatorStatusAgent {
   name: string;
   repo: string;
-  runtime: string;
+  runtime: RuntimeId;
   model: string | null;
   status: string;
   branch: string;
@@ -60,10 +61,7 @@ function observedAtForAgent(agent: AgentSummary, lane: Lane | undefined): string
   if (typeof agent.lastActivityAt === 'number' && Number.isFinite(agent.lastActivityAt)) {
     return new Date(agent.lastActivityAt).toISOString();
   }
-  for (const value of [agent.lastEventAt, lane?.lastEventAt, lane?.updatedAt]) {
-    if (value && Number.isFinite(Date.parse(value))) return new Date(value).toISOString();
-  }
-  return new Date(0).toISOString();
+  return agent.lastEventAt || lane?.lastEventAt || lane?.updatedAt || '';
 }
 
 function approvalMatchesAgent(approval: ApprovalRecord, agent: AgentSummary, lane: Lane | undefined): boolean {
@@ -135,6 +133,28 @@ export function resolveAgentSummaryStatusEvidence(
   return mergeEvidence(evidence, previous);
 }
 
+function safeResolveAgentSummaryStatusEvidence(
+  agent: AgentSummary,
+  lane: Lane | undefined,
+  context: OperatorStatusEvidenceContext,
+): TerminalStatusEvidence {
+  try {
+    return resolveAgentSummaryStatusEvidence(agent, lane, context);
+  } catch (error) {
+    const sessionId = agent.sessionKey || agent.id || 'unknown-session';
+    const runtime = agent.runtime || 'unknown';
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[terminal-status] Failed to resolve status for ${sessionId}: ${message}`);
+    return unknownTerminalStatusEvidence({
+      sessionId,
+      runtime,
+      observedAt: agent.lastActivityAt ?? agent.lastEventAt,
+      summary: 'Terminal status evidence could not be resolved for this session.',
+      fallbackReason: `Status resolution failed for this session: ${message}`,
+    });
+  }
+}
+
 export function resolveAgentSummaryStatuses(
   sessions: AgentSummary[],
   lanes: Lane[],
@@ -146,7 +166,7 @@ export function resolveAgentSummaryStatuses(
       .map((lane) => [lane.sessionKey as string, lane]),
   );
   return sessions.map((agent) => {
-    const statusEvidence = resolveAgentSummaryStatusEvidence(
+    const statusEvidence = safeResolveAgentSummaryStatusEvidence(
       agent,
       laneBySession.get(agent.sessionKey),
       context,
@@ -192,7 +212,7 @@ export function buildOperatorStatusAgents(
 
   return filtered.map((session) => {
     const lane = laneBySession.get(session.sessionKey);
-    const statusEvidence = resolveAgentSummaryStatusEvidence(session, lane, context);
+    const statusEvidence = safeResolveAgentSummaryStatusEvidence(session, lane, context);
     return {
       name: session.name || session.sessionKey,
       repo: repoFromWorkspace(lane?.repoPath || session.workspace),

--- a/src/lib/orchestrator/operator-status-model.ts
+++ b/src/lib/orchestrator/operator-status-model.ts
@@ -1,6 +1,15 @@
-import { packetStatusFromLaneStatus } from '@/lib/orchestrator/packet-state';
-import type { AgentSummary } from '@/lib/fleet/types';
-import type { Lane } from '@/lib/lane/types';
+import type { ApprovalRecord } from '@/lib/approvals/types';
+import type { AgentStatus, AgentSummary } from '@/lib/fleet/types';
+import type { Lane, LaneEvent } from '@/lib/lane/types';
+import { isOrchestratorRuntime } from '@/lib/orchestrator/runtime-capabilities';
+import type { RuntimeSessionStatus } from '@/lib/runtimes/types';
+import {
+  agentStatusFromTerminalState,
+  resolveTerminalStatusEvidence,
+  type TerminalReviewQueueEvidence,
+  type TerminalStatusEvidence,
+  type TerminalStatusState,
+} from '@/lib/terminal-status/resolve';
 
 export interface OperatorStatusAgent {
   name: string;
@@ -12,25 +21,167 @@ export interface OperatorStatusAgent {
   elapsed: string;
   sessionKey: string;
   task: string | null;
+  authority: TerminalStatusEvidence['authority'];
+  summary: string;
+  observedAt: string;
+  statusEvidence: TerminalStatusEvidence;
+}
+
+export interface OperatorStatusEvidenceContext {
+  laneEventsByLaneId?: ReadonlyMap<string, LaneEvent[]>;
+  approvals?: ApprovalRecord[];
+  reviewQueue?: TerminalReviewQueueEvidence[];
 }
 
 function repoFromWorkspace(workspace: string | undefined) {
   return workspace?.split('/').filter(Boolean).pop() || 'unknown';
 }
 
-function canonicalAgentStatus(agent: AgentSummary, lane: Lane | undefined): string {
-  const laneStatus = packetStatusFromLaneStatus(lane?.status);
-  if (!laneStatus) return agent.status || 'idle';
+function runtimeStatusFromAgent(status: AgentStatus): RuntimeSessionStatus {
+  switch (status) {
+    case 'running':
+    case 'huddling':
+      return 'running';
+    case 'blocked':
+    case 'waiting':
+      return 'waiting';
+    case 'reviewing':
+      return 'reviewing';
+    case 'failed':
+      return 'failed';
+    case 'completed':
+      return 'completed';
+    case 'idle':
+      return 'idle';
+  }
+}
 
-  // A live lane is the canonical packet truth. This masks transient runtime
-  // discovery failures while the owned session is still progressing.
-  return laneStatus;
+function observedAtForAgent(agent: AgentSummary, lane: Lane | undefined): string {
+  if (agent.statusEvidence?.observedAt) return agent.statusEvidence.observedAt;
+  if (typeof agent.lastActivityAt === 'number' && Number.isFinite(agent.lastActivityAt)) {
+    return new Date(agent.lastActivityAt).toISOString();
+  }
+  for (const value of [agent.lastEventAt, lane?.lastEventAt, lane?.updatedAt]) {
+    if (value && Number.isFinite(Date.parse(value))) return new Date(value).toISOString();
+  }
+  return new Date(0).toISOString();
+}
+
+function approvalMatchesAgent(approval: ApprovalRecord, agent: AgentSummary, lane: Lane | undefined): boolean {
+  if (approval.sessionKey === agent.sessionKey) return true;
+  if (!lane) return false;
+  if (approval.continuation?.kind === 'lane' && approval.continuation.laneId === lane.id) return true;
+  return approval.metadata?.laneId === lane.id || approval.metadata?.LaneId === lane.id;
+}
+
+function mergeEvidence(
+  resolved: TerminalStatusEvidence,
+  previous: TerminalStatusEvidence | undefined,
+): TerminalStatusEvidence {
+  if (!previous) return resolved;
+  const seen = new Set<string>();
+  const evidence = [...previous.evidence, ...resolved.evidence].filter((item) => {
+    const key = `${item.source}\u0000${item.value}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  if (resolved.authority === 'runtime-event' && previous.authority === 'runtime-event') {
+    return { ...resolved, observedAt: previous.observedAt, summary: previous.summary, evidence };
+  }
+  return { ...resolved, evidence };
+}
+
+export function resolveAgentSummaryStatusEvidence(
+  agent: AgentSummary,
+  lane: Lane | undefined,
+  context: OperatorStatusEvidenceContext = {},
+): TerminalStatusEvidence | undefined {
+  if (!isOrchestratorRuntime(agent.runtime)) return undefined;
+  const previous = agent.statusEvidence;
+  const observedAt = observedAtForAgent(agent, lane);
+  const laneEvents = lane ? context.laneEventsByLaneId?.get(lane.id) ?? [] : [];
+  const approvals = (context.approvals ?? []).filter((approval) => (
+    approval.status === 'pending' && approvalMatchesAgent(approval, agent, lane)
+  ));
+  const reviewQueue = lane
+    ? (context.reviewQueue ?? []).filter((review) => review.laneId === lane.id)
+    : [];
+  const rawLifecycle = previous?.authority === 'raw-terminal'
+    ? {
+        sessionId: agent.sessionKey,
+        runtime: agent.runtime,
+        state: previous.state,
+        observedAt: previous.observedAt,
+      }
+    : undefined;
+  const runtimeSession = previous?.authority === 'raw-terminal'
+    || previous?.authority === 'lane-state'
+    || previous?.authority === 'known-screen-adapter'
+    ? undefined
+    : {
+        sessionKey: agent.sessionKey,
+        runtimeId: agent.runtime,
+        status: runtimeStatusFromAgent(agent.status),
+        observedAt,
+        lifecycle: agent.runtimeSurface?.lifecycle,
+      };
+  const evidence = resolveTerminalStatusEvidence({
+    runtimeSession,
+    lane,
+    laneEvents,
+    approvals,
+    reviewQueue,
+    rawLifecycle,
+  });
+  return mergeEvidence(evidence, previous);
+}
+
+export function resolveAgentSummaryStatuses(
+  sessions: AgentSummary[],
+  lanes: Lane[],
+  context: OperatorStatusEvidenceContext = {},
+): AgentSummary[] {
+  const laneBySession = new Map(
+    lanes
+      .filter((lane) => lane.sessionKey)
+      .map((lane) => [lane.sessionKey as string, lane]),
+  );
+  return sessions.map((agent) => {
+    const statusEvidence = resolveAgentSummaryStatusEvidence(
+      agent,
+      laneBySession.get(agent.sessionKey),
+      context,
+    );
+    if (!statusEvidence) return agent;
+    return {
+      ...agent,
+      status: agentStatusFromTerminalState(statusEvidence.state, agent.status),
+      statusEvidence,
+    };
+  });
+}
+
+function operatorStatusFromTerminalState(state: TerminalStatusState, fallback: string): string {
+  if (state === 'review-ready') return 'awaiting_review';
+  if (state === 'working') return 'running';
+  if (state === 'complete') return 'completed';
+  return state === 'unknown' ? fallback : state;
+}
+
+function canonicalAgentStatus(
+  agent: AgentSummary,
+  statusEvidence: TerminalStatusEvidence,
+): string {
+  // resolveTerminalStatusEvidence is the single source for status precedence.
+  return operatorStatusFromTerminalState(statusEvidence.state, agent.status || 'idle');
 }
 
 export function buildOperatorStatusAgents(
   sessions: AgentSummary[],
   lanes: Lane[],
   sessionKeyFilter?: string,
+  context: OperatorStatusEvidenceContext = {},
 ): OperatorStatusAgent[] {
   const laneBySession = new Map(
     lanes
@@ -42,19 +193,25 @@ export function buildOperatorStatusAgents(
     ? sessions.filter((session) => session.sessionKey === sessionKeyFilter)
     : sessions;
 
-  return filtered.map((session) => {
+  return filtered.flatMap((session) => {
     const lane = laneBySession.get(session.sessionKey);
-    return {
+    const statusEvidence = resolveAgentSummaryStatusEvidence(session, lane, context);
+    if (!statusEvidence) return [];
+    return [{
       name: session.name || session.sessionKey,
       repo: repoFromWorkspace(lane?.repoPath || session.workspace),
       runtime: session.runtime || 'unknown',
       model: lane?.model ?? session.model ?? null,
-      status: canonicalAgentStatus(session, lane),
+      status: canonicalAgentStatus(session, statusEvidence),
       branch: lane?.branch || session.branch || 'main',
       elapsed: session.lastEventAt || '',
       sessionKey: session.sessionKey,
       task: session.currentTask || lane?.lastEventLabel || null,
-    };
+      authority: statusEvidence.authority,
+      summary: statusEvidence.summary,
+      observedAt: statusEvidence.observedAt,
+      statusEvidence,
+    }];
   });
 }
 

--- a/src/lib/orchestrator/persisted-mission.ts
+++ b/src/lib/orchestrator/persisted-mission.ts
@@ -1,0 +1,18 @@
+import { normalizeOrchestratorMissionState } from '@/lib/orchestrator/store';
+import type { OrchestratorMissionState } from '@/lib/orchestrator/types';
+
+/** Normalize durable mission state while removing read-time status projections. */
+export function normalizeOrchestratorMissionStateForPersistence(
+  raw: unknown,
+): OrchestratorMissionState {
+  const normalized = normalizeOrchestratorMissionState(raw);
+  return {
+    ...normalized,
+    packets: normalized.packets.map((packet) => {
+      if (!packet.statusEvidence) return packet;
+      const persisted = { ...packet };
+      delete persisted.statusEvidence;
+      return persisted;
+    }),
+  };
+}

--- a/src/lib/orchestrator/store.ts
+++ b/src/lib/orchestrator/store.ts
@@ -8,6 +8,7 @@ import type { DomainLaneSummary } from '@/lib/orchestrator/domain-lane-summary';
 import { normalizeQualitySearchPacketState } from '@/lib/orchestrator/quality-search';
 import { normalizePacketStorageAdmission, normalizePacketStorageAdmissionEpoch } from '@/lib/orchestrator/packet-storage-admission-normalize';
 import { normalizeLaneBinding } from '@/lib/orchestrator/lane-binding';
+import { normalizeTerminalStatusEvidenceField } from '@/lib/terminal-status/normalize';
 import { hydrateOrchestratorTurnPinEntry, installOrchestratorTurnPinFetchPatch, persistOrchestratorTurnPin, readCachedOrchestratorTurnPin, stageOrchestratorTurnPin } from '@/lib/orchestrator/turn-pins';
 import {
   normalizeRequestedRuntime,
@@ -25,8 +26,7 @@ import type {
   OrchestratorQueueState,
   OrchestratorRuntime,
   OrchestratorRuntimeTruth,
-  OrchestratorStateApiResponse,
-  WorkerRouting,
+  OrchestratorStateApiResponse, WorkerRouting,
 } from '@/lib/orchestrator/types';
 import { isDispatchableRuntime } from '@/lib/orchestrator/runtime-capabilities';
 import {
@@ -366,7 +366,7 @@ function normalizePacket(raw: unknown, index: number, existing: Array<Pick<Orche
     // Huddle mode (per-mission alignment turn) lives only on the packet — drop
     // it here and a rerun/re-read would silently disarm the huddle.
     huddle: typeof packet.huddle === 'boolean' ? packet.huddle : undefined,
-    blockedReason: typeof packet.blockedReason === 'string' ? packet.blockedReason : null,
+    blockedReason: typeof packet.blockedReason === 'string' ? packet.blockedReason : null, ...normalizeTerminalStatusEvidenceField(packet.statusEvidence),
     storageAdmission: normalizePacketStorageAdmission(packet.storageAdmission), storageAdmissionEpoch: normalizePacketStorageAdmissionEpoch(packet.storageAdmissionEpoch),
     recovery: normalizePacketRecovery(packet.recovery),
     lastEventAt: typeof packet.lastEventAt === 'string' ? packet.lastEventAt : null,

--- a/src/lib/orchestrator/types.ts
+++ b/src/lib/orchestrator/types.ts
@@ -8,6 +8,7 @@ import type { OrchestratorRuntime, RuntimeWorkerProvider } from '@/lib/orchestra
 import type { PacketSpendCap, PacketSpendTelemetry } from '@/lib/orchestrator/metered-spend';
 import type { PacketContextTelemetry } from '@/lib/orchestrator/packet-context-telemetry';
 import type { AgentSummary } from '@/lib/fleet/types';
+import type { TerminalStatusEvidence } from '@/lib/terminal-status/resolve';
 
 export type { OrchestratorRuntime } from '@/lib/orchestrator/runtime-capabilities';
 export type OrchestratorExecutionMode = 'fleet' | 'single' | 'fusion';
@@ -338,6 +339,8 @@ export interface OrchestratorPacket {
   spendTelemetry?: PacketSpendTelemetry;
   contextTelemetry?: PacketContextTelemetry;
   blockedReason?: string | null;
+  /** Read-time status projection; recomputed from runtime or lane evidence. */
+  statusEvidence?: TerminalStatusEvidence;
   /** Durable dispatch admission decision; reserved bytes are not physical usage. */
   storageAdmission?: OrchestratorPacketStorageAdmission | null;
   /** Durable lifecycle floor incremented by reset/rerun before any fresh dispatch. */

--- a/src/lib/orchestrator/types.ts
+++ b/src/lib/orchestrator/types.ts
@@ -7,6 +7,7 @@ import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import type { OrchestratorRuntime, RuntimeWorkerProvider } from '@/lib/orchestrator/runtime-capabilities';
 import type { PacketSpendCap, PacketSpendTelemetry } from '@/lib/orchestrator/metered-spend';
 import type { PacketContextTelemetry } from '@/lib/orchestrator/packet-context-telemetry';
+import type { AgentSummary } from '@/lib/fleet/types';
 
 export type { OrchestratorRuntime } from '@/lib/orchestrator/runtime-capabilities';
 export type OrchestratorExecutionMode = 'fleet' | 'single' | 'fusion';
@@ -654,6 +655,7 @@ export interface OrchestratorDagMetadata {
 export interface OrchestratorStateApiResponse {
   mission: OrchestratorMissionState;
   dag: OrchestratorDagMetadata;
+  agents: AgentSummary[];
 }
 
 export interface OrchestratorStateApiErrorResponse {

--- a/src/lib/runtime/ide-session-registry.ts
+++ b/src/lib/runtime/ide-session-registry.ts
@@ -16,6 +16,7 @@ export interface IdeRuntimeSessionDescriptor {
   model?: string;
   repoName?: string;
   repoPath?: string;
+  supervisorStatus?: string | null;
   scope: string;
   savedAt?: string;
   isCurrentSession: boolean;
@@ -135,6 +136,7 @@ export function listIdeRuntimeTabs(): IdeRuntimeSessionDescriptor[] {
           model: tab.chatModel,
           repoName: tab.repoName,
           repoPath: tab.repoPath,
+          supervisorStatus: tab.supervisorStatus,
           scope,
           savedAt: parsed.savedAt,
           isCurrentSession: parsed.activeTabId === tab.id,

--- a/src/lib/runtime/ide-terminal-state.ts
+++ b/src/lib/runtime/ide-terminal-state.ts
@@ -14,6 +14,7 @@ export type PersistedTab = {
   chatModel?: string;
   repoName?: string;
   repoPath?: string;
+  supervisorStatus?: string | null;
 };
 
 export type PersistedTabState = {

--- a/src/lib/runtime/inventory-all-runtimes.test.ts
+++ b/src/lib/runtime/inventory-all-runtimes.test.ts
@@ -102,60 +102,53 @@ function runtime(id: RuntimeId): AgentRuntime {
 
 describe('canonical runtime inventory discovery', () => {
   beforeEach(() => {
-    registryFixture.runtimes = [
-      runtime('gemini'),
-      runtime('aider'),
-      runtime('cloud'),
-      runtime('remote-customer'),
-    ];
+    registryFixture.runtimes = [];
     invalidateRuntimeInventoryCache();
   });
 
-  it('discovers owned sessions from every discoverable registered adapter', async () => {
+  it('matches main policy by never discovering non-dispatchable registered adapters', async () => {
+    const geminiRuntime = runtime('gemini');
+    const aiderRuntime = runtime('aider');
+    const cloudRuntime = runtime('cloud');
+    const remoteCustomerRuntime = runtime('remote-customer');
+    const cloudDiscovery = vi.spyOn(cloudRuntime, 'discoverSessions');
+    const remoteCustomerDiscovery = vi.spyOn(remoteCustomerRuntime, 'discoverSessions');
+    registryFixture.runtimes = [
+      geminiRuntime,
+      aiderRuntime,
+      cloudRuntime,
+      remoteCustomerRuntime,
+    ];
+    invalidateRuntimeInventoryCache();
+
     const snapshot = await getRuntimeInventorySnapshot({ fresh: true });
 
-    expect(snapshot.agents.map((agent) => agent.runtime)).toEqual([
-      'gemini',
-      'aider',
-      'cloud',
-      'remote-customer',
-    ]);
+    expect(cloudDiscovery).not.toHaveBeenCalled();
+    expect(remoteCustomerDiscovery).not.toHaveBeenCalled();
+    expect(snapshot.agents.map((agent) => agent.runtime)).toEqual(['gemini', 'aider']);
     expect(snapshot.agents.map((agent) => agent.identityId)).toEqual([
       'gemini-identity',
       'aider-identity',
-      'cloud-identity',
-      'remote-customer-identity',
     ]);
-    for (const runtimeId of ['cloud', 'remote-customer'] as const) {
-      expect(snapshot.agents.find((agent) => agent.runtime === runtimeId)?.statusEvidence).toMatchObject({
-        runtime: runtimeId,
-        authority: 'runtime-event',
-        state: 'working',
-      });
-    }
-    expect(snapshot.meta.note).toBe('Showing every discovered registered runtime surface.');
+    expect(snapshot.meta.note).toBe('Showing every discovered dispatchable runtime surface.');
   });
 
   it('uses total unknown evidence for an invalid observation without dropping healthy sessions', async () => {
-    const malformedRuntime = runtime('custom-malformed');
+    const malformedRuntime = runtime('aider');
     const discoverSessions = malformedRuntime.discoverSessions;
     malformedRuntime.discoverSessions = async () => {
       const sessions = await discoverSessions();
       return sessions.map((session) => ({ ...session, lastActivityAt: new Date('not-a-time') }));
     };
-    registryFixture.runtimes = [runtime('cloud'), runtime('remote-customer'), malformedRuntime];
+    registryFixture.runtimes = [runtime('gemini'), malformedRuntime];
     invalidateRuntimeInventoryCache();
 
     const snapshot = await getRuntimeInventorySnapshot({ fresh: true });
 
-    expect(snapshot.agents.map((agent) => agent.runtime)).toEqual([
-      'cloud',
-      'remote-customer',
-      'custom-malformed',
-    ]);
-    expect(snapshot.agents.find((agent) => agent.runtime === 'custom-malformed')?.statusEvidence)
+    expect(snapshot.agents.map((agent) => agent.runtime)).toEqual(['gemini', 'aider']);
+    expect(snapshot.agents.find((agent) => agent.runtime === 'aider')?.statusEvidence)
       .toMatchObject({
-        runtime: 'custom-malformed',
+        runtime: 'aider',
         state: 'unknown',
         authority: 'raw-terminal',
         summary: 'No observation with a valid time was available.',
@@ -164,13 +157,13 @@ describe('canonical runtime inventory discovery', () => {
   });
 
   it('contains a missing session identity and warns without dropping peers', async () => {
-    const malformedRuntime = runtime('custom-missing-id');
+    const malformedRuntime = runtime('aider');
     const discoverSessions = malformedRuntime.discoverSessions;
     malformedRuntime.discoverSessions = async () => {
       const sessions = await discoverSessions();
       return sessions.map((session) => ({ ...session, sessionKey: '' }));
     };
-    registryFixture.runtimes = [runtime('cloud'), malformedRuntime];
+    registryFixture.runtimes = [runtime('gemini'), malformedRuntime];
     invalidateRuntimeInventoryCache();
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -178,10 +171,10 @@ describe('canonical runtime inventory discovery', () => {
       const snapshot = await getRuntimeInventorySnapshot({ fresh: true });
 
       expect(snapshot.agents).toHaveLength(2);
-      expect(snapshot.agents.map((agent) => agent.runtime)).toEqual(['cloud', 'custom-missing-id']);
+      expect(snapshot.agents.map((agent) => agent.runtime)).toEqual(['gemini', 'aider']);
       expect(snapshot.agents[1].statusEvidence).toMatchObject({
-        sessionId: 'custom-missing-id',
-        runtime: 'custom-missing-id',
+        sessionId: 'aider',
+        runtime: 'aider',
         state: 'unknown',
         authority: 'raw-terminal',
         evidence: [],

--- a/src/lib/runtime/inventory-all-runtimes.test.ts
+++ b/src/lib/runtime/inventory-all-runtimes.test.ts
@@ -7,9 +7,15 @@ import type {
   RuntimeId,
   RuntimeSession,
 } from '@/lib/runtimes/types';
+import type { IdeRuntimeSessionDescriptor } from '@/lib/runtime/ide-session-registry';
 
 const registryFixture = vi.hoisted(() => ({
   runtimes: [] as AgentRuntime[],
+}));
+
+const ideRegistryFixture = vi.hoisted(() => ({
+  sessions: [] as IdeRuntimeSessionDescriptor[],
+  tabs: [] as IdeRuntimeSessionDescriptor[],
 }));
 
 vi.mock('@/lib/runtimes', () => ({
@@ -21,8 +27,8 @@ vi.mock('@/lib/runtime/ide-terminal-state', () => ({
 }));
 
 vi.mock('@/lib/runtime/ide-session-registry', () => ({
-  listIdeRuntimeSessions: () => [],
-  listIdeRuntimeTabs: () => [],
+  listIdeRuntimeSessions: () => ideRegistryFixture.sessions,
+  listIdeRuntimeTabs: () => ideRegistryFixture.tabs,
 }));
 
 vi.mock('@/lib/runtime/terminal-session-registry', () => ({
@@ -103,6 +109,8 @@ function runtime(id: RuntimeId): AgentRuntime {
 describe('canonical runtime inventory discovery', () => {
   beforeEach(() => {
     registryFixture.runtimes = [];
+    ideRegistryFixture.sessions = [];
+    ideRegistryFixture.tabs = [];
     invalidateRuntimeInventoryCache();
   });
 
@@ -183,5 +191,39 @@ describe('canonical runtime inventory discovery', () => {
     } finally {
       warn.mockRestore();
     }
+  });
+
+  it('uses an owned IDE session status as runtime evidence', async () => {
+    const descriptor: IdeRuntimeSessionDescriptor = {
+      tabId: 'claude-reviewing-tab',
+      runtimeId: 'claude-code',
+      sessionKey: 'claude-code-owned:reviewing-session',
+      liveSessionKey: 'claude-code-owned:reviewing-session',
+      label: 'Reviewing worker',
+      repoPath: testRoot,
+      scope: 'tile-root',
+      savedAt: '2026-08-29T12:00:00.000Z',
+      supervisorStatus: 'reviewing',
+      isCurrentSession: true,
+    };
+    ideRegistryFixture.sessions = [descriptor];
+    ideRegistryFixture.tabs = [descriptor];
+    invalidateRuntimeInventoryCache();
+
+    const snapshot = await getRuntimeInventorySnapshot({ fresh: true });
+
+    expect(snapshot.agents).toHaveLength(1);
+    expect(snapshot.agents[0]).toMatchObject({
+      sessionKey: descriptor.sessionKey,
+      runtime: 'claude-code',
+      status: 'reviewing',
+      statusEvidence: {
+        sessionId: descriptor.sessionKey,
+        runtime: 'claude-code',
+        state: 'review-ready',
+        authority: 'runtime-event',
+        summary: 'claude-code runtime reports this session as review-ready.',
+      },
+    });
   });
 });

--- a/src/lib/runtime/inventory-all-runtimes.test.ts
+++ b/src/lib/runtime/inventory-all-runtimes.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   AgentRuntime,
+  RuntimeId,
   RuntimeSession,
 } from '@/lib/runtimes/types';
 
@@ -50,9 +51,16 @@ afterAll(() => {
   rmSync(testRoot, { recursive: true, force: true });
 });
 
-function runtime(id: 'gemini' | 'aider'): AgentRuntime {
+function runtime(id: RuntimeId): AgentRuntime {
   const cwd = join(testRoot, id);
   mkdirSync(cwd, { recursive: true });
+  const lastActivityAt = id === 'gemini'
+    ? '2026-07-24T12:00:02.000Z'
+    : id === 'aider'
+      ? '2026-07-24T12:00:01.000Z'
+      : id === 'cloud'
+        ? '2026-07-24T12:00:00.000Z'
+        : '2026-07-23T12:00:00.000Z';
   const session: RuntimeSession = {
     sessionKey: `${id}-owned:inventory-parity`,
     runtimeId: id,
@@ -67,9 +75,7 @@ function runtime(id: 'gemini' | 'aider'): AgentRuntime {
       canInterrupt: false,
       canReviewDiffs: true,
     },
-    lastActivityAt: new Date(
-      id === 'gemini' ? '2026-07-24T12:00:01.000Z' : '2026-07-24T12:00:00.000Z',
-    ),
+    lastActivityAt: new Date(lastActivityAt),
   };
 
   return {
@@ -96,15 +102,24 @@ function runtime(id: 'gemini' | 'aider'): AgentRuntime {
 
 describe('canonical runtime inventory discovery', () => {
   beforeEach(() => {
-    registryFixture.runtimes = [runtime('gemini'), runtime('aider')];
+    registryFixture.runtimes = [runtime('gemini'), runtime('aider'), runtime('cloud')];
     invalidateRuntimeInventoryCache();
   });
 
   it('discovers owned sessions from every dispatchable registered adapter', async () => {
     const snapshot = await getRuntimeInventorySnapshot({ fresh: true });
 
-    expect(snapshot.agents.map((agent) => agent.runtime)).toEqual(['gemini', 'aider']);
-    expect(snapshot.agents.map((agent) => agent.identityId)).toEqual(['gemini-identity', 'aider-identity']);
+    expect(snapshot.agents.map((agent) => agent.runtime)).toEqual(['gemini', 'aider', 'cloud']);
+    expect(snapshot.agents.map((agent) => agent.identityId)).toEqual([
+      'gemini-identity',
+      'aider-identity',
+      'cloud-identity',
+    ]);
+    expect(snapshot.agents.find((agent) => agent.runtime === 'cloud')?.statusEvidence).toMatchObject({
+      runtime: 'cloud',
+      authority: 'runtime-event',
+      state: 'working',
+    });
     expect(snapshot.meta.note).toBe('Showing every discovered dispatchable runtime surface.');
   });
 });

--- a/src/lib/runtime/inventory-all-runtimes.test.ts
+++ b/src/lib/runtime/inventory-all-runtimes.test.ts
@@ -102,24 +102,93 @@ function runtime(id: RuntimeId): AgentRuntime {
 
 describe('canonical runtime inventory discovery', () => {
   beforeEach(() => {
-    registryFixture.runtimes = [runtime('gemini'), runtime('aider'), runtime('cloud')];
+    registryFixture.runtimes = [
+      runtime('gemini'),
+      runtime('aider'),
+      runtime('cloud'),
+      runtime('remote-customer'),
+    ];
     invalidateRuntimeInventoryCache();
   });
 
-  it('discovers owned sessions from every dispatchable registered adapter', async () => {
+  it('discovers owned sessions from every discoverable registered adapter', async () => {
     const snapshot = await getRuntimeInventorySnapshot({ fresh: true });
 
-    expect(snapshot.agents.map((agent) => agent.runtime)).toEqual(['gemini', 'aider', 'cloud']);
+    expect(snapshot.agents.map((agent) => agent.runtime)).toEqual([
+      'gemini',
+      'aider',
+      'cloud',
+      'remote-customer',
+    ]);
     expect(snapshot.agents.map((agent) => agent.identityId)).toEqual([
       'gemini-identity',
       'aider-identity',
       'cloud-identity',
+      'remote-customer-identity',
     ]);
-    expect(snapshot.agents.find((agent) => agent.runtime === 'cloud')?.statusEvidence).toMatchObject({
-      runtime: 'cloud',
-      authority: 'runtime-event',
-      state: 'working',
-    });
-    expect(snapshot.meta.note).toBe('Showing every discovered dispatchable runtime surface.');
+    for (const runtimeId of ['cloud', 'remote-customer'] as const) {
+      expect(snapshot.agents.find((agent) => agent.runtime === runtimeId)?.statusEvidence).toMatchObject({
+        runtime: runtimeId,
+        authority: 'runtime-event',
+        state: 'working',
+      });
+    }
+    expect(snapshot.meta.note).toBe('Showing every discovered registered runtime surface.');
+  });
+
+  it('uses total unknown evidence for an invalid observation without dropping healthy sessions', async () => {
+    const malformedRuntime = runtime('custom-malformed');
+    const discoverSessions = malformedRuntime.discoverSessions;
+    malformedRuntime.discoverSessions = async () => {
+      const sessions = await discoverSessions();
+      return sessions.map((session) => ({ ...session, lastActivityAt: new Date('not-a-time') }));
+    };
+    registryFixture.runtimes = [runtime('cloud'), runtime('remote-customer'), malformedRuntime];
+    invalidateRuntimeInventoryCache();
+
+    const snapshot = await getRuntimeInventorySnapshot({ fresh: true });
+
+    expect(snapshot.agents.map((agent) => agent.runtime)).toEqual([
+      'cloud',
+      'remote-customer',
+      'custom-malformed',
+    ]);
+    expect(snapshot.agents.find((agent) => agent.runtime === 'custom-malformed')?.statusEvidence)
+      .toMatchObject({
+        runtime: 'custom-malformed',
+        state: 'unknown',
+        authority: 'raw-terminal',
+        summary: 'No observation with a valid time was available.',
+        evidence: [],
+      });
+  });
+
+  it('contains a missing session identity and warns without dropping peers', async () => {
+    const malformedRuntime = runtime('custom-missing-id');
+    const discoverSessions = malformedRuntime.discoverSessions;
+    malformedRuntime.discoverSessions = async () => {
+      const sessions = await discoverSessions();
+      return sessions.map((session) => ({ ...session, sessionKey: '' }));
+    };
+    registryFixture.runtimes = [runtime('cloud'), malformedRuntime];
+    invalidateRuntimeInventoryCache();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const snapshot = await getRuntimeInventorySnapshot({ fresh: true });
+
+      expect(snapshot.agents).toHaveLength(2);
+      expect(snapshot.agents.map((agent) => agent.runtime)).toEqual(['cloud', 'custom-missing-id']);
+      expect(snapshot.agents[1].statusEvidence).toMatchObject({
+        sessionId: 'custom-missing-id',
+        runtime: 'custom-missing-id',
+        state: 'unknown',
+        authority: 'raw-terminal',
+        evidence: [],
+      });
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('[terminal-status]'));
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/src/lib/runtime/inventory.ts
+++ b/src/lib/runtime/inventory.ts
@@ -12,7 +12,6 @@ import { readSessionTransformCatalog } from '@/lib/runtime/session-transform-cat
 import { invalidateProcessCwdSnapshot } from '@/lib/runtime/process-cwd-snapshot';
 import {
   isDispatchableRuntime,
-  isOrchestratorRuntime,
   ORCHESTRATOR_RUNTIMES,
 } from '@/lib/orchestrator/runtime-capabilities';
 import { getAllEvents, getLaneEvents, listLanes } from '@/lib/lane/registry';
@@ -278,16 +277,14 @@ function mapIdeGhostRuntimeTabToAgent(session: IdeRuntimeSessionDescriptor): Age
     : 'Idle';
   const parsedLastActivity = new Date(session.savedAt ?? Date.now()).getTime();
   const observedAt = new Date(Number.isNaN(parsedLastActivity) ? Date.now() : parsedLastActivity).toISOString();
-  const statusEvidence = isOrchestratorRuntime(session.runtimeId)
-    ? resolveTerminalStatusEvidence({
-        rawLifecycle: {
-          sessionId: session.sessionKey,
-          runtime: session.runtimeId,
-          state: session.liveSessionKey ? 'unknown' : 'idle',
-          observedAt,
-        },
-      })
-    : undefined;
+  const statusEvidence = resolveTerminalStatusEvidence({
+    rawLifecycle: {
+      sessionId: session.sessionKey,
+      runtime: session.runtimeId,
+      state: session.liveSessionKey ? 'unknown' : 'idle',
+      observedAt,
+    },
+  });
 
   return {
     id: session.sessionKey,
@@ -364,7 +361,6 @@ function selectRepoFallbackAgents(agents: AgentSummary[], existingSessionKeys: S
 
   for (const agent of agents) {
     if (existingSessionKeys.has(agent.sessionKey)) continue;
-    if (!isDispatchableRuntime(agent.runtime)) continue;
     if (!['running', 'reviewing', 'waiting'].includes(agent.status)) continue;
     // Only include IDE-owned sessions as fallbacks — discovered user-terminal
     // sessions shouldn't appear as phantom agents when the runtime restarts.
@@ -384,7 +380,7 @@ function selectRepoFallbackAgents(agents: AgentSummary[], existingSessionKeys: S
 
 async function buildCliRuntimeSnapshot(): Promise<FleetSnapshot> {
   const runtimes: AgentRuntime[] = getAllRuntimes()
-    .filter((runtime) => runtime.capabilities.discover && isDispatchableRuntime(runtime.id));
+    .filter((runtime) => runtime.capabilities.discover);
   const ideSessions = listIdeRuntimeSessions();
   const ideTabs = listIdeRuntimeTabs();
   const ideSessionByKey = new Map(ideSessions.map((session) => [session.liveSessionKey ?? session.sessionKey, session]));
@@ -454,8 +450,7 @@ async function buildCliRuntimeSnapshot(): Promise<FleetSnapshot> {
   }
 
   // resolveTerminalStatusEvidence is the single source for status precedence.
-  const resolvedDiscoveredAll = discoveredAll.flatMap(({ runtime, session }) => {
-    if (!isOrchestratorRuntime(runtime.id)) return [];
+  const resolvedDiscoveredAll = discoveredAll.map(({ runtime, session }) => {
     const debouncedStatus = debouncedSessionStatus(
       session.sessionKey,
       session.status,
@@ -469,14 +464,14 @@ async function buildCliRuntimeSnapshot(): Promise<FleetSnapshot> {
         lifecycle: session.lifecycle,
       },
     });
-    return [{
+    return {
       runtime,
       session: {
         ...session,
         status: runtimeSessionStatusFromTerminalState(statusEvidence.state, debouncedStatus),
       },
       statusEvidence,
-    }];
+    };
   });
   resolvedDiscoveredAll.sort((left, right) => (
     compareTerminalStatusEvidence(left.statusEvidence, right.statusEvidence)
@@ -494,7 +489,7 @@ async function buildCliRuntimeSnapshot(): Promise<FleetSnapshot> {
     // they're not in the IDE registry (orchestrator dispatch doesn't touch
     // the IDE workspace tabs) and not in the terminal-session registry
     // (orchestrator goes through the bridge terminal, not user PTY).
-    || (session.ownership === 'owned' && isDispatchableRuntime(session.runtimeId))
+    || session.ownership === 'owned'
   ));
 
   const agents = discovered.map(({ runtime, session, statusEvidence }) => (

--- a/src/lib/runtime/inventory.ts
+++ b/src/lib/runtime/inventory.ts
@@ -2,7 +2,7 @@
 import { existsSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import type { AgentRuntime, RuntimeSession } from '@/lib/runtimes/types';
+import type { AgentRuntime, RuntimeSession, RuntimeSessionStatus } from '@/lib/runtimes/types';
 import type { AgentSummary, EventItem, FleetSnapshot, SquadSummary } from '@/lib/fleet/types';
 import { getAllRuntimes } from '@/lib/runtimes';
 import { listCurrentIdeRepoPaths } from '@/lib/runtime/ide-terminal-state';
@@ -270,22 +270,65 @@ function mapRuntimeSessionToAgent(
   };
 }
 
+function ideRuntimeSessionStatus(status: string | null | undefined): RuntimeSessionStatus | null {
+  switch (status?.trim().toLowerCase()) {
+    case 'launched':
+    case 'launching':
+    case 'retrying':
+    case 'running':
+    case 'recovering':
+    case 'merging':
+      return 'running';
+    case 'waiting':
+    case 'blocked':
+    case 'stuck':
+    case 'interrupted':
+    case 'awaiting_input':
+    case 'awaiting_orchestrator':
+    case 'awaiting_human':
+      return 'waiting';
+    case 'reviewing':
+    case 'awaiting_review':
+      return 'reviewing';
+    case 'failed':
+      return 'failed';
+    case 'completed':
+    case 'archived':
+      return 'completed';
+    case 'idle':
+    case 'paused':
+      return 'idle';
+    default:
+      return null;
+  }
+}
+
 function mapIdeGhostRuntimeTabToAgent(session: IdeRuntimeSessionDescriptor): AgentSummary {
   const workspace = shortenHomePath(session.repoPath ?? '~');
   const runtimeName = defaultRuntimeDisplayName(session.runtimeId);
+  const status = ideRuntimeSessionStatus(session.supervisorStatus);
   const currentTask = session.liveSessionKey
     ? 'Reconnecting\u2026'
     : 'Idle';
   const parsedLastActivity = new Date(session.savedAt ?? Date.now()).getTime();
   const observedAt = new Date(Number.isNaN(parsedLastActivity) ? Date.now() : parsedLastActivity).toISOString();
-  const statusEvidence = resolveTerminalStatusEvidence({
-    rawLifecycle: {
-      sessionId: session.sessionKey,
-      runtime: session.runtimeId,
-      state: session.liveSessionKey ? 'unknown' : 'idle',
-      observedAt,
-    },
-  });
+  const statusEvidence = status
+    ? resolveTerminalStatusEvidence({
+        runtimeSession: {
+          sessionKey: session.sessionKey,
+          runtimeId: session.runtimeId,
+          status,
+          observedAt,
+        },
+      })
+    : resolveTerminalStatusEvidence({
+        rawLifecycle: {
+          sessionId: session.sessionKey,
+          runtime: session.runtimeId,
+          state: session.liveSessionKey ? 'unknown' : 'idle',
+          observedAt,
+        },
+      });
 
   return {
     id: session.sessionKey,
@@ -294,7 +337,7 @@ function mapIdeGhostRuntimeTabToAgent(session: IdeRuntimeSessionDescriptor): Age
     runtime: session.runtimeId,
     model: session.model || runtimeName,
     primaryModel: session.model || runtimeName,
-    status: 'idle',
+    status: status ?? 'idle',
     statusEvidence,
     currentTask,
     workspace,

--- a/src/lib/runtime/inventory.ts
+++ b/src/lib/runtime/inventory.ts
@@ -21,6 +21,7 @@ import {
   compareTerminalStatusEvidence,
   resolveTerminalStatusEvidence,
   runtimeSessionStatusFromTerminalState,
+  unknownTerminalStatusEvidence,
   type TerminalStatusEvidence,
 } from '@/lib/terminal-status/resolve';
 
@@ -455,15 +456,32 @@ async function buildCliRuntimeSnapshot(): Promise<FleetSnapshot> {
       session.sessionKey,
       session.status,
     ) as RuntimeSession['status'];
-    const statusEvidence = resolveTerminalStatusEvidence({
-      runtimeSession: {
-        sessionKey: session.sessionKey,
-        runtimeId: runtime.id,
-        status: debouncedStatus,
-        observedAt: session.lastActivityAt.toISOString(),
-        lifecycle: session.lifecycle,
-      },
-    });
+    let statusEvidence: TerminalStatusEvidence;
+    try {
+      statusEvidence = resolveTerminalStatusEvidence({
+        runtimeSession: {
+          sessionKey: session.sessionKey,
+          runtimeId: runtime.id,
+          status: debouncedStatus,
+          observedAt: session.lastActivityAt instanceof Date
+            && Number.isFinite(session.lastActivityAt.getTime())
+            ? session.lastActivityAt.toISOString()
+            : '',
+          lifecycle: session.lifecycle,
+        },
+      });
+    } catch (error) {
+      const sessionId = session.sessionKey || session.displayName || 'unknown-session';
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[terminal-status] Failed to resolve status for ${sessionId}: ${message}`);
+      statusEvidence = unknownTerminalStatusEvidence({
+        sessionId,
+        runtime: runtime.id,
+        observedAt: session.lastActivityAt,
+        summary: 'Terminal status evidence could not be resolved for this session.',
+        fallbackReason: `Status resolution failed for this session: ${message}`,
+      });
+    }
     return {
       runtime,
       session: {
@@ -583,7 +601,7 @@ async function buildCliRuntimeSnapshot(): Promise<FleetSnapshot> {
       gatewayReachable: true,
       mirrorMode: 'current-session-first',
       observablePending: false,
-      note: 'Showing every discovered dispatchable runtime surface.',
+      note: 'Showing every discovered registered runtime surface.',
       primarySessionKey,
     },
     squads,

--- a/src/lib/runtime/inventory.ts
+++ b/src/lib/runtime/inventory.ts
@@ -12,10 +12,20 @@ import { readSessionTransformCatalog } from '@/lib/runtime/session-transform-cat
 import { invalidateProcessCwdSnapshot } from '@/lib/runtime/process-cwd-snapshot';
 import {
   isDispatchableRuntime,
+  isOrchestratorRuntime,
   ORCHESTRATOR_RUNTIMES,
 } from '@/lib/orchestrator/runtime-capabilities';
 import { getAllEvents, getLaneEvents, listLanes } from '@/lib/lane/registry';
 import type { Lane, LaneEvent } from '@/lib/lane/types';
+import { debouncedSessionStatus } from '@/lib/terminal-status/debounce';
+import {
+  compareTerminalStatusEvidence,
+  resolveTerminalStatusEvidence,
+  runtimeSessionStatusFromTerminalState,
+  type TerminalStatusEvidence,
+} from '@/lib/terminal-status/resolve';
+
+export { debouncedSessionStatus } from '@/lib/terminal-status/debounce';
 
 const RUNTIME_INVENTORY_TTL_MS = 15_000;
 const RUNTIME_INVENTORY_FRESH_COALESCE_MS = 2_000;
@@ -186,39 +196,10 @@ function runtimeSourceLabel(runtime: AgentRuntime, session: RuntimeSession) {
   return `${runtime.displayName} discovery`;
 }
 
-// #1476 lie 2 — a failed→heal blip on the discovery side surfaced as
-// status:'failed' for a single snapshot while the worker was alive and
-// mid-flow; callers polling in that window read a terminal-looking verdict.
-// Hysteresis: 'failed' must persist for FAILED_CONFIRM_MS before it surfaces;
-// until then the session reports its last known non-failed status. A session
-// whose FIRST observation is failed reports failed immediately (no history to
-// mask with — that's a genuinely dead discovery, not a blip).
-const FAILED_CONFIRM_MS = 90_000;
-const failureDebounceBySession = new Map<string, { lastGood: string; failedSince: number | null }>();
-
-export function debouncedSessionStatus(sessionKey: string, status: string): string {
-  if (failureDebounceBySession.size > 512 && !failureDebounceBySession.has(sessionKey)) {
-    const oldest = failureDebounceBySession.keys().next().value;
-    if (oldest !== undefined) failureDebounceBySession.delete(oldest);
-  }
-  const entry = failureDebounceBySession.get(sessionKey) ?? { lastGood: status, failedSince: null };
-  if (status !== 'failed') {
-    entry.lastGood = status;
-    entry.failedSince = null;
-    failureDebounceBySession.set(sessionKey, entry);
-    return status;
-  }
-  if (entry.failedSince === null) entry.failedSince = Date.now();
-  failureDebounceBySession.set(sessionKey, entry);
-  if (entry.lastGood === 'failed' || Date.now() - entry.failedSince >= FAILED_CONFIRM_MS) {
-    return 'failed';
-  }
-  return entry.lastGood;
-}
-
 function mapRuntimeSessionToAgent(
   runtime: AgentRuntime,
   session: RuntimeSession,
+  statusEvidence: TerminalStatusEvidence,
   overrides?: {
     label?: string;
     model?: string;
@@ -227,8 +208,7 @@ function mapRuntimeSessionToAgent(
 ): AgentSummary {
   const contextUsed = Math.max(0, Math.min(100, session.contextUsedPercent ?? 0));
   const workspace = shortenHomePath(overrides?.repoPath ?? session.cwd);
-  const sessionStatus = debouncedSessionStatus(session.sessionKey, session.status) as typeof session.status;
-  const alerts = Number(sessionStatus === 'failed') + Number(contextUsed >= 75);
+  const alerts = Number(session.status === 'failed') + Number(contextUsed >= 75);
   const rawDisplayName = overrides?.label?.trim() || session.displayName;
   const displayName = decorateRuntimeDisplayName(runtime.id, rawDisplayName, session, workspace);
   const model = overrides?.model || session.model || runtime.displayName;
@@ -240,7 +220,8 @@ function mapRuntimeSessionToAgent(
     runtime: runtime.id,
     model,
     primaryModel: model,
-    status: sessionStatus,
+    status: session.status,
+    statusEvidence,
     currentTask: session.initialTask ?? `${runtime.displayName} session`,
     workspace,
     branch: session.branch ?? 'unknown',
@@ -296,6 +277,17 @@ function mapIdeGhostRuntimeTabToAgent(session: IdeRuntimeSessionDescriptor): Age
     ? 'Reconnecting\u2026'
     : 'Idle';
   const parsedLastActivity = new Date(session.savedAt ?? Date.now()).getTime();
+  const observedAt = new Date(Number.isNaN(parsedLastActivity) ? Date.now() : parsedLastActivity).toISOString();
+  const statusEvidence = isOrchestratorRuntime(session.runtimeId)
+    ? resolveTerminalStatusEvidence({
+        rawLifecycle: {
+          sessionId: session.sessionKey,
+          runtime: session.runtimeId,
+          state: session.liveSessionKey ? 'unknown' : 'idle',
+          observedAt,
+        },
+      })
+    : undefined;
 
   return {
     id: session.sessionKey,
@@ -305,6 +297,7 @@ function mapIdeGhostRuntimeTabToAgent(session: IdeRuntimeSessionDescriptor): Age
     model: session.model || runtimeName,
     primaryModel: session.model || runtimeName,
     status: 'idle',
+    statusEvidence,
     currentTask,
     workspace,
     branch: 'unknown',
@@ -460,20 +453,36 @@ async function buildCliRuntimeSnapshot(): Promise<FleetSnapshot> {
     discoveredKeys.add(key);
   }
 
-  discoveredAll.sort((left, right) => {
-    const statusWeight = (status: RuntimeSession['status']) => (
-      status === 'running' ? 5
-        : status === 'reviewing' ? 4
-          : status === 'waiting' ? 3
-            : status === 'failed' ? 2
-              : 1
-    );
-    const statusDelta = statusWeight(right.session.status) - statusWeight(left.session.status);
-    if (statusDelta !== 0) return statusDelta;
-    return right.session.lastActivityAt.getTime() - left.session.lastActivityAt.getTime();
+  // resolveTerminalStatusEvidence is the single source for status precedence.
+  const resolvedDiscoveredAll = discoveredAll.flatMap(({ runtime, session }) => {
+    if (!isOrchestratorRuntime(runtime.id)) return [];
+    const debouncedStatus = debouncedSessionStatus(
+      session.sessionKey,
+      session.status,
+    ) as RuntimeSession['status'];
+    const statusEvidence = resolveTerminalStatusEvidence({
+      runtimeSession: {
+        sessionKey: session.sessionKey,
+        runtimeId: runtime.id,
+        status: debouncedStatus,
+        observedAt: session.lastActivityAt.toISOString(),
+        lifecycle: session.lifecycle,
+      },
+    });
+    return [{
+      runtime,
+      session: {
+        ...session,
+        status: runtimeSessionStatusFromTerminalState(statusEvidence.state, debouncedStatus),
+      },
+      statusEvidence,
+    }];
   });
+  resolvedDiscoveredAll.sort((left, right) => (
+    compareTerminalStatusEvidence(left.statusEvidence, right.statusEvidence)
+  ));
 
-  const discovered = discoveredAll.filter(({ runtime, session }) => (
+  const discovered = resolvedDiscoveredAll.filter(({ runtime, session }) => (
     session.sessionKey?.startsWith('codex-owned:')
     || ideSessionByKey.has(session.sessionKey)
     || isRegistryBackedRuntimeSession(session.sessionKey)
@@ -488,16 +497,20 @@ async function buildCliRuntimeSnapshot(): Promise<FleetSnapshot> {
     || (session.ownership === 'owned' && isDispatchableRuntime(session.runtimeId))
   ));
 
-  const agents = discovered.map(({ runtime, session }) => mapRuntimeSessionToAgent(runtime, session, ideSessionByKey.get(session.sessionKey)));
+  const agents = discovered.map(({ runtime, session, statusEvidence }) => (
+    mapRuntimeSessionToAgent(runtime, session, statusEvidence, ideSessionByKey.get(session.sessionKey))
+  ));
   const fallbackAgents = selectRepoFallbackAgents(
-    discoveredAll.map(({ runtime, session }) => mapRuntimeSessionToAgent(runtime, session, ideSessionByKey.get(session.sessionKey))),
+    resolvedDiscoveredAll.map(({ runtime, session, statusEvidence }) => (
+      mapRuntimeSessionToAgent(runtime, session, statusEvidence, ideSessionByKey.get(session.sessionKey))
+    )),
     new Set(agents.map((agent) => agent.sessionKey)),
   );
   agents.push(...fallbackAgents);
   const visibleAgents = applyHuddleLaneStatus(agents);
 
   const liveSessionKeys = new Set(
-    [...discovered, ...discoveredAll.filter(({ session }) => fallbackAgents.some((agent) => agent.sessionKey === session.sessionKey))]
+    [...discovered, ...resolvedDiscoveredAll.filter(({ session }) => fallbackAgents.some((agent) => agent.sessionKey === session.sessionKey))]
       .map(({ session }) => session.sessionKey),
   );
   // Ghost-agent promotion: tabs whose session isn't in the live set become

--- a/src/lib/runtime/inventory.ts
+++ b/src/lib/runtime/inventory.ts
@@ -362,6 +362,7 @@ function selectRepoFallbackAgents(agents: AgentSummary[], existingSessionKeys: S
 
   for (const agent of agents) {
     if (existingSessionKeys.has(agent.sessionKey)) continue;
+    if (!isDispatchableRuntime(agent.runtime)) continue;
     if (!['running', 'reviewing', 'waiting'].includes(agent.status)) continue;
     // Only include IDE-owned sessions as fallbacks — discovered user-terminal
     // sessions shouldn't appear as phantom agents when the runtime restarts.
@@ -381,7 +382,7 @@ function selectRepoFallbackAgents(agents: AgentSummary[], existingSessionKeys: S
 
 async function buildCliRuntimeSnapshot(): Promise<FleetSnapshot> {
   const runtimes: AgentRuntime[] = getAllRuntimes()
-    .filter((runtime) => runtime.capabilities.discover);
+    .filter((runtime) => runtime.capabilities.discover && isDispatchableRuntime(runtime.id));
   const ideSessions = listIdeRuntimeSessions();
   const ideTabs = listIdeRuntimeTabs();
   const ideSessionByKey = new Map(ideSessions.map((session) => [session.liveSessionKey ?? session.sessionKey, session]));
@@ -507,7 +508,7 @@ async function buildCliRuntimeSnapshot(): Promise<FleetSnapshot> {
     // they're not in the IDE registry (orchestrator dispatch doesn't touch
     // the IDE workspace tabs) and not in the terminal-session registry
     // (orchestrator goes through the bridge terminal, not user PTY).
-    || session.ownership === 'owned'
+    || (session.ownership === 'owned' && isDispatchableRuntime(session.runtimeId))
   ));
 
   const agents = discovered.map(({ runtime, session, statusEvidence }) => (
@@ -601,7 +602,7 @@ async function buildCliRuntimeSnapshot(): Promise<FleetSnapshot> {
       gatewayReachable: true,
       mirrorMode: 'current-session-first',
       observablePending: false,
-      note: 'Showing every discovered registered runtime surface.',
+      note: 'Showing every discovered dispatchable runtime surface.',
       primarySessionKey,
     },
     squads,

--- a/src/lib/terminal-status/debounce.ts
+++ b/src/lib/terminal-status/debounce.ts
@@ -1,0 +1,23 @@
+// Failed discovery must survive one debounce window before it becomes operator truth.
+const FAILED_CONFIRM_MS = 90_000;
+const failureDebounceBySession = new Map<string, { lastGood: string; failedSince: number | null }>();
+
+export function debouncedSessionStatus(sessionKey: string, status: string): string {
+  if (failureDebounceBySession.size > 512 && !failureDebounceBySession.has(sessionKey)) {
+    const oldest = failureDebounceBySession.keys().next().value;
+    if (oldest !== undefined) failureDebounceBySession.delete(oldest);
+  }
+  const entry = failureDebounceBySession.get(sessionKey) ?? { lastGood: status, failedSince: null };
+  if (status !== 'failed') {
+    entry.lastGood = status;
+    entry.failedSince = null;
+    failureDebounceBySession.set(sessionKey, entry);
+    return status;
+  }
+  if (entry.failedSince === null) entry.failedSince = Date.now();
+  failureDebounceBySession.set(sessionKey, entry);
+  if (entry.lastGood === 'failed' || Date.now() - entry.failedSince >= FAILED_CONFIRM_MS) {
+    return 'failed';
+  }
+  return entry.lastGood;
+}

--- a/src/lib/terminal-status/debounce.ts
+++ b/src/lib/terminal-status/debounce.ts
@@ -1,4 +1,10 @@
-// Failed discovery must survive one debounce window before it becomes operator truth.
+// #1476 lie 2 — a failed→heal blip on the discovery side surfaced as
+// status:'failed' for a single snapshot while the worker was alive and
+// mid-flow; callers polling in that window read a terminal-looking verdict.
+// Hysteresis: 'failed' must persist for FAILED_CONFIRM_MS before it surfaces;
+// until then the session reports its last known non-failed status. A session
+// whose FIRST observation is failed reports failed immediately (no history to
+// mask with — that's a genuinely dead discovery, not a blip).
 const FAILED_CONFIRM_MS = 90_000;
 const failureDebounceBySession = new Map<string, { lastGood: string; failedSince: number | null }>();
 

--- a/src/lib/terminal-status/normalize.ts
+++ b/src/lib/terminal-status/normalize.ts
@@ -1,0 +1,71 @@
+import type { RuntimeId } from '@/lib/runtimes/types';
+import type {
+  TerminalStatusAuthority,
+  TerminalStatusEvidence,
+  TerminalStatusState,
+} from '@/lib/terminal-status/resolve';
+
+const TERMINAL_STATUS_STATES = new Set<TerminalStatusState>([
+  'idle',
+  'working',
+  'blocked',
+  'failed',
+  'complete',
+  'review-ready',
+  'unknown',
+]);
+
+const TERMINAL_STATUS_AUTHORITIES = new Set<TerminalStatusAuthority>([
+  'runtime-event',
+  'lane-state',
+  'known-screen-adapter',
+  'raw-terminal',
+]);
+
+/** Preserve a route-projected record when valid; never manufacture evidence. */
+export function normalizeTerminalStatusEvidence(value: unknown): TerminalStatusEvidence | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const raw = value as Record<string, unknown>;
+  if (
+    typeof raw.sessionId !== 'string'
+    || !raw.sessionId.trim()
+    || typeof raw.runtime !== 'string'
+    || !raw.runtime.trim()
+    || !TERMINAL_STATUS_STATES.has(raw.state as TerminalStatusState)
+    || !TERMINAL_STATUS_AUTHORITIES.has(raw.authority as TerminalStatusAuthority)
+    || typeof raw.observedAt !== 'string'
+    || !Number.isFinite(Date.parse(raw.observedAt))
+    || typeof raw.summary !== 'string'
+    || !Array.isArray(raw.evidence)
+    || !raw.evidence.every((item) => (
+      item
+      && typeof item === 'object'
+      && typeof (item as Record<string, unknown>).source === 'string'
+      && typeof (item as Record<string, unknown>).value === 'string'
+    ))
+    || (raw.fallbackReason !== undefined && typeof raw.fallbackReason !== 'string')
+  ) {
+    return undefined;
+  }
+
+  return {
+    sessionId: raw.sessionId,
+    runtime: raw.runtime as RuntimeId,
+    state: raw.state as TerminalStatusState,
+    authority: raw.authority as TerminalStatusAuthority,
+    observedAt: raw.observedAt,
+    summary: raw.summary,
+    evidence: raw.evidence.map((item) => ({
+      source: (item as Record<string, string>).source,
+      value: (item as Record<string, string>).value,
+    })),
+    ...(raw.fallbackReason === undefined ? {} : { fallbackReason: raw.fallbackReason }),
+  };
+}
+
+export function normalizeTerminalStatusEvidenceField(
+  value: unknown,
+): Pick<{ statusEvidence?: TerminalStatusEvidence }, 'statusEvidence'> {
+  const statusEvidence = normalizeTerminalStatusEvidence(value);
+  return statusEvidence ? { statusEvidence } : {};
+}

--- a/src/lib/terminal-status/resolve.test.ts
+++ b/src/lib/terminal-status/resolve.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { ApprovalRecord } from '@/lib/approvals/types';
-import type { Lane } from '@/lib/lane/types';
+import type { Lane, LaneEvent } from '@/lib/lane/types';
 import type { OwnedRunRecord } from '@/lib/runtimes/shared/owned-session/types';
 import {
   resolveTerminalStatusEvidence,
@@ -149,6 +149,63 @@ describe('resolveTerminalStatusEvidence', () => {
 
     expect(resolved).toMatchObject({ authority: 'lane-state', state });
     expect(resolved.fallbackReason).toContain('No runtime event evidence');
+  });
+
+  it('uses the lane id and last event label for a sessionless orchestrator blocker', () => {
+    const parkedLane = {
+      ...lane('awaiting_orchestrator'),
+      sessionKey: null,
+      lastEventLabel: 'worktree_missing_unverified',
+    };
+    const resolved = resolveTerminalStatusEvidence({
+      lane: parkedLane,
+      laneEvents: [{
+        id: 'event-worktree-missing',
+        laneId: parkedLane.id,
+        verb: 'status_change',
+        actor: 'system',
+        payload: {
+          status: 'awaiting_orchestrator',
+          eventLabel: 'worktree_missing_unverified',
+        },
+        timestamp: observedAt,
+      }],
+    });
+
+    expect(resolved).toMatchObject({
+      sessionId: parkedLane.id,
+      authority: 'lane-state',
+      state: 'blocked',
+    });
+    expect(resolved.summary).toContain('worktree_missing_unverified');
+    expect(resolved.evidence).toContainEqual({
+      source: 'lane-event:worktree_missing_unverified',
+      value: JSON.stringify({
+        status: 'awaiting_orchestrator',
+        eventLabel: 'worktree_missing_unverified',
+      }),
+    });
+  });
+
+  it('names the latest agent question for an awaiting-input lane', () => {
+    const question = {
+      id: 'event-agent-question',
+      laneId: 'lane-status-evidence',
+      verb: 'agent_report',
+      actor: 'system',
+      payload: { event: 'question', message: 'Which branch should I target?' },
+      timestamp: '2026-08-29T11:59:00.000Z',
+    } satisfies LaneEvent;
+    const resolved = resolveTerminalStatusEvidence({
+      lane: lane('awaiting_input'),
+      laneEvents: [question],
+    });
+
+    expect(resolved.summary).toBe('Agent question: Which branch should I target?');
+    expect(resolved.evidence).toContainEqual({
+      source: 'lane-event:question',
+      value: JSON.stringify(question.payload),
+    });
   });
 
   const rawStates: TerminalStatusState[] = [
@@ -322,11 +379,12 @@ describe('resolveTerminalStatusEvidence', () => {
       updatedAt: Date.parse(observedAt),
     } as ApprovalRecord;
     const resolved = resolveTerminalStatusEvidence({
-      lane: lane('running', '2026-08-29T11:59:00.000Z'),
+      lane: lane('awaiting_human', '2026-08-29T12:01:00.000Z'),
       approvals: [approval],
     });
 
     expect(resolved).toMatchObject({ authority: 'lane-state', state: 'blocked' });
+    expect(resolved.summary).toBe('Approval pending: Allow governed continuation.');
     expect(resolved.evidence).toContainEqual({
       source: 'approval:approval-status-evidence',
       value: 'pending · Operator approval is required.',

--- a/src/lib/terminal-status/resolve.test.ts
+++ b/src/lib/terminal-status/resolve.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ApprovalRecord } from '@/lib/approvals/types';
+import type { Lane } from '@/lib/lane/types';
+import type { OwnedRunRecord } from '@/lib/runtimes/shared/owned-session/types';
+import {
+  resolveTerminalStatusEvidence,
+  type RawTerminalLifecycleEvidence,
+  type TerminalStatusState,
+} from './resolve';
+
+const observedAt = '2026-08-29T12:00:00.000Z';
+
+function lane(status: Lane['status'], updatedAt = observedAt): Lane {
+  return {
+    id: 'lane-status-evidence',
+    projectId: null,
+    label: 'status evidence',
+    repoPath: '/repo',
+    worktreePath: '/repo/worktree',
+    branch: 'feat/status-evidence',
+    baseBranch: 'main',
+    runtime: 'codex',
+    sessionKey: 'codex-owned:status-evidence',
+    packetId: 'pkt-status-evidence',
+    prNumber: null,
+    status,
+    ownership: 'managed',
+    writerToken: null,
+    lastHeartbeatAt: null,
+    createdAt: updatedAt,
+    updatedAt,
+    lastEventAt: updatedAt,
+    lastEventLabel: status,
+  };
+}
+
+function ownedRun(outcome: OwnedRunRecord['outcome']): OwnedRunRecord {
+  return {
+    id: `run-${outcome}`,
+    mode: 'launch',
+    prompt: 'test status evidence',
+    startedAt: observedAt,
+    finishedAt: outcome === 'running' ? undefined : observedAt,
+    pid: 42,
+    stdoutPath: '/tmp/status-evidence.stdout',
+    stderrPath: '/tmp/status-evidence.stderr',
+    outcome,
+  };
+}
+
+describe('resolveTerminalStatusEvidence', () => {
+  const runtimeCases = [
+    ['idle', 'idle'],
+    ['running', 'working'],
+    ['waiting', 'blocked'],
+    ['failed', 'failed'],
+    ['completed', 'complete'],
+    ['reviewing', 'review-ready'],
+  ] as const;
+
+  it.each(runtimeCases)('maps runtime status %s to %s under runtime-event authority', (status, state) => {
+    const resolved = resolveTerminalStatusEvidence({
+      runtimeSession: {
+        sessionKey: 'codex-owned:status-evidence',
+        runtimeId: 'codex',
+        status,
+        observedAt,
+      },
+    });
+
+    expect(resolved).toMatchObject({ authority: 'runtime-event', state });
+  });
+
+  const laneCases = [
+    ['idle', 'idle'],
+    ['running', 'working'],
+    ['awaiting_input', 'blocked'],
+    ['failed', 'failed'],
+    ['completed', 'complete'],
+    ['reviewing', 'review-ready'],
+  ] as const;
+
+  it.each(laneCases)('maps lane status %s to %s under lane-state authority', (status, state) => {
+    const resolved = resolveTerminalStatusEvidence({ lane: lane(status) });
+
+    expect(resolved).toMatchObject({ authority: 'lane-state', state });
+    expect(resolved.fallbackReason).toContain('No runtime event evidence');
+  });
+
+  const rawStates: TerminalStatusState[] = [
+    'idle',
+    'working',
+    'blocked',
+    'failed',
+    'complete',
+    'review-ready',
+    'unknown',
+  ];
+
+  it.each(rawStates)('preserves raw terminal state %s under the weakest authority', (state) => {
+    const rawLifecycle: RawTerminalLifecycleEvidence = {
+      sessionId: 'codex-owned:status-evidence',
+      runtime: 'codex',
+      state,
+      observedAt,
+    };
+    const resolved = resolveTerminalStatusEvidence({ rawLifecycle });
+
+    expect(resolved).toMatchObject({ authority: 'raw-terminal', state });
+    expect(resolved.fallbackReason).toContain('No runtime event or lane state evidence');
+  });
+
+  it.each([
+    ['running', 'working'],
+    ['finished', 'complete'],
+    ['interrupted', 'blocked'],
+    ['failed', 'failed'],
+  ] as const)('maps owned run outcome %s to %s as runtime evidence', (outcome, state) => {
+    const resolved = resolveTerminalStatusEvidence({
+      runtimeSession: {
+        sessionKey: 'codex-owned:status-evidence',
+        runtimeId: 'codex',
+        status: outcome === 'running' ? 'running' : 'idle',
+        observedAt: '2026-08-29T11:59:00.000Z',
+      },
+      ownedRun: ownedRun(outcome),
+    });
+
+    expect(resolved).toMatchObject({ authority: 'runtime-event', state });
+    expect(resolved.evidence).toContainEqual({ source: `owned-run:run-${outcome}`, value: outcome });
+  });
+
+  it('keeps runtime failure authoritative when a lower lane says working', () => {
+    const resolved = resolveTerminalStatusEvidence({
+      runtimeSession: {
+        sessionKey: 'codex-owned:status-evidence',
+        runtimeId: 'codex',
+        status: 'failed',
+        observedAt,
+      },
+      lane: lane('running', '2026-08-29T12:01:00.000Z'),
+    });
+
+    expect(resolved).toMatchObject({ authority: 'runtime-event', state: 'failed' });
+    expect(resolved.evidence).toContainEqual({
+      source: 'lane:lane-status-evidence.status',
+      value: 'running',
+    });
+    expect(resolved.fallbackReason).toBeUndefined();
+  });
+
+  it('keeps runtime evidence above raw terminal disagreement', () => {
+    const resolved = resolveTerminalStatusEvidence({
+      runtimeSession: {
+        sessionKey: 'codex-owned:status-evidence',
+        runtimeId: 'codex',
+        status: 'idle',
+        observedAt,
+      },
+      rawLifecycle: {
+        sessionId: 'codex-owned:status-evidence',
+        runtime: 'codex',
+        state: 'stalled',
+        observedAt: '2026-08-29T12:01:00.000Z',
+      },
+    });
+
+    expect(resolved).toMatchObject({ authority: 'runtime-event', state: 'idle' });
+    expect(resolved.evidence).toContainEqual({ source: 'raw-terminal.lifecycle', value: 'stalled' });
+  });
+
+  it('keeps lane evidence above raw terminal disagreement', () => {
+    const resolved = resolveTerminalStatusEvidence({
+      lane: lane('awaiting_input'),
+      rawLifecycle: {
+        sessionId: 'codex-owned:status-evidence',
+        runtime: 'codex',
+        state: 'active',
+        observedAt: '2026-08-29T12:01:00.000Z',
+      },
+    });
+
+    expect(resolved).toMatchObject({ authority: 'lane-state', state: 'blocked' });
+    expect(resolved.evidence).toContainEqual({ source: 'raw-terminal.lifecycle', value: 'active' });
+  });
+
+  it('uses RuntimeSession lifecycle outcome as runtime-event evidence', () => {
+    const resolved = resolveTerminalStatusEvidence({
+      runtimeSession: {
+        sessionKey: 'codex-owned:status-evidence',
+        runtimeId: 'codex',
+        status: 'idle',
+        observedAt,
+        lifecycle: {
+          availability: 'ready-for-resume',
+          lastOutcome: 'failed',
+          lastRunFinishedAt: observedAt,
+        },
+      },
+    });
+
+    expect(resolved).toMatchObject({ authority: 'runtime-event', state: 'failed' });
+    expect(resolved.evidence).toContainEqual({
+      source: 'runtime-session.lifecycle',
+      value: 'ready-for-resume · failed',
+    });
+  });
+
+  it('falls through to lane state only when runtime evidence is explicitly stale', () => {
+    const resolved = resolveTerminalStatusEvidence({
+      runtimeSession: {
+        sessionKey: 'codex-owned:status-evidence',
+        runtimeId: 'codex',
+        status: 'running',
+        observedAt: '2026-08-29T11:00:00.000Z',
+        stale: true,
+      },
+      lane: lane('reviewing'),
+    });
+
+    expect(resolved).toMatchObject({ authority: 'lane-state', state: 'review-ready' });
+    expect(resolved.fallbackReason).toContain('Runtime event evidence was stale');
+    expect(resolved.evidence).toContainEqual({ source: 'runtime-session.status', value: 'running' });
+  });
+
+  it('maps a pending approval to blocked lane evidence and cites the approval', () => {
+    const approval = {
+      id: 'approval-status-evidence',
+      status: 'pending',
+      sessionKey: 'codex-owned:status-evidence',
+      title: 'Allow governed continuation',
+      summary: 'Operator approval is required.',
+      updatedAt: Date.parse(observedAt),
+    } as ApprovalRecord;
+    const resolved = resolveTerminalStatusEvidence({
+      lane: lane('running', '2026-08-29T11:59:00.000Z'),
+      approvals: [approval],
+    });
+
+    expect(resolved).toMatchObject({ authority: 'lane-state', state: 'blocked' });
+    expect(resolved.evidence).toContainEqual({
+      source: 'approval:approval-status-evidence',
+      value: 'pending · Operator approval is required.',
+    });
+  });
+
+  it('maps an active review_queue row to review-ready lane evidence', () => {
+    const resolved = resolveTerminalStatusEvidence({
+      lane: lane('running', '2026-08-29T11:59:00.000Z'),
+      reviewQueue: [{
+        id: 'review-status-evidence',
+        laneId: 'lane-status-evidence',
+        status: 'pending',
+        updatedAt: observedAt,
+      }],
+    });
+
+    expect(resolved).toMatchObject({ authority: 'lane-state', state: 'review-ready' });
+    expect(resolved.evidence).toContainEqual({
+      source: 'review_queue:review-status-evidence',
+      value: 'pending',
+    });
+  });
+
+  it('never produces the reserved known-screen-adapter authority in child A', () => {
+    const resolved = [
+      resolveTerminalStatusEvidence({ lane: lane('idle') }),
+      resolveTerminalStatusEvidence({
+        runtimeSession: {
+          sessionKey: 'codex-owned:status-evidence',
+          runtimeId: 'codex',
+          status: 'running',
+          observedAt,
+        },
+      }),
+      resolveTerminalStatusEvidence({
+        rawLifecycle: {
+          sessionId: 'codex-owned:status-evidence',
+          runtime: 'codex',
+          state: 'stalled',
+          observedAt,
+        },
+      }),
+    ];
+
+    expect(resolved.every((evidence) => evidence.authority !== 'known-screen-adapter')).toBe(true);
+  });
+});

--- a/src/lib/terminal-status/resolve.test.ts
+++ b/src/lib/terminal-status/resolve.test.ts
@@ -72,6 +72,24 @@ describe('resolveTerminalStatusEvidence', () => {
     expect(resolved).toMatchObject({ authority: 'runtime-event', state });
   });
 
+  it('accepts a registered non-orchestrator cloud runtime session', () => {
+    const resolved = resolveTerminalStatusEvidence({
+      runtimeSession: {
+        sessionKey: 'cloud-owned:status-evidence',
+        runtimeId: 'cloud',
+        status: 'running',
+        observedAt,
+      },
+    });
+
+    expect(resolved).toMatchObject({
+      sessionId: 'cloud-owned:status-evidence',
+      runtime: 'cloud',
+      authority: 'runtime-event',
+      state: 'working',
+    });
+  });
+
   const laneCases = [
     ['idle', 'idle'],
     ['running', 'working'],

--- a/src/lib/terminal-status/resolve.test.ts
+++ b/src/lib/terminal-status/resolve.test.ts
@@ -72,22 +72,67 @@ describe('resolveTerminalStatusEvidence', () => {
     expect(resolved).toMatchObject({ authority: 'runtime-event', state });
   });
 
-  it('accepts a registered non-orchestrator cloud runtime session', () => {
+  it.each(['cloud', 'remote-customer'] as const)(
+    'accepts a registered non-orchestrator %s runtime session',
+    (runtime) => {
+      const resolved = resolveTerminalStatusEvidence({
+        runtimeSession: {
+          sessionKey: `${runtime}-owned:status-evidence`,
+          runtimeId: runtime,
+          status: 'running',
+          observedAt,
+        },
+      });
+
+      expect(resolved).toMatchObject({
+        sessionId: `${runtime}-owned:status-evidence`,
+        runtime,
+        authority: 'runtime-event',
+        state: 'working',
+      });
+    },
+  );
+
+  it('returns an unknown record when every observation time is invalid', () => {
+    const before = Date.now();
     const resolved = resolveTerminalStatusEvidence({
       runtimeSession: {
-        sessionKey: 'cloud-owned:status-evidence',
+        sessionKey: 'remote-customer-owned:invalid-observation',
+        runtimeId: 'remote-customer',
+        status: 'running',
+        observedAt: 'not-a-time',
+      },
+      rawLifecycle: {
+        sessionId: 'remote-customer-owned:invalid-observation',
+        runtime: 'remote-customer',
+        state: 'active',
+        observedAt: 'also-not-a-time',
+      },
+    });
+    const after = Date.now();
+
+    expect(resolved).toMatchObject({
+      sessionId: 'remote-customer-owned:invalid-observation',
+      runtime: 'remote-customer',
+      state: 'unknown',
+      authority: 'raw-terminal',
+      summary: 'No observation with a valid time was available.',
+      evidence: [],
+    });
+    expect(resolved.fallbackReason).toContain('invalid observation times');
+    expect(Date.parse(resolved.observedAt)).toBeGreaterThanOrEqual(before);
+    expect(Date.parse(resolved.observedAt)).toBeLessThanOrEqual(after);
+  });
+
+  it('keeps missing session identity or runtime as a programming error', () => {
+    expect(() => resolveTerminalStatusEvidence({
+      runtimeSession: {
+        sessionKey: '',
         runtimeId: 'cloud',
         status: 'running',
         observedAt,
       },
-    });
-
-    expect(resolved).toMatchObject({
-      sessionId: 'cloud-owned:status-evidence',
-      runtime: 'cloud',
-      authority: 'runtime-event',
-      state: 'working',
-    });
+    })).toThrow('requires an existing session id and registered runtime');
   });
 
   const laneCases = [

--- a/src/lib/terminal-status/resolve.test.ts
+++ b/src/lib/terminal-status/resolve.test.ts
@@ -213,6 +213,31 @@ describe('resolveTerminalStatusEvidence', () => {
     expect(resolved.fallbackReason).toBeUndefined();
   });
 
+  it.each([
+    ['reviewing', 'review-ready'],
+    ['awaiting_human', 'blocked'],
+  ] as const)(
+    'lets lane governance state %s outrank a finished runtime as %s',
+    (laneStatus, state) => {
+      const resolved = resolveTerminalStatusEvidence({
+        runtimeSession: {
+          sessionKey: 'codex-owned:status-evidence',
+          runtimeId: 'codex',
+          status: 'completed',
+          observedAt,
+        },
+        lane: lane(laneStatus, '2026-08-29T12:01:00.000Z'),
+      });
+
+      expect(resolved).toMatchObject({ authority: 'lane-state', state });
+      expect(resolved.evidence).toContainEqual({
+        source: 'runtime-session.status',
+        value: 'completed',
+      });
+      expect(resolved.fallbackReason).toBeUndefined();
+    },
+  );
+
   it('keeps runtime evidence above raw terminal disagreement', () => {
     const resolved = resolveTerminalStatusEvidence({
       runtimeSession: {

--- a/src/lib/terminal-status/resolve.ts
+++ b/src/lib/terminal-status/resolve.ts
@@ -98,9 +98,9 @@ function oneLine(value: string): string {
   return value.replace(/\s+/g, ' ').trim();
 }
 
-function validIso(value: string | undefined): string | null {
-  if (!value) return null;
-  const timestamp = Date.parse(value);
+function validIso(value: string | number | Date | undefined): string | null {
+  if (value === undefined || value === '') return null;
+  const timestamp = value instanceof Date ? value.getTime() : new Date(value).getTime();
   return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : null;
 }
 
@@ -246,6 +246,25 @@ function fallbackReason(
   return 'No runtime event or lane state evidence was available.';
 }
 
+export function unknownTerminalStatusEvidence(input: {
+  sessionId: string;
+  runtime: RuntimeId;
+  observedAt?: string | number | Date;
+  summary?: string;
+  fallbackReason: string;
+}): TerminalStatusEvidence {
+  return {
+    sessionId: input.sessionId,
+    runtime: input.runtime,
+    state: 'unknown',
+    authority: 'raw-terminal',
+    observedAt: validIso(input.observedAt) ?? new Date().toISOString(),
+    summary: input.summary ?? 'No observation with a valid time was available.',
+    evidence: [],
+    fallbackReason: input.fallbackReason,
+  };
+}
+
 /** Resolve one semantic session state through the shared authority ladder. */
 export function resolveTerminalStatusEvidence(
   input: ResolveTerminalStatusEvidenceInput,
@@ -348,7 +367,7 @@ export function resolveTerminalStatusEvidence(
   }
   for (const approval of input.approvals ?? []) {
     if (approval.status !== 'pending') continue;
-    const observedAt = validIso(new Date(approval.updatedAt).toISOString());
+    const observedAt = validIso(approval.updatedAt);
     if (!observedAt) continue;
     laneCandidates.push({
       authority: 'lane-state',
@@ -401,7 +420,11 @@ export function resolveTerminalStatusEvidence(
     ?? selectNewest(laneCandidates)
     ?? selectNewest(rawCandidates);
   if (!selected) {
-    throw new Error(`Terminal status evidence for ${sessionId} had no valid observation time.`);
+    return unknownTerminalStatusEvidence({
+      sessionId,
+      runtime,
+      fallbackReason: 'Runtime event, lane state, and raw terminal evidence were absent or had invalid observation times.',
+    });
   }
 
   const allCandidates = [

--- a/src/lib/terminal-status/resolve.ts
+++ b/src/lib/terminal-status/resolve.ts
@@ -1,0 +1,468 @@
+import type { ApprovalRecord } from '@/lib/approvals/types';
+import type { AgentStatus } from '@/lib/fleet/types';
+import type { Lane, LaneEvent, LaneStatus } from '@/lib/lane/types';
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+import type { RuntimeSession, RuntimeSessionStatus } from '@/lib/runtimes/types';
+import type { OwnedRunRecord, OwnedRunOutcome } from '@/lib/runtimes/shared/owned-session/types';
+
+export type TerminalStatusState =
+  | 'idle'
+  | 'working'
+  | 'blocked'
+  | 'failed'
+  | 'complete'
+  | 'review-ready'
+  | 'unknown';
+
+export type TerminalStatusAuthority =
+  | 'runtime-event'
+  | 'lane-state'
+  | 'known-screen-adapter'
+  | 'raw-terminal';
+
+export interface TerminalStatusEvidenceItem {
+  source: string;
+  value: string;
+}
+
+export interface TerminalStatusEvidence {
+  sessionId: string;
+  runtime: OrchestratorRuntime;
+  state: TerminalStatusState;
+  authority: TerminalStatusAuthority;
+  observedAt: string;
+  summary: string;
+  evidence: TerminalStatusEvidenceItem[];
+  fallbackReason?: string;
+}
+
+export interface TerminalRuntimeSessionEvidence {
+  sessionKey: string;
+  runtimeId: OrchestratorRuntime;
+  status: RuntimeSessionStatus;
+  observedAt: string;
+  lifecycle?: Partial<NonNullable<RuntimeSession['lifecycle']>>;
+  stale?: boolean;
+}
+
+export type TerminalOwnedRunEvidence = OwnedRunRecord & {
+  stale?: boolean;
+};
+
+export interface TerminalReviewQueueEvidence {
+  id: string;
+  laneId: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
+  updatedAt: string;
+  lastError?: string | null;
+}
+
+export interface RawTerminalLifecycleEvidence {
+  sessionId: string;
+  runtime: OrchestratorRuntime;
+  state: TerminalStatusState | 'active' | 'completed' | 'killed' | 'stalled';
+  observedAt: string;
+  exitCode?: number;
+}
+
+export interface ResolveTerminalStatusEvidenceInput {
+  runtimeSession?: TerminalRuntimeSessionEvidence | null;
+  ownedRun?: TerminalOwnedRunEvidence | null;
+  lane?: Lane | null;
+  laneEvents?: LaneEvent[];
+  approvals?: ApprovalRecord[];
+  reviewQueue?: TerminalReviewQueueEvidence[];
+  rawLifecycle?: RawTerminalLifecycleEvidence | null;
+}
+
+interface StatusCandidate {
+  authority: Exclude<TerminalStatusAuthority, 'known-screen-adapter'>;
+  state: TerminalStatusState;
+  observedAt: string;
+  summary: string;
+  source: string;
+  value: string;
+  sourceRank: number;
+}
+
+const STATE_PRIORITY: Record<TerminalStatusState, number> = {
+  working: 6,
+  'review-ready': 5,
+  blocked: 4,
+  failed: 3,
+  idle: 2,
+  complete: 1,
+  unknown: 0,
+};
+
+function oneLine(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function validIso(value: string | undefined): string | null {
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : null;
+}
+
+function newestIso(...values: Array<string | undefined>): string | null {
+  return values
+    .map(validIso)
+    .filter((value): value is string => Boolean(value))
+    .sort((left, right) => right.localeCompare(left))[0] ?? null;
+}
+
+function runtimeState(status: RuntimeSessionStatus): TerminalStatusState {
+  switch (status) {
+    case 'running': return 'working';
+    case 'waiting': return 'blocked';
+    case 'reviewing': return 'review-ready';
+    case 'failed': return 'failed';
+    case 'completed': return 'complete';
+    case 'idle': return 'idle';
+  }
+}
+
+function ownedRunState(outcome: OwnedRunOutcome): TerminalStatusState {
+  switch (outcome) {
+    case 'running': return 'working';
+    case 'finished': return 'complete';
+    case 'interrupted': return 'blocked';
+    case 'failed': return 'failed';
+  }
+}
+
+function runtimeLifecycleState(
+  lifecycle: NonNullable<TerminalRuntimeSessionEvidence['lifecycle']>,
+  fallback: TerminalStatusState,
+): TerminalStatusState {
+  if (lifecycle.availability === 'running' || lifecycle.availability === 'awaiting-thread') {
+    return 'working';
+  }
+  switch (lifecycle.lastOutcome) {
+    case 'failed': return 'failed';
+    case 'finished': return 'complete';
+    case 'interrupted': return 'blocked';
+    default: return fallback;
+  }
+}
+
+function laneState(status: LaneStatus): TerminalStatusState {
+  switch (status) {
+    case 'launching':
+    case 'running':
+    case 'recovering':
+    case 'merging':
+      return 'working';
+    case 'awaiting_input':
+    case 'awaiting_orchestrator':
+    case 'awaiting_human':
+      return 'blocked';
+    case 'reviewing':
+      return 'review-ready';
+    case 'failed':
+      return 'failed';
+    case 'completed':
+    case 'archived':
+      return 'complete';
+    case 'idle':
+    case 'paused':
+      return 'idle';
+  }
+}
+
+function rawState(state: RawTerminalLifecycleEvidence['state']): TerminalStatusState {
+  switch (state) {
+    case 'active': return 'working';
+    case 'completed': return 'complete';
+    case 'killed': return 'failed';
+    case 'stalled': return 'blocked';
+    default: return state;
+  }
+}
+
+function laneEventState(event: LaneEvent): TerminalStatusState | null {
+  if (event.verb === 'runtime_process_exit') {
+    const clean = event.payload.classification === 'clean-exit'
+      || (event.payload.exitCode === 0 && !event.payload.signal);
+    return clean ? 'complete' : 'failed';
+  }
+  if (event.verb === 'review_queue_blocked' || event.verb === 'spend_cap_hit') return 'blocked';
+  if (event.verb !== 'agent_report') return null;
+  switch (event.payload.event) {
+    case 'blocked':
+    case 'question':
+      return 'blocked';
+    case 'review':
+    case 'review_ready':
+      return 'review-ready';
+    case 'complete':
+    case 'completed':
+      return 'complete';
+    case 'progress':
+      return 'working';
+    default:
+      return null;
+  }
+}
+
+function selectNewest(candidates: StatusCandidate[]): StatusCandidate | null {
+  return [...candidates].sort((left, right) => {
+    const timeDelta = right.observedAt.localeCompare(left.observedAt);
+    if (timeDelta !== 0) return timeDelta;
+    const sourceDelta = right.sourceRank - left.sourceRank;
+    if (sourceDelta !== 0) return sourceDelta;
+    return STATE_PRIORITY[right.state] - STATE_PRIORITY[left.state];
+  })[0] ?? null;
+}
+
+function candidateEvidence(candidates: StatusCandidate[]): TerminalStatusEvidenceItem[] {
+  const seen = new Set<string>();
+  return candidates.flatMap((candidate) => {
+    const key = `${candidate.source}\u0000${candidate.value}`;
+    if (seen.has(key)) return [];
+    seen.add(key);
+    return [{ source: candidate.source, value: candidate.value }];
+  });
+}
+
+function fallbackReason(
+  selectedAuthority: StatusCandidate['authority'],
+  runtimeWasStale: boolean,
+  hasRuntimeInput: boolean,
+  hasLaneCandidate: boolean,
+): string | undefined {
+  if (selectedAuthority === 'runtime-event') return undefined;
+  if (selectedAuthority === 'lane-state') {
+    return runtimeWasStale
+      ? 'Runtime event evidence was stale, so lane state is the next available authority.'
+      : 'No runtime event evidence was available, so lane state is the next available authority.';
+  }
+  if (runtimeWasStale && !hasLaneCandidate) {
+    return 'Runtime event evidence was stale and no lane state evidence was available.';
+  }
+  if (hasRuntimeInput) {
+    return 'No current runtime event or lane state evidence was available.';
+  }
+  return 'No runtime event or lane state evidence was available.';
+}
+
+/** Resolve one semantic session state through the shared authority ladder. */
+export function resolveTerminalStatusEvidence(
+  input: ResolveTerminalStatusEvidenceInput,
+): TerminalStatusEvidence {
+  const runtimeSession = input.runtimeSession ?? null;
+  const ownedRun = input.ownedRun ?? null;
+  const lane = input.lane ?? null;
+  const rawLifecycle = input.rawLifecycle ?? null;
+  const sessionId = runtimeSession?.sessionKey ?? lane?.sessionKey ?? rawLifecycle?.sessionId;
+  const runtime = runtimeSession?.runtimeId ?? lane?.runtime ?? rawLifecycle?.runtime;
+  if (!sessionId || !runtime) {
+    throw new Error('Terminal status evidence requires an existing session id and orchestrator runtime.');
+  }
+
+  const runtimeCandidates: StatusCandidate[] = [];
+  const staleRuntimeCandidates: StatusCandidate[] = [];
+  if (runtimeSession) {
+    const observedAt = validIso(runtimeSession.observedAt);
+    if (observedAt) {
+      const state = runtimeState(runtimeSession.status);
+      const candidate: StatusCandidate = {
+        authority: 'runtime-event',
+        state,
+        observedAt,
+        summary: `${runtime} runtime reports this session as ${state}.`,
+        source: 'runtime-session.status',
+        value: runtimeSession.status,
+        sourceRank: 1,
+      };
+      (runtimeSession.stale ? staleRuntimeCandidates : runtimeCandidates).push(candidate);
+      if (runtimeSession.lifecycle) {
+        const lifecycleValue = [
+          runtimeSession.lifecycle.availability,
+          runtimeSession.lifecycle.lastOutcome,
+        ].filter(Boolean).join(' · ');
+        if (lifecycleValue) {
+          const lifecycleCandidate: StatusCandidate = {
+            ...candidate,
+            state: runtimeLifecycleState(runtimeSession.lifecycle, state),
+            observedAt: newestIso(
+              runtimeSession.lifecycle.lastRunFinishedAt,
+              runtimeSession.lifecycle.lastRunStartedAt,
+              observedAt,
+            ) ?? observedAt,
+            source: 'runtime-session.lifecycle',
+            value: lifecycleValue,
+            sourceRank: 2,
+          };
+          (runtimeSession.stale ? staleRuntimeCandidates : runtimeCandidates).push(lifecycleCandidate);
+        }
+      }
+    }
+  }
+  if (ownedRun) {
+    const observedAt = newestIso(ownedRun.finishedAt, ownedRun.startedAt);
+    if (observedAt) {
+      const state = ownedRunState(ownedRun.outcome);
+      const candidate: StatusCandidate = {
+        authority: 'runtime-event',
+        state,
+        observedAt,
+        summary: `Owned ${runtime} run ${ownedRun.id} is ${state}.`,
+        source: `owned-run:${ownedRun.id}`,
+        value: ownedRun.outcome,
+        sourceRank: 3,
+      };
+      (ownedRun.stale ? staleRuntimeCandidates : runtimeCandidates).push(candidate);
+    }
+  }
+
+  const laneCandidates: StatusCandidate[] = [];
+  if (lane) {
+    const observedAt = newestIso(lane.lastEventAt ?? undefined, lane.updatedAt);
+    if (observedAt) {
+      const state = laneState(lane.status);
+      laneCandidates.push({
+        authority: 'lane-state',
+        state,
+        observedAt,
+        summary: `Lane ${lane.label} is ${state}.`,
+        source: `lane:${lane.id}.status`,
+        value: lane.status,
+        sourceRank: 1,
+      });
+    }
+  }
+  for (const event of input.laneEvents ?? []) {
+    const state = laneEventState(event);
+    const observedAt = validIso(event.timestamp);
+    if (!state || !observedAt) continue;
+    laneCandidates.push({
+      authority: 'lane-state',
+      state,
+      observedAt,
+      summary: `Lane event ${event.verb} reports ${state}.`,
+      source: `lane-event:${event.verb}`,
+      value: oneLine(JSON.stringify(event.payload)),
+      sourceRank: 2,
+    });
+  }
+  for (const approval of input.approvals ?? []) {
+    if (approval.status !== 'pending') continue;
+    const observedAt = validIso(new Date(approval.updatedAt).toISOString());
+    if (!observedAt) continue;
+    laneCandidates.push({
+      authority: 'lane-state',
+      state: 'blocked',
+      observedAt,
+      summary: `Approval pending: ${oneLine(approval.title)}.`,
+      source: `approval:${approval.id}`,
+      value: `pending · ${oneLine(approval.summary || approval.title)}`,
+      sourceRank: 3,
+    });
+  }
+  for (const review of input.reviewQueue ?? []) {
+    const observedAt = validIso(review.updatedAt);
+    if (!observedAt) continue;
+    const state = review.status === 'pending' || review.status === 'in_progress'
+      ? 'review-ready'
+      : null;
+    if (!state) continue;
+    laneCandidates.push({
+      authority: 'lane-state',
+      state,
+      observedAt,
+      summary: `Lane review ${review.id} is ${review.status === 'pending' ? 'queued' : 'in progress'}.`,
+      source: `review_queue:${review.id}`,
+      value: review.status,
+      sourceRank: 3,
+    });
+  }
+
+  const rawCandidates: StatusCandidate[] = [];
+  if (rawLifecycle) {
+    const observedAt = validIso(rawLifecycle.observedAt);
+    if (observedAt) {
+      const state = rawState(rawLifecycle.state);
+      rawCandidates.push({
+        authority: 'raw-terminal',
+        state,
+        observedAt,
+        summary: `Raw terminal lifecycle reports this session as ${state}.`,
+        source: 'raw-terminal.lifecycle',
+        value: rawLifecycle.exitCode === undefined
+          ? rawLifecycle.state
+          : `${rawLifecycle.state} · exit ${rawLifecycle.exitCode}`,
+        sourceRank: 1,
+      });
+    }
+  }
+
+  const selected = selectNewest(runtimeCandidates)
+    ?? selectNewest(laneCandidates)
+    ?? selectNewest(rawCandidates);
+  if (!selected) {
+    throw new Error(`Terminal status evidence for ${sessionId} had no valid observation time.`);
+  }
+
+  const allCandidates = [
+    ...runtimeCandidates,
+    ...staleRuntimeCandidates,
+    ...laneCandidates,
+    ...rawCandidates,
+  ];
+  return {
+    sessionId,
+    runtime,
+    state: selected.state,
+    authority: selected.authority,
+    observedAt: selected.observedAt,
+    summary: oneLine(selected.summary),
+    evidence: candidateEvidence(allCandidates),
+    fallbackReason: fallbackReason(
+      selected.authority,
+      staleRuntimeCandidates.length > 0,
+      Boolean(runtimeSession || ownedRun),
+      laneCandidates.length > 0,
+    ),
+  };
+}
+
+export function agentStatusFromTerminalState(
+  state: TerminalStatusState,
+  fallback: AgentStatus = 'idle',
+): AgentStatus {
+  switch (state) {
+    case 'working': return 'running';
+    case 'blocked': return 'blocked';
+    case 'failed': return 'failed';
+    case 'complete': return 'completed';
+    case 'review-ready': return 'reviewing';
+    case 'idle': return 'idle';
+    case 'unknown': return fallback;
+  }
+}
+
+export function runtimeSessionStatusFromTerminalState(
+  state: TerminalStatusState,
+  fallback: RuntimeSessionStatus = 'idle',
+): RuntimeSessionStatus {
+  switch (state) {
+    case 'working': return 'running';
+    case 'blocked': return 'waiting';
+    case 'failed': return 'failed';
+    case 'complete': return 'completed';
+    case 'review-ready': return 'reviewing';
+    case 'idle': return 'idle';
+    case 'unknown': return fallback;
+  }
+}
+
+export function compareTerminalStatusEvidence(
+  left: TerminalStatusEvidence,
+  right: TerminalStatusEvidence,
+): number {
+  const stateDelta = STATE_PRIORITY[right.state] - STATE_PRIORITY[left.state];
+  if (stateDelta !== 0) return stateDelta;
+  return right.observedAt.localeCompare(left.observedAt);
+}

--- a/src/lib/terminal-status/resolve.ts
+++ b/src/lib/terminal-status/resolve.ts
@@ -1,8 +1,7 @@
 import type { ApprovalRecord } from '@/lib/approvals/types';
 import type { AgentStatus } from '@/lib/fleet/types';
 import type { Lane, LaneEvent, LaneStatus } from '@/lib/lane/types';
-import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
-import type { RuntimeSession, RuntimeSessionStatus } from '@/lib/runtimes/types';
+import type { RuntimeId, RuntimeSession, RuntimeSessionStatus } from '@/lib/runtimes/types';
 import type { OwnedRunRecord, OwnedRunOutcome } from '@/lib/runtimes/shared/owned-session/types';
 
 export type TerminalStatusState =
@@ -27,7 +26,7 @@ export interface TerminalStatusEvidenceItem {
 
 export interface TerminalStatusEvidence {
   sessionId: string;
-  runtime: OrchestratorRuntime;
+  runtime: RuntimeId;
   state: TerminalStatusState;
   authority: TerminalStatusAuthority;
   observedAt: string;
@@ -38,7 +37,7 @@ export interface TerminalStatusEvidence {
 
 export interface TerminalRuntimeSessionEvidence {
   sessionKey: string;
-  runtimeId: OrchestratorRuntime;
+  runtimeId: RuntimeId;
   status: RuntimeSessionStatus;
   observedAt: string;
   lifecycle?: Partial<NonNullable<RuntimeSession['lifecycle']>>;
@@ -59,7 +58,7 @@ export interface TerminalReviewQueueEvidence {
 
 export interface RawTerminalLifecycleEvidence {
   sessionId: string;
-  runtime: OrchestratorRuntime;
+  runtime: RuntimeId;
   state: TerminalStatusState | 'active' | 'completed' | 'killed' | 'stalled';
   observedAt: string;
   exitCode?: number;
@@ -258,7 +257,7 @@ export function resolveTerminalStatusEvidence(
   const sessionId = runtimeSession?.sessionKey ?? lane?.sessionKey ?? rawLifecycle?.sessionId;
   const runtime = runtimeSession?.runtimeId ?? lane?.runtime ?? rawLifecycle?.runtime;
   if (!sessionId || !runtime) {
-    throw new Error('Terminal status evidence requires an existing session id and orchestrator runtime.');
+    throw new Error('Terminal status evidence requires an existing session id and registered runtime.');
   }
 
   const runtimeCandidates: StatusCandidate[] = [];

--- a/src/lib/terminal-status/resolve.ts
+++ b/src/lib/terminal-status/resolve.ts
@@ -187,6 +187,26 @@ function laneEventState(event: LaneEvent): TerminalStatusState | null {
     return clean ? 'complete' : 'failed';
   }
   if (event.verb === 'review_queue_blocked' || event.verb === 'spend_cap_hit') return 'blocked';
+  if (event.verb === 'status_change') {
+    switch (event.payload.status) {
+      case 'idle':
+      case 'launching':
+      case 'running':
+      case 'paused':
+      case 'awaiting_input':
+      case 'awaiting_orchestrator':
+      case 'awaiting_human':
+      case 'recovering':
+      case 'reviewing':
+      case 'merging':
+      case 'failed':
+      case 'completed':
+      case 'archived':
+        return laneState(event.payload.status);
+      default:
+        return null;
+    }
+  }
   if (event.verb !== 'agent_report') return null;
   switch (event.payload.event) {
     case 'blocked':
@@ -203,6 +223,48 @@ function laneEventState(event: LaneEvent): TerminalStatusState | null {
     default:
       return null;
   }
+}
+
+function laneEventSource(event: LaneEvent): string {
+  if (event.verb === 'status_change' && typeof event.payload.eventLabel === 'string') {
+    return `lane-event:${oneLine(event.payload.eventLabel)}`;
+  }
+  if (event.verb === 'agent_report' && typeof event.payload.event === 'string') {
+    return `lane-event:${oneLine(event.payload.event)}`;
+  }
+  return `lane-event:${event.verb}`;
+}
+
+function newestAgentQuestion(events: LaneEvent[]): string | null {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event?.verb !== 'agent_report' || event.payload.event !== 'question') continue;
+    const message = event.payload.message;
+    if (typeof message === 'string' && oneLine(message)) return oneLine(message);
+  }
+  return null;
+}
+
+function blockedLaneSummary(
+  lane: Lane | null,
+  laneEvents: LaneEvent[],
+  approvals: ApprovalRecord[],
+): string | null {
+  if (!lane) return null;
+  if (lane.status === 'awaiting_orchestrator' && lane.lastEventLabel) {
+    return `Lane ${lane.label} is blocked: ${oneLine(lane.lastEventLabel)}.`;
+  }
+  if (lane.status === 'awaiting_human') {
+    const approval = approvals
+      .filter((candidate) => candidate.status === 'pending')
+      .sort((left, right) => right.updatedAt - left.updatedAt)[0];
+    if (approval) return `Approval pending: ${oneLine(approval.title)}.`;
+  }
+  if (lane.status === 'awaiting_input') {
+    const question = newestAgentQuestion(laneEvents);
+    if (question) return `Agent question: ${question}`;
+  }
+  return null;
 }
 
 function selectNewest(candidates: StatusCandidate[]): StatusCandidate | null {
@@ -273,7 +335,7 @@ export function resolveTerminalStatusEvidence(
   const ownedRun = input.ownedRun ?? null;
   const lane = input.lane ?? null;
   const rawLifecycle = input.rawLifecycle ?? null;
-  const sessionId = runtimeSession?.sessionKey ?? lane?.sessionKey ?? rawLifecycle?.sessionId;
+  const sessionId = runtimeSession?.sessionKey ?? lane?.sessionKey ?? lane?.id ?? rawLifecycle?.sessionId;
   const runtime = runtimeSession?.runtimeId ?? lane?.runtime ?? rawLifecycle?.runtime;
   if (!sessionId || !runtime) {
     throw new Error('Terminal status evidence requires an existing session id and registered runtime.');
@@ -360,7 +422,7 @@ export function resolveTerminalStatusEvidence(
       state,
       observedAt,
       summary: `Lane event ${event.verb} reports ${state}.`,
-      source: `lane-event:${event.verb}`,
+      source: laneEventSource(event),
       value: oneLine(JSON.stringify(event.payload)),
       sourceRank: 2,
     });
@@ -445,7 +507,11 @@ export function resolveTerminalStatusEvidence(
     state: selected.state,
     authority: selected.authority,
     observedAt: selected.observedAt,
-    summary: oneLine(selected.summary),
+    summary: oneLine(
+      selected.authority === 'lane-state' && selected.state === 'blocked'
+        ? blockedLaneSummary(lane, input.laneEvents ?? [], input.approvals ?? []) ?? selected.summary
+        : selected.summary,
+    ),
     evidence: candidateEvidence(allCandidates),
     fallbackReason: governanceLaneOutranksFinishedRuntime
       ? undefined

--- a/src/lib/terminal-status/resolve.ts
+++ b/src/lib/terminal-status/resolve.ts
@@ -416,9 +416,15 @@ export function resolveTerminalStatusEvidence(
     }
   }
 
-  const selected = selectNewest(runtimeCandidates)
-    ?? selectNewest(laneCandidates)
-    ?? selectNewest(rawCandidates);
+  const selectedRuntime = selectNewest(runtimeCandidates);
+  const selectedGovernanceLane = selectNewest(laneCandidates.filter((candidate) => (
+    candidate.state === 'review-ready' || candidate.state === 'blocked'
+  )));
+  const governanceLaneOutranksFinishedRuntime = selectedRuntime?.state === 'complete'
+    && Boolean(selectedGovernanceLane);
+  const selected = governanceLaneOutranksFinishedRuntime
+    ? selectedGovernanceLane
+    : selectedRuntime ?? selectNewest(laneCandidates) ?? selectNewest(rawCandidates);
   if (!selected) {
     return unknownTerminalStatusEvidence({
       sessionId,
@@ -441,12 +447,14 @@ export function resolveTerminalStatusEvidence(
     observedAt: selected.observedAt,
     summary: oneLine(selected.summary),
     evidence: candidateEvidence(allCandidates),
-    fallbackReason: fallbackReason(
-      selected.authority,
-      staleRuntimeCandidates.length > 0,
-      Boolean(runtimeSession || ownedRun),
-      laneCandidates.length > 0,
-    ),
+    fallbackReason: governanceLaneOutranksFinishedRuntime
+      ? undefined
+      : fallbackReason(
+          selected.authority,
+          staleRuntimeCandidates.length > 0,
+          Boolean(runtimeSession || ownedRun),
+          laneCandidates.length > 0,
+        ),
   };
 }
 

--- a/src/lib/terminal-status/store.ts
+++ b/src/lib/terminal-status/store.ts
@@ -1,0 +1,23 @@
+import { getSqlite } from '@/lib/db';
+import type { TerminalReviewQueueEvidence } from '@/lib/terminal-status/resolve';
+
+export function listTerminalReviewQueueEvidence(): TerminalReviewQueueEvidence[] {
+  const rows = getSqlite().prepare(
+    `SELECT id, lane_id, status, updated_at, last_error
+     FROM review_queue
+     WHERE status IN ('pending', 'in_progress')`,
+  ).all() as Array<{
+    id: string;
+    lane_id: string;
+    status: TerminalReviewQueueEvidence['status'];
+    updated_at: string;
+    last_error: string | null;
+  }>;
+  return rows.map((row) => ({
+    id: row.id,
+    laneId: row.lane_id,
+    status: row.status,
+    updatedAt: row.updated_at.includes('T') ? row.updated_at : `${row.updated_at.replace(' ', 'T')}Z`,
+    lastError: row.last_error,
+  }));
+}

--- a/tests/packet-control-fields-survive-normalize.test.ts
+++ b/tests/packet-control-fields-survive-normalize.test.ts
@@ -4,8 +4,9 @@
  * normalizePacket() rebuilds every packet from scratch and is the single
  * chokepoint EVERY orchestrator-state read and write funnels through. Any field
  * it forgets to copy is silently dropped on the next round-trip. The fixture
- * below intentionally satisfies Required<OrchestratorPacket> so adding a new
- * packet field forces this test to pin its normalize behavior.
+ * below intentionally requires every persisted packet field so adding one
+ * forces this test to pin its normalize behavior. statusEvidence is excluded
+ * because the state route recomputes that read-time projection on every GET.
  */
 import { describe, expect, it, vi } from 'vitest';
 
@@ -222,7 +223,7 @@ function fullPacketFixture() {
       error: null,
     },
     recovery: null,
-  } satisfies Required<OrchestratorPacket>;
+  } satisfies Required<Omit<OrchestratorPacket, 'statusEvidence'>>;
 
   return packet;
 }

--- a/tests/packet-control-fields-survive-normalize.test.ts
+++ b/tests/packet-control-fields-survive-normalize.test.ts
@@ -4,9 +4,9 @@
  * normalizePacket() rebuilds every packet from scratch and is the single
  * chokepoint EVERY orchestrator-state read and write funnels through. Any field
  * it forgets to copy is silently dropped on the next round-trip. The fixture
- * below intentionally requires every persisted packet field so adding one
- * forces this test to pin its normalize behavior. statusEvidence is excluded
- * because the state route recomputes that read-time projection on every GET.
+ * below intentionally satisfies Required<OrchestratorPacket> so adding a new
+ * packet field forces this test to pin its normalize behavior. The persistence
+ * assertion separately proves read-time projections do not enter durable state.
  */
 import { describe, expect, it, vi } from 'vitest';
 
@@ -15,6 +15,7 @@ import {
   createEmptyOrchestratorMissionState,
   normalizeOrchestratorMissionState,
 } from '@/lib/orchestrator/store';
+import { normalizeOrchestratorMissionStateForPersistence } from '@/lib/orchestrator/persisted-mission';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 
 const NOW = new Date('2026-01-01T00:00:00.000Z');
@@ -71,6 +72,16 @@ function fullPacketFixture() {
       observedAt: '2026-01-01T00:00:30.000Z',
     },
     blockedReason: 'operator_stopped',
+    statusEvidence: {
+      sessionId: 'codex-owned:pkt-control-1',
+      runtime: 'codex',
+      state: 'blocked',
+      authority: 'lane-state',
+      observedAt: '2026-01-01T00:02:30.000Z',
+      summary: 'Lane control-field packet is blocked: operator_stopped.',
+      evidence: [{ source: 'lane:lane-1.status', value: 'awaiting_orchestrator' }],
+      fallbackReason: 'No live runtime event was available.',
+    },
     storageAdmission: {
       schema: 'o8/packet-storage-admission/v1',
       state: 'held',
@@ -223,7 +234,7 @@ function fullPacketFixture() {
       error: null,
     },
     recovery: null,
-  } satisfies Required<Omit<OrchestratorPacket, 'statusEvidence'>>;
+  } satisfies Required<OrchestratorPacket>;
 
   return packet;
 }
@@ -243,6 +254,8 @@ describe('packet fields survive normalize', () => {
       const packet = fullPacketFixture();
       const normalized = normalizeOrchestratorMissionState(stateWithPacket(packet));
       expect(normalized.packets[0]).toEqual(packet);
+      const persisted = normalizeOrchestratorMissionStateForPersistence(normalized);
+      expect(persisted.packets[0]).not.toHaveProperty('statusEvidence');
     } finally {
       vi.useRealTimers();
     }
@@ -258,6 +271,7 @@ describe('packet fields survive normalize', () => {
       taskContractRequired: undefined,
       taskContractSource: undefined,
       storageAdmissionEpoch: undefined,
+      statusEvidence: undefined,
     }));
 
     expect(normalized.packets[0].operatorStopped).toBeUndefined();
@@ -267,6 +281,7 @@ describe('packet fields survive normalize', () => {
     expect(normalized.packets[0].taskContractRequired).toBeUndefined();
     expect(normalized.packets[0].taskContractSource).toBeUndefined();
     expect(normalized.packets[0].storageAdmissionEpoch).toBe(1);
+    expect(normalized.packets[0].statusEvidence).toBeUndefined();
   });
 
   it('preserves an explicit disabled task-contract gate', () => {

--- a/tests/real-path-seams.test.ts
+++ b/tests/real-path-seams.test.ts
@@ -36,10 +36,13 @@ import { execFileSync } from 'node:child_process';
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import { basename, join } from 'node:path';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
+import { TerminalStatusEvidenceDisclosure } from '@/components/desktop/TerminalStatusEvidenceRows';
 import type { OrchestratorMissionState, OrchestratorPacket } from '@/lib/orchestrator/types';
 import type { TypedRow } from '@/lib/cortex/qa/types';
 
@@ -758,7 +761,7 @@ describe('seam E — review-ready projection is suppressed while owned Codex is 
 describe('seam E — orchestrator state projects one terminal status authority', () => {
   const url = 'http://localhost:3001/api/orchestrator/state';
 
-  it('real state GET resolves fabricated inventory against a persisted lane through TerminalStatusEvidence', async () => {
+  it('real state GET carries resolved evidence from fabricated inventory to the desktop status rows', async () => {
     const packetId = 'pkt-seam-E-status-evidence';
     const surfaceId = 'codex-owned:seam-E-status-evidence';
     const repoPath = mkdtempSync(join(os.tmpdir(), 'o8-seam-E-status-repo-'));
@@ -804,6 +807,12 @@ describe('seam E — orchestrator state projects one terminal status authority',
       source: `lane:${persistedLane.id}.status`,
       value: 'running',
     });
+    const desktopMarkup = renderToStaticMarkup(createElement(TerminalStatusEvidenceDisclosure, {
+      evidence: agent.statusEvidence,
+      defaultExpanded: true,
+    }));
+    expect(desktopMarkup).toContain('failed · runtime');
+    expect(desktopMarkup).toContain(`lane:${persistedLane.id}.status`);
     expect(runtimeInventoryMock.requests.at(-1)).toEqual({ fresh: false });
   });
 

--- a/tests/real-path-seams.test.ts
+++ b/tests/real-path-seams.test.ts
@@ -149,7 +149,10 @@ const searchRoute = await import('@/app/api/panel/search/route');
 const { archiveLane, createLane, findLaneByPacket, getLane, getLaneEvents, setLaneStatus, updateLane } = await import('@/lib/lane/registry');
 const { dispatch } = await import('@/lib/lane/commands');
 const { listApprovalsForContext } = await import('@/lib/approvals/store');
-const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+const {
+  createEmptyOrchestratorMissionState,
+  normalizeOrchestratorMissionState,
+} = await import('@/lib/orchestrator/store');
 const {
   readOrchestratorControlPlaneState,
   withControlPlaneLock,
@@ -833,11 +836,12 @@ describe('seam E — review-ready projection is suppressed while owned Codex is 
 describe('seam E — orchestrator state projects one terminal status authority', () => {
   const url = 'http://localhost:3001/api/orchestrator/state';
 
-  it('real state GET resolves lane evidence for a parked packet with no inventory agent', async () => {
+  it('real state GET carries lane-only evidence through the desktop mission normalizer', async () => {
     const packetId = 'pkt-seam-E-lane-only-blocked';
     const surfaceId = 'codex-owned:seam-E-lane-only-blocked';
     const repoPath = mkdtempSync(join(os.tmpdir(), 'o8-seam-E-lane-only-repo-'));
     tempDirs.push(repoPath);
+    writeOrchestratorControlPlaneState(createEmptyOrchestratorMissionState());
 
     const persistedLane = createLane({
       repoPath,
@@ -870,22 +874,28 @@ describe('seam E — orchestrator state projects one terminal status authority',
     const response = await stateRoute.GET(operatorGet(url));
     expect(response.status).toBe(200);
     const json = await response.json();
-    const packet = json.mission.packets.find((candidate: OrchestratorPacket) => (
+    const routePacket = json.mission.packets.find((candidate: OrchestratorPacket) => (
       candidate.id === packetId
     ));
+    const desktopMission = normalizeOrchestratorMissionState(json.mission);
+    const packet = desktopMission.packets[0];
+    const statusEvidence = packet.statusEvidence;
 
     expect(json.agents).toEqual([]);
-    expect(packet.statusEvidence).toMatchObject({
+    expect(routePacket.statusEvidence).toEqual(statusEvidence);
+    expect(packet.id).toBe(packetId);
+    expect(statusEvidence).toMatchObject({
       sessionId: surfaceId,
       runtime: 'codex',
       state: 'blocked',
       authority: 'lane-state',
     });
-    expect(packet.statusEvidence.summary).toContain('worktree_missing_unverified');
-    expect(packet.statusEvidence.evidence).toContainEqual({
+    expect(statusEvidence?.summary).toContain('worktree_missing_unverified');
+    expect(statusEvidence?.evidence).toContainEqual({
       source: 'lane-event:worktree_missing_unverified',
       value: expect.stringContaining('awaiting_orchestrator'),
     });
+    expect(readOrchestratorControlPlaneState().packets[0]).not.toHaveProperty('statusEvidence');
     expect(runtimeInventoryMock.requests.at(-1)).toEqual({ fresh: false });
   });
 

--- a/tests/real-path-seams.test.ts
+++ b/tests/real-path-seams.test.ts
@@ -57,7 +57,11 @@ const runtimeInventoryMock = vi.hoisted(() => ({
     runtimeSurface?: {
       ownership?: 'provider' | 'discovered' | 'owned';
       capabilities?: { sendInput?: boolean; interrupt?: boolean };
-      lifecycle?: { availability?: 'awaiting-thread' | 'running' | 'ready-for-resume' };
+      lifecycle?: {
+        availability?: 'awaiting-thread' | 'running' | 'ready-for-resume';
+        lastOutcome?: 'finished' | 'interrupted' | 'failed';
+        lastRunFinishedAt?: string;
+      };
     };
   }>,
   requests: [] as Array<{ fresh?: boolean } | undefined>,
@@ -757,6 +761,71 @@ describe('seam E — review-ready projection is suppressed while owned Codex is 
     expect(packet).toBeTruthy();
     expect(packet.status).toBe('running');
     expect(packet.status).not.toBe('awaiting_review');
+  });
+
+  it('real state GET keeps lane review-ready authoritative after the owned run finishes', async () => {
+    const packetId = 'pkt-seam-E-finished-reviewing';
+    const surfaceId = 'codex-owned:seam-E-finished';
+    const repoPath = mkdtempSync(join(os.tmpdir(), 'o8-seam-E-finished-repo-'));
+    const finishedAt = '2026-08-29T12:10:00.000Z';
+    tempDirs.push(repoPath);
+
+    const lane = createLane({
+      repoPath,
+      worktreePath: repoPath,
+      branch: 'inline/seam-e-finished',
+      runtime: 'codex',
+      packetId,
+      sessionKey: surfaceId,
+    });
+    setLaneStatus(lane.id, 'reviewing', 'system', 'review_ready');
+
+    runtimeInventoryMock.agents = [{
+      sessionKey: surfaceId,
+      runtime: 'codex',
+      status: 'completed',
+      currentTask: 'Worker finished and awaits review',
+      lastEventAt: finishedAt,
+      runtimeSurface: {
+        ownership: 'owned',
+        capabilities: { sendInput: false, interrupt: false },
+        lifecycle: {
+          availability: 'ready-for-resume',
+          lastOutcome: 'finished',
+          lastRunFinishedAt: finishedAt,
+        },
+      },
+    }];
+
+    const seed = await (await stateRoute.GET(operatorGet(url))).json();
+    const current: OrchestratorMissionState = seed.mission ?? createEmptyOrchestratorMissionState();
+    const mission: OrchestratorMissionState = {
+      ...current,
+      packets: [
+        ...current.packets,
+        packetFixture({ id: packetId, status: 'awaiting_review', lane: null }),
+      ],
+    };
+    const postRes = await stateRoute.POST(operatorReq(url, { mission }));
+    expect(postRes.status).toBe(200);
+
+    const getRes = await stateRoute.GET(operatorGet(url));
+    expect(getRes.status).toBe(200);
+    const json = await getRes.json();
+    const packet = json.mission.packets.find((candidate: OrchestratorPacket) => candidate.id === packetId);
+    const agent = json.agents.find((candidate: { sessionKey: string }) => candidate.sessionKey === surfaceId);
+
+    expect(packet.status).toBe('awaiting_review');
+    expect(agent.status).toBe('reviewing');
+    expect(agent.statusEvidence).toMatchObject({
+      state: 'review-ready',
+      authority: 'lane-state',
+    });
+    expect(agent.statusEvidence).not.toHaveProperty('fallbackReason');
+    expect(agent.statusEvidence.evidence).toContainEqual({
+      source: 'runtime-session.status',
+      value: 'completed',
+    });
   });
 });
 

--- a/tests/real-path-seams.test.ts
+++ b/tests/real-path-seams.test.ts
@@ -33,7 +33,7 @@
  *      operator-defaults resolution, not resolveBrainEnabledWith in isolation.
  */
 import { execFileSync } from 'node:child_process';
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import { basename, join } from 'node:path';
 
@@ -747,6 +747,74 @@ describe('seam E — review-ready projection is suppressed while owned Codex is 
     expect(packet).toBeTruthy();
     expect(packet.status).toBe('running');
     expect(packet.status).not.toBe('awaiting_review');
+  });
+});
+
+describe('seam E — orchestrator state projects one terminal status authority', () => {
+  const url = 'http://localhost:3001/api/orchestrator/state';
+
+  it('real state GET resolves fabricated inventory against a persisted lane through TerminalStatusEvidence', async () => {
+    const packetId = 'pkt-seam-E-status-evidence';
+    const surfaceId = 'codex-owned:seam-E-status-evidence';
+    const repoPath = mkdtempSync(join(os.tmpdir(), 'o8-seam-E-status-repo-'));
+    tempDirs.push(repoPath);
+
+    const persistedLane = createLane({
+      repoPath,
+      worktreePath: repoPath,
+      branch: 'inline/seam-e-status',
+      runtime: 'codex',
+      packetId,
+      sessionKey: surfaceId,
+    });
+    setLaneStatus(persistedLane.id, 'running', 'system', 'session_running');
+
+    runtimeInventoryMock.agents = [{
+      sessionKey: surfaceId,
+      runtime: 'codex',
+      status: 'failed',
+      currentTask: 'Runtime exited while lane remained active',
+      lastEventAt: '2026-08-29T12:00:00.000Z',
+      runtimeSurface: {
+        ownership: 'owned',
+        capabilities: { sendInput: false, interrupt: false },
+        lifecycle: { availability: 'ready-for-resume' },
+      },
+    }];
+
+    const response = await stateRoute.GET(operatorGet(url));
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    const agent = json.agents.find((candidate: { sessionKey: string }) => candidate.sessionKey === surfaceId);
+
+    expect(agent.status).toBe('failed');
+    expect(agent.statusEvidence).toMatchObject({
+      sessionId: surfaceId,
+      runtime: 'codex',
+      state: 'failed',
+      authority: 'runtime-event',
+      observedAt: '2026-08-29T12:00:00.000Z',
+    });
+    expect(agent.statusEvidence.evidence).toContainEqual({
+      source: `lane:${persistedLane.id}.status`,
+      value: 'running',
+    });
+  });
+
+  it('keeps precedence code in the terminal status resolver instead of the old call sites', () => {
+    const inventorySource = readFileSync(
+      join(process.cwd(), 'src/lib/runtime/inventory.ts'),
+      'utf-8',
+    );
+    const operatorStatusSource = readFileSync(
+      join(process.cwd(), 'src/lib/orchestrator/operator-status-model.ts'),
+      'utf-8',
+    );
+
+    expect(inventorySource).not.toContain('const statusWeight');
+    expect(operatorStatusSource).not.toContain('packetStatusFromLaneStatus');
+    expect(inventorySource).toContain('resolveTerminalStatusEvidence');
+    expect(operatorStatusSource).toContain('resolveTerminalStatusEvidence');
   });
 });
 

--- a/tests/real-path-seams.test.ts
+++ b/tests/real-path-seams.test.ts
@@ -826,11 +826,68 @@ describe('seam E — review-ready projection is suppressed while owned Codex is 
       source: 'runtime-session.status',
       value: 'completed',
     });
+    expect(packet.statusEvidence).toEqual(agent.statusEvidence);
   });
 });
 
 describe('seam E — orchestrator state projects one terminal status authority', () => {
   const url = 'http://localhost:3001/api/orchestrator/state';
+
+  it('real state GET resolves lane evidence for a parked packet with no inventory agent', async () => {
+    const packetId = 'pkt-seam-E-lane-only-blocked';
+    const surfaceId = 'codex-owned:seam-E-lane-only-blocked';
+    const repoPath = mkdtempSync(join(os.tmpdir(), 'o8-seam-E-lane-only-repo-'));
+    tempDirs.push(repoPath);
+
+    const persistedLane = createLane({
+      repoPath,
+      worktreePath: repoPath,
+      branch: 'inline/seam-e-lane-only',
+      runtime: 'codex',
+      packetId,
+      sessionKey: surfaceId,
+    });
+    setLaneStatus(
+      persistedLane.id,
+      'awaiting_orchestrator',
+      'system',
+      'worktree_missing_unverified',
+    );
+    runtimeInventoryMock.agents = [];
+
+    const seed = await (await stateRoute.GET(operatorGet(url))).json();
+    const current: OrchestratorMissionState = seed.mission ?? createEmptyOrchestratorMissionState();
+    const mission: OrchestratorMissionState = {
+      ...current,
+      packets: [
+        ...current.packets,
+        packetFixture({ id: packetId, status: 'blocked', lane: null }),
+      ],
+    };
+    const postRes = await stateRoute.POST(operatorReq(url, { mission }));
+    expect(postRes.status).toBe(200);
+
+    const response = await stateRoute.GET(operatorGet(url));
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    const packet = json.mission.packets.find((candidate: OrchestratorPacket) => (
+      candidate.id === packetId
+    ));
+
+    expect(json.agents).toEqual([]);
+    expect(packet.statusEvidence).toMatchObject({
+      sessionId: surfaceId,
+      runtime: 'codex',
+      state: 'blocked',
+      authority: 'lane-state',
+    });
+    expect(packet.statusEvidence.summary).toContain('worktree_missing_unverified');
+    expect(packet.statusEvidence.evidence).toContainEqual({
+      source: 'lane-event:worktree_missing_unverified',
+      value: expect.stringContaining('awaiting_orchestrator'),
+    });
+    expect(runtimeInventoryMock.requests.at(-1)).toEqual({ fresh: false });
+  });
 
   it('real state GET carries resolved evidence from fabricated inventory to the desktop status rows', async () => {
     const packetId = 'pkt-seam-E-status-evidence';

--- a/tests/real-path-seams.test.ts
+++ b/tests/real-path-seams.test.ts
@@ -46,7 +46,7 @@ import type { TypedRow } from '@/lib/cortex/qa/types';
 const runtimeInventoryMock = vi.hoisted(() => ({
   agents: [] as Array<{
     sessionKey: string;
-    runtime: 'codex' | 'claude-code';
+    runtime: string;
     status: string;
     currentTask?: string | null;
     lastEventAt?: string | null;
@@ -56,6 +56,7 @@ const runtimeInventoryMock = vi.hoisted(() => ({
       lifecycle?: { availability?: 'awaiting-thread' | 'running' | 'ready-for-resume' };
     };
   }>,
+  requests: [] as Array<{ fresh?: boolean } | undefined>,
 }));
 
 const authDetectMock = vi.hoisted(() => {
@@ -88,7 +89,10 @@ vi.mock('@/lib/realtime/publisher', () => ({
 }));
 
 vi.mock('@/lib/runtime/inventory', () => ({
-  getRuntimeInventorySnapshot: vi.fn(async () => ({ agents: runtimeInventoryMock.agents })),
+  getRuntimeInventorySnapshot: vi.fn(async (options?: { fresh?: boolean }) => {
+    runtimeInventoryMock.requests.push(options);
+    return { agents: runtimeInventoryMock.agents };
+  }),
 }));
 
 vi.mock('@/lib/runtimes/shared/auth-detect', () => ({
@@ -170,6 +174,7 @@ const {
 
 afterEach(() => {
   runtimeInventoryMock.agents = [];
+  runtimeInventoryMock.requests = [];
   authDetectMock.unauthRuntime = null;
   resetRecallCacheForTests();
   rmSync(join(dataDir, 'operator-defaults.json'), { force: true });
@@ -798,6 +803,37 @@ describe('seam E — orchestrator state projects one terminal status authority',
     expect(agent.statusEvidence.evidence).toContainEqual({
       source: `lane:${persistedLane.id}.status`,
       value: 'running',
+    });
+    expect(runtimeInventoryMock.requests.at(-1)).toEqual({ fresh: false });
+  });
+
+  it('real state GET keeps a non-orchestrator cloud session with TerminalStatusEvidence', async () => {
+    const surfaceId = 'cloud-owned:seam-E-status-evidence';
+    runtimeInventoryMock.agents = [{
+      sessionKey: surfaceId,
+      runtime: 'cloud',
+      status: 'running',
+      currentTask: 'Running on registered cloud worker',
+      lastEventAt: '2026-08-29T12:05:00.000Z',
+      runtimeSurface: {
+        ownership: 'owned',
+        capabilities: { sendInput: false, interrupt: true },
+        lifecycle: { availability: 'running' },
+      },
+    }];
+
+    const response = await stateRoute.GET(operatorGet(url));
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    const agent = json.agents.find((candidate: { sessionKey: string }) => candidate.sessionKey === surfaceId);
+
+    expect(agent).toBeTruthy();
+    expect(agent.runtime).toBe('cloud');
+    expect(agent.statusEvidence).toMatchObject({
+      sessionId: surfaceId,
+      runtime: 'cloud',
+      state: 'working',
+      authority: 'runtime-event',
     });
   });
 

--- a/tests/real-path-seams.test.ts
+++ b/tests/real-path-seams.test.ts
@@ -53,6 +53,7 @@ const runtimeInventoryMock = vi.hoisted(() => ({
     status: string;
     currentTask?: string | null;
     lastEventAt?: string | null;
+    lastActivityAt?: number | null;
     runtimeSurface?: {
       ownership?: 'provider' | 'discovered' | 'owned';
       capabilities?: { sendInput?: boolean; interrupt?: boolean };
@@ -137,6 +138,7 @@ const { addSessionRule } = await import('@/lib/db/session-rules-store');
 const mergeRoute = await import('@/app/api/orchestrator/merge/route');
 const mergePreviewRoute = await import('@/app/api/orchestrator/merge-preview/route');
 const stateRoute = await import('@/app/api/orchestrator/state/route');
+const operatorStatusRoute = await import('@/app/api/operator/status/route');
 const createMissionRoute = await import('@/app/api/orchestrator/create-mission/route');
 const chatHistoryRoute = await import('@/app/api/v2/chat-history/route');
 const searchRoute = await import('@/app/api/panel/search/route');
@@ -816,34 +818,105 @@ describe('seam E — orchestrator state projects one terminal status authority',
     expect(runtimeInventoryMock.requests.at(-1)).toEqual({ fresh: false });
   });
 
-  it('real state GET keeps a non-orchestrator cloud session with TerminalStatusEvidence', async () => {
-    const surfaceId = 'cloud-owned:seam-E-status-evidence';
-    runtimeInventoryMock.agents = [{
-      sessionKey: surfaceId,
-      runtime: 'cloud',
+  it('real state GET keeps cloud and remote-customer sessions with TerminalStatusEvidence', async () => {
+    runtimeInventoryMock.agents = ['cloud', 'remote-customer'].map((runtime, index) => ({
+      sessionKey: `${runtime}-owned:seam-E-status-evidence`,
+      runtime,
       status: 'running',
-      currentTask: 'Running on registered cloud worker',
-      lastEventAt: '2026-08-29T12:05:00.000Z',
+      currentTask: `Running on registered ${runtime} worker`,
+      lastEventAt: `2026-08-29T12:0${5 + index}:00.000Z`,
       runtimeSurface: {
-        ownership: 'owned',
+        ownership: 'owned' as const,
         capabilities: { sendInput: false, interrupt: true },
-        lifecycle: { availability: 'running' },
+        lifecycle: { availability: 'running' as const },
       },
-    }];
+    }));
 
     const response = await stateRoute.GET(operatorGet(url));
     expect(response.status).toBe(200);
     const json = await response.json();
-    const agent = json.agents.find((candidate: { sessionKey: string }) => candidate.sessionKey === surfaceId);
+    for (const runtime of ['cloud', 'remote-customer']) {
+      const sessionId = `${runtime}-owned:seam-E-status-evidence`;
+      const agent = json.agents.find((candidate: { sessionKey: string }) => candidate.sessionKey === sessionId);
+      expect(agent).toBeTruthy();
+      expect(agent.runtime).toBe(runtime);
+      expect(agent.statusEvidence).toMatchObject({
+        sessionId,
+        runtime,
+        state: 'working',
+        authority: 'runtime-event',
+      });
+    }
+  });
 
-    expect(agent).toBeTruthy();
-    expect(agent.runtime).toBe('cloud');
-    expect(agent.statusEvidence).toMatchObject({
-      sessionId: surfaceId,
-      runtime: 'cloud',
-      state: 'working',
-      authority: 'runtime-event',
+  it('real operator status GET keeps cloud and remote-customer sessions', async () => {
+    runtimeInventoryMock.agents = ['cloud', 'remote-customer'].map((runtime) => ({
+      sessionKey: `${runtime}-owned:operator-status`,
+      runtime,
+      status: 'running',
+      currentTask: `Running on registered ${runtime} worker`,
+      lastEventAt: '2026-08-29T12:05:00.000Z',
+      runtimeSurface: {
+        ownership: 'owned' as const,
+        capabilities: { sendInput: false, interrupt: true },
+        lifecycle: { availability: 'running' as const },
+      },
+    }));
+
+    const response = await operatorStatusRoute.GET(operatorGet('http://localhost:3001/api/operator/status'));
+    expect(response.status).toBe(200);
+    const json = await response.json();
+
+    expect(json.agents.map((candidate: { runtime: string }) => candidate.runtime)).toEqual([
+      'cloud',
+      'remote-customer',
+    ]);
+    expect(json.agents.map((candidate: { statusEvidence: { runtime: string } }) => (
+      candidate.statusEvidence.runtime
+    ))).toEqual(['cloud', 'remote-customer']);
+  });
+
+  it('real state GET returns 200 and preserves peers when one observation time is invalid', async () => {
+    const invalidSessionId = 'remote-customer-owned:invalid-time';
+    const healthySessionId = 'cloud-owned:healthy-time';
+    runtimeInventoryMock.agents = [
+      {
+        sessionKey: invalidSessionId,
+        runtime: 'remote-customer',
+        status: 'running',
+        currentTask: 'Waiting for a valid observation',
+        lastEventAt: 'not-a-time',
+        lastActivityAt: null,
+      },
+      {
+        sessionKey: healthySessionId,
+        runtime: 'cloud',
+        status: 'running',
+        currentTask: 'Healthy registered runtime session',
+        lastEventAt: '2026-08-29T12:08:00.000Z',
+      },
+    ];
+
+    const response = await stateRoute.GET(operatorGet(url));
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    const invalid = json.agents.find((candidate: { sessionKey: string }) => (
+      candidate.sessionKey === invalidSessionId
+    ));
+
+    expect(json.agents.map((candidate: { sessionKey: string }) => candidate.sessionKey)).toEqual([
+      invalidSessionId,
+      healthySessionId,
+    ]);
+    expect(invalid.statusEvidence).toMatchObject({
+      sessionId: invalidSessionId,
+      runtime: 'remote-customer',
+      state: 'unknown',
+      authority: 'raw-terminal',
+      summary: 'No observation with a valid time was available.',
+      evidence: [],
     });
+    expect(Date.parse(invalid.statusEvidence.observedAt)).not.toBeNaN();
   });
 
   it('keeps precedence code in the terminal status resolver instead of the old call sites', () => {


### PR DESCRIPTION
Part of #1722 (child A: the status-evidence contract). Child B (governed action adapters, screen signatures, controls) is deliberately not started.

## What changes

**One resolver, one authority per state.** `src/lib/terminal-status/resolve.ts` turns the records o8 already keeps (runtime session status and lifecycle, owned-run records, lane status and lane events, pending approvals, review-queue rows, the raw ws-server lifecycle) into a `TerminalStatusEvidence` record: `state`, the `authority` that decided it (`runtime-event` > `lane-state` > `raw-terminal`; `known-screen-adapter` is reserved for child B and never produced), `observedAt`, a one-line `summary`, the `evidence[]` that was considered, and a `fallbackReason` when a higher authority was absent or stale. The resolver is total: a session with no usable observation yields `unknown` instead of throwing, and both status routes catch per session, so one malformed session can no longer fail the whole response.

**The two competing precedence rules are gone.** The operator status model's lane-over-runtime rule and the runtime inventory's status weight table both delegated to the resolver and were deleted; a real-path test asserts neither can come back. Inventory policy is otherwise unchanged from main: the four `isDispatchableRuntime` guards stay exactly where they were, with a parity test that pins them.

**Governance states outrank a finished run.** A live runtime event (working, failed, blocked) wins; once the runtime reports the run finished, a lane in `review-ready` or `blocked` outranks that completion, matching the existing precedent that review-ready is suppressed only while the worker is still active. Owned IDE sessions contribute their supervisor status as runtime evidence instead of resolving to `unknown`.

**Packets without a live session carry evidence too.** A parked or finished packet whose worker is gone resolves from its lane, lane events, pending approvals and review-queue rows (authority `lane-state`); the blocked summary names the reason (the orchestrator event label, the pending approval's title, or the agent's last question). The record is a read-time projection: it survives the desktop's mission normalizer (a real-path test runs the route JSON through it) and is stripped by every mission persistence write.

**Same record on every surface.** `AgentSummary.statusEvidence` flows through the existing state and fleet feeds (no new polling) to one shared `TerminalStatusEvidenceDisclosure`: the terminal panel strip and Terminal Mode tabs show `state · authority` with the summary and expandable evidence rows; the agent tile caption, the packet details popover, the spawned-agent hover card and the extra-agents list read the same record. `/api/operator/status` (MCP `o8_status`, CLI) carries `authority`, `summary` and `observedAt`.

**State route cost.** `/api/orchestrator/state` is polled by desktop, mobile, MCP and the CLI; it now uses the cached inventory snapshot and reads at most 50 lane events, only for sessions in the response.

**Incidental fix.** The extra-agents list parsed `json.agents` from the command-center snapshot, which has always returned `{ fleet: { agents } }`, so it was silently empty on every fetch; it now reads `fleet.agents`.

## Verification

Unit ladder table (every state, every disagreement: runtime failed over lane working, runtime and lane over raw terminal, stale runtime falling through, approvals → blocked, review queue → review-ready, never `known-screen-adapter`, total on invalid time); real-path tests through the actual `/api/orchestrator/state` route (fabricated inventory against a persisted lane; malformed agent leaves peers intact); inventory parity test for non-dispatchable adapters; component tests for the disclosure (readable source labels, relative observation time, duplicate-row folding, packet-only evidence). tsc, focused suites, real-path integration 45/45, lint at the cap with zero errors, classification check, full hermetic suite (633 files, 3,788 tests), run by the worker and again by the reviewer on the final tree.

## Not in this PR

Screen-derived adapters and any visual controls (child B). The strip's placement above resident terminal panels is a taste call still open with the operator; moving it is a one-file change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified terminal status indicators across agent panels, workspace terminals, packet rows, and mission details.
  * Added expandable status diagnostics showing evidence sources, timestamps, summaries, and fallback reasons.
  * Included runtime, approval, review, and lane activity information in orchestrator and operator status views.
  * Preserved status context across attached terminal sessions and active workspace tabs.

* **Bug Fixes**
  * Improved status accuracy and reduced transient failure flicker.
  * Prevented read-only status diagnostics from being saved as mission data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->