### PR TITLE
feat(receipts): signed packet receipts with a dedicated key and offline verification

### DIFF
--- a/cli/src/commands/harness.ts
+++ b/cli/src/commands/harness.ts
@@ -305,6 +305,7 @@ export async function runVerify(mode: OutputMode, rest: string[]): Promise<numbe
 }
 
 export async function runHarness(mode: OutputMode, subcommand: string | undefined, rest: string[]): Promise<number> {
+  if (subcommand === 'verify') return runVerify(mode, rest);
   const parsed = parseFlags(rest);
   const repoPath = value(parsed, 'repo') ?? process.cwd();
   if (subcommand === 'status') {
@@ -354,7 +355,7 @@ export async function runHarness(mode: OutputMode, subcommand: string | undefine
     }
     return output(mode, 'HarnessBundle imported', await harnessCall('bundle_import', { repoPath, bundle }));
   }
-  throw new CliError('invalid_args', 'usage: o8 harness status|measure|transition|export|import', EXIT.INVALID_ARGS);
+  throw new CliError('invalid_args', 'usage: o8 harness status|measure|transition|verify|export|import', EXIT.INVALID_ARGS);
 }
 
 export async function runCapabilities(mode: OutputMode, rest: string[]): Promise<number> {

--- a/cli/src/commands/packet/help.ts
+++ b/cli/src/commands/packet/help.ts
@@ -20,6 +20,8 @@ export const PACKET_SUBCOMMANDS = [
   'report',
   'capture',
   'mirror-proof',
+  'receipt',
+  'receipts',
   'log',
   'runtime-drift',
 ] as const;
@@ -45,6 +47,8 @@ export const PACKET_COMMAND_LINES = `  packet info [id]     packet metadata; exp
   packet report [id]   append an agent_report event for this packet
   packet capture [id]  screenshot the agent's app as visual proof (--url --label --before/--after --clip/--full-page --wait-for --hover/--click)
   packet mirror-proof [id] mirror the packet's before/after proof onto a GitHub PR (--pr <n> [--repo owner/repo])
+  packet receipt [id]  write a signed receipt JSON for a merged or discarded packet (--out <path>)
+  packet receipts [id] list stored signed receipts for a packet
   packet log [id]      read or follow packet lane events (--follow, --since)
   packet runtime-drift [id] detect and warn when a lane's bound runtime drifted`;
 

--- a/cli/src/commands/packet/help.ts
+++ b/cli/src/commands/packet/help.ts
@@ -20,10 +20,13 @@ export const PACKET_SUBCOMMANDS = [
   'report',
   'capture',
   'mirror-proof',
-  'receipt',
-  'receipts',
   'log',
   'runtime-drift',
+] as const;
+
+export const OPERATOR_PACKET_SUBCOMMANDS = [
+  'receipt',
+  'receipts',
 ] as const;
 
 export const PACKET_COMMAND_LINES = `  packet info [id]     packet metadata; explicit packet/lane id overrides cwd
@@ -47,15 +50,16 @@ export const PACKET_COMMAND_LINES = `  packet info [id]     packet metadata; exp
   packet report [id]   append an agent_report event for this packet
   packet capture [id]  screenshot the agent's app as visual proof (--url --label --before/--after --clip/--full-page --wait-for --hover/--click)
   packet mirror-proof [id] mirror the packet's before/after proof onto a GitHub PR (--pr <n> [--repo owner/repo])
-  packet receipt [id]  write a signed receipt JSON for a merged or discarded packet (--out <path>)
-  packet receipts [id] list stored signed receipts for a packet
   packet log [id]      read or follow packet lane events (--follow, --since)
   packet runtime-drift [id] detect and warn when a lane's bound runtime drifted`;
+
+export const OPERATOR_PACKET_COMMAND_LINES = `  packet receipt [id]  operator only: write a signed receipt JSON for a closed packet (--out <path>)
+  packet receipts [id] operator only: list stored signed receipts for a packet`;
 
 export function packetGroupUsage(): string {
   return `usage: o8 packet <subcommand> [flags]\n\n${PACKET_COMMAND_LINES}\n\nRun \`o8 --help\` for the full command surface.\n`;
 }
 
 export function packetSubcommandHint(): string {
-  return `Valid packet subcommands: ${PACKET_SUBCOMMANDS.join(', ')}.`;
+  return `Valid worker packet subcommands: ${PACKET_SUBCOMMANDS.join(', ')}. Operator-only packet subcommands: ${OPERATOR_PACKET_SUBCOMMANDS.join(', ')}.`;
 }

--- a/cli/src/commands/packet/receipt.ts
+++ b/cli/src/commands/packet/receipt.ts
@@ -1,0 +1,123 @@
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { apiFetch, CliError, EXIT } from '../../api.js';
+import { resolveConfig } from '../../config.js';
+import { printHumanHeading, printHumanKv, printJson, type OutputMode } from '../../output.js';
+import type { PacketReceipt } from '../../../../src/lib/receipts/types.js';
+import {
+  parsePacketArguments,
+  requirePacketId,
+  resolvePacketTarget,
+} from './target.js';
+
+interface ReceiptRouteItem {
+  id: string;
+  relPath: string;
+  bytes: number | null;
+  createdAt: string;
+  receipt: PacketReceipt;
+}
+
+interface ReceiptMutationResponse {
+  ok: true;
+  result: ReceiptRouteItem;
+}
+
+interface ReceiptListResponse {
+  ok: true;
+  result: {
+    packetId: string;
+    count: number;
+    receipts: ReceiptRouteItem[];
+  };
+}
+
+export async function runPacketReceipt(mode: OutputMode, rest: string[]): Promise<number> {
+  const args = parsePacketArguments(rest, {
+    command: 'receipt',
+    valueFlags: ['out'],
+  });
+  const packetId = requirePacketId(await resolvePacketTarget(args.target), 'receipt');
+  const response = await apiFetch<ReceiptMutationResponse>(
+    resolveConfig(),
+    '/api/orchestrator/receipts',
+    { method: 'POST', body: { packetId } },
+  );
+  const result = response.data?.result;
+  if (!result?.receipt) {
+    throw new CliError('receipt_unavailable', 'Receipt route returned no receipt.', EXIT.CONFLICT);
+  }
+  const outputPath = resolve(args.values.out?.trim() || `${result.receipt.receiptId}.json`);
+  try {
+    writeFileSync(outputPath, `${JSON.stringify(result.receipt, null, 2)}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+      mode: 0o600,
+    });
+  } catch (error) {
+    throw new CliError(
+      'receipt_write_failed',
+      `Unable to write ${outputPath}: ${error instanceof Error ? error.message : String(error)}`,
+      EXIT.CONFLICT,
+      'Pass --out with a new path. Existing files are never overwritten.',
+    );
+  }
+
+  if (mode.human) {
+    printHumanHeading('packet receipt');
+    printHumanKv([
+      ['packet', packetId],
+      ['receipt', result.receipt.receiptId],
+      ['key id', result.receipt.keyId],
+      ['disposition', result.receipt.disposition.kind],
+      ['file', outputPath],
+    ]);
+  } else {
+    printJson({
+      schema: 'o8/cli/packet.receipt/v1',
+      packetId,
+      path: outputPath,
+      artifact: {
+        id: result.id,
+        relPath: result.relPath,
+        bytes: result.bytes,
+        createdAt: result.createdAt,
+      },
+      receipt: result.receipt,
+    });
+  }
+  return EXIT.OK;
+}
+
+export async function runPacketReceipts(mode: OutputMode, rest: string[]): Promise<number> {
+  const args = parsePacketArguments(rest, { command: 'receipts' });
+  const packetId = requirePacketId(await resolvePacketTarget(args.target), 'receipts');
+  const response = await apiFetch<ReceiptListResponse>(
+    resolveConfig(),
+    '/api/orchestrator/receipts',
+    { query: { packetId } },
+  );
+  const result = response.data?.result;
+  if (!result) throw new CliError('receipt_list_failed', 'Receipt route returned no list.', EXIT.CONFLICT);
+
+  if (mode.human) {
+    printHumanHeading('packet receipts');
+    if (result.receipts.length === 0) {
+      process.stdout.write('No receipts recorded.\n');
+    } else {
+      for (const item of result.receipts) {
+        printHumanKv([
+          ['receipt', item.receipt.receiptId],
+          ['disposition', item.receipt.disposition.kind],
+          ['key id', item.receipt.keyId],
+          ['created', item.receipt.createdAt],
+          ['artifact', item.relPath],
+        ]);
+      }
+    }
+  } else {
+    printJson({ schema: 'o8/cli/packet.receipts/v1', ...result });
+  }
+  return EXIT.OK;
+}

--- a/cli/src/commands/verify-receipt.ts
+++ b/cli/src/commands/verify-receipt.ts
@@ -1,0 +1,129 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { CliError, EXIT } from '../api.js';
+import { printHumanHeading, printHumanKv, printJson, type OutputMode } from '../output.js';
+import { resolveReceiptPublicKey } from '../../../src/lib/receipts/public-key.js';
+import {
+  getReceiptIdentityPublicKey,
+  receiptKeyIdForPublicKey,
+} from '../../../src/lib/receipts/receipt-identity.js';
+import { verifyPacketReceiptFile } from '../../../src/lib/receipts/verify-receipt.js';
+
+interface VerifyReceiptArgs {
+  receiptPath: string | null;
+  key: string | null;
+  repoPath: string | null;
+  showKey: boolean;
+}
+
+function requireValue(rest: string[], index: number, flag: string): string {
+  const value = rest[index + 1];
+  if (!value || value.startsWith('-')) {
+    throw new CliError('invalid_args', `${flag} requires a value.`, EXIT.INVALID_ARGS);
+  }
+  return value;
+}
+
+function parseVerifyReceiptArgs(rest: string[]): VerifyReceiptArgs {
+  let receiptPath: string | null = null;
+  let key: string | null = null;
+  let repoPath: string | null = null;
+  let showKey = false;
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index];
+    if (token === '--show-key') {
+      showKey = true;
+    } else if (token === '--key' || token === '--repo') {
+      const value = requireValue(rest, index, token);
+      index += 1;
+      if (token === '--key') key = value;
+      else repoPath = value;
+    } else if (token.startsWith('-')) {
+      throw new CliError('invalid_args', `Unknown o8 verify flag: ${token}.`, EXIT.INVALID_ARGS);
+    } else if (!receiptPath) {
+      receiptPath = token;
+    } else {
+      throw new CliError('invalid_args', `Unexpected o8 verify argument: ${token}.`, EXIT.INVALID_ARGS);
+    }
+  }
+  return { receiptPath, key, repoPath, showKey };
+}
+
+function detectRepoPath(explicit: string | null): string | null {
+  if (explicit) return resolve(explicit);
+  try {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+export function isReceiptVerifyInvocation(rest: string[]): boolean {
+  if (rest.includes('--show-key') || rest.includes('--key')) return true;
+  const positional = rest.find((token) => !token.startsWith('-'));
+  return Boolean(positional && (positional.endsWith('.json') || existsSync(positional)));
+}
+
+export async function runVerifyReceipt(mode: OutputMode, rest: string[]): Promise<number> {
+  const args = parseVerifyReceiptArgs(rest);
+  let publicKey = resolveReceiptPublicKey(args.key);
+  if (!publicKey && args.showKey) publicKey = getReceiptIdentityPublicKey();
+  if (!publicKey) {
+    throw new CliError(
+      'receipt_key_not_found',
+      'No receipt public key was found.',
+      EXIT.NOT_FOUND,
+      'Supply --key <base64-or-path>, or run `o8 verify --show-key` on the signing machine.',
+    );
+  }
+  const keyId = receiptKeyIdForPublicKey(publicKey);
+  if (!args.receiptPath) {
+    if (!args.showKey) {
+      throw new CliError('invalid_args', 'o8 verify requires a receipt JSON file.', EXIT.INVALID_ARGS);
+    }
+    if (mode.human) {
+      printHumanHeading('receipt public key');
+      printHumanKv([['key id', keyId], ['public key', publicKey]]);
+    } else {
+      printJson({ schema: 'o8/cli/receipt.key/v1', keyId, publicKey });
+    }
+    return EXIT.OK;
+  }
+
+  const receiptPath = resolve(args.receiptPath);
+  const verdict = await verifyPacketReceiptFile({
+    receiptPath,
+    publicKeyB64: publicKey,
+    repoPath: detectRepoPath(args.repoPath),
+  });
+  if (mode.human) {
+    printHumanHeading('receipt verification');
+    printHumanKv([
+      ['receipt', verdict.receiptId ?? receiptPath],
+      ['signature', verdict.signatureValid ? 'valid' : 'invalid'],
+      ['key id', verdict.keyIdMatches ? 'matches' : 'mismatch'],
+      ['repository', verdict.repository.checked
+        ? verdict.repository.treeMatches ? 'tree matches' : 'tree mismatch'
+        : 'not checked'],
+      ['verdict', verdict.ok ? 'accepted' : 'rejected'],
+      ...(args.showKey ? [['public key', publicKey] as [string, string]] : []),
+    ]);
+    for (const error of verdict.errors) process.stdout.write(`error  ${error}\n`);
+  } else {
+    const { schema: receiptSchema, ...verdictBody } = verdict;
+    printJson({
+      schema: 'o8/cli/receipt.verify/v1',
+      receiptSchema,
+      receiptPath,
+      ...verdictBody,
+      ...(args.showKey ? { publicKey } : {}),
+    });
+  }
+  return verdict.ok ? EXIT.OK : EXIT.CONFLICT;
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -66,6 +66,7 @@ import { runPacketClose } from './commands/packet/close.js';
 import { runPacketWorkspace } from './commands/packet/workspace.js';
 import { runPacketStop } from './commands/packet/stop.js';
 import {
+  OPERATOR_PACKET_COMMAND_LINES,
   PACKET_COMMAND_LINES,
   packetGroupUsage,
   packetSubcommandHint,
@@ -263,6 +264,7 @@ commands:
   inbox list           pending governance approvals (--all includes resolved)
   inbox approve <id>   approve a card → runs the deferred action (e.g. a held merge)
   inbox reject <id>    reject a pending approval
+${OPERATOR_PACKET_COMMAND_LINES}
   session show <key>   provider-native transform capabilities, lineage, and checkpoints
   session import <key> add a discovered provider session without claiming packet ownership
   session checkpoint <key> save a durable provider position for later forks

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -40,6 +40,7 @@ import { runInbox } from './commands/inbox.js';
 import { runHistory } from './commands/history.js';
 import { runLaneTouches } from './commands/lane.js';
 import { runLease } from './commands/lease.js';
+import { isReceiptVerifyInvocation, runVerifyReceipt } from './commands/verify-receipt.js';
 import { runMission } from './commands/mission.js';
 import { runMcp } from './commands/mcp.js';
 import { runProject, runRepo } from './commands/resources.js';
@@ -54,6 +55,7 @@ import { runPacketLog } from './commands/packet/log.js';
 import { runPacketReport } from './commands/packet/report.js';
 import { runPacketCapture } from './commands/packet/capture.js';
 import { runPacketMirrorProof } from './commands/packet/mirror-proof.js';
+import { runPacketReceipt, runPacketReceipts } from './commands/packet/receipt.js';
 import { runPacketReview } from './commands/packet/review.js';
 import { runPacketScope } from './commands/packet/scope.js';
 import { runPacketExpandScope } from './commands/packet/expand-scope.js';
@@ -216,7 +218,8 @@ commands:
   boot [--task "..."]  session boot envelope: git, instructions, ledger, contract, grounding
   contract ...         propose and accept generator/evaluator contracts
   sprint ...           start or tick a one-feature-at-a-time sprint
-  verify <feature-id>  record computational evidence and optionally tick a sprint
+  verify <receipt.json> verify a signed packet receipt locally (--key, --repo, --show-key)
+  harness verify <feature-id> record computational evidence and optionally tick a sprint
   harness ...          model-keyed lift, lifecycle, and HarnessBundle operations
   capabilities         discover harness artifacts and recommended call order
   evaluate-diff        independent skeptic review of a supplied or git diff
@@ -362,7 +365,9 @@ async function dispatch(args: ParsedArgs): Promise<number> {
     case 'sprint':
       return runSprint(args.mode, secondary, args.rest);
     case 'verify':
-      return runVerify(args.mode, singleLevelArgs(secondary, args.rest, args.secondaryBeforeRest));
+      return isReceiptVerifyInvocation(singleLevelArgs(secondary, args.rest, args.secondaryBeforeRest))
+        ? runVerifyReceipt(args.mode, singleLevelArgs(secondary, args.rest, args.secondaryBeforeRest))
+        : runVerify(args.mode, singleLevelArgs(secondary, args.rest, args.secondaryBeforeRest));
     case 'harness':
       return runHarness(args.mode, secondary, args.rest);
     case 'capabilities':
@@ -445,6 +450,8 @@ async function dispatch(args: ParsedArgs): Promise<number> {
       if (secondary === 'report') return runPacketReport(args.mode, args.rest);
       if (secondary === 'capture') return runPacketCapture(args.mode, args.rest);
       if (secondary === 'mirror-proof') return runPacketMirrorProof(args.mode, args.rest);
+      if (secondary === 'receipt') return runPacketReceipt(args.mode, args.rest);
+      if (secondary === 'receipts') return runPacketReceipts(args.mode, args.rest);
       if (secondary === 'log') return runPacketLog(args.mode, args.rest);
       if (secondary === 'runtime-drift') return runPacketRuntimeDrift(args.mode, args.rest);
       throw unknownSubcommandError('packet', secondary);

--- a/docs/user/receipts.md
+++ b/docs/user/receipts.md
@@ -11,8 +11,10 @@ encryption identity and from every release or updater signing key.
 
 ## Create and list receipts
 
-Merged and discarded packets create receipts automatically. To create another
-receipt for a closed packet or write it to a particular path, run:
+Merged and discarded packets create receipts automatically. Receipt creation
+and listing are operator-only governance operations. To create another receipt
+for a closed packet or write it to a particular path, run from an operator
+session:
 
 ```bash
 o8 packet receipt <packet-id> --out ./packet-receipt.json
@@ -86,6 +88,12 @@ signature covers the UTF-8 bytes of the complete receipt except `signature`,
 serialized as compact JSON with object keys sorted recursively. A merged
 disposition records the persisted release evidence plus its Git tree; a
 discarded disposition records the close reason and any preserved branches.
+
+The signed `repo` object contains `name`, optional `remote`, and `baseBranch`.
+The remote is reduced to `host/owner/name`; credentials, URL schemes, and local
+or file remotes are not included. A receipt never stores the local repository
+path. The path supplied through `o8 verify --repo <path>` exists only for that
+verification process and is not written back to the receipt.
 
 The signed review and approval arrays capture the governance record that was
 available when the receipt was created. A later receipt for the same packet is

--- a/docs/user/receipts.md
+++ b/docs/user/receipts.md
@@ -1,0 +1,96 @@
+# Verify packet receipts
+
+o8 creates a signed JSON receipt when a packet is merged or discarded. Copy
+that receipt to another machine and verify it with the operator's published
+receipt public key. Verification is local: it does not contact a running o8
+server.
+
+Packet receipts use a dedicated Ed25519 identity. The private key is stored at
+`~/.o8/receipt-identity.key` with mode `0600`. It is separate from the mobile
+encryption identity and from every release or updater signing key.
+
+## Create and list receipts
+
+Merged and discarded packets create receipts automatically. To create another
+receipt for a closed packet or write it to a particular path, run:
+
+```bash
+o8 packet receipt <packet-id> --out ./packet-receipt.json
+```
+
+The command refuses to overwrite an existing file. List the receipt artifacts
+stored for a packet with:
+
+```bash
+o8 packet receipts <packet-id>
+```
+
+Receipt artifacts remain in the configured o8 data directory under
+`artifacts/<packet-id>/`. Their stored paths are relative to that data
+directory, so a copied o8 data directory remains readable at its new location.
+
+The same operations are available to an operator MCP client as
+`o8_packet_receipt` and `o8_verify_receipt`.
+
+## Publish the public key
+
+On the signing machine, create the dedicated identity if necessary and print
+only its public key:
+
+```bash
+o8 verify --show-key
+```
+
+Publish the printed base64 public key and its key ID through a channel outside
+the receipt itself, such as a trusted project website or repository. Never
+publish, copy, or commit `~/.o8/receipt-identity.key`.
+
+A verifier can save the published base64 value as
+`~/.o8/receipt-public.key`, or pass it directly or by file path:
+
+```bash
+o8 verify ./packet-receipt.json --key ./receipt-public.key
+o8 verify ./packet-receipt.json --key '<base64-public-key>'
+```
+
+The key ID is the first 16 hexadecimal characters of the SHA-256 digest of the
+public key. It identifies the expected key; it is not a substitute for obtaining
+that key through a trusted channel.
+
+## Verify repository evidence
+
+When verification runs inside a Git repository, o8 also checks a merged
+receipt's Git evidence. Use `--repo` when the repository is elsewhere:
+
+```bash
+o8 verify ./packet-receipt.json --repo /path/to/repository
+```
+
+An accepted merged receipt proves all of the following:
+
+- the receipt signature is valid for the supplied public key;
+- the receipt's key ID matches that public key;
+- the recorded merge commit exists in the selected repository; and
+- the commit's tree matches the tree recorded in the receipt.
+
+A discarded receipt has no merge commit or tree, so its verdict covers the
+signature, key identity, and signed discard record. Editing any signed field,
+including the disposition, review trail, approval trail, runtime, or model,
+causes verification to reject the receipt. A different public key is also
+rejected.
+
+## Receipt format
+
+Version 1 receipts use the schema `o8/packet-receipt/v1`. The detached
+signature covers the UTF-8 bytes of the complete receipt except `signature`,
+serialized as compact JSON with object keys sorted recursively. A merged
+disposition records the persisted release evidence plus its Git tree; a
+discarded disposition records the close reason and any preserved branches.
+
+The signed review and approval arrays capture the governance record that was
+available when the receipt was created. A later receipt for the same packet is
+a new signed observation with its own receipt ID and creation time.
+
+Receipt verification does not use the o8 updater key and has no code path to
+the updater key material. Release download verification remains a separate
+process described in [Verify o8 release downloads](release-verification.md).

--- a/src/app/api/orchestrator/receipts/route.ts
+++ b/src/app/api/orchestrator/receipts/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest } from 'next/server';
+
+import { resolveRequestPrincipal } from '@/lib/auth/principal';
+import { requirePanelAuth } from '@/lib/panel/auth';
+import {
+  createPacketReceiptForClosedPacket,
+  listStoredPacketReceipts,
+} from '@/lib/receipts/packet-receipt';
+import { asRecord, operatorError, operatorSuccess, parseJsonBody } from '../_utils';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function artifactSummary(receipt: ReturnType<typeof listStoredPacketReceipts>[number]) {
+  return {
+    id: receipt.artifact.id,
+    relPath: receipt.artifact.relPath,
+    bytes: receipt.artifact.bytes,
+    createdAt: receipt.artifact.createdAt,
+    receipt: receipt.receipt,
+  };
+}
+
+function requireOperator(request: NextRequest) {
+  const denied = requirePanelAuth(request);
+  if (denied) return denied;
+  if (resolveRequestPrincipal(request) !== 'operator') {
+    return operatorError('forbidden', 'Packet receipts are operator-only.', 403);
+  }
+  return null;
+}
+
+export async function GET(request: NextRequest) {
+  const denied = requireOperator(request);
+  if (denied) return denied;
+  const packetId = request.nextUrl.searchParams.get('packetId')?.trim() ?? '';
+  if (!packetId) return operatorError('invalid_request', 'packetId is required.', 400);
+  const receipts = listStoredPacketReceipts(packetId).map(artifactSummary);
+  return operatorSuccess({ packetId, count: receipts.length, receipts });
+}
+
+export async function POST(request: NextRequest) {
+  const denied = requireOperator(request);
+  if (denied) return denied;
+  const body = asRecord(await parseJsonBody(request));
+  const packetId = typeof body?.packetId === 'string' ? body.packetId.trim() : '';
+  if (!packetId) return operatorError('invalid_request', 'packetId is required.', 400);
+  try {
+    const receipt = await createPacketReceiptForClosedPacket({ packetId, source: 'manual' });
+    return operatorSuccess(artifactSummary(receipt));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to create packet receipt.';
+    const status = /was not found|No lane was found/.test(message) ? 404 : 409;
+    return operatorError('receipt_unavailable', message, status);
+  }
+}

--- a/src/app/api/panel/artifacts/route.ts
+++ b/src/app/api/panel/artifacts/route.ts
@@ -97,7 +97,8 @@ export async function GET(request: Request) {
   }
 
   try {
-    const rows = listArtifacts({ packetId, prNumber, laneId, threadId });
+    const rows = listArtifacts({ packetId, prNumber, laneId, threadId })
+      .filter((artifact) => artifact.kind !== 'receipt');
     return NextResponse.json({ artifacts: rows.map(toArtifactView) });
   } catch (err) {
     return NextResponse.json({ error: err instanceof Error ? err.message : 'list failed', artifacts: [] }, { status: 500 });

--- a/src/lib/artifacts/store.ts
+++ b/src/lib/artifacts/store.ts
@@ -19,7 +19,7 @@ import { randomUUID } from 'node:crypto';
 import { getDb, artifacts } from '@/lib/db';
 import { getDataDir } from '@/lib/data-dir-migration';
 
-export type ArtifactKind = 'screenshot' | 'video' | 'report';
+export type ArtifactKind = 'screenshot' | 'video' | 'report' | 'receipt';
 export type ArtifactSource = 'agent-capture' | 'review-boundary' | 'manual';
 export type ArtifactPhase = 'before' | 'after' | null;
 
@@ -73,6 +73,7 @@ const EXT_BY_MIME: Record<string, string> = {
   'video/mp4': 'mp4',
   'video/webm': 'webm',
   'text/html': 'html',
+  'application/json': 'json',
 };
 
 /** Filesystem-safe slug for a path segment (packet ids can contain `/` or `:`). */

--- a/src/lib/mcp/operator-handlers/receipts.ts
+++ b/src/lib/mcp/operator-handlers/receipts.ts
@@ -1,0 +1,71 @@
+import { resolveReceiptPublicKey } from '@/lib/receipts/public-key';
+import { verifyPacketReceiptFile } from '@/lib/receipts/verify-receipt';
+import {
+  apiFetch,
+  errorText,
+  jsonResult,
+  optionalString,
+  requiredString,
+  textResult,
+  type McpTool,
+  type McpToolResult,
+} from './shared';
+
+export const RECEIPT_TOOLS: McpTool[] = [
+  {
+    name: 'o8_packet_receipt',
+    description: 'Build, sign, and store the receipt for one merged or discarded packet from its persisted release/disposition records.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        packetId: { type: 'string', minLength: 1 },
+      },
+      required: ['packetId'],
+    },
+  },
+  {
+    name: 'o8_verify_receipt',
+    description: 'Verify a packet receipt locally with an Ed25519 public key and, when repoPath is supplied, confirm the recorded merge commit tree.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        receiptPath: { type: 'string', minLength: 1 },
+        key: { type: 'string', description: 'Base64 public key or path to a public-key file.' },
+        repoPath: { type: 'string', description: 'Optional repository checkout for merge/tree verification.' },
+        showKey: { type: 'boolean' },
+      },
+      required: ['receiptPath'],
+    },
+  },
+];
+
+export async function handlePacketReceipt(args: Record<string, unknown>): Promise<McpToolResult> {
+  try {
+    return jsonResult(await apiFetch('/api/orchestrator/receipts', {
+      method: 'POST',
+      body: JSON.stringify({ packetId: requiredString(args, 'packetId') }),
+    }));
+  } catch (error) {
+    return textResult(`o8_packet_receipt failed: ${errorText(error)}`, true);
+  }
+}
+
+export async function handleVerifyReceipt(args: Record<string, unknown>): Promise<McpToolResult> {
+  try {
+    const key = resolveReceiptPublicKey(optionalString(args, 'key'));
+    if (!key) throw new Error('No receipt public key was found. Supply key or publish receipt-public.key.');
+    const verdict = await verifyPacketReceiptFile({
+      receiptPath: requiredString(args, 'receiptPath'),
+      publicKeyB64: key,
+      repoPath: optionalString(args, 'repoPath') || null,
+    });
+    return jsonResult({
+      ...verdict,
+      ...(args.showKey === true ? { publicKey: key } : {}),
+    });
+  } catch (error) {
+    return textResult(`o8_verify_receipt failed: ${errorText(error)}`, true);
+  }
+}

--- a/src/lib/mcp/operator-mcp-host.ts
+++ b/src/lib/mcp/operator-mcp-host.ts
@@ -75,6 +75,11 @@ import {
   handleSetProjectRepos,
 } from '@/lib/mcp/operator-handlers/repo-management';
 import {
+  RECEIPT_TOOLS,
+  handlePacketReceipt,
+  handleVerifyReceipt,
+} from '@/lib/mcp/operator-handlers/receipts';
+import {
   type McpTool,
   type McpToolResult,
   checkApiHealth,
@@ -275,6 +280,7 @@ const TOOLS: McpTool[] = [
   ...SPEC_TOOLS,
   ...TARGETING_TOOLS,
   ...LEASE_TOOLS,
+  ...RECEIPT_TOOLS,
   ...AGENT_MESSAGE_TOOLS,
   ...BROADCAST_TOOLS,
   ...UPDATE_TOOLS,
@@ -364,6 +370,8 @@ const TOOL_HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<M
   o8_lease_release: handleLeaseRelease,
   o8_lease_status: handleLeaseStatus,
   o8_lease_list: handleLeaseList,
+  o8_packet_receipt: handlePacketReceipt,
+  o8_verify_receipt: handleVerifyReceipt,
   o8_msg_send: handleAgentMessageSend,
   o8_msg_inbox: handleAgentMessageInbox,
   o8_broadcast_post: handleBroadcastPost,

--- a/src/lib/orchestrator/close-unmerged.ts
+++ b/src/lib/orchestrator/close-unmerged.ts
@@ -35,6 +35,10 @@ import {
   type CloseUnmergedResult,
 } from './close-unmerged-shared';
 import { classifyClosePreservation } from './close-unmerged-preservation';
+import {
+  buildDiscardedPacketDisposition,
+  PACKET_DISPOSITION_EVENT_CODE,
+} from '@/lib/receipts/disposition';
 
 // Re-export the shared vocabulary so existing server-side importers of this
 // module keep working unchanged.
@@ -312,6 +316,28 @@ async function closePacketUnmergedUnlocked(input: {
       lane,
       summary: outcomeNote,
     });
+
+    const packetDisposition = buildDiscardedPacketDisposition({
+      disposition: rawDisposition,
+      reason: note,
+      preservedBranches,
+      closedAt,
+    });
+    recordLaneEvent(lane.id, 'update', 'system', {
+      code: PACKET_DISPOSITION_EVENT_CODE,
+      disposition: packetDisposition,
+      preservationReceipts,
+    });
+    void import('@/lib/receipts/packet-receipt')
+      .then(({ createPacketReceiptForClosedPacket }) => createPacketReceiptForClosedPacket({
+        packetId: input.packetId,
+        laneId: lane.id,
+        repoPath: lane.repoPath,
+        disposition: packetDisposition,
+      }))
+      .catch((error) => {
+        console.warn(`[receipts] Discard receipt failed for packet ${input.packetId}:`, error);
+      });
 
     void requestRealtimeRefresh({
       targets: ['global', 'mobileInbox'],

--- a/src/lib/orchestrator/operator-mission-service/merge.ts
+++ b/src/lib/orchestrator/operator-mission-service/merge.ts
@@ -531,6 +531,21 @@ async function dispatchPacketMerge(
     });
   }
 
+  // The receipt signer re-reads the persisted release payload. Launch it only
+  // after withLockedState releases, and never let artifact I/O delay a merge.
+  if (result.ok && result.mergeSha) {
+    void import('@/lib/receipts/packet-receipt')
+      .then(({ createPacketReceiptForClosedPacket }) => createPacketReceiptForClosedPacket({
+        packetId: packet.id,
+        laneId: lane.id,
+        repoPath: lane.repoPath,
+        expectedMergeCommit: result.mergeSha,
+      }))
+      .catch((error) => {
+        console.warn(`[receipts] Merge receipt failed for packet ${packet.id}:`, error);
+      });
+  }
+
   // The dispatch tick stays OUTSIDE the lock (it clones worktrees and spawns
   // sessions); its outcome is merged per changed packet under the lock so a
   // write that landed mid-tick survives.

--- a/src/lib/orchestrator/operator-mission-service/merge.ts
+++ b/src/lib/orchestrator/operator-mission-service/merge.ts
@@ -561,36 +561,16 @@ async function dispatchPacketMerge(
   // merge; the packet carries a generating→ready|failed status and the released
   // card only surfaces a link when ready. Off by default (operator opt-in).
   if (result.ok) {
-    try {
-      const { resolveBuyinDocEnabledSync } = await import('@/lib/operator/defaults');
-      const { shouldGenerateBuyinDoc, generateBuyinDoc } = await import('@/lib/lane/buyin-doc');
-      if (shouldGenerateBuyinDoc({ enabled: resolveBuyinDocEnabledSync(), mergeOk: result.ok, packetId: packet.id })) {
-        const { listArtifacts, artifactAbsPath } = await import('@/lib/artifacts/store');
-        const demoArtifacts = listArtifacts({ packetId: packet.id })
-          .filter((a) => a.kind === 'screenshot' || a.kind === 'video')
-          .map((a) => ({
-            absPath: artifactAbsPath(a.relPath),
-            label: a.label,
-            phase: a.phase,
-            kind: a.kind,
-            mimeType: a.mimeType,
-          }));
-        void generateBuyinDoc({
-          repoPath: lane.repoPath,
-          laneId: lane.id,
-          packetId: packet.id,
-          packetTitle: packet.title,
-          packetSummary: packet.summary ?? '',
-          mergeSha: result.mergeSha ?? null,
-          deviationsRaw: packet.deviations?.raw ?? null,
-          demoArtifacts,
-        }).catch((error) => {
-          console.warn(`[buyin-doc] Generation threw for packet ${packet.id}:`, error);
-        });
-      }
-    } catch (error) {
-      console.warn(`[buyin-doc] Failed to launch generation for packet ${packet.id}:`, error);
-    }
+    const { launchPostMergeBuyin } = await import('./post-merge-buyin');
+    await launchPostMergeBuyin({
+      repoPath: lane.repoPath,
+      laneId: lane.id,
+      packetId: packet.id,
+      packetTitle: packet.title,
+      packetSummary: packet.summary ?? '',
+      mergeSha: result.mergeSha ?? null,
+      deviationsRaw: packet.deviations?.raw ?? null,
+    });
   }
 
   log(`Merge command finished for packet ${packet.id}.`, {

--- a/src/lib/orchestrator/operator-mission-service/mission.ts
+++ b/src/lib/orchestrator/operator-mission-service/mission.ts
@@ -784,7 +784,9 @@ export async function getMissionStatus(input: MissionStatusInput) {
           reviewedHeadSha: packet.review.reviewedHeadSha ?? null,
           auditApprovalId: packet.review.auditApprovalId ?? null,
         } : null,
-        artifacts: listArtifacts({ packetId: packet.id }).map(toArtifactRef),
+        artifacts: listArtifacts({ packetId: packet.id })
+          .filter((artifact) => artifact.kind !== 'receipt')
+          .map(toArtifactRef),
       };
     }),
     agents,

--- a/src/lib/orchestrator/operator-mission-service/post-merge-buyin.ts
+++ b/src/lib/orchestrator/operator-mission-service/post-merge-buyin.ts
@@ -1,0 +1,44 @@
+export async function launchPostMergeBuyin(input: {
+  repoPath: string;
+  laneId: string;
+  packetId: string;
+  packetTitle: string;
+  packetSummary: string;
+  mergeSha: string | null;
+  deviationsRaw: string | null;
+}): Promise<void> {
+  try {
+    const { resolveBuyinDocEnabledSync } = await import('@/lib/operator/defaults');
+    const { shouldGenerateBuyinDoc, generateBuyinDoc } = await import('@/lib/lane/buyin-doc');
+    if (!shouldGenerateBuyinDoc({
+      enabled: resolveBuyinDocEnabledSync(),
+      mergeOk: true,
+      packetId: input.packetId,
+    })) return;
+
+    const { listArtifacts, artifactAbsPath } = await import('@/lib/artifacts/store');
+    const demoArtifacts = listArtifacts({ packetId: input.packetId })
+      .filter((artifact) => artifact.kind === 'screenshot' || artifact.kind === 'video')
+      .map((artifact) => ({
+        absPath: artifactAbsPath(artifact.relPath),
+        label: artifact.label,
+        phase: artifact.phase,
+        kind: artifact.kind,
+        mimeType: artifact.mimeType,
+      }));
+    void generateBuyinDoc({
+      repoPath: input.repoPath,
+      laneId: input.laneId,
+      packetId: input.packetId,
+      packetTitle: input.packetTitle,
+      packetSummary: input.packetSummary,
+      mergeSha: input.mergeSha,
+      deviationsRaw: input.deviationsRaw,
+      demoArtifacts,
+    }).catch((error) => {
+      console.warn(`[buyin-doc] Generation threw for packet ${input.packetId}:`, error);
+    });
+  } catch (error) {
+    console.warn(`[buyin-doc] Failed to launch generation for packet ${input.packetId}:`, error);
+  }
+}

--- a/src/lib/receipts/canonical.test.ts
+++ b/src/lib/receipts/canonical.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { canonicalJson } from './canonical';
+
+describe('canonicalJson', () => {
+  it('sorts object keys without whitespace', () => {
+    expect(canonicalJson({ zebra: 1, alpha: 2, middle: 3 }))
+      .toBe('{"alpha":2,"middle":3,"zebra":1}');
+  });
+
+  it('sorts nested objects while preserving array order', () => {
+    expect(canonicalJson({
+      outer: [{ z: true, a: false }, { second: 2, first: 1 }],
+      alpha: { delta: 4, beta: 2 },
+    })).toBe('{"alpha":{"beta":2,"delta":4},"outer":[{"a":false,"z":true},{"first":1,"second":2}]}');
+  });
+
+  it('preserves unicode as UTF-8 JSON text', () => {
+    expect(Buffer.from(canonicalJson({ message: '雪とcafé', emoji: '🧾' }), 'utf8').toString('hex'))
+      .toBe(Buffer.from('{"emoji":"🧾","message":"雪とcafé"}', 'utf8').toString('hex'));
+  });
+});

--- a/src/lib/receipts/canonical.ts
+++ b/src/lib/receipts/canonical.ts
@@ -1,0 +1,30 @@
+/**
+ * Return compact JSON with object keys sorted recursively.
+ *
+ * Arrays keep their original order. JSON's ordinary handling of unsupported
+ * object values (omit) and array values (null) is preserved by normalizing the
+ * value before serialization.
+ */
+export function canonicalJson(value: unknown): string {
+  const serialized = JSON.stringify(sortJsonValue(value));
+  if (serialized === undefined) {
+    throw new TypeError('Canonical JSON requires a JSON-serializable root value.');
+  }
+  return serialized;
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortJsonValue);
+  }
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  const record = value as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.keys(record)
+      .sort()
+      .map((key) => [key, sortJsonValue(record[key])]),
+  );
+}

--- a/src/lib/receipts/disposition.test.ts
+++ b/src/lib/receipts/disposition.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildDiscardedPacketDisposition,
+  buildMergedPacketDisposition,
+} from './disposition';
+
+describe('packet receipt dispositions', () => {
+  it('builds merged evidence from the persisted release payload', () => {
+    expect(buildMergedPacketDisposition({
+      releaseStatePayload: {
+        source: 'approve_and_merge',
+        mergeCommit: 'merge-sha',
+        headSha: 'head-sha',
+        evidenceKind: 'merge_command',
+        releasedAt: '2026-08-29T19:00:00.000Z',
+      },
+      tree: 'tree-sha',
+      expectedMergeCommit: 'merge-sha',
+    })).toEqual({
+      kind: 'merged',
+      mergeCommit: 'merge-sha',
+      headSha: 'head-sha',
+      tree: 'tree-sha',
+      evidenceKind: 'merge_command',
+      releasedAt: '2026-08-29T19:00:00.000Z',
+    });
+  });
+
+  it('rejects a merge result that differs from persisted release truth', () => {
+    expect(() => buildMergedPacketDisposition({
+      releaseStatePayload: {
+        mergeCommit: 'persisted-sha',
+        releasedAt: '2026-08-29T19:00:00.000Z',
+      },
+      tree: 'tree-sha',
+      expectedMergeCommit: 'returned-sha',
+    })).toThrow(/does not match merge result/);
+  });
+
+  it('builds a discarded disposition with stable unique preserved branches', () => {
+    expect(buildDiscardedPacketDisposition({
+      disposition: 'superseded',
+      reason: '  Replaced by a later packet. ',
+      preservedBranches: ['preserved/one', 'preserved/one', ' preserved/two '],
+      closedAt: '2026-08-29T19:05:00.000Z',
+    })).toEqual({
+      kind: 'discarded',
+      disposition: 'superseded',
+      reason: 'Replaced by a later packet.',
+      preservedBranches: ['preserved/one', 'preserved/two'],
+      closedAt: '2026-08-29T19:05:00.000Z',
+    });
+  });
+});

--- a/src/lib/receipts/disposition.ts
+++ b/src/lib/receipts/disposition.ts
@@ -1,0 +1,91 @@
+import type { OrchestratorReleaseStatePayload } from '@/lib/orchestrator/types';
+import {
+  isCloseUnmergedDisposition,
+  type CloseUnmergedDisposition,
+} from '@/lib/orchestrator/close-unmerged-shared';
+import type { PacketDisposition } from './types';
+
+export const PACKET_DISPOSITION_EVENT_CODE = 'packet_disposition';
+
+export function buildMergedPacketDisposition(input: {
+  releaseStatePayload: OrchestratorReleaseStatePayload | null | undefined;
+  tree: string;
+  expectedMergeCommit?: string | null;
+}): Extract<PacketDisposition, { kind: 'merged' }> {
+  const payload = input.releaseStatePayload;
+  const mergeCommit = payload?.mergeCommit?.trim() ?? '';
+  const releasedAt = payload?.releasedAt?.trim() ?? '';
+  const tree = input.tree.trim();
+  if (!mergeCommit || !releasedAt || !tree) {
+    throw new Error('Merged packet receipt requires persisted mergeCommit, releasedAt, and tree evidence.');
+  }
+  const expected = input.expectedMergeCommit?.trim();
+  if (expected && expected !== mergeCommit) {
+    throw new Error(`Persisted release evidence ${mergeCommit} does not match merge result ${expected}.`);
+  }
+  return {
+    kind: 'merged',
+    mergeCommit,
+    headSha: payload?.headSha?.trim() || null,
+    tree,
+    evidenceKind: payload?.evidenceKind?.trim() || null,
+    releasedAt,
+  };
+}
+
+export function buildDiscardedPacketDisposition(input: {
+  disposition: CloseUnmergedDisposition;
+  reason?: string | null;
+  preservedBranches?: string[];
+  closedAt: string;
+}): Extract<PacketDisposition, { kind: 'discarded' }> {
+  if (!isCloseUnmergedDisposition(input.disposition)) {
+    throw new Error('Discarded packet receipt has an invalid disposition.');
+  }
+  const closedAt = input.closedAt.trim();
+  if (!closedAt) throw new Error('Discarded packet receipt requires closedAt.');
+  return {
+    kind: 'discarded',
+    disposition: input.disposition,
+    reason: input.reason?.trim() || '',
+    preservedBranches: [...new Set((input.preservedBranches ?? []).map((branch) => branch.trim()).filter(Boolean))],
+    closedAt,
+  };
+}
+
+export function parsePacketDisposition(value: unknown): PacketDisposition | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (record.kind === 'merged') {
+    if (
+      typeof record.mergeCommit !== 'string'
+      || typeof record.tree !== 'string'
+      || typeof record.releasedAt !== 'string'
+      || (record.headSha !== null && typeof record.headSha !== 'string')
+      || (record.evidenceKind !== null && typeof record.evidenceKind !== 'string')
+    ) return null;
+    return {
+      kind: 'merged',
+      mergeCommit: record.mergeCommit,
+      headSha: record.headSha,
+      tree: record.tree,
+      evidenceKind: record.evidenceKind,
+      releasedAt: record.releasedAt,
+    };
+  }
+  if (
+    record.kind !== 'discarded'
+    || !isCloseUnmergedDisposition(record.disposition)
+    || typeof record.reason !== 'string'
+    || !Array.isArray(record.preservedBranches)
+    || !record.preservedBranches.every((branch) => typeof branch === 'string')
+    || typeof record.closedAt !== 'string'
+  ) return null;
+  return {
+    kind: 'discarded',
+    disposition: record.disposition,
+    reason: record.reason,
+    preservedBranches: record.preservedBranches,
+    closedAt: record.closedAt,
+  };
+}

--- a/src/lib/receipts/packet-receipt.ts
+++ b/src/lib/receipts/packet-receipt.ts
@@ -1,0 +1,256 @@
+import { randomUUID } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+import { listApprovalsForContext } from '@/lib/approvals/store';
+import {
+  artifactAbsPath,
+  artifactRelPath,
+  ensureArtifactBucket,
+  listArtifacts,
+  recordArtifact,
+  type ArtifactRecord,
+  type ArtifactSource,
+} from '@/lib/artifacts/store';
+import { getLaneEvents, getLane, findLatestLaneByPacket } from '@/lib/lane/registry';
+import type { Lane, LaneEvent } from '@/lib/lane/types';
+import { readOrchestratorControlPlaneState } from '@/lib/orchestrator/control-plane';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import { canonicalJson } from './canonical';
+import {
+  buildMergedPacketDisposition,
+  PACKET_DISPOSITION_EVENT_CODE,
+  parsePacketDisposition,
+} from './disposition';
+import {
+  getReceiptIdentity,
+  signReceiptBytes,
+} from './receipt-identity';
+import {
+  readGitRemote,
+  readGitTree,
+  parsePacketReceipt,
+} from './verify-receipt';
+import {
+  PACKET_RECEIPT_SCHEMA,
+  type PacketDisposition,
+  type PacketReceipt,
+  type PacketReceiptApproval,
+  type PacketReceiptReview,
+  type UnsignedPacketReceipt,
+} from './types';
+
+export interface StoredPacketReceipt {
+  artifact: ArtifactRecord;
+  receipt: PacketReceipt;
+}
+
+function collectReviews(events: LaneEvent[]): PacketReceiptReview[] {
+  const starts = new Map<string, {
+    backend: string;
+    startedAt: string;
+    outcome: PacketReceiptReview['outcome'];
+    finishedAt: string | null;
+  }>();
+  for (const event of events) {
+    const turnId = typeof event.payload.reviewTurnId === 'string'
+      ? event.payload.reviewTurnId.trim()
+      : '';
+    if (!turnId) continue;
+    if (event.verb === 'review_turn_started') {
+      starts.set(turnId, {
+        backend: typeof event.payload.backend === 'string' && event.payload.backend.trim()
+          ? event.payload.backend.trim()
+          : 'unknown',
+        startedAt: event.timestamp,
+        outcome: 'active',
+        finishedAt: null,
+      });
+    } else if (event.verb === 'review_turn_finished') {
+      const turn = starts.get(turnId);
+      const outcome = event.payload.outcome;
+      if (turn && ['completed', 'failed', 'quota_discarded'].includes(String(outcome))) {
+        turn.outcome = outcome as PacketReceiptReview['outcome'];
+        turn.finishedAt = event.timestamp;
+      }
+    }
+  }
+  return [...starts.entries()].map(([turnId, turn]) => ({
+    turnId,
+    backend: turn.backend,
+    outcome: turn.outcome,
+    at: turn.finishedAt ?? turn.startedAt,
+  }));
+}
+
+function collectApprovals(packetId: string, lane: Lane): PacketReceiptApproval[] {
+  return listApprovalsForContext({
+    packetId,
+    laneId: lane.id,
+    projectId: lane.projectId,
+  })
+    .filter((approval) => approval.status === 'approved' || approval.status === 'rejected')
+    .map((approval) => ({
+      id: approval.id,
+      title: approval.title,
+      principal: approval.resolution?.actor
+        ?? [...approval.audit].reverse().find((event) => event.type === 'approved' || event.type === 'rejected')?.actor
+        ?? 'unknown',
+      decision: approval.status as PacketReceiptApproval['decision'],
+      at: new Date(approval.resolvedAt ?? approval.updatedAt).toISOString(),
+    }))
+    .sort((left, right) => left.at.localeCompare(right.at));
+}
+
+function readDispositionEvent(events: LaneEvent[]): PacketDisposition | null {
+  for (const event of [...events].reverse()) {
+    if (event.payload.code !== PACKET_DISPOSITION_EVENT_CODE) continue;
+    const disposition = parsePacketDisposition(event.payload.disposition);
+    if (disposition) return disposition;
+  }
+  return null;
+}
+
+function receiptFromArtifact(artifact: ArtifactRecord): StoredPacketReceipt | null {
+  try {
+    const receipt = parsePacketReceipt(JSON.parse(readFileSync(artifactAbsPath(artifact.relPath), 'utf8')) as unknown);
+    return receipt ? { artifact, receipt } : null;
+  } catch {
+    return null;
+  }
+}
+
+export function listStoredPacketReceipts(packetId: string): StoredPacketReceipt[] {
+  return listArtifacts({ packetId })
+    .filter((artifact) => artifact.kind === 'receipt')
+    .map(receiptFromArtifact)
+    .filter((receipt): receipt is StoredPacketReceipt => receipt !== null);
+}
+
+async function resolveDisposition(input: {
+  packet: OrchestratorPacket;
+  lane: Lane;
+  repoPath: string;
+  expectedMergeCommit?: string | null;
+  disposition?: PacketDisposition;
+}): Promise<PacketDisposition> {
+  if (input.disposition) return input.disposition;
+  if (input.packet.releaseState === 'released') {
+    const mergeCommit = input.packet.releaseStatePayload?.mergeCommit?.trim() ?? '';
+    if (!mergeCommit) throw new Error(`Packet ${input.packet.id} has no persisted merge commit.`);
+    const tree = await readGitTree(input.repoPath, mergeCommit);
+    if (!tree) throw new Error(`Unable to resolve tree for merge commit ${mergeCommit}.`);
+    return buildMergedPacketDisposition({
+      releaseStatePayload: input.packet.releaseStatePayload,
+      tree,
+      expectedMergeCommit: input.expectedMergeCommit,
+    });
+  }
+  const recorded = readDispositionEvent(getLaneEvents(input.lane.id, 10_000));
+  if (!recorded) {
+    throw new Error(`Packet ${input.packet.id} has no persisted closed disposition.`);
+  }
+  return recorded;
+}
+
+function signReceipt(unsigned: UnsignedPacketReceipt): PacketReceipt {
+  const identity = getReceiptIdentity();
+  return {
+    ...unsigned,
+    signature: signReceiptBytes(
+      new TextEncoder().encode(canonicalJson(unsigned)),
+      identity.secretKey,
+    ),
+  };
+}
+
+async function buildPacketReceipt(input: {
+  packet: OrchestratorPacket;
+  lane: Lane;
+  repoPath: string;
+  disposition: PacketDisposition;
+}): Promise<PacketReceipt> {
+  const identity = getReceiptIdentity();
+  const createdAt = new Date().toISOString();
+  const remote = await readGitRemote(input.repoPath);
+  return signReceipt({
+    schema: PACKET_RECEIPT_SCHEMA,
+    receiptId: `receipt-${randomUUID()}`,
+    packetId: input.packet.id,
+    packetTitle: input.packet.title,
+    laneId: input.lane.id,
+    repo: {
+      path: input.repoPath,
+      ...(remote ? { remote } : {}),
+      baseBranch: input.lane.baseBranch,
+    },
+    disposition: input.disposition,
+    reviews: collectReviews(getLaneEvents(input.lane.id, 10_000)),
+    approvals: collectApprovals(input.packet.id, input.lane),
+    runtime: input.packet.runtime,
+    model: input.packet.model ?? input.lane.model ?? null,
+    createdAt,
+    keyId: identity.keyId,
+  });
+}
+
+function storePacketReceipt(
+  receipt: PacketReceipt,
+  lane: Lane,
+  source: ArtifactSource,
+): StoredPacketReceipt {
+  ensureArtifactBucket(receipt.packetId);
+  const relPath = artifactRelPath(receipt.packetId, receipt.receiptId, 'json');
+  const serialized = `${canonicalJson(receipt)}\n`;
+  writeFileSync(artifactAbsPath(relPath), serialized, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+  const artifact = recordArtifact({
+    id: receipt.receiptId,
+    kind: 'receipt',
+    source,
+    relPath,
+    laneId: lane.id,
+    packetId: receipt.packetId,
+    repoPath: lane.repoPath,
+    label: 'Signed packet receipt',
+    mimeType: 'application/json',
+    bytes: Buffer.byteLength(serialized),
+  });
+  if (!artifact) throw new Error(`Unable to record receipt artifact ${receipt.receiptId}.`);
+  return { artifact, receipt };
+}
+
+export async function createPacketReceiptForClosedPacket(input: {
+  packetId: string;
+  laneId?: string | null;
+  repoPath?: string | null;
+  expectedMergeCommit?: string | null;
+  disposition?: PacketDisposition;
+  source?: ArtifactSource;
+}): Promise<StoredPacketReceipt> {
+  const existing = listStoredPacketReceipts(input.packetId).at(-1);
+  if (existing) return existing;
+
+  // This read is deliberately inside receipt creation. Merge callers invoke
+  // this function only after markPacketReleased's locked write completes, so
+  // release evidence comes from the persisted packet and is never re-derived.
+  const state = readOrchestratorControlPlaneState();
+  const packet = state.packets.find((candidate) => candidate.id === input.packetId);
+  if (!packet) throw new Error(`Packet ${input.packetId} was not found.`);
+  const lane = (input.laneId ? getLane(input.laneId) : null) ?? findLatestLaneByPacket(input.packetId);
+  if (!lane) throw new Error(`No lane was found for packet ${input.packetId}.`);
+  const repoPath = input.repoPath?.trim() || lane.repoPath;
+  const disposition = await resolveDisposition({
+    packet,
+    lane,
+    repoPath,
+    expectedMergeCommit: input.expectedMergeCommit,
+    disposition: input.disposition,
+  });
+  if (disposition.kind === 'merged' && packet.releaseState !== 'released') {
+    throw new Error(`Packet ${input.packetId} is not released.`);
+  }
+  if (disposition.kind === 'discarded' && packet.status !== 'archived') {
+    throw new Error(`Packet ${input.packetId} is not closed unmerged.`);
+  }
+  const receipt = await buildPacketReceipt({ packet, lane, repoPath, disposition });
+  return storePacketReceipt(receipt, lane, input.source ?? 'review-boundary');
+}

--- a/src/lib/receipts/packet-receipt.ts
+++ b/src/lib/receipts/packet-receipt.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
 
 import { listApprovalsForContext } from '@/lib/approvals/store';
 import {
@@ -179,7 +180,7 @@ async function buildPacketReceipt(input: {
     packetTitle: input.packet.title,
     laneId: input.lane.id,
     repo: {
-      path: input.repoPath,
+      name: path.basename(path.resolve(input.repoPath)) || 'repository',
       ...(remote ? { remote } : {}),
       baseBranch: input.lane.baseBranch,
     },

--- a/src/lib/receipts/public-key.ts
+++ b/src/lib/receipts/public-key.ts
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import nacl from 'tweetnacl';
+import naclUtil from 'tweetnacl-util';
+
+import { getDataDir } from '@/lib/data-dir-migration';
+import { RECEIPT_IDENTITY_FILENAME } from './receipt-identity';
+
+export const RECEIPT_PUBLIC_KEY_FILENAME = 'receipt-public.key';
+
+function keyText(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('{')) return trimmed;
+  try {
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+    const key = parsed.publicKey ?? parsed.publicKeyB64;
+    return typeof key === 'string' ? key.trim() : trimmed;
+  } catch {
+    return trimmed;
+  }
+}
+
+export function normalizeReceiptPublicKey(value: string): string {
+  const decoded = naclUtil.decodeBase64(keyText(value));
+  if (decoded.length === nacl.sign.publicKeyLength) return naclUtil.encodeBase64(decoded);
+  if (decoded.length === nacl.sign.secretKeyLength) {
+    return naclUtil.encodeBase64(decoded.subarray(nacl.sign.secretKeyLength - nacl.sign.publicKeyLength));
+  }
+  throw new Error('Receipt key must contain a base64 Ed25519 public key.');
+}
+
+export function resolveReceiptPublicKey(value?: string | null): string | null {
+  if (value?.trim()) {
+    const candidate = value.trim();
+    const raw = existsSync(candidate) ? readFileSync(candidate, 'utf8') : candidate;
+    return normalizeReceiptPublicKey(raw);
+  }
+
+  const dataDir = getDataDir();
+  for (const filename of [RECEIPT_PUBLIC_KEY_FILENAME, RECEIPT_IDENTITY_FILENAME]) {
+    const candidate = path.join(dataDir, filename);
+    if (!existsSync(candidate)) continue;
+    return normalizeReceiptPublicKey(readFileSync(candidate, 'utf8'));
+  }
+  return null;
+}

--- a/src/lib/receipts/receipt-identity.test.ts
+++ b/src/lib/receipts/receipt-identity.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, statSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import nacl from 'tweetnacl';
+import naclUtil from 'tweetnacl-util';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  loadOrCreateReceiptIdentityAt,
+  signReceiptBytes,
+  verifyReceiptBytes,
+} from './receipt-identity';
+
+const temporaryDirectories: string[] = [];
+
+function identityPath(): string {
+  const directory = mkdtempSync(path.join(os.tmpdir(), 'o8-receipt-identity-'));
+  temporaryDirectories.push(directory);
+  return path.join(directory, 'receipt-identity.key');
+}
+
+afterEach(async () => {
+  const { rm } = await import('node:fs/promises');
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => (
+    rm(directory, { recursive: true, force: true })
+  )));
+});
+
+describe('receipt identity', () => {
+  it('creates a dedicated key file with owner-only permissions', () => {
+    const file = identityPath();
+    const identity = loadOrCreateReceiptIdentityAt(file);
+
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+    expect(identity.keyId).toMatch(/^[a-f0-9]{16}$/);
+    expect(naclUtil.decodeBase64(identity.publicKeyB64)).toHaveLength(nacl.sign.publicKeyLength);
+  });
+
+  it('uses the winner when another process wins the exclusive-create race', () => {
+    const file = identityPath();
+    const winner = nacl.sign.keyPair();
+    const identity = loadOrCreateReceiptIdentityAt(file, {
+      beforeExclusiveWrite: () => {
+        writeFileSync(file, naclUtil.encodeBase64(winner.secretKey), { flag: 'wx', mode: 0o600 });
+      },
+    });
+
+    expect(identity.publicKeyB64).toBe(naclUtil.encodeBase64(winner.publicKey));
+    expect(loadOrCreateReceiptIdentityAt(file).publicKeyB64).toBe(identity.publicKeyB64);
+  });
+
+  it('signs and verifies bytes with the receipt identity only', () => {
+    const identity = loadOrCreateReceiptIdentityAt(identityPath());
+    const other = loadOrCreateReceiptIdentityAt(identityPath());
+    const message = new TextEncoder().encode('{"schema":"o8/packet-receipt/v1"}');
+    const signature = signReceiptBytes(message, identity.secretKey);
+
+    expect(verifyReceiptBytes(message, signature, identity.publicKeyB64)).toBe(true);
+    expect(verifyReceiptBytes(message, signature, other.publicKeyB64)).toBe(false);
+  });
+});

--- a/src/lib/receipts/receipt-identity.test.ts
+++ b/src/lib/receipts/receipt-identity.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, statSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -48,6 +48,16 @@ describe('receipt identity', () => {
 
     expect(identity.publicKeyB64).toBe(naclUtil.encodeBase64(winner.publicKey));
     expect(loadOrCreateReceiptIdentityAt(file).publicKeyB64).toBe(identity.publicKeyB64);
+  });
+
+  it('refuses to replace a malformed identity that already owns the trust-root path', () => {
+    const file = identityPath();
+    writeFileSync(file, 'malformed-receipt-identity\n', { mode: 0o600 });
+
+    expect(() => loadOrCreateReceiptIdentityAt(file)).toThrow(
+      `receipt identity exists but is unreadable; refusing to replace the trust root: ${file}`,
+    );
+    expect(readFileSync(file, 'utf8')).toBe('malformed-receipt-identity\n');
   });
 
   it('signs and verifies bytes with the receipt identity only', () => {

--- a/src/lib/receipts/receipt-identity.ts
+++ b/src/lib/receipts/receipt-identity.ts
@@ -73,9 +73,12 @@ export function loadOrCreateReceiptIdentityAt(
     if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
       const concurrent = readStoredSecret(identityPath);
       if (concurrent) return identityFromSecret(concurrent);
+      throw new Error(
+        `receipt identity exists but is unreadable; refusing to replace the trust root: ${identityPath}`,
+        { cause: error },
+      );
     }
-    writeFileSync(identityPath, encoded, { mode: 0o600 });
-    return identityFromSecret(keyPair.secretKey);
+    throw error;
   }
 }
 

--- a/src/lib/receipts/receipt-identity.ts
+++ b/src/lib/receipts/receipt-identity.ts
@@ -42,8 +42,16 @@ function identityFromSecret(secretKey: Uint8Array): ReceiptIdentity {
   return {
     publicKeyB64: naclUtil.encodeBase64(publicKey),
     secretKey,
-    keyId: createHash('sha256').update(publicKey).digest('hex').slice(0, 16),
+    keyId: receiptKeyIdForPublicKey(publicKey),
   };
+}
+
+export function receiptKeyIdForPublicKey(publicKey: Uint8Array | string): string {
+  const bytes = typeof publicKey === 'string' ? naclUtil.decodeBase64(publicKey) : publicKey;
+  if (bytes.length !== nacl.sign.publicKeyLength) {
+    throw new Error('Receipt public key must be a 32-byte Ed25519 key.');
+  }
+  return createHash('sha256').update(bytes).digest('hex').slice(0, 16);
 }
 
 export function loadOrCreateReceiptIdentityAt(

--- a/src/lib/receipts/receipt-identity.ts
+++ b/src/lib/receipts/receipt-identity.ts
@@ -1,0 +1,102 @@
+/** Dedicated Ed25519 identity for signed packet receipts. */
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import nacl from 'tweetnacl';
+import naclUtil from 'tweetnacl-util';
+
+import { getDataDir } from '@/lib/data-dir-migration';
+
+export const RECEIPT_IDENTITY_FILENAME = 'receipt-identity.key';
+export const RECEIPT_IDENTITY_PATH = path.join(getDataDir(), RECEIPT_IDENTITY_FILENAME);
+
+export interface ReceiptIdentity {
+  publicKeyB64: string;
+  secretKey: Uint8Array;
+  keyId: string;
+}
+
+export interface ReceiptIdentityCreateHooks {
+  /** Test seam for a second process winning the exclusive-create race. */
+  beforeExclusiveWrite?: () => void;
+}
+
+let cached: ReceiptIdentity | null = null;
+
+function readStoredSecret(identityPath: string): Uint8Array | null {
+  try {
+    if (!existsSync(identityPath)) return null;
+    const raw = readFileSync(identityPath, 'utf8').trim();
+    if (!raw) return null;
+    const secret = naclUtil.decodeBase64(raw);
+    return secret.length === nacl.sign.secretKeyLength ? secret : null;
+  } catch {
+    return null;
+  }
+}
+
+function identityFromSecret(secretKey: Uint8Array): ReceiptIdentity {
+  const publicKey = secretKey.subarray(32);
+  return {
+    publicKeyB64: naclUtil.encodeBase64(publicKey),
+    secretKey,
+    keyId: createHash('sha256').update(publicKey).digest('hex').slice(0, 16),
+  };
+}
+
+export function loadOrCreateReceiptIdentityAt(
+  identityPath: string,
+  hooks: ReceiptIdentityCreateHooks = {},
+): ReceiptIdentity {
+  const existing = readStoredSecret(identityPath);
+  if (existing) return identityFromSecret(existing);
+
+  const keyPair = nacl.sign.keyPair();
+  const encoded = naclUtil.encodeBase64(keyPair.secretKey);
+  mkdirSync(path.dirname(identityPath), { recursive: true });
+  hooks.beforeExclusiveWrite?.();
+
+  try {
+    writeFileSync(identityPath, encoded, { flag: 'wx', mode: 0o600 });
+    return identityFromSecret(keyPair.secretKey);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      const concurrent = readStoredSecret(identityPath);
+      if (concurrent) return identityFromSecret(concurrent);
+    }
+    writeFileSync(identityPath, encoded, { mode: 0o600 });
+    return identityFromSecret(keyPair.secretKey);
+  }
+}
+
+/** Load or create the receipt-only identity. The updater identity is never read. */
+export function getReceiptIdentity(): ReceiptIdentity {
+  cached ??= loadOrCreateReceiptIdentityAt(RECEIPT_IDENTITY_PATH);
+  return cached;
+}
+
+export function getReceiptIdentityPublicKey(): string {
+  return getReceiptIdentity().publicKeyB64;
+}
+
+export function signReceiptBytes(message: Uint8Array, secretKey: Uint8Array): string {
+  return naclUtil.encodeBase64(nacl.sign.detached(message, secretKey));
+}
+
+export function verifyReceiptBytes(
+  message: Uint8Array,
+  signatureB64: string,
+  publicKeyB64: string,
+): boolean {
+  try {
+    return nacl.sign.detached.verify(
+      message,
+      naclUtil.decodeBase64(signatureB64),
+      naclUtil.decodeBase64(publicKeyB64),
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/receipts/types.ts
+++ b/src/lib/receipts/types.ts
@@ -41,7 +41,7 @@ export interface UnsignedPacketReceipt {
   packetTitle: string;
   laneId: string;
   repo: {
-    path: string;
+    name: string;
     remote?: string;
     baseBranch: string;
   };

--- a/src/lib/receipts/types.ts
+++ b/src/lib/receipts/types.ts
@@ -1,0 +1,79 @@
+import type { CloseUnmergedDisposition } from '@/lib/orchestrator/close-unmerged-shared';
+
+export const PACKET_RECEIPT_SCHEMA = 'o8/packet-receipt/v1' as const;
+
+export type PacketDisposition =
+  | {
+    kind: 'merged';
+    mergeCommit: string;
+    headSha: string | null;
+    tree: string;
+    evidenceKind: string | null;
+    releasedAt: string;
+  }
+  | {
+    kind: 'discarded';
+    disposition: CloseUnmergedDisposition;
+    reason: string;
+    preservedBranches: string[];
+    closedAt: string;
+  };
+
+export interface PacketReceiptReview {
+  turnId: string;
+  backend: string;
+  outcome: 'active' | 'completed' | 'failed' | 'quota_discarded';
+  at: string;
+}
+
+export interface PacketReceiptApproval {
+  id: string;
+  title: string;
+  principal: string;
+  decision: 'approved' | 'rejected';
+  at: string;
+}
+
+export interface UnsignedPacketReceipt {
+  schema: typeof PACKET_RECEIPT_SCHEMA;
+  receiptId: string;
+  packetId: string;
+  packetTitle: string;
+  laneId: string;
+  repo: {
+    path: string;
+    remote?: string;
+    baseBranch: string;
+  };
+  disposition: PacketDisposition;
+  reviews: PacketReceiptReview[];
+  approvals: PacketReceiptApproval[];
+  runtime: string;
+  model: string | null;
+  createdAt: string;
+  keyId: string;
+}
+
+export interface PacketReceipt extends UnsignedPacketReceipt {
+  signature: string;
+}
+
+export interface PacketReceiptRepositoryVerification {
+  checked: boolean;
+  repoPath: string | null;
+  commitExists: boolean | null;
+  treeMatches: boolean | null;
+  actualTree: string | null;
+}
+
+export interface PacketReceiptVerification {
+  ok: boolean;
+  schema: typeof PACKET_RECEIPT_SCHEMA | null;
+  receiptId: string | null;
+  packetId: string | null;
+  keyId: string | null;
+  signatureValid: boolean;
+  keyIdMatches: boolean;
+  repository: PacketReceiptRepositoryVerification;
+  errors: string[];
+}

--- a/src/lib/receipts/verify-receipt.test.ts
+++ b/src/lib/receipts/verify-receipt.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeGitRemote, parsePacketReceipt } from './verify-receipt';
+
+function receiptWithRepo(repo: Record<string, unknown>): unknown {
+  return {
+    schema: 'o8/packet-receipt/v1',
+    receiptId: 'receipt-test',
+    packetId: 'packet-test',
+    packetTitle: 'Receipt contract test',
+    laneId: 'lane-test',
+    repo,
+    disposition: {
+      kind: 'merged',
+      mergeCommit: 'a'.repeat(40),
+      headSha: 'a'.repeat(40),
+      tree: 'b'.repeat(40),
+      evidenceKind: 'merge_command',
+      releasedAt: '2026-08-29T20:00:00.000Z',
+    },
+    reviews: [],
+    approvals: [],
+    runtime: 'codex',
+    model: null,
+    createdAt: '2026-08-29T20:00:01.000Z',
+    keyId: '0123456789abcdef',
+    signature: 'signature',
+  };
+}
+
+describe('packet receipt repository contract', () => {
+  it('accepts a repository name and rejects the legacy local path field', () => {
+    expect(parsePacketReceipt(receiptWithRepo({
+      name: 'o8',
+      remote: 'example.test/operator/o8',
+      baseBranch: 'main',
+    }))).not.toBeNull();
+    expect(parsePacketReceipt(receiptWithRepo({
+      path: '/home/operator/o8',
+      baseBranch: 'main',
+    }))).toBeNull();
+  });
+
+  it('keeps only host, owner, and repository name from network remotes', () => {
+    expect(normalizeGitRemote('https://user:secret@Example.test/owner/repo.git'))
+      .toBe('example.test/owner/repo');
+    expect(normalizeGitRemote('git@example.test:owner/repo.git'))
+      .toBe('example.test/owner/repo');
+    expect(normalizeGitRemote('ssh://git@example.test/owner/repo.git'))
+      .toBe('example.test/owner/repo');
+  });
+
+  it('omits local and file remotes instead of signing a machine path', () => {
+    expect(normalizeGitRemote('/home/operator/repo.git')).toBeNull();
+    expect(normalizeGitRemote('file:///home/operator/repo.git')).toBeNull();
+  });
+});

--- a/src/lib/receipts/verify-receipt.ts
+++ b/src/lib/receipts/verify-receipt.ts
@@ -44,7 +44,7 @@ export function parsePacketReceipt(value: unknown): PacketReceipt | null {
 
   const repo = record.repo as Record<string, unknown>;
   if (
-    !nonEmptyString(repo.path)
+    !nonEmptyString(repo.name)
     || !nonEmptyString(repo.baseBranch)
     || (repo.remote !== undefined && typeof repo.remote !== 'string')
   ) return null;
@@ -86,6 +86,32 @@ export function readGitTree(repoPath: string, commit: string): Promise<string | 
   return gitRevParse(repoPath, `${commit}^{tree}`);
 }
 
+function normalizedRemoteHostPath(host: string, rawPath: string): string | null {
+  const segments = rawPath
+    .replace(/^\/+|\/+$/g, '')
+    .split('/')
+    .filter(Boolean);
+  if (!host || segments.length < 2) return null;
+  const owner = segments.at(-2)!;
+  const name = segments.at(-1)!.replace(/\.git$/i, '');
+  return owner && name ? `${host.toLowerCase()}/${owner}/${name}` : null;
+}
+
+export function normalizeGitRemote(remote: string): string | null {
+  const trimmed = remote.trim();
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol === 'file:') return null;
+    const normalized = normalizedRemoteHostPath(url.hostname, url.pathname);
+    if (normalized) return normalized;
+  } catch {
+    // Fall through to the SCP-style syntax used by Git SSH remotes.
+  }
+  const scp = /^(?:[^@/\s]+@)?([^:/\s]+):(.+)$/.exec(trimmed);
+  return scp ? normalizedRemoteHostPath(scp[1]!, scp[2]!) : null;
+}
+
 export async function readGitRemote(repoPath: string): Promise<string | null> {
   try {
     const result = await execFileAsync(
@@ -93,7 +119,7 @@ export async function readGitRemote(repoPath: string): Promise<string | null> {
       ['-C', repoPath, 'remote', 'get-url', 'origin'],
       { encoding: 'utf8', maxBuffer: 1024 * 1024 },
     );
-    return result.stdout.trim() || null;
+    return normalizeGitRemote(result.stdout);
   } catch {
     return null;
   }

--- a/src/lib/receipts/verify-receipt.ts
+++ b/src/lib/receipts/verify-receipt.ts
@@ -1,0 +1,204 @@
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
+
+import { canonicalJson } from './canonical';
+import { parsePacketDisposition } from './disposition';
+import {
+  receiptKeyIdForPublicKey,
+  verifyReceiptBytes,
+} from './receipt-identity';
+import {
+  PACKET_RECEIPT_SCHEMA,
+  type PacketReceipt,
+  type PacketReceiptVerification,
+} from './types';
+
+const execFileAsync = promisify(execFile);
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function parsePacketReceipt(value: unknown): PacketReceipt | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (
+    record.schema !== PACKET_RECEIPT_SCHEMA
+    || !nonEmptyString(record.receiptId)
+    || !nonEmptyString(record.packetId)
+    || typeof record.packetTitle !== 'string'
+    || !nonEmptyString(record.laneId)
+    || !record.repo
+    || typeof record.repo !== 'object'
+    || Array.isArray(record.repo)
+    || !parsePacketDisposition(record.disposition)
+    || !Array.isArray(record.reviews)
+    || !Array.isArray(record.approvals)
+    || !nonEmptyString(record.runtime)
+    || (record.model !== null && typeof record.model !== 'string')
+    || !nonEmptyString(record.createdAt)
+    || !/^[a-f0-9]{16}$/.test(typeof record.keyId === 'string' ? record.keyId : '')
+    || !nonEmptyString(record.signature)
+  ) return null;
+
+  const repo = record.repo as Record<string, unknown>;
+  if (
+    !nonEmptyString(repo.path)
+    || !nonEmptyString(repo.baseBranch)
+    || (repo.remote !== undefined && typeof repo.remote !== 'string')
+  ) return null;
+
+  const reviewsValid = record.reviews.every((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false;
+    const review = entry as Record<string, unknown>;
+    return nonEmptyString(review.turnId)
+      && nonEmptyString(review.backend)
+      && ['active', 'completed', 'failed', 'quota_discarded'].includes(String(review.outcome))
+      && nonEmptyString(review.at);
+  });
+  const approvalsValid = record.approvals.every((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false;
+    const approval = entry as Record<string, unknown>;
+    return nonEmptyString(approval.id)
+      && typeof approval.title === 'string'
+      && nonEmptyString(approval.principal)
+      && ['approved', 'rejected'].includes(String(approval.decision))
+      && nonEmptyString(approval.at);
+  });
+  return reviewsValid && approvalsValid ? record as unknown as PacketReceipt : null;
+}
+
+async function gitRevParse(repoPath: string, revision: string): Promise<string | null> {
+  try {
+    const result = await execFileAsync(
+      'git',
+      ['-C', repoPath, 'rev-parse', '--verify', '--end-of-options', revision],
+      { encoding: 'utf8', maxBuffer: 1024 * 1024 },
+    );
+    return result.stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+export function readGitTree(repoPath: string, commit: string): Promise<string | null> {
+  return gitRevParse(repoPath, `${commit}^{tree}`);
+}
+
+export async function readGitRemote(repoPath: string): Promise<string | null> {
+  try {
+    const result = await execFileAsync(
+      'git',
+      ['-C', repoPath, 'remote', 'get-url', 'origin'],
+      { encoding: 'utf8', maxBuffer: 1024 * 1024 },
+    );
+    return result.stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function emptyVerdict(errors: string[]): PacketReceiptVerification {
+  return {
+    ok: false,
+    schema: null,
+    receiptId: null,
+    packetId: null,
+    keyId: null,
+    signatureValid: false,
+    keyIdMatches: false,
+    repository: {
+      checked: false,
+      repoPath: null,
+      commitExists: null,
+      treeMatches: null,
+      actualTree: null,
+    },
+    errors,
+  };
+}
+
+export async function verifyPacketReceipt(input: {
+  receipt: unknown;
+  publicKeyB64: string;
+  repoPath?: string | null;
+}): Promise<PacketReceiptVerification> {
+  const receipt = parsePacketReceipt(input.receipt);
+  if (!receipt) return emptyVerdict(['Receipt does not match the o8/packet-receipt/v1 contract.']);
+
+  const errors: string[] = [];
+  let keyIdMatches = false;
+  try {
+    keyIdMatches = receiptKeyIdForPublicKey(input.publicKeyB64) === receipt.keyId;
+  } catch {
+    errors.push('The supplied public key is not a valid Ed25519 public key.');
+  }
+  if (!keyIdMatches && errors.length === 0) {
+    errors.push(`The supplied public key does not match receipt keyId ${receipt.keyId}.`);
+  }
+
+  const { signature, ...unsigned } = receipt;
+  const signatureValid = keyIdMatches && verifyReceiptBytes(
+    new TextEncoder().encode(canonicalJson(unsigned)),
+    signature,
+    input.publicKeyB64,
+  );
+  if (keyIdMatches && !signatureValid) errors.push('The receipt signature is invalid.');
+
+  const repoPath = input.repoPath?.trim() || null;
+  const repository: PacketReceiptVerification['repository'] = {
+    checked: false,
+    repoPath,
+    commitExists: null,
+    treeMatches: null,
+    actualTree: null,
+  };
+
+  if (repoPath && receipt.disposition.kind === 'merged') {
+    repository.checked = true;
+    const commit = await gitRevParse(repoPath, `${receipt.disposition.mergeCommit}^{commit}`);
+    repository.commitExists = commit !== null;
+    if (!repository.commitExists) {
+      repository.treeMatches = false;
+      errors.push(`Merge commit ${receipt.disposition.mergeCommit} does not exist in ${repoPath}.`);
+    } else {
+      repository.actualTree = await readGitTree(repoPath, receipt.disposition.mergeCommit);
+      repository.treeMatches = repository.actualTree === receipt.disposition.tree;
+      if (!repository.treeMatches) {
+        errors.push(`Merge commit tree does not match recorded tree ${receipt.disposition.tree}.`);
+      }
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    schema: receipt.schema,
+    receiptId: receipt.receiptId,
+    packetId: receipt.packetId,
+    keyId: receipt.keyId,
+    signatureValid,
+    keyIdMatches,
+    repository,
+    errors,
+  };
+}
+
+export async function verifyPacketReceiptFile(input: {
+  receiptPath: string;
+  publicKeyB64: string;
+  repoPath?: string | null;
+}): Promise<PacketReceiptVerification> {
+  try {
+    const raw = await readFile(input.receiptPath, 'utf8');
+    return verifyPacketReceipt({
+      receipt: JSON.parse(raw) as unknown,
+      publicKeyB64: input.publicKeyB64,
+      repoPath: input.repoPath,
+    });
+  } catch (error) {
+    return emptyVerdict([
+      error instanceof Error ? `Unable to read receipt: ${error.message}` : 'Unable to read receipt.',
+    ]);
+  }
+}

--- a/tests/cli-packet-target-parsing.test.ts
+++ b/tests/cli-packet-target-parsing.test.ts
@@ -3,6 +3,8 @@ import { CliError, EXIT } from '../cli/src/api';
 import { parseCaptureArgs, runPacketCapture } from '../cli/src/commands/packet/capture';
 import { parsePacketCommitMessage } from '../cli/src/commands/packet/commit';
 import {
+  OPERATOR_PACKET_COMMAND_LINES,
+  OPERATOR_PACKET_SUBCOMMANDS,
   PACKET_SUBCOMMANDS,
   packetGroupUsage,
   packetSubcommandHint,
@@ -151,19 +153,25 @@ describe('packet CLI target parsing', () => {
 });
 
 describe('packet CLI help', () => {
-  it('prints packet-group help with the complete packet subcommand list', () => {
+  it('keeps operator-only receipt commands out of worker packet-group help', () => {
     const output = packetGroupUsage();
 
     expect(output).toContain('usage: o8 packet <subcommand> [flags]');
     for (const subcommand of PACKET_SUBCOMMANDS) {
       expect(output).toContain(`packet ${subcommand}`);
     }
+    for (const subcommand of OPERATOR_PACKET_SUBCOMMANDS) {
+      expect(output).not.toContain(`packet ${subcommand}`);
+      expect(OPERATOR_PACKET_COMMAND_LINES).toContain(`packet ${subcommand}`);
+    }
+    expect(OPERATOR_PACKET_COMMAND_LINES).toContain('operator only');
     expect(output).not.toContain('CLI version + connected server version');
   });
 
   it('names valid packet subcommands in the unknown-subcommand hint', () => {
     const hint = packetSubcommandHint();
-    expect(hint).toContain('Valid packet subcommands:');
+    expect(hint).toContain('Valid worker packet subcommands:');
+    expect(hint).toContain('Operator-only packet subcommands: receipt, receipts');
     expect(hint).toContain('rerun');
     expect(hint).toContain('steer');
     expect(hint).toContain('merge-preview');

--- a/tests/close-packet-unmerged-preservation-real-path.test.ts
+++ b/tests/close-packet-unmerged-preservation-real-path.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 
 import { afterAll, describe, expect, it } from 'vitest';
 import { NextRequest } from 'next/server';
@@ -21,6 +21,7 @@ const { closeDb } = await import('@/lib/db');
 const { createLane, getLane, setLaneStatus } = await import('@/lib/lane/registry');
 const { writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
 const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+const { listStoredPacketReceipts } = await import('@/lib/receipts/packet-receipt');
 
 const roots: string[] = [dataDir];
 
@@ -115,6 +116,16 @@ function closeRequest(packetId: string) {
   });
 }
 
+async function waitForPacketReceipt(packetId: string) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const receipt = listStoredPacketReceipts(packetId).at(-1);
+    if (receipt) return receipt;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for packet receipt ${packetId}.`);
+}
+
 afterAll(() => {
   closeDb();
   for (const root of roots) rmSync(root, { recursive: true, force: true });
@@ -147,6 +158,18 @@ describe('close_packet_unmerged preservation classification — real route', () 
     });
     expect(getLane(lane.id)?.status).toBe('archived');
     expect(existsSync(worktreePath)).toBe(false);
+    const storedReceipt = await waitForPacketReceipt(packetId);
+    expect(storedReceipt.receipt).toMatchObject({
+      packetId,
+      laneId: lane.id,
+      disposition: {
+        kind: 'discarded',
+        disposition: 'wontfix',
+        preservedBranches: [],
+      },
+    });
+    expect(storedReceipt.artifact.kind).toBe('receipt');
+    expect(isAbsolute(storedReceipt.artifact.relPath)).toBe(false);
   });
 
   it('closes when both the branch and worktree are absent and records branch-absent', async () => {

--- a/tests/packet-receipt-cli-real-path.test.ts
+++ b/tests/packet-receipt-cli-real-path.test.ts
@@ -25,6 +25,7 @@ const receiptPath = path.join(testHome, 'packet-receipt.json');
 const tamperedPath = path.join(testHome, 'packet-receipt-tampered.json');
 const wrongKeyPath = path.join(testHome, 'packet-receipt-wrong-key.json');
 const token = 'packet-receipt-real-path-token';
+const workerToken = 'packet-receipt-worker-token';
 const packetId = 'pkt-receipt-real-path';
 const originalHome = process.env.HOME;
 const originalO8DataDir = process.env.O8_DATA_DIR;
@@ -33,6 +34,7 @@ const originalCortexDataDir = process.env.CORTEX_IDE_DATA_DIR;
 mkdirSync(dataDir, { recursive: true });
 mkdirSync(verifierDataDir, { recursive: true });
 writeFileSync(path.join(dataDir, 'ws-token'), `${token}\n`, 'utf8');
+writeFileSync(path.join(dataDir, 'worker-token'), `${workerToken}\n`, 'utf8');
 process.env.HOME = testHome;
 process.env.O8_DATA_DIR = dataDir;
 process.env.CORTEX_IDE_DATA_DIR = dataDir;
@@ -47,12 +49,14 @@ const { canonicalJson } = await import('@/lib/receipts/canonical');
 const {
   loadOrCreateReceiptIdentityAt,
   signReceiptBytes,
+  verifyReceiptBytes,
 } = await import('@/lib/receipts/receipt-identity');
 const { setApiBase } = await import('@/lib/mcp/operator-handlers/shared');
 const { handleOperatorMcpMessage } = await import('@/lib/mcp/operator-mcp-host');
 
 let apiServer: Server | null = null;
 let apiPort = 0;
+let publishedKey: { publicKey: string; keyId: string } | null = null;
 
 function git(args: string[]): string {
   return execFileSync('git', args, {
@@ -92,6 +96,31 @@ function runCli(
   });
 }
 
+function expectNoLocalPaths(serialized: string): void {
+  expect(serialized).not.toContain(testHome);
+  expect(serialized).not.toContain(dataDir);
+  expect(serialized).not.toContain(repoPath);
+}
+
+function receiptRouteRequest(method: 'GET' | 'POST', bearer: string): Promise<Response> {
+  const url = method === 'GET'
+    ? `http://127.0.0.1:${apiPort}/api/orchestrator/receipts?packetId=${packetId}`
+    : `http://127.0.0.1:${apiPort}/api/orchestrator/receipts`;
+  return fetch(url, {
+    method,
+    headers: {
+      authorization: `Bearer ${bearer}`,
+      ...(method === 'POST' ? { 'content-type': 'application/json' } : {}),
+    },
+    body: method === 'POST' ? JSON.stringify({ packetId }) : undefined,
+  });
+}
+
+function requirePublishedKey(): { publicKey: string; keyId: string } {
+  if (!publishedKey) throw new Error('The receipt public key fixture was not created.');
+  return publishedKey;
+}
+
 async function readBody(request: IncomingMessage): Promise<string> {
   const chunks: Buffer[] = [];
   for await (const chunk of request) chunks.push(Buffer.from(chunk));
@@ -119,6 +148,7 @@ beforeAll(async () => {
   execFileSync('git', ['init', '--initial-branch=main', repoPath], { cwd: testHome, stdio: 'pipe' });
   git(['config', 'user.name', 'o8-test']);
   git(['config', 'user.email', 'o8@example.test']);
+  git(['remote', 'add', 'origin', 'https://fixture-user:fixture-secret@example.test/operator/receipt-fixture.git']);
   writeFileSync(path.join(repoPath, 'receipt.txt'), 'signed packet receipt\n');
   git(['add', 'receipt.txt']);
   git(['commit', '-m', 'receipt fixture']);
@@ -212,8 +242,28 @@ afterAll(async () => {
   else process.env.CORTEX_IDE_DATA_DIR = originalCortexDataDir;
 });
 
-describe('packet receipt CLI real path', () => {
-  it('creates through CLI and MCP, then verifies offline and rejects tampering or a wrong key', async () => {
+describe.sequential('packet receipt CLI real path', () => {
+  it('enforces operator-only routes, omits local paths, and verifies offline', async () => {
+    expect((await receiptRouteRequest('GET', workerToken)).status).toBe(403);
+    expect((await receiptRouteRequest('POST', workerToken)).status).toBe(403);
+
+    const operatorPost = await receiptRouteRequest('POST', token);
+    expect(operatorPost.status).toBe(200);
+    const operatorPostPayload = await operatorPost.json() as {
+      ok: boolean;
+      result: { receipt: PacketReceipt };
+    };
+    expect(operatorPostPayload).toMatchObject({
+      ok: true,
+      result: { receipt: { packetId, disposition: { kind: 'merged' } } },
+    });
+    const operatorGet = await receiptRouteRequest('GET', token);
+    expect(operatorGet.status).toBe(200);
+    expect(await operatorGet.json()).toMatchObject({
+      ok: true,
+      result: { packetId, count: 1 },
+    });
+
     const mcpCreate = await handleOperatorMcpMessage({
       jsonrpc: '2.0',
       id: 1,
@@ -231,11 +281,20 @@ describe('packet receipt CLI real path', () => {
       mergeCommit: git(['rev-parse', 'HEAD']),
       tree: git(['rev-parse', 'HEAD^{tree}']),
     });
+    expect(mcpCreatePayload.result.receipt.repo).toEqual({
+      name: 'repo',
+      remote: 'example.test/operator/receipt-fixture',
+      baseBranch: 'main',
+    });
+    expect('path' in mcpCreatePayload.result.receipt.repo).toBe(false);
+    expectNoLocalPaths(JSON.stringify(mcpCreatePayload.result.receipt));
+    expectNoLocalPaths(readFileSync(path.join(dataDir, mcpCreatePayload.result.relPath), 'utf8'));
     expect(path.isAbsolute(mcpCreatePayload.result.relPath)).toBe(false);
 
     const showKeyOnline = await runCli(['verify', '--show-key']);
     expect(showKeyOnline.exitCode, showKeyOnline.stderr).toBe(0);
     const keyPayload = JSON.parse(showKeyOnline.stdout) as { publicKey: string; keyId: string };
+    publishedKey = keyPayload;
     expect(keyPayload.keyId).toBe(mcpCreatePayload.result.receipt.keyId);
 
     const mcpVerify = await handleOperatorMcpMessage({
@@ -268,6 +327,7 @@ describe('packet receipt CLI real path', () => {
       receipt: { keyId: keyPayload.keyId, disposition: { kind: 'merged' } },
     });
     expect(existsSync(receiptPath)).toBe(true);
+    expectNoLocalPaths(readFileSync(receiptPath, 'utf8'));
 
     const listed = await runCli(['packet', 'receipts', packetId]);
     expect(listed.exitCode, listed.stderr).toBe(0);
@@ -293,6 +353,20 @@ describe('packet receipt CLI real path', () => {
       repository: { checked: true, commitExists: true, treeMatches: true },
     });
 
+    const showKeyOffline = await runCli(
+      ['verify', '--show-key'],
+      { home: verifierHome, data: verifierDataDir },
+    );
+    expect(showKeyOffline.exitCode, showKeyOffline.stderr).toBe(0);
+    expect(JSON.parse(showKeyOffline.stdout)).toEqual({
+      schema: 'o8/cli/receipt.key/v1',
+      keyId: keyPayload.keyId,
+      publicKey: keyPayload.publicKey,
+    });
+  }, 30_000);
+
+  it('rejects a receipt after a signed field is tampered with', async () => {
+    const keyPayload = requirePublishedKey();
     const original = JSON.parse(readFileSync(receiptPath, 'utf8')) as PacketReceipt;
     writeFileSync(tamperedPath, `${JSON.stringify({ ...original, packetTitle: `${original.packetTitle}!` })}\n`);
     const tampered = await runCli(
@@ -305,18 +379,25 @@ describe('packet receipt CLI real path', () => {
       signatureValid: false,
       errors: [expect.stringContaining('signature is invalid')],
     });
+  });
 
+  it('rejects a valid receipt signature from a different trust root', async () => {
+    const keyPayload = requirePublishedKey();
+    const original = JSON.parse(readFileSync(receiptPath, 'utf8')) as PacketReceipt;
     const otherIdentity = loadOrCreateReceiptIdentityAt(path.join(testHome, 'other-receipt.key'));
     const unsigned = { ...original };
     delete (unsigned as { signature?: string }).signature;
     const wrongKeyUnsigned = { ...unsigned, keyId: otherIdentity.keyId };
+    const canonicalBytes = new TextEncoder().encode(canonicalJson(wrongKeyUnsigned));
     const wrongKeyReceipt: PacketReceipt = {
       ...wrongKeyUnsigned,
-      signature: signReceiptBytes(
-        new TextEncoder().encode(canonicalJson(wrongKeyUnsigned)),
-        otherIdentity.secretKey,
-      ),
+      signature: signReceiptBytes(canonicalBytes, otherIdentity.secretKey),
     };
+    expect(verifyReceiptBytes(
+      canonicalBytes,
+      wrongKeyReceipt.signature,
+      otherIdentity.publicKeyB64,
+    )).toBe(true);
     writeFileSync(wrongKeyPath, `${JSON.stringify(wrongKeyReceipt)}\n`);
     const wrongKey = await runCli(
       ['verify', wrongKeyPath, '--key', keyPayload.publicKey],
@@ -325,19 +406,9 @@ describe('packet receipt CLI real path', () => {
     expect(wrongKey.exitCode).toBe(5);
     expect(JSON.parse(wrongKey.stdout)).toMatchObject({
       ok: false,
+      signatureValid: false,
       keyIdMatches: false,
       errors: [expect.stringContaining('does not match receipt keyId')],
     });
-
-    const showKeyOffline = await runCli(
-      ['verify', '--show-key'],
-      { home: verifierHome, data: verifierDataDir },
-    );
-    expect(showKeyOffline.exitCode, showKeyOffline.stderr).toBe(0);
-    expect(JSON.parse(showKeyOffline.stdout)).toEqual({
-      schema: 'o8/cli/receipt.key/v1',
-      keyId: keyPayload.keyId,
-      publicKey: keyPayload.publicKey,
-    });
-  }, 30_000);
+  });
 });

--- a/tests/packet-receipt-cli-real-path.test.ts
+++ b/tests/packet-receipt-cli-real-path.test.ts
@@ -1,0 +1,343 @@
+import { execFileSync, spawn } from 'node:child_process';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { NextRequest } from 'next/server';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import type { PacketReceipt } from '@/lib/receipts/types';
+
+interface CliResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+const testHome = mkdtempSync(path.join(os.tmpdir(), 'o8-packet-receipt-real-path-'));
+const dataDir = path.join(testHome, '.o8');
+const verifierHome = path.join(testHome, 'verifier-home');
+const verifierDataDir = path.join(verifierHome, '.o8');
+const repoPath = path.join(testHome, 'repo');
+const receiptPath = path.join(testHome, 'packet-receipt.json');
+const tamperedPath = path.join(testHome, 'packet-receipt-tampered.json');
+const wrongKeyPath = path.join(testHome, 'packet-receipt-wrong-key.json');
+const token = 'packet-receipt-real-path-token';
+const packetId = 'pkt-receipt-real-path';
+const originalHome = process.env.HOME;
+const originalO8DataDir = process.env.O8_DATA_DIR;
+const originalCortexDataDir = process.env.CORTEX_IDE_DATA_DIR;
+
+mkdirSync(dataDir, { recursive: true });
+mkdirSync(verifierDataDir, { recursive: true });
+writeFileSync(path.join(dataDir, 'ws-token'), `${token}\n`, 'utf8');
+process.env.HOME = testHome;
+process.env.O8_DATA_DIR = dataDir;
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+
+const lanesRoute = await import('@/app/api/lanes/route');
+const receiptsRoute = await import('@/app/api/orchestrator/receipts/route');
+const { closeDb } = await import('@/lib/db');
+const { createLane, setLaneStatus } = await import('@/lib/lane/registry');
+const { writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+const { canonicalJson } = await import('@/lib/receipts/canonical');
+const {
+  loadOrCreateReceiptIdentityAt,
+  signReceiptBytes,
+} = await import('@/lib/receipts/receipt-identity');
+const { setApiBase } = await import('@/lib/mcp/operator-handlers/shared');
+const { handleOperatorMcpMessage } = await import('@/lib/mcp/operator-mcp-host');
+
+let apiServer: Server | null = null;
+let apiPort = 0;
+
+function git(args: string[]): string {
+  return execFileSync('git', args, {
+    cwd: repoPath,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function runCli(
+  args: string[],
+  options: { home?: string; data?: string; cwd?: string } = {},
+): Promise<CliResult> {
+  return new Promise((resolveRun, reject) => {
+    const childEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: options.home ?? testHome,
+      O8_DATA_DIR: options.data ?? dataDir,
+      CORTEX_IDE_DATA_DIR: options.data ?? dataDir,
+      O8_API_PORT: String(apiPort),
+      O8_API_TOKEN: token,
+      O8_WORKER_TOKEN: '',
+      O8_WORKER_PACKET_ID: '',
+    };
+    delete childEnv.NODE_OPTIONS;
+    const child = spawn(process.execPath, [path.join(process.cwd(), 'cli/dist/o8.mjs'), ...args], {
+      cwd: options.cwd ?? repoPath,
+      env: childEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+    child.once('error', reject);
+    child.once('exit', (exitCode) => resolveRun({ exitCode, stdout, stderr }));
+  });
+}
+
+async function readBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+async function writeRouteResponse(response: ServerResponse, routeResponse: Response): Promise<void> {
+  response.writeHead(routeResponse.status, {
+    'Content-Type': routeResponse.headers.get('Content-Type') ?? 'application/json',
+    'Cache-Control': routeResponse.headers.get('Cache-Control') ?? 'no-store',
+  });
+  response.end(await routeResponse.text());
+}
+
+async function closeServer(): Promise<void> {
+  if (!apiServer) return;
+  const server = apiServer;
+  apiServer = null;
+  await new Promise<void>((resolveClose, reject) => {
+    server.close((error) => error ? reject(error) : resolveClose());
+  });
+}
+
+beforeAll(async () => {
+  execFileSync('git', ['init', '--initial-branch=main', repoPath], { cwd: testHome, stdio: 'pipe' });
+  git(['config', 'user.name', 'o8-test']);
+  git(['config', 'user.email', 'o8@example.test']);
+  writeFileSync(path.join(repoPath, 'receipt.txt'), 'signed packet receipt\n');
+  git(['add', 'receipt.txt']);
+  git(['commit', '-m', 'receipt fixture']);
+  const mergeCommit = git(['rev-parse', 'HEAD']);
+  const lane = createLane({
+    repoPath,
+    branch: 'inline/receipt-real-path',
+    baseBranch: 'main',
+    runtime: 'codex',
+    packetId,
+    label: 'Receipt real path',
+  });
+  setLaneStatus(lane.id, 'completed', 'system', 'merged');
+  writeOrchestratorControlPlaneState({
+    ...createEmptyOrchestratorMissionState(),
+    missionId: 'mission-receipt-real-path',
+    repoPath,
+    runtime: 'codex',
+    packets: [{
+      id: packetId,
+      referenceLabel: 'PKT-RECEIPT',
+      title: 'Signed receipt fixture',
+      summary: 'Persist a released packet for the compiled CLI real path.',
+      workspaceTargetPath: repoPath,
+      branchTarget: lane.branch,
+      runtime: 'codex',
+      model: 'receipt-test-model',
+      dependencyLabels: [],
+      dependencyPacketIds: [],
+      queueState: 'held',
+      releaseState: 'released',
+      releaseStatePayload: {
+        source: 'approve_and_merge',
+        mergeCommit,
+        headSha: mergeCommit,
+        evidenceKind: 'merge_command',
+        releasedAt: '2026-08-29T19:30:00.000Z',
+      },
+      status: 'released',
+      blockedReason: null,
+      lane: null,
+      review: null,
+    } as OrchestratorPacket],
+    updatedAt: new Date().toISOString(),
+  });
+
+  execFileSync(process.execPath, [path.join(process.cwd(), 'cli/esbuild.config.mjs')], {
+    cwd: process.cwd(),
+    stdio: 'ignore',
+  });
+  apiServer = createServer(async (request, response) => {
+    try {
+      const requestUrl = new URL(request.url ?? '/', `http://127.0.0.1:${apiPort}`);
+      const body = await readBody(request);
+      const nextRequest = new NextRequest(requestUrl, {
+        method: request.method,
+        headers: request.headers as HeadersInit,
+        body: body || undefined,
+      });
+      if (requestUrl.pathname === '/api/lanes' && request.method === 'GET') {
+        await writeRouteResponse(response, await lanesRoute.GET(nextRequest));
+      } else if (requestUrl.pathname === '/api/orchestrator/receipts' && request.method === 'GET') {
+        await writeRouteResponse(response, await receiptsRoute.GET(nextRequest));
+      } else if (requestUrl.pathname === '/api/orchestrator/receipts' && request.method === 'POST') {
+        await writeRouteResponse(response, await receiptsRoute.POST(nextRequest));
+      } else {
+        response.writeHead(404, { 'Content-Type': 'application/json' });
+        response.end(JSON.stringify({ error: 'missing fixture route' }));
+      }
+    } catch (error) {
+      response.writeHead(500, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }));
+    }
+  });
+  await new Promise<void>((resolveListen) => apiServer!.listen(0, '127.0.0.1', resolveListen));
+  const address = apiServer.address();
+  if (!address || typeof address === 'string') throw new Error('Receipt fixture server did not bind.');
+  apiPort = address.port;
+  setApiBase(`http://127.0.0.1:${apiPort}`);
+}, 30_000);
+
+afterAll(async () => {
+  await closeServer();
+  closeDb();
+  rmSync(testHome, { recursive: true, force: true });
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalO8DataDir === undefined) delete process.env.O8_DATA_DIR;
+  else process.env.O8_DATA_DIR = originalO8DataDir;
+  if (originalCortexDataDir === undefined) delete process.env.CORTEX_IDE_DATA_DIR;
+  else process.env.CORTEX_IDE_DATA_DIR = originalCortexDataDir;
+});
+
+describe('packet receipt CLI real path', () => {
+  it('creates through CLI and MCP, then verifies offline and rejects tampering or a wrong key', async () => {
+    const mcpCreate = await handleOperatorMcpMessage({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'o8_packet_receipt', arguments: { packetId } },
+    });
+    const mcpCreateText = (mcpCreate?.result as { content: Array<{ text: string }> }).content[0]!.text;
+    const mcpCreatePayload = JSON.parse(mcpCreateText) as {
+      ok: boolean;
+      result: { relPath: string; receipt: PacketReceipt };
+    };
+    expect(mcpCreatePayload.ok).toBe(true);
+    expect(mcpCreatePayload.result.receipt.disposition).toMatchObject({
+      kind: 'merged',
+      mergeCommit: git(['rev-parse', 'HEAD']),
+      tree: git(['rev-parse', 'HEAD^{tree}']),
+    });
+    expect(path.isAbsolute(mcpCreatePayload.result.relPath)).toBe(false);
+
+    const showKeyOnline = await runCli(['verify', '--show-key']);
+    expect(showKeyOnline.exitCode, showKeyOnline.stderr).toBe(0);
+    const keyPayload = JSON.parse(showKeyOnline.stdout) as { publicKey: string; keyId: string };
+    expect(keyPayload.keyId).toBe(mcpCreatePayload.result.receipt.keyId);
+
+    const mcpVerify = await handleOperatorMcpMessage({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: {
+        name: 'o8_verify_receipt',
+        arguments: {
+          receiptPath: path.join(dataDir, mcpCreatePayload.result.relPath),
+          key: keyPayload.publicKey,
+          repoPath,
+        },
+      },
+    });
+    const mcpVerifyText = (mcpVerify?.result as { content: Array<{ text: string }> }).content[0]!.text;
+    expect(JSON.parse(mcpVerifyText)).toMatchObject({
+      ok: true,
+      signatureValid: true,
+      keyIdMatches: true,
+      repository: { checked: true, commitExists: true, treeMatches: true },
+    });
+
+    const created = await runCli(['packet', 'receipt', packetId, '--out', receiptPath]);
+    expect(created.exitCode, created.stderr).toBe(0);
+    expect(JSON.parse(created.stdout)).toMatchObject({
+      schema: 'o8/cli/packet.receipt/v1',
+      packetId,
+      path: receiptPath,
+      receipt: { keyId: keyPayload.keyId, disposition: { kind: 'merged' } },
+    });
+    expect(existsSync(receiptPath)).toBe(true);
+
+    const listed = await runCli(['packet', 'receipts', packetId]);
+    expect(listed.exitCode, listed.stderr).toBe(0);
+    expect(JSON.parse(listed.stdout)).toMatchObject({
+      schema: 'o8/cli/packet.receipts/v1',
+      packetId,
+      count: 1,
+    });
+
+    writeFileSync(path.join(verifierDataDir, 'receipt-public.key'), `${keyPayload.publicKey}\n`, 'utf8');
+    await closeServer();
+
+    const accepted = await runCli(
+      ['verify', receiptPath, '--repo', repoPath],
+      { home: verifierHome, data: verifierDataDir },
+    );
+    expect(accepted.exitCode, accepted.stderr).toBe(0);
+    expect(JSON.parse(accepted.stdout)).toMatchObject({
+      schema: 'o8/cli/receipt.verify/v1',
+      ok: true,
+      signatureValid: true,
+      keyIdMatches: true,
+      repository: { checked: true, commitExists: true, treeMatches: true },
+    });
+
+    const original = JSON.parse(readFileSync(receiptPath, 'utf8')) as PacketReceipt;
+    writeFileSync(tamperedPath, `${JSON.stringify({ ...original, packetTitle: `${original.packetTitle}!` })}\n`);
+    const tampered = await runCli(
+      ['verify', tamperedPath, '--key', keyPayload.publicKey, '--repo', repoPath],
+      { home: verifierHome, data: verifierDataDir },
+    );
+    expect(tampered.exitCode).toBe(5);
+    expect(JSON.parse(tampered.stdout)).toMatchObject({
+      ok: false,
+      signatureValid: false,
+      errors: [expect.stringContaining('signature is invalid')],
+    });
+
+    const otherIdentity = loadOrCreateReceiptIdentityAt(path.join(testHome, 'other-receipt.key'));
+    const unsigned = { ...original };
+    delete (unsigned as { signature?: string }).signature;
+    const wrongKeyUnsigned = { ...unsigned, keyId: otherIdentity.keyId };
+    const wrongKeyReceipt: PacketReceipt = {
+      ...wrongKeyUnsigned,
+      signature: signReceiptBytes(
+        new TextEncoder().encode(canonicalJson(wrongKeyUnsigned)),
+        otherIdentity.secretKey,
+      ),
+    };
+    writeFileSync(wrongKeyPath, `${JSON.stringify(wrongKeyReceipt)}\n`);
+    const wrongKey = await runCli(
+      ['verify', wrongKeyPath, '--key', keyPayload.publicKey],
+      { home: verifierHome, data: verifierDataDir },
+    );
+    expect(wrongKey.exitCode).toBe(5);
+    expect(JSON.parse(wrongKey.stdout)).toMatchObject({
+      ok: false,
+      keyIdMatches: false,
+      errors: [expect.stringContaining('does not match receipt keyId')],
+    });
+
+    const showKeyOffline = await runCli(
+      ['verify', '--show-key'],
+      { home: verifierHome, data: verifierDataDir },
+    );
+    expect(showKeyOffline.exitCode, showKeyOffline.stderr).toBe(0);
+    expect(JSON.parse(showKeyOffline.stdout)).toEqual({
+      schema: 'o8/cli/receipt.key/v1',
+      keyId: keyPayload.keyId,
+      publicKey: keyPayload.publicKey,
+    });
+  }, 30_000);
+});

--- a/tests/real-path-seams.test.ts
+++ b/tests/real-path-seams.test.ts
@@ -164,6 +164,7 @@ const { getMissionStatus, approveAndMergePacket, submitPacketReview } = await im
 const { recordMission } = await import('@/lib/db/missions-store');
 const { getSqlite } = await import('@/lib/db');
 const { mintPacketWorkerToken } = await import('@/lib/auth/packet-worker-token');
+const { listStoredPacketReceipts } = await import('@/lib/receipts/packet-receipt');
 const { syncTranscriptSearchDocument } = await import('@/lib/search/transcripts');
 const { getActiveProjectScopeForRepo } = await import('@/lib/repos/projects');
 const {
@@ -1118,6 +1119,16 @@ function commitMergeFile(cwd: string, file: string, body: string, message: strin
   return gitOut(cwd, ['rev-parse', 'HEAD']);
 }
 
+async function waitForPacketReceipt(packetId: string) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const receipt = listStoredPacketReceipts(packetId).at(-1);
+    if (receipt) return receipt;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for packet receipt ${packetId}.`);
+}
+
 async function makeMergeWorktree(repoPath: string, packetId: string, branch: string): Promise<string> {
   const previous = process.env.O8_SKIP_PRELAUNCH_TYPECHECK;
   process.env.O8_SKIP_PRELAUNCH_TYPECHECK = '1';
@@ -1238,6 +1249,17 @@ describe('seam G — merge truth verifies release claims and carries same-patch 
     expect(result.merged).toBe(true);
     expect(result.alreadyReleased).toBeUndefined();
     expect(result.mergeSha).toBe(gitOut(repoPath, ['rev-parse', 'HEAD']));
+    const storedReceipt = await waitForPacketReceipt(packetId);
+    expect(storedReceipt.receipt).toMatchObject({
+      packetId,
+      laneId: lane.id,
+      disposition: {
+        kind: 'merged',
+        mergeCommit: result.mergeSha,
+        tree: gitOut(repoPath, ['rev-parse', 'HEAD^{tree}']),
+      },
+    });
+    expect(storedReceipt.artifact.kind).toBe('receipt');
   }, 20_000);
 
   it('patch-id carry allows unchanged rebased review and still rejects changed content', async () => {

--- a/tests/route-coverage.test.ts
+++ b/tests/route-coverage.test.ts
@@ -281,6 +281,7 @@ const EXPLICIT_GATED = [
   /^\/api\/prompt-library(\/|$)/,
   /^\/api\/mcp\/?$/,
   /^\/api\/leases\/?$/,
+  /^\/api\/orchestrator\/receipts\/?$/,
   /^\/api\/orchestrator\/ui-loop(?:\/steer)?\/?$/,
   /^\/api\/broadcast\/tokens\/?$/,
   /^\/api\/broadcast\/post\/?$/,

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1883,6 +1883,15 @@
       ]
     },
     {
+      "path": "tests/packet-receipt-cli-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "network-listener",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/panel-repos-clone.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
Closes #1997. First layer of the receipts wedge (L2); truth queries (#1998) build on this.

## What changes

**A receipt for every closed packet.** When a packet merges (`approve_and_merge`) or is discarded (`close_packet_unmerged`), o8 builds a `o8/packet-receipt/v1` record from the records it already keeps: packet id and title, lane id, repository name, normalized remote and base branch, the disposition (merge commit, head, tree and evidence kind for merges; disposition, reason, preserved branches for discards), the review turns and their outcomes, the approvals with the principal that granted them, runtime, model and timestamps. Emission is fire-and-forget after the merge lock releases and can never fail or delay a merge or a close.

**Signed with a dedicated key.** The record is canonicalized (recursively sorted keys, compact JSON) and signed with a detached Ed25519 signature from a new receipt-only identity created once under the data directory (exclusive create, mode 0600). The receipt path never reads the updater key, the mobile E2EE identity, or the release scripts; an unreadable existing identity is refused rather than replaced, so the trust root cannot silently change. `keyId` is derived from the public key.

**Verify anywhere, no server.** `o8 verify <receipt.json>` checks the signature against the published public key (`--key` or the data-directory public key file), reports the verdict, and, given `--repo`, confirms the merge commit exists and its tree matches; it makes no network or API call. `--show-key` prints the public key. Receipts carry the repository's name and remote, never a local path, so they can be published.

**Surfaces.** `o8 packet receipt` (write) and `o8 packet receipts` (list) for operators; MCP `o8_packet_receipt` and `o8_verify_receipt`; a gated operator-only route for creation and listing. Worker tokens get 403 and the worker help no longer advertises the verbs. Receipts are stored as `receipt` artifacts with data-directory-relative paths. Operator guide in `docs/user/receipts.md`.

**Incidental.** The post-merge buy-in launch moved into its own module to keep the merge service under the file ceiling; same calls, same guard, same error handling.

## Verification

Real-path CLI test against a real server and the built CLI: create via CLI and MCP; verify offline after the server stops (accept, commit and tree confirmed); tampered field rejected; a receipt signed with a different key rejected with a key-id mismatch; `--show-key` without a server; the signed payload contains no segment of HOME, the data directory, or the repository path; worker token 403 on GET and POST. Unit tests for canonical JSON, identity creation and the race, the overwrite guard, the disposition builders and the verifier. Emission covered through the close-unmerged real-path test and the real-path seams. tsc, focused suites, integration, lint at the cap with zero errors, classification check, full hermetic suite, run with a clean environment by the worker and again by the reviewer.
