### PR TITLE
fix: close after verified branch preservation

### DIFF
--- a/src/lib/orchestrator/close-unmerged-preservation.ts
+++ b/src/lib/orchestrator/close-unmerged-preservation.ts
@@ -65,8 +65,8 @@ async function deleteRef(repoPath: string, ref: string): Promise<void> {
 /**
  * Classify close preservation against actual Git state. A missing branch and a
  * branch already contained by the base carry no recoverable work. A genuinely
- * unmerged head is banked under preserved/*, but close remains refused so the
- * operator must make an explicit disposition for that work.
+ * unmerged head is banked under preserved/* so the explicit close disposition
+ * can retire the lane without making the commits unreachable.
  */
 export async function classifyClosePreservation(
   packetId: string,
@@ -135,26 +135,29 @@ export async function classifyClosePreservation(
 
   const preservedBranch: `preserved/${string}` = `preserved/packet-${safeRefPart(packetId)}-${safeRefPart(lane.id).slice(0, 12)}`;
   const preservedRef = `refs/heads/${preservedBranch}`;
+  let writeError: unknown = null;
   try {
     await execFileAsync('git', ['update-ref', preservedRef, head], {
       windowsHide: true,
       cwd: lane.repoPath,
       timeout: 10_000,
     });
-    const verified = await readCommit(lane.repoPath, preservedRef);
-    if (verified !== head) {
-      throw new Error(`expected ${head}, read ${verified ?? 'missing'}`);
-    }
   } catch (error) {
+    writeError = error;
+  }
+  const verified = await readCommit(lane.repoPath, preservedRef);
+  if (verified !== head) {
     await deleteRef(lane.repoPath, temporaryRef);
     return {
       receipt: { branch: lane.branch, reason: preservedBranch, ref: preservedRef },
       failure: {
         code: 'branch_preservation_failed',
-        reason: 'ref_verification_failed',
+        reason: writeError ? 'ref_write_failed' : 'ref_verification_failed',
         branch: lane.branch,
         ref: preservedRef,
-        message: errorMessage(error),
+        message: writeError
+          ? errorMessage(writeError)
+          : `expected ${head}, read ${verified ?? 'missing'}`,
       },
     };
   }
@@ -162,12 +165,6 @@ export async function classifyClosePreservation(
 
   return {
     receipt: { branch: lane.branch, reason: preservedBranch, ref: preservedRef },
-    failure: {
-      code: 'unmerged_work_present',
-      reason: 'unmerged_work_present',
-      branch: lane.branch,
-      ref: preservedRef,
-      message: `Branch ${lane.branch} contains commits not in ${lane.baseBranch || 'main'}; work was banked at ${preservedBranch}.`,
-    },
+    failure: null,
   };
 }

--- a/src/lib/orchestrator/close-unmerged-shared.ts
+++ b/src/lib/orchestrator/close-unmerged-shared.ts
@@ -25,8 +25,8 @@ export const CLOSE_UNMERGED_DISPOSITIONS = [
 export type CloseUnmergedDisposition = typeof CLOSE_UNMERGED_DISPOSITIONS[number];
 
 export type BranchPreservationFailure = {
-  code: 'branch_preservation_failed' | 'unmerged_work_present';
-  reason: 'ref_write_failed' | 'ref_verification_failed' | 'unmerged_work_present';
+  code: 'branch_preservation_failed';
+  reason: 'ref_write_failed' | 'ref_verification_failed';
   branch: string;
   ref: string;
   message: string;
@@ -43,6 +43,17 @@ export type CloseUnmergedResult =
     ok: true;
     result: {
       closed: true;
+      alreadyClosed: true;
+      packetId: string;
+      laneId: string | null;
+      note: string;
+    };
+  }
+  | {
+    ok: true;
+    result: {
+      closed: true;
+      alreadyClosed: false;
       discarded: true;
       disposition: CloseUnmergedDisposition;
       laneId: string;

--- a/src/lib/orchestrator/close-unmerged.ts
+++ b/src/lib/orchestrator/close-unmerged.ts
@@ -129,6 +129,27 @@ async function closePacketUnmergedUnlocked(input: {
       status: 404,
     } satisfies CloseUnmergedResult;
   }
+  if (guard.previousPacket.status === 'archived') {
+    const priorLane = findLatestLaneByPacket(input.packetId);
+    if (!await restorePacketLifecycleGuard(guard)) {
+      return {
+        ok: false,
+        code: 'packet_state_changed',
+        message: `Packet ${input.packetId} changed while its closed state was being confirmed.`,
+        status: 409,
+      };
+    }
+    return {
+      ok: true,
+      result: {
+        closed: true,
+        alreadyClosed: true,
+        packetId: input.packetId,
+        laneId: priorLane?.id ?? null,
+        note: `Packet ${input.packetId} is already closed.`,
+      },
+    };
+  }
   const persistedLanes = listLanes().filter((candidate) => (
     candidate.packetId === input.packetId
     && candidate.status !== 'archived'
@@ -234,12 +255,8 @@ async function closePacketUnmergedUnlocked(input: {
       }
       if (preservation.failure) {
         preservationFailure = preservation.failure;
-        const auditNote = preservation.failure.code === 'unmerged_work_present'
-          ? preservation.failure.message
-          : `Preservation FAILED for ${preservation.failure.ref}; the worktree remains intact and close was refused.`;
-        recordLaneEvent(target.id, preservation.failure.code === 'branch_preservation_failed'
-          ? 'branch_preservation_failed'
-          : 'update', 'system', {
+        const auditNote = `Preservation FAILED for ${preservation.failure.ref}; the worktree remains intact and close was refused.`;
+        recordLaneEvent(target.id, 'branch_preservation_failed', 'system', {
           code: preservation.failure.code,
           reason: preservation.failure.reason,
           packetId: input.packetId,
@@ -253,18 +270,11 @@ async function closePacketUnmergedUnlocked(input: {
       }
     }
     if (preservationFailure) {
-      await markPacketLifecycleFailure(
-        guard,
-        preservationFailure.code === 'unmerged_work_present'
-          ? 'branch_preservation_failed'
-          : preservationFailure.code,
-      );
+      await markPacketLifecycleFailure(guard, preservationFailure.code);
       return {
         ok: false,
         code: preservationFailure.code,
-        message: preservationFailure.code === 'unmerged_work_present'
-          ? `Close refused because ${preservationFailure.message} The lane and worktree remain intact.`
-          : `Close refused because work on ${preservationFailure.branch} could not be preserved. The lane and worktree remain intact.`,
+        message: `Close refused because work on ${preservationFailure.branch} could not be preserved. The lane and worktree remain intact.`,
         status: 409,
       };
     }
@@ -430,6 +440,7 @@ async function closePacketUnmergedUnlocked(input: {
       ok: true,
       result: {
         closed: true,
+        alreadyClosed: false,
         discarded: true,
         disposition: rawDisposition,
         laneId: lane.id,

--- a/tests/close-packet-unmerged-preservation-real-path.test.ts
+++ b/tests/close-packet-unmerged-preservation-real-path.test.ts
@@ -6,6 +6,7 @@ import { isAbsolute, join } from 'node:path';
 
 import { afterAll, describe, expect, it } from 'vitest';
 import { NextRequest } from 'next/server';
+import { eq } from 'drizzle-orm';
 
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 
@@ -17,7 +18,8 @@ writeFileSync(join(dataDir, 'ws-token'), `${operatorToken}\n`, 'utf8');
 
 const closeRoute = await import('@/app/api/orchestrator/discard-packet/route');
 const resetRoute = await import('@/app/api/orchestrator/reset-packet/route');
-const { closeDb } = await import('@/lib/db');
+const { closeDb, getDb } = await import('@/lib/db');
+const { sessionOutcomes } = await import('@/lib/db/schema');
 const { createLane, getLane, setLaneStatus } = await import('@/lib/lane/registry');
 const { writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
 const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
@@ -108,11 +110,16 @@ function operatorRequest(pathname: string, body: Record<string, unknown>) {
   });
 }
 
-function closeRequest(packetId: string) {
+function closeRequest(
+  packetId: string,
+  disposition: 'adopted_elsewhere' | 'superseded' | 'spec_changed' | 'wontfix' = 'wontfix',
+  acknowledgeMissingWorktree = false,
+) {
   return operatorRequest('/api/orchestrator/discard-packet', {
     packetId,
     clientMutationId: randomUUID(),
-    disposition: 'wontfix',
+    disposition,
+    acknowledgeMissingWorktree,
   });
 }
 
@@ -179,7 +186,7 @@ describe('close_packet_unmerged preservation classification — real route', () 
     const worktreePath = join(root, 'already-gone');
     const lane = persistPacket({ packetId, repoPath, worktreePath, branch });
 
-    const response = await closeRoute.POST(closeRequest(packetId));
+    const response = await closeRoute.POST(closeRequest(packetId, 'wontfix', true));
     const payload = await response.json();
 
     expect(response.status).toBe(200);
@@ -194,7 +201,7 @@ describe('close_packet_unmerged preservation classification — real route', () 
     expect(getLane(lane.id)?.status).toBe('archived');
   });
 
-  it('refuses a branch with real unmerged commits and names its preserved ref', async () => {
+  it('banks an unmerged branch, closes with its disposition, and is idempotent', async () => {
     const packetId = 'pkt-close-real-unmerged';
     const branch = 'inline/close-real-unmerged';
     const { root, repoPath } = makeRepo('o8-close-real-unmerged');
@@ -203,22 +210,87 @@ describe('close_packet_unmerged preservation classification — real route', () 
     writeFileSync(join(worktreePath, 'unmerged.txt'), 'unmerged\n');
     git(worktreePath, ['add', 'unmerged.txt']);
     git(worktreePath, ['commit', '-m', 'unmerged feature']);
+    const branchHead = git(worktreePath, ['rev-parse', 'HEAD']);
     const lane = persistPacket({ packetId, repoPath, worktreePath, branch });
 
-    const response = await closeRoute.POST(closeRequest(packetId));
+    const response = await closeRoute.POST(closeRequest(packetId, 'adopted_elsewhere'));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({
+      ok: true,
+      result: {
+        closed: true,
+        disposition: 'adopted_elsewhere',
+        preservationFailure: null,
+        note: expect.stringContaining('Work preserved on branch preserved/'),
+      },
+    });
+    const preservedRef = git(repoPath, ['for-each-ref', '--format=%(refname:short)', `refs/heads/preserved/packet-${packetId}-*`]);
+    expect(preservedRef).toMatch(/^preserved\//);
+    expect(git(repoPath, ['rev-parse', preservedRef])).toBe(branchHead);
+    expect(getLane(lane.id)).toMatchObject({
+      status: 'archived',
+      outcome: 'closed_unmerged',
+      outcomeNote: expect.stringContaining(preservedRef),
+    });
+    expect(existsSync(worktreePath)).toBe(false);
+
+    const secondResponse = await closeRoute.POST(closeRequest(packetId, 'adopted_elsewhere'));
+    const secondPayload = await secondResponse.json();
+    expect(secondResponse.status).toBe(200);
+    expect(secondPayload).toMatchObject({
+      ok: true,
+      result: {
+        closed: true,
+        alreadyClosed: true,
+        packetId,
+        laneId: lane.id,
+        note: expect.stringContaining('already closed'),
+      },
+    });
+    expect(getLane(lane.id)?.status).toBe('archived');
+
+    const db = getDb();
+    const outcomes = await db!
+      .select({
+        outcome: sessionOutcomes.outcome,
+        summary: sessionOutcomes.summary,
+        mergedClean: sessionOutcomes.mergedClean,
+      })
+      .from(sessionOutcomes)
+      .where(eq(sessionOutcomes.packetId, packetId));
+    expect(outcomes).toEqual([{
+      outcome: 'adopted_elsewhere',
+      summary: expect.stringContaining(preservedRef),
+      mergedClean: false,
+    }]);
+  });
+
+  it('refuses an unmerged branch when no preserved ref can be created', async () => {
+    const packetId = 'pkt-close-preservation-failed';
+    const branch = 'inline/close-preservation-failed';
+    const { root, repoPath } = makeRepo('o8-close-preservation-failed');
+    const worktreePath = join(root, 'worktree');
+    git(repoPath, ['worktree', 'add', '-b', branch, worktreePath]);
+    writeFileSync(join(worktreePath, 'unmerged.txt'), 'unmerged\n');
+    git(worktreePath, ['add', 'unmerged.txt']);
+    git(worktreePath, ['commit', '-m', 'unmerged feature']);
+    writeFileSync(join(repoPath, '.git', 'refs', 'heads', 'preserved'), 'blocked\n');
+    const lane = persistPacket({ packetId, repoPath, worktreePath, branch });
+
+    const response = await closeRoute.POST(closeRequest(packetId, 'superseded'));
     const payload = await response.json();
 
     expect(response.status).toBe(409);
     expect(payload).toMatchObject({
       ok: false,
       error: {
-        code: 'unmerged_work_present',
-        message: expect.stringContaining('work was banked at preserved/'),
+        code: 'branch_preservation_failed',
+        message: expect.stringContaining(`work on ${branch} could not be preserved`),
       },
     });
-    const preservedRef = git(repoPath, ['for-each-ref', '--format=%(refname:short)', `refs/heads/preserved/packet-${packetId}-*`]);
-    expect(preservedRef).toMatch(/^preserved\//);
-    expect(git(repoPath, ['show', `${preservedRef}:unmerged.txt`])).toBe('unmerged');
+    expect(git(repoPath, ['for-each-ref', '--format=%(refname:short)', `refs/heads/preserved/packet-${packetId}-*`])).toBe('');
     expect(getLane(lane.id)).toMatchObject({ status: 'reviewing', worktreePath });
     expect(existsSync(worktreePath)).toBe(true);
   });


### PR DESCRIPTION
Fixes #2004.

`close_packet_unmerged` banked an unmerged branch under `preserved/…` and then refused the close because the branch still had commits not in main. Banking never changes that condition, so the refusal fired on every call and the packet could not be closed through the tool.

## Change

- `close-unmerged-preservation.ts`: a verified `preserved/…` ref now clears the close (`failure: null`). Only a preserve that fails to write or verify refuses, with `ref_write_failed` / `ref_verification_failed` telling the operator which.
- `close-unmerged.ts`: an already-archived packet returns `ok: true, alreadyClosed: true` instead of a refusal, so a repeat close is idempotent. The `unmerged_work_present` code is gone from the result union.
- The disposition note and the outcome ledger row carry the preserved ref.

## Verification

Real-path test through the discard route: lane in `reviewing`, branch one commit ahead of main, close with `adopted_elsewhere` → 200, lane archived, `preserved/…` ref at the branch head, ledger row with the disposition and ref; a second call returns `alreadyClosed`. A second test blocks the preserve write and asserts the 409 refusal still fires with the worktree intact.

`npx tsc --noEmit` clean, `npm run lint` exit 0, close real-path suite 16/16.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Closing a packet with unmerged work now preserves the branch and completes closure using the selected disposition.
  * Re-closing an already archived packet now returns a successful, idempotent response.

* **Bug Fixes**
  * Preservation failures now provide consistent error reporting, including distinct write and verification failure messages.
  * Improved handling when a packet’s worktree is missing or its state changes during closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->