### PR TITLE
fix: bound packet scope payloads, wait through reruns, and summarize silent exits

### DIFF
--- a/cli/src/commands/packet/help.ts
+++ b/cli/src/commands/packet/help.ts
@@ -31,7 +31,7 @@ export const OPERATOR_PACKET_SUBCOMMANDS = [
 ] as const;
 
 export const PACKET_COMMAND_LINES = `  packet info [id]     packet metadata; explicit packet/lane id overrides cwd
-  packet scope [id]    one-call worker context (auto-resolves from cwd)
+  packet scope [id]    bounded worker context (--include-directives for bodies)
   packet expand-scope [id] request bounded paths (--paths <path[,path]> --reason <text>)
   packet diff [id]     the packet's code diff vs base (committed + uncommitted)
   packet commit -m ".." stage + commit the current worktree with an explicit pathspec

--- a/cli/src/commands/packet/scope.ts
+++ b/cli/src/commands/packet/scope.ts
@@ -16,12 +16,12 @@ import { parsePacketArguments, resolvePacketTarget } from './target.js';
 interface PacketScopeDirective {
   id: string;
   title: string;
-  scope: string;
-  repoName: string | null;
-  priority: number | null;
-  body: string;
-  projects: string[];
-  recentMerges: string[];
+  scope?: string;
+  repoName?: string | null;
+  priority?: number | null;
+  body?: string;
+  projects?: string[];
+  recentMerges?: string[];
 }
 
 interface RelatedPacketScope {
@@ -91,14 +91,21 @@ interface PacketScope {
   fileLineCeiling: number;
   allowedPaths: string[];
   blockedPaths: string[];
+  directiveCount: number;
   directives: PacketScopeDirective[];
   relatedPackets: RelatedPacketScope[];
   project?: PacketScopeProject;
 }
 
-async function resolveScopeId(rest: string[]): Promise<string> {
-  const args = parsePacketArguments(rest, { command: 'scope' });
-  return (await resolvePacketTarget(args.target)).laneId;
+async function resolveScopeInput(rest: string[]): Promise<{ id: string; includeDirectives: boolean }> {
+  const args = parsePacketArguments(rest, {
+    command: 'scope',
+    booleanFlags: ['include-directives'],
+  });
+  return {
+    id: (await resolvePacketTarget(args.target)).laneId,
+    includeDirectives: args.booleans.has('include-directives'),
+  };
 }
 
 function printHumanScope(scope: PacketScope): void {
@@ -162,13 +169,14 @@ function printHumanScope(scope: PacketScope): void {
   printHumanHeading(`blocked paths (${scope.blockedPaths.length})`);
   process.stdout.write(scope.blockedPaths.map((path) => `  ${path}`).join('\n') + '\n');
 
-  printHumanHeading(`directives (${scope.directives.length})`);
+  printHumanHeading(`directives (${scope.directiveCount})`);
   if (scope.directives.length === 0) {
     process.stdout.write('  (none)\n');
   } else {
     for (const directive of scope.directives) {
-      const priority = directive.priority === null ? '' : ` priority=${directive.priority}`;
-      process.stdout.write(`  ${directive.title} [${directive.scope}]${priority}\n`);
+      const scopeLabel = directive.scope ? ` [${directive.scope}]` : '';
+      const priority = directive.priority === undefined || directive.priority === null ? '' : ` priority=${directive.priority}`;
+      process.stdout.write(`  ${directive.title}${scopeLabel}${priority}\n`);
     }
   }
 
@@ -183,26 +191,11 @@ function printHumanScope(scope: PacketScope): void {
   }
 }
 
-// Agents pipe `o8 packet scope` JSON straight into their context. Keep every
-// directive but cap each body so a directive-heavy project doesn't flood it.
-// (Human output already prints only directive titles.)
-const DIRECTIVE_BODY_CAP = 600;
-function capScopeForJson(scope: PacketScope): PacketScope {
-  if (!Array.isArray(scope.directives) || scope.directives.length === 0) return scope;
-  return {
-    ...scope,
-    directives: scope.directives.map((directive) => (
-      typeof directive.body === 'string' && directive.body.length > DIRECTIVE_BODY_CAP
-        ? { ...directive, body: `${directive.body.slice(0, DIRECTIVE_BODY_CAP)}…[+${directive.body.length - DIRECTIVE_BODY_CAP} chars truncated — read o8.md / directive source for the rest]` }
-        : directive
-    )),
-  };
-}
-
 export async function runPacketScope(mode: OutputMode, rest: string[]): Promise<number> {
-  const id = await resolveScopeId(rest);
+  const { id, includeDirectives } = await resolveScopeInput(rest);
   const cfg = resolveConfig();
-  const res = await apiFetch<PacketScope>(cfg, `/api/lanes/${encodeURIComponent(id)}/scope`);
+  const query = includeDirectives ? '?includeDirectives=true' : '';
+  const res = await apiFetch<PacketScope>(cfg, `/api/lanes/${encodeURIComponent(id)}/scope${query}`);
   if (!res.data) {
     throw new CliError('invalid_response', 'Server returned an empty packet scope.', EXIT.INVALID_ARGS);
   }
@@ -211,7 +204,7 @@ export async function runPacketScope(mode: OutputMode, rest: string[]): Promise<
   if (mode.human) {
     printHumanScope(res.data);
   } else {
-    printJson(capScopeForJson(res.data));
+    printJson(res.data);
   }
   return 0;
 }

--- a/src/app/api/lanes/[id]/scope/route.ts
+++ b/src/app/api/lanes/[id]/scope/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { requirePanelAuth } from '@/lib/panel/auth';
 import { resolveRequestPrincipalContext, workerPacketRefusal } from '@/lib/auth/principal';
-import { getPacketScope } from '@/lib/lanes/scope';
+import { getPacketScope, projectPacketScope } from '@/lib/lanes/scope';
 import { requestPacketScopeExpansion } from '@/lib/orchestrator/packet-scope-expansion';
 
 export const runtime = 'nodejs';
@@ -25,7 +25,10 @@ export async function GET(
     return NextResponse.json({ ok: false, error: ownershipRefusal }, { status: 403 });
   }
 
-  return NextResponse.json(scope, {
+  return NextResponse.json(projectPacketScope(
+    scope,
+    req.nextUrl.searchParams.get('includeDirectives') === 'true',
+  ), {
     headers: { 'Cache-Control': 'no-store, max-age=0' },
   });
 }

--- a/src/lib/lanes/scope.ts
+++ b/src/lib/lanes/scope.ts
@@ -34,6 +34,11 @@ export interface PacketScopeDirective {
   recentMerges: string[];
 }
 
+export interface PacketScopeDirectiveReference {
+  id: string;
+  title: string;
+}
+
 export interface RelatedPacketScope {
   packetId: string;
   laneId: string | null;
@@ -104,6 +109,24 @@ export interface PacketScope {
   directives: PacketScopeDirective[];
   relatedPackets: RelatedPacketScope[];
   project: PacketScopeProject;
+}
+
+export type PacketScopeResponse = Omit<PacketScope, 'directives'> & {
+  directiveCount: number;
+  directives: PacketScopeDirective[] | PacketScopeDirectiveReference[];
+};
+
+export function projectPacketScope(
+  scope: PacketScope,
+  includeDirectives = false,
+): PacketScopeResponse {
+  return {
+    ...scope,
+    directiveCount: scope.directives.length,
+    directives: includeDirectives
+      ? scope.directives
+      : scope.directives.map(({ id, title }) => ({ id, title })),
+  };
 }
 
 export interface GetPacketScopeInput {

--- a/src/lib/mcp/operator-handlers/mission-wait.ts
+++ b/src/lib/mcp/operator-handlers/mission-wait.ts
@@ -16,7 +16,7 @@ export interface MinimalMissionStatusShape {
 }
 
 // Packets in these states need caller attention unless authoritative lane
-// evidence says a rerun/review is still active.
+// evidence says a rerun is still active.
 const PACKET_ATTENTION_STATUSES = new Set(['awaiting_review', 'released', 'failed', 'archived', 'blocked']);
 
 export function missionPacketSignature(packets: MinimalMissionPacket[] | undefined): string {
@@ -29,8 +29,7 @@ export function missionPacketSignature(packets: MinimalMissionPacket[] | undefin
 
 function packetIsActive(packet: MinimalMissionPacket): boolean {
   return packet.blockedReason === 'rerun_in_progress'
-    || packet.lane?.status === 'running'
-    || packet.lane?.status === 'reviewing';
+    || packet.lane?.status === 'running';
 }
 
 export function findMissionAttentionPacket(

--- a/src/lib/mcp/operator-handlers/mission-wait.ts
+++ b/src/lib/mcp/operator-handlers/mission-wait.ts
@@ -1,0 +1,48 @@
+export interface MinimalMissionPacket {
+  id?: string;
+  status?: string;
+  releaseState?: string;
+  blockedReason?: string | null;
+  blockedBy?: unknown;
+  lane?: {
+    status?: string;
+  } | null;
+}
+
+export interface MinimalMissionStatusShape {
+  packets?: MinimalMissionPacket[];
+  currentWave?: number;
+  totalWaves?: number;
+}
+
+// Packets in these states need caller attention unless authoritative lane
+// evidence says a rerun/review is still active.
+const PACKET_ATTENTION_STATUSES = new Set(['awaiting_review', 'released', 'failed', 'archived', 'blocked']);
+
+export function missionPacketSignature(packets: MinimalMissionPacket[] | undefined): string {
+  if (!Array.isArray(packets)) return '';
+  return packets
+    .map((packet) => `${packet.id ?? ''}:${packet.status ?? ''}:${packet.releaseState ?? ''}:${packet.blockedReason ?? ''}:${packet.lane?.status ?? ''}`)
+    .sort()
+    .join(',');
+}
+
+function packetIsActive(packet: MinimalMissionPacket): boolean {
+  return packet.blockedReason === 'rerun_in_progress'
+    || packet.lane?.status === 'running'
+    || packet.lane?.status === 'reviewing';
+}
+
+export function findMissionAttentionPacket(
+  status: MinimalMissionStatusShape,
+  packetIdFilter: string | null,
+): MinimalMissionPacket | null {
+  for (const packet of status.packets ?? []) {
+    if (packetIdFilter && packet.id !== packetIdFilter) continue;
+    if (packetIsActive(packet)) continue;
+    if (typeof packet.status === 'string' && PACKET_ATTENTION_STATUSES.has(packet.status)) {
+      return packet;
+    }
+  }
+  return null;
+}

--- a/src/lib/mcp/operator-handlers/mission.ts
+++ b/src/lib/mcp/operator-handlers/mission.ts
@@ -13,7 +13,7 @@ import {
   resetPacket,
   submitPacketReview,
 } from '@/lib/mcp/operator-mission-tools';
-import { getPacketScope } from '@/lib/lanes/scope';
+import { getPacketScope, projectPacketScope } from '@/lib/lanes/scope';
 import {
   archiveTask,
   blockTask,
@@ -43,6 +43,11 @@ import {
   textResult,
 } from './shared';
 import type { WorkerIntent } from '@/lib/orchestrator/types';
+import {
+  findMissionAttentionPacket,
+  missionPacketSignature,
+  type MinimalMissionStatusShape,
+} from './mission-wait';
 import { parseMissionCandidateMode, parseTaskContractSetting, QUALITY_SEARCH_INPUT_SCHEMA, TASK_CONTRACT_SETTING_SCHEMA } from './quality-search-input';
 import { MISSION_WORKER_PIN_PROPERTIES, parseMissionWorkerPinInput, parseWorkerProvider, WORKER_PROVIDER_OPTIONS } from './mission-worker-input';
 import { CONTRACT_COVERAGE_EVIDENCE_SCHEMA, parseContractCoverageEvidenceInput } from './review-coverage-input';
@@ -189,7 +194,7 @@ export const MISSION_TOOLS: McpTool[] = [
   {
     name: 'get_packet_scope',
     description:
-      'Return one-call worker context for a packet or lane: project brief, main/current/related repos, active locks, branch, base, head SHA, worktree, file ceiling, allowed/blocked paths, repo-filtered directives, and active related packets with overlapping files. Provide packetId or laneId.',
+      'Return bounded one-call worker context for a packet or lane: project brief, repos, locks, branch, base, head SHA, worktree, path limits, directive count plus id/title references, and related packet overlaps. Directive bodies are omitted by default; pass includeDirectives:true only when their full text is needed. Provide packetId or laneId.',
     inputSchema: {
       // No top-level anyOf — OpenAI strict function-calling rejects oneOf /
       // anyOf / allOf siblings to `type: 'object'`. Handler validates that
@@ -203,6 +208,10 @@ export const MISSION_TOOLS: McpTool[] = [
         laneId: {
           type: 'string',
           description: 'Lane id, for example lane-xyz. Either packetId or laneId is required.',
+        },
+        includeDirectives: {
+          type: 'boolean',
+          description: 'Include full directive metadata and bodies. Default false; the bounded default returns only directive id/title references plus directiveCount.',
         },
       },
     },
@@ -544,7 +553,7 @@ export const MISSION_TOOLS: McpTool[] = [
   {
     name: 'wait_for_mission_ready',
     description:
-      'Long-poll until any packet in the mission transitions to a terminal/review state (awaiting_review, released, failed, archived) or the mission completes. Returns the same payload as get_mission_status plus a `wakeReason` field ("state-change" | "timeout" | "already-terminal"). Use after dispatching to get notified when Codex is done without manually polling. Specify `packetId` to wait for a specific packet only. Default timeout 600000ms (10 min); cap 1800000ms (30 min).',
+      'Long-poll until a packet reaches an attention state or its packet/lane state changes. Reruns and packets with running/reviewing lanes remain active instead of returning already-terminal. Returns the get_mission_status payload plus `wakeReason` ("state-change" | "timeout" | "already-terminal"). Specify packetId to watch one packet. Default timeout 600000ms; cap 1800000ms.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -968,19 +977,7 @@ export async function handleGetPacketScope(args: Record<string, unknown>): Promi
     if (!result) {
       return textResult('Packet scope not found', true);
     }
-    // Bound directive prose so a project with many/long directives doesn't
-    // flood the worker's context — keep every directive, cap each body.
-    const DIRECTIVE_BODY_CAP = 600;
-    const scope = result as unknown as Record<string, unknown>;
-    if (Array.isArray(scope.directives)) {
-      scope.directives = (scope.directives as Array<Record<string, unknown>>).map((directive) => {
-        const body = directive.body;
-        return typeof body === 'string' && body.length > DIRECTIVE_BODY_CAP
-          ? { ...directive, body: `${body.slice(0, DIRECTIVE_BODY_CAP)}…[+${body.length - DIRECTIVE_BODY_CAP} chars truncated]` }
-          : directive;
-      });
-    }
-    return jsonResult(scope);
+    return jsonResult(projectPacketScope(result, args.includeDirectives === true));
   } catch (error) {
     console.error(`${'[mcp-operator]'} get_packet_scope failed: ${errorText(error)}`);
     return textResult(`Failed to read packet scope: ${errorText(error)}`, true);
@@ -1177,52 +1174,15 @@ export async function handleTaskPrune(args: Record<string, unknown>): Promise<Mc
   }
 }
 
-// Packet states that need the caller's attention — the runtime is done working
-// for now and a decision is required. `blocked` belongs here (#1467): it is what
-// awaiting_input / awaiting_orchestrator (huddle, #1495) / awaiting_human lanes
-// and dispatch failures map to, and none of those progress without a decision.
-// Excluding it deadlocked the loop: the orchestrator sat in wait_for_mission_ready
-// while its worker sat in awaiting_orchestrator waiting for the orchestrator.
-// Dependency-held packets stay `queued` (with blockedBy), so they never
-// false-wake this set. `running`, `queued`, `launching` are NOT included.
-const PACKET_ATTENTION_STATUSES = new Set(['awaiting_review', 'released', 'failed', 'archived', 'blocked']);
+type MissionStatusReader = (input: {
+  missionId?: string;
+  includeCost: boolean;
+}) => Promise<MinimalMissionStatusShape | Awaited<ReturnType<typeof getMissionStatus>>>;
 
-interface MinimalMissionPacket {
-  id?: string;
-  status?: string;
-  releaseState?: string;
-  blockedBy?: unknown;
-}
-
-interface MinimalMissionStatusShape {
-  packets?: MinimalMissionPacket[];
-  currentWave?: number;
-  totalWaves?: number;
-}
-
-function packetSignature(packets: MinimalMissionPacket[] | undefined): string {
-  if (!Array.isArray(packets)) return '';
-  return packets
-    .map((p) => `${p.id ?? ''}:${p.status ?? ''}:${p.releaseState ?? ''}`)
-    .sort()
-    .join(',');
-}
-
-function findTerminalPacket(
-  status: MinimalMissionStatusShape,
-  packetIdFilter: string | null,
-): MinimalMissionPacket | null {
-  const packets = status.packets ?? [];
-  for (const p of packets) {
-    if (packetIdFilter && p.id !== packetIdFilter) continue;
-    if (typeof p.status === 'string' && PACKET_ATTENTION_STATUSES.has(p.status)) {
-      return p;
-    }
-  }
-  return null;
-}
-
-export async function handleWaitForMissionReady(args: Record<string, unknown>, readStatus: typeof getMissionStatus = getMissionStatus): Promise<McpToolResult> {
+export async function handleWaitForMissionReady(
+  args: Record<string, unknown>,
+  readStatus: MissionStatusReader = getMissionStatus,
+): Promise<McpToolResult> {
   const TIMEOUT_DEFAULT_MS = 10 * 60 * 1000;
   const TIMEOUT_MAX_MS = 30 * 60 * 1000;
   const POLL_DEFAULT_MS = 3000;
@@ -1240,12 +1200,12 @@ export async function handleWaitForMissionReady(args: Record<string, unknown>, r
 
     // If a terminal state already exists at baseline, return immediately so
     // the caller never blocks unnecessarily.
-    const baselineTerminal = findTerminalPacket(baseline, packetIdFilter);
+    const baselineTerminal = findMissionAttentionPacket(baseline, packetIdFilter);
     if (baselineTerminal) {
       return jsonResult({ ...baseline, wakeReason: 'already-terminal', terminalPacketId: baselineTerminal.id ?? null });
     }
 
-    const baselineSig = packetSignature(baseline.packets);
+    const baselineSig = missionPacketSignature(baseline.packets);
     const deadline = Date.now() + timeoutMs;
 
     while (Date.now() < deadline) {
@@ -1258,11 +1218,11 @@ export async function handleWaitForMissionReady(args: Record<string, unknown>, r
       if (Date.now() >= deadline) break;
 
       const next = (await readStatus({ missionId, includeCost: false })) as MinimalMissionStatusShape;
-      const terminal = findTerminalPacket(next, packetIdFilter);
+      const terminal = findMissionAttentionPacket(next, packetIdFilter);
       if (terminal) {
         return jsonResult({ ...next, wakeReason: 'state-change', terminalPacketId: terminal.id ?? null });
       }
-      if (packetSignature(next.packets) !== baselineSig) {
+      if (missionPacketSignature(next.packets) !== baselineSig) {
         return jsonResult({ ...next, wakeReason: 'state-change', terminalPacketId: null });
       }
     }

--- a/src/lib/orchestrator/context-relay.ts
+++ b/src/lib/orchestrator/context-relay.ts
@@ -407,7 +407,7 @@ export async function recordPacketReviewContext(
   return nextContext;
 }
 
-export async function capturePacketCompletionContext(packetId: string, sessionKey: string): Promise<PacketContext> {
+export async function capturePacketCompletionContext(packetId: string, sessionKey: string, options: { fallbackSummary?: string } = {}): Promise<PacketContext> {
   const normalizedPacketId = packetId.trim();
   const normalizedSessionKey = sessionKey.trim();
   const runtimeId = inferRuntimeId(normalizedSessionKey);
@@ -433,6 +433,8 @@ export async function capturePacketCompletionContext(packetId: string, sessionKe
   const agent = agentResult.status === 'fulfilled' ? agentResult.value : null;
   const telemetry = telemetryResult.status === 'fulfilled' ? telemetryResult.value : undefined;
   const lastAssistantEntry = findLastAssistantEntry(transcript);
+  const assistantSummary = normalizeSummaryText(stripPacketTaskContract(stripPacketSelfReview(lastAssistantEntry?.text ?? '')), SUMMARY_LIMIT);
+  const fallbackSummary = normalizeSummaryText(options.fallbackSummary ?? '', SUMMARY_LIMIT);
   const selfReview = findLatestSelfReview(transcript);
   const taskContractCapture = findFirstTaskContractCapture(transcript);
   const taskContract = taskContractCapture?.contract;
@@ -455,15 +457,14 @@ export async function capturePacketCompletionContext(packetId: string, sessionKe
           diffFingerprint: spokenDiffResult.value.fingerprint,
         }
       : {}),
-    summary: buildPacketSummary({
-      lifecycleSummary: normalizeSummaryText(agent?.runtimeSurface?.lifecycle?.summary ?? '', SUMMARY_LIMIT),
-      assistantSummary: normalizeSummaryText(
-        stripPacketTaskContract(stripPacketSelfReview(lastAssistantEntry?.text ?? '')),
-        SUMMARY_LIMIT,
-      ),
-      note: findRecentNote(transcript, lastAssistantEntry?.id ?? null),
-      changedFiles,
-    }),
+    summary: fallbackSummary
+      ? assistantSummary || fallbackSummary
+      : buildPacketSummary({
+          lifecycleSummary: normalizeSummaryText(agent?.runtimeSurface?.lifecycle?.summary ?? '', SUMMARY_LIMIT),
+          assistantSummary,
+          note: findRecentNote(transcript, lastAssistantEntry?.id ?? null),
+          changedFiles,
+        }),
     changedFiles,
     selfReview,
     ...(taskContract ? { taskContract } : {}),

--- a/src/lib/orchestrator/operator-mission-service/mission-status-transcript.ts
+++ b/src/lib/orchestrator/operator-mission-service/mission-status-transcript.ts
@@ -1,0 +1,53 @@
+import {
+  latestTranscriptEventAt,
+  readSessionTranscriptEvents,
+} from '@/lib/orchestrator/packet-transcript';
+
+interface MissionTranscriptActivity {
+  lastTranscriptAt: string | null;
+  transcriptUnsupportedReason: string | null;
+}
+
+export function latestIsoTimestamp(...timestamps: Array<string | null | undefined>): string | null {
+  let latestMs = 0;
+  let latestIso: string | null = null;
+  for (const timestamp of timestamps) {
+    if (!timestamp) continue;
+    const parsed = new Date(timestamp).getTime();
+    if (!Number.isFinite(parsed) || parsed <= latestMs) continue;
+    latestMs = parsed;
+    latestIso = new Date(parsed).toISOString();
+  }
+  return latestIso;
+}
+
+export function activityLabel(
+  lastActivityAt: string | null,
+  lastTranscriptAt: string | null,
+  lastEventLabel: string | null | undefined,
+) {
+  return lastActivityAt && lastTranscriptAt && lastActivityAt === lastTranscriptAt
+    ? 'transcript_activity'
+    : lastEventLabel ?? null;
+}
+
+export async function readTranscriptActivityBySession(
+  sessionKeys: string[],
+): Promise<Map<string, MissionTranscriptActivity>> {
+  const uniqueKeys = [...new Set(sessionKeys.map((key) => key.trim()).filter(Boolean))];
+  const pairs = await Promise.all(uniqueKeys.map(async (sessionKey) => {
+    try {
+      const readback = await readSessionTranscriptEvents(sessionKey);
+      return [sessionKey, {
+        lastTranscriptAt: latestTranscriptEventAt(readback.events),
+        transcriptUnsupportedReason: readback.unsupportedReason ?? null,
+      }] as const;
+    } catch {
+      return [sessionKey, {
+        lastTranscriptAt: null,
+        transcriptUnsupportedReason: null,
+      }] as const;
+    }
+  }));
+  return new Map(pairs);
+}

--- a/src/lib/orchestrator/operator-mission-service/mission.ts
+++ b/src/lib/orchestrator/operator-mission-service/mission.ts
@@ -16,10 +16,7 @@ import {
   readMissionRegistryEntry,
   withMissionRegistryState,
 } from '@/lib/orchestrator/mission-registry';
-import {
-  latestTranscriptEventAt,
-  readSessionTranscriptEvents,
-} from '@/lib/orchestrator/packet-transcript';
+import { readPacketCompletionContext } from '@/lib/orchestrator/context-relay';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 import { bindWorkerLaunchParent } from '@/lib/orchestrator/worker-launch-context';
 import { assertQualitySearchMissionCompatibility, resolveTaskContractRequired } from '@/lib/orchestrator/task-contract-required';
@@ -27,6 +24,11 @@ import { withMissionHandoffBarrier } from '@/lib/orchestrator/lifecycle-mutation
 import { releaseAbandonedMissionLifecycleHold } from '@/lib/orchestrator/mission-lifecycle-hold';
 import { getTopRulesForPacket, readRepoScopedRules } from '@/lib/dispatch/rules-store';
 import { prepareMissionBranches, type MissionBranchDecision } from './branch-cleanup';
+import {
+  activityLabel,
+  latestIsoTimestamp,
+  readTranscriptActivityBySession,
+} from './mission-status-transcript';
 import { recordOutgoingMissionSnapshot } from './mission-handoff';
 import { logDispatchRoutingRecommendations } from './mission-routing-log';
 import { preparePacketsForExplicitDispatch, summarizeDispatchMission } from './dispatch-runtime-override';
@@ -442,58 +444,6 @@ export async function dispatchMission(input: DispatchMissionInput) {
   };
 }
 
-interface MissionTranscriptActivity {
-  lastTranscriptAt: string | null;
-  transcriptUnsupportedReason: string | null;
-}
-
-function latestIsoTimestamp(...timestamps: Array<string | null | undefined>): string | null {
-  let latestMs = 0;
-  let latestIso: string | null = null;
-
-  for (const timestamp of timestamps) {
-    if (!timestamp) continue;
-    const parsed = new Date(timestamp).getTime();
-    if (!Number.isFinite(parsed) || parsed <= latestMs) continue;
-    latestMs = parsed;
-    latestIso = new Date(parsed).toISOString();
-  }
-
-  return latestIso;
-}
-
-function activityLabel(
-  lastActivityAt: string | null,
-  lastTranscriptAt: string | null,
-  lastEventLabel: string | null | undefined,
-) {
-  return lastActivityAt && lastTranscriptAt && lastActivityAt === lastTranscriptAt
-    ? 'transcript_activity'
-    : lastEventLabel ?? null;
-}
-
-async function readTranscriptActivityBySession(
-  sessionKeys: string[],
-): Promise<Map<string, MissionTranscriptActivity>> {
-  const uniqueKeys = [...new Set(sessionKeys.map((key) => key.trim()).filter(Boolean))];
-  const pairs = await Promise.all(uniqueKeys.map(async (sessionKey) => {
-    try {
-      const readback = await readSessionTranscriptEvents(sessionKey);
-      return [sessionKey, {
-        lastTranscriptAt: latestTranscriptEventAt(readback.events),
-        transcriptUnsupportedReason: readback.unsupportedReason ?? null,
-      }] as const;
-    } catch {
-      return [sessionKey, {
-        lastTranscriptAt: null,
-        transcriptUnsupportedReason: null,
-      }] as const;
-    }
-  }));
-
-  return new Map(pairs);
-}
-
 /**
  * Build a lite mission status snapshot from the SQLite archive + live lanes.
  *
@@ -554,6 +504,7 @@ function buildHistoricalMissionStatus(record: import('@/lib/db/missions-store').
       releaseState: inferReleaseState(lane),
       blockedBy: [] as string[],
       blockedReason: null,
+      summary: null,
       recovery,
       lane: lane ? {
         laneId: lane.id,
@@ -651,6 +602,9 @@ export async function getMissionStatus(input: MissionStatusInput) {
     return sessionKey ? [sessionKey] : [];
   });
   const transcriptActivityBySession = await readTranscriptActivityBySession(sessionKeys);
+  const completionContextByPacketId = new Map(await Promise.all(state.packets.map(async (packet) => (
+    [packet.id, await readPacketCompletionContext(packet.id)] as const
+  ))));
   const mergePolicy = currentLaneMergePolicy();
 
   const agents = state.packets
@@ -736,6 +690,10 @@ export async function getMissionStatus(input: MissionStatusInput) {
       const lastTranscriptAt = activity?.lastTranscriptAt ?? null;
       const laneLastEventAt = lane?.lastEventAt ?? packet.lane?.lastEventAt ?? null;
       const lastActivityAt = latestIsoTimestamp(laneLastEventAt, lastTranscriptAt);
+      const storedCompletionContext = completionContextByPacketId.get(packet.id);
+      const completionContext = storedCompletionContext?.sessionKey === laneSessionKey
+        ? storedCompletionContext
+        : null;
       return {
         id: packet.id,
         referenceLabel: packet.referenceLabel,
@@ -746,6 +704,10 @@ export async function getMissionStatus(input: MissionStatusInput) {
         releaseState: packet.releaseState,
         blockedBy: node.blockedBy,
         blockedReason: packet.blockedReason ?? null,
+        summary: packet.completionSummary?.trim()
+          || completionContext?.selfReview?.outcome?.trim()
+          || completionContext?.summary?.trim()
+          || null,
         storageAdmission: packet.storageAdmission ?? null,
         spendCap: packet.spendCap ?? null, spendTelemetry: packet.spendTelemetry ?? null,
         recovery,

--- a/src/lib/orchestrator/operator-mission-service/rerun-with-feedback.ts
+++ b/src/lib/orchestrator/operator-mission-service/rerun-with-feedback.ts
@@ -159,6 +159,7 @@ export function resetPacketFields(packet: OrchestratorPacket) {
   packet.releaseStatePayload = null;
   packet.archivedAt = null;
   packet.blockedReason = null;
+  packet.completionSummary = null;
   packet.recovery = null;
   packet.lane = null;
   packet.review = null;

--- a/src/lib/orchestrator/operator-mission-service/reset.ts
+++ b/src/lib/orchestrator/operator-mission-service/reset.ts
@@ -73,6 +73,7 @@ function markPacketResetHeld(packet: OrchestratorPacket) {
   packet.releaseStatePayload = null;
   packet.archivedAt = null;
   packet.blockedReason = null;
+  packet.completionSummary = null;
   packet.recovery = null;
   packet.lane = null;
   packet.review = null;

--- a/src/lib/orchestrator/store.ts
+++ b/src/lib/orchestrator/store.ts
@@ -366,7 +366,7 @@ function normalizePacket(raw: unknown, index: number, existing: Array<Pick<Orche
     // Huddle mode (per-mission alignment turn) lives only on the packet — drop
     // it here and a rerun/re-read would silently disarm the huddle.
     huddle: typeof packet.huddle === 'boolean' ? packet.huddle : undefined,
-    blockedReason: typeof packet.blockedReason === 'string' ? packet.blockedReason : null, ...normalizeTerminalStatusEvidenceField(packet.statusEvidence),
+    blockedReason: typeof packet.blockedReason === 'string' ? packet.blockedReason : null, completionSummary: typeof packet.completionSummary === 'string' && packet.completionSummary.trim() ? packet.completionSummary.trim() : null, ...normalizeTerminalStatusEvidenceField(packet.statusEvidence),
     storageAdmission: normalizePacketStorageAdmission(packet.storageAdmission), storageAdmissionEpoch: normalizePacketStorageAdmissionEpoch(packet.storageAdmissionEpoch),
     recovery: normalizePacketRecovery(packet.recovery),
     lastEventAt: typeof packet.lastEventAt === 'string' ? packet.lastEventAt : null,

--- a/src/lib/orchestrator/types.ts
+++ b/src/lib/orchestrator/types.ts
@@ -339,6 +339,8 @@ export interface OrchestratorPacket {
   spendTelemetry?: PacketSpendTelemetry;
   contextTelemetry?: PacketContextTelemetry;
   blockedReason?: string | null;
+  /** Worker-reported or recovered completion text shown by mission status. */
+  completionSummary?: string | null;
   /** Read-time status projection; recomputed from runtime or lane evidence. */
   statusEvidence?: TerminalStatusEvidence;
   /** Durable dispatch admission decision; reserved bytes are not physical usage. */

--- a/src/lib/supervisor/silent-exit-detector.test.ts
+++ b/src/lib/supervisor/silent-exit-detector.test.ts
@@ -22,6 +22,9 @@ import {
 } from './silent-exit-detector';
 
 const { createLane, deleteLane, getLane, getLaneEvents, listActiveLanes, updateLane } = await import('@/lib/lane/registry');
+const { getMissionStatus } = await import('@/lib/orchestrator/operator-mission-service');
+const { writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
 
 let ownedRoot: string | null = null;
 let tempWorktree: string | null = null;
@@ -196,6 +199,29 @@ describe('silent-exit detector policy (wave-1B burial incident)', () => {
     const { clone } = makePacketClone('o8-silent-exit-unmerged');
     const packetId = `pkt-silent-unmerged-${Date.now()}`;
     const lane = createDeadOwnedLane(clone, packetId);
+    const missionId = `mission-silent-unmerged-${Date.now()}`;
+    writeOrchestratorControlPlaneState({
+      ...createEmptyOrchestratorMissionState(),
+      missionId,
+      prompt: 'Recover committed work after a silent worker exit.',
+      summary: 'Silent-exit completion summary real path.',
+      repoPath: clone,
+      packets: [{
+        id: packetId,
+        referenceLabel: 'silent-1',
+        title: 'Recover silent completion',
+        summary: 'Promote committed work to review with a useful completion summary.',
+        workspaceTargetPath: clone,
+        branchTarget: 'packet',
+        runtime: 'codex',
+        dependencyLabels: [],
+        dependencyPacketIds: [],
+        queueState: 'queued',
+        releaseState: 'pending',
+        status: 'running',
+        lane: null,
+      }],
+    });
 
     await runSilentExitTickForTesting();
 
@@ -206,5 +232,8 @@ describe('silent-exit detector policy (wave-1B burial incident)', () => {
       item.packetId === packetId
       && item.kind === 'silent_exit_but_work_present'
     ))).toBe(true);
+
+    const status = await getMissionStatus({ missionId, includeCost: false });
+    expect(status.packets.find((packet) => packet.id === packetId)?.summary).toBe('packet work');
   }, 20_000);
 });

--- a/src/lib/supervisor/silent-exit-detector.ts
+++ b/src/lib/supervisor/silent-exit-detector.ts
@@ -168,6 +168,19 @@ async function readLastCommit(cwd: string): Promise<string> {
   }
 }
 
+async function readLastCommitSubject(cwd: string): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['log', '-1', '--format=%s'],
+      { windowsHide: true, cwd, timeout: GIT_COMMAND_TIMEOUT_MS, maxBuffer: GIT_COMMAND_MAX_BUFFER },
+    );
+    return stdout.trim();
+  } catch {
+    return '';
+  }
+}
+
 async function readHeadSha(cwd: string): Promise<string | null> {
   try {
     const { stdout } = await execFileAsync(
@@ -309,6 +322,34 @@ function enqueueSilentExitInbox(
   console.log(`[silent-exit] Enqueued inbox item ${inboxId} for lane ${lane.id} (${kind})`);
 }
 
+async function captureSilentExitCompletionSummary(lane: Lane, cwd: string): Promise<void> {
+  const packetId = lane.packetId?.trim() ?? '';
+  if (!packetId) return;
+
+  const commitSubject = await readLastCommitSubject(cwd);
+  let completionSummary = commitSubject;
+  if (lane.sessionKey) {
+    try {
+      const { capturePacketCompletionContext } = await import('@/lib/orchestrator/context-relay');
+      const context = await capturePacketCompletionContext(packetId, lane.sessionKey, {
+        fallbackSummary: commitSubject,
+      });
+      completionSummary = context.selfReview?.outcome?.trim()
+        || context.summary.trim()
+        || commitSubject;
+    } catch (error) {
+      console.warn(`[silent-exit] Failed to capture completion context for lane ${lane.id}:`, error);
+    }
+  }
+  if (!completionSummary) return;
+
+  const { withLockedState } = await import('@/lib/orchestrator/control-plane');
+  await withLockedState((mission) => {
+    const packet = mission.packets.find((candidate) => candidate.id === packetId);
+    if (packet) packet.completionSummary = completionSummary.slice(0, 1_200);
+  });
+}
+
 /**
  * #1500 — a verification-failed silent exit must leave a learning behind, or
  * every respawn goes out with the identical brief and trips the identical
@@ -411,6 +452,7 @@ async function triageSilentExit(lane: Lane): Promise<boolean> {
       return true;
     }
 
+    await captureSilentExitCompletionSummary(lane, cwd);
     setLaneStatus(lane.id, 'reviewing', 'system', 'silent_exit_work_present');
     enqueueSilentExitInbox(
       lane,
@@ -457,6 +499,7 @@ async function triageSilentExit(lane: Lane): Promise<boolean> {
     return true;
   }
 
+  await captureSilentExitCompletionSummary(lane, cwd);
   setLaneStatus(lane.id, 'reviewing', 'system', 'silent_exit_work_present');
   enqueueSilentExitInbox(
     lane,

--- a/tests/inline-packet-scope.test.ts
+++ b/tests/inline-packet-scope.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -60,5 +60,79 @@ describe('get_packet_scope inline packet contract', () => {
     expect(result.isError).not.toBe(true);
     expect(scope.laneId).toBe(lane.id);
     expect(scope.allowedPaths).toEqual(['**/*']);
+  });
+
+  it('keeps directive bodies opt-in through the real MCP handler', async () => {
+    const repoPath = mkdtempSync(join(tmpdir(), 'o8-bounded-packet-scope-repo-'));
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repoPath });
+    const directivesDir = join(dataDir, 'directives');
+    mkdirSync(directivesDir, { recursive: true });
+    for (let index = 0; index < 72; index += 1) {
+      writeFileSync(join(directivesDir, `bounded-${index}.md`), [
+        '---',
+        `id: bounded-${index}`,
+        `title: Bounded directive ${index}`,
+        'scope: global',
+        '---',
+        'x'.repeat(20_000),
+      ].join('\n'));
+    }
+
+    const packetId = 'pkt-bounded-scope-real-handler';
+    createLane({
+      repoPath,
+      worktreePath: repoPath,
+      branch: 'fix/bounded-scope',
+      runtime: 'codex',
+      packetId,
+    });
+    writeOrchestratorControlPlaneState({
+      ...createEmptyOrchestratorMissionState(),
+      missionId: 'mission-bounded-scope',
+      repoPath,
+      packets: [{
+        id: packetId,
+        referenceLabel: 'bounded-1',
+        title: 'Bound packet scope',
+        summary: 'Keep directive bodies out of the default MCP response.',
+        workspaceTargetPath: repoPath,
+        branchTarget: 'fix/bounded-scope',
+        runtime: 'codex',
+        dependencyLabels: [],
+        dependencyPacketIds: [],
+        queueState: 'queued',
+        releaseState: 'pending',
+        status: 'running',
+        lane: null,
+      }],
+    });
+
+    const boundedResult = await handleGetPacketScope({ packetId });
+    const boundedText = boundedResult.content[0]?.type === 'text'
+      ? boundedResult.content[0].text
+      : '{}';
+    const bounded = JSON.parse(boundedText) as {
+      directiveCount: number;
+      directives: Array<Record<string, unknown>>;
+    };
+
+    expect(Buffer.byteLength(boundedText, 'utf8')).toBeLessThan(64 * 1024);
+    expect(bounded.directiveCount).toBe(72);
+    expect(bounded.directives).toHaveLength(72);
+    expect(bounded.directives.every((directive) => (
+      Object.keys(directive).sort().join(',') === 'id,title'
+    ))).toBe(true);
+
+    const fullResult = await handleGetPacketScope({ packetId, includeDirectives: true });
+    const fullText = fullResult.content[0]?.type === 'text' ? fullResult.content[0].text : '{}';
+    const full = JSON.parse(fullText) as {
+      directiveCount: number;
+      directives: Array<{ body?: string }>;
+    };
+
+    expect(full.directiveCount).toBe(72);
+    expect(full.directives).toHaveLength(72);
+    expect(full.directives[0]?.body).toHaveLength(20_000);
+    expect(Buffer.byteLength(fullText, 'utf8')).toBeGreaterThan(1_400_000);
   });
 });

--- a/tests/packet-control-fields-survive-normalize.test.ts
+++ b/tests/packet-control-fields-survive-normalize.test.ts
@@ -72,6 +72,7 @@ function fullPacketFixture() {
       observedAt: '2026-01-01T00:00:30.000Z',
     },
     blockedReason: 'operator_stopped',
+    completionSummary: 'Recovered completion summary',
     statusEvidence: {
       sessionId: 'codex-owned:pkt-control-1',
       runtime: 'codex',

--- a/tests/wait-wakes-on-blocked.test.ts
+++ b/tests/wait-wakes-on-blocked.test.ts
@@ -45,4 +45,26 @@ describe('#1467 — wait_for_mission_ready wakes on blocked packets', () => {
     // The old set slept to the timeout; the fix answers on the first read.
     expect(Date.now() - started).toBeLessThan(1_500);
   });
+
+  it('long-polls a rerun-in-progress packet while its lane is running', async () => {
+    const readStatus = vi.fn(async () => ({
+      packets: [{
+        id: 'pkt-rerun',
+        status: 'blocked',
+        releaseState: 'pending',
+        blockedReason: 'rerun_in_progress',
+        lane: { status: 'running' },
+      }],
+    }));
+
+    const result = await handleWaitForMissionReady(
+      { packetId: 'pkt-rerun', timeoutMs: 1_000, pollIntervalMs: 1_000 },
+      readStatus,
+    );
+    const payload = parsePayload(result as { content?: Array<{ type: string; text?: string }> });
+
+    expect(payload.wakeReason).toBe('timeout');
+    expect(payload.wakeReason).not.toBe('already-terminal');
+    expect(readStatus).toHaveBeenCalledTimes(2);
+  });
 });

--- a/tests/wait-wakes-on-blocked.test.ts
+++ b/tests/wait-wakes-on-blocked.test.ts
@@ -67,4 +67,25 @@ describe('#1467 — wait_for_mission_ready wakes on blocked packets', () => {
     expect(payload.wakeReason).not.toBe('already-terminal');
     expect(readStatus).toHaveBeenCalledTimes(2);
   });
+
+  it('returns immediately when a reviewing lane is already awaiting review', async () => {
+    const readStatus = vi.fn(async () => ({
+      packets: [{
+        id: 'pkt-review',
+        status: 'awaiting_review',
+        releaseState: 'pending',
+        lane: { status: 'reviewing' },
+      }],
+    }));
+
+    const result = await handleWaitForMissionReady(
+      { packetId: 'pkt-review', timeoutMs: 2_000, pollIntervalMs: 1_000 },
+      readStatus,
+    );
+    const payload = parsePayload(result as { content?: Array<{ type: string; text?: string }> });
+
+    expect(payload.wakeReason).toBe('already-terminal');
+    expect(payload.terminalPacketId).toBe('pkt-review');
+    expect(readStatus).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Fixes #2006.

Three ergonomics defects in the orchestrator MCP surface, all hit while driving one mission from an external client.

## 1. `get_packet_scope` returned ~1.4 MB

Directive bodies were 99% of the payload. The scope response now carries `directiveCount` plus `{ id, title }` references by default; `includeDirectives: true` (MCP) / `--include-directives` (CLI) / `?includeDirectives=true` (route) returns the full records. The old 600-char body cap is gone since bodies are opt-in.

## 2. `wait_for_mission_ready` returned at once on a rerun

A packet in `blocked` / `rerun_in_progress` with a running lane was treated as terminal. The wait now keeps polling while a packet's `blockedReason` is `rerun_in_progress` or its lane is `running`; a lane in `reviewing` (work done, review needed) still wakes the wait immediately, and the packet signature now includes `blockedReason` and lane status so those transitions wake it too.

## 3. Silent exit had no completion summary

When a worker committed and exited without reporting, the lane moved to `reviewing` but the status payload had no outcome text. The silent-exit path now captures the worker's last assistant message (or the last commit subject as fallback) into a `completionSummary` on the packet, which mission status surfaces as `summary`. The field survives packet normalization and is cleared on reset and rerun.

## Verification

- Real MCP handler test: 72 directives of 20 KB each → default response under 64 KB with 72 `{id,title}` references; `includeDirectives:true` returns the bodies.
- Wait handler tests: rerun-in-progress with a running lane long-polls to timeout instead of `already-terminal`; `awaiting_review` with a `reviewing` lane returns `already-terminal` on the first read.
- Silent-exit real-path test: the detector promotes committed work to `reviewing` and mission status reports the commit subject as the summary.
- `npx tsc --noEmit` clean, `npm run lint` exit 0, touched suites green.
