### PR TITLE
fix(lane): pin the creation receipt to the commit the packet branch is cut from

### DIFF
--- a/src/lib/lane/commands.ts
+++ b/src/lib/lane/commands.ts
@@ -147,11 +147,19 @@ async function dispatchUnlocked(
         return { ok: true, laneId: updatedExisting.id, note: 'Lane already exists for this repo and branch.', lane: updatedExisting };
       }
 
+      const baseBranch = command.baseBranch?.trim() || 'main';
+      const baseCommit = command.packetId
+        ? await import('@/lib/worktree').then(({ getWorktreeManager }) => (
+          getWorktreeManager(command.repoPath).resolveCreationBaseCommit(baseBranch, command.branch)
+        ))
+        : undefined;
+
       const lane = createLane({
         repoPath: command.repoPath,
         projectId: command.projectId,
         branch: command.branch,
-        baseBranch: command.baseBranch,
+        baseBranch,
+        baseCommit,
         runtime: workerRouting.selectedRuntime,
         label: command.label,
         packetId: command.packetId,

--- a/src/lib/lane/creation-base.ts
+++ b/src/lib/lane/creation-base.ts
@@ -25,7 +25,15 @@ export function resolveLaneCreationBaseCommit(input: {
   repoPath: string;
   branch: string;
   baseBranch: string;
+  baseCommit?: string | null;
 }): string | null {
+  const pinnedBase = input.baseCommit?.trim().toLowerCase() ?? '';
+  if (pinnedBase) {
+    if (!OBJECT_ID_PATTERN.test(pinnedBase)) {
+      throw new Error('Resolved lane creation base is not a full Git object ID.');
+    }
+    return pinnedBase;
+  }
   return gitObject(input.repoPath, ['merge-base', input.branch, input.baseBranch])
     ?? gitObject(input.repoPath, ['rev-parse', '--verify', `${input.baseBranch}^{commit}`]);
 }
@@ -38,6 +46,20 @@ export function laneCreationBaseCommit(events: LaneEvent[]): string | null {
 
 /** Read a lane's creation base without coupling review paths to the lane registry. */
 export function readLaneCreationBaseCommit(laneId: string): string | null {
+  const payload = readLaneCreationReceipt(laneId);
+  const value = payload?.baseCommit;
+  return typeof value === 'string' && OBJECT_ID_PATTERN.test(value) ? value : null;
+}
+
+/** Read the exact base that managed packet provisioning must start from. */
+export function readPinnedLaneCreationBaseCommit(laneId: string): string | null {
+  const payload = readLaneCreationReceipt(laneId);
+  if (payload?.baseCommitPinned !== true) return null;
+  const value = payload.baseCommit;
+  return typeof value === 'string' && OBJECT_ID_PATTERN.test(value) ? value : null;
+}
+
+function readLaneCreationReceipt(laneId: string): Record<string, unknown> | null {
   const db = getDb();
   if (!db) return null;
   const row = db
@@ -49,9 +71,7 @@ export function readLaneCreationBaseCommit(laneId: string): string | null {
     .get();
   if (!row) return null;
   try {
-    const payload = JSON.parse(row.payloadJson) as Record<string, unknown>;
-    const value = payload.baseCommit;
-    return typeof value === 'string' && OBJECT_ID_PATTERN.test(value) ? value : null;
+    return JSON.parse(row.payloadJson) as Record<string, unknown>;
   } catch {
     return null;
   }

--- a/src/lib/lane/registry.ts
+++ b/src/lib/lane/registry.ts
@@ -275,6 +275,7 @@ export function createLane(opts: {
   sessionKey?: string;
   worktreePath?: string;
   actor?: LaneEventActor;
+  baseCommit?: string;
 }): Lane {
   const db = getSqlite();
   const id = generateLaneId();
@@ -300,7 +301,6 @@ export function createLane(opts: {
     lastEventAt: null,
     lastEventLabel: null,
   };
-
   db.transaction(() => {
     getLaneDb().insert(lanes).values(lane).run();
     appendEvent(id, 'open_lane', opts.actor ?? 'system', {
@@ -308,7 +308,7 @@ export function createLane(opts: {
       repoPath: opts.repoPath,
       branch: opts.branch,
       baseBranch: lane.baseBranch,
-      baseCommit: resolveLaneCreationBaseCommit(lane),
+      baseCommit: resolveLaneCreationBaseCommit({ ...lane, baseCommit: opts.baseCommit }), baseCommitPinned: opts.baseCommit !== undefined,
       runtime: opts.runtime,
       packetId: opts.packetId ?? null,
       sessionKey: opts.sessionKey ?? null,

--- a/src/lib/worktree/manager.ts
+++ b/src/lib/worktree/manager.ts
@@ -364,6 +364,11 @@ export class WorktreeManager {
     const baseTaskId = deriveWorktreeId(opts);
     let taskId = baseTaskId;
     const baseBranch = opts.baseBranch ?? await this.getCurrentBranch();
+    const creationBaseCommit = opts.laneId
+      ? await import('@/lib/lane/creation-base').then(({ readPinnedLaneCreationBaseCommit }) => (
+        readPinnedLaneCreationBaseCommit(opts.laneId!)
+      ))
+      : null;
     const now = Date.now();
 
     // Avoid ID collisions — append suffix if already exists in metadata,
@@ -494,6 +499,7 @@ export class WorktreeManager {
         taskId,
         branchName,
         baseBranch,
+        creationBaseCommit,
         worktreePath,
         now,
         baseExecutionIdentity,
@@ -538,7 +544,7 @@ export class WorktreeManager {
         'worktree', 'add',
         taskId,
         '-b', branchName,
-        baseBranch,
+        creationBaseCommit ?? baseBranch,
       ], { windowsHide: true, cwd: this.worktreeBase, timeout: 30_000 })
     ));
     await assertManagedWorktreeCreatedBoundary(
@@ -549,10 +555,8 @@ export class WorktreeManager {
     );
     await this.bindCreatedMaterializationIdentity(taskId, createdExecutionIdentity);
 
-    // Rebase onto origin/<baseBranch> before handing the worktree to an agent.
-    // The worktree was branched from local <baseBranch>, which may be behind
-    // origin after parallel merges. Without this step, the agent's diff against
-    // origin/<baseBranch> would show reverts of already-merged upstream work.
+    // Packet lanes with a pinned creation receipt were cut from the exact
+    // fetched base above. Other callers retain the remote-first rebase path.
     // On conflict we abort + tear down the worktree and throw a typed error so
     // the caller can surface it to the operator instead of spawning codex into
     // a broken tree.
@@ -560,7 +564,9 @@ export class WorktreeManager {
       if (pinnedLaneBranch) {
         await this.assertCreatedWorktreeBranch(worktreePath, pinnedLaneBranch);
       }
-      await this.rebaseOntoBase(worktreePath, baseBranch, branchName);
+      if (!creationBaseCommit) {
+        await this.rebaseOntoBase(worktreePath, baseBranch, branchName);
+      }
 
     const info: WorktreeInfo = {
       id: taskId,
@@ -696,6 +702,7 @@ export class WorktreeManager {
     taskId: string;
     branchName: string;
     baseBranch: string;
+    creationBaseCommit: string | null;
     worktreePath: string;
     now: number;
     baseExecutionIdentity: Awaited<ReturnType<typeof captureWorktreeMaterializationIdentity>>;
@@ -705,7 +712,7 @@ export class WorktreeManager {
     creationOwner: NonNullable<WorktreeMetaEntry['creationOwner']>;
   }): Promise<WorktreeInfo> {
     const {
-      opts, taskId, branchName, baseBranch, worktreePath, now, baseExecutionIdentity,
+      opts, taskId, branchName, baseBranch, creationBaseCommit, worktreePath, now, baseExecutionIdentity,
       admittedVolumeId, admittedRootIdentity, baseIdentity,
       creationOwner,
     } = params;
@@ -757,7 +764,7 @@ export class WorktreeManager {
         });
       }
 
-      await execFileAsync('git', ['checkout', '-B', branchName, baseBranch], {
+      await execFileAsync('git', ['checkout', '-B', branchName, creationBaseCommit ?? baseBranch], {
         windowsHide: true,
         cwd: worktreePath,
         timeout: 30_000,
@@ -767,10 +774,12 @@ export class WorktreeManager {
         await this.assertCreatedWorktreeBranch(worktreePath, opts.branchName.trim());
       }
 
-      try {
-        await this.rebaseOntoBase(worktreePath, baseBranch, branchName);
-      } catch (err) {
-        throw err;
+      if (!creationBaseCommit) {
+        try {
+          await this.rebaseOntoBase(worktreePath, baseBranch, branchName);
+        } catch (err) {
+          throw err;
+        }
       }
 
       // #1132 — Reset to HEAD so operator WIP can't leak into the agent's
@@ -893,12 +902,23 @@ export class WorktreeManager {
     await this.rebaseOntoBase(worktreePath, baseBranch, branchName, opts.strategy);
   }
 
-  private async rebaseOntoBase(
-    worktreePath: string,
+  /** Resolve the exact fetched base a managed packet branch will start from. */
+  async resolveCreationBaseCommit(baseBranch: string, branchName: string): Promise<string> {
+    const base = baseBranch.trim() || 'main';
+    const { target } = await this.resolveBaseTarget(this.repoRoot, base, branchName);
+    const { stdout } = await execFileAsync('git', ['rev-parse', '--verify', `${target}^{commit}`], {
+      windowsHide: true,
+      cwd: this.repoRoot,
+      timeout: 5_000,
+    });
+    return stdout.trim().toLowerCase();
+  }
+
+  private async resolveBaseTarget(
+    cwd: string,
     baseBranch: string,
     branchName: string,
-    strategy?: WorktreeRebaseStrategy,
-  ): Promise<void> {
+  ): Promise<{ target: string; originMissing: boolean }> {
     // Fetch the latest base ref from origin. Failure is recoverable only if
     // the local base ref is recent — otherwise the agent would branch from a
     // stale base and generate a diff that reverts already-merged upstream
@@ -907,28 +927,28 @@ export class WorktreeManager {
     try {
       await execFileAsync('git', ['fetch', 'origin', baseBranch, '--quiet'], {
         windowsHide: true,
-        cwd: worktreePath,
+        cwd,
         timeout: 60_000,
       });
     } catch (fetchErr) {
       const fetchErrorMessage = gitCommandErrorMessage(fetchErr);
-      if (await shouldClassifyFetchAsOriginMissing(worktreePath, fetchErrorMessage)) {
+      if (await shouldClassifyFetchAsOriginMissing(cwd, fetchErrorMessage)) {
         // Local-only repo with no origin: keep dispatching. The worktree branch
         // already came off local main at checkout time; there's nothing to
         // rebase onto upstream. The operator pushes manually after merge.
         console.warn(
           `[worktree-rebase] origin not configured for ${baseBranch} — skipping rebase (local-only repo).`,
         );
-        return;
+        return { target: baseBranch, originMissing: true };
       }
-      const localRefAgeMs = await this.localBaseRefAgeMs(worktreePath, baseBranch);
+      const localRefAgeMs = await this.localBaseRefAgeMs(cwd, baseBranch);
       if (localRefAgeMs == null || localRefAgeMs > LOCAL_BASE_REF_FRESHNESS_MS) {
         console.warn(
           `[worktree-rebase] fetch origin ${baseBranch} failed (${fetchErrorMessage}) and local ${baseBranch} ref is ${localRefAgeMs == null ? 'missing' : `${Math.round(localRefAgeMs / 60_000)} min old`} — escalating as fetch_unreachable.`,
         );
         throw new WorktreeFetchUnreachableError({
           baseBranch,
-          worktreePath,
+          worktreePath: cwd,
           branch: branchName,
           localRefAgeMs: localRefAgeMs ?? Number.POSITIVE_INFINITY,
           fetchErrorMessage,
@@ -940,11 +960,11 @@ export class WorktreeManager {
     }
 
     // Prefer origin/<baseBranch> if it exists; fall back to the local ref.
-    let rebaseTarget = `origin/${baseBranch}`;
+    let target = `origin/${baseBranch}`;
     try {
-      await execFileAsync('git', ['rev-parse', '--verify', rebaseTarget], {
+      await execFileAsync('git', ['rev-parse', '--verify', target], {
         windowsHide: true,
-        cwd: worktreePath,
+        cwd,
         timeout: 5000,
       });
       // #1469 — when LOCAL base is strictly ahead of origin (unpushed merge
@@ -956,26 +976,41 @@ export class WorktreeManager {
       try {
         const { stdout: aheadRaw } = await execFileAsync(
           'git',
-          ['rev-list', '--count', `${rebaseTarget}..${baseBranch}`],
-          { windowsHide: true, cwd: worktreePath, timeout: 5000 },
+          ['rev-list', '--count', `${target}..${baseBranch}`],
+          { windowsHide: true, cwd, timeout: 5000 },
         );
         const { stdout: behindRaw } = await execFileAsync(
           'git',
-          ['rev-list', '--count', `${baseBranch}..${rebaseTarget}`],
-          { windowsHide: true, cwd: worktreePath, timeout: 5000 },
+          ['rev-list', '--count', `${baseBranch}..${target}`],
+          { windowsHide: true, cwd, timeout: 5000 },
         );
         const ahead = Number.parseInt(aheadRaw.trim(), 10) || 0;
         const behind = Number.parseInt(behindRaw.trim(), 10) || 0;
         if (ahead > 0 && behind === 0) {
           console.log(
-            `[worktree-rebase] local ${baseBranch} is ${ahead} commit(s) ahead of ${rebaseTarget} (not behind) — rebasing onto local ${baseBranch}.`,
+            `[worktree-rebase] local ${baseBranch} is ${ahead} commit(s) ahead of ${target} (not behind) — rebasing onto local ${baseBranch}.`,
           );
-          rebaseTarget = baseBranch;
+          target = baseBranch;
         }
       } catch { /* comparison failed — keep origin target */ }
     } catch {
-      rebaseTarget = baseBranch;
+      target = baseBranch;
     }
+    return { target, originMissing: false };
+  }
+
+  private async rebaseOntoBase(
+    worktreePath: string,
+    baseBranch: string,
+    branchName: string,
+    strategy?: WorktreeRebaseStrategy,
+  ): Promise<void> {
+    const { target: rebaseTarget, originMissing } = await this.resolveBaseTarget(
+      worktreePath,
+      baseBranch,
+      branchName,
+    );
+    if (originMissing) return;
 
     try {
       const rebaseArgs = ['rebase'];

--- a/tests/lane-creation-base-real-path.test.ts
+++ b/tests/lane-creation-base-real-path.test.ts
@@ -1,0 +1,170 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+const root = mkdtempSync(path.join(os.tmpdir(), 'o8-lane-creation-base-'));
+const dataDir = path.join(root, 'data');
+const worktreeRoot = path.join(root, 'worktrees');
+mkdirSync(worktreeRoot, { recursive: true });
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.O8_DATA_DIR = dataDir;
+process.env.O8_WORKTREE_ROOT = worktreeRoot;
+process.env.O8_SKIP_PRELAUNCH_TYPECHECK = '1';
+
+vi.mock('@/lib/worktree/storage-telemetry', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/worktree/storage-telemetry')>(),
+  measureHostVolume: vi.fn(async () => ({
+    accountingStatus: 'observed' as const,
+    probePath: root,
+    availableBytes: 90_000_000_000,
+    freeBytes: 90_000_000_000,
+    totalBytes: 100_000_000_000,
+    error: null,
+  })),
+}));
+
+vi.mock('@/lib/worktree/safety-hooks', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/worktree/safety-hooks')>(),
+  writeManagedWorkspaceSafetyHooks: vi.fn(async () => {}),
+}));
+
+const { closeDb } = await import('@/lib/db');
+const { dispatch } = await import('@/lib/lane/commands');
+const { getLaneEvents, setLaneStatus } = await import('@/lib/lane/registry');
+const { getLaneSpokenDiffFacts } = await import('@/lib/lane/lane-diff-facts');
+const { previewPacketMerge } = await import('@/lib/lane/preview-merge');
+const { addRepo } = await import('@/lib/repos/registry');
+const { prepareLaunchWorktree } = await import('@/lib/worktree/launch');
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function commitAll(cwd: string, message: string): string {
+  git(cwd, ['add', '-A']);
+  git(cwd, [
+    '-c', 'user.name=o8-test',
+    '-c', 'user.email=o8@example.test',
+    'commit', '-m', message,
+  ]);
+  return git(cwd, ['rev-parse', 'HEAD']);
+}
+
+function createStaleRegisteredRepo(): {
+  repo: string;
+  remoteHead: string;
+  localHead: string;
+} {
+  const origin = path.join(root, 'origin.git');
+  const repo = path.join(root, 'registered');
+  const publisher = path.join(root, 'publisher');
+
+  execFileSync('git', ['init', '--bare', origin], { stdio: 'pipe' });
+  execFileSync('git', ['clone', origin, repo], { stdio: 'pipe' });
+  git(repo, ['checkout', '-b', 'main']);
+  writeFileSync(path.join(repo, 'README.md'), 'base\n');
+  const localHead = commitAll(repo, 'base');
+  git(repo, ['push', '-u', 'origin', 'main']);
+
+  execFileSync('git', ['clone', origin, publisher], { stdio: 'pipe' });
+  git(publisher, ['checkout', 'main']);
+  writeFileSync(
+    path.join(publisher, 'upstream-only.ts'),
+    Array.from({ length: 54 }, (_, index) => `export const upstream${index} = ${index};`).join('\n') + '\n',
+  );
+  commitAll(publisher, 'upstream one');
+  writeFileSync(path.join(publisher, 'upstream-two.txt'), 'second upstream commit\n');
+  const remoteHead = commitAll(publisher, 'upstream two');
+  git(publisher, ['push', 'origin', 'main']);
+
+  expect(git(repo, ['rev-parse', 'main'])).toBe(localHead);
+  expect(git(repo, ['rev-list', '--count', 'main..origin/main'])).toBe('0');
+  return { repo, remoteHead, localHead };
+}
+
+afterAll(() => {
+  closeDb();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('managed lane creation base', () => {
+  it('pins the fetched remote base into the receipt and packet branch', async () => {
+    const { repo, remoteHead, localHead } = createStaleRegisteredRepo();
+    await addRepo(repo);
+    const packetId = `pkt-creation-base-${Date.now()}`;
+    const branch = `issue/creation-base-${Date.now()}`;
+
+    const opened = await dispatch({
+      verb: 'open_lane',
+      repoPath: repo,
+      branch,
+      baseBranch: 'main',
+      runtime: 'codex',
+      packetId,
+      actor: 'orchestrator',
+    });
+    expect(opened.ok).toBe(true);
+    expect(git(repo, ['rev-parse', 'main'])).toBe(localHead);
+    expect(git(repo, ['rev-parse', 'origin/main'])).toBe(remoteHead);
+    expect(git(repo, ['rev-list', '--count', 'main..origin/main'])).toBe('2');
+
+    const openEvent = getLaneEvents(opened.laneId!, 100)
+      .find((event) => event.verb === 'open_lane');
+    expect(openEvent?.payload).toMatchObject({
+      baseCommit: remoteHead,
+      baseCommitPinned: true,
+    });
+
+    const launch = await prepareLaunchWorktree({
+      repoRoot: repo,
+      agentType: 'codex',
+      taskName: packetId,
+      branchName: branch,
+      baseBranch: 'main',
+      isolate: true,
+      skipSetup: true,
+      packetId,
+      laneId: opened.laneId!,
+      isolationPreference: 'git-worktree',
+    });
+    expect(launch).not.toBeNull();
+    const worktree = launch!.worktree;
+    const bound = await dispatch({
+      verb: 'bind_worktree',
+      laneId: opened.laneId!,
+      worktreePath: worktree.path,
+      actor: 'system',
+    });
+    expect(bound.ok).toBe(true);
+
+    writeFileSync(path.join(worktree.path, 'packet-only.ts'), 'export const packetOnly = true;\n');
+    const packetHead = commitAll(worktree.path, 'packet change');
+    expect(git(worktree.path, ['rev-parse', `${packetHead}^`])).toBe(remoteHead);
+    setLaneStatus(opened.laneId!, 'reviewing', 'system', 'review_ready');
+
+    const preview = await previewPacketMerge(packetId);
+    expect(preview.diffBase).toMatchObject({
+      requestedRef: remoteHead,
+      comparisonRef: remoteHead,
+      mergeBase: remoteHead,
+      fetchedRemoteBase: false,
+      usedFallback: false,
+    });
+    expect(preview.checks.find((check) => check.name === 'diff-budget')).toMatchObject({
+      verdict: 'pass',
+    });
+
+    const facts = await getLaneSpokenDiffFacts(bound.lane!);
+    expect(facts.changedFiles).toEqual(['packet-only.ts']);
+    expect(git(worktree.path, ['diff', '--name-only', `${preview.diffBase!.comparisonRef}...HEAD`]))
+      .toBe('packet-only.ts');
+    expect(JSON.stringify(preview)).not.toContain('upstream-only.ts');
+  }, 30_000);
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1514,6 +1514,14 @@
       ]
     },
     {
+      "path": "tests/lane-creation-base-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/lane-lifecycle-1810-real-path.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
Closes #2002.

## What

- Dispatch resolves the packet's base commit once, up front: `WorktreeManager.resolveCreationBaseCommit` fetches `origin/<base>` using the same origin-vs-local target rule the rebase path already had (extracted as `resolveBaseTarget`) and returns the exact sha.
- `createLane` records that sha in the `open_lane` receipt as `baseCommit` with `baseCommitPinned: true`.
- Managed worktree provisioning reads the pinned receipt and cuts the packet branch from exactly that commit (`git checkout -B <branch> <sha>`), skipping the post-checkout rebase for pinned lanes. The receipt and the branch can no longer disagree.
- Lanes without a pinned receipt (legacy lanes, non-packet lanes) keep the previous behavior: `merge-base` / local base fallback at open time and the remote-first rebase after checkout.

## Why

`open_lane.baseCommit` was resolved in the registered repo at open time, before the worktree existed, so it fell back to the repo's local `main`. When local `main` lagged `origin/main` (merges land on GitHub; the local checkout is pulled only before ships), every gate that trusts the receipt attributed the upstream commits to the packet: false `diff-budget` blocks, an auto-review that rejected the packet as off-task, a `high` risk tier for migrations the packet never touched, and an approval card per packet.

## Tests

`tests/lane-creation-base-real-path.test.ts` (integration): a registered repo whose local `main` is two commits behind `origin/main`; the lane opens through the real `dispatch` command, provisions through `prepareLaunchWorktree`, and the test asserts `open_lane.baseCommit` equals the packet commit's first parent, the merge preview uses that sha, and only the packet's own file is attributed to it.

Gates: tsc clean; targeted unit 306 passed; integration 16 passed across the three creation-receipt suites; lint 0 errors / 152 warnings; classification manifest matches; full unit suite 3,847 passed.

## Notes

`src/lib/worktree/manager.ts` and `src/lib/lane/commands.ts` were already past the file-size ceiling before this change; the net growth here is +35 and +10 lines, mostly the extracted `resolveBaseTarget`. Splitting `manager.ts` is a separate task.
