### PR TITLE
fix(lane): let operators close packets whose worktree is gone and stop review turns on discard

### DIFF
--- a/cli/src/commands/packet/close.test.ts
+++ b/cli/src/commands/packet/close.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  fetchMutation: vi.fn(),
+  printJson: vi.fn(),
+}));
+
+vi.mock('../../config.js', () => ({ resolveConfig: () => ({ apiBase: 'http://127.0.0.1:47120' }) }));
+vi.mock('../../output.js', () => ({
+  printHumanHeading: vi.fn(),
+  printHumanKv: vi.fn(),
+  printJson: h.printJson,
+}));
+vi.mock('./correlated-mutation.js', () => ({ fetchCorrelatedPacketMutation: h.fetchMutation }));
+vi.mock('./target.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./target')>();
+  return {
+    ...actual,
+    resolvePacketTarget: async (target: string) => ({ packetId: target, laneId: 'lane-1' }),
+    requirePacketId: (target: { packetId: string }) => target.packetId,
+  };
+});
+
+import { runPacketClose } from './close';
+
+describe('o8 packet discard', () => {
+  beforeEach(() => {
+    h.fetchMutation.mockReset();
+    h.printJson.mockReset();
+  });
+
+  it('sends the missing-worktree acknowledgement through the canonical discard route', async () => {
+    h.fetchMutation.mockResolvedValue({
+      status: 200,
+      data: {
+        ok: true,
+        result: {
+          closed: true,
+          disposition: 'wontfix',
+          laneId: 'lane-1',
+          worktreeCleanup: 'missing',
+          note: 'Worktree was already missing.',
+        },
+      },
+    });
+
+    await expect(runPacketClose(
+      { human: false, verbose: false },
+      ['packet-1', '--acknowledge-missing-worktree'],
+      'discard',
+    )).resolves.toBe(0);
+
+    expect(h.fetchMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      '/api/orchestrator/discard-packet',
+      expect.objectContaining({
+        packetId: 'packet-1',
+        disposition: 'wontfix',
+        acknowledgeMissingWorktree: true,
+        clientMutationId: expect.any(String),
+      }),
+      expect.anything(),
+    );
+    expect(h.printJson).toHaveBeenCalledWith(expect.objectContaining({
+      schema: 'o8/cli/packet.discard/v1',
+      packet: expect.objectContaining({ worktreeCleanup: 'missing' }),
+    }));
+  });
+});

--- a/cli/src/commands/packet/close.ts
+++ b/cli/src/commands/packet/close.ts
@@ -27,6 +27,7 @@ interface CloseResponse {
     status?: string;
     laneId?: string;
     worktreeRemoved?: boolean;
+    worktreeCleanup?: 'missing' | 'removed' | 'preserved';
     preservedBranch?: string | null;
   };
   error?: { message?: string } | string;
@@ -38,13 +39,21 @@ function errorMessage(response: CloseResponse | null | undefined): string {
   return 'Packet close was rejected.';
 }
 
-export async function runPacketClose(mode: OutputMode, rest: string[]): Promise<number> {
-  const args = parsePacketArguments(rest, { command: 'close', valueFlags: ['reason', 'note', 'idempotency-key'] });
-  const reason = args.values.reason?.trim();
+export async function runPacketClose(
+  mode: OutputMode,
+  rest: string[],
+  command: 'close' | 'discard' = 'close',
+): Promise<number> {
+  const args = parsePacketArguments(rest, {
+    command,
+    valueFlags: ['reason', 'note', 'idempotency-key'],
+    booleanFlags: ['acknowledge-missing-worktree'],
+  });
+  const reason = args.values.reason?.trim() || (command === 'discard' ? 'wontfix' : '');
   if (!reason || !(DISPOSITIONS as readonly string[]).includes(reason)) {
     throw new CliError(
       'invalid_args',
-      'o8 packet close requires --reason adopted_elsewhere|superseded|spec_changed|wontfix.',
+      `o8 packet ${command} requires --reason adopted_elsewhere|superseded|spec_changed|wontfix.`,
       EXIT.INVALID_ARGS,
       'Example: o8 packet close --reason adopted_elsewhere --note "Implemented in o8-mobile."',
     );
@@ -59,6 +68,7 @@ export async function runPacketClose(mode: OutputMode, rest: string[]): Promise<
       packetId,
       disposition: reason,
       note: args.values.note?.trim() || undefined,
+      acknowledgeMissingWorktree: args.booleans.has('acknowledge-missing-worktree'),
       clientMutationId: args.values['idempotency-key']?.trim() || randomUUID(),
     },
     { timeoutMs: SLOW_MUTATION_TIMEOUT_MS },
@@ -69,23 +79,24 @@ export async function runPacketClose(mode: OutputMode, rest: string[]): Promise<
 
   const result = res.data.result;
   const payload = {
-    schema: 'o8/cli/packet.close/v1',
+    schema: `o8/cli/packet.${command}/v1`,
     packet: {
       id: packetId,
       disposition: result.disposition ?? reason,
       laneId: result.laneId ?? null,
       preservedBranch: result.preservedBranch ?? null,
       worktreeRemoved: result.worktreeRemoved === true,
+      worktreeCleanup: result.worktreeCleanup ?? null,
     },
     note: result.note ?? 'Closed unmerged.',
   };
   if (mode.human) {
-    printHumanHeading('packet close');
+    printHumanHeading(`packet ${command}`);
     printHumanKv([
       ['packet', packetId],
       ['disposition', result.disposition ?? reason],
       ['branch', result.preservedBranch ?? '(none)'],
-      ['worktree', result.worktreeRemoved ? 'removed' : 'preserved or already absent'],
+      ['worktree', result.worktreeCleanup ?? (result.worktreeRemoved ? 'removed' : 'preserved')],
       ['note', result.note ?? 'Closed unmerged.'],
     ]);
   } else {

--- a/cli/src/commands/packet/help.ts
+++ b/cli/src/commands/packet/help.ts
@@ -9,6 +9,7 @@ export const PACKET_SUBCOMMANDS = [
   'park',
   'restore',
   'close',
+  'discard',
   'reset',
   'stop',
   'cancel',
@@ -34,6 +35,7 @@ export const PACKET_COMMAND_LINES = `  packet info [id]     packet metadata; exp
   packet park [id]     remove a verified review-ready workspace while preserving immutable review
   packet restore [id]  restore a parked workspace to its exact reviewed state
   packet close [id]    close without merging (--reason adopted_elsewhere|superseded|spec_changed|wontfix)
+  packet discard [id]  discard without merging (--acknowledge-missing-worktree when the path is gone)
   packet reset [id]    wipe a stuck packet's worktree + lane (then mission dispatch)
   packet stop [id]     interrupt the worker and hold the packet (resume with packet reset/rerun)
   packet cancel [id]   alias for packet stop; interrupt and hold the packet

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -434,7 +434,9 @@ async function dispatch(args: ParsedArgs): Promise<number> {
       if (secondary === 'park' || secondary === 'restore') {
         return runPacketWorkspace(args.mode, secondary, args.rest);
       }
-      if (secondary === 'close') return runPacketClose(args.mode, args.rest);
+      if (secondary === 'close' || secondary === 'discard') {
+        return runPacketClose(args.mode, args.rest, secondary);
+      }
       if (secondary === 'reset') return runPacketReset(args.mode, args.rest);
       if (secondary === 'stop' || secondary === 'cancel') return runPacketStop(args.mode, args.rest);
       if (secondary === 'retry') return runPacketRetry(args.mode, args.rest);

--- a/docs/user/orchestration-playbook.md
+++ b/docs/user/orchestration-playbook.md
@@ -77,6 +77,8 @@ diagnose before spending a third worker.
 
 ### Verify your own verbs fired
 
+Packet discard has three worktree cases. If the directory still exists, o8 removes it through the normal guarded cleanup and closes only after removal is confirmed. If the directory is already absent and the lane has a clean `runtime_process_exit` receipt for its worker session, o8 stops any active review turn, records `worktree_missing`, and closes without trying to delete the missing path. If the directory is absent without that worker-exit receipt, the lane parks as `worktree_missing_unverified` and the Incident Queue offers an acknowledgement action; use `o8 packet discard --acknowledge-missing-worktree` or pass `acknowledgeMissingWorktree: true` to `close_packet_unmerged` after inspecting the packet. The acknowledgement applies only while the path is absent; a directory that exists still requires confirmed cleanup.
+
 A steer that returns ok can still be a silent no-op (live-hit: every
 steer-resume for hours was exiting code 2 pre-turn; the UI showed nothing).
 After steering, confirm the session actually relaunched (lane event, live

--- a/src/app/api/orchestrator/discard-packet/route.ts
+++ b/src/app/api/orchestrator/discard-packet/route.ts
@@ -34,7 +34,17 @@ export async function POST(request: NextRequest) {
   if (!clientKey) return operatorError('client_mutation_id_required', 'clientMutationId is required.', 400);
   const disposition = record.disposition ?? record.reason;
   const note = record.note;
-  const canonicalBody = JSON.stringify({ packetId, disposition, note });
+  if (record.acknowledgeMissingWorktree !== undefined
+    && typeof record.acknowledgeMissingWorktree !== 'boolean') {
+    return operatorError('invalid_request', 'acknowledgeMissingWorktree must be a boolean.', 400);
+  }
+  const acknowledgeMissingWorktree = record.acknowledgeMissingWorktree === true;
+  const canonicalBody = JSON.stringify({
+    packetId,
+    disposition,
+    note,
+    acknowledgeMissingWorktree,
+  });
   try {
     const binding = bindIdempotencyClientMutation({
       namespace: 'discard_packet',
@@ -51,7 +61,12 @@ export async function POST(request: NextRequest) {
       key: deriveIdempotencyKey({ verb: 'discard_packet', scopeId: packetId, clientKey, body: canonicalBody }),
       verb: 'discard_packet',
       scopeId: packetId,
-    }, async () => closePacketUnmerged({ packetId, disposition, note }));
+    }, async () => closePacketUnmerged({
+      packetId,
+      disposition,
+      note,
+      acknowledgeMissingWorktree,
+    }));
     if (outcome.inProgress) return unresolvedIdempotencyResponse(outcome, 'packet close') ?? operatorSuccess(replayShape(outcome), 202);
     const close = outcome.result;
     if (!close.ok) {

--- a/src/components/desktop/O8InboxPane.tsx
+++ b/src/components/desktop/O8InboxPane.tsx
@@ -329,31 +329,33 @@ export function O8InboxPane({ active = true }: { active?: boolean }) {
 
   const stopPacket = useCallback(async (item: SupervisorInboxItem) => {
     if (!item.packetId || !beginIncidentAction(item.id)) return;
-    setActionNote(item.id, 'Stopping the packet...');
+    const acknowledgeMissing = item.payload.recoveryAction === 'acknowledge_missing_worktree';
+    setActionNote(item.id, acknowledgeMissing ? 'Acknowledging the missing worktree...' : 'Stopping the packet...');
     let inProgress = false;
     try {
+      const endpoint = acknowledgeMissing ? '/api/orchestrator/discard-packet' : '/api/agent-control/action';
+      const requestBody = acknowledgeMissing
+        ? { packetId: item.packetId, disposition: 'wontfix', acknowledgeMissingWorktree: true, clientMutationId: crypto.randomUUID() }
+        : { ref: { kind: 'packet', id: item.packetId }, action: { kind: 'terminate' }, clientMutationId: crypto.randomUUID() };
       const { response, payload } = await fetchCorrelatedActionReceipt<{
         ok?: boolean;
-        error?: string;
+        error?: { message?: string } | string;
         result?: { ok?: boolean; note?: string; inProgress?: boolean; status?: string };
-      }>('/api/agent-control/action', {
+      }>(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          ref: { kind: 'packet', id: item.packetId },
-          action: { kind: 'terminate' },
-          clientMutationId: crypto.randomUUID(),
-        }),
+        body: JSON.stringify(requestBody),
       });
+      const errorMessage = typeof payload?.error === 'string' ? payload.error : payload?.error?.message;
       if (!response.ok || payload?.ok === false || payload?.result?.ok === false) {
-        throw new Error(payload?.result?.note ?? payload?.error ?? 'Stop was rejected.');
+        throw new Error(payload?.result?.note ?? errorMessage ?? 'Packet action was rejected.');
       }
       await fetch('/api/panel/supervisor-inbox', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'dismiss', id: item.id }),
       }).catch(() => {});
-      setActionNote(item.id, 'Packet stopped and held.');
+      setActionNote(item.id, acknowledgeMissing ? 'Missing worktree acknowledged; packet discarded.' : 'Packet stopped and held.');
       window.dispatchEvent(new CustomEvent('o8:supervisor-inbox'));
       await refresh();
     } catch (error) {
@@ -481,6 +483,7 @@ export function O8InboxPane({ active = true }: { active?: boolean }) {
             const isSelfHealed = item.status === 'self_healed';
             const isResolved = item.status === 'resolved';
             const isOutsideHumanWaiting = item.kind === 'outside_human_waiting';
+            const acknowledgeMissing = item.payload.recoveryAction === 'acknowledge_missing_worktree';
             const threadUrl = typeof item.payload.url === 'string' ? item.payload.url : null;
             const transcriptPreview = expandedTranscriptById[item.id] ?? null;
             const actionNote = actionNoteById[item.id] ?? null;
@@ -606,11 +609,11 @@ export function O8InboxPane({ active = true }: { active?: boolean }) {
                         <RetryGlyph />
                       </InboxActionButton>
                       <InboxActionButton
-                        title="Stop packet"
+                        title={acknowledgeMissing ? 'Acknowledge missing worktree and discard packet' : 'Stop packet'}
                         onClick={() => { void stopPacket(item); }}
                         disabled={busyIncidentId !== null}
                       >
-                        <StopGlyph />
+                        {acknowledgeMissing ? <ArchiveGlyph /> : <StopGlyph />}
                       </InboxActionButton>
                     </>
                   ) : null}

--- a/src/lib/inbox/card-copy.ts
+++ b/src/lib/inbox/card-copy.ts
@@ -82,6 +82,12 @@ export function composeSupervisorInboxCardCopy(item: SupervisorInboxItem): Inbox
         subline: supervisorMetadata(item, [worktree]),
       };
     case 'packet_missing':
+      if (item.payload.recoveryAction === 'acknowledge_missing_worktree') {
+        return {
+          headline: 'The packet worktree is gone and merge ancestry is unverified; acknowledge the missing path to discard it.',
+          subline: supervisorMetadata(item, [item.errorExcerpt, worktree]),
+        };
+      }
       return {
         headline: 'o8 could not find the packet record; inspect the lane before merging or retrying.',
         subline: supervisorMetadata(item, [worktree]),

--- a/src/lib/lane/reconcile.ts
+++ b/src/lib/lane/reconcile.ts
@@ -8,6 +8,7 @@ import type { Lane, LaneRuntime, LaneStatus } from '@/lib/lane/types';
 import { getRuntime } from '@/lib/runtimes';
 import { crashSurvivableWorkersEnabled } from '@/lib/runtimes/shared/owned-session/crash-survival';
 import { listWorkspaceSnapshotsByPacketId } from '@/lib/worktree/snapshot-state';
+import { enqueueInboxItem } from '@/lib/supervisor/inbox';
 
 const execFileAsync = promisify(execFile);
 
@@ -255,6 +256,20 @@ async function runReconcileOrphanedWorktrees(): Promise<number> {
       continue;
     }
     setLaneStatus(lane.id, 'awaiting_orchestrator', 'system', 'worktree_missing_unverified');
+    enqueueInboxItem({
+      repoPath: lane.repoPath,
+      packetId: lane.packetId,
+      kind: 'packet_missing',
+      status: 'human_required',
+      payload: {
+        laneId: lane.id,
+        laneLabel: lane.label,
+        worktreePath: lane.worktreePath,
+        blockedReason: 'worktree_missing_unverified',
+        recoveryAction: 'acknowledge_missing_worktree',
+        summary: 'The packet worktree is missing and merge ancestry could not be verified. Acknowledge the missing path to discard the packet without deleting anything that still exists on disk.',
+      },
+    });
     console.warn(
       `[reconcile] Lane ${lane.id} (${lane.label || lane.branch}) worktree is gone but merge ancestry is unverified — left for operator review`,
     );

--- a/src/lib/lane/review-quota-fallback.ts
+++ b/src/lib/lane/review-quota-fallback.ts
@@ -9,7 +9,11 @@ import { getOperatorDefaultsSync } from '@/lib/operator/defaults';
 import { createBackendRoleRouteChoice } from '@/lib/operator/role-routing';
 import { recordRoleRoutingReceiptSafely } from '@/lib/operator/role-routing-ledger';
 import { MODEL_IDS } from '@/lib/models';
-import { finishReviewTurn, startReviewTurn } from '@/lib/lane/review-turn-state';
+import {
+  bindReviewTurnAbortController,
+  finishReviewTurn,
+  startReviewTurn,
+} from '@/lib/lane/review-turn-state';
 import type { OrchestratorEvent } from './orchestrator-stream-events';
 import {
   getActiveReviewerBackend,
@@ -76,6 +80,15 @@ async function runAttempt(input: {
     surface: input.surface,
     expectedHeadSha: input.expectedHeadSha,
   });
+  const turnController = new AbortController();
+  const forwardAbort = () => turnController.abort(input.signal?.reason);
+  if (input.signal?.aborted) forwardAbort();
+  else input.signal?.addEventListener('abort', forwardAbort, { once: true });
+  const unbindAbortController = bindReviewTurnAbortController(
+    input.laneId,
+    reviewTurnId,
+    turnController,
+  );
   let text = '';
   let quotaError: string | null = null;
   let unavailableReason: ReviewUnavailableReason | null = null;
@@ -93,7 +106,7 @@ async function runAttempt(input: {
     }, {
       threadId: input.threadId,
       ...(input.model ? { model: input.model } : {}),
-      ...(input.signal ? { signal: input.signal } : {}),
+      signal: turnController.signal,
     });
   } catch (error) {
     if (isRuntimeQuotaLimitError(error)) quotaError = message(error);
@@ -102,6 +115,9 @@ async function runAttempt(input: {
       if (isReviewerSessionBusyMessage(errorMessage)) unavailableReason = 'session_busy';
       errors.push(errorMessage);
     }
+  } finally {
+    unbindAbortController();
+    input.signal?.removeEventListener('abort', forwardAbort);
   }
   // Claude Code can emit a terminal subscription denial as ordinary assistant
   // text and then exit successfully. Treat that observed frame as exhaustion so
@@ -110,7 +126,11 @@ async function runAttempt(input: {
     quotaError = text;
     text = '';
   }
-  const outcome = quotaError ? 'quota_discarded' : errors.length > 0 ? 'failed' : 'completed';
+  const outcome = turnController.signal.aborted
+    ? 'failed'
+    : quotaError
+      ? 'quota_discarded'
+      : errors.length > 0 ? 'failed' : 'completed';
   try {
     finishReviewTurn({ laneId: input.laneId, reviewTurnId, outcome });
   } catch (error) {

--- a/src/lib/lane/review-turn-state.ts
+++ b/src/lib/lane/review-turn-state.ts
@@ -6,15 +6,28 @@ import { recordLaneEvent } from '@/lib/lane/events';
 
 interface ReviewTurnEventPayload {
   reviewTurnId?: unknown;
+  threadId?: unknown;
+  backend?: unknown;
   surface?: unknown;
   expectedHeadSha?: unknown;
 }
 
 export interface ActiveReviewTurn {
   id: string;
+  threadId: string | null;
+  backend: string | null;
   surface: string | null;
   expectedHeadSha: string | null;
 }
+
+export interface ReviewTurnStopResult extends ActiveReviewTurn {
+  abortRequested: boolean;
+}
+
+const reviewTurnAbortControllers = new Map<string, {
+  laneId: string;
+  controller: AbortController;
+}>();
 
 export function startReviewTurn(input: {
   laneId: string;
@@ -39,7 +52,7 @@ export function findActiveReviewTurn(laneId: string): ActiveReviewTurn | null {
     SELECT verb, payload_json
     FROM lane_events
     WHERE lane_id = ?
-      AND verb IN ('review_turn_started', 'review_turn_finished')
+      AND verb IN ('review_turn_started', 'review_turn_finished', 'review_turn_stopped')
     ORDER BY rowid DESC
     LIMIT 1
   `).get(laneId) as { verb: string; payload_json: string } | undefined;
@@ -49,6 +62,8 @@ export function findActiveReviewTurn(laneId: string): ActiveReviewTurn | null {
     return typeof payload.reviewTurnId === 'string'
       ? {
           id: payload.reviewTurnId,
+          threadId: typeof payload.threadId === 'string' ? payload.threadId : null,
+          backend: typeof payload.backend === 'string' ? payload.backend : null,
           surface: typeof payload.surface === 'string' ? payload.surface : null,
           expectedHeadSha: typeof payload.expectedHeadSha === 'string'
             ? payload.expectedHeadSha
@@ -62,6 +77,44 @@ export function findActiveReviewTurn(laneId: string): ActiveReviewTurn | null {
 
 export function findActiveReviewTurnId(laneId: string): string | null {
   return findActiveReviewTurn(laneId)?.id ?? null;
+}
+
+export function bindReviewTurnAbortController(
+  laneId: string,
+  reviewTurnId: string,
+  controller: AbortController,
+): () => void {
+  reviewTurnAbortControllers.set(reviewTurnId, { laneId, controller });
+  return () => {
+    const binding = reviewTurnAbortControllers.get(reviewTurnId);
+    if (binding?.laneId === laneId && binding.controller === controller) {
+      reviewTurnAbortControllers.delete(reviewTurnId);
+    }
+  };
+}
+
+export function stopActiveReviewTurn(input: {
+  laneId: string;
+  reason: 'packet_discarded' | 'packet_stopped';
+}): ReviewTurnStopResult | null {
+  const active = findActiveReviewTurn(input.laneId);
+  if (!active) return null;
+  const binding = reviewTurnAbortControllers.get(active.id);
+  const abortRequested = binding?.laneId === input.laneId;
+  if (abortRequested) {
+    binding.controller.abort(input.reason);
+    reviewTurnAbortControllers.delete(active.id);
+  }
+  recordLaneEvent(input.laneId, 'review_turn_stopped', 'system', {
+    reviewTurnId: active.id,
+    threadId: active.threadId,
+    backend: active.backend,
+    surface: active.surface,
+    sessionClass: 'review',
+    reason: input.reason,
+    abortRequested,
+  });
+  return { ...active, abortRequested };
 }
 
 export function finishReviewTurn(input: {

--- a/src/lib/lane/types.ts
+++ b/src/lib/lane/types.ts
@@ -415,6 +415,10 @@ export type LaneEventVerb =
   | 'task_contract_missing'
   | 'review_turn_started'
   | 'review_turn_finished'
+  | 'review_turn_stopped'
+  // Operator close receipt. Payload includes packetId, worktreeCleanup,
+  // reason, and whether missing-worktree acknowledgement was supplied.
+  | 'packet_discarded'
   | 'worker_quota_exhausted'
   | 'worker_fallback'
   | 'worker_fallback_terminal'

--- a/src/lib/lane/worker-session-state.ts
+++ b/src/lib/lane/worker-session-state.ts
@@ -1,0 +1,48 @@
+import { getLaneEvents } from '@/lib/lane/registry';
+import type { Lane, LaneEvent } from '@/lib/lane/types';
+
+function eventMatchesWorkerSession(event: LaneEvent, lane: Lane): boolean {
+  if (event.verb !== 'runtime_process_exit') return false;
+  const surfaceId = typeof event.payload.surfaceId === 'string'
+    ? event.payload.surfaceId.trim()
+    : '';
+  const sessionKey = lane.sessionKey?.trim() ?? '';
+  if (surfaceId && sessionKey) return surfaceId === sessionKey;
+  return !surfaceId || !sessionKey;
+}
+
+/** The newest durable process-exit receipt for this lane's worker session. */
+export function newestWorkerProcessExit(lane: Lane): LaneEvent | null {
+  return getLaneEvents(lane.id, 200)
+    .findLast((event) => eventMatchesWorkerSession(event, lane)) ?? null;
+}
+
+export function hasRecordedWorkerExit(lane: Lane): boolean {
+  return newestWorkerProcessExit(lane) !== null;
+}
+
+export function hasRecordedCleanWorkerExit(lane: Lane): boolean {
+  const event = newestWorkerProcessExit(lane);
+  if (!event) return false;
+  const { classification, exitCode, signal } = event.payload;
+  return classification === 'clean-exit'
+    || (exitCode === 0 && (signal === null || signal === undefined));
+}
+
+/**
+ * Return one target per worker session that has no durable exit receipt.
+ * Review turns are tracked separately and never enter this worker kill set.
+ */
+export function liveWorkerSessionLanes(lanes: Lane[]): Lane[] {
+  const seen = new Set<string>();
+  const live: Lane[] = [];
+  for (const lane of lanes) {
+    const sessionKey = lane.sessionKey?.trim();
+    if (!sessionKey || hasRecordedWorkerExit(lane)) continue;
+    const key = `${lane.runtime}\0${sessionKey}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    live.push(lane);
+  }
+  return live;
+}

--- a/src/lib/mcp/operator-handlers/close-packet.ts
+++ b/src/lib/mcp/operator-handlers/close-packet.ts
@@ -31,6 +31,10 @@ export const CLOSE_PACKET_TOOLS: McpTool[] = [
           type: 'string',
           description: 'Optional operator context, up to 1,000 characters.',
         },
+        acknowledgeMissingWorktree: {
+          type: 'boolean',
+          description: 'Close when the recorded worktree path is absent even if no clean worker-exit receipt exists. Never bypasses cleanup when the directory still exists.',
+        },
       },
       required: ['packetId', 'disposition'],
     },
@@ -43,12 +47,17 @@ export async function handleClosePacketUnmerged(args: Record<string, unknown>): 
     if (!(CLOSE_UNMERGED_DISPOSITIONS as readonly string[]).includes(disposition)) {
       throw new Error(`disposition must be one of: ${CLOSE_UNMERGED_DISPOSITIONS.join(', ')}.`);
     }
+    if (args.acknowledgeMissingWorktree !== undefined
+      && typeof args.acknowledgeMissingWorktree !== 'boolean') {
+      throw new Error('acknowledgeMissingWorktree must be a boolean.');
+    }
     const result = await apiFetchCorrelatedMutation(
       '/api/orchestrator/discard-packet',
       {
         packetId: requiredString(args, 'packetId'),
         disposition,
         note: optionalString(args, 'note') || undefined,
+        acknowledgeMissingWorktree: args.acknowledgeMissingWorktree === true,
       },
       'clientMutationId',
     );

--- a/src/lib/orchestrator/close-unmerged-shared.ts
+++ b/src/lib/orchestrator/close-unmerged-shared.ts
@@ -48,6 +48,8 @@ export type CloseUnmergedResult =
       laneId: string;
       packetId: string;
       worktreeRemoved: boolean;
+      worktreeCleanup: 'missing' | 'removed' | 'preserved';
+      stoppedReviewTurns: number;
       preservedBranch: string | null;
       preservedBranches: string[];
       preservationReceipts: BranchPreservationReceipt[];

--- a/src/lib/orchestrator/close-unmerged.ts
+++ b/src/lib/orchestrator/close-unmerged.ts
@@ -1,6 +1,13 @@
+import { existsSync } from 'node:fs';
 import { dispatch } from '@/lib/lane/commands';
 import { recordLaneEvent } from '@/lib/lane/events';
-import { findLatestLaneByPacket, listLanes } from '@/lib/lane/registry';
+import { findLatestLaneByPacket, listLanes, updateLane } from '@/lib/lane/registry';
+import { cancelAutoReviewForLane } from '@/lib/lane/review-cancellation';
+import { stopActiveReviewTurn } from '@/lib/lane/review-turn-state';
+import {
+  hasRecordedCleanWorkerExit,
+  liveWorkerSessionLanes,
+} from '@/lib/lane/worker-session-state';
 import {
   archiveLaneSessionsConfirmed,
   killLaneSessionsConfirmed,
@@ -61,7 +68,11 @@ const CLOSEABLE_LANE_STATUSES = new Set([
   'failed',
 ]);
 
-async function markPacketClosed(guard: PacketLifecycleGuard, closedAt: string): Promise<boolean> {
+async function markPacketClosed(
+  guard: PacketLifecycleGuard,
+  closedAt: string,
+  worktreeCleanup: 'missing' | 'removed' | 'preserved',
+): Promise<boolean> {
   const closed = await mutatePacketLifecycleGuard(guard, (packet) => {
     packet.status = 'archived';
     packet.queueState = 'held';
@@ -72,7 +83,9 @@ async function markPacketClosed(guard: PacketLifecycleGuard, closedAt: string): 
     packet.archivedAt = closedAt;
     packet.blockedReason = null;
     packet.lastEventAt = closedAt;
-    packet.lastEventLabel = 'closed_unmerged';
+    packet.lastEventLabel = worktreeCleanup === 'missing'
+      ? 'discarded_worktree_missing'
+      : 'closed_unmerged';
     return true;
   });
   return closed.matched && closed.result === true;
@@ -82,6 +95,7 @@ async function closePacketUnmergedUnlocked(input: {
   packetId: string;
   disposition: unknown;
   note: unknown;
+  acknowledgeMissingWorktree: boolean;
 }): Promise<CloseUnmergedResult> {
   const rawDisposition = input.disposition ?? 'wontfix';
   if (!isCloseUnmergedDisposition(rawDisposition)) {
@@ -158,15 +172,45 @@ async function closePacketUnmergedUnlocked(input: {
     worktreeRefs.set(refKey, target.worktreePath);
   }
 
+  const missingWorktreeBindings = new Set(lanesToClose.flatMap((target) => {
+    const worktreePath = target.worktreePath?.trim();
+    return worktreePath && !existsSync(worktreePath)
+      ? [`${target.id}\0${worktreePath}`]
+      : [];
+  }));
   try {
-    const kills = await killLaneSessionsConfirmed(lanesToClose);
+    const stoppedReviewTurns = [];
+    const reviewedLaneIds = new Set<string>();
+    for (const target of lanesToClose) {
+      if (reviewedLaneIds.has(target.id)) continue;
+      reviewedLaneIds.add(target.id);
+      cancelAutoReviewForLane(target.id, 'packet_discarded');
+      const stopped = stopActiveReviewTurn({ laneId: target.id, reason: 'packet_discarded' });
+      if (stopped) stoppedReviewTurns.push(stopped);
+    }
+
+    const kills = await killLaneSessionsConfirmed(liveWorkerSessionLanes(lanesToClose));
     const survivors = kills.filter((outcome) => !outcome.confirmed && !outcome.alreadyDead);
     if (survivors.length > 0) {
       await markPacketLifecycleFailure(guard, 'kill_unconfirmed');
       return {
         ok: false,
         code: 'kill_unconfirmed',
-        message: 'Close refused because the worker process could not be confirmed stopped. The lane and worktree remain intact.',
+        message: `Close refused because ${survivors.length} worker session class process${survivors.length === 1 ? '' : 'es'} could not be confirmed stopped. The lane and worktree remain intact.`,
+        status: 409,
+      };
+    }
+    const unverifiedMissing = lanesToClose.find((target) => {
+      const worktreePath = target.worktreePath?.trim();
+      if (!worktreePath || !missingWorktreeBindings.has(`${target.id}\0${worktreePath}`)) return false;
+      return !input.acknowledgeMissingWorktree && !hasRecordedCleanWorkerExit(target);
+    });
+    if (unverifiedMissing) {
+      await restorePacketLifecycleGuard(guard);
+      return {
+        ok: false,
+        code: 'worktree_missing_unverified',
+        message: `Close refused because worktree ${unverifiedMissing.worktreePath} is missing without a recorded clean worker exit. Inspect the packet, then acknowledge the missing worktree to discard it without deleting any path that still exists.`,
         status: 409,
       };
     }
@@ -247,6 +291,10 @@ async function closePacketUnmergedUnlocked(input: {
     }
     let worktreeRemoved = false;
     for (const candidate of lanesToClose) {
+      const worktreePath = candidate.worktreePath?.trim();
+      if (worktreePath && missingWorktreeBindings.has(`${candidate.id}\0${worktreePath}`)) {
+        continue;
+      }
       try {
         const cleanupAttempt = await runRuntimeAwareWorktreeCleanup({
           runtime: candidate.runtime,
@@ -276,6 +324,13 @@ async function closePacketUnmergedUnlocked(input: {
         };
       }
     }
+    const primaryWorktreePath = lane.worktreePath?.trim();
+    const worktreeCleanup = primaryWorktreePath
+      && missingWorktreeBindings.has(`${lane.id}\0${primaryWorktreePath}`)
+      ? 'missing' as const
+      : worktreeRemoved
+        ? 'removed' as const
+        : 'preserved' as const;
     const persistedIds = new Set(persistedLanes.map((candidate) => candidate.id));
     for (const candidate of lanesToClose.filter((target) => persistedIds.has(target.id))) {
       const archived = await dispatch({
@@ -294,10 +349,36 @@ async function closePacketUnmergedUnlocked(input: {
           status: 422,
         };
       }
+      const candidateWorktreePath = candidate.worktreePath?.trim();
+      const candidateCleanup = candidateWorktreePath
+        && missingWorktreeBindings.has(`${candidate.id}\0${candidateWorktreePath}`)
+        ? 'missing'
+        : worktreeRemoved ? 'removed' : 'preserved';
+      const eventLabel = candidateCleanup === 'missing'
+        ? 'discarded_worktree_missing'
+        : 'closed_unmerged';
+      updateLane(candidate.id, {
+        lastEventAt: new Date().toISOString(),
+        lastEventLabel: eventLabel,
+      }, 'user', {
+        eventLabel,
+        packetId: input.packetId,
+        worktreeCleanup: candidateCleanup,
+        reason: candidateCleanup === 'missing' ? 'worktree_missing' : 'close_unmerged',
+        acknowledgedMissingWorktree: input.acknowledgeMissingWorktree,
+      });
+      recordLaneEvent(candidate.id, 'packet_discarded', 'user', {
+        packetId: input.packetId,
+        disposition: rawDisposition,
+        worktreeCleanup: candidateCleanup,
+        reason: candidateCleanup === 'missing' ? 'worktree_missing' : 'close_unmerged',
+        acknowledgedMissingWorktree: input.acknowledgeMissingWorktree,
+        stoppedReviewTurns: stoppedReviewTurns.length,
+      });
     }
 
     const closedAt = new Date().toISOString();
-    if (!await markPacketClosed(guard, closedAt)) {
+    if (!await markPacketClosed(guard, closedAt, worktreeCleanup)) {
       return {
         ok: false,
         code: 'close_failed',
@@ -328,11 +409,17 @@ async function closePacketUnmergedUnlocked(input: {
         laneId: lane.id,
         packetId: input.packetId,
         worktreeRemoved,
+        worktreeCleanup,
+        stoppedReviewTurns: stoppedReviewTurns.length,
         preservedBranch,
         preservedBranches,
         preservationReceipts,
         preservationFailure,
-        note: `${outcomeNote}${worktreeRemoved ? ' Worktree removed.' : ''}`,
+        note: `${outcomeNote}${worktreeCleanup === 'missing'
+          ? ' Worktree was already missing; close recorded worktree_missing.'
+          : worktreeRemoved ? ' Worktree removed.' : ''}${stoppedReviewTurns.length > 0
+          ? ` Stopped ${stoppedReviewTurns.length} active review turn${stoppedReviewTurns.length === 1 ? '' : 's'} before close.`
+          : ''}`,
       },
     };
   } catch (error) {
@@ -351,6 +438,7 @@ export function closePacketUnmerged(input: {
   packetId: string;
   disposition: unknown;
   note: unknown;
+  acknowledgeMissingWorktree?: boolean;
 }): Promise<CloseUnmergedResult> {
   return withPacketLifecycleMutationLock(input.packetId, async ({ contended }) => {
     if (contended) {
@@ -361,6 +449,9 @@ export function closePacketUnmerged(input: {
         status: 409,
       };
     }
-    return closePacketUnmergedUnlocked(input);
+    return closePacketUnmergedUnlocked({
+      ...input,
+      acknowledgeMissingWorktree: input.acknowledgeMissingWorktree === true,
+    });
   });
 }

--- a/src/lib/orchestrator/stop-packet.ts
+++ b/src/lib/orchestrator/stop-packet.ts
@@ -8,6 +8,9 @@
  * adapter), THEN archive — and must NOT relaunch. "Stop" means stop.
  */
 import { archiveLaneSessions, killLaneSessionsConfirmed } from '@/lib/lane/reap-sessions';
+import { cancelAutoReviewForLane } from '@/lib/lane/review-cancellation';
+import { stopActiveReviewTurn } from '@/lib/lane/review-turn-state';
+import { liveWorkerSessionLanes } from '@/lib/lane/worker-session-state';
 import { withPacketLifecycleMutationLock } from '@/lib/orchestrator/lifecycle-mutation-lock';
 import {
   holdPacketLifecycleMutation,
@@ -26,6 +29,7 @@ export interface StopPacketResult {
   worktreePruned: boolean;
   /** #1471 S1 — false when a worker survived even SIGKILL (lane parked kill_unconfirmed). */
   killConfirmed: boolean;
+  stoppedReviewTurns: number;
   /** Set to 'kill_unconfirmed' when the process could not be confirmed dead. */
   blockedReason?: string;
   note: string;
@@ -115,6 +119,7 @@ async function stopPacketInner(
       archivedLanes: 0,
       worktreePruned: false,
       killConfirmed: true,
+      stoppedReviewTurns: 0,
       note: `Nothing to stop — no live lanes and no mission packet for ${packetId}.`,
     };
   }
@@ -124,7 +129,18 @@ async function stopPacketInner(
   // from under a worker that is still churning (the zombie the stop verb exists
   // to prevent). If ANY session survived even SIGKILL, park the packet
   // `kill_unconfirmed` and DO NOT archive/prune — telling the truth beats lying.
-  const kills = await killLaneSessionsConfirmed(lanes);
+  let stoppedReviewTurns = 0;
+  const reviewedLaneIds = new Set<string>();
+  for (const lane of lanes) {
+    if (reviewedLaneIds.has(lane.id)) continue;
+    reviewedLaneIds.add(lane.id);
+    cancelAutoReviewForLane(lane.id, 'packet_stopped');
+    if (stopActiveReviewTurn({ laneId: lane.id, reason: 'packet_stopped' })) {
+      stoppedReviewTurns += 1;
+    }
+  }
+
+  const kills = await killLaneSessionsConfirmed(liveWorkerSessionLanes(lanes));
   const reaped = kills.filter((kill) => kill.confirmed || kill.alreadyDead).length;
   const survivors = kills.filter((kill) => !kill.confirmed && !kill.alreadyDead);
 
@@ -143,8 +159,9 @@ async function stopPacketInner(
       archivedLanes: 0,
       worktreePruned: false,
       killConfirmed: false,
+      stoppedReviewTurns,
       blockedReason: 'kill_unconfirmed',
-      note: `Stop could not confirm ${survivors.length} live worker${survivors.length === 1 ? '' : 's'} exited after SIGKILL. Packet parked kill_unconfirmed; worktree left intact. Reset again or kill the pid manually.`,
+      note: `Stop could not confirm ${survivors.length} worker session class process${survivors.length === 1 ? '' : 'es'} exited after SIGKILL. Packet parked kill_unconfirmed; worktree left intact. Reset again or kill the pid manually.`,
     };
   }
 
@@ -186,7 +203,8 @@ async function stopPacketInner(
     archivedLanes: 0,
     worktreePruned: false,
     killConfirmed: true,
-    note: `Stopped packet ${packetId}: confirmed-killed ${reaped} live session${reaped === 1 ? '' : 's'}; held against relaunch. Archiving ${lanes.length} lane${lanes.length === 1 ? '' : 's'} + pruning the worktree in the background (audit via lane events). Not relaunched.`,
+    stoppedReviewTurns,
+    note: `Stopped packet ${packetId}: confirmed-killed ${reaped} live worker session${reaped === 1 ? '' : 's'}; stopped ${stoppedReviewTurns} review turn${stoppedReviewTurns === 1 ? '' : 's'}; held against relaunch. Archiving ${lanes.length} lane${lanes.length === 1 ? '' : 's'} + pruning the worktree in the background (audit via lane events). Not relaunched.`,
   };
 }
 
@@ -317,6 +335,6 @@ export async function stopAllLanes(opts: { repoPath?: string } = {}): Promise<St
     failedLanes,
     note: ok
       ? `Stopped everything${opts.repoPath ? ' in this repo' : ''}: reaped ${interrupted} live session${interrupted === 1 ? '' : 's'}, archived ${archived} lane${archived === 1 ? '' : 's'} across ${stoppedPackets} packet${stoppedPackets === 1 ? '' : 's'}. Nothing relaunched.`
-      : `Stop-all was incomplete: ${failedPackets} packet${failedPackets === 1 ? '' : 's'} and ${failedLanes} lane${failedLanes === 1 ? '' : 's'} could not be confirmed stopped. Their live bindings were preserved.`,
+      : `Stop-all was incomplete: ${failedPackets} packet${failedPackets === 1 ? '' : 's'} and ${failedLanes} worker session class lane${failedLanes === 1 ? '' : 's'} could not be confirmed stopped. Their live bindings were preserved.`,
   };
 }

--- a/tests/close-packet-unmerged.test.ts
+++ b/tests/close-packet-unmerged.test.ts
@@ -338,7 +338,10 @@ describe('close_packet_unmerged real path (#1570)', () => {
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toMatchObject({
       ok: false,
-      error: { code: 'kill_unconfirmed' },
+      error: {
+        code: 'kill_unconfirmed',
+        message: expect.stringContaining('worker session class'),
+      },
     });
     expect(getLane(lane.id)).toMatchObject({
       status: 'paused',

--- a/tests/packet-discard-missing-worktree-real-path.test.ts
+++ b/tests/packet-discard-missing-worktree-real-path.test.ts
@@ -1,0 +1,261 @@
+import { randomUUID } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import type { Lane } from '@/lib/lane/types';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+
+const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-packet-discard-missing-'));
+const wsToken = 'operator-packet-discard-missing-token-0123456789';
+process.env.O8_DATA_DIR = dataDir;
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+writeFileSync(join(dataDir, 'ws-token'), `${wsToken}\n`, 'utf8');
+
+const discardRoute = await import('@/app/api/orchestrator/discard-packet/route');
+const stopRoute = await import('@/app/api/orchestrator/stop-packet/route');
+const { closeDb } = await import('@/lib/db');
+const {
+  createLane,
+  getLane,
+  getLaneEvents,
+  setLaneStatus,
+} = await import('@/lib/lane/registry');
+const { reconcileOrphanedWorktrees } = await import('@/lib/lane/reconcile');
+const { recordLaneEvent } = await import('@/lib/lane/events');
+const {
+  bindReviewTurnAbortController,
+  startReviewTurn,
+} = await import('@/lib/lane/review-turn-state');
+const {
+  readOrchestratorControlPlaneState,
+  writeOrchestratorControlPlaneState,
+} = await import('@/lib/orchestrator/control-plane');
+const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+const { listInboxItems } = await import('@/lib/supervisor/inbox');
+
+afterAll(() => {
+  closeDb();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+function operatorRequest(path: string, body: Record<string, unknown>) {
+  return new NextRequest(`http://localhost:3001${path}`, {
+    method: 'POST',
+    headers: {
+      host: 'localhost:3001',
+      authorization: `Bearer ${wsToken}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function persistPacket(input: {
+  packetId: string;
+  repoPath: string;
+  worktreePath: string;
+  sessionKey?: string | null;
+  blockedReason?: string | null;
+}) {
+  const lane = createLane({
+    repoPath: input.repoPath,
+    worktreePath: input.worktreePath,
+    branch: `fix/${input.packetId}`,
+    baseBranch: 'main',
+    runtime: 'codex',
+    label: `Packet ${input.packetId}`,
+    packetId: input.packetId,
+    sessionKey: input.sessionKey ?? undefined,
+  });
+  setLaneStatus(
+    lane.id,
+    input.blockedReason ? 'awaiting_orchestrator' : 'reviewing',
+    'system',
+    input.blockedReason ?? 'review_requested',
+  );
+  const packet = {
+    id: input.packetId,
+    referenceLabel: '#1995',
+    title: 'Close a packet whose worktree is gone',
+    summary: 'The worker completed before the worktree disappeared.',
+    workspaceTargetPath: input.repoPath,
+    branchTarget: lane.branch,
+    runtime: 'codex',
+    dependencyLabels: [],
+    dependencyPacketIds: [],
+    queueState: 'held',
+    releaseState: 'pending',
+    status: input.blockedReason ? 'blocked' : 'awaiting_review',
+    blockedReason: input.blockedReason ?? null,
+    lane: {
+      tileId: lane.id,
+      tabId: lane.id,
+      repoPath: input.repoPath,
+      worktreePath: input.worktreePath,
+      runtime: 'codex',
+      laneId: lane.id,
+      sessionKey: input.sessionKey ?? null,
+    },
+    review: null,
+  } as OrchestratorPacket;
+  writeOrchestratorControlPlaneState({
+    ...createEmptyOrchestratorMissionState(),
+    missionId: `mission-${input.packetId}`,
+    repoPath: input.repoPath,
+    runtime: 'codex',
+    packets: [packet],
+    updatedAt: new Date().toISOString(),
+  });
+  return lane;
+}
+
+function recordCleanWorkerExit(lane: Lane, sessionKey: string) {
+  recordLaneEvent(lane.id, 'runtime_process_exit', 'system', {
+    runtime: lane.runtime,
+    surfaceId: sessionKey,
+    runId: `run-${lane.id}`,
+    exitCode: 0,
+    signal: null,
+    classification: 'clean-exit',
+    completedTurn: true,
+  });
+}
+
+function discardRequest(packetId: string, extra: Record<string, unknown> = {}) {
+  return operatorRequest('/api/orchestrator/discard-packet', {
+    packetId,
+    disposition: 'wontfix',
+    clientMutationId: `discard-${randomUUID()}`,
+    ...extra,
+  });
+}
+
+describe('packet missing-worktree close paths (#1995)', () => {
+  it('discard route closes after a recorded clean worker exit when the worktree is already missing', async () => {
+    const packetId = 'pkt-1995-clean-exit';
+    const repoPath = mkdtempSync(join(dataDir, 'clean-exit-repo-'));
+    const worktreePath = join(dataDir, 'missing-clean-exit-worktree');
+    const sessionKey = 'codex-worker:clean-exit';
+    const lane = persistPacket({ packetId, repoPath, worktreePath, sessionKey });
+    recordCleanWorkerExit(lane, sessionKey);
+
+    const response = await discardRoute.POST(discardRequest(packetId));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      result: {
+        closed: true,
+        packetId,
+        worktreeCleanup: 'missing',
+        worktreeRemoved: false,
+      },
+    });
+    expect(getLane(lane.id)).toMatchObject({
+      status: 'archived',
+      lastEventLabel: 'discarded_worktree_missing',
+    });
+    expect(readOrchestratorControlPlaneState().packets[0]).toMatchObject({
+      status: 'archived',
+      lastEventLabel: 'discarded_worktree_missing',
+    });
+    expect(getLaneEvents(lane.id).find((event) => event.verb === 'packet_discarded')).toMatchObject({
+      payload: {
+        packetId,
+        worktreeCleanup: 'missing',
+        reason: 'worktree_missing',
+        acknowledgedMissingWorktree: false,
+      },
+    });
+  });
+
+  it('stop route excludes the exited worker and stops the active review turn as its own session class', async () => {
+    const packetId = 'pkt-1995-stop-review';
+    const repoPath = mkdtempSync(join(dataDir, 'stop-review-repo-'));
+    const worktreePath = join(dataDir, 'missing-stop-review-worktree');
+    const sessionKey = 'codex-worker:already-exited';
+    const lane = persistPacket({ packetId, repoPath, worktreePath, sessionKey });
+    recordCleanWorkerExit(lane, sessionKey);
+    const reviewTurnId = startReviewTurn({
+      laneId: lane.id,
+      threadId: `auto-review-${lane.id}`,
+      backend: 'codex',
+      surface: 'auto-review',
+    });
+    const controller = new AbortController();
+    bindReviewTurnAbortController(lane.id, reviewTurnId, controller);
+
+    const response = await stopRoute.POST(operatorRequest('/api/orchestrator/stop-packet', { packetId }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      result: {
+        ok: true,
+        packetId,
+        interruptedSessions: 0,
+        stoppedReviewTurns: 1,
+        killConfirmed: true,
+      },
+    });
+    expect(controller.signal.aborted).toBe(true);
+    expect(getLaneEvents(lane.id).find((event) => event.verb === 'review_turn_stopped')).toMatchObject({
+      payload: {
+        reviewTurnId,
+        sessionClass: 'review',
+        reason: 'packet_stopped',
+        abortRequested: true,
+      },
+    });
+  });
+
+  it('discard route requires acknowledgement for the parked missing-worktree state and the inbox carries that action', async () => {
+    const packetId = 'pkt-1995-acknowledge-missing';
+    const repoPath = mkdtempSync(join(dataDir, 'acknowledge-repo-'));
+    const worktreePath = join(dataDir, 'missing-unverified-worktree');
+    const lane = persistPacket({ packetId, repoPath, worktreePath });
+
+    await expect(reconcileOrphanedWorktrees()).resolves.toBe(0);
+    expect(getLane(lane.id)).toMatchObject({
+      status: 'awaiting_orchestrator',
+      lastEventLabel: 'worktree_missing_unverified',
+    });
+    expect(listInboxItems({ includeAllProjects: true }).find((item) => item.packetId === packetId)).toMatchObject({
+      kind: 'packet_missing',
+      status: 'human_required',
+      payload: {
+        recoveryAction: 'acknowledge_missing_worktree',
+        laneId: lane.id,
+        worktreePath,
+      },
+    });
+
+    const refused = await discardRoute.POST(discardRequest(packetId));
+    expect(refused.status).toBe(409);
+    await expect(refused.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'worktree_missing_unverified' },
+    });
+
+    const acknowledged = await discardRoute.POST(discardRequest(packetId, {
+      acknowledgeMissingWorktree: true,
+    }));
+    expect(acknowledged.status).toBe(200);
+    await expect(acknowledged.json()).resolves.toMatchObject({
+      ok: true,
+      result: {
+        closed: true,
+        packetId,
+        worktreeCleanup: 'missing',
+      },
+    });
+    expect(getLane(lane.id)).toMatchObject({
+      status: 'archived',
+      lastEventLabel: 'discarded_worktree_missing',
+    });
+  });
+});

--- a/tests/packet-mutation-caller-correlation.test.ts
+++ b/tests/packet-mutation-caller-correlation.test.ts
@@ -165,6 +165,7 @@ describe('packet mutation callers preserve one correlation id across transport r
     const request = handleClosePacketUnmerged({
       packetId: 'pkt-mcp-close',
       disposition: 'wontfix',
+      acknowledgeMissingWorktree: true,
     });
     await vi.runAllTimersAsync();
     await request;
@@ -175,6 +176,7 @@ describe('packet mutation callers preserve one correlation id across transport r
     expect(JSON.parse(requestBodies[0])).toMatchObject({
       packetId: 'pkt-mcp-close',
       disposition: 'wontfix',
+      acknowledgeMissingWorktree: true,
       clientMutationId: expect.any(String),
     });
   });

--- a/tests/stop-concurrent-truth.test.ts
+++ b/tests/stop-concurrent-truth.test.ts
@@ -5,6 +5,7 @@ const h = vi.hoisted(() => ({
   kill: vi.fn(),
   archiveSessions: vi.fn(),
   archiveLane: vi.fn(),
+  getLaneEvents: vi.fn(),
   listActiveLanes: vi.fn(),
   listLanes: vi.fn(),
   reset: vi.fn(),
@@ -17,6 +18,7 @@ vi.mock('@/lib/lane/reap-sessions', () => ({
 }));
 vi.mock('@/lib/lane/registry', () => ({
   archiveLane: h.archiveLane,
+  getLaneEvents: h.getLaneEvents,
   listActiveLanes: h.listActiveLanes,
   listLanes: h.listLanes,
 }));
@@ -39,6 +41,7 @@ const stopRoute = await import('@/app/api/orchestrator/stop-packet/route');
 describe('concurrent packet stop truth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    h.getLaneEvents.mockReturnValue([]);
     h.listActiveLanes.mockReturnValue([]);
     h.listLanes.mockReturnValue([]);
     h.archiveSessions.mockResolvedValue({ targeted: 0, archived: 0, outcomes: [], failures: [] });
@@ -222,7 +225,10 @@ describe('concurrent packet stop truth', () => {
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toMatchObject({
       ok: false,
-      error: { code: 'kill_unconfirmed' },
+      error: {
+        code: 'kill_unconfirmed',
+        message: expect.stringContaining('worker session class'),
+      },
     });
     expect(h.archiveLane).not.toHaveBeenCalled();
   });

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1869,6 +1869,13 @@
       ]
     },
     {
+      "path": "tests/packet-discard-missing-worktree-real-path.test.ts",
+      "reasons": [
+        "real-path",
+        "worktree"
+      ]
+    },
+    {
       "path": "tests/packet-explainer-priority-real-path.test.ts",
       "reasons": [
         "real-path"


### PR DESCRIPTION
Closes #1995.

A packet whose worker had already exited cleanly could not be closed once its worktree directory was gone and an auto-review turn was live: discard refused with `close_failed` (worktree cleanup unconfirmed), stop refused with `kill_unconfirmed` (it was counting the review turn's processes as workers), and the lane parked as `awaiting_orchestrator` / `worktree_missing_unverified` with no way out.

## What changes

- **Missing worktree, clean exit → closable.** When the lane's newest `runtime_process_exit` for its worker session is a clean exit and the worktree path no longer exists, cleanup is confirmed as `worktreeCleanup: 'missing'`; the close records `discarded_worktree_missing` on the lane and packet. A directory that still exists follows the existing path: removal must be confirmed or the close is refused.
- **Workers and review turns are separate session classes.** The kill set excludes any worker session with a durable exit receipt; before a discard, the active review turn is cancelled and stopped as its own recorded event (`packet_discarded`), and a refusal names the class it could not confirm.
- **An operator exit for the parked state.** The parked `worktree_missing_unverified` state (missing directory, no recorded clean exit) is closable only with an explicit acknowledgement: `o8 packet discard --acknowledge-missing-worktree`, MCP `close_packet_unmerged({ acknowledgeMissingWorktree: true })`, and the Incident Queue card for that state carries the same action. Without the flag it is still refused.
- The operator playbook documents the three cases.

## Verification

Real-route tests with persisted lanes and events and a missing directory: discard after a recorded clean exit with the worktree gone; stop excludes the exited worker and stops the review turn as its own class; the parked state requires the acknowledgement and the inbox carries it. tsc, focused suites, real-path integration, lint at the cap with zero errors, classification check, full hermetic suite, run by the worker and again by the reviewer on the final tree.

## Not changed

Nothing deletes a directory that exists on disk without the existing confirmed-removal path. Reviewer-process exits without a surface id can match a lane whose session key is also unset; both are unset only for legacy lanes, and the match is logged on the close event.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `packet discard` command for closing packets without merging.
  - Added support for acknowledging missing worktrees when ancestry cannot be verified.
  - Inbox actions now guide operators through missing-worktree recovery.
  - Close and discard results report worktree cleanup status and stopped review activity.
  - Stopping or discarding packets now cancels associated automatic reviews.

- **Bug Fixes**
  - Missing worktrees are handled safely without attempting invalid cleanup.
  - Improved messaging identifies unconfirmed worker sessions and required recovery actions.

- **Documentation**
  - Updated the orchestration playbook with missing-worktree handling guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->