### PR TITLE
fix(merge): squash governed merges to one attributed commit

### DIFF
--- a/src/lib/lane/commands-remote-merge.ts
+++ b/src/lib/lane/commands-remote-merge.ts
@@ -129,6 +129,11 @@ export async function performRemoteCustomerMerge(
     }
 
     await execFileAsync('git', ['checkout', lane.baseBranch], { windowsHide: true, cwd: lane.repoPath });
+    const preMergeHeadSha = (await execFileAsync('git', ['rev-parse', 'HEAD'], {
+      windowsHide: true,
+      cwd: lane.repoPath,
+      timeout: 5000,
+    })).stdout.trim();
 
     try {
       const mergeArgs = historyPlan.kind === 'squash'
@@ -157,10 +162,21 @@ export async function performRemoteCustomerMerge(
         // best effort
       }
 
-      try {
-        await execFileAsync('git', ['merge', '--abort'], { windowsHide: true, cwd: lane.repoPath });
-      } catch {
-        // already clean
+      if (historyPlan.kind === 'squash') {
+        try {
+          await execFileAsync('git', ['reset', '--merge'], { windowsHide: true, cwd: lane.repoPath });
+        } catch {
+          await execFileAsync('git', ['reset', '--hard', preMergeHeadSha], {
+            windowsHide: true,
+            cwd: lane.repoPath,
+          });
+        }
+      } else {
+        try {
+          await execFileAsync('git', ['merge', '--abort'], { windowsHide: true, cwd: lane.repoPath });
+        } catch {
+          // already clean
+        }
       }
 
       const mergeMessage = formatLaneCommandError(mergeErr);

--- a/src/lib/lane/commands-remote-merge.ts
+++ b/src/lib/lane/commands-remote-merge.ts
@@ -1,6 +1,8 @@
 import { cleanupRemoteMergeWorktree, fetchWorkerBranch } from '@/lib/lane/remote-fetch';
 import { dogfoodPrOnlyActive, DOGFOOD_PR_ONLY_NOTE } from '@/lib/lane/dogfood-guard';
 import { runLaneRebaseTypecheck } from '@/lib/lane/rebase-typecheck';
+import { resolveAttributedCommitMessage } from '@/lib/lane/commit-attribution';
+import { resolveGovernedMergeHistoryPlan } from '@/lib/lane/governed-merge-history';
 import { getLane, setLaneStatus } from '@/lib/lane/registry';
 import type { Lane, LaneCommand, LaneCommandResult, LaneEventActor } from '@/lib/lane/types';
 import { fetchWorkerRun } from '@/lib/worker/runs';
@@ -50,7 +52,10 @@ export async function performRemoteCustomerMerge(
       maxBuffer: 1024 * 1024,
     })).stdout.trim();
 
-    if (command.commitMessage) {
+    const attributedCommitMessage = command.commitMessage?.trim()
+      ? resolveAttributedCommitMessage(command.commitMessage.trim())
+      : undefined;
+    if (attributedCommitMessage) {
       try {
         await execFileAsync('git', ['add', '-A'], { windowsHide: true, cwd: fetched.tempWorktreePath });
         const { stdout: porcelain } = await execFileAsync(
@@ -58,7 +63,7 @@ export async function performRemoteCustomerMerge(
           { windowsHide: true, cwd: fetched.tempWorktreePath, timeout: 5000 },
         );
         if (porcelain.trim()) {
-          await execFileAsync('git', ['commit', '-m', command.commitMessage], {
+          await execFileAsync('git', ['commit', '-m', attributedCommitMessage], {
             windowsHide: true,
             cwd: fetched.tempWorktreePath,
           });
@@ -112,15 +117,34 @@ export async function performRemoteCustomerMerge(
       };
     }
 
+    const historyPlan = await resolveGovernedMergeHistoryPlan({
+      cwd: fetched.tempWorktreePath,
+      baseRef: lane.baseBranch,
+      candidateRef: actualBranch,
+      commitMessage: command.commitMessage,
+    });
+    if (historyPlan.kind === 'refuse') {
+      setLaneStatus(command.laneId, 'reviewing', 'system', 'wip_commit_requires_message');
+      return { ok: false, laneId: command.laneId, note: historyPlan.note };
+    }
+
     await execFileAsync('git', ['checkout', lane.baseBranch], { windowsHide: true, cwd: lane.repoPath });
 
     try {
-      const mergeArgs = ['merge', '--no-ff', '-m', `Merge lane ${lane.label} (${actualBranch})`];
+      const mergeArgs = historyPlan.kind === 'squash'
+        ? ['merge', '--squash']
+        : ['merge', '--no-ff', '-m', `Merge lane ${lane.label} (${actualBranch})`];
       if (command.strategy === 'ours' || command.strategy === 'theirs') {
         mergeArgs.push('-X', command.strategy);
       }
       mergeArgs.push(actualBranch);
       await execFileAsync('git', mergeArgs, { windowsHide: true, cwd: lane.repoPath });
+      if (historyPlan.kind === 'squash') {
+        await execFileAsync('git', ['commit', '-m', historyPlan.commitMessage], {
+          windowsHide: true,
+          cwd: lane.repoPath,
+        });
+      }
     } catch (mergeErr) {
       let conflictFiles: string[] = [];
       try {

--- a/src/lib/lane/governed-merge-history.ts
+++ b/src/lib/lane/governed-merge-history.ts
@@ -1,0 +1,71 @@
+import { resolveAttributedCommitMessage } from '@/lib/lane/commit-attribution';
+import { git, type GitCommandRunner } from '@/lib/lane/worktree-merge-git';
+
+interface CandidateCommit {
+  sha: string;
+  subject: string;
+}
+
+export type GovernedMergeHistoryPlan =
+  | { kind: 'preserve' }
+  | { kind: 'squash'; commitMessage: string }
+  | { kind: 'refuse'; note: string };
+
+function isWipSubject(subject: string): boolean {
+  return /^wip\s*:/i.test(subject.trim().replace(/^[*_`]+/, ''));
+}
+
+async function candidateCommits(input: {
+  cwd: string;
+  baseRef: string;
+  candidateRef: string;
+  runGit: GitCommandRunner;
+}): Promise<CandidateCommit[]> {
+  const { stdout } = await input.runGit(input.cwd, [
+    'log',
+    '--format=%H%x1f%s%x1e',
+    `${input.baseRef}..${input.candidateRef}`,
+  ], { timeout: 5000 });
+  return stdout
+    .split('\x1e')
+    .map((record) => record.trim())
+    .filter(Boolean)
+    .map((record) => {
+      const [sha = '', subject = ''] = record.split('\x1f');
+      return { sha, subject };
+    });
+}
+
+export async function resolveGovernedMergeHistoryPlan(input: {
+  cwd: string;
+  baseRef: string;
+  candidateRef: string;
+  commitMessage?: string;
+  runGit?: GitCommandRunner;
+}): Promise<GovernedMergeHistoryPlan> {
+  const explicitMessage = input.commitMessage?.trim();
+  if (explicitMessage) {
+    return {
+      kind: 'squash',
+      commitMessage: resolveAttributedCommitMessage(explicitMessage),
+    };
+  }
+
+  const commits = await candidateCommits({ ...input, runGit: input.runGit ?? git });
+  const wipCommits = commits.filter((commit) => isWipSubject(commit.subject));
+  if (wipCommits.length === 0) return { kind: 'preserve' };
+
+  const finalCommit = commits.find((commit) => !isWipSubject(commit.subject));
+  if (finalCommit) {
+    return {
+      kind: 'squash',
+      commitMessage: resolveAttributedCommitMessage(finalCommit.subject),
+    };
+  }
+
+  const wipCommit = wipCommits[0]!;
+  return {
+    kind: 'refuse',
+    note: `Merge refused: packet history has no non-wip subject for squash. Commit ${wipCommit.sha.slice(0, 12)} is named "${wipCommit.subject}". Supply commitMessage and retry.`,
+  };
+}

--- a/src/lib/lane/worktree-side-merge.ts
+++ b/src/lib/lane/worktree-side-merge.ts
@@ -137,10 +137,9 @@ async function prepareGovernedMergeCandidate(input: {
   | { ok: true; candidateSha: string; squashed: boolean }
   | { ok: false; note: string }
 > {
-  const baseSha = await resolveSquashBaseSha(input);
   const plan = await resolveGovernedMergeHistoryPlan({
     cwd: input.repoPath,
-    baseRef: baseSha,
+    baseRef: input.originBaseRef ?? `refs/heads/${input.baseBranch}`,
     candidateRef: input.candidateRef,
     commitMessage: input.commitMessage,
   });
@@ -149,6 +148,7 @@ async function prepareGovernedMergeCandidate(input: {
     return { ok: true, candidateSha: input.candidateSha, squashed: false };
   }
 
+  const baseSha = await resolveSquashBaseSha(input);
   const { stdout: treeOutput } = await git(
     input.repoPath,
     ['rev-parse', `${input.candidateRef}^{tree}`],

--- a/src/lib/lane/worktree-side-merge.ts
+++ b/src/lib/lane/worktree-side-merge.ts
@@ -5,6 +5,7 @@ import type {
   MergeStrategy,
 } from '@/lib/approvals/types';
 import { resolveAttributedCommitMessage } from '@/lib/lane/commit-attribution';
+import { resolveGovernedMergeHistoryPlan } from '@/lib/lane/governed-merge-history';
 import { checkExpectedHeadSha, formatHeadShaMismatchNote } from '@/lib/lane/head-sha-lock';
 import { checkReviewedHeadIntegrity, formatReviewedHeadMismatchNote } from '@/lib/lane/review-head-integrity';
 import { dogfoodPrOnlyActive, DOGFOOD_PR_ONLY_NOTE } from '@/lib/lane/dogfood-guard';
@@ -88,6 +89,88 @@ type CreateLaneActionApproval = (
     strategy?: MergeStrategy;
   },
 ) => Promise<LaneCommandResult>;
+
+async function resolveSquashBaseSha(input: {
+  repoPath: string;
+  baseBranch: string;
+  candidateRef: string;
+  originBaseRef: string | null;
+}): Promise<string> {
+  const localBaseRef = `refs/heads/${input.baseBranch}`;
+  const { stdout: localBaseOutput } = await git(
+    input.repoPath,
+    ['rev-parse', '--verify', localBaseRef],
+    { timeout: 5000 },
+  );
+  const localBaseSha = localBaseOutput.trim();
+  const localIsAncestor = await isAncestor(input.repoPath, localBaseSha, input.candidateRef);
+  if (!input.originBaseRef) {
+    if (localIsAncestor) return localBaseSha;
+    throw new Error(`${localBaseRef} is not an ancestor of the exact reviewed candidate.`);
+  }
+
+  const { stdout: originBaseOutput } = await git(
+    input.repoPath,
+    ['rev-parse', '--verify', input.originBaseRef],
+    { timeout: 5000 },
+  );
+  const originBaseSha = originBaseOutput.trim();
+  const originIsAncestor = await isAncestor(input.repoPath, originBaseSha, input.candidateRef);
+  if (!localIsAncestor && !originIsAncestor) {
+    throw new Error(`${localBaseRef} and ${input.originBaseRef} are not ancestors of the exact reviewed candidate.`);
+  }
+  if (!localIsAncestor) return originBaseSha;
+  if (!originIsAncestor || localBaseSha === originBaseSha) return localBaseSha;
+  if (await isAncestor(input.repoPath, localBaseSha, originBaseSha)) return originBaseSha;
+  if (await isAncestor(input.repoPath, originBaseSha, localBaseSha)) return localBaseSha;
+  throw new Error(`${localBaseRef} and ${input.originBaseRef} have diverged; a one-parent squash cannot preserve both histories.`);
+}
+
+async function prepareGovernedMergeCandidate(input: {
+  repoPath: string;
+  baseBranch: string;
+  candidateRef: string;
+  candidateSha: string;
+  originBaseRef: string | null;
+  commitMessage?: string;
+}): Promise<
+  | { ok: true; candidateSha: string; squashed: boolean }
+  | { ok: false; note: string }
+> {
+  const baseSha = await resolveSquashBaseSha(input);
+  const plan = await resolveGovernedMergeHistoryPlan({
+    cwd: input.repoPath,
+    baseRef: baseSha,
+    candidateRef: input.candidateRef,
+    commitMessage: input.commitMessage,
+  });
+  if (plan.kind === 'refuse') return { ok: false, note: plan.note };
+  if (plan.kind === 'preserve') {
+    return { ok: true, candidateSha: input.candidateSha, squashed: false };
+  }
+
+  const { stdout: treeOutput } = await git(
+    input.repoPath,
+    ['rev-parse', `${input.candidateRef}^{tree}`],
+    { timeout: 5000 },
+  );
+  const { stdout: squashOutput } = await git(input.repoPath, [
+    'commit-tree',
+    treeOutput.trim(),
+    '-p',
+    baseSha,
+    '-m',
+    plan.commitMessage,
+  ]);
+  const squashSha = squashOutput.trim();
+  await git(input.repoPath, [
+    'update-ref',
+    input.candidateRef,
+    squashSha,
+    input.candidateSha,
+  ], { timeout: 5000 });
+  return { ok: true, candidateSha: squashSha, squashed: true };
+}
 
 export interface WorktreeSideMergeInput {
   lane: Lane;
@@ -534,6 +617,7 @@ async function performWorktreeSideMergeInner(input: WorktreeSideMergeInput): Pro
     if (publicationGovernanceDrift) return publicationGovernanceDrift;
     const integrationRef = mergeRefForLane(command.laneId);
     let mergeCandidateSha = rebasedSha;
+    let mergedEquivalentHeadSha = spokenEvidence.present ? reviewedSnapshotSha : rebasedSha;
     let expectedRemoteBaseSha: string | undefined;
     try {
       await fetchWorkerHeadIntoMainRepo(lane.repoPath, mergeWorktreePath, rebasedSha, integrationRef);
@@ -553,11 +637,41 @@ async function performWorktreeSideMergeInner(input: WorktreeSideMergeInput): Pro
 
       const integrationSha = (await git(lane.repoPath, ['rev-parse', integrationRef], { timeout: 5000 })).stdout.trim();
       mergeCandidateSha = integrationSha;
+      if (!spokenEvidence.present) mergedEquivalentHeadSha = integrationSha;
       if (integrationSha !== rebasedSha) {
         await pushWorkerBranchLeaseBestEffort(worktreePath, actualBranch, integrationSha, rebasedSha);
       }
-      const pushLease = await exactPushLeaseForCandidate(lane.repoPath, originBaseRef, integrationRef);
+      let pushLease = await exactPushLeaseForCandidate(lane.repoPath, originBaseRef, integrationRef);
       if (!pushLease.safe) return createFastForwardFailureApproval(input, new Error(`${originBaseRef} is no longer an ancestor of the exact reviewed candidate.`));
+
+      let governedCandidate;
+      try {
+        governedCandidate = await prepareGovernedMergeCandidate({
+          repoPath: lane.repoPath,
+          baseBranch: lane.baseBranch,
+          candidateRef: integrationRef,
+          candidateSha: integrationSha,
+          originBaseRef,
+          commitMessage: command.commitMessage,
+        });
+      } catch (error) {
+        return createFastForwardFailureApproval(input, error);
+      }
+      if (!governedCandidate.ok) {
+        setLaneStatus(command.laneId, 'reviewing', 'system', 'wip_commit_requires_message');
+        return { ok: false, laneId: command.laneId, note: governedCandidate.note };
+      }
+      mergeCandidateSha = governedCandidate.candidateSha;
+      if (governedCandidate.squashed) {
+        await pushWorkerBranchLeaseBestEffort(
+          lane.repoPath,
+          actualBranch,
+          mergeCandidateSha,
+          integrationSha,
+        );
+        pushLease = await exactPushLeaseForCandidate(lane.repoPath, originBaseRef, integrationRef);
+        if (!pushLease.safe) return createFastForwardFailureApproval(input, new Error(`${originBaseRef} is no longer an ancestor of the governed squash candidate.`));
+      }
       expectedRemoteBaseSha = pushLease.expectedRemoteSha;
 
       const finalGovernanceDrift = await rejectSpokenReviewGovernanceDrift({
@@ -575,7 +689,7 @@ async function performWorktreeSideMergeInner(input: WorktreeSideMergeInput): Pro
           repoPath: lane.repoPath,
           baseBranch: lane.baseBranch,
           candidateRef: integrationRef,
-          candidateSha: integrationSha,
+          candidateSha: mergeCandidateSha,
         });
       } catch (error) {
         return createFastForwardFailureApproval(input, error);
@@ -609,7 +723,7 @@ async function performWorktreeSideMergeInner(input: WorktreeSideMergeInput): Pro
       lane,
       worktreeId,
       pushedToOrigin,
-      mergedEquivalentHeadSha: spokenEvidence.present ? reviewedSnapshotSha : undefined,
+      mergedEquivalentHeadSha,
     });
     setLaneStatus(command.laneId, 'completed', actor, pushedToOrigin ? 'merged_pushed' : 'merged');
 

--- a/tests/approve-and-merge-squash-real-path.test.ts
+++ b/tests/approve-and-merge-squash-real-path.test.ts
@@ -73,7 +73,14 @@ function commitAll(cwd: string, message: string): string {
   return git(cwd, ['rev-parse', 'HEAD']);
 }
 
-async function createFixture(label: string) {
+async function createFixture(
+  label: string,
+  workingSubjects = [
+    'fix: add first packet change',
+    'wip: preserve intermediate packet state',
+    'fix: finalize packet state',
+  ],
+) {
   const root = mkdtempSync(join(os.tmpdir(), `o8-governed-squash-${label}-`));
   const origin = join(root, 'origin.git');
   const repo = join(root, 'operator');
@@ -101,11 +108,6 @@ async function createFixture(label: string) {
   });
   git(worktree.path, ['config', 'user.name', 'o8-test']);
   git(worktree.path, ['config', 'user.email', 'o8@example.test']);
-  const workingSubjects = [
-    'fix: add first packet change',
-    'wip: preserve intermediate packet state',
-    'fix: finalize packet state',
-  ];
   writeFileSync(join(worktree.path, 'first.txt'), 'first\n');
   commitAll(worktree.path, workingSubjects[0]!);
   writeFileSync(join(worktree.path, 'intermediate.txt'), 'intermediate\n');
@@ -250,5 +252,22 @@ describe('approve_and_merge governed squash through the route handler', () => {
     expect(git(fixture.repo, ['log', '-1', '--format=%s', 'refs/heads/main']))
       .toBe('fix: finalize packet state');
     expect(baseSubjects(fixture.repo)).not.toEqual(expect.arrayContaining(fixture.workingSubjects));
+  }, 60_000);
+
+  it('preserves clean multi-commit history when no message is supplied', async () => {
+    const workingSubjects = [
+      'fix: add preserved packet change',
+      'chore: refine preserved packet change',
+      'fix: finalize preserved packet change',
+    ];
+    const fixture = await createFixture('preserve-history', workingSubjects);
+
+    const response = await mergeRoute.POST(mergeRequest(fixture.packetId));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({ ok: true, result: { merged: true } });
+    expect(git(fixture.repo, ['rev-list', '--count', `${fixture.baseSha}..refs/heads/main`])).toBe('3');
+    expect(baseSubjects(fixture.repo)).toEqual(expect.arrayContaining(workingSubjects));
   }, 60_000);
 });

--- a/tests/approve-and-merge-squash-real-path.test.ts
+++ b/tests/approve-and-merge-squash-real-path.test.ts
@@ -1,0 +1,254 @@
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+
+const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-governed-squash-'));
+const originalDataDir = process.env.CORTEX_IDE_DATA_DIR;
+const originalO8DataDir = process.env.O8_DATA_DIR;
+const originalSkipTypecheck = process.env.O8_SKIP_PRELAUNCH_TYPECHECK;
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.O8_DATA_DIR = dataDir;
+process.env.O8_SKIP_PRELAUNCH_TYPECHECK = '1';
+
+vi.mock('@/lib/realtime/publisher', () => ({
+  publishRealtimeMutation: vi.fn(async () => {}),
+}));
+
+vi.mock('@/lib/worktree/storage-telemetry', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/worktree/storage-telemetry')>(),
+  measureHostVolume: vi.fn(async () => ({
+    accountingStatus: 'observed' as const,
+    probePath: '/',
+    availableBytes: 90_000_000_000,
+    freeBytes: 90_000_000_000,
+    totalBytes: 100_000_000_000,
+    error: null,
+  })),
+}));
+
+const mergeRoute = await import('@/app/api/orchestrator/merge/route');
+const { recordOrchestratorReview } = await import('@/lib/approvals/store');
+const { AGENT_COMMIT_TRAILER } = await import('@/lib/lane/commit-attribution');
+const { createLane } = await import('@/lib/lane/registry');
+const { recordMission } = await import('@/lib/db/missions-store');
+const { writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+const {
+  createEmptyOrchestratorMissionState,
+  normalizeOrchestratorMissionState,
+} = await import('@/lib/orchestrator/store');
+const { __resetIdempotencyStoreForTests } = await import('@/lib/orchestrator/idempotency-store');
+const { updateOperatorDefaults } = await import('@/lib/operator/defaults');
+const { getWorktreeManager } = await import('@/lib/worktree/launch');
+const { getOrCreateWsToken } = await import('@/lib/ws-auth');
+
+const roots: string[] = [];
+
+function restoreEnv(key: 'CORTEX_IDE_DATA_DIR' | 'O8_DATA_DIR' | 'O8_SKIP_PRELAUNCH_TYPECHECK', value: string | undefined) {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function commitAll(cwd: string, message: string): string {
+  git(cwd, ['add', '-A']);
+  git(cwd, [
+    '-c', 'user.name=o8-test',
+    '-c', 'user.email=o8@example.test',
+    'commit', '-m', message,
+  ]);
+  return git(cwd, ['rev-parse', 'HEAD']);
+}
+
+async function createFixture(label: string) {
+  const root = mkdtempSync(join(os.tmpdir(), `o8-governed-squash-${label}-`));
+  const origin = join(root, 'origin.git');
+  const repo = join(root, 'operator');
+  const packetId = `pkt-governed-squash-${label}-${Date.now()}`;
+  const branch = `inline/governed-squash-${label}-${Date.now()}`;
+  roots.push(root);
+
+  execFileSync('git', ['init', '--bare', origin], { stdio: 'pipe' });
+  execFileSync('git', ['clone', origin, repo], { stdio: 'pipe' });
+  git(repo, ['checkout', '-b', 'main']);
+  git(repo, ['config', 'user.name', 'o8-test']);
+  git(repo, ['config', 'user.email', 'o8@example.test']);
+  writeFileSync(join(repo, 'base.txt'), 'base\n');
+  const baseSha = commitAll(repo, 'chore: initialize fixture');
+  git(repo, ['push', '-u', 'origin', 'main']);
+
+  const worktree = await getWorktreeManager(repo).create({
+    agentType: 'codex',
+    taskName: packetId,
+    branchName: branch,
+    baseBranch: 'main',
+    packetId,
+    skipSetup: true,
+    isolationPreference: 'git-worktree',
+  });
+  git(worktree.path, ['config', 'user.name', 'o8-test']);
+  git(worktree.path, ['config', 'user.email', 'o8@example.test']);
+  const workingSubjects = [
+    'fix: add first packet change',
+    'wip: preserve intermediate packet state',
+    'fix: finalize packet state',
+  ];
+  writeFileSync(join(worktree.path, 'first.txt'), 'first\n');
+  commitAll(worktree.path, workingSubjects[0]!);
+  writeFileSync(join(worktree.path, 'intermediate.txt'), 'intermediate\n');
+  commitAll(worktree.path, workingSubjects[1]!);
+  writeFileSync(join(worktree.path, 'final.txt'), 'final\n');
+  const reviewedHeadSha = commitAll(worktree.path, workingSubjects[2]!);
+
+  createLane({
+    repoPath: repo,
+    worktreePath: worktree.path,
+    branch,
+    baseBranch: 'main',
+    runtime: 'codex',
+    packetId,
+    sessionKey: `codex:${packetId}`,
+    label: `Governed squash ${label}`,
+  });
+  recordOrchestratorReview(packetId, {
+    approved: true,
+    findings: [],
+    reviewer: 'codex',
+    reviewedHeadSha,
+    requiresSecondPass: false,
+  });
+
+  const packet = {
+    id: packetId,
+    referenceLabel: 'P1',
+    title: `Governed squash ${label}`,
+    summary: `Governed squash ${label}`,
+    status: 'awaiting_review',
+    queueState: 'held',
+    releaseState: 'pending',
+    runtime: 'codex',
+    wave: 1,
+    dependencyPacketIds: [],
+    dependencyLabels: [],
+    blockedReason: null,
+    lane: null,
+    review: {
+      approved: true,
+      findings: [],
+      recordedAt: new Date().toISOString(),
+      reviewedHeadSha,
+      summary: 'Approved. No findings recorded.',
+      auditApprovalId: null,
+    },
+    workspaceTargetPath: repo,
+    branchTarget: branch,
+  } as OrchestratorPacket;
+  const missionState = normalizeOrchestratorMissionState({
+    version: 2,
+    missionId: `mission-${packetId}`,
+    prompt: packet.summary,
+    summary: packet.summary,
+    repoPath: repo,
+    runtime: 'codex',
+    constraints: '',
+    packets: [packet],
+    updatedAt: new Date().toISOString(),
+  });
+  recordMission({
+    id: missionState.missionId!,
+    repoPath: repo,
+    runtime: 'codex',
+    prompt: missionState.prompt,
+    summary: missionState.summary,
+    constraints: '',
+    packetMeta: [{ id: packetId, title: packet.title, referenceLabel: packet.referenceLabel }],
+    missionState,
+    totalWaves: 1,
+  });
+  writeOrchestratorControlPlaneState(missionState);
+  return { baseSha, origin, packetId, repo, reviewedHeadSha, workingSubjects };
+}
+
+function mergeRequest(packetId: string, commitMessage?: string): NextRequest {
+  return new NextRequest('http://localhost:3001/api/orchestrator/merge', {
+    method: 'POST',
+    headers: {
+      host: 'localhost:3001',
+      authorization: `Bearer ${getOrCreateWsToken()}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ packetId, commitMessage, idempotencyKey: randomUUID() }),
+  });
+}
+
+function baseSubjects(repo: string): string[] {
+  return git(repo, ['log', '--format=%s', 'refs/heads/main']).split('\n');
+}
+
+beforeAll(async () => {
+  await updateOperatorDefaults({
+    commitAttributionEnabled: true,
+    productTelemetryEnabled: false,
+    storageReserveRatio: 0.0001,
+    storageReserveFloorGb: 0.001,
+  });
+});
+
+afterEach(() => {
+  writeOrchestratorControlPlaneState(createEmptyOrchestratorMissionState());
+  __resetIdempotencyStoreForTests();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+afterAll(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+  restoreEnv('CORTEX_IDE_DATA_DIR', originalDataDir);
+  restoreEnv('O8_DATA_DIR', originalO8DataDir);
+  restoreEnv('O8_SKIP_PRELAUNCH_TYPECHECK', originalSkipTypecheck);
+});
+
+describe('approve_and_merge governed squash through the route handler', () => {
+  it('lands one attributed commit with the explicit message', async () => {
+    const fixture = await createFixture('explicit-message');
+    const commitMessage = 'fix: land the reviewed packet as one commit';
+
+    const response = await mergeRoute.POST(mergeRequest(fixture.packetId, commitMessage));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({ ok: true, result: { merged: true } });
+    expect(git(fixture.repo, ['rev-list', '--count', `${fixture.baseSha}..refs/heads/main`])).toBe('1');
+    expect(git(fixture.repo, ['log', '-1', '--format=%s', 'refs/heads/main'])).toBe(commitMessage);
+    expect(git(fixture.repo, ['log', '-1', '--format=%B', 'refs/heads/main'])).toContain(AGENT_COMMIT_TRAILER);
+    expect(baseSubjects(fixture.repo)).not.toEqual(expect.arrayContaining(fixture.workingSubjects));
+    expect(git(fixture.repo, ['ls-remote', '--heads', fixture.origin, 'main']).split(/\s+/)[0])
+      .toBe(payload.result.mergeSha);
+  }, 60_000);
+
+  it('squashes wip history to the final non-wip subject when no message is supplied', async () => {
+    const fixture = await createFixture('implicit-message');
+
+    const response = await mergeRoute.POST(mergeRequest(fixture.packetId));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({ ok: true, result: { merged: true } });
+    expect(git(fixture.repo, ['rev-list', '--count', `${fixture.baseSha}..refs/heads/main`])).toBe('1');
+    expect(git(fixture.repo, ['log', '-1', '--format=%s', 'refs/heads/main']))
+      .toBe('fix: finalize packet state');
+    expect(baseSubjects(fixture.repo)).not.toEqual(expect.arrayContaining(fixture.workingSubjects));
+  }, 60_000);
+});

--- a/tests/remote-governed-squash-real-path.test.ts
+++ b/tests/remote-governed-squash-real-path.test.ts
@@ -1,0 +1,177 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import type { Lane } from '@/lib/lane/types';
+
+const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-remote-governed-squash-'));
+const originalDataDir = process.env.CORTEX_IDE_DATA_DIR;
+const originalO8DataDir = process.env.O8_DATA_DIR;
+const originalCommitAttribution = process.env.O8_COMMIT_ATTRIBUTION;
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.O8_DATA_DIR = dataDir;
+process.env.O8_COMMIT_ATTRIBUTION = '1';
+
+vi.mock('@/lib/realtime/publisher', () => ({
+  publishRealtimeMutation: vi.fn(async () => {}),
+}));
+
+const { AGENT_COMMIT_TRAILER } = await import('@/lib/lane/commit-attribution');
+const { performRemoteCustomerMerge } = await import('@/lib/lane/commands-remote-merge');
+const { createLane } = await import('@/lib/lane/registry');
+const { CustomerWorkerTransport } = await import('@/lib/runtimes/remote/customer-worker-transport');
+const { createToken } = await import('@/lib/worker/tokens');
+
+const roots: string[] = [];
+const transport = new CustomerWorkerTransport();
+
+function restoreEnv(
+  key: 'CORTEX_IDE_DATA_DIR' | 'O8_DATA_DIR' | 'O8_COMMIT_ATTRIBUTION',
+  value: string | undefined,
+) {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function commitAll(cwd: string, message: string): string {
+  git(cwd, ['add', '-A']);
+  git(cwd, [
+    '-c', 'user.name=o8-test',
+    '-c', 'user.email=o8@example.test',
+    'commit', '-m', message,
+  ]);
+  return git(cwd, ['rev-parse', 'HEAD']);
+}
+
+async function createFixture(label: string, conflict: boolean) {
+  const root = mkdtempSync(join(os.tmpdir(), `o8-remote-governed-${label}-`));
+  const origin = join(root, 'origin.git');
+  const repo = join(root, 'operator');
+  const worker = join(root, 'worker');
+  const remoteBranch = `packet/remote-${label}-${Date.now()}`;
+  const savedBranch = `operator/${label}-${Date.now()}`;
+  roots.push(root);
+
+  execFileSync('git', ['init', '--bare', origin], { stdio: 'pipe' });
+  execFileSync('git', ['clone', origin, repo], { stdio: 'pipe' });
+  git(repo, ['checkout', '-b', 'main']);
+  git(repo, ['config', 'user.name', 'o8-test']);
+  git(repo, ['config', 'user.email', 'o8@example.test']);
+  writeFileSync(join(repo, 'shared.txt'), 'base\n');
+  const baseSha = commitAll(repo, 'chore: initialize remote fixture');
+  git(repo, ['push', '-u', 'origin', 'main']);
+
+  execFileSync('git', ['clone', origin, worker], { stdio: 'pipe' });
+  git(worker, ['checkout', '-b', remoteBranch, 'origin/main']);
+  git(worker, ['config', 'user.name', 'o8-test']);
+  git(worker, ['config', 'user.email', 'o8@example.test']);
+  if (conflict) {
+    writeFileSync(join(worker, 'shared.txt'), 'remote\n');
+    commitAll(worker, 'fix: change shared file remotely');
+  } else {
+    writeFileSync(join(worker, 'first.txt'), 'first\n');
+    commitAll(worker, 'fix: add first remote change');
+    writeFileSync(join(worker, 'second.txt'), 'second\n');
+    commitAll(worker, 'fix: add second remote change');
+  }
+  git(worker, ['push', '-u', 'origin', remoteBranch]);
+
+  if (conflict) {
+    writeFileSync(join(repo, 'shared.txt'), 'local\n');
+    commitAll(repo, 'fix: change shared file locally');
+    git(repo, ['push', 'origin', 'main']);
+  }
+  const preMergeMainSha = git(repo, ['rev-parse', 'refs/heads/main']);
+  git(repo, ['checkout', '-b', savedBranch]);
+
+  const lane = createLane({
+    repoPath: repo,
+    branch: remoteBranch,
+    baseBranch: 'main',
+    runtime: 'remote-customer' as Lane['runtime'],
+    packetId: `pkt-remote-${label}-${Date.now()}`,
+    label: `Remote governed merge ${label}`,
+  });
+  const runId = `run-remote-${label}-${Date.now()}`;
+  const launched = await transport.sendLaunch({
+    runId,
+    laneId: lane.id,
+    repoUrl: origin,
+    baseRef: 'main',
+    remoteBranch,
+    packetPrompt: 'Exercise governed remote merge history.',
+  });
+  expect(launched.accepted).toBe(true);
+
+  return { baseSha, lane, origin, preMergeMainSha, repo, savedBranch };
+}
+
+beforeAll(() => {
+  createToken({
+    label: 'Remote merge fixture token',
+    scope: 'global',
+    maxWorkers: 2,
+  });
+});
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+afterAll(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+  restoreEnv('CORTEX_IDE_DATA_DIR', originalDataDir);
+  restoreEnv('O8_DATA_DIR', originalO8DataDir);
+  restoreEnv('O8_COMMIT_ATTRIBUTION', originalCommitAttribution);
+});
+
+describe('remote governed squash with real repositories', () => {
+  it('restores the saved checkout after a squash conflict', async () => {
+    const fixture = await createFixture('conflict', true);
+
+    const result = await performRemoteCustomerMerge(fixture.lane, {
+      verb: 'merge',
+      laneId: fixture.lane.id,
+      commitMessage: 'fix: squash conflicting remote packet',
+    }, 'user');
+
+    expect(result).toMatchObject({ ok: false, laneId: fixture.lane.id });
+    expect(result.note).toContain('Conflicting files:');
+    expect(result.note).toContain('shared.txt');
+    expect(git(fixture.repo, ['status', '--porcelain'])).toBe('');
+    expect(git(fixture.repo, ['rev-parse', '--abbrev-ref', 'HEAD'])).toBe(fixture.savedBranch);
+    expect(git(fixture.repo, ['rev-parse', 'refs/heads/main'])).toBe(fixture.preMergeMainSha);
+  }, 30_000);
+
+  it('lands one attributed commit with the explicit message', async () => {
+    const fixture = await createFixture('success', false);
+    const commitMessage = 'fix: squash remote packet history';
+
+    const result = await performRemoteCustomerMerge(fixture.lane, {
+      verb: 'merge',
+      laneId: fixture.lane.id,
+      commitMessage,
+    }, 'user');
+
+    expect(result).toMatchObject({ ok: true, pushedToOrigin: true });
+    expect(git(fixture.repo, ['status', '--porcelain'])).toBe('');
+    expect(git(fixture.repo, ['rev-parse', '--abbrev-ref', 'HEAD'])).toBe(fixture.savedBranch);
+    expect(git(fixture.repo, ['rev-list', '--count', `${fixture.baseSha}..refs/heads/main`])).toBe('1');
+    expect(git(fixture.repo, ['log', '-1', '--format=%s', 'refs/heads/main'])).toBe(commitMessage);
+    expect(git(fixture.repo, ['log', '-1', '--format=%B', 'refs/heads/main']))
+      .toContain(AGENT_COMMIT_TRAILER);
+    expect(git(fixture.repo, ['ls-remote', '--heads', fixture.origin, 'main']).split(/\s+/)[0])
+      .toBe(git(fixture.repo, ['rev-parse', 'refs/heads/main']));
+  }, 30_000);
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2046,6 +2046,14 @@
       ]
     },
     {
+      "path": "tests/remote-governed-squash-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/repo-package-manager-contract-real-path.test.ts",
       "reasons": [
         "child-process",

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -946,6 +946,15 @@
       ]
     },
     {
+      "path": "tests/approve-and-merge-squash-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path",
+        "worktree-api"
+      ]
+    },
+    {
       "path": "tests/attempt-learnings-respawn.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
Fixes #2017.

`approve_and_merge` accepted a `commitMessage` and still pushed the packet branch's raw working commits to main — four commits from one packet landed, including a `wip:` subject that is now permanent on the default branch.

## Change

- New `src/lib/lane/governed-merge-history.ts`: resolves a history plan for a governed merge. An explicit `commitMessage` always squashes to one attributed commit with that message. Without one, a history containing `wip:` subjects squashes to the final non-wip subject, and a history that is *only* wip commits is refused with a note naming the commit and asking for a message (lane returns to `reviewing` with `wip_commit_requires_message`). Clean histories without a message keep today's behaviour.
- `worktree-side-merge.ts`: the squash rewrites the integration ref with `git commit-tree <candidate-tree> -p <base> -m <message>` plus a compare-and-swap `update-ref`, so the merged tree is byte-identical to the reviewed candidate; the push lease is re-taken after the rewrite, and the pre-squash head is recorded as merged-equivalent so branch-ancestry cleanup still recognizes the packet branch.
- The remote-customer merge path applies the same plan via `merge --squash`, with the commit message run through the attribution helper. Because `--squash` sets no `MERGE_HEAD`, its conflict cleanup uses `git reset --merge` (falling back to `git reset --hard` at the recorded pre-merge head) instead of `merge --abort`, so a conflicted squash leaves the operator checkout clean, on the saved branch, with main untouched.

## Verification

Real-path test through the actual merge route handler: a packet branch with three commits (`fix:`, `wip:`, `fix:`) merged with an explicit message → main gains exactly one commit with that subject and the attribution trailer, none of the working subjects appear in main's log, and origin main matches the returned merge sha; the same shape merged without a message squashes to the final non-wip subject, and a clean multi-commit history without a message keeps all its commits. A second real-path suite drives the remote-customer merge: a conflicted squash returns the conflict note and leaves the repo clean on the saved branch; a passing remote squash lands one attributed commit. `npx tsc --noEmit` clean, `npm run lint` exit 0 at cap, rule-check clean.
