### PR TITLE
fix(review): cancel superseded reviewer turns and salvage awaiting-input lanes on retry

### DIFF
--- a/src/lib/lane/review-attempt-head.ts
+++ b/src/lib/lane/review-attempt-head.ts
@@ -28,6 +28,7 @@ import { recordLaneEvent } from './events';
 import { cancelReviewAttempt } from './review-cancellation';
 import { surfaceReviewQueueBlocker } from './review-queue-blocker';
 import { MAX_REVIEW_ATTEMPTS } from './review-queue-settlement';
+import { stopActiveReviewTurn } from './review-turn-state';
 import type { Lane } from './types';
 
 /** How long a claimed attempt may sit untouched before it is reclaimable. */
@@ -136,6 +137,9 @@ export function settleSupersededReviewAttempts(input: {
         previousStatus: row.status,
         reason: input.reason,
       });
+      if (row.status === 'in_progress') {
+        stopActiveReviewTurn({ laneId: input.lane.id, reason: 'superseded' });
+      }
       settled += 1;
     }
   } catch (error) {

--- a/src/lib/lane/review-turn-state.ts
+++ b/src/lib/lane/review-turn-state.ts
@@ -95,7 +95,7 @@ export function bindReviewTurnAbortController(
 
 export function stopActiveReviewTurn(input: {
   laneId: string;
-  reason: 'packet_discarded' | 'packet_stopped';
+  reason: 'packet_discarded' | 'packet_stopped' | 'superseded';
 }): ReviewTurnStopResult | null {
   const active = findActiveReviewTurn(input.laneId);
   if (!active) return null;

--- a/src/lib/orchestrator/operator-mission-service/retry-salvage.ts
+++ b/src/lib/orchestrator/operator-mission-service/retry-salvage.ts
@@ -63,6 +63,22 @@ function buildRetrySalvageGuard(
   };
 }
 
+function retrySalvageCandidateForPacket(
+  packet: OrchestratorPacket,
+  packetLanes: Lane[],
+): Lane | null {
+  const boundLaneId = packet.lane?.laneId?.trim();
+  if (boundLaneId) {
+    return packetLanes.find((lane) => lane.id === boundLaneId) ?? null;
+  }
+
+  // An awaiting-input lane can outlive the packet's runtime binding after the
+  // reviewer/session settles. Recover it only when persisted state identifies
+  // one unambiguous lane; never guess between sibling or older packet lanes.
+  const awaitingInputLanes = packetLanes.filter((lane) => lane.status === 'awaiting_input');
+  return awaitingInputLanes.length === 1 ? awaitingInputLanes[0]! : null;
+}
+
 function markPacketRetrySalvageHeld(packet: OrchestratorPacket, guard: RetrySalvageGuard): void {
   packet.status = 'failed';
   packet.queueState = 'held';
@@ -85,15 +101,16 @@ function packetMatchesRetrySalvageGuard(packet: OrchestratorPacket, guard: Retry
 async function holdPacketForRetrySalvageUnlocked(input: ResetPacketInput): Promise<RetrySalvageGuard | null> {
   if (input.clearWorktree || input.scope) return null;
 
-  const { getLane, listLanes } = await import('@/lib/lane/registry');
+  const { listLanes } = await import('@/lib/lane/registry');
   const { withLockedState } = await import('@/lib/orchestrator/control-plane');
   const { result: currentGuard } = await withLockedState((fresh) => {
     const missionId = fresh.missionId?.trim();
     if (!missionId) return null;
     const target = fresh.packets.find((candidate) => candidate.id === input.packetId);
     if (!target) return null;
-    const guardedLane = target.lane?.laneId ? getLane(target.lane.laneId) : null;
-    const laneIds = listLanes().filter((lane) => lane.packetId === target.id).map((lane) => lane.id);
+    const packetLanes = listLanes().filter((lane) => lane.packetId === target.id);
+    const guardedLane = retrySalvageCandidateForPacket(target, packetLanes);
+    const laneIds = packetLanes.map((lane) => lane.id);
     const guard = buildRetrySalvageGuard(target, { store: 'current', missionId }, guardedLane, laneIds);
     markPacketRetrySalvageHeld(target, guard);
     return guard;
@@ -109,8 +126,9 @@ async function holdPacketForRetrySalvageUnlocked(input: ResetPacketInput): Promi
   const { result } = await withMissionRegistryState(registryEntry.id, (fresh) => {
     const target = fresh.packets.find((candidate) => candidate.id === input.packetId);
     if (!target) throw new Error(`Packet ${input.packetId} not found.`);
-    const guardedLane = target.lane?.laneId ? getLane(target.lane.laneId) : null;
-    const laneIds = listLanes().filter((lane) => lane.packetId === target.id).map((lane) => lane.id);
+    const packetLanes = listLanes().filter((lane) => lane.packetId === target.id);
+    const guardedLane = retrySalvageCandidateForPacket(target, packetLanes);
+    const laneIds = packetLanes.map((lane) => lane.id);
     const guard = buildRetrySalvageGuard(target, { store: 'registry', missionId: registryEntry.id }, guardedLane, laneIds);
     markPacketRetrySalvageHeld(target, guard);
     return { state: fresh, result: guard };

--- a/tests/review-supersede-retry-real-path.test.ts
+++ b/tests/review-supersede-retry-real-path.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Real-path regressions for issue #2003.
+ *
+ * The review case drives the durable queue, real quota-fallback turn wrapper,
+ * persisted lane events, and submit-review route. The retry case drives the
+ * reset route against a real Git worktree and persisted awaiting-input lane.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+
+import { NextRequest } from 'next/server';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+
+const reviewer = vi.hoisted(() => ({
+  active: false,
+  holdNextTurn: false,
+  signals: [] as AbortSignal[],
+  threadIds: [] as string[],
+  ensureStatuses: [] as Array<'ready' | 'busy'>,
+  releaseHeldTurns: [] as Array<() => void>,
+}));
+
+vi.mock('@/lib/lane/orchestrator-backends/registry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/lane/orchestrator-backends/registry')>();
+  const backend = {
+    id: 'claude' as const,
+    label: 'Test reviewer',
+    peekSession: () => ({
+      sessionName: 'issue-2003-reviewer',
+      status: reviewer.active ? 'busy' as const : 'ready' as const,
+    }),
+    ensureSession: () => {
+      const status = reviewer.active ? 'busy' as const : 'ready' as const;
+      reviewer.ensureStatuses.push(status);
+      return { sessionName: 'issue-2003-reviewer', status };
+    },
+    sendTurn: async (
+      _repoPath: string,
+      _message: string,
+      onEvent: (event: { type: 'text'; text: string }) => void,
+      options?: { threadId?: string | null; signal?: AbortSignal },
+    ) => {
+      reviewer.threadIds.push(options?.threadId ?? '');
+      if (options?.signal) reviewer.signals.push(options.signal);
+      reviewer.active = true;
+
+      if (reviewer.holdNextTurn) {
+        reviewer.holdNextTurn = false;
+        await new Promise<void>((resolve, reject) => {
+          let settled = false;
+          const finish = (error?: Error) => {
+            if (settled) return;
+            settled = true;
+            reviewer.active = false;
+            if (error) reject(error);
+            else resolve();
+          };
+          reviewer.releaseHeldTurns.push(() => finish());
+          const abort = () => finish(new Error(String(options?.signal?.reason ?? 'aborted')));
+          if (options?.signal?.aborted) abort();
+          else options?.signal?.addEventListener('abort', abort, { once: true });
+        });
+        return;
+      }
+
+      try {
+        onEvent({ type: 'text', text: 'Reviewed. No blocking findings.' });
+      } finally {
+        reviewer.active = false;
+      }
+    },
+  };
+  return {
+    ...actual,
+    getActiveReviewerBackend: () => backend,
+    getOrchestratorBackend: () => backend,
+  };
+});
+
+vi.mock('@/lib/realtime/publisher', () => ({ publishRealtimeMutation: vi.fn(async () => {}) }));
+vi.mock('@/lib/command-center/snapshot', () => ({ invalidateCommandCenterSnapshotCaches: vi.fn() }));
+vi.mock('@/lib/mobile/inbox', () => ({ invalidateInboxCache: vi.fn() }));
+
+const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-issue-2003-data-'));
+const wsToken = 'issue-2003-operator-token-0123456789abcdef';
+writeFileSync(join(dataDir, 'ws-token'), `${wsToken}\n`, 'utf8');
+process.env.O8_DATA_DIR = dataDir;
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+
+const tempDirs: string[] = [];
+
+const { closeDb, getSqlite } = await import('@/lib/db');
+const reviewRoute = await import('@/app/api/orchestrator/review/route');
+const resetRoute = await import('@/app/api/orchestrator/reset-packet/route');
+const { drainReviewQueue, triggerAutoReview } = await import('@/lib/lane/auto-review');
+const {
+  createLane,
+  getLane,
+  getLaneEvents,
+  setLaneStatus,
+} = await import('@/lib/lane/registry');
+const {
+  readOrchestratorControlPlaneState,
+  writeOrchestratorControlPlaneState,
+} = await import('@/lib/orchestrator/control-plane');
+const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+
+function git(repoDir: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd: repoDir,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function commitFile(repoDir: string, path: string, contents: string, message: string): string {
+  const absolutePath = join(repoDir, path);
+  mkdirSync(join(absolutePath, '..'), { recursive: true });
+  writeFileSync(absolutePath, contents, 'utf8');
+  git(repoDir, ['add', '--', path]);
+  git(repoDir, ['commit', '-q', '-m', message]);
+  return git(repoDir, ['rev-parse', 'HEAD']);
+}
+
+function createRepo(branch: string): string {
+  const repoDir = mkdtempSync(join(os.tmpdir(), 'o8-issue-2003-repo-'));
+  tempDirs.push(repoDir);
+  git(repoDir, ['init', '-q', '-b', 'main']);
+  git(repoDir, ['config', 'user.email', 'o8@example.test']);
+  git(repoDir, ['config', 'user.name', 'o8-test']);
+  commitFile(repoDir, 'README.md', 'fixture\n', 'base');
+  git(repoDir, ['checkout', '-q', '-b', branch]);
+  return repoDir;
+}
+
+function packetFixture(input: {
+  packetId: string;
+  repoPath: string;
+  branch: string;
+  laneId?: string;
+}): OrchestratorPacket {
+  return {
+    id: input.packetId,
+    referenceLabel: input.packetId,
+    title: input.packetId,
+    summary: input.packetId,
+    workspaceTargetPath: input.repoPath,
+    branchTarget: input.branch,
+    runtime: 'codex',
+    dependencyLabels: [],
+    dependencyPacketIds: [],
+    queueState: input.laneId ? 'queued' : 'held',
+    releaseState: 'pending',
+    status: input.laneId ? 'awaiting_review' : 'blocked',
+    blockedReason: input.laneId ? null : 'Awaiting operator input',
+    lastEventAt: null,
+    lastEventLabel: null,
+    archivedAt: null,
+    review: null,
+    lane: input.laneId ? {
+      tileId: input.laneId,
+      tabId: input.laneId,
+      repoPath: input.repoPath,
+      worktreePath: input.repoPath,
+      runtime: 'codex',
+      laneId: input.laneId,
+      sessionKey: null,
+    } : null,
+  };
+}
+
+function persistCurrentMission(repoPath: string, packet: OrchestratorPacket): void {
+  const state = createEmptyOrchestratorMissionState();
+  state.missionId = `mission-${packet.id}`;
+  state.repoPath = repoPath;
+  state.prompt = packet.summary;
+  state.summary = packet.summary;
+  state.packets = [packet];
+  writeOrchestratorControlPlaneState(state);
+}
+
+function operatorPost(path: string, body: Record<string, unknown>): NextRequest {
+  return new NextRequest(`http://localhost:3001${path}`, {
+    method: 'POST',
+    headers: {
+      host: 'localhost:3001',
+      authorization: `Bearer ${wsToken}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function queueRows(laneId: string) {
+  return getSqlite().prepare(
+    `SELECT id, status, head_sha, last_error
+       FROM review_queue
+      WHERE lane_id = ?
+      ORDER BY rowid ASC`,
+  ).all(laneId) as Array<{
+    id: string;
+    status: string;
+    head_sha: string | null;
+    last_error: string | null;
+  }>;
+}
+
+beforeEach(() => {
+  reviewer.active = false;
+  reviewer.holdNextTurn = false;
+  reviewer.signals = [];
+  reviewer.threadIds = [];
+  reviewer.ensureStatuses = [];
+  while (reviewer.releaseHeldTurns.length > 0) reviewer.releaseHeldTurns.pop()!();
+});
+
+afterAll(async () => {
+  while (reviewer.releaseHeldTurns.length > 0) reviewer.releaseHeldTurns.pop()!();
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  closeDb();
+  rmSync(dataDir, { recursive: true, force: true });
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('superseded active reviewer turn (#2003)', () => {
+  it('aborts head A, starts head B without a busy deferral, and accepts head B through submit_review', async () => {
+    const packetId = 'pkt-review-supersede-2003';
+    const branch = 'inline/review-supersede-2003';
+    const repoDir = createRepo(branch);
+    const lane = createLane({
+      repoPath: repoDir,
+      worktreePath: repoDir,
+      branch,
+      baseBranch: 'main',
+      runtime: 'codex',
+      label: 'review supersede fixture',
+      packetId,
+    });
+    const headA = commitFile(repoDir, 'result-a.txt', 'head A\n', 'head A');
+    setLaneStatus(lane.id, 'reviewing', 'system', 'review_requested');
+    persistCurrentMission(repoDir, packetFixture({ packetId, repoPath: repoDir, branch, laneId: lane.id }));
+
+    triggerAutoReview(getLane(lane.id)!);
+    reviewer.holdNextTurn = true;
+    const firstDrain = drainReviewQueue();
+    await vi.waitFor(() => {
+      expect(reviewer.signals).toHaveLength(1);
+      expect(getLaneEvents(lane.id, 100).some((event) => (
+        event.verb === 'review_turn_started' && event.payload.expectedHeadSha === headA
+      ))).toBe(true);
+    });
+    const headASignal = reviewer.signals[0]!;
+    expect(headASignal.aborted).toBe(false);
+
+    const headB = commitFile(repoDir, 'result-b.txt', 'head B\n', 'head B');
+    triggerAutoReview(getLane(lane.id)!);
+
+    expect(headASignal.aborted).toBe(true);
+    expect(headASignal.reason).toBe('superseded');
+    expect(getLaneEvents(lane.id, 100).find((event) => event.verb === 'review_turn_stopped')).toMatchObject({
+      payload: {
+        reason: 'superseded',
+        abortRequested: true,
+      },
+    });
+    expect(queueRows(lane.id)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ status: 'completed', head_sha: headA }),
+      expect.objectContaining({ status: 'pending', head_sha: headB }),
+    ]));
+
+    await firstDrain;
+
+    const reviewResponse = await reviewRoute.POST(operatorPost('/api/orchestrator/review', {
+      packetId,
+      findings: [],
+      approved: true,
+      reviewedHeadSha: headB,
+      clientMutationId: 'review-head-b-after-supersede-2003',
+    }));
+    expect(reviewResponse.status).toBe(200);
+    await expect(reviewResponse.json()).resolves.toMatchObject({
+      ok: true,
+      result: {
+        recorded: true,
+        reviewedHeadSha: headB,
+      },
+    });
+    expect(getLaneEvents(lane.id, 100).filter((event) => event.verb === 'review_head_drift_rejected')).toHaveLength(0);
+
+    await drainReviewQueue();
+
+    expect(getLaneEvents(lane.id, 200).some((event) => (
+      event.verb === 'review_turn_started' && event.payload.expectedHeadSha === headB
+    ))).toBe(true);
+    expect(getLaneEvents(lane.id, 200).filter((event) => (
+      event.verb === 'review_deferred' && event.payload.reason === 'Reviewer session busy'
+    ))).toHaveLength(0);
+    expect(reviewer.ensureStatuses).toEqual(['ready', 'ready']);
+  });
+});
+
+describe('retry_packet awaiting-input salvage (#2003)', () => {
+  it('moves one clean committed awaiting-input lane to review without a worker relaunch', async () => {
+    const packetId = 'pkt-awaiting-input-salvage-2003';
+    const branch = 'inline/awaiting-input-salvage-2003';
+    const repoDir = createRepo(branch);
+    const lane = createLane({
+      repoPath: repoDir,
+      worktreePath: repoDir,
+      branch,
+      baseBranch: 'main',
+      runtime: 'codex',
+      label: 'awaiting input salvage fixture',
+      packetId,
+    });
+    const committedHead = commitFile(repoDir, 'worker-result.txt', 'finished work\n', 'worker result');
+    setLaneStatus(lane.id, 'awaiting_input', 'system', 'approval_required');
+
+    // A durable awaiting-input lane can remain after its live packet.lane
+    // binding clears. retry_packet must recover only this unambiguous row.
+    persistCurrentMission(repoDir, packetFixture({ packetId, repoPath: repoDir, branch }));
+
+    const response = await resetRoute.POST(operatorPost('/api/orchestrator/reset-packet', {
+      packetId,
+      reason: 'review the clean committed result',
+      clearWorktree: false,
+      idempotencyKey: 'retry-awaiting-input-salvage-2003',
+    }));
+    expect(response.status).toBe(200);
+    const body = await response.json() as {
+      ok: boolean;
+      result: { reset: boolean; salvaged: boolean; laneId: string; note: string };
+    };
+    expect(body).toMatchObject({
+      ok: true,
+      result: {
+        reset: false,
+        salvaged: true,
+        laneId: expect.stringMatching(/^lane-/),
+      },
+    });
+    expect(body.result.note).toContain('no worker was relaunched');
+
+    const packet = readOrchestratorControlPlaneState().packets.find((candidate) => candidate.id === packetId);
+    expect(packet).toMatchObject({
+      status: 'awaiting_review',
+      lastEventLabel: 'retry_salvaged_work',
+      lane: {
+        laneId: body.result.laneId,
+        worktreePath: repoDir,
+        sessionKey: null,
+      },
+    });
+    expect(getLane(body.result.laneId)).toMatchObject({
+      status: 'reviewing',
+      packetId,
+      worktreePath: repoDir,
+      sessionKey: null,
+    });
+    expect(getLane(lane.id)).toMatchObject({
+      status: 'archived',
+      packetId: '',
+      worktreePath: null,
+    });
+    expect(git(repoDir, ['rev-parse', 'HEAD'])).toBe(committedHead);
+    expect(git(repoDir, ['status', '--porcelain'])).toBe('');
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2116,6 +2116,14 @@
       ]
     },
     {
+      "path": "tests/review-supersede-retry-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/runtime-action-idempotency-real-path.test.ts",
       "reasons": [
         "real-path"


### PR DESCRIPTION
Closes #2003.

## What

- Superseding a claimed review attempt now stops the active reviewer turn for that lane (`stopActiveReviewTurn` with reason `superseded`), firing its bound abort controller and recording `review_turn_stopped`. The orphaned turn no longer keeps the reviewer session busy, so the successor review starts instead of deferring, and the head-drift check accepts the new head because no stale turn pins the lane.
- `retry_packet` salvages a clean committed `awaiting_input` lane when the packet's runtime binding is gone: if persisted state identifies exactly one `awaiting_input` lane for the packet, it moves back to review on the existing head instead of resetting and holding. Ambiguous cases still hold.

## Why

A steered rebase moved a packet's HEAD while its review turn was running. The queue marked the attempt superseded but the turn kept running (and shelling in the packet worktree), the successor review deferred every ~10 s with "Reviewer session busy", `submit_review` was rejected with `review_head_drift`, and `retry_packet` reset the packet instead of salvaging the finished branch. The way out cost a fresh worker launch on a branch that already contained the work.

## Tests

`tests/review-supersede-retry-real-path.test.ts` (integration, real SQLite + real git worktree, driving the review and reset-packet route handlers with bearer auth):

- claim a turn on head A, move HEAD to B → abort signal fires, `review_turn_stopped{reason:'superseded'}` recorded, successor review reaches `review_turn_started` with no busy deferral, and `submit_review` on head B succeeds;
- `retry_packet` on an `awaiting_input` lane with a clean committed worktree returns `salvaged:true` and no relaunch.

Gates: tsc clean; lane/orchestrator suites 589 passed; integration 2/2; lint 0 errors / 152 warnings; classification check; full unit suite 3,845 passed.

## Not in scope

Reviewer turns still run shell inside the packet worktree; keeping them read-only (or in a disposable clone) is a separate follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Superseding an active review now cleanly stops the in-progress turn and allows the next review to start without unnecessary delays.
  * Retry recovery now correctly identifies eligible awaiting-input work and salvages it without restarting a worker.

* **Tests**
  * Added end-to-end coverage for review supersession, retry recovery, persisted events, and real Git workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->