### PR TITLE
fix: authorize worker scope expansion and seal only repo paths

### DIFF
--- a/src/lib/orchestrator/packet-scope-policy.ts
+++ b/src/lib/orchestrator/packet-scope-policy.ts
@@ -150,13 +150,13 @@ export function resolvePacketScope(
   const predictionTouchesForbidden = predictedPaths.some((path) => isForbidden(path, forbiddenPaths));
   const predictionMatchesTarget = statedTargets.length > 0
     && statedTargets.some((target) => predictedPaths.some((path) => pathOverlaps(path, target)));
-  const fallbackReason = predictedPaths.length === 0 && statedTargets.length === 0
+  const fallbackReason = predictedPaths.length === 0
     ? 'File prediction was empty.'
-    : predictedPaths.length <= TINY_PREDICTION_MAX && statedTargets.length === 0
+    : predictedPaths.length <= TINY_PREDICTION_MAX
       ? 'File prediction was too small to seal safely.'
       : predictionTouchesForbidden
         ? 'File prediction included a path forbidden by the task brief.'
-        : predictedPaths.length > 0 && statedTargets.length > 0 && !predictionMatchesTarget
+        : !predictionMatchesTarget
           ? 'File prediction was not supported by the task brief targets.'
           : null;
 

--- a/src/lib/orchestrator/packet-scope-policy.ts
+++ b/src/lib/orchestrator/packet-scope-policy.ts
@@ -1,8 +1,17 @@
+import { existsSync, realpathSync } from 'node:fs';
+import { dirname, extname, isAbsolute, relative, resolve, sep } from 'node:path';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 
 const REPO_WIDE_SCOPE = '**/*';
 const TINY_PREDICTION_MAX = 1;
 const PATH_TOKEN = /(?:^|[\s`'"(])((?:\.\/)?(?:[A-Za-z0-9_.-]+\/)*[A-Za-z0-9_.-]+\.[A-Za-z0-9_-]+(?:\/\*\*)?)/g;
+const NEW_FILE_PATH = /^[\w./-]+\.\w+$/;
+const KNOWN_ROOT_FILE_EXTENSIONS = new Set([
+  'c', 'cc', 'cpp', 'css', 'csv', 'env', 'go', 'gql', 'graphql', 'h', 'hpp',
+  'htm', 'html', 'java', 'js', 'json', 'jsx', 'kt', 'kts', 'less', 'lock',
+  'md', 'mjs', 'php', 'proto', 'py', 'rb', 'rs', 'sass', 'scss', 'sh', 'sql',
+  'swift', 'toml', 'ts', 'tsx', 'txt', 'xml', 'yaml', 'yml', 'zsh',
+]);
 const FORBIDDEN_LINE = /\b(?:do not|don't|never|must not)\s+(?:touch|edit|modify|write|change)|\bforbid(?:s|den|ding)?\s+(?:touching|editing|modifying|writing|changing)/i;
 
 export interface PacketScopeResolution {
@@ -22,13 +31,53 @@ function uniquePaths(paths: string[]): string[] {
   return [...new Set(paths.map(normalizePath).filter(Boolean))];
 }
 
-function extractPaths(text: string): string[] {
+function pathIsInside(repoRoot: string, candidate: string): boolean {
+  const rel = relative(repoRoot, candidate);
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
+}
+
+function existingAncestor(path: string): string | null {
+  let candidate = path;
+  while (!existsSync(candidate)) {
+    const parent = dirname(candidate);
+    if (parent === candidate) return null;
+    candidate = parent;
+  }
+  return candidate;
+}
+
+function isRepoPathCandidate(repoPath: string | null, value: string): boolean {
+  if (!repoPath) return false;
+  const path = normalizePath(value);
+  if (!path || path.includes('..') || path.endsWith('/**')) return false;
+
+  try {
+    const repoRoot = realpathSync(repoPath);
+    const target = resolve(repoRoot, path);
+    if (!pathIsInside(repoRoot, target)) return false;
+    if (existsSync(target)) return pathIsInside(repoRoot, realpathSync(target));
+    if (!NEW_FILE_PATH.test(path)) return false;
+
+    const extension = extname(path).slice(1).toLowerCase();
+    if (!path.includes('/') && !KNOWN_ROOT_FILE_EXTENSIONS.has(extension)) return false;
+    const ancestor = existingAncestor(dirname(target));
+    return Boolean(ancestor && pathIsInside(repoRoot, realpathSync(ancestor)));
+  } catch {
+    return false;
+  }
+}
+
+function repoPaths(paths: string[], repoPath: string | null): string[] {
+  return uniquePaths(paths).filter((path) => isRepoPathCandidate(repoPath, path));
+}
+
+function extractPaths(text: string, repoPath: string | null): string[] {
   const paths: string[] = [];
   for (const match of text.matchAll(PATH_TOKEN)) {
     const path = normalizePath(match[1] ?? '');
     if (path) paths.push(path);
   }
-  return uniquePaths(paths);
+  return repoPaths(paths, repoPath);
 }
 
 function taskText(packet: Pick<OrchestratorPacket, 'title' | 'summary' | 'issue'>): string {
@@ -37,11 +86,13 @@ function taskText(packet: Pick<OrchestratorPacket, 'title' | 'summary' | 'issue'
     .join('\n');
 }
 
-function forbiddenTaskPaths(packet: Pick<OrchestratorPacket, 'title' | 'summary' | 'issue'>): string[] {
+function forbiddenTaskPaths(
+  packet: Pick<OrchestratorPacket, 'title' | 'summary' | 'issue' | 'workspaceTargetPath'>,
+): string[] {
   return uniquePaths(taskText(packet)
     .split(/\r?\n/)
     .filter((line) => FORBIDDEN_LINE.test(line))
-    .flatMap(extractPaths));
+    .flatMap((line) => extractPaths(line, packet.workspaceTargetPath)));
 }
 
 function pathOverlaps(left: string, right: string): boolean {
@@ -59,10 +110,11 @@ function isForbidden(path: string, forbiddenPaths: string[]): boolean {
 }
 
 export function resolvePacketScope(
-  packet: Pick<OrchestratorPacket, 'title' | 'summary' | 'issue' | 'allowedFiles' | 'predictedFiles'>,
+  packet: Pick<OrchestratorPacket,
+    'title' | 'summary' | 'issue' | 'allowedFiles' | 'predictedFiles' | 'workspaceTargetPath'>,
   predictedFiles: string[] = packet.predictedFiles ?? [],
 ): PacketScopeResolution {
-  const predictedPaths = uniquePaths(predictedFiles);
+  const predictedPaths = repoPaths(predictedFiles, packet.workspaceTargetPath);
   const forbiddenPaths = forbiddenTaskPaths(packet);
   const explicitPaths = uniquePaths(packet.allowedFiles ?? []);
 
@@ -93,17 +145,18 @@ export function resolvePacketScope(
     };
   }
 
-  const statedTargets = extractPaths(taskText(packet)).filter((path) => !isForbidden(path, forbiddenPaths));
+  const statedTargets = extractPaths(taskText(packet), packet.workspaceTargetPath)
+    .filter((path) => !isForbidden(path, forbiddenPaths));
   const predictionTouchesForbidden = predictedPaths.some((path) => isForbidden(path, forbiddenPaths));
   const predictionMatchesTarget = statedTargets.length > 0
     && statedTargets.some((target) => predictedPaths.some((path) => pathOverlaps(path, target)));
-  const fallbackReason = predictedPaths.length === 0
+  const fallbackReason = predictedPaths.length === 0 && statedTargets.length === 0
     ? 'File prediction was empty.'
-    : predictedPaths.length <= TINY_PREDICTION_MAX
+    : predictedPaths.length <= TINY_PREDICTION_MAX && statedTargets.length === 0
       ? 'File prediction was too small to seal safely.'
       : predictionTouchesForbidden
         ? 'File prediction included a path forbidden by the task brief.'
-        : !predictionMatchesTarget
+        : predictedPaths.length > 0 && statedTargets.length > 0 && !predictionMatchesTarget
           ? 'File prediction was not supported by the task brief targets.'
           : null;
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -154,6 +154,9 @@ const WORKER_CAPABILITIES: Array<{ methods: ReadonlySet<string>; path: RegExp }>
   // Agents can coordinate named resources but cannot bypass ownership checks in the handler.
   { methods: new Set(['GET', 'POST']), path: /^\/api\/leases\/?$/ },
   { methods: new Set(['GET']), path: /^\/api\/lanes(?:\/[^/]+(?:\/(?:scope|diff))?)?\/?$/ },
+  // Scope expansion is the worker's bounded escape hatch. The handler binds
+  // the bearer to the resolved lane packet before it mutates the allowlist.
+  { methods: new Set(['POST']), path: /^\/api\/lanes\/[^/]+\/scope\/?$/ },
   { methods: new Set(['GET', 'POST']), path: /^\/api\/lanes\/[^/]+\/(?:events|heartbeat)\/?$/ },
   { methods: new Set(['POST']), path: /^\/api\/(?:browser\/agent|cortex\/ask\/answer)\/?$/ },
   { methods: new Set(['POST']), path: /^\/api\/cortex\/proposals\/?$/ },

--- a/tests/github-issue-packet-scope-real-path.test.ts
+++ b/tests/github-issue-packet-scope-real-path.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import { join } from 'node:path';
 
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
 
 const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-github-scope-data-'));
 process.env.O8_DATA_DIR = dataDir;
@@ -48,6 +49,112 @@ beforeEach(() => {
 });
 
 describe('GitHub issue packet scope real path', () => {
+  it('keeps only repo paths when an issue body also contains a Git range and event field', async () => {
+    const repoPath = createRepo();
+    const { scanRepo } = await import('@/lib/skeleton');
+    await scanRepo({ repoPath, chunks: false });
+
+    const { createMission } = await import('@/lib/orchestrator/operator-mission-service');
+    const created = await createMission({
+      issues: [{
+        number: 20_050,
+        title: 'Constrain packet scope prediction',
+        body: 'Compare ead1b7a15..HEAD with open_lane.baseCommit, then update src/worker.ts.',
+        url: 'https://example.test/issues/20050',
+      }],
+      repoPath,
+      runtime: 'codex',
+      constraints: 'Seal the packet to paths stated in the issue.',
+    });
+    const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+    const packet = readOrchestratorControlPlaneState().packets
+      .find((candidate) => candidate.id === created.packets[0]!.id)!;
+
+    expect(packet.allowedFiles).toEqual(['src/worker.ts']);
+  });
+
+  it('lets a packet-bound worker expand its own lane through middleware and the route only', async () => {
+    const repoPath = createRepo();
+    const packetA = 'pkt-scope-authz-a';
+    const packetB = 'pkt-scope-authz-b';
+    const { createLane } = await import('@/lib/lane/registry');
+    const laneA = createLane({
+      repoPath,
+      worktreePath: repoPath,
+      branch: 'issue/scope-authz-a',
+      runtime: 'codex',
+      packetId: packetA,
+    });
+    const laneB = createLane({
+      repoPath,
+      worktreePath: repoPath,
+      branch: 'issue/scope-authz-b',
+      runtime: 'codex',
+      packetId: packetB,
+    });
+    const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+    const { readOrchestratorControlPlaneState, writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+    const packet = (id: string, branchTarget: string) => ({
+      id,
+      referenceLabel: id,
+      title: 'Expand bounded scope',
+      summary: 'Edit src/worker.ts.',
+      workspaceTargetPath: repoPath,
+      branchTarget,
+      runtime: 'codex' as const,
+      dependencyLabels: [],
+      dependencyPacketIds: [],
+      queueState: 'queued' as const,
+      releaseState: 'pending' as const,
+      status: 'running' as const,
+      lane: null,
+      predictedFiles: ['src/worker.ts'],
+      allowedFiles: ['src/worker.ts'],
+    });
+    writeOrchestratorControlPlaneState({
+      ...createEmptyOrchestratorMissionState(),
+      missionId: 'mission-scope-authz',
+      repoPath,
+      packets: [packet(packetA, laneA.branch), packet(packetB, laneB.branch)],
+    });
+
+    const { mintPacketWorkerToken } = await import('@/lib/auth/packet-worker-token');
+    const { panelGateMiddleware } = await import('@/middleware');
+    const scopeRoute = await import('@/app/api/lanes/[id]/scope/route');
+    const bearer = mintPacketWorkerToken(packetA);
+    const scopeRequest = (laneId: string, path: string) => new NextRequest(
+      `http://localhost:3001/api/lanes/${laneId}/scope`,
+      {
+        method: 'POST',
+        headers: { host: 'localhost:3001', authorization: `Bearer ${bearer}` },
+        body: JSON.stringify({ paths: [path], reason: 'Cover the real route regression.' }),
+      },
+    );
+
+    const ownRequest = scopeRequest(laneA.id, 'tests/scope-regression.test.ts');
+    expect(panelGateMiddleware(ownRequest).status).toBe(200);
+    const ownResponse = await scopeRoute.POST(ownRequest, { params: Promise.resolve({ id: laneA.id }) });
+    expect(ownResponse.status).toBe(200);
+    await expect(ownResponse.json()).resolves.toMatchObject({
+      ok: true,
+      expanded: true,
+      allowedPaths: ['src/worker.ts', 'tests/scope-regression.test.ts'],
+    });
+    expect(readOrchestratorControlPlaneState().packets.find((candidate) => candidate.id === packetA)?.allowedFiles)
+      .toEqual(['src/worker.ts', 'tests/scope-regression.test.ts']);
+
+    const otherRequest = scopeRequest(laneB.id, 'tests/other-packet.test.ts');
+    expect(panelGateMiddleware(otherRequest).status).toBe(200);
+    const otherResponse = await scopeRoute.POST(otherRequest, { params: Promise.resolve({ id: laneB.id }) });
+    expect(otherResponse.status).toBe(403);
+    await expect(otherResponse.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'worker_packet_mismatch' },
+    });
+    expect(readOrchestratorControlPlaneState().packets.find((candidate) => candidate.id === packetB)?.allowedFiles)
+      .toEqual(['src/worker.ts']);
+  });
+
   it('never launches a packet whose only predicted file is forbidden by its task brief', async () => {
     const repoPath = createRepo();
     const { scanRepo } = await import('@/lib/skeleton');

--- a/tests/github-issue-packet-scope-real-path.test.ts
+++ b/tests/github-issue-packet-scope-real-path.test.ts
@@ -51,26 +51,22 @@ beforeEach(() => {
 describe('GitHub issue packet scope real path', () => {
   it('keeps only repo paths when an issue body also contains a Git range and event field', async () => {
     const repoPath = createRepo();
-    const { scanRepo } = await import('@/lib/skeleton');
-    await scanRepo({ repoPath, chunks: false });
-
-    const { createMission } = await import('@/lib/orchestrator/operator-mission-service');
-    const created = await createMission({
-      issues: [{
+    writeFileSync(join(repoPath, 'src', 'scope-support.ts'), 'export const scopeSupport = true;\n');
+    const { resolvePacketScope } = await import('@/lib/orchestrator/packet-scope-policy');
+    const resolution = resolvePacketScope({
+      title: 'Constrain packet scope prediction',
+      summary: 'Seal the packet to paths stated in the issue.',
+      issue: {
         number: 20_050,
-        title: 'Constrain packet scope prediction',
         body: 'Compare ead1b7a15..HEAD with open_lane.baseCommit, then update src/worker.ts.',
         url: 'https://example.test/issues/20050',
-      }],
-      repoPath,
-      runtime: 'codex',
-      constraints: 'Seal the packet to paths stated in the issue.',
-    });
-    const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
-    const packet = readOrchestratorControlPlaneState().packets
-      .find((candidate) => candidate.id === created.packets[0]!.id)!;
+      },
+      workspaceTargetPath: repoPath,
+    }, ['src/worker.ts', 'src/scope-support.ts', 'ead1b7a15..HEAD', 'open_lane.baseCommit']);
 
-    expect(packet.allowedFiles).toEqual(['src/worker.ts']);
+    expect(resolution.allowedPaths).toEqual(['src/worker.ts', 'src/scope-support.ts']);
+    expect(resolution.allowedPaths).not.toContain('ead1b7a15..HEAD');
+    expect(resolution.allowedPaths).not.toContain('open_lane.baseCommit');
   });
 
   it('lets a packet-bound worker expand its own lane through middleware and the route only', async () => {

--- a/tests/middleware-gate.test.ts
+++ b/tests/middleware-gate.test.ts
@@ -498,6 +498,13 @@ describe('panelGateMiddleware — worker capability scope', () => {
     expect(workerRequest('/api/cortex/proposals', 'DELETE').status).toBe(403);
   });
 
+  it('admits only POST on the packet scope escape hatch', () => {
+    expect(workerRequest('/api/lanes/lane-owned/scope', 'GET').status).toBe(200);
+    expect(workerRequest('/api/lanes/lane-owned/scope', 'POST').status).toBe(200);
+    expect(workerRequest('/api/lanes/lane-owned/scope', 'DELETE').status).toBe(403);
+    expect(workerRequest('/api/lanes/lane-owned/diff', 'POST').status).toBe(403);
+  });
+
   it('keeps ungranted lease methods and operator mutations closed to workers', () => {
     expect(workerRequest('/api/leases', 'DELETE').status).toBe(403);
     expect(workerRequest('/api/orchestrator/merge', 'POST').status).toBe(403);

--- a/tests/packet-scope-policy.test.ts
+++ b/tests/packet-scope-policy.test.ts
@@ -12,6 +12,7 @@ function createRepoFixture(): string {
   tempDirs.push(repoPath);
   mkdirSync(join(repoPath, 'src'), { recursive: true });
   writeFileSync(join(repoPath, 'src', 'existing.ts'), 'export const existing = true;\n');
+  writeFileSync(join(repoPath, 'src', 'support.ts'), 'export const support = true;\n');
   return repoPath;
 }
 
@@ -20,17 +21,17 @@ afterAll(() => {
 });
 
 describe('packet scope path scraper', () => {
-  it('drops Git ranges and dotted identifiers while retaining an existing repo path', () => {
+  it('drops Git ranges and dotted identifiers while retaining existing repo paths', () => {
     const repoPath = createRepoFixture();
     const resolution = resolvePacketScope({
       title: 'Repair the scoped file',
-      summary: 'Compare ead1b7a15..HEAD and open_lane.baseCommit before editing src/existing.ts.',
+      summary: 'Compare ead1b7a15..HEAD and open_lane.baseCommit before editing src/existing.ts and src/support.ts.',
       workspaceTargetPath: repoPath,
-      predictedFiles: ['ead1b7a15..HEAD', 'open_lane.baseCommit', 'src/existing.ts'],
+      predictedFiles: ['ead1b7a15..HEAD', 'open_lane.baseCommit', 'src/existing.ts', 'src/support.ts'],
     });
 
-    expect(resolution.predictedPaths).toEqual(['src/existing.ts']);
-    expect(resolution.allowedPaths).toEqual(['src/existing.ts']);
+    expect(resolution.predictedPaths).toEqual(['src/existing.ts', 'src/support.ts']);
+    expect(resolution.allowedPaths).toEqual(['src/existing.ts', 'src/support.ts']);
     expect(resolution.source).toBe('prediction');
   });
 

--- a/tests/packet-scope-policy.test.ts
+++ b/tests/packet-scope-policy.test.ts
@@ -1,0 +1,49 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+import { resolvePacketScope } from '@/lib/orchestrator/packet-scope-policy';
+
+const tempDirs: string[] = [];
+
+function createRepoFixture(): string {
+  const repoPath = mkdtempSync(join(tmpdir(), 'o8-packet-scope-policy-'));
+  tempDirs.push(repoPath);
+  mkdirSync(join(repoPath, 'src'), { recursive: true });
+  writeFileSync(join(repoPath, 'src', 'existing.ts'), 'export const existing = true;\n');
+  return repoPath;
+}
+
+afterAll(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('packet scope path scraper', () => {
+  it('drops Git ranges and dotted identifiers while retaining an existing repo path', () => {
+    const repoPath = createRepoFixture();
+    const resolution = resolvePacketScope({
+      title: 'Repair the scoped file',
+      summary: 'Compare ead1b7a15..HEAD and open_lane.baseCommit before editing src/existing.ts.',
+      workspaceTargetPath: repoPath,
+      predictedFiles: ['ead1b7a15..HEAD', 'open_lane.baseCommit', 'src/existing.ts'],
+    });
+
+    expect(resolution.predictedPaths).toEqual(['src/existing.ts']);
+    expect(resolution.allowedPaths).toEqual(['src/existing.ts']);
+    expect(resolution.source).toBe('prediction');
+  });
+
+  it('admits path-shaped new files inside the repo, including known root extensions', () => {
+    const repoPath = createRepoFixture();
+    const resolution = resolvePacketScope({
+      title: 'Add src/new-module.ts and root-test.ts',
+      summary: 'Do not treat event.payloadField as a file.',
+      workspaceTargetPath: repoPath,
+      predictedFiles: ['src/new-module.ts', 'root-test.ts', 'event.payloadField'],
+    });
+
+    expect(resolution.predictedPaths).toEqual(['src/new-module.ts', 'root-test.ts']);
+    expect(resolution.allowedPaths).toEqual(['src/new-module.ts', 'root-test.ts']);
+  });
+});


### PR DESCRIPTION
Fixes #2005.

Two defects in the GitHub-issue packet scope seal.

## 1. Worker credential refused on its own packet's expand-scope

The packet ids matched all along. The middleware's worker capability table only granted `GET` on `/api/lanes/:id/scope`, so a worker's `POST` never reached the handler and came back as a 403 the CLI reported as a token mismatch. The table now grants `POST` on that one path; the handler still binds the bearer to the resolved lane's packet before it mutates the allowlist, so a worker addressing another packet's lane still gets `worker_packet_mismatch`.

## 2. Scraper sealed non-paths

`allowedPaths` prediction admitted tokens like a git range (`a..b`) and an event field (`open_lane.baseCommit`). Predicted and stated paths are now filtered to entries that resolve to an existing repo path, or a path-shaped new file inside the repo (root-level new files need a known source extension). The fallback ladder (empty / tiny / forbidden / unsupported prediction → repo-wide scope) is unchanged.

## Verification

- Real-path test: a worker token minted for lane A, `POST /api/lanes/A/scope` through `panelGateMiddleware` and the route handler → 200, allowlist widened and persisted; same token against lane B → 403 `worker_packet_mismatch`, B untouched.
- Middleware gate test: `POST` admitted on the scope path, `DELETE` and `POST` on `/diff` still 403.
- Scope resolution test: a prediction containing two real repo paths plus both junk tokens seals to the two paths only.
- `npx tsc --noEmit` clean, `npm run lint` exit 0, middleware 105/105, route coverage 366/366, real-path suite 5/5.
