### PR TITLE
Fix dev NODE_OPTIONS stub path resolution

### DIFF
--- a/scripts/bench/run-memory.mjs
+++ b/scripts/bench/run-memory.mjs
@@ -2,6 +2,7 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { withServerOnlyStubNodeOptions } from '../run-lib.mjs';
 
 const CATEGORIES = [
   'ownership',
@@ -117,7 +118,7 @@ function main() {
       ...process.env,
       O8_EVAL_MODE: '1',
       THREE_WAY_LIMIT: process.env.BENCH_QA_LIMIT ?? undefined,
-      NODE_OPTIONS: '--import=./scripts/register-server-only-stub.mjs',
+      NODE_OPTIONS: withServerOnlyStubNodeOptions(),
     },
   });
 

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
-import { resolveSpawn } from './run-lib.mjs';
+import { resolveSpawn, withServerOnlyStubNodeOptions } from './run-lib.mjs';
 
 const root = process.cwd();
 const stateDir = join(
@@ -173,9 +173,7 @@ const mode = process.argv[2] || 'all';
 if (mode === 'cleanup') await cleanup();
 else if (mode === 'next') run('dev:next', 'next', ['dev', '-p', env.PORT]);
 else if (mode === 'ws') {
-  env.NODE_OPTIONS = [env.NODE_OPTIONS, '--import=./scripts/register-server-only-stub.mjs']
-    .filter(Boolean)
-    .join(' ');
+  env.NODE_OPTIONS = withServerOnlyStubNodeOptions(env.NODE_OPTIONS);
   run('dev:ws', 'tsx', ['src/ws-server.ts']);
 } else if (mode === 'all') await all();
 else {

--- a/scripts/run-lib.d.mts
+++ b/scripts/run-lib.d.mts
@@ -1,5 +1,15 @@
-// Types for run-lib.mjs (allowJs is off repo-wide). Only the pure parser is
-// declared — the spawn helpers are script-side only and have no TS callers.
+// Types for run-lib.mjs (allowJs is off repo-wide). Spawn helpers remain
+// script-side only; these pure helpers also have TypeScript callers.
+export declare const SERVER_ONLY_STUB_NODE_OPTION: string;
+
+export declare function canonicalizeServerOnlyStubNodeOptions(
+  value: string | undefined,
+): string | undefined;
+
+export declare function withServerOnlyStubNodeOptions(
+  value?: string,
+): string;
+
 export declare function parseEnvPrefixArgv(argv: string[]): {
   assignments: Record<string, string>;
   command: string | undefined;

--- a/scripts/run-lib.mjs
+++ b/scripts/run-lib.mjs
@@ -19,6 +19,37 @@ import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
+// NODE_OPTIONS resolves relative imports from each child's cwd, so descendants
+// launched in worktrees need this module-anchored file URL rather than the legacy token.
+const LEGACY_SERVER_ONLY_STUB_NODE_OPTION = '--import=./scripts/register-server-only-stub.mjs';
+export const SERVER_ONLY_STUB_NODE_OPTION = `--import=${new URL('./register-server-only-stub.mjs', import.meta.url).href}`;
+const SERVER_ONLY_STUB_NODE_OPTION_PATTERN = new RegExp(
+  `(^|\\s)(?:${escapeRegExp(LEGACY_SERVER_ONLY_STUB_NODE_OPTION)}|${escapeRegExp(SERVER_ONLY_STUB_NODE_OPTION)})(?=\\s|$)`,
+  'g',
+);
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalizeServerOnlyStubNodeOptions(value, appendIfMissing) {
+  let found = false;
+  const normalized = value?.replace(SERVER_ONLY_STUB_NODE_OPTION_PATTERN, (_match, prefix) => {
+    if (found) return '';
+    found = true;
+    return `${prefix}${SERVER_ONLY_STUB_NODE_OPTION}`;
+  });
+  if (found || !appendIfMissing) return normalized;
+  return value ? `${value} ${SERVER_ONLY_STUB_NODE_OPTION}` : SERVER_ONLY_STUB_NODE_OPTION;
+}
+
+export function canonicalizeServerOnlyStubNodeOptions(value) {
+  return normalizeServerOnlyStubNodeOptions(value, false);
+}
+
+export function withServerOnlyStubNodeOptions(value) {
+  return normalizeServerOnlyStubNodeOptions(value, true);
+}
 
 /**
  * CLI name -> the package subpath its `node_modules/.bin` entry points at.

--- a/scripts/run.mjs
+++ b/scripts/run.mjs
@@ -9,7 +9,11 @@
  * inline prefix had, minus the requirement for a POSIX shell.
  */
 
-import { parseEnvPrefixArgv, runAndExit } from './run-lib.mjs';
+import {
+  canonicalizeServerOnlyStubNodeOptions,
+  parseEnvPrefixArgv,
+  runAndExit,
+} from './run-lib.mjs';
 
 const { assignments, command, args } = parseEnvPrefixArgv(process.argv.slice(2));
 
@@ -18,4 +22,8 @@ if (!command) {
   process.exit(1);
 }
 
-runAndExit(command, args, { ...process.env, ...assignments });
+const env = { ...process.env, ...assignments };
+if (env.NODE_OPTIONS) {
+  env.NODE_OPTIONS = canonicalizeServerOnlyStubNodeOptions(env.NODE_OPTIONS);
+}
+runAndExit(command, args, env);

--- a/scripts/verify-symon-agent-mode.ts
+++ b/scripts/verify-symon-agent-mode.ts
@@ -23,6 +23,7 @@ import { mkdtempSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import WebSocket from 'ws';
+import { withServerOnlyStubNodeOptions } from './run-lib.mjs';
 
 const WS_TOKEN = 'verify-symon-agent-mode-token-0123456789';
 const WS_PORT = 34000 + Math.floor(Math.random() * 4000);
@@ -101,7 +102,7 @@ async function main() {
       cwd: process.cwd(),
       env: {
         ...process.env,
-        NODE_OPTIONS: '--import=./scripts/register-server-only-stub.mjs',
+        NODE_OPTIONS: withServerOnlyStubNodeOptions(),
         NEXT_ORIGIN: `http://127.0.0.1:${stub.port}`,
         WS_TOKEN,
         WS_PORT: String(WS_PORT),

--- a/tests/server-only-stub-node-options.test.ts
+++ b/tests/server-only-stub-node-options.test.ts
@@ -1,0 +1,41 @@
+import { spawnSync } from 'node:child_process';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+  canonicalizeServerOnlyStubNodeOptions,
+  SERVER_ONLY_STUB_NODE_OPTION,
+  withServerOnlyStubNodeOptions,
+} from '../scripts/run-lib.mjs';
+
+const runScript = fileURLToPath(new URL('../scripts/run.mjs', import.meta.url));
+const legacyServerOnlyStubNodeOption = '--import=./scripts/register-server-only-stub.mjs';
+
+describe('server-only stub node options', () => {
+  it('canonicalizes the stub without changing unrelated options', () => {
+    expect(canonicalizeServerOnlyStubNodeOptions('--trace-warnings')).toBe('--trace-warnings');
+    expect(withServerOnlyStubNodeOptions(
+      `--trace-warnings ${legacyServerOnlyStubNodeOption} ${SERVER_ONLY_STUB_NODE_OPTION}`,
+    )).toBe(`--trace-warnings ${SERVER_ONLY_STUB_NODE_OPTION}`);
+  });
+
+  it('starts a Node child outside the repository through the package script runner', () => {
+    const env = { ...process.env };
+    delete env.NODE_OPTIONS;
+    const result = spawnSync(process.execPath, [
+      runScript,
+      `NODE_OPTIONS=${legacyServerOnlyStubNodeOption}`,
+      '--',
+      'tsx',
+      '--eval',
+      "require('server-only')",
+    ], {
+      cwd: os.tmpdir(),
+      env,
+      encoding: 'utf8',
+    });
+
+    expect(result.status, result.error?.message ?? result.stderr).toBe(0);
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2162,6 +2162,12 @@
       ]
     },
     {
+      "path": "tests/server-only-stub-node-options.test.ts",
+      "reasons": [
+        "child-process"
+      ]
+    },
+    {
       "path": "tests/session-transform-real-path.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
## Summary

- resolve the inherited `server-only` stub import to a module-anchored absolute file URL
- reuse the shared helper across dev, shell-neutral smoke/bench launchers, memory bench, and Symon verification while preserving unrelated `NODE_OPTIONS`
- add a temp-directory real-runner regression that proves the stub is inherited and executed

## Verification

- `node --version` — `v22.22.0`
- focused integration test — 2 passed
- test-classification manifest check — passed
- `npx tsc --noEmit` — passed
- `npm run typecheck` — passed
- touched-file ESLint — passed
- `npm run lint` — passed (0 errors; 152 existing warnings)
- `npm run rule-check -- --base=upstream/main` — passed
- `git diff --check` — passed

## Local Windows limitations

- `npm test`: 3,782 passed; 69 unrelated platform/environment failures involving POSIX assumptions, Windows symlink privileges, and locked SQLite cleanup. The focused regression passes.
- `npm run protocol:check`: the raw check differs because of CRLF checkout normalization; the LF-normalized contract hash exactly matches the committed generated hash.

Closes #1994


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of server-only Node runtime options across development, benchmarking, verification, and command-running workflows.
  * Automatically normalizes legacy or duplicate options to ensure consistent child-process behavior.

* **Tests**
  * Added coverage for option normalization and child-process execution using legacy configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->