### PR TITLE
Add low-latency preset for UI edit turns

### DIFF
--- a/src/app/api/orchestrator/create-mission/route.ts
+++ b/src/app/api/orchestrator/create-mission/route.ts
@@ -179,10 +179,19 @@ export async function POST(request: NextRequest) {
   if (!profileRouting.ok) {
     return operatorError(profileRouting.code, profileRouting.message, 400);
   }
-  const runtimePreset = origin && !requestedModelText && profileRouting.requestedRuntime
-    ? resolveRuntimePreset('ui-edit-low-latency', profileRouting.requestedRuntime)
+  const runtimePresetId = origin && !requestedModelText ? 'ui-edit-low-latency' as const : null;
+  const runtimePreset = runtimePresetId
+    && profileRouting.requestedRuntime
+    && !(claudeCodeCarrier && profileRouting.requestedRuntime === 'claude-code')
+    ? resolveRuntimePreset(runtimePresetId, profileRouting.requestedRuntime)
     : null;
-  const effectiveRequestedModel = runtimePreset?.model ?? profileRouting.requestedModel;
+  const carrierOwnsMissionModel = Boolean(
+    claudeCodeCarrier && profileRouting.requestedRuntime === 'claude-code',
+  );
+  const effectiveRequestedModel = carrierOwnsMissionModel
+    ? null
+    : runtimePreset?.model ?? profileRouting.requestedModel;
+  const issueRoutings = [];
   for (const issue of issues) {
     if (!issue.runtime) continue;
     const dispatchError = runtimeDispatchError(issue.runtime);
@@ -196,6 +205,19 @@ export async function POST(request: NextRequest) {
     if (!issueProfileRouting.ok) {
       return operatorError(issueProfileRouting.code, issueProfileRouting.message, 400);
     }
+    const issueRuntime = issueProfileRouting.requestedRuntime ?? issue.runtime;
+    const carrierOwnsIssueModel = Boolean(claudeCodeCarrier && issueRuntime === 'claude-code');
+    const issuePreset = runtimePresetId && !carrierOwnsIssueModel
+      ? resolveRuntimePreset(runtimePresetId, issueProfileRouting.requestedRuntime ?? issue.runtime)
+      : null;
+    issueRoutings.push(resolveWorkerRouting({
+      workerIntent: record.workerIntent,
+      requestedProvider: record.requestedProvider,
+      requestedRuntime: issueRuntime,
+      requestedModel: carrierOwnsIssueModel ? null : issuePreset?.model ?? issueProfileRouting.requestedModel,
+      requestedEffort,
+      source: 'create-mission-api-issue',
+    }));
   }
   const workerRouting = resolveWorkerRouting({
     workerIntent: record.workerIntent,
@@ -223,16 +245,7 @@ export async function POST(request: NextRequest) {
   });
   try {
     await assertRuntimeDispatchable(workerRouting.selectedRuntime, workerRouting.selectedModel, repoPath);
-    for (const issue of issues) {
-      if (!issue.runtime) continue;
-      const issueRouting = resolveWorkerRouting({
-        workerIntent: record.workerIntent,
-        requestedProvider: record.requestedProvider,
-        requestedRuntime: issue.runtime,
-        requestedModel: profileRouting.requestedModel,
-        requestedEffort,
-        source: 'create-mission-api-issue',
-      });
+    for (const issueRouting of issueRoutings) {
       await assertRuntimeDispatchable(issueRouting.selectedRuntime, issueRouting.selectedModel, repoPath);
     }
   } catch (error) {
@@ -279,6 +292,7 @@ export async function POST(request: NextRequest) {
       requestedProvider: workerRouting.requestedProvider,
       requestedRuntime: profileRouting.requestedRuntime,
       requestedModel: workerRouting.requestedModel,
+      ...(runtimePresetId ? { runtimePreset: runtimePresetId } : {}),
       ...(hasClaudeCodePacket && claudeCodeModel ? { claudeCodeModel } : {}),
       ...(hasClaudeCodePacket && claudeCodeCarrier ? { claudeCodeCarrier } : {}),
       requestedEffort,

--- a/src/app/api/orchestrator/create-mission/route.ts
+++ b/src/app/api/orchestrator/create-mission/route.ts
@@ -17,6 +17,7 @@ import {
   formatDispatchableRuntimeChoices,
   getRuntimeCapability,
   isOrchestratorRuntime,
+  resolveRuntimePreset,
 } from '@/lib/orchestrator/runtime-capabilities';
 import { assertRuntimeDispatchable, DispatchPreflightError } from '@/lib/runtimes/shared/auth-detect';
 import { ControlPlaneLockTimeoutError } from '@/lib/orchestrator/control-plane';
@@ -131,6 +132,7 @@ export async function POST(request: NextRequest) {
   if (record.origin !== undefined && record.origin !== 'design-mode') {
     return operatorError('invalid_request', 'origin must be "design-mode" when provided.', 400);
   }
+  const origin = record.origin === 'design-mode' ? 'design-mode' as const : undefined;
   const launchContext = normalizeWorkerLaunchContext(record.launchContext);
   if (record.launchContext !== undefined && !launchContext) {
     return operatorError('invalid_request', 'launchContext must name a valid source, presentation, and repoContext.', 400);
@@ -177,6 +179,10 @@ export async function POST(request: NextRequest) {
   if (!profileRouting.ok) {
     return operatorError(profileRouting.code, profileRouting.message, 400);
   }
+  const runtimePreset = origin && !requestedModelText && profileRouting.requestedRuntime
+    ? resolveRuntimePreset('ui-edit-low-latency', profileRouting.requestedRuntime)
+    : null;
+  const effectiveRequestedModel = runtimePreset?.model ?? profileRouting.requestedModel;
   for (const issue of issues) {
     if (!issue.runtime) continue;
     const dispatchError = runtimeDispatchError(issue.runtime);
@@ -195,7 +201,7 @@ export async function POST(request: NextRequest) {
     workerIntent: record.workerIntent,
     requestedProvider: record.requestedProvider,
     requestedRuntime: profileRouting.requestedRuntime,
-    requestedModel: profileRouting.requestedModel,
+    requestedModel: effectiveRequestedModel,
     requestedEffort,
     source: 'create-mission-api',
   });
@@ -265,8 +271,6 @@ export async function POST(request: NextRequest) {
   if (qualitySearch && taskContract === 'off') {
     return operatorError('invalid_request', 'qualitySearch already uses a sealed contract and cannot be combined with taskContract: "off".', 400);
   }
-  const origin = record.origin === 'design-mode' ? 'design-mode' as const : undefined;
-
   const createInput = {
       issues,
       repoPath,

--- a/src/lib/orchestrator/operator-mission-service/mission.ts
+++ b/src/lib/orchestrator/operator-mission-service/mission.ts
@@ -30,6 +30,7 @@ import { prepareMissionBranches, type MissionBranchDecision } from './branch-cle
 import { recordOutgoingMissionSnapshot } from './mission-handoff';
 import { logDispatchRoutingRecommendations } from './mission-routing-log';
 import { preparePacketsForExplicitDispatch, summarizeDispatchMission } from './dispatch-runtime-override';
+import { resolveRuntimePresetModel } from './runtime-preset-routing';
 import {
   buildMissionId,
   buildMissionPrompt,
@@ -134,7 +135,7 @@ export async function createMission(input: CreateMissionInput) {
     workerIntent: input.workerIntent,
     requestedProvider: input.requestedProvider,
     requestedRuntime: input.requestedRuntime ?? input.runtime,
-    requestedModel: input.requestedModel,
+    requestedModel: resolveRuntimePresetModel(input.runtimePreset, input.requestedRuntime ?? input.runtime, input.requestedModel, input.claudeCodeCarrier),
     requestedEffort: input.requestedEffort,
     source: 'mission-create',
   });
@@ -170,7 +171,7 @@ export async function createMission(input: CreateMissionInput) {
           workerIntent: input.workerIntent,
           requestedProvider: input.requestedProvider,
           requestedRuntime: issue.runtime,
-          requestedModel: input.requestedModel,
+          requestedModel: resolveRuntimePresetModel(input.runtimePreset, issue.runtime, input.requestedModel, input.claudeCodeCarrier),
           requestedEffort: input.requestedEffort,
           source: 'mission-create-packet',
         })

--- a/src/lib/orchestrator/operator-mission-service/runtime-preset-routing.test.ts
+++ b/src/lib/orchestrator/operator-mission-service/runtime-preset-routing.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveRuntimePreset } from '@/lib/orchestrator/runtime-capabilities';
+import { resolveRuntimePresetModel } from './runtime-preset-routing';
+
+describe('resolveRuntimePresetModel', () => {
+  it('returns the preset model for a runtime the preset knows', () => {
+    expect(resolveRuntimePresetModel('ui-edit-low-latency', 'codex', 'operator/model', undefined))
+      .toBe(resolveRuntimePreset('ui-edit-low-latency', 'codex')!.model);
+  });
+
+  it('keeps the operator model for a runtime without a preset entry', () => {
+    expect(resolveRuntimePresetModel('ui-edit-low-latency', 'gemini', 'operator/model', undefined))
+      .toBe('operator/model');
+  });
+
+  it('returns the fallback untouched when no preset is armed', () => {
+    expect(resolveRuntimePresetModel(undefined, 'gemini', 'operator/model', undefined))
+      .toBe('operator/model');
+  });
+
+  it('yields model ownership to a claude-code carrier', () => {
+    expect(resolveRuntimePresetModel('ui-edit-low-latency', 'claude-code', 'operator/model', { on: true }))
+      .toBeNull();
+  });
+});

--- a/src/lib/orchestrator/operator-mission-service/runtime-preset-routing.ts
+++ b/src/lib/orchestrator/operator-mission-service/runtime-preset-routing.ts
@@ -1,0 +1,14 @@
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+import { resolveRuntimePreset, type RuntimePresetId } from '@/lib/orchestrator/runtime-capabilities';
+
+/** Resolve a semantic preset for one runtime without leaking cross-runtime model ids. */
+export function resolveRuntimePresetModel(
+  preset: RuntimePresetId | undefined,
+  runtime: OrchestratorRuntime,
+  fallback: string | null | undefined,
+  carrier?: unknown,
+) {
+  if (!preset) return fallback;
+  if (runtime === 'claude-code' && carrier) return null;
+  return resolveRuntimePreset(preset, runtime)?.model ?? null;
+}

--- a/src/lib/orchestrator/operator-mission-service/runtime-preset-routing.ts
+++ b/src/lib/orchestrator/operator-mission-service/runtime-preset-routing.ts
@@ -10,5 +10,7 @@ export function resolveRuntimePresetModel(
 ) {
   if (!preset) return fallback;
   if (runtime === 'claude-code' && carrier) return null;
-  return resolveRuntimePreset(preset, runtime)?.model ?? null;
+  // A runtime with no preset entry keeps the caller's model: the preset is a
+  // hint for runtimes it knows, never a reason to drop the operator's routing.
+  return resolveRuntimePreset(preset, runtime)?.model ?? fallback;
 }

--- a/src/lib/orchestrator/operator-mission-service/types.ts
+++ b/src/lib/orchestrator/operator-mission-service/types.ts
@@ -11,6 +11,7 @@ import type {
 } from '@/lib/orchestrator/types';
 import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import type { ClaudeCodeModelSource } from '@/lib/claude-code/worker-profile-types';
+import type { RuntimePresetId } from '@/lib/orchestrator/runtime-capabilities';
 
 export interface LoadedIssue {
   number: number;
@@ -37,6 +38,8 @@ export interface CreateMissionInput {
   requestedProvider?: WorkerProvider | null;
   requestedRuntime?: OrchestratorRuntime | null;
   requestedModel?: string | null;
+  /** Semantic model preset resolved independently for each packet runtime. */
+  runtimePreset?: RuntimePresetId;
   /** Explicit per-packet model pin for Claude Code workers. */
   claudeCodeModel?: string | null;
   /** Explicit per-packet carrier pin for Claude Code workers. */

--- a/src/lib/orchestrator/runtime-capabilities.test.ts
+++ b/src/lib/orchestrator/runtime-capabilities.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { MODEL_IDS } from '@/lib/models';
+
 import {
   ORCHESTRATOR_RUNTIMES,
   ORCHESTRATOR_RUNTIME_IDS,
@@ -11,6 +13,7 @@ import {
   listDeclarativeRuntimes,
   listDispatchableRuntimes,
   listDispatchableWorkerProviders,
+  resolveRuntimePreset,
 } from './runtime-capabilities';
 
 describe('runtime capability catalog', () => {
@@ -51,5 +54,17 @@ describe('runtime capability catalog', () => {
     expect(listDispatchableWorkerProviders()).toEqual(expected);
     expect(expected.every((provider) => isRuntimeWorkerProvider(provider))).toBe(true);
     expect(isRuntimeWorkerProvider('made-up-provider')).toBe(false);
+  });
+
+  it('resolves the UI-edit preset through the selected subscription runtime', () => {
+    expect(resolveRuntimePreset('ui-edit-low-latency', 'codex')).toEqual({
+      runtime: 'codex',
+      model: MODEL_IDS.codexScoutDefault,
+    });
+    expect(resolveRuntimePreset('ui-edit-low-latency', 'claude-code')).toEqual({
+      runtime: 'claude-code',
+      model: MODEL_IDS.claudeHaikuQaDefault,
+    });
+    expect(resolveRuntimePreset('ui-edit-low-latency', 'gemini')).toBeNull();
   });
 });

--- a/src/lib/orchestrator/runtime-capabilities.ts
+++ b/src/lib/orchestrator/runtime-capabilities.ts
@@ -423,6 +423,29 @@ export type RuntimeAuthHouse = Exclude<
 >;
 type CatalogRuntimeCapability = OrchestratorRuntimeCapability<RuntimeWorkerProvider, RuntimeAuthHouse>;
 
+export const RUNTIME_PRESETS = {
+  'ui-edit-low-latency': {
+    modelByRuntime: {
+      codex: MODEL_IDS.codexScoutDefault,
+      'claude-code': MODEL_IDS.claudeHaikuQaDefault,
+    },
+  },
+} as const satisfies Record<string, {
+  modelByRuntime: Partial<Record<OrchestratorRuntime, string>>;
+}>;
+
+export type RuntimePresetId = keyof typeof RUNTIME_PRESETS;
+
+/** Resolve a semantic preset through the runtime already selected by operator policy. */
+export function resolveRuntimePreset(
+  presetId: RuntimePresetId,
+  runtime: OrchestratorRuntime,
+): { runtime: OrchestratorRuntime; model: string } | null {
+  const modelByRuntime = RUNTIME_PRESETS[presetId].modelByRuntime as Partial<Record<OrchestratorRuntime, string>>;
+  const model = modelByRuntime[runtime];
+  return model ? { runtime, model } : null;
+}
+
 export const ORCHESTRATOR_RUNTIME_IDS = Object.freeze(
   Object.keys(ORCHESTRATOR_RUNTIMES) as OrchestratorRuntime[],
 );

--- a/tests/ui-edit-runtime-preset-route.test.ts
+++ b/tests/ui-edit-runtime-preset-route.test.ts
@@ -8,6 +8,7 @@ import { MODEL_IDS } from '@/lib/models';
 import type { LaneCommand, LaneCommandResult } from '@/lib/lane/types';
 
 const laneCommandMock = vi.hoisted(() => vi.fn());
+const runtimeDispatchableMock = vi.hoisted(() => vi.fn(async () => undefined));
 
 vi.mock('@/lib/panel/auth', () => ({
   requirePanelAuth: vi.fn(() => null),
@@ -15,7 +16,7 @@ vi.mock('@/lib/panel/auth', () => ({
 
 vi.mock('@/lib/runtimes/shared/auth-detect', async (importOriginal) => ({
   ...await importOriginal<typeof import('@/lib/runtimes/shared/auth-detect')>(),
-  assertRuntimeDispatchable: vi.fn(async () => undefined),
+  assertRuntimeDispatchable: runtimeDispatchableMock,
 }));
 
 vi.mock('@/lib/orchestrator/operator-mission-service/branch-cleanup', async (importOriginal) => ({
@@ -120,11 +121,14 @@ delete process.env.CORTEX_IDE_DB_PATH;
 delete process.env.O8_DEFAULT_DISPATCH_RUNTIME;
 delete process.env.O8_DISPATCH_MODEL;
 delete process.env.O8_SUBSCRIPTION_PROFILE;
-writeFileSync(path.join(dataDir, 'operator-defaults.json'), JSON.stringify({
-  subscriptionProfile: 'both',
-  defaultDispatchRuntime: 'codex',
-  defaultDispatchModel: MODEL_IDS.codexWorkerDefault,
-}));
+function writeTestOperatorDefaults(defaultDispatchModel: string) {
+  writeFileSync(path.join(dataDir, 'operator-defaults.json'), JSON.stringify({
+    subscriptionProfile: 'both',
+    defaultDispatchRuntime: 'codex',
+    defaultDispatchModel,
+  }));
+}
+writeTestOperatorDefaults(MODEL_IDS.codexWorkerDefault);
 
 const { NextRequest } = await import('next/server');
 const { POST } = await import('@/app/api/orchestrator/create-mission/route');
@@ -168,6 +172,47 @@ async function createAndReadPacket(input: {
   return readOrchestratorControlPlaneState().packets.find((packet) => packet.id === packetId);
 }
 
+async function createAndReadMixedRuntimePackets(input: { carrier?: 'openrouter' } = {}) {
+  requestSequence += 1;
+  const issueNumber = 19_040_000 + requestSequence * 10;
+  runtimeDispatchableMock.mockClear();
+  const response = await POST(new NextRequest('http://127.0.0.1:47120/api/orchestrator/create-mission', {
+    method: 'POST',
+    headers: { host: 'localhost:47120', 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      clientMutationId: `ui-edit-runtime-preset-${requestSequence}`,
+      repoPath,
+      ...(input.carrier ? { carrier: input.carrier } : {}),
+      origin: 'design-mode',
+      requestedRuntime: 'codex',
+      issues: [{
+        number: issueNumber,
+        title: 'Codex UI edit runtime preset',
+        body: '',
+        url: '',
+      }, {
+        number: issueNumber + 1,
+        title: 'Claude UI edit runtime preset',
+        body: '',
+        url: '',
+        runtime: 'claude-code',
+      }],
+    }),
+  }));
+  const payload = await response.json() as {
+    ok: boolean;
+    result: { packets: Array<{ id: string }> };
+  };
+  expect(response.status).toBe(201);
+  expect(payload.ok).toBe(true);
+  const packetIds = new Set(payload.result.packets.map((packet) => packet.id));
+  const state = readOrchestratorControlPlaneState();
+  return {
+    missionId: state.missionId,
+    packets: state.packets.filter((packet) => packetIds.has(packet.id)),
+  };
+}
+
 afterAll(async () => {
   const { closeDb } = await import('@/lib/db');
   closeDb();
@@ -188,7 +233,7 @@ afterAll(async () => {
 
 describe('UI edit runtime preset dispatch routing', () => {
   it('selects the low-latency preset unless the operator pins a model', async () => {
-    const { createLane, getLane } = await import('@/lib/lane/registry');
+    const { createLane, getLane, setLaneStatus } = await import('@/lib/lane/registry');
     laneCommandMock.mockImplementation(async (command: LaneCommand): Promise<LaneCommandResult> => {
       if (command.verb === 'open_lane') {
         const lane = createLane({
@@ -277,6 +322,41 @@ describe('UI edit runtime preset dispatch routing', () => {
       },
     });
 
+    laneCommandMock.mockClear();
+    runtimeDispatchableMock.mockClear();
+    writeTestOperatorDefaults(MODEL_IDS.claudeWorkerDefault);
+    const designCarrier = await createAndReadPacket({
+      carrier: 'openrouter',
+      origin: 'design-mode',
+      requestedRuntime: 'claude-code',
+    });
+    expect(designCarrier).toMatchObject({
+      origin: 'design-mode',
+      claudeCodeCarrier: 'openrouter',
+      claudeCodeModel: null,
+      assignedModel: null,
+      workerRouting: {
+        requestedModel: null,
+        selectedRuntime: 'claude-code',
+        selectedModel: null,
+        modelDisposition: 'runtime-default',
+      },
+    });
+    expect(runtimeDispatchableMock).toHaveBeenCalledWith('claude-code', null, repoPath);
+    const carrierDispatch = await dispatchMission({
+      missionId: readOrchestratorControlPlaneState().missionId,
+    });
+    expect(carrierDispatch.dispatched).toBe(1);
+    const carrierLaunch = laneCommandMock.mock.calls
+      .map(([command]) => command as LaneCommand)
+      .find((command) => command.verb === 'launch_session');
+    expect(carrierLaunch).toMatchObject({
+      verb: 'launch_session',
+      claudeCodeCarrier: 'openrouter',
+      claudeCodeModel: undefined,
+    });
+    expect(carrierLaunch?.model).not.toBe(MODEL_IDS.claudeHaikuQaDefault);
+
     const claudeDefault = await createAndReadPacket({
       origin: 'design-mode',
       requestedRuntime: 'claude-code',
@@ -289,5 +369,86 @@ describe('UI edit runtime preset dispatch routing', () => {
         selectedModel: MODEL_IDS.claudeHaikuQaDefault,
       },
     });
+
+    laneCommandMock.mockClear();
+    const mixedRuntime = await createAndReadMixedRuntimePackets();
+    expect(mixedRuntime.packets.map((packet) => ({
+      runtime: packet.runtime,
+      assignedModel: packet.assignedModel,
+      selectedModel: packet.workerRouting?.selectedModel,
+      modelDisposition: packet.workerRouting?.modelDisposition,
+    }))).toEqual(expect.arrayContaining([{
+      runtime: 'codex',
+      assignedModel: MODEL_IDS.codexScoutDefault,
+      selectedModel: MODEL_IDS.codexScoutDefault,
+      modelDisposition: 'requested',
+    }, {
+      runtime: 'claude-code',
+      assignedModel: MODEL_IDS.claudeHaikuQaDefault,
+      selectedModel: MODEL_IDS.claudeHaikuQaDefault,
+      modelDisposition: 'requested',
+    }]));
+    expect(runtimeDispatchableMock).toHaveBeenCalledWith('codex', MODEL_IDS.codexScoutDefault, repoPath);
+    expect(runtimeDispatchableMock).toHaveBeenCalledWith('claude-code', MODEL_IDS.claudeHaikuQaDefault, repoPath);
+
+    const mixedDispatch = await dispatchMission({ missionId: mixedRuntime.missionId });
+    expect(mixedDispatch.dispatched).toBe(2);
+    const mixedLaunchRouting = laneCommandMock.mock.calls
+      .map(([command]) => command as LaneCommand)
+      .filter((command) => command.verb === 'launch_session')
+      .map((command) => ({
+        runtime: getLane(command.laneId)?.runtime,
+        model: command.model,
+      }));
+    expect(mixedLaunchRouting).toEqual(expect.arrayContaining([{
+      runtime: 'codex',
+      model: MODEL_IDS.codexScoutDefault,
+    }, {
+      runtime: 'claude-code',
+      model: MODEL_IDS.claudeHaikuQaDefault,
+    }]));
+
+    laneCommandMock.mockClear();
+    const mixedCarrier = await createAndReadMixedRuntimePackets({ carrier: 'openrouter' });
+    expect(mixedCarrier.packets.map((packet) => ({
+      runtime: packet.runtime,
+      carrier: packet.claudeCodeCarrier,
+      assignedModel: packet.assignedModel,
+      selectedModel: packet.workerRouting?.selectedModel,
+      modelDisposition: packet.workerRouting?.modelDisposition,
+    }))).toEqual(expect.arrayContaining([{
+      runtime: 'codex',
+      carrier: null,
+      assignedModel: MODEL_IDS.codexScoutDefault,
+      selectedModel: MODEL_IDS.codexScoutDefault,
+      modelDisposition: 'requested',
+    }, {
+      runtime: 'claude-code',
+      carrier: 'openrouter',
+      assignedModel: null,
+      selectedModel: null,
+      modelDisposition: 'runtime-default',
+    }]));
+    expect(runtimeDispatchableMock).toHaveBeenCalledWith('codex', MODEL_IDS.codexScoutDefault, repoPath);
+    expect(runtimeDispatchableMock).toHaveBeenCalledWith('claude-code', null, repoPath);
+
+    const mixedCarrierDispatch = await dispatchMission({ missionId: mixedCarrier.missionId });
+    expect(mixedCarrierDispatch.dispatched).toBe(1);
+    const firstMixedCarrierLaunch = laneCommandMock.mock.calls
+      .map(([command]) => command as LaneCommand)
+      .find((command) => command.verb === 'launch_session');
+    expect(firstMixedCarrierLaunch?.model).toBe(MODEL_IDS.codexScoutDefault);
+    setLaneStatus(firstMixedCarrierLaunch!.laneId, 'completed', 'system', 'test-completed');
+    laneCommandMock.mockClear();
+    const deferredCarrierDispatch = await dispatchMission({ missionId: mixedCarrier.missionId });
+    expect(deferredCarrierDispatch.dispatched).toBe(1);
+    const claudeCarrierMissionLaunch = laneCommandMock.mock.calls
+      .map(([command]) => command as LaneCommand)
+      .find((command) => command.verb === 'launch_session');
+    expect(claudeCarrierMissionLaunch).toMatchObject({
+      claudeCodeCarrier: 'openrouter',
+      claudeCodeModel: undefined,
+    });
+    expect(claudeCarrierMissionLaunch?.model).not.toBe(MODEL_IDS.claudeHaikuQaDefault);
   });
 });

--- a/tests/ui-edit-runtime-preset-route.test.ts
+++ b/tests/ui-edit-runtime-preset-route.test.ts
@@ -1,0 +1,293 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+import { MODEL_IDS } from '@/lib/models';
+import type { LaneCommand, LaneCommandResult } from '@/lib/lane/types';
+
+const laneCommandMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/panel/auth', () => ({
+  requirePanelAuth: vi.fn(() => null),
+}));
+
+vi.mock('@/lib/runtimes/shared/auth-detect', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/runtimes/shared/auth-detect')>(),
+  assertRuntimeDispatchable: vi.fn(async () => undefined),
+}));
+
+vi.mock('@/lib/orchestrator/operator-mission-service/branch-cleanup', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/orchestrator/operator-mission-service/branch-cleanup')>(),
+  prepareMissionBranches: vi.fn(async () => []),
+}));
+
+vi.mock('@/lib/realtime/publisher', () => ({
+  publishRealtimeMutation: vi.fn(async () => undefined),
+}));
+
+vi.mock('@/lib/lane/commands', () => ({
+  dispatch: laneCommandMock,
+}));
+
+vi.mock('@/lib/orchestrator/storage-pressure-policy', () => ({
+  getStoragePressureAdmissionCoordinator: () => ({
+    reserveForLaunch: async (packet: { id: string }) => {
+      const recordedAt = Date.now();
+      const receipt = {
+        schema: 'o8/packet-storage-admission/v1' as const,
+        state: 'reserved' as const,
+        reason: 'test_admitted',
+        reservationId: `ui-edit-launch:${packet.id}`,
+        mutationId: `ui-edit-launch:${packet.id}`,
+        ownerId: packet.id,
+        ownerGeneration: 1,
+        estimateBytes: 1,
+        estimateSource: 'source-size-fallback' as const,
+        historySamples: 0,
+        volumeId: 'test-volume',
+        physicalAvailableBytes: 1_000_000,
+        reservedBeforeBytes: 0,
+        requiredReserveBytes: 1,
+        dispatchHeadroomBytes: 999_999,
+        pressure: null,
+        recordedAt,
+      };
+      return { receipt, reservation: { state: 'reserved' as const }, baselineWorkspacePaths: [] };
+    },
+    commitAfterLaunch: async (lease: { receipt: Record<string, unknown> }) => ({
+      ...lease.receipt,
+      state: 'committed' as const,
+    }),
+    settleFailedLaunch: async (_packet: unknown, lease: { receipt: Record<string, unknown> }) => ({
+      ...lease.receipt,
+      state: 'held' as const,
+    }),
+  }),
+}));
+
+vi.mock('@/lib/projects/context', () => ({
+  getProjectContext: vi.fn(async () => ({ runtimeProjectId: 'ui-edit-runtime-preset-test' })),
+}));
+
+vi.mock('@/lib/repos/registry', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/repos/registry')>(),
+  resolveDefaultBranch: vi.fn(async () => 'main'),
+}));
+
+vi.mock('@/lib/orchestrator/packet-prompt', () => ({
+  buildPacketPrompt: vi.fn(async () => 'Apply the bounded UI element edit.'),
+}));
+
+vi.mock('@/lib/lane/repo-preflight', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/lane/repo-preflight')>(),
+  isGitWorkTreeSync: vi.fn(() => true),
+}));
+
+vi.mock('@/lib/worktree/metadata-lock-process-identity', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/worktree/metadata-lock-process-identity')>();
+  const identity = {
+    version: 1 as const,
+    platform: 'win32' as const,
+    bootId: 'ui-edit-runtime-preset-test-boot',
+    startId: 'ui-edit-runtime-preset-test-process',
+  };
+  return {
+    ...actual,
+    probeMetadataLockProcessIdentity: vi.fn(async () => ({ state: 'live' as const, identity })),
+    probeMetadataLockProcessIdentitySync: vi.fn(() => ({ state: 'live' as const, identity })),
+  };
+});
+
+const controlledEnvKeys = [
+  'CORTEX_IDE_DATA_DIR',
+  'CORTEX_IDE_DB_PATH',
+  'O8_DATA_DIR',
+  'O8_DEFAULT_DISPATCH_RUNTIME',
+  'O8_DISPATCH_MODEL',
+  'O8_SUBSCRIPTION_PROFILE',
+] as const;
+const priorEnv = Object.fromEntries(controlledEnvKeys.map((key) => [key, process.env[key]]));
+const testRoot = mkdtempSync(path.join(os.tmpdir(), 'o8-ui-edit-runtime-preset-'));
+const dataDir = path.join(testRoot, 'data');
+const repoPath = path.join(testRoot, 'repo');
+mkdirSync(dataDir, { recursive: true });
+mkdirSync(repoPath, { recursive: true });
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.O8_DATA_DIR = dataDir;
+delete process.env.CORTEX_IDE_DB_PATH;
+delete process.env.O8_DEFAULT_DISPATCH_RUNTIME;
+delete process.env.O8_DISPATCH_MODEL;
+delete process.env.O8_SUBSCRIPTION_PROFILE;
+writeFileSync(path.join(dataDir, 'operator-defaults.json'), JSON.stringify({
+  subscriptionProfile: 'both',
+  defaultDispatchRuntime: 'codex',
+  defaultDispatchModel: MODEL_IDS.codexWorkerDefault,
+}));
+
+const { NextRequest } = await import('next/server');
+const { POST } = await import('@/app/api/orchestrator/create-mission/route');
+const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+
+let requestSequence = 0;
+
+async function createAndReadPacket(input: {
+  carrier?: 'openrouter';
+  origin?: 'design-mode';
+  requestedModel?: string;
+  requestedRuntime?: 'codex' | 'claude-code';
+}) {
+  requestSequence += 1;
+  const issueNumber = 19_040_000 + requestSequence;
+  const response = await POST(new NextRequest('http://127.0.0.1:47120/api/orchestrator/create-mission', {
+    method: 'POST',
+    headers: { host: 'localhost:47120', 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      clientMutationId: `ui-edit-runtime-preset-${requestSequence}`,
+      repoPath,
+      ...(input.carrier ? { carrier: input.carrier } : {}),
+      ...(input.origin ? { origin: input.origin } : {}),
+      ...(input.requestedModel ? { requestedModel: input.requestedModel } : {}),
+      ...(input.requestedRuntime ? { requestedRuntime: input.requestedRuntime } : {}),
+      issues: [{
+        number: issueNumber,
+        title: `UI edit runtime preset ${requestSequence}`,
+        body: '',
+        url: '',
+      }],
+    }),
+  }));
+  const payload = await response.json() as {
+    ok: boolean;
+    result: { packets: Array<{ id: string }> };
+  };
+  expect(response.status).toBe(201);
+  expect(payload.ok).toBe(true);
+  const packetId = payload.result.packets[0]!.id;
+  return readOrchestratorControlPlaneState().packets.find((packet) => packet.id === packetId);
+}
+
+afterAll(async () => {
+  const { closeDb } = await import('@/lib/db');
+  closeDb();
+  for (const key of controlledEnvKeys) {
+    const prior = priorEnv[key];
+    if (prior === undefined) delete process.env[key];
+    else process.env[key] = prior;
+  }
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch (error) {
+    // skeleton.db is a process-lifetime disposable cache and remains locked on
+    // Windows until this isolated Vitest worker exits. Global fixture cleanup
+    // reclaims the stale o8-* directory on the next test run.
+    if ((error as NodeJS.ErrnoException).code !== 'EBUSY' || process.platform !== 'win32') throw error;
+  }
+});
+
+describe('UI edit runtime preset dispatch routing', () => {
+  it('selects the low-latency preset unless the operator pins a model', async () => {
+    const { createLane, getLane } = await import('@/lib/lane/registry');
+    laneCommandMock.mockImplementation(async (command: LaneCommand): Promise<LaneCommandResult> => {
+      if (command.verb === 'open_lane') {
+        const lane = createLane({
+          repoPath: command.repoPath,
+          projectId: command.projectId,
+          branch: command.branch,
+          baseBranch: command.baseBranch,
+          runtime: command.runtime,
+          label: command.label,
+          packetId: command.packetId,
+          actor: command.actor,
+        });
+        return { ok: true, laneId: lane.id, note: 'opened', lane };
+      }
+      if (command.verb === 'launch_session') {
+        const lane = getLane(command.laneId);
+        return {
+          ok: true,
+          laneId: command.laneId,
+          note: 'launched',
+          ...(lane ? { lane: { ...lane, sessionKey: `codex-owned:${lane.id}` } } : {}),
+          dependencyMaterializationMode: null,
+        };
+      }
+      return { ok: false, laneId: 'unknown', note: `Unexpected command ${command.verb}` };
+    });
+
+    const designDefault = await createAndReadPacket({ origin: 'design-mode' });
+    expect(designDefault).toMatchObject({
+      origin: 'design-mode',
+      assignedModel: MODEL_IDS.codexScoutDefault,
+      workerRouting: {
+        selectedRuntime: 'codex',
+        selectedModel: MODEL_IDS.codexScoutDefault,
+      },
+    });
+    const { dispatchMission } = await import('@/lib/orchestrator/operator-mission-service');
+    const dispatchResult = await dispatchMission({
+      missionId: readOrchestratorControlPlaneState().missionId,
+    });
+    expect(dispatchResult.dispatched).toBe(1);
+    const launchCommand = laneCommandMock.mock.calls
+      .map(([command]) => command as LaneCommand)
+      .find((command) => command.verb === 'launch_session');
+    expect(launchCommand).toMatchObject({
+      verb: 'launch_session',
+      model: MODEL_IDS.codexScoutDefault,
+    });
+
+    const designExplicit = await createAndReadPacket({
+      origin: 'design-mode',
+      requestedModel: MODEL_IDS.codexDefault,
+    });
+    expect(designExplicit).toMatchObject({
+      origin: 'design-mode',
+      assignedModel: MODEL_IDS.codexDefault,
+      workerRouting: {
+        selectedRuntime: 'codex',
+        selectedModel: MODEL_IDS.codexDefault,
+      },
+    });
+
+    const ordinary = await createAndReadPacket({});
+    expect(ordinary).toMatchObject({
+      assignedModel: MODEL_IDS.codexWorkerDefault,
+      workerRouting: {
+        selectedRuntime: 'codex',
+        selectedModel: MODEL_IDS.codexWorkerDefault,
+      },
+    });
+    expect(ordinary?.origin).toBeUndefined();
+
+    const ordinaryCarrier = await createAndReadPacket({
+      carrier: 'openrouter',
+      requestedModel: 'gateway/model-y',
+      requestedRuntime: 'claude-code',
+    });
+    expect(ordinaryCarrier).toMatchObject({
+      claudeCodeCarrier: 'openrouter',
+      claudeCodeModel: 'gateway/model-y',
+      assignedModel: null,
+      workerRouting: {
+        requestedModel: null,
+        selectedRuntime: 'claude-code',
+        selectedModel: null,
+      },
+    });
+
+    const claudeDefault = await createAndReadPacket({
+      origin: 'design-mode',
+      requestedRuntime: 'claude-code',
+    });
+    expect(claudeDefault).toMatchObject({
+      origin: 'design-mode',
+      assignedModel: MODEL_IDS.claudeHaikuQaDefault,
+      workerRouting: {
+        selectedRuntime: 'claude-code',
+        selectedModel: MODEL_IDS.claudeHaikuQaDefault,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add a registry-backed `ui-edit-low-latency` preset that resolves Codex to Luna and Claude Code to Haiku
- apply the preset to fresh element-edit missions while preserving explicit model choices, subscription routing, and ordinary mission defaults
- add real-path regression coverage through mission persistence, scheduling, and the `launch_session` dispatch boundary

## Testing

- `vitest`: 2 focused files, 6 tests passed on Node 22
- `tsc --noEmit`
- ESLint on touched files
- test-classification check
- repository rule check against `upstream/main`

The full `npm test` command was not a meaningful host baseline because npm invoked system Node 24 against the repository's Node-22-built `better-sqlite3` binary. The focused suites were run directly with the required Node 22 runtime and passed.

Closes #1904


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added low-latency model selection for design-mode UI editing missions.
  * Design-mode requests can automatically use optimized Codex or Claude models when no model is specified.
  * Explicitly selected models and other mission types continue to use their existing routing behavior.

* **Tests**
  * Added coverage for runtime-specific model selection and mission launch routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->