### PR TITLE
fix(dispatch): allow internal dependency hardlinks in the provisioning audit

### DIFF
--- a/src/lib/workspace/dependency-image-source-authority.ts
+++ b/src/lib/workspace/dependency-image-source-authority.ts
@@ -59,6 +59,7 @@ export function dependencyPathInside(candidate: string, root: string): boolean {
 export async function digestDependencyTree(root: string): Promise<string> {
   const canonicalRoot = await realpath(root);
   const hash = createHash('sha256');
+  const hardlinks = new Map<string, { path: string; nlink: number; internal: number }>();
   async function walk(candidate: string, relative: string): Promise<void> {
     const entry = await lstat(candidate);
     const normalized = relative.replaceAll(path.sep, '/');
@@ -88,9 +89,6 @@ export async function digestDependencyTree(root: string): Promise<string> {
       return;
     }
     if (entry.isFile()) {
-      if (entry.nlink !== 1) {
-        throw new DependencyImageRefusalError(`Dependency image contains a shared hardlink: ${normalized}`);
-      }
       hash.update('file\0');
       hash.update(await readFile(candidate));
       const after = await lstat(candidate);
@@ -98,6 +96,14 @@ export async function digestDependencyTree(root: string): Promise<string> {
         || after.mode !== entry.mode || after.nlink !== entry.nlink
         || after.mtimeMs !== entry.mtimeMs || after.ctimeMs !== entry.ctimeMs) {
         throw new DependencyImageRefusalError(`Dependency image source changed during validation: ${normalized}`);
+      }
+      const key = `${entry.dev}:${entry.ino}`;
+      const audited = hardlinks.get(key);
+      if (audited) {
+        audited.internal += 1;
+        audited.nlink = Math.max(audited.nlink, entry.nlink);
+      } else {
+        hardlinks.set(key, { path: normalized, nlink: entry.nlink, internal: 1 });
       }
       return;
     }
@@ -118,6 +124,13 @@ export async function digestDependencyTree(root: string): Promise<string> {
     }
   }
   await walk(root, '');
+  for (const audited of hardlinks.values()) {
+    if (audited.nlink > 1 && audited.internal < audited.nlink) {
+      throw new DependencyImageRefusalError(
+        `Dependency image contains a shared hardlink: ${audited.path} (nlink=${audited.nlink}, internal=${audited.internal})`,
+      );
+    }
+  }
   return hash.digest('hex');
 }
 

--- a/src/lib/workspace/dependency-install.test.ts
+++ b/src/lib/workspace/dependency-install.test.ts
@@ -22,6 +22,7 @@ import {
   runDependencyInstall,
   type SupportedPackageManager,
 } from './dependency-install';
+import { digestDependencyTree } from './dependency-image-source-authority';
 
 const roots: string[] = [];
 const versions: Record<SupportedPackageManager, string> = {
@@ -377,22 +378,50 @@ describe('package-manager-native dependency install contract', { timeout: 30_000
     })).rejects.toThrow(/escapes its workspace/);
   });
 
-  it('refuses external links and shared hardlinks in an installed view', async () => {
+  it('allows two installed paths to share one inode inside the private view', async () => {
+    const workspace = fixture('npm');
+    const platformBinary = path.join(workspace, 'node_modules', 'platform', 'bin', 'tool');
+    const wrapperBinary = path.join(workspace, 'node_modules', 'wrapper', 'bin', 'tool');
+    mkdirSync(path.dirname(platformBinary), { recursive: true });
+    mkdirSync(path.dirname(wrapperBinary), { recursive: true });
+    writeFileSync(platformBinary, 'internal hardlink\n');
+    linkSync(platformBinary, wrapperBinary);
+
+    await expect(auditPrivateDependencyView(workspace)).resolves.toBeUndefined();
+    await expect(digestDependencyTree(path.join(workspace, 'node_modules'))).resolves.toMatch(
+      /^[0-9a-f]{64}$/,
+    );
+  });
+
+  it('refuses an installed file with a hardlink outside the private view', async () => {
     const workspace = fixture('npm');
     const external = path.join(path.dirname(workspace), `${path.basename(workspace)}-outside`);
     roots.push(external);
     mkdirSync(external);
     writeFileSync(path.join(external, 'shared.js'), 'shared\n');
     mkdirSync(path.join(workspace, 'node_modules', 'fixture'), { recursive: true });
-    symlinkSync(external, path.join(workspace, 'node_modules', 'external'));
-    await expect(auditPrivateDependencyView(workspace)).rejects.toThrow(/escapes/);
-
-    rmSync(path.join(workspace, 'node_modules', 'external'));
     linkSync(
       path.join(external, 'shared.js'),
       path.join(workspace, 'node_modules', 'fixture', 'shared.js'),
     );
-    await expect(auditPrivateDependencyView(workspace)).rejects.toThrow(/shared hardlink/);
+
+    await expect(auditPrivateDependencyView(workspace)).rejects.toThrow(
+      /shared hardlink: node_modules\/fixture\/shared\.js \(nlink=2, internal=1\)/,
+    );
+    await expect(digestDependencyTree(path.join(workspace, 'node_modules'))).rejects.toThrow(
+      /shared hardlink: fixture\/shared\.js \(nlink=2, internal=1\)/,
+    );
+  });
+
+  it('still refuses a symlink that escapes the private workspace', async () => {
+    const workspace = fixture('npm');
+    const external = path.join(path.dirname(workspace), `${path.basename(workspace)}-outside`);
+    roots.push(external);
+    mkdirSync(external);
+    mkdirSync(path.join(workspace, 'node_modules'), { recursive: true });
+    symlinkSync(external, path.join(workspace, 'node_modules', 'external'));
+
+    await expect(auditPrivateDependencyView(workspace)).rejects.toThrow(/escapes/);
   });
 
   it.each([

--- a/src/lib/workspace/dependency-install.ts
+++ b/src/lib/workspace/dependency-install.ts
@@ -667,7 +667,17 @@ async function defaultRun(
   });
 }
 
-async function auditInstalledEntry(workspacePath: string, absolutePath: string): Promise<void> {
+interface InstalledHardlinkAudit {
+  path: string;
+  nlink: number;
+  internal: number;
+}
+
+async function auditInstalledEntry(
+  workspacePath: string,
+  absolutePath: string,
+  hardlinks: Map<string, InstalledHardlinkAudit>,
+): Promise<void> {
   const entry = await lstat(absolutePath);
   if (entry.isSymbolicLink()) {
     const target = await realpath(absolutePath);
@@ -676,13 +686,21 @@ async function auditInstalledEntry(workspacePath: string, absolutePath: string):
     }
     return;
   }
-  if (entry.isFile() && entry.nlink > 1) {
-    throw new Error(`Installed dependency uses a shared hardlink: ${path.relative(workspacePath, absolutePath)}`);
+  if (entry.isFile()) {
+    const key = `${entry.dev}:${entry.ino}`;
+    const audited = hardlinks.get(key);
+    if (audited) {
+      audited.internal += 1;
+      audited.nlink = Math.max(audited.nlink, entry.nlink);
+    } else {
+      hardlinks.set(key, { path: absolutePath, nlink: entry.nlink, internal: 1 });
+    }
+    return;
   }
   if (!entry.isDirectory()) return;
   const children = await readdir(absolutePath);
   for (const child of children) {
-    await auditInstalledEntry(workspacePath, path.join(absolutePath, child));
+    await auditInstalledEntry(workspacePath, path.join(absolutePath, child), hardlinks);
   }
 }
 
@@ -700,7 +718,15 @@ export async function auditPrivateDependencyView(workspacePath: string): Promise
   if (!root.isDirectory() || root.isSymbolicLink() || (root.mode & 0o200) === 0) {
     throw new Error('Installed dependency view is not a private writable directory.');
   }
-  await auditInstalledEntry(workspacePath, nodeModules);
+  const hardlinks = new Map<string, InstalledHardlinkAudit>();
+  await auditInstalledEntry(workspacePath, nodeModules, hardlinks);
+  for (const audited of hardlinks.values()) {
+    if (audited.nlink > 1 && audited.internal < audited.nlink) {
+      throw new Error(
+        `Installed dependency uses a shared hardlink: ${path.relative(workspacePath, audited.path)} (nlink=${audited.nlink}, internal=${audited.internal})`,
+      );
+    }
+  }
 }
 
 export async function runDependencyInstall(


### PR DESCRIPTION
Fixes #2024.

The private-view install audit refused any regular file with `nlink > 1`, and esbuild's install links its wrapper binary to the platform package binary inside the same `node_modules` — so every fresh packet install of this repo (npm 11) failed provisioning with `Installed dependency uses a shared hardlink`, killing the lane with no retry. The blanket check also condemned the same shape during dependency-image digesting.

## Change

- `auditPrivateDependencyView` / `auditInstalledEntry`: the walk now collects `(dev, ino) → {nlink, internal count}` for regular files; a multi-linked file only refuses when its audited-path count is **less** than its `nlink` — meaning a link exists outside the view. Internal hardlinks (the esbuild shape) pass. Refusal messages carry `nlink=N, internal=M`.
- `digestDependencyTree` (image source authority) applies the same internal-vs-external distinction after the walk, so a read-only image built from an audited tree accepts its own internal links while still refusing externally shared content.
- The symlink-escape refusal is unchanged.

## Verification

Tests: two installed paths sharing one inode inside the view pass both the audit and the image digest; a file hardlinked to a path outside the view refuses in both with the counted message; an escaping symlink still refuses. Dependency-install/materializer suites 55/55, APFS image real-path 10/10, `npx tsc --noEmit` clean, `npm run lint` exit 0, rule-check clean.


Note: `tests/apfs-dependency-image-real-path.test.ts` has one pre-existing failure on this machine (`waits for a live concurrent publisher…`, publisher child never reaches its staging boundary) that reproduces identically on the merge base — unrelated to this change; the other 9 cases pass.
