### PR TITLE
fix(dispatch): install and verify gate dependencies for packet clones

### DIFF
--- a/src/lib/lane/commands-launch.ts
+++ b/src/lib/lane/commands-launch.ts
@@ -189,7 +189,7 @@ export async function launchSession(
       effort: command.effort,
       clientMutationId: command.clientMutationId,
       isolate: !lane.worktreePath,
-      skipSetup: true,
+      skipSetup: Boolean(lane.worktreePath),
       existingLaneId: command.laneId,
       packetId: lane.packetId ?? undefined,
       spendCap: command.spendCap,

--- a/src/lib/lane/dependency-materialization-merge-blocker.ts
+++ b/src/lib/lane/dependency-materialization-merge-blocker.ts
@@ -1,0 +1,101 @@
+import { access } from 'node:fs/promises';
+import path from 'node:path';
+
+import { appendEvent, setLaneStatus } from '@/lib/lane/registry';
+import type { Lane, LaneCommandResult } from '@/lib/lane/types';
+import { withLockedState } from '@/lib/orchestrator/control-plane';
+import { retireDependencyImage } from '@/lib/workspace/apfs-dependency-image';
+import { detachDependencyMaterialization } from '@/lib/workspace/dependency-materializer';
+import {
+  DEPENDENCY_MATERIALIZATION_INCOMPLETE,
+  DependencyMaterializationIncompleteError,
+  verifyDependencyMaterialization,
+} from '@/lib/workspace/dependency-materialization-verification';
+import type { WorktreeManager } from '@/lib/worktree/manager';
+
+async function hasPackageJson(workspacePath: string): Promise<boolean> {
+  try {
+    await access(path.join(workspacePath, 'package.json'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function blockIncompleteMergeDependencies(
+  input: { lane: Lane; command: { laneId: string } },
+  manager: WorktreeManager,
+  verificationPath: string,
+): Promise<LaneCommandResult | null> {
+  if (!(await hasPackageJson(verificationPath))) return null;
+  const verification = await verifyDependencyMaterialization(verificationPath);
+  if (verification.missingBinaries.length === 0) return null;
+
+  const materializationPath = input.lane.worktreePath ?? verificationPath;
+  const worktree = (await manager.list()).find((candidate) => candidate.path === materializationPath);
+  const materialization = worktree?.dependencyMaterialization ?? null;
+  let imageGenerationInvalidated = false;
+  let imageInvalidationError: string | null = null;
+  if (materialization?.mode === 'image') {
+    try {
+      await detachDependencyMaterialization(materializationPath, materialization);
+      if (worktree) await manager.clearDependencyMaterialization(worktree.id);
+      await retireDependencyImage(materialization.recipeKey);
+      imageGenerationInvalidated = true;
+    } catch (error) {
+      imageInvalidationError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  const blocker = new DependencyMaterializationIncompleteError(
+    verification,
+    imageGenerationInvalidated,
+    imageInvalidationError,
+  );
+  appendEvent(input.command.laneId, DEPENDENCY_MATERIALIZATION_INCOMPLETE, 'system', {
+    code: blocker.code,
+    packetId: input.lane.packetId,
+    phase: 'merge_gate',
+    mode: materialization?.mode ?? null,
+    recipeKey: materialization?.recipeKey ?? null,
+    topLevelEntryCount: verification.topLevelEntryCount,
+    verifiedBinaries: verification.verifiedBinaries,
+    missingBinaries: verification.missingBinaries,
+    scriptBinaries: verification.scriptBinaries,
+    imageGenerationInvalidated,
+    imageInvalidationError,
+  });
+  setLaneStatus(
+    input.command.laneId,
+    'awaiting_orchestrator',
+    'system',
+    DEPENDENCY_MATERIALIZATION_INCOMPLETE,
+  );
+
+  const recordedAt = new Date().toISOString();
+  try {
+    await withLockedState((state) => {
+      const packet = state.packets.find((candidate) => candidate.id === input.lane.packetId);
+      if (!packet) return;
+      packet.status = 'blocked';
+      packet.blockedReason = blocker.message;
+      packet.lastEventAt = recordedAt;
+      packet.lastEventLabel = DEPENDENCY_MATERIALIZATION_INCOMPLETE;
+      if (packet.lane?.laneId === input.command.laneId) {
+        packet.lane.lastEventAt = recordedAt;
+        packet.lane.lastEventLabel = DEPENDENCY_MATERIALIZATION_INCOMPLETE;
+      }
+    });
+  } catch (error) {
+    console.warn(
+      `[lane-merge] Could not persist dependency blocker for packet ${input.lane.packetId ?? 'unknown'}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  return {
+    ok: false,
+    laneId: input.command.laneId,
+    note: blocker.message,
+    reason: DEPENDENCY_MATERIALIZATION_INCOMPLETE,
+  };
+}

--- a/src/lib/lane/dependency-materialization-merge-blocker.ts
+++ b/src/lib/lane/dependency-materialization-merge-blocker.ts
@@ -9,6 +9,7 @@ import { detachDependencyMaterialization } from '@/lib/workspace/dependency-mate
 import {
   DEPENDENCY_MATERIALIZATION_INCOMPLETE,
   DependencyMaterializationIncompleteError,
+  isDependencyMaterializationIncomplete,
   verifyDependencyMaterialization,
 } from '@/lib/workspace/dependency-materialization-verification';
 import type { WorktreeManager } from '@/lib/worktree/manager';
@@ -29,10 +30,16 @@ export async function blockIncompleteMergeDependencies(
 ): Promise<LaneCommandResult | null> {
   if (!(await hasPackageJson(verificationPath))) return null;
   const verification = await verifyDependencyMaterialization(verificationPath);
-  if (verification.missingBinaries.length === 0) return null;
+  if (!isDependencyMaterializationIncomplete(verification)) return null;
 
-  const materializationPath = input.lane.worktreePath ?? verificationPath;
-  const worktree = (await manager.list()).find((candidate) => candidate.path === materializationPath);
+  let materializationPath = verificationPath;
+  let worktree = await manager.getDependencyMaterializationByPath(verificationPath);
+  if (!worktree && input.lane.worktreePath && input.lane.worktreePath !== verificationPath) {
+    // A canonical-repo relocation verifies a temporary merge checkout while its dependency
+    // receipt remains attached to the packet clone, so only that divergence uses the lane path.
+    materializationPath = input.lane.worktreePath;
+    worktree = await manager.getDependencyMaterializationByPath(materializationPath);
+  }
   const materialization = worktree?.dependencyMaterialization ?? null;
   let imageGenerationInvalidated = false;
   let imageInvalidationError: string | null = null;
@@ -61,7 +68,9 @@ export async function blockIncompleteMergeDependencies(
     topLevelEntryCount: verification.topLevelEntryCount,
     verifiedBinaries: verification.verifiedBinaries,
     missingBinaries: verification.missingBinaries,
+    resolutionErrors: verification.resolutionErrors,
     scriptBinaries: verification.scriptBinaries,
+    unreadableFiles: verification.unreadableFiles,
     imageGenerationInvalidated,
     imageInvalidationError,
   });

--- a/src/lib/lane/types.ts
+++ b/src/lib/lane/types.ts
@@ -336,6 +336,10 @@ export type LaneEventVerb =
   // Packet dispatch refused to launch without a managed worktree.
   // Payload: { code, runtime, packetId, laneId, repoPath, cause, note }
   | 'worktree_provision_failed'
+  // Dependency setup completed and its package-script binaries were checked
+  // before a worker could start. The incomplete event is a launch blocker.
+  | 'dependency_materialized'
+  | 'dependency_materialization_incomplete'
   // Worker-requested bounded scope expansion. Payload records requested paths,
   // effective allowlist, reason, and whether the request widened the scope.
   | 'scope_expansion_requested'

--- a/src/lib/lane/worktree-side-merge.ts
+++ b/src/lib/lane/worktree-side-merge.ts
@@ -6,6 +6,7 @@ import type {
 } from '@/lib/approvals/types';
 import { resolveAttributedCommitMessage } from '@/lib/lane/commit-attribution';
 import { checkExpectedHeadSha, formatHeadShaMismatchNote } from '@/lib/lane/head-sha-lock';
+import { blockIncompleteMergeDependencies } from '@/lib/lane/dependency-materialization-merge-blocker';
 import { checkReviewedHeadIntegrity, formatReviewedHeadMismatchNote } from '@/lib/lane/review-head-integrity';
 import { dogfoodPrOnlyActive, DOGFOOD_PR_ONLY_NOTE } from '@/lib/lane/dogfood-guard';
 import {
@@ -65,7 +66,6 @@ import { fastForwardBaseBranch } from '@/lib/lane/operator-checkout-merge';
 import { canonicalRepoRoot } from '@/lib/worktree/root-layout';
 
 const BASE_ADVANCED_RETRY_LIMIT = 3;
-
 type MergeCommand = Extract<LaneCommand, { verb: 'merge' }>;
 
 type CreateLaneActionApproval = (
@@ -259,6 +259,12 @@ async function retryBaseAdvancedAfterRebase(
       throw error;
     }
 
+    const dependencyBlocker = await blockIncompleteMergeDependencies(
+      input,
+      opts.mgr,
+      opts.worktreePath,
+    );
+    if (dependencyBlocker) return dependencyBlocker;
     const verify = await runLaneRebaseVerify({
       cwd: opts.worktreePath,
       baseRef: lane.baseBranch,
@@ -503,6 +509,8 @@ async function performWorktreeSideMergeInner(input: WorktreeSideMergeInput): Pro
       throw error;
     }
 
+    const dependencyBlocker = await blockIncompleteMergeDependencies(input, mgr, mergeWorktreePath);
+    if (dependencyBlocker) return dependencyBlocker;
     const verify = await runLaneRebaseVerify({
       cwd: mergeWorktreePath,
       baseRef: lane.baseBranch,

--- a/src/lib/runtime/actions.ts
+++ b/src/lib/runtime/actions.ts
@@ -19,6 +19,7 @@ import { buildLaunchPromptWithProjectBrief, summarizeTaskName } from '@/lib/runt
 import { selfHealActiveByKindAndRepo } from '@/lib/supervisor/inbox';
 import {
   prepareLaunchWorktree,
+  DependencyMaterializationIncompleteError,
   WorktreeFetchUnreachableError,
   WorktreeOriginMissingError,
   WorktreeRebaseConflictError,
@@ -243,6 +244,7 @@ export async function launchRuntimeSurface(payload: RuntimeLaunchRequest): Promi
         }
       }
     } catch (err) {
+      if (err instanceof DependencyMaterializationIncompleteError) throw err;
       // Known failures keep their existing operator-facing escalation details.
       if (err instanceof WorktreeRebaseConflictError) {
         const baseBranchForInbox = err.baseBranch;

--- a/src/lib/workspace/dependency-materialization-verification.test.ts
+++ b/src/lib/workspace/dependency-materialization-verification.test.ts
@@ -1,0 +1,99 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  DependencyMaterializationIncompleteError,
+  isDependencyMaterializationIncomplete,
+  verifyDependencyMaterialization,
+} from './dependency-materialization-verification';
+
+const workspaces: string[] = [];
+
+function workspace(scripts: Record<string, string>, binaries: string[] = []): string {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'o8-dependency-verification-'));
+  workspaces.push(root);
+  writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: 'fixture', scripts }));
+  const binRoot = path.join(root, 'node_modules', '.bin');
+  mkdirSync(binRoot, { recursive: true });
+  for (const binary of binaries) {
+    const binaryPath = path.join(binRoot, binary);
+    writeFileSync(binaryPath, '#!/bin/sh\nexit 0\n');
+    chmodSync(binaryPath, 0o755);
+  }
+  return root;
+}
+
+afterEach(() => {
+  for (const root of workspaces.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('dependency materialization verification', () => {
+  it('resolves the repository typecheck chain through one package script', async () => {
+    const root = workspace({
+      typecheck: 'npm run verify:routes && node scripts/typecheck.mjs',
+      'verify:routes': 'vitest run tests/route-coverage.test.ts -t "route module shape"',
+    });
+
+    const result = await verifyDependencyMaterialization(root);
+
+    expect(result.scriptBinaries.typecheck).toEqual(['node', 'vitest']);
+    expect(result.requiredBinaries).toEqual(['node', 'vitest']);
+    expect(result.verifiedBinaries).toEqual(['node']);
+    expect(result.missingBinaries).toEqual(['vitest']);
+  });
+
+  it.each([
+    ['npx vitest run', 'npx'],
+    ['pnpm exec vitest run', 'pnpm exec'],
+    ['yarn vitest run', 'yarn'],
+  ])('requires the wrapped binary for %s', async (script) => {
+    const result = await verifyDependencyMaterialization(workspace({ test: script }));
+
+    expect(result.requiredBinaries).toEqual(['vitest']);
+    expect(result.missingBinaries).toEqual(['vitest']);
+  });
+
+  it('verifies cross-env itself as the first local binary', async () => {
+    const result = await verifyDependencyMaterialization(workspace({
+      test: 'cross-env NODE_ENV=test vitest run',
+    }, ['vitest']));
+
+    expect(result.requiredBinaries).toEqual(['cross-env']);
+    expect(result.missingBinaries).toEqual(['cross-env']);
+  });
+
+  it('verifies every chained command segment', async () => {
+    const result = await verifyDependencyMaterialization(workspace({
+      lint: 'eslint . && tsc --noEmit',
+    }, ['eslint']));
+
+    expect(result.requiredBinaries).toEqual(['eslint', 'tsc']);
+    expect(result.verifiedBinaries).toEqual(['eslint']);
+    expect(result.missingBinaries).toEqual(['tsc']);
+  });
+
+  it('resolves node --run through the same bounded package-script path', async () => {
+    const result = await verifyDependencyMaterialization(workspace({
+      typecheck: 'node --run verify:routes',
+      'verify:routes': 'vitest run tests/route-coverage.test.ts',
+    }));
+
+    expect(result.requiredBinaries).toEqual(['vitest']);
+    expect(result.missingBinaries).toEqual(['vitest']);
+  });
+
+  it('returns a structured incomplete result for malformed package.json', async () => {
+    const root = workspace({});
+    writeFileSync(path.join(root, 'package.json'), '{ nope');
+
+    const result = await verifyDependencyMaterialization(root);
+    const blocker = new DependencyMaterializationIncompleteError(result, false, null);
+
+    expect(isDependencyMaterializationIncomplete(result)).toBe(true);
+    expect(result.unreadableFiles).toEqual(['package.json']);
+    expect(blocker.message).toContain('package.json');
+  });
+});

--- a/src/lib/workspace/dependency-materialization-verification.test.ts
+++ b/src/lib/workspace/dependency-materialization-verification.test.ts
@@ -48,9 +48,25 @@ describe('dependency materialization verification', () => {
   it.each([
     ['npx vitest run', 'npx'],
     ['pnpm exec vitest run', 'pnpm exec'],
-    ['yarn vitest run', 'yarn'],
   ])('requires the wrapped binary for %s', async (script) => {
     const result = await verifyDependencyMaterialization(workspace({ test: script }));
+
+    expect(result.requiredBinaries).toEqual(['vitest']);
+    expect(result.missingBinaries).toEqual(['vitest']);
+  });
+
+  it.each(['yarn', 'pnpm'])('resolves %s run through the nested package script', async (runner) => {
+    const result = await verifyDependencyMaterialization(workspace({
+      test: `${runner} run nested`,
+      nested: 'vitest run',
+    }));
+
+    expect(result.requiredBinaries).toEqual(['vitest']);
+    expect(result.missingBinaries).toEqual(['vitest']);
+  });
+
+  it('keeps plain yarn binary resolution local', async () => {
+    const result = await verifyDependencyMaterialization(workspace({ test: 'yarn vitest' }));
 
     expect(result.requiredBinaries).toEqual(['vitest']);
     expect(result.missingBinaries).toEqual(['vitest']);

--- a/src/lib/workspace/dependency-materialization-verification.ts
+++ b/src/lib/workspace/dependency-materialization-verification.ts
@@ -1,0 +1,143 @@
+import { constants } from 'node:fs';
+import { access, readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const GATE_SCRIPTS = ['lint', 'test', 'typecheck'] as const;
+const HOST_BINARIES = new Set([
+  'bash', 'bun', 'cargo', 'cmd', 'corepack', 'deno', 'go', 'make', 'node',
+  'npm', 'npx', 'pnpm', 'powershell', 'pwsh', 'python', 'python3', 'sh', 'yarn',
+  'zsh',
+]);
+const SHELL_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+type GateScriptName = typeof GATE_SCRIPTS[number];
+
+interface PackageJsonShape {
+  scripts?: Partial<Record<GateScriptName, unknown>>;
+}
+
+export interface DependencyMaterializationVerification {
+  missingBinaries: string[];
+  requiredBinaries: string[];
+  scriptBinaries: Partial<Record<GateScriptName, string>>;
+  topLevelEntryCount: number;
+  verifiedBinaries: string[];
+}
+
+export const DEPENDENCY_MATERIALIZATION_INCOMPLETE = 'dependency_materialization_incomplete';
+
+export class DependencyMaterializationIncompleteError extends Error {
+  readonly code = DEPENDENCY_MATERIALIZATION_INCOMPLETE;
+
+  constructor(
+    public readonly verification: DependencyMaterializationVerification,
+    public readonly imageGenerationInvalidated: boolean,
+    public readonly imageInvalidationError: string | null,
+  ) {
+    super(
+      `[${DEPENDENCY_MATERIALIZATION_INCOMPLETE}] Missing required dependency binaries: ${verification.missingBinaries.join(', ')}.`,
+    );
+    this.name = 'DependencyMaterializationIncompleteError';
+  }
+}
+
+function unquoteToken(token: string): string {
+  if (token.length >= 2) {
+    const first = token[0];
+    const last = token[token.length - 1];
+    if ((first === '"' && last === '"') || (first === '\'' && last === '\'')) {
+      return token.slice(1, -1);
+    }
+  }
+  return token;
+}
+
+function scriptTokens(script: string): string[] {
+  return (script.match(/(?:[^\s"'\\]+|"(?:\\.|[^"])*"|'[^']*')+/g) ?? [])
+    .map(unquoteToken);
+}
+
+function firstScriptBinary(script: string): string | null {
+  const tokens = scriptTokens(script);
+  let index = 0;
+  if (tokens[index] === 'env') {
+    index += 1;
+    while (index < tokens.length) {
+      const token = tokens[index]!;
+      if (token === '-u' || token === '--unset') {
+        index += 2;
+        continue;
+      }
+      if (token.startsWith('-') || SHELL_ASSIGNMENT.test(token)) {
+        index += 1;
+        continue;
+      }
+      break;
+    }
+  } else {
+    while (index < tokens.length && SHELL_ASSIGNMENT.test(tokens[index]!)) index += 1;
+  }
+  const token = tokens[index];
+  return token ? path.basename(token) : null;
+}
+
+async function localBinaryExists(workspacePath: string, binary: string): Promise<boolean> {
+  const binRoot = path.join(workspacePath, 'node_modules', '.bin');
+  const candidates = process.platform === 'win32'
+    ? [binary, `${binary}.cmd`, `${binary}.exe`, `${binary}.ps1`]
+    : [binary];
+  for (const candidate of candidates) {
+    try {
+      await access(
+        path.join(binRoot, candidate),
+        process.platform === 'win32' ? constants.F_OK : constants.X_OK,
+      );
+      return true;
+    } catch {
+      // Try the next platform-specific shim.
+    }
+  }
+  return false;
+}
+
+export async function verifyDependencyMaterialization(
+  workspacePath: string,
+): Promise<DependencyMaterializationVerification> {
+  const packageJson = JSON.parse(
+    await readFile(path.join(workspacePath, 'package.json'), 'utf8'),
+  ) as PackageJsonShape;
+  const scriptBinaries: Partial<Record<GateScriptName, string>> = {};
+  for (const scriptName of GATE_SCRIPTS) {
+    const script = packageJson.scripts?.[scriptName];
+    if (typeof script !== 'string' || !script.trim()) continue;
+    const binary = firstScriptBinary(script);
+    if (binary) scriptBinaries[scriptName] = binary;
+  }
+
+  const requiredBinaries = [...new Set(Object.values(scriptBinaries))].sort();
+  const verifiedBinaries: string[] = [];
+  const missingBinaries: string[] = [];
+  for (const binary of requiredBinaries) {
+    // Package scripts resolve local shims first, while runtimes and package managers
+    // such as node/npm are provided by the launch environment rather than .bin.
+    if (await localBinaryExists(workspacePath, binary) || HOST_BINARIES.has(binary)) {
+      verifiedBinaries.push(binary);
+    } else {
+      missingBinaries.push(binary);
+    }
+  }
+
+  const topLevelEntryCount = await readdir(path.join(workspacePath, 'node_modules'))
+    .then((entries) => entries.length)
+    .catch((error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') return 0;
+      throw error;
+    });
+  return {
+    missingBinaries,
+    requiredBinaries,
+    scriptBinaries,
+    topLevelEntryCount,
+    verifiedBinaries,
+  };
+}

--- a/src/lib/workspace/dependency-materialization-verification.ts
+++ b/src/lib/workspace/dependency-materialization-verification.ts
@@ -3,28 +3,64 @@ import { access, readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 
 const GATE_SCRIPTS = ['lint', 'test', 'typecheck'] as const;
-const HOST_BINARIES = new Set([
-  'bash', 'bun', 'cargo', 'cmd', 'corepack', 'deno', 'go', 'make', 'node',
-  'npm', 'npx', 'pnpm', 'powershell', 'pwsh', 'python', 'python3', 'sh', 'yarn',
-  'zsh',
+const HOST_COMMANDS = new Set([
+  '.', 'bash', 'bun', 'cargo', 'cd', 'cmd', 'corepack', 'cp', 'deno', 'echo',
+  'export', 'false', 'go', 'make', 'mkdir', 'mv', 'node', 'npm', 'npx', 'pnpm',
+  'powershell', 'printf', 'pwsh', 'python', 'python3', 'rm', 'set', 'sh', 'source',
+  'test', 'touch', 'true', 'yarn', 'zsh',
 ]);
+const MAX_SCRIPT_NESTING_DEPTH = 3;
 const SHELL_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
 
 type GateScriptName = typeof GATE_SCRIPTS[number];
 
 interface PackageJsonShape {
-  scripts?: Partial<Record<GateScriptName, unknown>>;
+  scripts?: Record<string, unknown>;
+}
+
+interface BinaryRequirement {
+  local: boolean;
+  name: string;
+}
+
+interface ScriptResolution {
+  errors: string[];
+  requirements: BinaryRequirement[];
 }
 
 export interface DependencyMaterializationVerification {
   missingBinaries: string[];
   requiredBinaries: string[];
-  scriptBinaries: Partial<Record<GateScriptName, string>>;
+  resolutionErrors: string[];
+  scriptBinaries: Partial<Record<GateScriptName, string[]>>;
   topLevelEntryCount: number;
+  unreadableFiles: string[];
   verifiedBinaries: string[];
 }
 
 export const DEPENDENCY_MATERIALIZATION_INCOMPLETE = 'dependency_materialization_incomplete';
+
+export function isDependencyMaterializationIncomplete(
+  verification: DependencyMaterializationVerification,
+): boolean {
+  return verification.missingBinaries.length > 0
+    || verification.resolutionErrors.length > 0
+    || verification.unreadableFiles.length > 0;
+}
+
+function formatIncompleteVerification(verification: DependencyMaterializationVerification): string {
+  const details: string[] = [];
+  if (verification.unreadableFiles.length > 0) {
+    details.push(`Unreadable dependency manifest: ${verification.unreadableFiles.join(', ')}.`);
+  }
+  if (verification.resolutionErrors.length > 0) {
+    details.push(`Dependency script resolution failed: ${verification.resolutionErrors.join('; ')}.`);
+  }
+  if (verification.missingBinaries.length > 0) {
+    details.push(`Missing required dependency binaries: ${verification.missingBinaries.join(', ')}.`);
+  }
+  return details.join(' ') || 'Dependency materialization is incomplete.';
+}
 
 export class DependencyMaterializationIncompleteError extends Error {
   readonly code = DEPENDENCY_MATERIALIZATION_INCOMPLETE;
@@ -34,9 +70,7 @@ export class DependencyMaterializationIncompleteError extends Error {
     public readonly imageGenerationInvalidated: boolean,
     public readonly imageInvalidationError: string | null,
   ) {
-    super(
-      `[${DEPENDENCY_MATERIALIZATION_INCOMPLETE}] Missing required dependency binaries: ${verification.missingBinaries.join(', ')}.`,
-    );
+    super(`[${DEPENDENCY_MATERIALIZATION_INCOMPLETE}] ${formatIncompleteVerification(verification)}`);
     this.name = 'DependencyMaterializationIncompleteError';
   }
 }
@@ -57,28 +91,173 @@ function scriptTokens(script: string): string[] {
     .map(unquoteToken);
 }
 
-function firstScriptBinary(script: string): string | null {
-  const tokens = scriptTokens(script);
-  let index = 0;
-  if (tokens[index] === 'env') {
-    index += 1;
-    while (index < tokens.length) {
-      const token = tokens[index]!;
-      if (token === '-u' || token === '--unset') {
-        index += 2;
-        continue;
-      }
-      if (token.startsWith('-') || SHELL_ASSIGNMENT.test(token)) {
-        index += 1;
-        continue;
-      }
-      break;
+function splitCommandSegments(script: string): string[] {
+  const segments: string[] = [];
+  let current = '';
+  let escaped = false;
+  let quote: '"' | '\'' | null = null;
+  for (let index = 0; index < script.length; index += 1) {
+    const character = script[index]!;
+    if (escaped) {
+      current += character;
+      escaped = false;
+      continue;
     }
-  } else {
-    while (index < tokens.length && SHELL_ASSIGNMENT.test(tokens[index]!)) index += 1;
+    if (character === '\\' && quote !== '\'') {
+      current += character;
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      current += character;
+      if (character === quote) quote = null;
+      continue;
+    }
+    if (character === '"' || character === '\'') {
+      current += character;
+      quote = character;
+      continue;
+    }
+    const pair = script.slice(index, index + 2);
+    if (character === ';' || pair === '&&' || pair === '||') {
+      if (current.trim()) segments.push(current.trim());
+      current = '';
+      if (pair === '&&' || pair === '||') index += 1;
+      continue;
+    }
+    current += character;
   }
-  const token = tokens[index];
-  return token ? path.basename(token) : null;
+  if (current.trim()) segments.push(current.trim());
+  return segments;
+}
+
+function commandStartIndex(tokens: string[]): number {
+  let index = 0;
+  while (index < tokens.length && SHELL_ASSIGNMENT.test(tokens[index]!)) index += 1;
+  if (tokens[index] !== 'env') return index;
+  index += 1;
+  while (index < tokens.length) {
+    const token = tokens[index]!;
+    if (token === '-u' || token === '--unset') {
+      index += 2;
+      continue;
+    }
+    if (token.startsWith('-') || SHELL_ASSIGNMENT.test(token)) {
+      index += 1;
+      continue;
+    }
+    break;
+  }
+  return index;
+}
+
+function firstNonFlag(tokens: string[], startIndex = 0): { index: number; token: string } | null {
+  for (let index = startIndex; index < tokens.length; index += 1) {
+    const token = tokens[index]!;
+    if (!token.startsWith('-')) return { index, token };
+  }
+  return null;
+}
+
+function localRequirement(token: string | undefined, wrapper: string): ScriptResolution {
+  if (!token) {
+    return { requirements: [], errors: [`${wrapper} does not name a dependency binary`] };
+  }
+  return {
+    requirements: [{ name: path.basename(token), local: true }],
+    errors: [],
+  };
+}
+
+function resolveNestedScript(
+  scriptName: string | undefined,
+  scripts: Record<string, unknown>,
+  depth: number,
+  visited: Set<string>,
+): ScriptResolution {
+  if (!scriptName) {
+    return { requirements: [], errors: ['package script wrapper does not name a script'] };
+  }
+  if (visited.has(scriptName)) {
+    return { requirements: [], errors: [`package.json script cycle at "${scriptName}"`] };
+  }
+  if (depth > MAX_SCRIPT_NESTING_DEPTH) {
+    return {
+      requirements: [],
+      errors: [`package.json script nesting exceeds ${MAX_SCRIPT_NESTING_DEPTH} at "${scriptName}"`],
+    };
+  }
+  const nested = scripts[scriptName];
+  if (typeof nested !== 'string' || !nested.trim()) {
+    return { requirements: [], errors: [`package.json script "${scriptName}" is missing`] };
+  }
+  const nextVisited = new Set(visited);
+  nextVisited.add(scriptName);
+  return resolveScript(nested, scripts, depth, nextVisited);
+}
+
+function resolveSegment(
+  segment: string,
+  scripts: Record<string, unknown>,
+  depth: number,
+  visited: Set<string>,
+): ScriptResolution {
+  const tokens = scriptTokens(segment);
+  const startIndex = commandStartIndex(tokens);
+  const commandToken = tokens[startIndex];
+  if (!commandToken) return { requirements: [], errors: [] };
+  const command = path.basename(commandToken);
+  const args = tokens.slice(startIndex + 1);
+
+  if (command === 'npx') {
+    return localRequirement(firstNonFlag(args)?.token, 'npx');
+  }
+  if (command === 'pnpm') {
+    const execIndex = args.indexOf('exec');
+    if (execIndex >= 0) {
+      return localRequirement(firstNonFlag(args, execIndex + 1)?.token, 'pnpm exec');
+    }
+  }
+  if (command === 'yarn') {
+    return localRequirement(firstNonFlag(args)?.token, 'yarn');
+  }
+  if (command === 'npm') {
+    const operation = firstNonFlag(args);
+    if (operation?.token === 'run') {
+      const scriptName = firstNonFlag(args, operation.index + 1)?.token;
+      return resolveNestedScript(scriptName, scripts, depth + 1, visited);
+    }
+  }
+  if (command === 'node') {
+    const inlineRun = args.find((token) => token.startsWith('--run='));
+    if (inlineRun) {
+      return resolveNestedScript(inlineRun.slice('--run='.length), scripts, depth + 1, visited);
+    }
+    const runIndex = args.indexOf('--run');
+    if (runIndex >= 0) {
+      return resolveNestedScript(firstNonFlag(args, runIndex + 1)?.token, scripts, depth + 1, visited);
+    }
+  }
+
+  return {
+    requirements: [{ name: command, local: !HOST_COMMANDS.has(command) }],
+    errors: [],
+  };
+}
+
+function resolveScript(
+  script: string,
+  scripts: Record<string, unknown>,
+  depth: number,
+  visited: Set<string>,
+): ScriptResolution {
+  const resolution: ScriptResolution = { requirements: [], errors: [] };
+  for (const segment of splitCommandSegments(script)) {
+    const segmentResolution = resolveSegment(segment, scripts, depth, visited);
+    resolution.requirements.push(...segmentResolution.requirements);
+    resolution.errors.push(...segmentResolution.errors);
+  }
+  return resolution;
 }
 
 async function localBinaryExists(workspacePath: string, binary: string): Promise<boolean> {
@@ -100,44 +279,86 @@ async function localBinaryExists(workspacePath: string, binary: string): Promise
   return false;
 }
 
+async function topLevelEntryCount(workspacePath: string): Promise<number> {
+  return readdir(path.join(workspacePath, 'node_modules'))
+    .then((entries) => entries.length)
+    .catch((error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') return 0;
+      throw error;
+    });
+}
+
 export async function verifyDependencyMaterialization(
   workspacePath: string,
 ): Promise<DependencyMaterializationVerification> {
-  const packageJson = JSON.parse(
-    await readFile(path.join(workspacePath, 'package.json'), 'utf8'),
-  ) as PackageJsonShape;
-  const scriptBinaries: Partial<Record<GateScriptName, string>> = {};
-  for (const scriptName of GATE_SCRIPTS) {
-    const script = packageJson.scripts?.[scriptName];
-    if (typeof script !== 'string' || !script.trim()) continue;
-    const binary = firstScriptBinary(script);
-    if (binary) scriptBinaries[scriptName] = binary;
+  const entryCount = await topLevelEntryCount(workspacePath);
+  let packageJson: PackageJsonShape;
+  try {
+    const parsed = JSON.parse(
+      await readFile(path.join(workspacePath, 'package.json'), 'utf8'),
+    ) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('package.json root must be an object');
+    }
+    packageJson = parsed as PackageJsonShape;
+  } catch {
+    return {
+      missingBinaries: [],
+      requiredBinaries: [],
+      resolutionErrors: [],
+      scriptBinaries: {},
+      topLevelEntryCount: entryCount,
+      unreadableFiles: ['package.json'],
+      verifiedBinaries: [],
+    };
   }
 
-  const requiredBinaries = [...new Set(Object.values(scriptBinaries))].sort();
+  const scripts = packageJson.scripts;
+  if (scripts !== undefined && (!scripts || typeof scripts !== 'object' || Array.isArray(scripts))) {
+    return {
+      missingBinaries: [],
+      requiredBinaries: [],
+      resolutionErrors: [],
+      scriptBinaries: {},
+      topLevelEntryCount: entryCount,
+      unreadableFiles: ['package.json'],
+      verifiedBinaries: [],
+    };
+  }
+  const packageScripts = scripts ?? {};
+  const requirements = new Map<string, boolean>();
+  const resolutionErrors: string[] = [];
+  const scriptBinaries: Partial<Record<GateScriptName, string[]>> = {};
+  for (const scriptName of GATE_SCRIPTS) {
+    const script = packageScripts[scriptName];
+    if (typeof script !== 'string' || !script.trim()) continue;
+    const resolution = resolveScript(script, packageScripts, 0, new Set([scriptName]));
+    const binaries = [...new Set(resolution.requirements.map((requirement) => requirement.name))].sort();
+    if (binaries.length > 0) scriptBinaries[scriptName] = binaries;
+    for (const requirement of resolution.requirements) {
+      requirements.set(requirement.name, (requirements.get(requirement.name) ?? false) || requirement.local);
+    }
+    resolutionErrors.push(...resolution.errors.map((error) => `${scriptName}: ${error}`));
+  }
+
+  const requiredBinaries = [...requirements.keys()].sort();
   const verifiedBinaries: string[] = [];
   const missingBinaries: string[] = [];
   for (const binary of requiredBinaries) {
-    // Package scripts resolve local shims first, while runtimes and package managers
-    // such as node/npm are provided by the launch environment rather than .bin.
-    if (await localBinaryExists(workspacePath, binary) || HOST_BINARIES.has(binary)) {
+    if (!requirements.get(binary) || await localBinaryExists(workspacePath, binary)) {
       verifiedBinaries.push(binary);
     } else {
       missingBinaries.push(binary);
     }
   }
 
-  const topLevelEntryCount = await readdir(path.join(workspacePath, 'node_modules'))
-    .then((entries) => entries.length)
-    .catch((error: NodeJS.ErrnoException) => {
-      if (error.code === 'ENOENT') return 0;
-      throw error;
-    });
   return {
     missingBinaries,
     requiredBinaries,
+    resolutionErrors,
     scriptBinaries,
-    topLevelEntryCount,
+    topLevelEntryCount: entryCount,
+    unreadableFiles: [],
     verifiedBinaries,
   };
 }

--- a/src/lib/workspace/dependency-materialization-verification.ts
+++ b/src/lib/workspace/dependency-materialization-verification.ts
@@ -213,13 +213,23 @@ function resolveSegment(
     return localRequirement(firstNonFlag(args)?.token, 'npx');
   }
   if (command === 'pnpm') {
+    const operation = firstNonFlag(args);
+    if (operation?.token === 'run') {
+      const scriptName = firstNonFlag(args, operation.index + 1)?.token;
+      return resolveNestedScript(scriptName, scripts, depth + 1, visited);
+    }
     const execIndex = args.indexOf('exec');
     if (execIndex >= 0) {
       return localRequirement(firstNonFlag(args, execIndex + 1)?.token, 'pnpm exec');
     }
   }
   if (command === 'yarn') {
-    return localRequirement(firstNonFlag(args)?.token, 'yarn');
+    const operation = firstNonFlag(args);
+    if (operation?.token === 'run') {
+      const scriptName = firstNonFlag(args, operation.index + 1)?.token;
+      return resolveNestedScript(scriptName, scripts, depth + 1, visited);
+    }
+    return localRequirement(operation?.token, 'yarn');
   }
   if (command === 'npm') {
     const operation = firstNonFlag(args);

--- a/src/lib/worktree/index.ts
+++ b/src/lib/worktree/index.ts
@@ -5,6 +5,7 @@
  */
 
 export { WorktreeManager, WorktreeFetchUnreachableError, WorktreeRebaseConflictError } from './manager';
+export { DependencyMaterializationIncompleteError } from '@/lib/workspace/dependency-materialization-verification';
 export { WorktreeOriginMissingError } from './errors';
 export {
   LEGACY_WORKTREE_DIR_NAME,

--- a/src/lib/worktree/manager.ts
+++ b/src/lib/worktree/manager.ts
@@ -87,6 +87,12 @@ import {
   queueDependencyImagePublication,
   type DependencyMaterializationReceipt,
 } from '@/lib/workspace/dependency-materializer';
+import { retireDependencyImage } from '@/lib/workspace/apfs-dependency-image';
+import {
+  DEPENDENCY_MATERIALIZATION_INCOMPLETE,
+  DependencyMaterializationIncompleteError,
+  verifyDependencyMaterialization,
+} from '@/lib/workspace/dependency-materialization-verification';
 import { applyWorkspaceManifest } from '@/lib/workspace/manifest/apply';
 import {
   probeMetadataLockProcessIdentity,
@@ -1288,6 +1294,58 @@ export class WorktreeManager {
           ),
         });
         dependencyMaterialization = result.receipt;
+        if (launch?.packetId && launch.laneId) {
+          const verification = await verifyDependencyMaterialization(worktreePath);
+          if (verification.missingBinaries.length > 0) {
+            let imageGenerationInvalidated = false;
+            let imageInvalidationError: string | null = null;
+            if (dependencyMaterialization.mode === 'image') {
+              try {
+                await detachDependencyMaterialization(worktreePath, dependencyMaterialization);
+                await this.clearDependencyMaterialization(path.basename(worktreePath));
+                await retireDependencyImage(dependencyMaterialization.recipeKey);
+                imageGenerationInvalidated = true;
+              } catch (error) {
+                imageInvalidationError = error instanceof Error ? error.message : String(error);
+              }
+            }
+            const blocker = new DependencyMaterializationIncompleteError(
+              verification,
+              imageGenerationInvalidated,
+              imageInvalidationError,
+            );
+            const { appendEvent, setLaneStatus } = await import('@/lib/lane/registry');
+            appendEvent(launch.laneId, DEPENDENCY_MATERIALIZATION_INCOMPLETE, 'system', {
+              code: blocker.code,
+              packetId: launch.packetId,
+              mode: dependencyMaterialization.mode,
+              recipeKey: dependencyMaterialization.recipeKey,
+              topLevelEntryCount: verification.topLevelEntryCount,
+              verifiedBinaries: verification.verifiedBinaries,
+              missingBinaries: verification.missingBinaries,
+              scriptBinaries: verification.scriptBinaries,
+              imageGenerationInvalidated,
+              imageInvalidationError,
+            });
+            setLaneStatus(
+              launch.laneId,
+              'failed',
+              'system',
+              DEPENDENCY_MATERIALIZATION_INCOMPLETE,
+            );
+            throw blocker;
+          }
+          const { appendEvent } = await import('@/lib/lane/registry');
+          appendEvent(launch.laneId, 'dependency_materialized', 'system', {
+            packetId: launch.packetId,
+            mode: dependencyMaterialization.mode,
+            recipeKey: dependencyMaterialization.recipeKey,
+            topLevelEntryCount: verification.topLevelEntryCount,
+            verifiedBinaries: verification.verifiedBinaries,
+            missingBinaries: verification.missingBinaries,
+            scriptBinaries: verification.scriptBinaries,
+          });
+        }
       }
       if (await this.pathExists(path.join(worktreePath, 'requirements.txt'))) {
         await execFileAsync('pip', ['install', '-r', 'requirements.txt'], {

--- a/src/lib/worktree/manager.ts
+++ b/src/lib/worktree/manager.ts
@@ -91,6 +91,7 @@ import { retireDependencyImage } from '@/lib/workspace/apfs-dependency-image';
 import {
   DEPENDENCY_MATERIALIZATION_INCOMPLETE,
   DependencyMaterializationIncompleteError,
+  isDependencyMaterializationIncomplete,
   verifyDependencyMaterialization,
 } from '@/lib/workspace/dependency-materialization-verification';
 import { applyWorkspaceManifest } from '@/lib/workspace/manifest/apply';
@@ -1235,6 +1236,29 @@ export class WorktreeManager {
     return all.find((wt) => wt.id === worktreeId) ?? null;
   }
 
+  /**
+   * Read only the dependency receipt for the managed worktree at an exact path.
+   * Unlike get()/list(), this avoids probing git status across the fleet.
+   */
+  async getDependencyMaterializationByPath(worktreePath: string): Promise<{
+    dependencyMaterialization?: DependencyMaterializationReceipt;
+    id: string;
+    path: string;
+  } | null> {
+    const id = path.basename(path.resolve(worktreePath));
+    const entry = (await this.loadAllMeta())[id];
+    if (!entry) return null;
+    const managedPath = entry.claudeManaged
+      ? path.join(this.repoRoot, CLAUDE_WORKTREE_DIR, id)
+      : await this.resolveManagedWorktreePath(id);
+    if (!(await this.samePath(managedPath, worktreePath))) return null;
+    return {
+      dependencyMaterialization: entry.dependencyMaterialization,
+      id,
+      path: managedPath,
+    };
+  }
+
   // ── Setup ──
 
   /**
@@ -1296,7 +1320,7 @@ export class WorktreeManager {
         dependencyMaterialization = result.receipt;
         if (launch?.packetId && launch.laneId) {
           const verification = await verifyDependencyMaterialization(worktreePath);
-          if (verification.missingBinaries.length > 0) {
+          if (isDependencyMaterializationIncomplete(verification)) {
             let imageGenerationInvalidated = false;
             let imageInvalidationError: string | null = null;
             if (dependencyMaterialization.mode === 'image') {
@@ -1323,7 +1347,9 @@ export class WorktreeManager {
               topLevelEntryCount: verification.topLevelEntryCount,
               verifiedBinaries: verification.verifiedBinaries,
               missingBinaries: verification.missingBinaries,
+              resolutionErrors: verification.resolutionErrors,
               scriptBinaries: verification.scriptBinaries,
+              unreadableFiles: verification.unreadableFiles,
               imageGenerationInvalidated,
               imageInvalidationError,
             });
@@ -1343,7 +1369,9 @@ export class WorktreeManager {
             topLevelEntryCount: verification.topLevelEntryCount,
             verifiedBinaries: verification.verifiedBinaries,
             missingBinaries: verification.missingBinaries,
+            resolutionErrors: verification.resolutionErrors,
             scriptBinaries: verification.scriptBinaries,
+            unreadableFiles: verification.unreadableFiles,
           });
         }
       }

--- a/tests/declarative-dispatch-worktree-real-path.test.ts
+++ b/tests/declarative-dispatch-worktree-real-path.test.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process';
 import {
   chmodSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   realpathSync,
@@ -120,6 +121,7 @@ const envKeys = [
   'O8_FAKE_QODER_CAPTURE',
   'O8_CRASH_SURVIVABLE_WORKERS',
   'O8_PACKAGED_APP',
+  'O8_APFS_DEPENDENCY_IMAGES',
   'O8_SKIP_PRELAUNCH_TYPECHECK',
 ] as const;
 
@@ -131,6 +133,7 @@ process.env.O8_QODER_BIN = fakeQoderPath;
 process.env.O8_FAKE_QODER_CAPTURE = capturePath;
 process.env.O8_CRASH_SURVIVABLE_WORKERS = '1';
 process.env.O8_PACKAGED_APP = '0';
+process.env.O8_APFS_DEPENDENCY_IMAGES = '0';
 process.env.O8_SKIP_PRELAUNCH_TYPECHECK = '1';
 
 writeFileSync(
@@ -167,6 +170,50 @@ function createRemoteBackedRepo(): string {
   git(seed, 'checkout', '-b', 'main');
   writeFileSync(join(seed, 'README.md'), 'declarative dispatch test\n', 'utf8');
   git(seed, 'add', 'README.md');
+  git(seed, '-c', 'user.name=o8 test', '-c', 'user.email=o8@test.invalid', 'commit', '-m', 'init');
+  git(seed, 'push', '-u', 'origin', 'main');
+  git(origin, 'symbolic-ref', 'HEAD', 'refs/heads/main');
+  execFileSync('git', ['clone', origin, repo], { stdio: 'pipe' });
+  return repo;
+}
+
+function createDependencyRemoteBackedRepo(removeGateBinary: boolean): string {
+  const suffix = Math.random().toString(36).slice(2, 8);
+  const origin = join(root, `dependency-origin-${suffix}.git`);
+  const seed = join(root, `dependency-seed-${suffix}`);
+  const repo = join(root, `dependency-repo-${suffix}`);
+  const packageRoot = join(seed, 'gate-cli');
+  execFileSync('git', ['init', '--bare', origin], { stdio: 'pipe' });
+  execFileSync('git', ['clone', origin, seed], { stdio: 'pipe' });
+  git(seed, 'checkout', '-b', 'main');
+  mkdirSync(packageRoot, { recursive: true });
+  writeFileSync(join(packageRoot, 'package.json'), JSON.stringify({
+    name: 'gate-cli',
+    version: '1.0.0',
+    bin: { 'gate-check': 'index.js' },
+  }), 'utf8');
+  writeFileSync(join(packageRoot, 'index.js'), '#!/usr/bin/env node\nprocess.exit(0);\n', 'utf8');
+  chmodSync(join(packageRoot, 'index.js'), 0o755);
+  writeFileSync(join(seed, '.gitignore'), 'node_modules/\n', 'utf8');
+  writeFileSync(join(seed, 'package.json'), JSON.stringify({
+    name: 'dependency-dispatch-fixture',
+    version: '1.0.0',
+    private: true,
+    scripts: {
+      lint: 'gate-check',
+      ...(removeGateBinary ? {
+        postinstall: "node -e \"require('node:fs').rmSync('node_modules/.bin/gate-check',{force:true})\"",
+      } : {}),
+    },
+    devDependencies: {
+      'gate-cli': 'file:gate-cli',
+    },
+  }), 'utf8');
+  execFileSync('npm', ['install', '--package-lock-only', '--ignore-scripts'], {
+    cwd: seed,
+    stdio: 'pipe',
+  });
+  git(seed, 'add', '.gitignore', 'package.json', 'package-lock.json', 'gate-cli');
   git(seed, '-c', 'user.name=o8 test', '-c', 'user.email=o8@test.invalid', 'commit', '-m', 'init');
   git(seed, 'push', '-u', 'origin', 'main');
   git(origin, 'symbolic-ref', 'HEAD', 'refs/heads/main');
@@ -310,6 +357,79 @@ describe('declarative packet dispatch worktree reachability', () => {
     const captureAfterFailure = readFileSync(capturePath, 'utf8').trim().split('\n').filter(Boolean);
     expect(captureAfterFailure).toEqual(captureBeforeFailure);
   }, 40_000);
+
+  it('verifies a materialized dev binary and blocks launch when the binary is incomplete', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200 })));
+    const [{ runDispatchTick, mergeDispatchTickOutcome }, laneRegistry, repoRegistry, controlPlane] = await Promise.all([
+      import('@/lib/orchestrator/scheduling'),
+      import('@/lib/lane/registry'),
+      import('@/lib/repos/registry'),
+      import('@/lib/orchestrator/control-plane'),
+    ]);
+
+    const completeRepo = createDependencyRemoteBackedRepo(false);
+    const completeRegistration = await repoRegistry.addRepo(completeRepo);
+    expect(completeRegistration.setup).toMatchObject({
+      installCommand: 'npm ci --prefer-offline',
+      installOnCreateWorkspace: true,
+    });
+    const completeId = 'pkt-dependency-materialized';
+    const launched = await runDispatchTick(mission(
+      completeRepo,
+      packet(completeRepo, completeId),
+    ), { launchBudget: { maxLaunches: 1 } });
+    const completeLane = laneRegistry.findLatestLaneByPacket(completeId);
+    expect(launched.packets[0]?.status).toBe('launching');
+    expect(completeLane?.worktreePath).toBeTruthy();
+    expect(existsSync(join(completeLane!.worktreePath!, 'node_modules', '.bin', 'gate-check'))).toBe(true);
+    expect(laneRegistry.getLaneEvents(completeLane!.id, 200)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        verb: 'dependency_materialized',
+        payload: expect.objectContaining({
+          mode: 'native',
+          recipeKey: expect.stringMatching(/^[0-9a-f]{64}$/),
+          topLevelEntryCount: expect.any(Number),
+          verifiedBinaries: ['gate-check'],
+          missingBinaries: [],
+        }),
+      }),
+    ]));
+
+    const incompleteRepo = createDependencyRemoteBackedRepo(true);
+    const incompleteRegistration = await repoRegistry.addRepo(incompleteRepo);
+    expect(incompleteRegistration.setup.installOnCreateWorkspace).toBe(true);
+    const incompleteId = 'pkt-dependency-incomplete';
+    const initial = mission(incompleteRepo, packet(incompleteRepo, incompleteId));
+    controlPlane.writeOrchestratorControlPlaneState(initial);
+    const captureCountBefore = existsSync(capturePath)
+      ? readFileSync(capturePath, 'utf8').trim().split('\n').filter(Boolean).length
+      : 0;
+    const blocked = await runDispatchTick(initial, { launchBudget: { maxLaunches: 1 } });
+    await controlPlane.withLockedState((fresh) => {
+      mergeDispatchTickOutcome(fresh, initial, blocked);
+    });
+    const incompleteLane = laneRegistry.findLatestLaneByPacket(incompleteId);
+    const persistedPacket = controlPlane.readOrchestratorControlPlaneState().packets
+      .find((candidate) => candidate.id === incompleteId);
+    const captureCountAfter = existsSync(capturePath)
+      ? readFileSync(capturePath, 'utf8').trim().split('\n').filter(Boolean).length
+      : 0;
+    expect(blocked.packets[0]?.status).toBe('blocked');
+    expect(persistedPacket?.blockedReason).toContain('dependency_materialization_incomplete');
+    expect(persistedPacket?.blockedReason).toContain('gate-check');
+    expect(incompleteLane?.status).toBe('failed');
+    expect(laneRegistry.getLaneEvents(incompleteLane!.id, 200)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        verb: 'dependency_materialization_incomplete',
+        payload: expect.objectContaining({
+          code: 'dependency_materialization_incomplete',
+          mode: 'native',
+          missingBinaries: ['gate-check'],
+        }),
+      }),
+    ]));
+    expect(captureCountAfter).toBe(captureCountBefore);
+  }, 120_000);
 
   it('keeps a never-launched lane live while slow worktree provisioning fails', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200 })));

--- a/tests/direct-merge-canonical-repo-real-path.test.ts
+++ b/tests/direct-merge-canonical-repo-real-path.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import { join } from 'node:path';
 
@@ -14,7 +14,7 @@ vi.mock('@/lib/realtime/publisher', () => ({
 process.env.O8_SKIP_PRELAUNCH_TYPECHECK = '1';
 
 const { recordMission } = await import('@/lib/db/missions-store');
-const { createLane, getLane, setLaneStatus } = await import('@/lib/lane/registry');
+const { createLane, getLane, getLaneEvents, setLaneStatus } = await import('@/lib/lane/registry');
 const {
   approveAndMergePacket,
   submitPacketReview,
@@ -67,7 +67,7 @@ function packetFixture(packetId: string, canonicalRepo: string, branch: string):
   } as OrchestratorPacket;
 }
 
-async function createRelocatedCloneMission(label: string) {
+async function createRelocatedCloneMission(label: string, incompleteDependencies = false) {
   const root = mkdtempSync(join(os.tmpdir(), `o8-direct-merge-${label}-`));
   const origin = join(root, 'github-like.git');
   const canonicalRepo = join(root, 'canonical');
@@ -81,6 +81,20 @@ async function createRelocatedCloneMission(label: string) {
   git(canonicalRepo, ['config', 'user.name', 'o8-test']);
   git(canonicalRepo, ['config', 'user.email', 'o8@example.test']);
   writeFileSync(join(canonicalRepo, 'base.txt'), 'base\n');
+  if (incompleteDependencies) {
+    mkdirSync(join(canonicalRepo, 'src'), { recursive: true });
+    writeFileSync(join(canonicalRepo, '.gitignore'), 'node_modules/\n');
+    writeFileSync(join(canonicalRepo, 'package.json'), JSON.stringify({
+      name: 'merge-dependency-fixture',
+      private: true,
+      scripts: { lint: 'gate-check', typecheck: 'tsc --noEmit' },
+    }));
+    writeFileSync(join(canonicalRepo, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: { noEmit: true, strict: true },
+      include: ['src/**/*.ts'],
+    }));
+    writeFileSync(join(canonicalRepo, 'src', 'index.ts'), 'export const ready: string = "yes";\n');
+  }
   const baseSha = commitAll(canonicalRepo, 'base');
   git(canonicalRepo, ['push', '-u', 'origin', 'main']);
 
@@ -98,6 +112,20 @@ async function createRelocatedCloneMission(label: string) {
   git(packetClone, ['config', 'user.email', 'o8@example.test']);
   writeFileSync(join(packetClone, 'feature.txt'), `${label}\n`);
   const packetSha = commitAll(packetClone, `feat: ${label} [via-o8]`);
+  const typecheckMarker = join(root, 'typecheck-ran');
+  if (incompleteDependencies) {
+    const binDir = join(packetClone, 'node_modules', '.bin');
+    mkdirSync(binDir, { recursive: true });
+    const tscPath = join(binDir, 'tsc');
+    writeFileSync(tscPath, [
+      '#!/bin/sh',
+      `touch ${JSON.stringify(typecheckMarker)}`,
+      'echo "src/index.ts(1,1): error TS2307: Cannot find module gate-check"',
+      'exit 2',
+      '',
+    ].join('\n'));
+    chmodSync(tscPath, 0o755);
+  }
 
   await addRepo(canonicalRepo);
   const worktreeId = `packet-${packetId}`;
@@ -153,7 +181,7 @@ async function createRelocatedCloneMission(label: string) {
   });
   writeOrchestratorControlPlaneState(mission);
 
-  return { baseSha, branch, canonicalRepo, lane, packetClone, packetId, packetSha };
+  return { baseSha, branch, canonicalRepo, lane, packetClone, packetId, packetSha, typecheckMarker };
 }
 
 async function reviewAndMerge(fixture: Awaited<ReturnType<typeof createRelocatedCloneMission>>) {
@@ -208,6 +236,40 @@ describe('direct merge publishes through the canonical mission repository', () =
       status: 'blocked',
       blockedReason: 'canonical_merge_ancestry_failed',
     });
+    expect(git(fixture.canonicalRepo, ['rev-parse', 'main'])).toBe(fixture.baseSha);
+  }, 30_000);
+
+  it('blocks an incomplete dependency tree before post-rebase typecheck consumes its retry', async () => {
+    const fixture = await createRelocatedCloneMission('incomplete-dependencies', true);
+
+    const result = await reviewAndMerge(fixture);
+    const packet = readOrchestratorControlPlaneState().packets
+      .find((candidate) => candidate.id === fixture.packetId);
+    const events = getLaneEvents(fixture.lane.id);
+
+    expect(result).toMatchObject({
+      merged: false,
+      reason: 'dependency_materialization_incomplete',
+    });
+    expect(result.note).toContain('gate-check');
+    expect(existsSync(fixture.typecheckMarker)).toBe(false);
+    expect(getLane(fixture.lane.id)).toMatchObject({
+      status: 'awaiting_orchestrator',
+      lastEventLabel: 'dependency_materialization_incomplete',
+    });
+    expect(packet?.typecheckAutoRetries ?? 0).toBe(0);
+    expect(packet?.blockedReason).toContain('dependency_materialization_incomplete');
+    expect(events.some((event) => event.verb === 'typecheck_auto_retry')).toBe(false);
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        verb: 'dependency_materialization_incomplete',
+        payload: expect.objectContaining({
+          phase: 'merge_gate',
+          missingBinaries: ['gate-check'],
+          verifiedBinaries: ['tsc'],
+        }),
+      }),
+    ]));
     expect(git(fixture.canonicalRepo, ['rev-parse', 'main'])).toBe(fixture.baseSha);
   }, 30_000);
 });

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -649,6 +649,12 @@
       ]
     },
     {
+      "path": "src/lib/workspace/dependency-materialization-verification.test.ts",
+      "reasons": [
+        "executable-fixture"
+      ]
+    },
+    {
       "path": "src/lib/workspace/dependency-materializer.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
Fixes #2014.

A packet relaunch got a fresh clone whose `node_modules` lacked every devDependency (no eslint, vitest, or tsx), so the worker could run no gate, and the governed merge's post-rebase typecheck later failed on the same clone with `TS2307` missing-module errors, burning its auto-retry on an environment failure.

## Mechanic

Dispatch launches passed `skipSetup: true` unconditionally, so a freshly provisioned clone bypassed the managed dependency install entirely; the tree it ended up with came from whatever ran later in the session, under the server's production environment, which omits devDependencies.

## Change

- `commands-launch.ts`: `skipSetup` is now only set when the lane already has a provisioned worktree; fresh provisioning runs the managed install (which pins `NODE_ENV=development`).
- New `dependency-materialization-verification.ts`: after install, resolve the binaries each of the repo's `lint` / `test` / `typecheck` scripts actually needs and check them against the clone's `node_modules/.bin`. Resolution splits chained segments (`&&`/`||`/`;`), unwraps `npx` / `pnpm exec` / plain `yarn <bin>`, and follows `npm run` / `yarn run` / `pnpm run` / `node --run` into nested package scripts (depth-capped, cycle-safe); shell builtins and host runtimes are exempt only as plain commands. A malformed `package.json` yields a structured unreadable-manifest result instead of an exception. Missing binaries raise `dependency_materialization_incomplete`: the launch is refused, the lane records the event with mode, recipe key, entry count, and the missing binary names, the packet carries the blockedReason, and an adopted dependency-image generation is retired so the next attempt installs natively. Complete trees record a `dependency_materialized` receipt.
- The same verification runs at the top of the governed merge verification (both merge paths), so an incomplete tree blocks with the named reason instead of a false typecheck failure, consumes no typecheck auto-retry, and parks the lane `awaiting_orchestrator`.

## Verification

- Real-path dispatch test: a temp repo whose lockfile ships a dev binary used by its lint script dispatches with the binary present and the `dependency_materialized` event recorded; the same repo with the binary removed refuses launch, records the event with the missing name, sets the packet blockedReason, and never spawns the runtime.
- Real-path merge test: an incomplete clone is refused before typecheck (a marker proves the fake `tsc` never executed), retry count stays 0, and canonical main is untouched.
- `npx tsc --noEmit` clean, `npm run lint` exit 0, rule-check clean.
