### PR TITLE
feat(cli): headless o8 serve daemon (#2022 phase 1)

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1,0 +1,611 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+import { spawn, type ChildProcess } from 'node:child_process';
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { createServer, Socket } from 'node:net';
+import { dirname, join, parse } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { CliError, EXIT } from '../api.js';
+import { resolveCliDataDir } from '../config.js';
+import { printHumanKv, printJson, type OutputMode } from '../output.js';
+
+const PROD_API_PORT_BLOCK = [47100, 47101, 47102, 47103, 47104] as const;
+const PROD_WS_PORT_BLOCK = [47105, 47106, 47107, 47108, 47109] as const;
+const START_TIMEOUT_MS = 60_000;
+const STOP_TIMEOUT_MS = 8_000;
+const POLL_MS = 100;
+
+type ServeMode = 'development' | 'packaged';
+type ServeStatus = 'starting' | 'ready' | 'stopping' | 'failed';
+
+interface ServeChildState {
+  role: 'api' | 'ws';
+  pid: number;
+}
+
+interface ServeState {
+  schema: 'o8/serve-state/v1';
+  pid: number;
+  apiPort: number;
+  wsPort: number;
+  mode: ServeMode;
+  root: string;
+  startedAt: string;
+  status: ServeStatus;
+  children: ServeChildState[];
+  error?: string;
+}
+
+interface ServePaths {
+  dataDir: string;
+  pidFile: string;
+  stateFile: string;
+  apiPortFile: string;
+  wsPortFile: string;
+  tokenFile: string;
+  logFile: string;
+}
+
+interface LaunchPlan {
+  mode: ServeMode;
+  root: string;
+  api: { command: string; args: string[] };
+  ws: { command: string; args: string[] };
+}
+
+function servePaths(): ServePaths {
+  const dataDir = resolveCliDataDir();
+  return {
+    dataDir,
+    pidFile: join(dataDir, 'serve.pid'),
+    stateFile: join(dataDir, 'serve-state.json'),
+    apiPortFile: join(dataDir, 'api-port'),
+    wsPortFile: join(dataDir, 'ws-port'),
+    tokenFile: join(dataDir, 'ws-token'),
+    logFile: join(dataDir, 'logs', 'serve.log'),
+  };
+}
+
+function parsePid(raw: string): number | null {
+  const pid = Number.parseInt(raw.trim(), 10);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+function readOwnerPid(paths: ServePaths): number | null {
+  try {
+    return parsePid(readFileSync(paths.pidFile, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readState(paths: ServePaths): ServeState | null {
+  try {
+    const parsed = JSON.parse(readFileSync(paths.stateFile, 'utf8')) as ServeState;
+    return parsed?.schema === 'o8/serve-state/v1' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeState(paths: ServePaths, state: ServeState): void {
+  const temporary = `${paths.stateFile}.${process.pid}.tmp`;
+  writeFileSync(temporary, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+  renameSync(temporary, paths.stateFile);
+}
+
+function cleanStaleOwner(paths: ServePaths): void {
+  const pid = readOwnerPid(paths);
+  if (pid && processAlive(pid)) return;
+  rmSync(paths.pidFile, { force: true });
+  rmSync(paths.stateFile, { force: true });
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+async function portAcceptsConnections(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = new Socket();
+    const finish = (value: boolean) => {
+      socket.destroy();
+      resolve(value);
+    };
+    socket.setTimeout(300);
+    socket.once('connect', () => finish(true));
+    socket.once('timeout', () => finish(false));
+    socket.once('error', () => finish(false));
+    socket.connect(port, '127.0.0.1');
+  });
+}
+
+async function apiIsReady(port: number): Promise<boolean> {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/setup/identity`, {
+      signal: AbortSignal.timeout(500),
+    });
+    if (!response.ok) return false;
+    const body = await response.json() as { product?: unknown };
+    return body.product === 'o8';
+  } catch {
+    return false;
+  }
+}
+
+async function takeAvailablePort(candidates: readonly number[], skip?: number): Promise<number> {
+  for (const candidate of candidates) {
+    if (candidate === skip) continue;
+    // A listener bound on IPv6 or 0.0.0.0 can coexist with a short-lived
+    // 127.0.0.1 probe on macOS. Check the real connect path before trusting a
+    // successful bind, matching the sidecar's collision guard.
+    if (await portAcceptsConnections(candidate)) continue;
+    const port = await new Promise<number | null>((resolve) => {
+      const server = createServer();
+      server.unref();
+      server.once('error', () => resolve(null));
+      server.listen(candidate, '127.0.0.1', () => {
+        server.close(() => resolve(candidate));
+      });
+    });
+    if (port) return port;
+  }
+  return new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('Failed to allocate an ephemeral port.')));
+        return;
+      }
+      const port = address.port;
+      if (port === skip) {
+        server.close(() => {
+          void takeAvailablePort([], skip).then(resolve, reject);
+        });
+        return;
+      }
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+function findProjectRoot(start: string): string | null {
+  let current = start;
+  const filesystemRoot = parse(current).root;
+  while (true) {
+    if (
+      existsSync(join(current, 'package.json'))
+      && existsSync(join(current, 'src', 'ws-server.ts'))
+      && existsSync(join(current, 'node_modules', 'next', 'dist', 'bin', 'next'))
+      && existsSync(join(current, 'node_modules', 'tsx', 'dist', 'cli.mjs'))
+    ) {
+      return current;
+    }
+    if (current === filesystemRoot) return null;
+    current = dirname(current);
+  }
+}
+
+function resolveLaunchPlan(): LaunchPlan {
+  const cliEntry = fileURLToPath(import.meta.url);
+  const bundledServerDir = dirname(dirname(cliEntry));
+  const bundledApi = join(bundledServerDir, 'server.js');
+  const bundledWs = join(bundledServerDir, 'ws-server.mjs');
+  if (existsSync(bundledApi) && existsSync(bundledWs)) {
+    return {
+      mode: 'packaged',
+      root: bundledServerDir,
+      api: { command: process.execPath, args: [bundledApi] },
+      ws: { command: process.execPath, args: [bundledWs] },
+    };
+  }
+
+  const configuredRoot = process.env.O8_SERVE_ROOT?.trim();
+  const projectRoot = (configuredRoot && findProjectRoot(configuredRoot))
+    || findProjectRoot(process.cwd())
+    || findProjectRoot(dirname(cliEntry));
+  if (!projectRoot) {
+    throw new CliError(
+      'serve_entries_missing',
+      'Could not find bundled server entries or a source checkout with installed dependencies.',
+      EXIT.NOT_FOUND,
+      'Run from an o8 source checkout after `npm install`, or reinstall the packaged app.',
+    );
+  }
+  return {
+    mode: 'development',
+    root: projectRoot,
+    api: {
+      command: process.execPath,
+      args: [join(projectRoot, 'node_modules', 'next', 'dist', 'bin', 'next'), 'dev'],
+    },
+    ws: {
+      command: process.execPath,
+      args: [join(projectRoot, 'node_modules', 'tsx', 'dist', 'cli.mjs'), 'src/ws-server.ts'],
+    },
+  };
+}
+
+function getOrCreateToken(paths: ServePaths): string {
+  try {
+    const existing = readFileSync(paths.tokenFile, 'utf8').trim();
+    if (existing.length >= 16) return existing;
+  } catch {}
+  const token = randomBytes(32).toString('hex');
+  try {
+    writeFileSync(paths.tokenFile, token, { flag: 'wx', mode: 0o600 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      const existing = readFileSync(paths.tokenFile, 'utf8').trim();
+      if (existing.length >= 16) return existing;
+    }
+    writeFileSync(paths.tokenFile, token, { mode: 0o600 });
+  }
+  return token;
+}
+
+function readOrCreateId(path: string): string {
+  try {
+    const existing = readFileSync(path, 'utf8').trim();
+    if (existing) return existing;
+  } catch {}
+  const id = randomUUID();
+  try {
+    writeFileSync(path, id, { flag: 'wx', mode: 0o600 });
+    return id;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      const existing = readFileSync(path, 'utf8').trim();
+      if (existing) return existing;
+    }
+    throw error;
+  }
+}
+
+function appendNodeImport(existing: string | undefined, path: string): string {
+  const flag = `--import=${path}`;
+  return existing?.trim() ? `${existing.trim()} ${flag}` : flag;
+}
+
+function spawnService(
+  role: ServeChildState['role'],
+  entry: LaunchPlan['api'],
+  plan: LaunchPlan,
+  env: NodeJS.ProcessEnv,
+  apiPort: number,
+): ChildProcess {
+  const args = role === 'api' && plan.mode === 'development'
+    ? [...entry.args, '-p', String(apiPort)]
+    : entry.args;
+  return spawn(entry.command, args, {
+    cwd: plan.root,
+    env,
+    stdio: 'inherit',
+  });
+}
+
+async function waitForDaemonReady(paths: ServePaths, pid: number): Promise<ServeState> {
+  const deadline = Date.now() + START_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const state = readState(paths);
+    if (state?.pid === pid && state.status === 'failed') {
+      throw new CliError('serve_start_failed', state.error ?? 'The daemon failed to start.', EXIT.CONNECTION_REFUSED);
+    }
+    if (
+      state?.pid === pid
+      && state.status === 'ready'
+      && await apiIsReady(state.apiPort)
+      && await portAcceptsConnections(state.wsPort)
+    ) {
+      return state;
+    }
+    if (!processAlive(pid)) break;
+    await wait(POLL_MS);
+  }
+  throw new CliError(
+    'serve_start_failed',
+    'The headless server did not become ready before the startup deadline.',
+    EXIT.CONNECTION_REFUSED,
+    `Inspect ${paths.logFile}.`,
+  );
+}
+
+function outputState(mode: OutputMode, state: ServeState, running: boolean, healthy: boolean): void {
+  const payload = {
+    schema: 'o8/cli/serve-status/v1',
+    running,
+    healthy,
+    pid: state.pid,
+    apiPort: state.apiPort,
+    wsPort: state.wsPort,
+    mode: state.mode,
+    status: state.status,
+    children: state.children,
+    startedAt: state.startedAt,
+  };
+  if (!mode.human) {
+    printJson(payload);
+    return;
+  }
+  printHumanKv([
+    ['running', String(running)],
+    ['healthy', String(healthy)],
+    ['pid', String(state.pid)],
+    ['api', String(state.apiPort)],
+    ['ws', String(state.wsPort)],
+    ['mode', state.mode],
+    ['status', state.status],
+  ]);
+}
+
+async function startServe(mode: OutputMode): Promise<number> {
+  const paths = servePaths();
+  mkdirSync(dirname(paths.logFile), { recursive: true });
+  cleanStaleOwner(paths);
+  const existingPid = readOwnerPid(paths);
+  if (existingPid && processAlive(existingPid)) {
+    throw new CliError(
+      'serve_already_running',
+      `Headless o8 is already running with pid ${existingPid}.`,
+      EXIT.CONFLICT,
+      'Run `o8 serve status` or `o8 serve stop`.',
+    );
+  }
+
+  const plan = resolveLaunchPlan();
+  const previousLog = `${paths.logFile}.prev`;
+  rmSync(previousLog, { force: true });
+  if (existsSync(paths.logFile)) renameSync(paths.logFile, previousLog);
+  const logFd = openSync(paths.logFile, 'a', 0o600);
+  const cliEntry = process.argv[1];
+  const child = spawn(process.execPath, [cliEntry, 'serve', '__daemon'], {
+    cwd: plan.root,
+    detached: true,
+    env: {
+      ...process.env,
+      O8_SERVE_ROOT: plan.root,
+      O8_SERVE_LAUNCH_MODE: plan.mode,
+    },
+    stdio: ['ignore', logFd, logFd],
+  });
+  closeSync(logFd);
+  if (!child.pid) {
+    throw new CliError('serve_spawn_failed', 'Failed to spawn the headless daemon.', EXIT.CONNECTION_REFUSED);
+  }
+  try {
+    writeFileSync(paths.pidFile, String(child.pid), { flag: 'wx', mode: 0o600 });
+  } catch (error) {
+    try { child.kill('SIGTERM'); } catch {}
+    const ownerPid = readOwnerPid(paths);
+    if (ownerPid && processAlive(ownerPid)) {
+      throw new CliError(
+        'serve_already_running',
+        `Headless o8 is already running with pid ${ownerPid}.`,
+        EXIT.CONFLICT,
+      );
+    }
+    throw error;
+  }
+  child.unref();
+  const state = await waitForDaemonReady(paths, child.pid);
+  outputState(mode, state, true, true);
+  return EXIT.OK;
+}
+
+async function statusServe(mode: OutputMode): Promise<number> {
+  const paths = servePaths();
+  const pid = readOwnerPid(paths);
+  const state = readState(paths);
+  if (!pid || !state || state.pid !== pid || !processAlive(pid)) {
+    cleanStaleOwner(paths);
+    const payload = { schema: 'o8/cli/serve-status/v1', running: false, healthy: false };
+    if (mode.human) printHumanKv([['running', 'false'], ['healthy', 'false']]);
+    else printJson(payload);
+    return EXIT.OK;
+  }
+  const healthy = state.status === 'ready'
+    && await apiIsReady(state.apiPort)
+    && await portAcceptsConnections(state.wsPort);
+  outputState(mode, state, true, healthy);
+  return healthy ? EXIT.OK : EXIT.CONNECTION_REFUSED;
+}
+
+async function stopServe(mode: OutputMode): Promise<number> {
+  const paths = servePaths();
+  const pid = readOwnerPid(paths);
+  const state = readState(paths);
+  if (!pid || !processAlive(pid)) {
+    cleanStaleOwner(paths);
+    throw new CliError('serve_not_running', 'Headless o8 is not running.', EXIT.NOT_FOUND);
+  }
+  const trackedPids = [pid, ...(state?.children.map((child) => child.pid) ?? [])];
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch {}
+  const deadline = Date.now() + STOP_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (trackedPids.every((trackedPid) => !processAlive(trackedPid)) && !existsSync(paths.pidFile)) {
+      const payload = { schema: 'o8/cli/serve-stop/v1', stopped: true, pid };
+      if (mode.human) printHumanKv([['stopped', 'true'], ['pid', String(pid)]]);
+      else printJson(payload);
+      return EXIT.OK;
+    }
+    await wait(POLL_MS);
+  }
+  throw new CliError(
+    'serve_stop_failed',
+    `Headless o8 pid ${pid} did not stop cleanly before the shutdown deadline.`,
+    EXIT.CONFLICT,
+    `Inspect ${paths.logFile}.`,
+  );
+}
+
+async function runDaemon(): Promise<number> {
+  const paths = servePaths();
+  mkdirSync(paths.dataDir, { recursive: true });
+  const ownerDeadline = Date.now() + 2_000;
+  while (readOwnerPid(paths) !== process.pid && Date.now() < ownerDeadline) await wait(10);
+  if (readOwnerPid(paths) !== process.pid) return EXIT.CONFLICT;
+
+  const plan = resolveLaunchPlan();
+  const requestedMode = process.env.O8_SERVE_LAUNCH_MODE;
+  if (requestedMode && requestedMode !== plan.mode) {
+    throw new Error(`Launch mode changed from ${requestedMode} to ${plan.mode}.`);
+  }
+  const apiPort = await takeAvailablePort(PROD_API_PORT_BLOCK);
+  const wsPort = await takeAvailablePort(PROD_WS_PORT_BLOCK, apiPort);
+  const instanceId = readOrCreateId(join(paths.dataDir, 'instance-id'));
+  const bootId = randomUUID();
+  writeFileSync(join(paths.dataDir, 'boot-id'), bootId, { mode: 0o600 });
+  writeFileSync(paths.apiPortFile, String(apiPort), { mode: 0o600 });
+  writeFileSync(paths.wsPortFile, String(wsPort), { mode: 0o600 });
+  const token = getOrCreateToken(paths);
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    O8_DATA_DIR: paths.dataDir,
+    CORTEX_IDE_DATA_DIR: paths.dataDir,
+    O8_API_PORT: String(apiPort),
+    O8_WS_PORT: String(wsPort),
+    PORT: String(apiPort),
+    WS_PORT: String(wsPort),
+    NEXT_ORIGIN: `http://127.0.0.1:${apiPort}`,
+    O8_BOOT_ID: bootId,
+    O8_INSTANCE_ID: instanceId,
+    O8_NODE_BIN: process.execPath,
+    O8_SIDECAR_PID: String(process.pid),
+    WS_TOKEN: token,
+    NODE_ENV: plan.mode === 'packaged' ? 'production' : 'development',
+  };
+  if (plan.mode === 'packaged') {
+    env.O8_PACKAGED_APP = '1';
+    env.NODE_COMPILE_CACHE = join(paths.dataDir, 'compile-cache');
+    if (existsSync(join(plan.root, 'operator-mcp-server.mjs'))) {
+      env.O8_BUNDLED_MCP_DIR = plan.root;
+      env.O8_BUNDLED_MCP_PATH = join(plan.root, 'operator-mcp-server.mjs');
+    }
+  } else {
+    env.NODE_OPTIONS = appendNodeImport(env.NODE_OPTIONS, join(plan.root, 'scripts', 'register-server-only-stub.mjs'));
+  }
+
+  const state: ServeState = {
+    schema: 'o8/serve-state/v1',
+    pid: process.pid,
+    apiPort,
+    wsPort,
+    mode: plan.mode,
+    root: plan.root,
+    startedAt: new Date().toISOString(),
+    status: 'starting',
+    children: [],
+  };
+  writeState(paths, state);
+
+  const apiChild = spawnService('api', plan.api, plan, env, apiPort);
+  const wsChild = spawnService('ws', plan.ws, plan, env, apiPort);
+  if (!apiChild.pid || !wsChild.pid) throw new Error('Failed to start one or more server children.');
+  state.children = [
+    { role: 'api', pid: apiChild.pid },
+    { role: 'ws', pid: wsChild.pid },
+  ];
+  writeState(paths, state);
+
+  let shuttingDown = false;
+  const shutdown = async (exitCode: number, reason?: string) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    state.status = reason ? 'failed' : 'stopping';
+    if (reason) state.error = reason;
+    writeState(paths, state);
+    for (const child of [apiChild, wsChild]) {
+      if (child.pid && processAlive(child.pid)) {
+        try { child.kill('SIGTERM'); } catch {}
+      }
+    }
+    const deadline = Date.now() + 3_000;
+    while (
+      Date.now() < deadline
+      && [apiChild, wsChild].some((child) => child.pid && processAlive(child.pid))
+    ) {
+      await wait(50);
+    }
+    for (const child of [apiChild, wsChild]) {
+      if (child.pid && processAlive(child.pid)) {
+        try { child.kill('SIGKILL'); } catch {}
+      }
+    }
+    await Promise.all([apiChild, wsChild].map((child) => new Promise<void>((resolve) => {
+      if (child.exitCode !== null || child.signalCode !== null) resolve();
+      else child.once('exit', () => resolve());
+    })));
+    if (readOwnerPid(paths) === process.pid) {
+      rmSync(paths.pidFile, { force: true });
+      rmSync(paths.stateFile, { force: true });
+    }
+    process.exit(exitCode);
+  };
+
+  process.once('SIGTERM', () => { void shutdown(EXIT.OK); });
+  process.once('SIGINT', () => { void shutdown(EXIT.OK); });
+  for (const [role, child] of [['api', apiChild], ['ws', wsChild]] as const) {
+    child.once('exit', (code, signal) => {
+      if (!shuttingDown) {
+        void shutdown(EXIT.CONNECTION_REFUSED, `${role} child exited code=${String(code)} signal=${String(signal)}`);
+      }
+    });
+  }
+
+  const readyDeadline = Date.now() + START_TIMEOUT_MS;
+  while (Date.now() < readyDeadline) {
+    if (await apiIsReady(apiPort) && await portAcceptsConnections(wsPort)) {
+      state.status = 'ready';
+      writeState(paths, state);
+      await new Promise<void>(() => {});
+      return EXIT.OK;
+    }
+    await wait(POLL_MS);
+  }
+  await shutdown(EXIT.CONNECTION_REFUSED, 'Server children did not become ready before the startup deadline.');
+  return EXIT.CONNECTION_REFUSED;
+}
+
+export async function runServe(
+  mode: OutputMode,
+  subcommand: string | undefined,
+  rest: string[],
+): Promise<number> {
+  if (rest.length > 0) {
+    throw new CliError('invalid_serve_args', `Unexpected serve arguments: ${rest.join(' ')}`, EXIT.INVALID_ARGS);
+  }
+  if (!subcommand) return startServe(mode);
+  if (subcommand === 'status') return statusServe(mode);
+  if (subcommand === 'stop') return stopServe(mode);
+  if (subcommand === '__daemon') return runDaemon();
+  throw new CliError(
+    'unknown_serve_subcommand',
+    `Unknown serve subcommand: ${subcommand}`,
+    EXIT.INVALID_ARGS,
+    'Use `o8 serve`, `o8 serve status`, or `o8 serve stop`.',
+  );
+}

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -23,6 +23,7 @@ const PROD_WS_PORT_BLOCK = [47105, 47106, 47107, 47108, 47109] as const;
 const START_TIMEOUT_MS = 60_000;
 const STOP_TIMEOUT_MS = 8_000;
 const POLL_MS = 100;
+const DESKTOP_COEXISTENCE_NOTE = 'The desktop app uses the next available API and WebSocket port block entries, so both can coexist.';
 
 type ServeMode = 'development' | 'packaged';
 type ServeStatus = 'starting' | 'ready' | 'stopping' | 'failed';
@@ -35,6 +36,7 @@ interface ServeChildState {
 interface ServeState {
   schema: 'o8/serve-state/v1';
   pid: number;
+  pgid: number;
   apiPort: number;
   wsPort: number;
   mode: ServeMode;
@@ -97,6 +99,32 @@ function processAlive(pid: number): boolean {
   }
 }
 
+function uniquePids(pids: number[]): number[] {
+  return [...new Set(pids.filter((pid) => Number.isInteger(pid) && pid > 0))];
+}
+
+function signalPids(pids: number[], signal: NodeJS.Signals): void {
+  for (const pid of uniquePids(pids)) {
+    if (!processAlive(pid)) continue;
+    try { process.kill(pid, signal); } catch {}
+  }
+}
+
+function signalProcessGroup(pgid: number | undefined, signal: NodeJS.Signals): void {
+  if (process.platform === 'win32' || !pgid || pgid <= 0) return;
+  try { process.kill(-pgid, signal); } catch {}
+}
+
+function processGroupAlive(pgid: number | undefined): boolean {
+  if (process.platform === 'win32' || !pgid || pgid <= 0) return false;
+  try {
+    process.kill(-pgid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function readState(paths: ServePaths): ServeState | null {
   try {
     const parsed = JSON.parse(readFileSync(paths.stateFile, 'utf8')) as ServeState;
@@ -121,6 +149,30 @@ function cleanStaleOwner(paths: ServePaths): void {
 
 function wait(ms: number): Promise<void> {
   return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+async function waitForPidsToExit(pids: number[], timeoutMs: number): Promise<boolean> {
+  const trackedPids = uniquePids(pids);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (trackedPids.every((pid) => !processAlive(pid))) return true;
+    await wait(POLL_MS);
+  }
+  return trackedPids.every((pid) => !processAlive(pid));
+}
+
+async function terminateTrackedPids(
+  pids: number[],
+  pgid: number | undefined,
+  termTimeoutMs: number,
+): Promise<boolean> {
+  const trackedPids = uniquePids(pids);
+  signalPids(trackedPids, 'SIGTERM');
+  const trackedExited = await waitForPidsToExit(trackedPids, termTimeoutMs);
+  if (trackedExited && !processGroupAlive(pgid)) return true;
+  signalProcessGroup(pgid, 'SIGKILL');
+  signalPids(trackedPids, 'SIGKILL');
+  return await waitForPidsToExit(trackedPids, 1_000) && !processGroupAlive(pgid);
 }
 
 async function portAcceptsConnections(port: number): Promise<boolean> {
@@ -149,6 +201,27 @@ async function apiIsReady(port: number): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function readPort(path: string): number | null {
+  try {
+    const port = Number.parseInt(readFileSync(path, 'utf8').trim(), 10);
+    return Number.isInteger(port) && port > 0 && port < 65_536 ? port : null;
+  } catch {
+    return null;
+  }
+}
+
+async function assertDataDirAvailableForServe(paths: ServePaths): Promise<void> {
+  if (existsSync(paths.pidFile)) return;
+  const apiPort = readPort(paths.apiPortFile);
+  if (!apiPort || !await apiIsReady(apiPort)) return;
+  throw new CliError(
+    'serve_desktop_owns_data_dir',
+    `The desktop app already owns this data directory through its healthy API on port ${apiPort}.`,
+    EXIT.CONFLICT,
+    'Quit the desktop app or use a different O8_DATA_DIR or CORTEX_IDE_DATA_DIR, then retry.',
+  );
 }
 
 async function takeAvailablePort(candidates: readonly number[], skip?: number): Promise<number> {
@@ -337,12 +410,14 @@ function outputState(mode: OutputMode, state: ServeState, running: boolean, heal
     running,
     healthy,
     pid: state.pid,
+    pgid: state.pgid,
     apiPort: state.apiPort,
     wsPort: state.wsPort,
     mode: state.mode,
     status: state.status,
     children: state.children,
     startedAt: state.startedAt,
+    note: DESKTOP_COEXISTENCE_NOTE,
   };
   if (!mode.human) {
     printJson(payload);
@@ -352,11 +427,20 @@ function outputState(mode: OutputMode, state: ServeState, running: boolean, heal
     ['running', String(running)],
     ['healthy', String(healthy)],
     ['pid', String(state.pid)],
+    ['pgid', String(state.pgid)],
     ['api', String(state.apiPort)],
     ['ws', String(state.wsPort)],
     ['mode', state.mode],
     ['status', state.status],
+    ['note', DESKTOP_COEXISTENCE_NOTE],
   ]);
+}
+
+function outputStopped(mode: OutputMode, pid: number): number {
+  const payload = { schema: 'o8/cli/serve-stop/v1', stopped: true, pid };
+  if (mode.human) printHumanKv([['stopped', 'true'], ['pid', String(pid)]]);
+  else printJson(payload);
+  return EXIT.OK;
 }
 
 async function startServe(mode: OutputMode): Promise<number> {
@@ -372,6 +456,7 @@ async function startServe(mode: OutputMode): Promise<number> {
       'Run `o8 serve status` or `o8 serve stop`.',
     );
   }
+  await assertDataDirAvailableForServe(paths);
 
   const plan = resolveLaunchPlan();
   const previousLog = `${paths.logFile}.prev`;
@@ -418,9 +503,21 @@ async function statusServe(mode: OutputMode): Promise<number> {
   const pid = readOwnerPid(paths);
   const state = readState(paths);
   if (!pid || !state || state.pid !== pid || !processAlive(pid)) {
-    cleanStaleOwner(paths);
-    const payload = { schema: 'o8/cli/serve-status/v1', running: false, healthy: false };
-    if (mode.human) printHumanKv([['running', 'false'], ['healthy', 'false']]);
+    const hasRecoverableChildren = Boolean(state?.children.some((child) => processAlive(child.pid)));
+    if (!hasRecoverableChildren) cleanStaleOwner(paths);
+    const payload = {
+      schema: 'o8/cli/serve-status/v1',
+      running: false,
+      healthy: false,
+      note: DESKTOP_COEXISTENCE_NOTE,
+    };
+    if (mode.human) {
+      printHumanKv([
+        ['running', 'false'],
+        ['healthy', 'false'],
+        ['note', DESKTOP_COEXISTENCE_NOTE],
+      ]);
+    }
     else printJson(payload);
     return EXIT.OK;
   }
@@ -435,27 +532,60 @@ async function stopServe(mode: OutputMode): Promise<number> {
   const paths = servePaths();
   const pid = readOwnerPid(paths);
   const state = readState(paths);
-  if (!pid || !processAlive(pid)) {
+  const stateMatchesOwner = state && (!pid || state.pid === pid) ? state : null;
+  const leaderPid = pid ?? stateMatchesOwner?.pid ?? null;
+  if (!leaderPid) {
     cleanStaleOwner(paths);
     throw new CliError('serve_not_running', 'Headless o8 is not running.', EXIT.NOT_FOUND);
   }
-  const trackedPids = [pid, ...(state?.children.map((child) => child.pid) ?? [])];
+  const childPids = stateMatchesOwner?.children.map((child) => child.pid) ?? [];
+  const trackedPids = uniquePids([leaderPid, ...childPids]);
+  if (!processAlive(leaderPid)) {
+    const stopped = await terminateTrackedPids(childPids, stateMatchesOwner?.pgid, 1_000);
+    cleanStaleOwner(paths);
+    if (stopped && trackedPids.every((trackedPid) => !processAlive(trackedPid)) && !existsSync(paths.pidFile)) {
+      return outputStopped(mode, leaderPid);
+    }
+    throw new CliError(
+      'serve_stop_failed',
+      `Headless o8 pid ${leaderPid} died, but one or more recorded children could not be stopped.`,
+      EXIT.CONFLICT,
+      `Inspect ${paths.logFile}.`,
+    );
+  }
   try {
-    process.kill(pid, 'SIGTERM');
+    process.kill(leaderPid, 'SIGTERM');
   } catch {}
-  const deadline = Date.now() + STOP_TIMEOUT_MS;
+  const startedAt = Date.now();
+  const deadline = startedAt + STOP_TIMEOUT_MS;
+  const escalationAt = startedAt + Math.floor(STOP_TIMEOUT_MS / 2);
+  let childrenSignaled = false;
   while (Date.now() < deadline) {
-    if (trackedPids.every((trackedPid) => !processAlive(trackedPid)) && !existsSync(paths.pidFile)) {
-      const payload = { schema: 'o8/cli/serve-stop/v1', stopped: true, pid };
-      if (mode.human) printHumanKv([['stopped', 'true'], ['pid', String(pid)]]);
-      else printJson(payload);
-      return EXIT.OK;
+    if (!childrenSignaled && Date.now() >= escalationAt) {
+      signalPids(childPids, 'SIGTERM');
+      childrenSignaled = true;
+    }
+    if (
+      trackedPids.every((trackedPid) => !processAlive(trackedPid))
+      && !processGroupAlive(stateMatchesOwner?.pgid)
+      && !existsSync(paths.pidFile)
+    ) {
+      return outputStopped(mode, leaderPid);
     }
     await wait(POLL_MS);
   }
+  signalProcessGroup(stateMatchesOwner?.pgid, 'SIGKILL');
+  signalPids(trackedPids, 'SIGKILL');
+  await waitForPidsToExit(trackedPids, 1_000);
+  const allProcessesStopped = trackedPids.every((trackedPid) => !processAlive(trackedPid))
+    && !processGroupAlive(stateMatchesOwner?.pgid);
+  if (allProcessesStopped) cleanStaleOwner(paths);
+  if (allProcessesStopped && !existsSync(paths.pidFile)) {
+    return outputStopped(mode, leaderPid);
+  }
   throw new CliError(
     'serve_stop_failed',
-    `Headless o8 pid ${pid} did not stop cleanly before the shutdown deadline.`,
+    `Headless o8 pid ${leaderPid} did not stop before the shutdown deadline.`,
     EXIT.CONFLICT,
     `Inspect ${paths.logFile}.`,
   );
@@ -475,7 +605,7 @@ async function runDaemon(): Promise<number> {
   }
   const apiPort = await takeAvailablePort(PROD_API_PORT_BLOCK);
   const wsPort = await takeAvailablePort(PROD_WS_PORT_BLOCK, apiPort);
-  const instanceId = readOrCreateId(join(paths.dataDir, 'instance-id'));
+  const instanceId = readOrCreateId(join(paths.dataDir, 'serve-instance-id'));
   const bootId = randomUUID();
   writeFileSync(join(paths.dataDir, 'boot-id'), bootId, { mode: 0o600 });
   writeFileSync(paths.apiPortFile, String(apiPort), { mode: 0o600 });
@@ -512,6 +642,7 @@ async function runDaemon(): Promise<number> {
   const state: ServeState = {
     schema: 'o8/serve-state/v1',
     pid: process.pid,
+    pgid: process.pid,
     apiPort,
     wsPort,
     mode: plan.mode,
@@ -566,8 +697,17 @@ async function runDaemon(): Promise<number> {
     process.exit(exitCode);
   };
 
+  const fatalShutdown = (kind: string, reason: unknown): void => {
+    const detail = reason instanceof Error ? reason.message : String(reason);
+    void shutdown(EXIT.CONNECTION_REFUSED, `${kind}: ${detail}`).catch(() => {
+      process.exit(EXIT.CONNECTION_REFUSED);
+    });
+  };
+
   process.once('SIGTERM', () => { void shutdown(EXIT.OK); });
   process.once('SIGINT', () => { void shutdown(EXIT.OK); });
+  process.once('uncaughtException', (error) => { fatalShutdown('uncaughtException', error); });
+  process.once('unhandledRejection', (reason) => { fatalShutdown('unhandledRejection', reason); });
   for (const [role, child] of [['api', apiChild], ['ws', wsChild]] as const) {
     child.once('exit', (code, signal) => {
       if (!shuttingDown) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -49,6 +49,7 @@ import { runProblem } from './commands/problem.js';
 import { runStatus } from './commands/status.js';
 import { runSession } from './commands/session.js';
 import { runRun } from './commands/run.js';
+import { runServe } from './commands/serve.js';
 import { runVersion } from './commands/version.js';
 import { runPacketInfo } from './commands/packet/info.js';
 import { runPacketHeartbeat } from './commands/packet/heartbeat.js';
@@ -214,6 +215,9 @@ commands:
   run [--detach] <cmd> run a process in an o8-owned terminal the operator can watch
   run --list           list managed runs (running + recent, with exit codes)
   run stop <runId>     stop a managed run from o8 run --list
+  serve                start the headless API, WebSocket layer, and supervisor daemon
+  serve status         report the daemon pid, ports, health, and launch mode
+  serve stop           stop the daemon and reap its server children
   ask [--terse] "<question>"  ask the Engineering Brain about this repo (answer + cited sources)
   feature list|next|add|verify  durable repo-scoped feature ledger
   ground "<task>"      persist a real-path impact map before execution
@@ -355,6 +359,8 @@ async function dispatch(args: ParsedArgs): Promise<number> {
       return runConnect(args.mode, 'disconnect', secondary ? [secondary, ...args.rest] : args.rest);
     case 'run':
       return runRun(args.mode, args.rest);
+    case 'serve':
+      return runServe(args.mode, secondary, args.rest);
     case 'ask':
       // The question lands in `secondary` (first positional) when quoted, or
       // spreads across secondary + rest when unquoted — hand both to the parser.

--- a/tests/o8-serve-real-path.test.ts
+++ b/tests/o8-serve-real-path.test.ts
@@ -1,0 +1,148 @@
+import { execFile, execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const root = resolve(import.meta.dirname, '..');
+const cliEntrypoint = join(root, 'cli', 'dist', 'o8.mjs');
+const dataDir = mkdtempSync(join(tmpdir(), 'o8-serve-real-path-'));
+
+interface CliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+interface ServeStatus {
+  schema: 'o8/cli/serve-status/v1';
+  running: boolean;
+  healthy: boolean;
+  pid: number;
+  apiPort: number;
+  wsPort: number;
+  mode: 'development' | 'packaged';
+  children: Array<{ role: string; pid: number }>;
+}
+
+function cliEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    O8_DATA_DIR: dataDir,
+    CORTEX_IDE_DATA_DIR: dataDir,
+    O8_SERVE_ROOT: root,
+    O8_WORKER_TOKEN: '',
+    O8_WORKER_PACKET_ID: '',
+  };
+  delete env.NODE_OPTIONS;
+  return env;
+}
+
+function runCli(args: string[], timeout = 75_000): Promise<CliResult> {
+  return new Promise((resolveResult) => {
+    execFile(process.execPath, [cliEntrypoint, ...args], {
+      cwd: root,
+      env: cliEnv(),
+      timeout,
+    }, (error, stdout, stderr) => {
+      resolveResult({
+        code: typeof error?.code === 'number' ? error.code : error ? 1 : 0,
+        stdout,
+        stderr,
+      });
+    });
+  });
+}
+
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function descendantPids(rootPid: number): number[] {
+  if (process.platform === 'win32') return [];
+  const rows = execFileSync('ps', ['-axo', 'pid=,ppid='], { encoding: 'utf8' });
+  const children = new Map<number, number[]>();
+  for (const row of rows.split('\n')) {
+    const [pidRaw, parentRaw] = row.trim().split(/\s+/);
+    const pid = Number.parseInt(pidRaw ?? '', 10);
+    const parent = Number.parseInt(parentRaw ?? '', 10);
+    if (!Number.isInteger(pid) || !Number.isInteger(parent)) continue;
+    children.set(parent, [...(children.get(parent) ?? []), pid]);
+  }
+  const descendants: number[] = [];
+  const pending = [...(children.get(rootPid) ?? [])];
+  while (pending.length > 0) {
+    const pid = pending.shift();
+    if (!pid) continue;
+    descendants.push(pid);
+    pending.push(...(children.get(pid) ?? []));
+  }
+  return descendants;
+}
+
+describe.sequential('o8 serve real CLI path', () => {
+  beforeAll(() => {
+    execFileSync(process.execPath, [join(root, 'cli', 'esbuild.config.mjs')], {
+      cwd: root,
+      env: cliEnv(),
+    });
+  });
+
+  afterAll(async () => {
+    await runCli(['serve', 'stop'], 15_000);
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('starts, authenticates, reports, refuses a second owner, and reaps every child', async () => {
+    const started = await runCli(['serve']);
+    expect(started.code, `${started.stderr}\n${readFileSync(join(dataDir, 'logs', 'serve.log'), 'utf8')}`).toBe(0);
+    const startStatus = JSON.parse(started.stdout) as ServeStatus;
+    expect(startStatus).toMatchObject({
+      schema: 'o8/cli/serve-status/v1',
+      running: true,
+      healthy: true,
+      mode: 'development',
+    });
+    expect(startStatus.pid).toBeGreaterThan(0);
+    expect(startStatus.apiPort).toBeGreaterThan(0);
+    expect(startStatus.wsPort).toBeGreaterThan(0);
+    expect(existsSync(join(dataDir, 'serve.pid'))).toBe(true);
+
+    const token = readFileSync(join(dataDir, 'ws-token'), 'utf8').trim();
+    const gatedResponse = await fetch(`http://127.0.0.1:${startStatus.apiPort}/api/panel/repos`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(60_000),
+    });
+    expect(gatedResponse.status, await gatedResponse.text()).toBe(200);
+
+    const statusResult = await runCli(['serve', 'status']);
+    expect(statusResult.code, statusResult.stderr).toBe(0);
+    expect(JSON.parse(statusResult.stdout)).toMatchObject({
+      running: true,
+      healthy: true,
+      pid: startStatus.pid,
+      apiPort: startStatus.apiPort,
+      wsPort: startStatus.wsPort,
+      mode: 'development',
+    });
+
+    const secondStart = await runCli(['serve']);
+    expect(secondStart.code).toBe(5);
+    expect(JSON.parse(secondStart.stderr)).toMatchObject({
+      error: { code: 'serve_already_running', ambiguous: false },
+    });
+
+    const ownedPids = [startStatus.pid, ...descendantPids(startStatus.pid)];
+    expect(ownedPids.length).toBeGreaterThanOrEqual(3);
+    const stopped = await runCli(['serve', 'stop'], 15_000);
+    expect(stopped.code, stopped.stderr).toBe(0);
+    expect(JSON.parse(stopped.stdout)).toMatchObject({ stopped: true, pid: startStatus.pid });
+    expect(existsSync(join(dataDir, 'serve.pid'))).toBe(false);
+    expect(ownedPids.filter(processAlive)).toEqual([]);
+  }, 120_000);
+});

--- a/tests/o8-serve-real-path.test.ts
+++ b/tests/o8-serve-real-path.test.ts
@@ -1,12 +1,19 @@
 import { execFile, execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer as createHttpServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const root = resolve(import.meta.dirname, '..');
 const cliEntrypoint = join(root, 'cli', 'dist', 'o8.mjs');
-const dataDir = mkdtempSync(join(tmpdir(), 'o8-serve-real-path-'));
+const dataDirs = new Set<string>();
+
+function makeDataDir(): string {
+  const dataDir = mkdtempSync(join(tmpdir(), 'o8-serve-real-path-'));
+  dataDirs.add(dataDir);
+  return dataDir;
+}
 
 interface CliResult {
   code: number;
@@ -19,13 +26,15 @@ interface ServeStatus {
   running: boolean;
   healthy: boolean;
   pid: number;
+  pgid: number;
   apiPort: number;
   wsPort: number;
   mode: 'development' | 'packaged';
   children: Array<{ role: string; pid: number }>;
+  note: string;
 }
 
-function cliEnv(): NodeJS.ProcessEnv {
+function cliEnv(dataDir: string): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     O8_DATA_DIR: dataDir,
@@ -38,11 +47,11 @@ function cliEnv(): NodeJS.ProcessEnv {
   return env;
 }
 
-function runCli(args: string[], timeout = 75_000): Promise<CliResult> {
+function runCli(args: string[], dataDir: string, timeout = 75_000): Promise<CliResult> {
   return new Promise((resolveResult) => {
     execFile(process.execPath, [cliEntrypoint, ...args], {
       cwd: root,
-      env: cliEnv(),
+      env: cliEnv(dataDir),
       timeout,
     }, (error, stdout, stderr) => {
       resolveResult({
@@ -85,22 +94,42 @@ function descendantPids(rootPid: number): number[] {
   return descendants;
 }
 
+async function waitForPidsToExit(pids: number[], timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (pids.every((pid) => !processAlive(pid))) return true;
+    await new Promise((resolveWait) => { setTimeout(resolveWait, 50); });
+  }
+  return pids.every((pid) => !processAlive(pid));
+}
+
+function readServeLog(dataDir: string): string {
+  const logPath = join(dataDir, 'logs', 'serve.log');
+  return existsSync(logPath) ? readFileSync(logPath, 'utf8') : '';
+}
+
 describe.sequential('o8 serve real CLI path', () => {
   beforeAll(() => {
+    const buildDataDir = makeDataDir();
     execFileSync(process.execPath, [join(root, 'cli', 'esbuild.config.mjs')], {
       cwd: root,
-      env: cliEnv(),
+      env: cliEnv(buildDataDir),
     });
   });
 
   afterAll(async () => {
-    await runCli(['serve', 'stop'], 15_000);
-    rmSync(dataDir, { recursive: true, force: true });
+    for (const dataDir of dataDirs) {
+      await runCli(['serve', 'stop'], dataDir, 15_000);
+      rmSync(dataDir, { recursive: true, force: true });
+    }
   });
 
   it('starts, authenticates, reports, refuses a second owner, and reaps every child', async () => {
-    const started = await runCli(['serve']);
-    expect(started.code, `${started.stderr}\n${readFileSync(join(dataDir, 'logs', 'serve.log'), 'utf8')}`).toBe(0);
+    const dataDir = makeDataDir();
+    const desktopInstanceId = 'desktop-instance-id';
+    writeFileSync(join(dataDir, 'instance-id'), desktopInstanceId, { mode: 0o600 });
+    const started = await runCli(['serve'], dataDir);
+    expect(started.code, `${started.stderr}\n${readServeLog(dataDir)}`).toBe(0);
     const startStatus = JSON.parse(started.stdout) as ServeStatus;
     expect(startStatus).toMatchObject({
       schema: 'o8/cli/serve-status/v1',
@@ -109,9 +138,13 @@ describe.sequential('o8 serve real CLI path', () => {
       mode: 'development',
     });
     expect(startStatus.pid).toBeGreaterThan(0);
+    expect(startStatus.pgid).toBe(startStatus.pid);
     expect(startStatus.apiPort).toBeGreaterThan(0);
     expect(startStatus.wsPort).toBeGreaterThan(0);
+    expect(startStatus.note).toContain('both can coexist');
     expect(existsSync(join(dataDir, 'serve.pid'))).toBe(true);
+    expect(readFileSync(join(dataDir, 'instance-id'), 'utf8')).toBe(desktopInstanceId);
+    expect(readFileSync(join(dataDir, 'serve-instance-id'), 'utf8').trim()).not.toBe(desktopInstanceId);
 
     const token = readFileSync(join(dataDir, 'ws-token'), 'utf8').trim();
     const gatedResponse = await fetch(`http://127.0.0.1:${startStatus.apiPort}/api/panel/repos`, {
@@ -120,7 +153,7 @@ describe.sequential('o8 serve real CLI path', () => {
     });
     expect(gatedResponse.status, await gatedResponse.text()).toBe(200);
 
-    const statusResult = await runCli(['serve', 'status']);
+    const statusResult = await runCli(['serve', 'status'], dataDir);
     expect(statusResult.code, statusResult.stderr).toBe(0);
     expect(JSON.parse(statusResult.stdout)).toMatchObject({
       running: true,
@@ -129,9 +162,11 @@ describe.sequential('o8 serve real CLI path', () => {
       apiPort: startStatus.apiPort,
       wsPort: startStatus.wsPort,
       mode: 'development',
+      pgid: startStatus.pid,
+      note: startStatus.note,
     });
 
-    const secondStart = await runCli(['serve']);
+    const secondStart = await runCli(['serve'], dataDir);
     expect(secondStart.code).toBe(5);
     expect(JSON.parse(secondStart.stderr)).toMatchObject({
       error: { code: 'serve_already_running', ambiguous: false },
@@ -139,10 +174,67 @@ describe.sequential('o8 serve real CLI path', () => {
 
     const ownedPids = [startStatus.pid, ...descendantPids(startStatus.pid)];
     expect(ownedPids.length).toBeGreaterThanOrEqual(3);
-    const stopped = await runCli(['serve', 'stop'], 15_000);
+    const stopped = await runCli(['serve', 'stop'], dataDir, 15_000);
     expect(stopped.code, stopped.stderr).toBe(0);
     expect(JSON.parse(stopped.stdout)).toMatchObject({ stopped: true, pid: startStatus.pid });
     expect(existsSync(join(dataDir, 'serve.pid'))).toBe(false);
     expect(ownedPids.filter(processAlive)).toEqual([]);
   }, 120_000);
+
+  it('reaps recorded children and stale ownership after the daemon leader is killed', async () => {
+    const dataDir = makeDataDir();
+    const started = await runCli(['serve'], dataDir);
+    expect(started.code, `${started.stderr}\n${readServeLog(dataDir)}`).toBe(0);
+    const status = JSON.parse(started.stdout) as ServeStatus;
+    const ownedPids = [status.pid, ...descendantPids(status.pid)];
+    const recordedChildPids = status.children.map((child) => child.pid);
+    expect(recordedChildPids.length).toBe(2);
+
+    process.kill(status.pid, 'SIGKILL');
+    expect(await waitForPidsToExit([status.pid], 5_000)).toBe(true);
+
+    const stopped = await runCli(['serve', 'stop'], dataDir, 15_000);
+    expect(stopped.code, stopped.stderr).toBe(0);
+    expect(JSON.parse(stopped.stdout)).toMatchObject({ stopped: true, pid: status.pid });
+    expect(existsSync(join(dataDir, 'serve.pid'))).toBe(false);
+    expect(existsSync(join(dataDir, 'serve-state.json'))).toBe(false);
+    expect(recordedChildPids.filter(processAlive)).toEqual([]);
+    expect(ownedPids.filter(processAlive)).toEqual([]);
+  }, 120_000);
+
+  it('refuses a data directory owned by a healthy desktop API', async () => {
+    const dataDir = makeDataDir();
+    const server = createHttpServer((request, response) => {
+      if (request.url === '/api/setup/identity') {
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({ product: 'o8' }));
+        return;
+      }
+      response.writeHead(404);
+      response.end();
+    });
+    await new Promise<void>((resolveListen, rejectListen) => {
+      server.once('error', rejectListen);
+      server.listen(0, '127.0.0.1', resolveListen);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('Fake desktop API did not bind to a TCP port.');
+      writeFileSync(join(dataDir, 'api-port'), String(address.port), { mode: 0o600 });
+
+      const result = await runCli(['serve'], dataDir, 15_000);
+      expect(result.code).toBe(5);
+      expect(JSON.parse(result.stderr)).toMatchObject({
+        error: {
+          code: 'serve_desktop_owns_data_dir',
+          hint: expect.stringContaining('different O8_DATA_DIR'),
+          ambiguous: false,
+        },
+      });
+      expect(existsSync(join(dataDir, 'serve.pid'))).toBe(false);
+      expect(existsSync(join(dataDir, 'serve-state.json'))).toBe(false);
+    } finally {
+      await new Promise<void>((resolveClose) => { server.close(() => resolveClose()); });
+    }
+  }, 30_000);
 });

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1835,6 +1835,14 @@
       ]
     },
     {
+      "path": "tests/o8-serve-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "process-signal",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/onboarding-runtime-picker-real-path.test.ts",
       "reasons": [
         "real-path"


### PR DESCRIPTION
Phase 1 of #2022: run the o8 server without the desktop window.

## What it does

- `o8 serve` daemonizes the API server, the WebSocket layer, and the supervisor: detached leader in its own process group, atomic (`wx`) pidfile and 0600 state/port/token files in the data dir, rotated file logs, readiness gated on the real API identity endpoint plus a WS connect probe.
- `o8 serve status` reports pid/pgid, ports, health, and launch mode (development from a source checkout; packaged from bundled server entries when present).
- `o8 serve stop` SIGTERMs the leader, escalates to the recorded children at half the deadline, and finishes with a process-group + tracked-pid SIGKILL backstop — reporting stopped only when every tracked pid is gone and the pidfile is removed. A leader that died outside the stop path (crash, hard kill) still gets its recorded children swept before the stale files are cleared.

## Coexistence with the desktop app

- The daemon owns a separate identity file (`serve-instance-id`) so the desktop app's stale-listener recovery can never classify the daemon as its own ghost; the desktop app boots onto the next port-block entries and both coexist (stated in `status` output).
- Starting `o8 serve` in a data dir whose `api-port` names a live healthy API with no daemon pidfile refuses with `serve_desktop_owns_data_dir` and a hint, instead of clobbering the desktop app's files.
- Fatal daemon errors (`uncaughtException`/`unhandledRejection`) route through the same drain-then-reap shutdown.

## Verification

Real-path suite drives the built CLI binary against temp data dirs: start → bearer-gated API call using the written token/port files → status → second-owner refusal → stop with a full descendant sweep asserting zero survivors; a hard-killed leader followed by `stop` still reaps both recorded children and cleans ownership files; the desktop-owner case refuses against a live fake identity endpoint without creating daemon files. `npx tsc --noEmit` clean, `npm run lint` exit 0, rule-check clean.

Residual (phase 1): packaged mode is implemented but exercised only in development mode here; port-block constants are duplicated from the panel constants per existing CLI-bundle precedent.
