### PR TITLE
feat(merge): lint changed files in the governed merge gate

### DIFF
--- a/src/app/api/orchestrator/merge-preview/route.ts
+++ b/src/app/api/orchestrator/merge-preview/route.ts
@@ -14,7 +14,7 @@ export const dynamic = 'force-dynamic';
 /**
  * GET /api/orchestrator/merge-preview?packetId=<id>
  *
- * Dry-runs the 5-layer merge gate for one packet (no worktree mutation) and
+ * Dry-runs the merge gate for one packet (no worktree mutation) and
  * returns `{ packetId, wouldMerge, checks[], blockers[], branch }` — the same
  * MergePreviewResult the `o8_merge_preview` MCP tool surfaces. The N-up compare
  * matrix renders this per column so the operator sees each candidate's GATE

--- a/src/lib/lane/commands.ts
+++ b/src/lib/lane/commands.ts
@@ -842,7 +842,11 @@ async function dispatchUnlocked(
         lane,
         command,
         actor,
-        gateResult: { passed: gateResult.passed, violations: gateResult.violations },
+        gateResult: {
+          passed: gateResult.passed,
+          violations: gateResult.violations,
+          diffBase: gateResult.diffBase,
+        },
         createLaneActionApproval,
       });
     }

--- a/src/lib/lane/preview-merge.ts
+++ b/src/lib/lane/preview-merge.ts
@@ -1,7 +1,7 @@
 /**
  * Merge preview — read-only wrapper around the merge gate (#623).
  *
- * Runs the same four enforcement checks as `runMergeGate` but returns a
+ * Runs the policy checks plus a changed-file lint preflight and returns a
  * structured `{ checks[], blockers[] }` shape without touching the worktree
  * or issuing a merge commit. Used by the `o8_merge_preview` MCP tool so
  * orchestrator agents can "dry-run" a merge before committing to it.
@@ -19,17 +19,20 @@ import type { Lane } from '@/lib/lane/types';
 import { readOrchestratorControlPlaneState } from '@/lib/orchestrator/control-plane';
 import type { PacketDiffBaseResolution } from '@/lib/diff/base-resolution';
 import { runMergeGate, type MergeGateResult, type MergeViolation } from './merge-gate';
+import { runLaneRebaseLint, type LaneRebaseLintResult } from './rebase-lint';
 import { immutableSnapshotDiffBase, resolveLaneReviewSource } from './review-source';
 
 // ── Public Types ──
 
-/** One row per enforcement check that ran, in the order listed below. */
+/** One row per enforcement check, in the order listed below. */
 export type MergeCheckName =
   | 'clean-worktree'
   | 'security-patterns'
   | 'diff-budget'
   | 'untracked-imports'
-  | 'self-review-integrity';
+  | 'self-review-integrity'
+  | 'typecheck'
+  | 'lint';
 
 export type MergeCheckVerdict = 'pass' | 'fail' | 'skipped';
 
@@ -74,15 +77,22 @@ const ALL_CHECKS: MergeCheckName[] = [
   'diff-budget',
   'untracked-imports',
   'self-review-integrity',
+  'typecheck',
+  'lint',
 ];
+
+const POST_REBASE_CHECKS = new Set<MergeCheckName>(['typecheck', 'lint']);
 
 // ── Shape translation ──
 
 /**
  * Map a `MergeGateResult` into the structured preview shape.
- * Every check in `ALL_CHECKS` appears in the output with a pass/fail verdict.
+ * Every check in `ALL_CHECKS` appears with a pass, fail, or skipped verdict.
  */
-export function buildCheckList(result: MergeGateResult): MergeCheckResult[] {
+export function buildCheckList(
+  result: MergeGateResult,
+  verificationChecks: MergeCheckResult[] = [],
+): MergeCheckResult[] {
   const firstViolationByCheck = new Map<MergeCheckName, MergeViolation>();
   for (const violation of result.violations) {
     if (violation.severity !== 'block') continue;
@@ -94,7 +104,18 @@ export function buildCheckList(result: MergeGateResult): MergeCheckResult[] {
     }
   }
 
+  const verificationByName = new Map(verificationChecks.map((check) => [check.name, check]));
+
   return ALL_CHECKS.map((name) => {
+    const verification = verificationByName.get(name);
+    if (verification) return verification;
+    if (POST_REBASE_CHECKS.has(name)) {
+      return {
+        name,
+        verdict: 'skipped' as const,
+        detail: 'Runs after rebase during approve_and_merge.',
+      };
+    }
     const violation = firstViolationByCheck.get(name);
     if (violation) {
       return { name, verdict: 'fail' as const, detail: violation.detail };
@@ -118,16 +139,26 @@ function resolveCheckName(violation: MergeViolation): MergeCheckName {
 }
 
 /** Derive a short blocker list from the gate result. Stable order, deduped. */
-export function buildBlockerList(result: MergeGateResult): string[] {
+export function buildBlockerList(
+  result: MergeGateResult,
+  verificationChecks: MergeCheckResult[] = [],
+): string[] {
   const seen = new Set<string>();
   const blockers: string[] = [];
-  for (const check of buildCheckList(result)) {
+  for (const check of buildCheckList(result, verificationChecks)) {
     if (check.verdict !== 'fail') continue;
     if (seen.has(check.name)) continue;
     seen.add(check.name);
     blockers.push(check.name);
   }
   return blockers;
+}
+
+
+function lintPreviewCheck(result: LaneRebaseLintResult): MergeCheckResult {
+  if (!result.ok) return { name: 'lint', verdict: 'fail', detail: result.output };
+  if (result.skipped) return { name: 'lint', verdict: 'skipped', detail: result.skipped };
+  return { name: 'lint', verdict: 'pass', detail: result.detail };
 }
 
 // ── Preview runner ──
@@ -183,8 +214,24 @@ export async function buildPreviewForLane(
     : { ...lane, worktreePath: reviewSource.cwd };
   const orchestratorApproved = options.orchestratorApproved ?? hasApprovedOrchestratorReview(packetId);
   const gateResult = await runMergeGate(resolvedLane, undefined, orchestratorApproved);
-  const checks = buildCheckList(gateResult);
-  const blockers = buildBlockerList(gateResult);
+  const lint = await runLaneRebaseLint({
+    cwd: reviewSource.cwd,
+    baseRef: gateResult.diffBase?.mergeBase
+      ?? gateResult.diffBase?.comparisonRef
+      ?? lane.baseBranch,
+    actualBranch: lane.branch ?? 'packet branch',
+    logPrefix: 'merge-preview',
+  });
+  const verificationChecks: MergeCheckResult[] = [
+    {
+      name: 'typecheck',
+      verdict: 'skipped',
+      detail: 'Runs after rebase during approve_and_merge.',
+    },
+    lintPreviewCheck(lint),
+  ];
+  const checks = buildCheckList(gateResult, verificationChecks);
+  const blockers = buildBlockerList(gateResult, verificationChecks);
   const dirtyDetail = readDirtyWorktreeDetail(reviewSource.cwd);
   if (dirtyDetail) {
     const cleanCheck = checks.find((check) => check.name === 'clean-worktree');
@@ -192,11 +239,11 @@ export async function buildPreviewForLane(
       cleanCheck.verdict = 'fail';
       cleanCheck.detail = dirtyDetail;
     }
-    blockers.unshift('clean-worktree');
+    if (!blockers.includes('clean-worktree')) blockers.unshift('clean-worktree');
   }
   return {
     packetId,
-    wouldMerge: gateResult.passed && !dirtyDetail,
+    wouldMerge: gateResult.passed && lint.ok && !dirtyDetail,
     checks,
     blockers,
     branch: lane.branch ?? null,

--- a/src/lib/lane/rebase-lint.test.ts
+++ b/src/lib/lane/rebase-lint.test.ts
@@ -1,0 +1,200 @@
+import { execFileSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { runLaneRebaseLint } from './rebase-lint';
+
+const tempDirs: string[] = [];
+
+function makeDir(label: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), `o8-rebase-lint-${label}-`));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function commitAll(cwd: string, message: string): void {
+  git(cwd, ['add', '-A']);
+  git(cwd, [
+    '-c', 'user.name=o8-test',
+    '-c', 'user.email=o8@example.test',
+    'commit',
+    '-m',
+    message,
+  ]);
+}
+
+function writePackage(cwd: string, lintScript = 'eslint .'): void {
+  writeFileSync(path.join(cwd, 'package.json'), JSON.stringify({
+    private: true,
+    scripts: lintScript ? { lint: lintScript } : {},
+    devDependencies: { eslint: '^9.39.5' },
+  }));
+}
+
+function initLintRepo(label: string): string {
+  const repo = makeDir(label);
+  git(repo, ['init', '-b', 'main']);
+  writePackage(repo);
+  writeFileSync(path.join(repo, '.gitignore'), 'node_modules/\n');
+  writeFileSync(path.join(repo, 'eslint.config.mjs'), [
+    'export default [{',
+    "  files: ['**/*.js'],",
+    "  rules: { 'no-console': 'warn', 'no-unused-vars': 'warn' },",
+    '}];',
+    '',
+  ].join('\n'));
+  mkdirSync(path.join(repo, 'src'), { recursive: true });
+  symlinkSync(path.join(process.cwd(), 'node_modules'), path.join(repo, 'node_modules'), 'junction');
+  return repo;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('runLaneRebaseLint', () => {
+  it('skips when the repository has no lint script or ESLint config', async () => {
+    const noScript = makeDir('no-script');
+    writePackage(noScript, '');
+    writeFileSync(path.join(noScript, 'eslint.config.mjs'), 'export default [];\n');
+    await expect(runLaneRebaseLint({
+      cwd: noScript,
+      baseRef: 'main',
+      actualBranch: 'packet/no-script',
+      logPrefix: 'test',
+    })).resolves.toEqual({ ok: true, skipped: 'package.json has no lint script' });
+
+    const noConfig = makeDir('no-config');
+    writePackage(noConfig);
+    await expect(runLaneRebaseLint({
+      cwd: noConfig,
+      baseRef: 'main',
+      actualBranch: 'packet/no-config',
+      logPrefix: 'test',
+    })).resolves.toEqual({ ok: true, skipped: 'no ESLint config was found' });
+  });
+
+  it('allows a changed file whose warning count does not increase and blocks a new warning', async () => {
+    const repo = initLintRepo('warning-diff');
+    writeFileSync(path.join(repo, 'src', 'packet.js'), 'console.log("base");\n');
+    commitAll(repo, 'base');
+    git(repo, ['checkout', '-b', 'packet/warnings']);
+    writeFileSync(path.join(repo, 'src', 'packet.js'), 'console.log("base");\nexport const value = 1;\n');
+    commitAll(repo, 'keep warning count');
+
+    await expect(runLaneRebaseLint({
+      cwd: repo,
+      baseRef: 'main',
+      actualBranch: 'packet/warnings',
+      logPrefix: 'test',
+    })).resolves.toEqual({ ok: true });
+
+    writeFileSync(
+      path.join(repo, 'src', 'packet.js'),
+      'console.log("base");\nconsole.log("new");\nexport const value = 1;\n',
+    );
+    commitAll(repo, 'add warning');
+
+    const result = await runLaneRebaseLint({
+      cwd: repo,
+      baseRef: 'main',
+      actualBranch: 'packet/warnings',
+      logPrefix: 'test',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.output).toContain('src/packet.js:2:no-console');
+  }, 20_000);
+
+  it('blocks a new warning identity when a different base warning was fixed', async () => {
+    const repo = initLintRepo('warning-swap');
+    writeFileSync(path.join(repo, 'src', 'packet.js'), 'console.log("base");\n');
+    commitAll(repo, 'base warning');
+    git(repo, ['checkout', '-b', 'packet/warning-swap']);
+    writeFileSync(path.join(repo, 'src', 'packet.js'), 'const replacement = 1;\nexport const value = 1;\n');
+    commitAll(repo, 'swap warning');
+
+    const result = await runLaneRebaseLint({
+      cwd: repo,
+      baseRef: 'main',
+      actualBranch: 'packet/warning-swap',
+      logPrefix: 'test',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.output).toContain('src/packet.js:1:no-unused-vars');
+      expect(result.output).not.toContain('no-console');
+    }
+  }, 20_000);
+
+  it('allows an unchanged warning identity after its line shifts', async () => {
+    const repo = initLintRepo('warning-shift');
+    writeFileSync(path.join(repo, 'src', 'packet.js'), 'console.log("base");\n');
+    commitAll(repo, 'base warning');
+    git(repo, ['checkout', '-b', 'packet/warning-shift']);
+    writeFileSync(
+      path.join(repo, 'src', 'packet.js'),
+      'export const value = 1;\n\nconsole.log("base");\n',
+    );
+    commitAll(repo, 'shift warning');
+
+    await expect(runLaneRebaseLint({
+      cwd: repo,
+      baseRef: 'main',
+      actualBranch: 'packet/warning-shift',
+      logPrefix: 'test',
+    })).resolves.toEqual({ ok: true });
+  }, 20_000);
+
+  it('turns the hard timeout into a skipped receipt', async () => {
+    const repo = makeDir('timeout');
+    git(repo, ['init', '-b', 'main']);
+    writePackage(repo);
+    writeFileSync(path.join(repo, '.gitignore'), 'node_modules/\n');
+    writeFileSync(path.join(repo, 'eslint.config.mjs'), 'export default [];\n');
+    mkdirSync(path.join(repo, 'node_modules', 'eslint', 'bin'), { recursive: true });
+    writeFileSync(path.join(repo, 'node_modules', 'eslint', 'package.json'), JSON.stringify({
+      name: 'eslint',
+      version: '9.0.0',
+    }));
+    const eslintScript = path.join(repo, 'node_modules', 'eslint', 'bin', 'eslint.js');
+    writeFileSync(eslintScript, '#!/usr/bin/env node\nsetTimeout(() => {}, 10_000);\n');
+    chmodSync(eslintScript, 0o755);
+    writeFileSync(path.join(repo, 'base.txt'), 'base\n');
+    commitAll(repo, 'base');
+    git(repo, ['checkout', '-b', 'packet/timeout']);
+    writeFileSync(path.join(repo, 'packet.js'), 'export const value = 1;\n');
+    commitAll(repo, 'packet');
+
+    const result = await runLaneRebaseLint({
+      cwd: repo,
+      baseRef: 'main',
+      actualBranch: 'packet/timeout',
+      logPrefix: 'test',
+      timeoutMs: 100,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.skipped).toContain('timeout');
+  });
+});

--- a/src/lib/lane/rebase-lint.ts
+++ b/src/lib/lane/rebase-lint.ts
@@ -1,0 +1,436 @@
+import { execFile } from 'node:child_process';
+import { createRequire } from 'node:module';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { materializationAwareExecFile } from '@/lib/worktree/materialization-execution';
+
+const execFileAsync = promisify(execFile);
+
+const LINT_TIMEOUT_MS = 90_000;
+const LINT_MAX_BUFFER_BYTES = 8 * 1024 * 1024;
+const LINT_OUTPUT_PREVIEW_CHARS = 4_000;
+const LINTABLE_EXTENSIONS = new Set([
+  '.astro',
+  '.cjs',
+  '.cts',
+  '.html',
+  '.js',
+  '.json',
+  '.jsonc',
+  '.jsx',
+  '.md',
+  '.mdx',
+  '.mjs',
+  '.mts',
+  '.svelte',
+  '.ts',
+  '.tsx',
+  '.vue',
+  '.yaml',
+  '.yml',
+]);
+const ESLINT_CONFIG_FILES = [
+  'eslint.config.js',
+  'eslint.config.mjs',
+  'eslint.config.cjs',
+  'eslint.config.ts',
+  'eslint.config.mts',
+  'eslint.config.cts',
+  '.eslintrc',
+  '.eslintrc.js',
+  '.eslintrc.cjs',
+  '.eslintrc.json',
+  '.eslintrc.yaml',
+  '.eslintrc.yml',
+];
+
+interface ChangedLintFile {
+  headPath: string;
+  basePath: string | null;
+}
+
+interface EslintMessage {
+  ruleId: string | null;
+  severity: number;
+  message: string;
+  line?: number;
+  column?: number;
+}
+
+interface EslintFileResult {
+  filePath: string;
+  messages: EslintMessage[];
+}
+
+interface LintSnapshot {
+  results: EslintFileResult[];
+  stderr: string;
+}
+
+export type LaneRebaseLintResult =
+  | { ok: true; skipped?: string; detail?: string }
+  | { ok: false; output: string };
+
+class LintTimeoutError extends Error {}
+
+function remainingTimeout(deadline: number): number {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) throw new LintTimeoutError('ESLint exceeded the 90 s timeout.');
+  return remaining;
+}
+
+function errorOutput(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  const stdout = 'stdout' in error ? String((error as { stdout?: unknown }).stdout ?? '').trim() : '';
+  const stderr = 'stderr' in error ? String((error as { stderr?: unknown }).stderr ?? '').trim() : '';
+  return stdout || stderr || error.message;
+}
+
+function isTimeoutError(error: unknown): boolean {
+  if (error instanceof LintTimeoutError) return true;
+  if (!(error instanceof Error)) return false;
+  const candidate = error as NodeJS.ErrnoException & { killed?: boolean; signal?: string };
+  return candidate.killed === true || candidate.code === 'ETIMEDOUT' || candidate.signal === 'SIGTERM';
+}
+
+function readPackageJson(cwd: string): Record<string, unknown> | null {
+  const packagePath = path.join(cwd, 'package.json');
+  if (!existsSync(packagePath)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(packagePath, 'utf8'));
+    return parsed && typeof parsed === 'object' ? parsed as Record<string, unknown> : null;
+  } catch {
+    return null;
+  }
+}
+
+function lintAvailability(cwd: string): { skip: false; eslintScript: string } | { skip: true; reason: string } {
+  const packageJson = readPackageJson(cwd);
+  const scripts = packageJson?.scripts;
+  const lintScript = scripts && typeof scripts === 'object'
+    ? (scripts as Record<string, unknown>).lint
+    : null;
+  if (typeof lintScript !== 'string' || lintScript.trim().length === 0) {
+    return { skip: true, reason: 'package.json has no lint script' };
+  }
+
+  const hasConfigFile = ESLINT_CONFIG_FILES.some((file) => existsSync(path.join(cwd, file)));
+  if (!hasConfigFile && !packageJson?.eslintConfig) {
+    return { skip: true, reason: 'no ESLint config was found' };
+  }
+
+  try {
+    const requireFromRepo = createRequire(path.join(cwd, 'package.json'));
+    const eslintPackage = requireFromRepo.resolve('eslint/package.json');
+    const eslintScript = path.join(path.dirname(eslintPackage), 'bin', 'eslint.js');
+    if (!existsSync(eslintScript)) {
+      return { skip: true, reason: 'no local ESLint installation was found' };
+    }
+    return { skip: false, eslintScript };
+  } catch {
+    return { skip: true, reason: 'no local ESLint installation was found' };
+  }
+}
+
+async function gitOutput(cwd: string, args: string[], deadline: number): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, {
+    windowsHide: true,
+    cwd,
+    timeout: remainingTimeout(deadline),
+    maxBuffer: LINT_MAX_BUFFER_BYTES,
+    encoding: 'utf8',
+  });
+  return stdout;
+}
+
+function isLintableFile(file: string): boolean {
+  return LINTABLE_EXTENSIONS.has(path.extname(file).toLowerCase());
+}
+
+function parseChangedFiles(output: string, cwd: string): ChangedLintFile[] {
+  const tokens = output.split('\0');
+  const changed: ChangedLintFile[] = [];
+  for (let index = 0; index < tokens.length;) {
+    const status = tokens[index++];
+    if (!status) continue;
+    const kind = status[0];
+    const firstPath = tokens[index++] ?? '';
+    const secondPath = kind === 'R' || kind === 'C' ? tokens[index++] ?? '' : '';
+    const headPath = secondPath || firstPath;
+    const basePath = kind === 'A' ? null : firstPath;
+    if (kind === 'D' || !headPath || !isLintableFile(headPath)) continue;
+    if (!existsSync(path.join(cwd, headPath))) continue;
+    changed.push({ headPath, basePath });
+  }
+  return changed;
+}
+
+async function changedLintFiles(
+  cwd: string,
+  baseRef: string,
+  deadline: number,
+): Promise<{ mergeBase: string; files: ChangedLintFile[] }> {
+  const mergeBase = (await gitOutput(cwd, ['merge-base', baseRef, 'HEAD'], deadline)).trim();
+  if (!mergeBase) throw new Error(`Unable to resolve the lint merge base from ${baseRef}.`);
+  const output = await gitOutput(
+    cwd,
+    ['diff', '--name-status', '-z', '--find-renames', `${mergeBase}..HEAD`],
+    deadline,
+  );
+  return { mergeBase, files: parseChangedFiles(output, cwd) };
+}
+
+function parseEslintResults(stdout: string, stderr: string): LintSnapshot {
+  try {
+    const parsed = JSON.parse(stdout);
+    if (!Array.isArray(parsed)) throw new Error('ESLint JSON output was not an array.');
+    return { results: parsed as EslintFileResult[], stderr };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`ESLint did not return valid JSON: ${reason}\n${stderr || stdout}`.trim());
+  }
+}
+
+async function lintSnapshot(input: {
+  cwd: string;
+  eslintScript: string;
+  files: string[];
+  deadline: number;
+}): Promise<LintSnapshot> {
+  const args = [
+    input.eslintScript,
+    '--format',
+    'json',
+    '--max-warnings',
+    '0',
+    '--no-error-on-unmatched-pattern',
+    ...input.files,
+  ];
+  try {
+    const { stdout, stderr } = await materializationAwareExecFile(process.execPath, args, {
+      windowsHide: true,
+      cwd: input.cwd,
+      timeout: remainingTimeout(input.deadline),
+      maxBuffer: LINT_MAX_BUFFER_BYTES,
+    });
+    return parseEslintResults(stdout, stderr);
+  } catch (error) {
+    if (isTimeoutError(error)) throw new LintTimeoutError('ESLint exceeded the 90 s timeout.');
+    const stdout = error instanceof Error && 'stdout' in error
+      ? String((error as { stdout?: unknown }).stdout ?? '')
+      : '';
+    const stderr = error instanceof Error && 'stderr' in error
+      ? String((error as { stderr?: unknown }).stderr ?? '')
+      : errorOutput(error);
+    if (stdout.trim()) return parseEslintResults(stdout, stderr);
+    throw new Error(stderr || errorOutput(error));
+  }
+}
+
+function relativeResultPath(cwd: string, filePath: string): string {
+  const canonicalCwd = realpathSync(cwd);
+  const canonicalFile = existsSync(filePath) ? realpathSync(filePath) : filePath;
+  const relativePath = path.relative(canonicalCwd, canonicalFile);
+  return relativePath.split(path.sep).join('/');
+}
+
+function isIgnoredFileWarning(message: EslintMessage): boolean {
+  return message.severity === 1
+    && message.ruleId === null
+    && /file ignored|no matching configuration/i.test(message.message);
+}
+
+function relevantMessages(result: EslintFileResult): EslintMessage[] {
+  return result.messages.filter((message) => !isIgnoredFileWarning(message));
+}
+
+function diagnosticRule(message: EslintMessage): string {
+  if (message.ruleId) return message.ruleId;
+  if (/unused eslint-disable directive/i.test(message.message)) return 'unused-disable';
+  return 'eslint';
+}
+
+function formatDiagnostic(file: string, message: EslintMessage): string {
+  const line = message.line ?? 1;
+  return `${file}:${line}:${diagnosticRule(message)} ${message.message}`;
+}
+
+function formatFailure(lines: string[]): string {
+  const output = lines.join('\n');
+  return output.slice(0, LINT_OUTPUT_PREVIEW_CHARS) || 'Unknown lint error';
+}
+
+async function makeBaseCheckout(
+  cwd: string,
+  mergeBase: string,
+  deadline: number,
+): Promise<string> {
+  const baseDir = mkdtempSync(path.join(tmpdir(), 'o8-lint-base-'));
+  try {
+    await gitOutput(baseDir, ['clone', '--quiet', '--shared', '--no-checkout', cwd, '.'], deadline);
+    await gitOutput(baseDir, ['checkout', '--quiet', '--detach', mergeBase], deadline);
+    const sourceModules = path.join(cwd, 'node_modules');
+    const baseModules = path.join(baseDir, 'node_modules');
+    if (existsSync(sourceModules) && !existsSync(baseModules)) {
+      symlinkSync(sourceModules, baseModules, 'junction');
+    }
+    return baseDir;
+  } catch (error) {
+    rmSync(baseDir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function warningsByPath(cwd: string, snapshot: LintSnapshot): Map<string, EslintMessage[]> {
+  const warnings = new Map<string, EslintMessage[]>();
+  for (const result of snapshot.results) {
+    warnings.set(
+      relativeResultPath(cwd, result.filePath),
+      relevantMessages(result).filter((message) => message.severity === 1),
+    );
+  }
+  return warnings;
+}
+
+function warningSignature(message: EslintMessage): string {
+  return `${message.ruleId ?? 'eslint'}\0${message.message}`;
+}
+
+function warningsAbsentFromBase(
+  baseWarnings: EslintMessage[],
+  headWarnings: EslintMessage[],
+): EslintMessage[] {
+  const remainingBaseSignatures = new Map<string, number>();
+  for (const message of baseWarnings) {
+    const signature = warningSignature(message);
+    remainingBaseSignatures.set(signature, (remainingBaseSignatures.get(signature) ?? 0) + 1);
+  }
+
+  const added: EslintMessage[] = [];
+  for (const message of headWarnings) {
+    const signature = warningSignature(message);
+    const remaining = remainingBaseSignatures.get(signature) ?? 0;
+    if (remaining === 0) {
+      added.push(message);
+    } else {
+      remainingBaseSignatures.set(signature, remaining - 1);
+    }
+  }
+  return added;
+}
+
+/**
+ * Lint only packet-attributed files, then compare warning identities with the
+ * merge-base revision. Severity-2 findings always block; warnings block only
+ * when their rule-and-message signature is absent from the base multiset.
+ */
+export async function runLaneRebaseLint(input: {
+  cwd: string;
+  baseRef: string;
+  actualBranch: string;
+  logPrefix: string;
+  timeoutMs?: number;
+}): Promise<LaneRebaseLintResult> {
+  const timeoutMs = input.timeoutMs ?? LINT_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  const availability = lintAvailability(input.cwd);
+  if (availability.skip) {
+    console.warn(`[${input.logPrefix}] Skipping lint for ${input.actualBranch}: ${availability.reason}.`);
+    return { ok: true, skipped: availability.reason };
+  }
+
+  try {
+    const { mergeBase, files } = await changedLintFiles(input.cwd, input.baseRef, deadline);
+    if (files.length === 0) {
+      return { ok: true, detail: 'No changed lintable files.' };
+    }
+
+    const head = await lintSnapshot({
+      cwd: input.cwd,
+      eslintScript: availability.eslintScript,
+      files: files.map((file) => file.headPath),
+      deadline,
+    });
+    const errors: string[] = [];
+    let warningCount = 0;
+    for (const result of head.results) {
+      const file = relativeResultPath(input.cwd, result.filePath);
+      const messages = relevantMessages(result);
+      warningCount += messages.filter((message) => message.severity === 1).length;
+      errors.push(...messages
+        .filter((message) => message.severity === 2)
+        .map((message) => formatDiagnostic(file, message)));
+    }
+    if (errors.length > 0) {
+      const output = formatFailure(errors);
+      console.error(`[${input.logPrefix}] Lint failed for ${input.actualBranch}:\n${output}`);
+      return { ok: false, output };
+    }
+    if (warningCount === 0) {
+      console.log(`[${input.logPrefix}] Lint passed for ${input.actualBranch}`);
+      return { ok: true };
+    }
+
+    const baseFiles = files.filter((file): file is ChangedLintFile & { basePath: string } => (
+      file.basePath !== null
+    ));
+    const baseWarnings = new Map<string, EslintMessage[]>();
+    if (baseFiles.length > 0) {
+      const baseDir = await makeBaseCheckout(input.cwd, mergeBase, deadline);
+      try {
+        if (lintAvailability(baseDir).skip) {
+          // The packet introduced lint itself, so the base had no configured
+          // warning budget. Every head warning is new.
+        } else {
+          const base = await lintSnapshot({
+            cwd: baseDir,
+            eslintScript: availability.eslintScript,
+            files: baseFiles.map((file) => file.basePath),
+            deadline,
+          });
+          for (const [file, messages] of warningsByPath(baseDir, base)) {
+            baseWarnings.set(file, messages);
+          }
+        }
+      } finally {
+        rmSync(baseDir, { recursive: true, force: true });
+      }
+    }
+
+    const headWarnings = warningsByPath(input.cwd, head);
+    const newWarnings: string[] = [];
+    for (const file of files) {
+      const current = headWarnings.get(file.headPath) ?? [];
+      const baseline = file.basePath ? baseWarnings.get(file.basePath) ?? [] : [];
+      newWarnings.push(...warningsAbsentFromBase(baseline, current)
+        .map((message) => formatDiagnostic(file.headPath, message)));
+    }
+    if (newWarnings.length > 0) {
+      const output = formatFailure(newWarnings);
+      console.error(`[${input.logPrefix}] Lint introduced warnings for ${input.actualBranch}:\n${output}`);
+      return { ok: false, output };
+    }
+
+    console.log(`[${input.logPrefix}] Lint passed for ${input.actualBranch}; existing base warnings did not increase.`);
+    return { ok: true };
+  } catch (error) {
+    if (isTimeoutError(error)) {
+      const reason = `ESLint exceeded the ${Math.ceil(timeoutMs / 1000)} s timeout`;
+      console.warn(`[${input.logPrefix}] Skipping lint for ${input.actualBranch}: ${reason}.`);
+      return { ok: true, skipped: reason };
+    }
+    const output = formatFailure([errorOutput(error)]);
+    console.error(`[${input.logPrefix}] Lint verification failed for ${input.actualBranch}:\n${output}`);
+    return { ok: false, output };
+  }
+}

--- a/src/lib/lane/rebase-typecheck.ts
+++ b/src/lib/lane/rebase-typecheck.ts
@@ -18,7 +18,7 @@ interface DiagnosticBlock {
 }
 
 export type LaneRebaseTypecheckResult =
-  | { ok: true }
+  | { ok: true; skipped?: string }
   | { ok: false; output: string };
 
 export async function runLaneRebaseTypecheck(input: {
@@ -32,7 +32,7 @@ export async function runLaneRebaseTypecheck(input: {
       `[${input.logPrefix}] Skipping typecheck for ${input.actualBranch}: ${skip.reason}. ` +
         'Treating as pass so the merge does not loop the layer-1 auto-retry (#1255).',
     );
-    return { ok: true };
+    return { ok: true, skipped: skip.reason };
   }
   try {
     const typecheck = cliInvocation('npx', ['tsc', '--noEmit']);
@@ -54,7 +54,7 @@ export async function runLaneRebaseTypecheck(input: {
       console.warn(
         `[${input.logPrefix}] No local TypeScript compiler in ${input.actualBranch} worktree; skipping typecheck (#1255).`,
       );
-      return { ok: true };
+      return { ok: true, skipped: 'no local TypeScript compiler was found' };
     }
 
     const diagnostics = splitDiagnosticBlocks(output);

--- a/src/lib/lane/rebase-verify.test.ts
+++ b/src/lib/lane/rebase-verify.test.ts
@@ -1,29 +1,42 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('./rebase-typecheck', () => ({ runLaneRebaseTypecheck: vi.fn() }));
+vi.mock('./rebase-lint', () => ({ runLaneRebaseLint: vi.fn() }));
 vi.mock('./rebase-tests', () => ({ runLaneRebaseTests: vi.fn() }));
 vi.mock('@/lib/operator/defaults', () => ({ resolveMergeTestReplayEnabledSync: vi.fn() }));
 
 import { resolveMergeTestReplayEnabledSync } from '@/lib/operator/defaults';
+import { runLaneRebaseLint } from './rebase-lint';
 import { runLaneRebaseTests } from './rebase-tests';
 import { runLaneRebaseTypecheck } from './rebase-typecheck';
 import { runLaneRebaseVerify } from './rebase-verify';
 
 const typecheck = vi.mocked(runLaneRebaseTypecheck);
+const lint = vi.mocked(runLaneRebaseLint);
 const tests = vi.mocked(runLaneRebaseTests);
 const setting = vi.mocked(resolveMergeTestReplayEnabledSync);
 
-const input = { cwd: '/tmp/x', actualBranch: 'branch', logPrefix: 'test' };
+const input = { cwd: '/tmp/x', baseRef: 'main', actualBranch: 'branch', logPrefix: 'test' };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  lint.mockResolvedValue({ ok: true });
 });
 
 describe('runLaneRebaseVerify', () => {
   it('fails with kind:typecheck and never runs tests when typecheck fails', async () => {
     typecheck.mockResolvedValue({ ok: false, output: 'TS1005' });
     const result = await runLaneRebaseVerify(input);
-    expect(result).toEqual({ ok: false, kind: 'typecheck', output: 'TS1005' });
+    expect(result).toEqual({
+      ok: false,
+      kind: 'typecheck',
+      output: 'TS1005',
+      checks: [
+        { name: 'typecheck', verdict: 'fail', detail: 'TS1005' },
+        { name: 'lint', verdict: 'skipped', detail: 'Not run because typecheck failed.' },
+      ],
+    });
+    expect(lint).not.toHaveBeenCalled();
     expect(tests).not.toHaveBeenCalled();
   });
 
@@ -31,7 +44,13 @@ describe('runLaneRebaseVerify', () => {
     typecheck.mockResolvedValue({ ok: true });
     setting.mockReturnValue(false);
     const result = await runLaneRebaseVerify(input);
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({
+      ok: true,
+      checks: [
+        { name: 'typecheck', verdict: 'pass' },
+        { name: 'lint', verdict: 'pass' },
+      ],
+    });
     expect(tests).not.toHaveBeenCalled();
   });
 
@@ -40,7 +59,13 @@ describe('runLaneRebaseVerify', () => {
     setting.mockReturnValue(true);
     tests.mockResolvedValue({ ok: true, skipped: false });
     const result = await runLaneRebaseVerify(input);
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({
+      ok: true,
+      checks: [
+        { name: 'typecheck', verdict: 'pass' },
+        { name: 'lint', verdict: 'pass' },
+      ],
+    });
     expect(tests).toHaveBeenCalledOnce();
   });
 
@@ -49,7 +74,15 @@ describe('runLaneRebaseVerify', () => {
     setting.mockReturnValue(true);
     tests.mockResolvedValue({ ok: false, output: 'boom' });
     const result = await runLaneRebaseVerify(input);
-    expect(result).toEqual({ ok: false, kind: 'tests', output: 'boom' });
+    expect(result).toEqual({
+      ok: false,
+      kind: 'tests',
+      output: 'boom',
+      checks: [
+        { name: 'typecheck', verdict: 'pass' },
+        { name: 'lint', verdict: 'pass' },
+      ],
+    });
   });
 
   it('defaults to off (no test run) when the settings read throws', async () => {
@@ -58,7 +91,50 @@ describe('runLaneRebaseVerify', () => {
       throw new Error('settings unavailable');
     });
     const result = await runLaneRebaseVerify(input);
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({
+      ok: true,
+      checks: [
+        { name: 'typecheck', verdict: 'pass' },
+        { name: 'lint', verdict: 'pass' },
+      ],
+    });
     expect(tests).not.toHaveBeenCalled();
+  });
+
+  it('fails with kind:lint and keeps typecheck next to the lint blocker', async () => {
+    typecheck.mockResolvedValue({ ok: true });
+    lint.mockResolvedValue({ ok: false, output: 'src/bad.ts:1:unused-disable unused directive' });
+
+    const result = await runLaneRebaseVerify(input);
+
+    expect(result).toEqual({
+      ok: false,
+      kind: 'lint',
+      output: 'src/bad.ts:1:unused-disable unused directive',
+      checks: [
+        { name: 'typecheck', verdict: 'pass' },
+        {
+          name: 'lint',
+          verdict: 'fail',
+          detail: 'src/bad.ts:1:unused-disable unused directive',
+        },
+      ],
+    });
+    expect(tests).not.toHaveBeenCalled();
+  });
+
+  it('reports lint timeout and unavailable projects as skipped checks', async () => {
+    typecheck.mockResolvedValue({ ok: true, skipped: 'no tsconfig.json' });
+    lint.mockResolvedValue({ ok: true, skipped: 'ESLint exceeded the 90 s timeout' });
+
+    const result = await runLaneRebaseVerify(input);
+
+    expect(result).toEqual({
+      ok: true,
+      checks: [
+        { name: 'typecheck', verdict: 'skipped', detail: 'no tsconfig.json' },
+        { name: 'lint', verdict: 'skipped', detail: 'ESLint exceeded the 90 s timeout' },
+      ],
+    });
   });
 });

--- a/src/lib/lane/rebase-verify.ts
+++ b/src/lib/lane/rebase-verify.ts
@@ -1,14 +1,16 @@
 import { resolveMergeTestReplayEnabledSync } from '@/lib/operator/defaults';
+import type { MergeCheckResult } from './preview-merge';
+import { runLaneRebaseLint } from './rebase-lint';
 import { runLaneRebaseTests } from './rebase-tests';
 import { runLaneRebaseTypecheck } from './rebase-typecheck';
 
 export type LaneRebaseVerifyResult =
-  | { ok: true }
-  | { ok: false; kind: 'typecheck' | 'tests'; output: string };
+  | { ok: true; checks: MergeCheckResult[] }
+  | { ok: false; kind: 'typecheck' | 'lint' | 'tests'; output: string; checks: MergeCheckResult[] };
 
 /**
- * The full post-rebase merge gate: typecheck first, then (opt-in) a test replay
- * against the rebased merged state. Returns a discriminated failure so the
+ * The full post-rebase merge gate: typecheck, changed-file lint, then an
+ * opt-in test replay against the rebased merged state. Returns a discriminated failure so the
  * caller can route to the layered escalation with the right kind label while
  * sharing the same 1-extra-turn retry budget.
  *
@@ -17,24 +19,49 @@ export type LaneRebaseVerifyResult =
  */
 export async function runLaneRebaseVerify(input: {
   cwd: string;
+  baseRef: string;
   actualBranch: string;
   logPrefix: string;
 }): Promise<LaneRebaseVerifyResult> {
   const typecheck = await runLaneRebaseTypecheck(input);
   if (!typecheck.ok) {
-    return { ok: false, kind: 'typecheck', output: typecheck.output };
+    return {
+      ok: false,
+      kind: 'typecheck',
+      output: typecheck.output,
+      checks: [
+        { name: 'typecheck', verdict: 'fail', detail: typecheck.output },
+        { name: 'lint', verdict: 'skipped', detail: 'Not run because typecheck failed.' },
+      ],
+    };
   }
+  const checks: MergeCheckResult[] = [{
+    name: 'typecheck',
+    verdict: typecheck.skipped ? 'skipped' : 'pass',
+    ...(typecheck.skipped ? { detail: typecheck.skipped } : {}),
+  }];
+
+  const lint = await runLaneRebaseLint(input);
+  if (!lint.ok) {
+    checks.push({ name: 'lint', verdict: 'fail', detail: lint.output });
+    return { ok: false, kind: 'lint', output: lint.output, checks };
+  }
+  checks.push({
+    name: 'lint',
+    verdict: lint.skipped ? 'skipped' : 'pass',
+    ...(lint.skipped ? { detail: lint.skipped } : lint.detail ? { detail: lint.detail } : {}),
+  });
 
   if (!mergeTestReplayEnabled()) {
-    return { ok: true };
+    return { ok: true, checks };
   }
 
   const tests = await runLaneRebaseTests(input);
   if (!tests.ok) {
-    return { ok: false, kind: 'tests', output: tests.output };
+    return { ok: false, kind: 'tests', output: tests.output, checks };
   }
 
-  return { ok: true };
+  return { ok: true, checks };
 }
 
 function mergeTestReplayEnabled(): boolean {

--- a/src/lib/lane/types.ts
+++ b/src/lib/lane/types.ts
@@ -14,6 +14,7 @@
  */
 
 import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
+import type { MergeCheckResult } from '@/lib/lane/preview-merge';
 import type { ClaudeCodeModelSource } from '@/lib/claude-code/worker-profile-types';
 import type { OrchestratorRuntime, WorkerLaunchContext } from '@/lib/orchestrator/types';
 import type { PacketSpendCap } from '@/lib/orchestrator/metered-spend';
@@ -522,6 +523,10 @@ export interface LaneCommandResult {
   currentHeadSha?: string;
   /** Merge-specific structured refusal reason */
   reason?: string;
+  /** Merge-specific verification receipt, including post-rebase checks. */
+  checks?: MergeCheckResult[];
+  /** Merge-specific blocking check names. */
+  blockers?: string[];
 }
 
 // ── Persisted State ──

--- a/src/lib/lane/worktree-side-merge-verify.ts
+++ b/src/lib/lane/worktree-side-merge-verify.ts
@@ -1,0 +1,173 @@
+import type { ApprovalGateResult } from '@/lib/approvals/types';
+import { supersedeDurableApprovedReviews } from '@/lib/lane/durable-review-approval';
+import { buildCheckList } from '@/lib/lane/preview-merge';
+import {
+  appendEvent,
+  countLaneEventsByVerbSinceLastLaunch,
+  setLaneStatus,
+} from '@/lib/lane/registry';
+import type { LaneRebaseVerifyResult } from '@/lib/lane/rebase-verify';
+import type { Lane, LaneCommand, LaneCommandResult, LaneEventActor } from '@/lib/lane/types';
+import type { MergePacketResult } from '@/lib/orchestrator/operator-mission-service/types';
+
+const VERIFY_FEEDBACK_MAX_BYTES = 4 * 1024;
+
+type MergeCommand = Extract<LaneCommand, { verb: 'merge' }>;
+type VerifyFailure = Extract<LaneRebaseVerifyResult, { ok: false }>;
+
+interface PostRebaseVerifyFailureInput {
+  lane: Lane;
+  command: MergeCommand;
+  actor: LaneEventActor;
+  gateResult: ApprovalGateResult;
+}
+
+export function mergePacketResultFromLaneCommand(result: LaneCommandResult): MergePacketResult {
+  return {
+    merged: result.ok,
+    note: result.note,
+    ...(result.mergeSha ? { mergeSha: result.mergeSha } : {}),
+    ...(result.approvalId ? { approvalId: result.approvalId } : {}),
+    ...(result.reason ? { reason: result.reason } : {}),
+    ...(result.checks ? { checks: result.checks } : {}),
+    ...(result.blockers ? { blockers: result.blockers } : {}),
+    ...(result.expectedHeadSha ? { expectedHeadSha: result.expectedHeadSha } : {}),
+    ...(result.reviewedHeadSha ? { reviewedHeadSha: result.reviewedHeadSha } : {}),
+    ...(result.currentHeadSha ? { currentHeadSha: result.currentHeadSha } : {}),
+  };
+}
+
+function truncateForBlocker(output: string): string {
+  if (output.length <= VERIFY_FEEDBACK_MAX_BYTES) return output;
+  return `${output.slice(0, VERIFY_FEEDBACK_MAX_BYTES)}\n\n[truncated — full output in lane_events]`;
+}
+
+function verificationLabel(kind: VerifyFailure['kind']): string {
+  if (kind === 'tests') return 'Tests';
+  return kind === 'lint' ? 'Lint' : 'Typecheck';
+}
+
+function formatVerificationFeedback(lane: Lane, failure: VerifyFailure): string {
+  const label = verificationLabel(failure.kind);
+  return [
+    `Post-rebase ${label.toLowerCase()} failed after rebasing ${lane.branch} onto ${lane.baseBranch}.`,
+    `Fix the ${label.toLowerCase()} errors below, then commit so the operator can re-attempt the merge.`,
+    '',
+    truncateForBlocker(failure.output),
+  ].join('\n');
+}
+
+/** Read the packet-scoped retry budget, falling back to lane events when absent. */
+async function readPacketTypecheckRetries(packetId: string | null | undefined): Promise<number | null> {
+  if (!packetId) return null;
+  try {
+    const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+    const packet = readOrchestratorControlPlaneState().packets.find((candidate) => candidate.id === packetId);
+    return packet ? (packet.typecheckAutoRetries ?? 0) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Feed every post-rebase verification failure through the existing bounded retry chain. */
+export async function handlePostRebaseVerifyFailure(
+  input: PostRebaseVerifyFailureInput,
+  failure: VerifyFailure,
+): Promise<LaneCommandResult> {
+  const { lane, command, actor } = input;
+  const truncatedOutput = truncateForBlocker(failure.output);
+  const checks = buildCheckList(input.gateResult, failure.checks);
+  const blockers = [failure.kind];
+  const label = verificationLabel(failure.kind);
+  const priorAutoRetries = (await readPacketTypecheckRetries(lane.packetId))
+    ?? countLaneEventsByVerbSinceLastLaunch(command.laneId, 'typecheck_auto_retry');
+
+  if (priorAutoRetries >= 1 || !lane.packetId) {
+    const escalationReason = priorAutoRetries >= 1 ? 'retry_exhausted' : 'no_packet';
+    const blockedReason = !lane.packetId
+      ? `${label} failed after rebase onto ${lane.baseBranch}. No packetId on lane, cannot auto-rerun. Orchestrator decision needed (steer / redispatch / abandon).\n\n${truncatedOutput}`
+      : `${label} failed after 1 auto-retry. Orchestrator decision needed (steer / redispatch / abandon).\n\n${truncatedOutput}`;
+    appendEvent(command.laneId, 'typecheck_escalation', 'system', {
+      kind: failure.kind,
+      reason: escalationReason,
+      priorAutoRetries,
+      branch: lane.branch,
+      baseBranch: lane.baseBranch,
+      packetId: lane.packetId,
+      output: truncatedOutput,
+    });
+    setLaneStatus(command.laneId, 'awaiting_orchestrator', 'system', `typecheck_escalated:${escalationReason}`);
+    return { ok: false, laneId: command.laneId, note: blockedReason, checks, blockers };
+  }
+
+  appendEvent(command.laneId, 'typecheck_auto_retry', 'system', {
+    kind: failure.kind,
+    branch: lane.branch,
+    baseBranch: lane.baseBranch,
+    packetId: lane.packetId,
+    output: truncatedOutput,
+  });
+  setLaneStatus(command.laneId, 'reviewing', actor, 'typecheck_auto_retry');
+  await supersedeDurableApprovedReviews(
+    lane.packetId,
+    failure.kind === 'typecheck'
+      ? 'Superseded by typecheck auto-rerun.'
+      : `Superseded by post-rebase ${label.toLowerCase()} auto-rerun.`,
+  );
+
+  try {
+    const { withLockedState } = await import('@/lib/orchestrator/control-plane');
+    await withLockedState((current) => {
+      const packet = current.packets.find((candidate) => candidate.id === lane.packetId);
+      if (packet) packet.typecheckAutoRetries = (packet.typecheckAutoRetries ?? 0) + 1;
+    });
+  } catch (error) {
+    console.warn(
+      `[lane-merge] Could not persist typecheck retry budget for packet ${lane.packetId}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const feedback = formatVerificationFeedback(lane, failure);
+  void (async () => {
+    try {
+      const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+      const currentPacket = readOrchestratorControlPlaneState().packets.find((candidate) => candidate.id === lane.packetId);
+      if (!currentPacket || currentPacket.queueState === 'held') {
+        console.log(
+          `[lane-merge] Skipping auto-rerun for packet ${lane.packetId} — ${currentPacket ? 'packet is held (reset_packet)' : 'packet no longer exists'} (#1257).`,
+        );
+        return;
+      }
+      const { rerunWithFeedback } = await import('@/lib/orchestrator/operator-mission-service');
+      await rerunWithFeedback({ packetId: lane.packetId!, feedback });
+      console.log(
+        `[lane-merge] Auto-rerun dispatched for packet ${lane.packetId} after ${label.toLowerCase()} failure on lane ${command.laneId}`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(
+        `[lane-merge] Auto-rerun failed for packet ${lane.packetId} on lane ${command.laneId}: ${message}`,
+      );
+      appendEvent(command.laneId, 'typecheck_escalation', 'system', {
+        kind: failure.kind,
+        reason: 'rerun_dispatch_failed',
+        priorAutoRetries: priorAutoRetries + 1,
+        branch: lane.branch,
+        baseBranch: lane.baseBranch,
+        packetId: lane.packetId,
+        output: truncatedOutput,
+        dispatchError: message,
+      });
+      setLaneStatus(command.laneId, 'awaiting_orchestrator', 'system', 'typecheck_rerun_failed');
+    }
+  })();
+
+  return {
+    ok: false,
+    laneId: command.laneId,
+    note: `${label} failed after rebase onto ${lane.baseBranch}. Auto-rerun dispatched with the ${label.toLowerCase()} output as feedback; the packet will retry in a fresh worktree.\n\n${truncatedOutput}`,
+    reason: 'typecheck_auto_retry',
+    checks,
+    blockers,
+  };
+}

--- a/src/lib/lane/worktree-side-merge.ts
+++ b/src/lib/lane/worktree-side-merge.ts
@@ -6,17 +6,17 @@ import type {
 } from '@/lib/approvals/types';
 import { resolveAttributedCommitMessage } from '@/lib/lane/commit-attribution';
 import { checkExpectedHeadSha, formatHeadShaMismatchNote } from '@/lib/lane/head-sha-lock';
-import { supersedeDurableApprovedReviews } from '@/lib/lane/durable-review-approval';
 import { checkReviewedHeadIntegrity, formatReviewedHeadMismatchNote } from '@/lib/lane/review-head-integrity';
 import { dogfoodPrOnlyActive, DOGFOOD_PR_ONLY_NOTE } from '@/lib/lane/dogfood-guard';
 import {
   appendEvent,
-  countLaneEventsByVerbSinceLastLaunch,
   getLane,
   setLaneStatus,
 } from '@/lib/lane/registry';
 import { runLaneRebaseVerify } from '@/lib/lane/rebase-verify';
+import { buildCheckList } from '@/lib/lane/preview-merge';
 import type { Lane, LaneCommand, LaneCommandResult, LaneEventActor } from '@/lib/lane/types';
+import { handlePostRebaseVerifyFailure } from '@/lib/lane/worktree-side-merge-verify';
 import { settleSuccessfulMergeWorktreeCleanup } from '@/lib/lane/successful-merge-worktree-cleanup';
 import {
   commitSpokenReviewSnapshotWithDriftRecovery,
@@ -199,169 +199,6 @@ function createFetchUnreachableResult(
   };
 }
 
-/**
- * Maximum bytes of tsc output we stuff into event payloads / blockedReason.
- * The head of the diagnostic is what the orchestrator needs to reason about;
- * the full output is still recoverable from the lane_events row.
- */
-const TYPECHECK_FEEDBACK_MAX_BYTES = 4 * 1024;
-
-function truncateForBlocker(output: string): string {
-  if (output.length <= TYPECHECK_FEEDBACK_MAX_BYTES) return output;
-  return `${output.slice(0, TYPECHECK_FEEDBACK_MAX_BYTES)}\n\n[truncated — full output in lane_events]`;
-}
-
-function formatTypecheckFeedback(lane: Lane, output: string): string {
-  return [
-    `Post-rebase typecheck failed after rebasing ${lane.branch} onto ${lane.baseBranch}.`,
-    'Fix the type errors below, then commit so the operator can re-attempt the merge.',
-    '',
-    truncateForBlocker(output),
-  ].join('\n');
-}
-
-/**
- * Read the packet's spent auto-rerun budget from control-plane state.
- * Returns null when the packet can't be found (caller falls back to the
- * per-lane event count, which is the legacy behavior).
- */
-async function readPacketTypecheckRetries(
-  packetId: string | null | undefined,
-): Promise<number | null> {
-  if (!packetId) return null;
-  try {
-    const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
-    const packet = readOrchestratorControlPlaneState().packets.find((p) => p.id === packetId);
-    return packet ? (packet.typecheckAutoRetries ?? 0) : null;
-  } catch {
-    return null;
-  }
-}
-
-async function handlePostRebaseVerifyFailure(
-  input: WorktreeSideMergeInput,
-  failure: { kind: 'typecheck' | 'tests'; output: string },
-): Promise<LaneCommandResult> {
-  const { lane, command, actor } = input;
-  const truncatedOutput = truncateForBlocker(failure.output);
-  // The retry budget lives ON the packet, not the lane: layer-1 auto-rerun
-  // archives this lane and dispatches a brand-new one, so a per-lane count is
-  // always 0 again on the retry's own merge attempt — which silently defeated
-  // the "1 extra worker turn" cost ceiling and let a persistently type-broken
-  // packet loop full workers. Per-lane count remains the fallback for lanes
-  // whose packet isn't in control-plane state.
-  const priorAutoRetries = (await readPacketTypecheckRetries(lane.packetId))
-    ?? countLaneEventsByVerbSinceLastLaunch(command.laneId, 'typecheck_auto_retry');
-
-  // ── Layer 2: escalate to orchestrator ──
-  // Reached when layer 1 already fired during this lane lifecycle (or when we
-  // have no packetId to redispatch against).
-  if (priorAutoRetries >= 1 || !lane.packetId) {
-    const escalationReason = priorAutoRetries >= 1 ? 'retry_exhausted' : 'no_packet';
-    const blockedReason = !lane.packetId
-      ? `${failure.kind === 'tests' ? 'Tests' : 'Typecheck'} failed after rebase onto ${lane.baseBranch}. No packetId on lane, cannot auto-rerun. Orchestrator decision needed (steer / redispatch / abandon).\n\n${truncatedOutput}`
-      : `${failure.kind === 'tests' ? 'Tests' : 'Typecheck'} failed after 1 auto-retry. Orchestrator decision needed (steer / redispatch / abandon).\n\n${truncatedOutput}`;
-    appendEvent(command.laneId, 'typecheck_escalation', 'system', {
-      reason: escalationReason,
-      priorAutoRetries,
-      branch: lane.branch,
-      baseBranch: lane.baseBranch,
-      packetId: lane.packetId,
-      output: truncatedOutput,
-    });
-    // The eventLabel is what the inbox / o8_status surfaces as the lane
-    // headline; keep it short and structured so the orchestrator can scan.
-    setLaneStatus(
-      command.laneId,
-      'awaiting_orchestrator',
-      'system',
-      `typecheck_escalated:${escalationReason}`,
-    );
-    return {
-      ok: false,
-      laneId: command.laneId,
-      note: blockedReason,
-    };
-  }
-
-  // ── Layer 1: auto-rerun (capped at 1) ──
-  // Record the attempt BEFORE dispatching so a crash mid-rerun still counts —
-  // we'd rather escalate on the next attempt than loop forever.
-  appendEvent(command.laneId, 'typecheck_auto_retry', 'system', {
-    branch: lane.branch,
-    baseBranch: lane.baseBranch,
-    packetId: lane.packetId,
-    output: truncatedOutput,
-  });
-  setLaneStatus(command.laneId, 'reviewing', actor, 'typecheck_auto_retry');
-
-  await supersedeDurableApprovedReviews(lane.packetId, 'Superseded by typecheck auto-rerun.');
-
-  // Persist the spent retry on the packet BEFORE dispatching — crash-safe in
-  // the same spirit as the event append above: better to escalate next time
-  // than to loop.
-  try {
-    const { withLockedState } = await import('@/lib/orchestrator/control-plane');
-    await withLockedState((current) => {
-      const packet = current.packets.find((p) => p.id === lane.packetId);
-      if (packet) packet.typecheckAutoRetries = (packet.typecheckAutoRetries ?? 0) + 1;
-    });
-  } catch (error) {
-    console.warn(
-      `[lane-merge] Could not persist typecheck retry budget for packet ${lane.packetId}: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-
-  // Fire-and-forget the redispatch. The operator's merge call returns
-  // immediately; the new lane spins up async. If the call fails outright
-  // we promote to awaiting_orchestrator so nothing silently stalls.
-  const feedback = formatTypecheckFeedback(lane, failure.output);
-  void (async () => {
-    try {
-      // Guard the reset_packet race (#1257): the operator may have held this
-      // packet during the async gap before this rerun launches. A held packet
-      // must never auto-dispatch — re-read the authoritative state and bail
-      // rather than spawn a fresh session that makes reset_packet "not stick".
-      const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
-      const currentPacket = readOrchestratorControlPlaneState().packets.find((p) => p.id === lane.packetId);
-      if (!currentPacket || currentPacket.queueState === 'held') {
-        console.log(
-          `[lane-merge] Skipping auto-rerun for packet ${lane.packetId} — ${currentPacket ? 'packet is held (reset_packet)' : 'packet no longer exists'} (#1257).`,
-        );
-        return;
-      }
-      const { rerunWithFeedback } = await import('@/lib/orchestrator/operator-mission-service');
-      await rerunWithFeedback({ packetId: lane.packetId!, feedback });
-      console.log(
-        `[lane-merge] Auto-rerun dispatched for packet ${lane.packetId} after typecheck failure on lane ${command.laneId}`,
-      );
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(
-        `[lane-merge] Auto-rerun failed for packet ${lane.packetId} on lane ${command.laneId}: ${message}`,
-      );
-      // Escalate so the operator/orchestrator sees the stall instead of a silent miss.
-      appendEvent(command.laneId, 'typecheck_escalation', 'system', {
-        reason: 'rerun_dispatch_failed',
-        priorAutoRetries: priorAutoRetries + 1,
-        branch: lane.branch,
-        baseBranch: lane.baseBranch,
-        packetId: lane.packetId,
-        output: truncatedOutput,
-        dispatchError: message,
-      });
-      setLaneStatus(command.laneId, 'awaiting_orchestrator', 'system', 'typecheck_rerun_failed');
-    }
-  })();
-
-  return {
-    ok: false,
-    laneId: command.laneId,
-    note: `Typecheck failed after rebase onto ${lane.baseBranch}. Auto-rerun dispatched with the tsc output as feedback; the packet will retry in a fresh worktree.\n\n${truncatedOutput}`,
-    reason: 'typecheck_auto_retry',
-  };
-}
-
 async function fetchOriginBaseForBaseDriftRetry(
   cwd: string,
   baseBranch: string,
@@ -422,7 +259,12 @@ async function retryBaseAdvancedAfterRebase(
       throw error;
     }
 
-    const verify = await runLaneRebaseVerify({ cwd: opts.worktreePath, actualBranch: opts.actualBranch, logPrefix: 'lane-merge' });
+    const verify = await runLaneRebaseVerify({
+      cwd: opts.worktreePath,
+      baseRef: lane.baseBranch,
+      actualBranch: opts.actualBranch,
+      logPrefix: 'lane-merge',
+    });
     if (!verify.ok) {
       return handlePostRebaseVerifyFailure(input, verify);
     }
@@ -663,6 +505,7 @@ async function performWorktreeSideMergeInner(input: WorktreeSideMergeInput): Pro
 
     const verify = await runLaneRebaseVerify({
       cwd: mergeWorktreePath,
+      baseRef: lane.baseBranch,
       actualBranch,
       logPrefix: 'lane-merge',
     });
@@ -674,6 +517,7 @@ async function performWorktreeSideMergeInner(input: WorktreeSideMergeInput): Pro
       // by the orchestrator and not handled in this file.
       return handlePostRebaseVerifyFailure(input, verify);
     }
+    const mergeChecks = buildCheckList(input.gateResult, verify.checks);
 
     if (!reviewedHead.reviewedHeadSha) await amendViaO8Suffix(mergeWorktreePath, lane.label);
     const { stdout: rebasedShaOutput } = await git(mergeWorktreePath, ['rev-parse', 'HEAD']);
@@ -786,6 +630,8 @@ async function performWorktreeSideMergeInner(input: WorktreeSideMergeInput): Pro
       mergeSha,
       pushedToOrigin,
       pushError,
+      checks: mergeChecks,
+      blockers: [],
     };
   } catch (error) {
     setLaneStatus(command.laneId, 'reviewing', 'system', 'merge_error');

--- a/src/lib/mcp/operator-handlers/approve.ts
+++ b/src/lib/mcp/operator-handlers/approve.ts
@@ -75,7 +75,7 @@ export const APPROVE_TOOLS: McpTool[] = [
   {
     name: 'o8_merge_preview',
     description:
-      'USE THIS BEFORE approve_and_merge — dry-runs the merge gate so you know which governance check (security patterns, diff budget, untracked imports, self-review integrity) might block and can address it cleanly. Returns {packetId, wouldMerge, checks[], blockers[], branch}. Example: o8_merge_preview({packetId: "pkt-abc"}).',
+      'USE THIS BEFORE approve_and_merge — dry-runs the merge gate so you know which governance check (security patterns, diff budget, untracked imports, self-review integrity, lint) might block and can address it cleanly. The typecheck row is marked skipped because it runs after rebase during approval. Returns {packetId, wouldMerge, checks[], blockers[], branch}. Example: o8_merge_preview({packetId: "pkt-abc"}).',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/lib/orchestrator/operator-mission-service/merge.ts
+++ b/src/lib/orchestrator/operator-mission-service/merge.ts
@@ -381,6 +381,7 @@ async function dispatchPacketMerge(
     surfaceDispatcherApproved: input.actor === 'user',
     actor,
   });
+  const { mergePacketResultFromLaneCommand } = await import('@/lib/lane/worktree-side-merge-verify');
 
   if (!result.ok && result.reason === 'head_moved_since_review' && result.reviewedHeadSha && result.currentHeadSha) {
     const { carryReviewAcrossRebaseIfSamePatch } = await loadReviewCarry();
@@ -502,12 +503,7 @@ async function dispatchPacketMerge(
   const failedLane = !result.ok ? findLatestLaneByPacket(packet.id) : null;
   if (!result.ok && (failedLane?.status === 'reviewing' || failedLane?.status === 'awaiting_orchestrator')) {
     log(`Merge command held for packet ${packet.id}.`, { note: result.note, actor });
-    return withGateVerdict(packet.id, {
-      merged: false,
-      note: result.note,
-      approvalId: result.approvalId,
-      reason: result.reason,
-    }, packet.review?.approved === true);
+    return withGateVerdict(packet.id, mergePacketResultFromLaneCommand(result), packet.review?.approved === true);
   }
 
   // Adversarial F3 — the release mutation lands under the lock against a
@@ -579,15 +575,7 @@ async function dispatchPacketMerge(
     actor,
   });
 
-  return withGateVerdict(packet.id, {
-    merged: result.ok,
-    note: result.note,
-    ...(result.mergeSha ? { mergeSha: result.mergeSha } : {}),
-    ...(result.approvalId ? { approvalId: result.approvalId } : {}),
-    ...(result.reason ? { reason: result.reason } : {}),
-    ...(result.reviewedHeadSha ? { reviewedHeadSha: result.reviewedHeadSha } : {}),
-    ...(result.currentHeadSha ? { currentHeadSha: result.currentHeadSha } : {}),
-  }, packet.review?.approved === true);
+  return withGateVerdict(packet.id, mergePacketResultFromLaneCommand(result), packet.review?.approved === true);
 }
 
 async function approveAndMergeSinglePacket(input: ApproveAndMergeInput): Promise<MergePacketResult> {
@@ -741,7 +729,7 @@ export async function approveAndMergePacket(input: ApproveAndMergeInput) {
   }
 
   return {
-    merged: true,
+    ...requestedResult,
     note: mergedPrerequisites.length > 0
       ? `Merged ${mergedPrerequisites.join(', ')} before ${packet.referenceLabel} based on recommended same-wave merge order. ${requestedResult.note}`
       : requestedResult.note,

--- a/tests/merge-checkout-coupling-real-path.test.ts
+++ b/tests/merge-checkout-coupling-real-path.test.ts
@@ -1,6 +1,13 @@
 import { execFileSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import os from 'node:os';
 import { join } from 'node:path';
 
@@ -33,6 +40,7 @@ vi.mock('@/lib/worktree/storage-telemetry', async (importOriginal) => ({
 }));
 
 const mergeRoute = await import('@/app/api/orchestrator/merge/route');
+const mergePreviewRoute = await import('@/app/api/orchestrator/merge-preview/route');
 const reviewStateRoute = await import('@/app/api/orchestrator/review-state/route');
 const { recordOrchestratorReview } = await import('@/lib/approvals/store');
 const { createLane } = await import('@/lib/lane/registry');
@@ -63,7 +71,9 @@ function commitAll(cwd: string, message: string): void {
   ]);
 }
 
-async function createFixture(label: string, approved: boolean) {
+type LintFixtureMode = 'error' | 'clean' | 'no-config';
+
+async function createFixture(label: string, approved: boolean, lintMode?: LintFixtureMode) {
   const root = mkdtempSync(join(os.tmpdir(), `o8-merge-checkout-${label}-`));
   const origin = join(root, 'origin.git');
   const repo = join(root, 'operator');
@@ -77,6 +87,23 @@ async function createFixture(label: string, approved: boolean) {
   git(repo, ['config', 'user.name', 'o8-test']);
   git(repo, ['config', 'user.email', 'o8@example.test']);
   writeFileSync(join(repo, 'file.txt'), 'base\n');
+  if (lintMode) {
+    writeFileSync(join(repo, 'package.json'), JSON.stringify({
+      private: true,
+      scripts: { lint: 'eslint .' },
+      devDependencies: { eslint: '^9.39.5' },
+    }, null, 2));
+    writeFileSync(join(repo, '.gitignore'), 'node_modules/\n');
+    if (lintMode !== 'no-config') {
+      writeFileSync(join(repo, 'eslint.config.mjs'), [
+        'export default [{',
+        "  files: ['**/*.js'],",
+        "  linterOptions: { reportUnusedDisableDirectives: 'error' },",
+        '}];',
+        '',
+      ].join('\n'));
+    }
+  }
   commitAll(repo, 'base');
   git(repo, ['push', '-u', 'origin', 'main']);
 
@@ -91,7 +118,18 @@ async function createFixture(label: string, approved: boolean) {
   });
   git(worktree.path, ['config', 'user.name', 'o8-test']);
   git(worktree.path, ['config', 'user.email', 'o8@example.test']);
-  writeFileSync(join(worktree.path, 'file.txt'), 'base\nworker\n');
+  if (lintMode) {
+    symlinkSync(join(process.cwd(), 'node_modules'), join(worktree.path, 'node_modules'), 'junction');
+    mkdirSync(join(worktree.path, 'src'), { recursive: true });
+    writeFileSync(
+      join(worktree.path, 'src', 'packet.js'),
+      lintMode === 'error'
+        ? '/* eslint-disable no-console */\nexport const packetValue = 1;\n'
+        : 'export const packetValue = 1;\n',
+    );
+  } else {
+    writeFileSync(join(worktree.path, 'file.txt'), 'base\nworker\n');
+  }
   commitAll(worktree.path, 'worker change');
   const reviewedHeadSha = git(worktree.path, ['rev-parse', 'HEAD']);
   const lane = createLane({
@@ -138,6 +176,7 @@ async function createFixture(label: string, approved: boolean) {
     } : null,
     workspaceTargetPath: repo,
     branchTarget: branch,
+    typecheckAutoRetries: lintMode === 'error' ? 1 : 0,
   } as OrchestratorPacket;
   const missionState = normalizeOrchestratorMissionState({
     version: 2,
@@ -189,6 +228,18 @@ function reviewStateRequest(packetId: string): NextRequest {
   );
 }
 
+function mergePreviewRequest(packetId: string): NextRequest {
+  return new NextRequest(
+    `http://localhost:3001/api/orchestrator/merge-preview?packetId=${encodeURIComponent(packetId)}`,
+    {
+      headers: {
+        host: 'localhost:3001',
+        authorization: `Bearer ${getOrCreateWsToken()}`,
+      },
+    },
+  );
+}
+
 beforeAll(async () => {
   await updateOperatorDefaults({
     productTelemetryEnabled: false,
@@ -209,6 +260,62 @@ afterAll(() => {
 });
 
 describe('merge checkout coupling through real handlers', () => {
+  it('refuses lint errors and reports the changed-file diagnostic through preview and approve_and_merge', async () => {
+    const fixture = await createFixture('lint-error', true, 'error');
+    const baseHead = git(fixture.repo, ['rev-parse', 'refs/heads/main']);
+
+    const previewResponse = await mergePreviewRoute.GET(mergePreviewRequest(fixture.packetId));
+    const preview = await previewResponse.json();
+    const previewLint = preview.checks.find((check: { name: string }) => check.name === 'lint');
+    const previewTypecheck = preview.checks.find((check: { name: string }) => check.name === 'typecheck');
+
+    expect(previewResponse.status).toBe(200);
+    expect(preview).toMatchObject({ wouldMerge: false, blockers: ['lint'] });
+    expect(previewTypecheck).toMatchObject({ name: 'typecheck', verdict: 'skipped' });
+    expect(previewLint).toMatchObject({ name: 'lint', verdict: 'fail' });
+    expect(previewLint.detail).toContain('src/packet.js:1:unused-disable');
+
+    const mergeResponse = await mergeRoute.POST(mergeRequest(fixture.packetId));
+    const payload = await mergeResponse.json();
+    const lintCheck = payload.result.checks.find((check: { name: string }) => check.name === 'lint');
+
+    expect(mergeResponse.status).toBe(200);
+    expect(payload).toMatchObject({
+      ok: true,
+      result: {
+        merged: false,
+        blockers: ['lint'],
+      },
+    });
+    expect(lintCheck).toMatchObject({ name: 'lint', verdict: 'fail' });
+    expect(lintCheck.detail).toContain('src/packet.js:1:unused-disable');
+    expect(payload.result.note).toContain('src/packet.js:1:unused-disable');
+    expect(git(fixture.repo, ['rev-parse', 'refs/heads/main'])).toBe(baseHead);
+  }, 60_000);
+
+  it('merges a clean linted packet with a passing receipt', async () => {
+    const clean = await createFixture('lint-clean', true, 'clean');
+    const cleanResponse = await mergeRoute.POST(mergeRequest(clean.packetId));
+    const cleanPayload = await cleanResponse.json();
+    const cleanLint = cleanPayload.result.checks.find((check: { name: string }) => check.name === 'lint');
+
+    expect(cleanResponse.status).toBe(200);
+    expect(cleanPayload).toMatchObject({ ok: true, result: { merged: true } });
+    expect(cleanLint).toMatchObject({ name: 'lint', verdict: 'pass' });
+  }, 60_000);
+
+  it('merges with a skipped lint receipt when config is absent', async () => {
+    const noConfig = await createFixture('lint-no-config', true, 'no-config');
+    const noConfigResponse = await mergeRoute.POST(mergeRequest(noConfig.packetId));
+    const noConfigPayload = await noConfigResponse.json();
+    const skippedLint = noConfigPayload.result.checks.find((check: { name: string }) => check.name === 'lint');
+
+    expect(noConfigResponse.status).toBe(200);
+    expect(noConfigPayload).toMatchObject({ ok: true, result: { merged: true } });
+    expect(skippedLint).toMatchObject({ name: 'lint', verdict: 'skipped' });
+    expect(skippedLint.detail).toContain('no ESLint config');
+  }, 60_000);
+
   it('refuses before advancing a base branch held by another worktree', async () => {
     const fixture = await createFixture('base-held-elsewhere', true);
     git(fixture.repo, ['checkout', '-b', 'operator/wip']);

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -263,6 +263,14 @@
       ]
     },
     {
+      "path": "src/lib/lane/rebase-lint.test.ts",
+      "reasons": [
+        "child-process",
+        "executable-fixture",
+        "git-cli"
+      ]
+    },
+    {
       "path": "src/lib/lane/remote-fetch.test.ts",
       "reasons": [
         "executable-fixture",


### PR DESCRIPTION
Fixes #2010.

Governed merges ran typecheck but never lint, and pushes to main from the governed path never hit CI, so a lint regression could land on main with nothing catching it (32481b1b4 did exactly that). This adds a `lint` check to the merge gate itself; no push-triggered CI.

## Change

- New `src/lib/lane/rebase-lint.ts`: after the post-rebase typecheck, run the repo's own eslint (local binary, repo config, `--format json`) on the packet's changed files only (merge-base diff, deletions and non-lintable extensions excluded), under a 90-second deadline shared across the git and eslint calls.
- Any lint error blocks, including unused eslint-disable directives. Warnings block only when a changed file carries a warning the same file did not have at the merge base: base and head warnings are compared per file as multisets of rule + message (line numbers excluded, so line shifts never count as new). The base revision is linted in a shared-clone checkout of the merge base so config-dependent rules resolve correctly.
- Graceful: no lint script, no eslint config, or no local eslint → `lint: skipped (reason)`; timeout → skipped; an eslint crash or unparseable output blocks rather than passes.
- A lint failure feeds the same escalation helper as the typecheck failure (the shared logic now lives in `worktree-side-merge-verify.ts`), so the 1-retry cap and `awaiting_orchestrator` chain apply unchanged. `o8_merge_preview` and `approve_and_merge` report the `lint` verdict in `checks[]` and name failures as `file:line:rule`.

## Verification

Real-path test through the merge and merge-preview route handlers against a temp repo with an eslint config: a packet adding one unused eslint-disable directive is refused with a lint blocker naming `src/packet.js:1:unused-disable`; a clean packet merges; a repo with no eslint config merges with `lint: skipped`. Warning-comparison unit tests cover the added, swapped (one fixed + one introduced, same count), and line-shift cases. `npx tsc --noEmit` clean, `npm run lint` exit 0, rule-check clean.
