### PR TITLE
feat(cli): headless serve service lifecycle, update story, and drift guard (#2029)

### DIFF
--- a/cli/src/commands/serve-lifecycle.test.ts
+++ b/cli/src/commands/serve-lifecycle.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildServeLaunchAgentPlist,
   decideServeLogRotation,
+  formatServeLogSessionBoundary,
   SERVE_LAUNCH_AGENT_LABEL,
   SERVE_LOG_ROTATE_BYTES,
   SERVE_PREVIOUS_LOG_TRUNCATE_BYTES,
@@ -42,5 +43,11 @@ describe('serve launch agent lifecycle', () => {
       rotateCurrent: false,
       truncatePrevious: false,
     });
+  });
+
+  it('formats a readable boundary for each daemon session', () => {
+    expect(formatServeLogSessionBoundary('2026-08-31T13:00:00.000Z', '0.1.723', 4242)).toBe(
+      '\n=== o8 serve session 2026-08-31T13:00:00.000Z version=0.1.723 pid=4242 ===\n',
+    );
   });
 });

--- a/cli/src/commands/serve-lifecycle.test.ts
+++ b/cli/src/commands/serve-lifecycle.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildServeLaunchAgentPlist,
+  decideServeSupervisorRetry,
   decideServeLogRotation,
   formatServeLogSessionBoundary,
+  formatServeSupervisorFailure,
   SERVE_LAUNCH_AGENT_LABEL,
   SERVE_LOG_ROTATE_BYTES,
   SERVE_PREVIOUS_LOG_TRUNCATE_BYTES,
@@ -48,6 +50,19 @@ describe('serve launch agent lifecycle', () => {
   it('formats a readable boundary for each daemon session', () => {
     expect(formatServeLogSessionBoundary('2026-08-31T13:00:00.000Z', '0.1.723', 4242)).toBe(
       '\n=== o8 serve session 2026-08-31T13:00:00.000Z version=0.1.723 pid=4242 ===\n',
+    );
+  });
+
+  it('backs off consecutive pre-ready failures and stops after the fifth', () => {
+    expect([1, 2, 3, 4, 5].map(decideServeSupervisorRetry)).toEqual([
+      { delayMs: 1_000, exhausted: false },
+      { delayMs: 2_000, exhausted: false },
+      { delayMs: 4_000, exhausted: false },
+      { delayMs: 8_000, exhausted: false },
+      { delayMs: 0, exhausted: true },
+    ]);
+    expect(formatServeSupervisorFailure('2026-08-31T14:00:00.000Z', 5)).toBe(
+      '=== o8 serve supervisor 2026-08-31T14:00:00.000Z exiting after 5 consecutive daemon failures before ready; launchd will retry ===\n',
     );
   });
 });

--- a/cli/src/commands/serve-lifecycle.test.ts
+++ b/cli/src/commands/serve-lifecycle.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildServeLaunchAgentPlist,
+  decideServeLogRotation,
+  SERVE_LAUNCH_AGENT_LABEL,
+  SERVE_LOG_ROTATE_BYTES,
+  SERVE_PREVIOUS_LOG_TRUNCATE_BYTES,
+} from './serve-lifecycle';
+
+describe('serve launch agent lifecycle', () => {
+  it('generates the per-user plist with the daemon entry, data paths, and crash restart policy', () => {
+    const plist = buildServeLaunchAgentPlist({
+      cliEntry: '/Applications/o8.app/Contents/Resources/server/bin/o8.mjs',
+      dataDir: '/Users/operator/Library/Application Support/o8 & data',
+      logPath: '/Users/operator/.o8/logs/serve.log',
+      nodePath: '/opt/node/bin/node',
+      workingDirectory: '/Applications/o8.app/Contents/Resources/server',
+    });
+
+    expect(plist).toContain(`<string>${SERVE_LAUNCH_AGENT_LABEL}</string>`);
+    expect(plist).toContain('<key>ProgramArguments</key>');
+    expect(plist).toContain('<string>/opt/node/bin/node</string>');
+    expect(plist).toContain('<string>/Applications/o8.app/Contents/Resources/server/bin/o8.mjs</string>');
+    expect(plist).toContain('<string>__launch_agent</string>');
+    expect(plist).toContain('/Users/operator/Library/Application Support/o8 &amp; data');
+    expect(plist).toContain('<key>KeepAlive</key>');
+    expect(plist).toContain('<key>SuccessfulExit</key>\n    <false/>');
+    expect(plist.match(/<string>\/Users\/operator\/\.o8\/logs\/serve\.log<\/string>/g)).toHaveLength(2);
+  });
+
+  it('rotates only an oversized current log and truncates only an oversized previous log', () => {
+    expect(decideServeLogRotation(SERVE_LOG_ROTATE_BYTES, SERVE_PREVIOUS_LOG_TRUNCATE_BYTES)).toEqual({
+      rotateCurrent: false,
+      truncatePrevious: false,
+    });
+    expect(decideServeLogRotation(SERVE_LOG_ROTATE_BYTES + 1, SERVE_PREVIOUS_LOG_TRUNCATE_BYTES + 1)).toEqual({
+      rotateCurrent: true,
+      truncatePrevious: true,
+    });
+    expect(decideServeLogRotation(null, null)).toEqual({
+      rotateCurrent: false,
+      truncatePrevious: false,
+    });
+  });
+});

--- a/cli/src/commands/serve-lifecycle.ts
+++ b/cli/src/commands/serve-lifecycle.ts
@@ -1,0 +1,262 @@
+import { spawn, spawnSync } from 'node:child_process';
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  truncateSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { CliError, EXIT } from '../api.js';
+import { printHumanKv, printJson, type OutputMode } from '../output.js';
+
+export const SERVE_LAUNCH_AGENT_LABEL = 'ai.o8.serve';
+export const SERVE_LOG_ROTATE_BYTES = 20 * 1024 * 1024;
+export const SERVE_PREVIOUS_LOG_TRUNCATE_BYTES = 5 * 1024 * 1024;
+
+export interface ServeLogRotationDecision {
+  rotateCurrent: boolean;
+  truncatePrevious: boolean;
+}
+
+export interface ServeLaunchAgentPlistOptions {
+  cliEntry: string;
+  dataDir: string;
+  logPath: string;
+  nodePath: string;
+  workingDirectory: string;
+}
+
+interface ServeAgentCommandOptions extends ServeLaunchAgentPlistOptions {
+  assertDataDirAvailable: () => Promise<void>;
+}
+
+interface SuperviseServeDaemonOptions {
+  cliEntry: string;
+  launchMode: 'development' | 'packaged';
+  logPath: string;
+  pidFile: string;
+  workingDirectory: string;
+}
+
+function escapePlistValue(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function plistString(value: string): string {
+  return `    <string>${escapePlistValue(value)}</string>`;
+}
+
+export function buildServeLaunchAgentPlist(options: ServeLaunchAgentPlistOptions): string {
+  const args = [options.nodePath, options.cliEntry, 'serve', '__launch_agent']
+    .map(plistString)
+    .join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${SERVE_LAUNCH_AGENT_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+${args}
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${escapePlistValue(options.workingDirectory)}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>O8_DATA_DIR</key>
+    <string>${escapePlistValue(options.dataDir)}</string>
+    <key>CORTEX_IDE_DATA_DIR</key>
+    <string>${escapePlistValue(options.dataDir)}</string>
+    <key>O8_NODE_BIN</key>
+    <string>${escapePlistValue(options.nodePath)}</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>ThrottleInterval</key>
+  <integer>5</integer>
+  <key>StandardOutPath</key>
+  <string>${escapePlistValue(options.logPath)}</string>
+  <key>StandardErrorPath</key>
+  <string>${escapePlistValue(options.logPath)}</string>
+</dict>
+</plist>
+`;
+}
+
+export function decideServeLogRotation(
+  currentBytes: number | null,
+  previousBytes: number | null,
+): ServeLogRotationDecision {
+  return {
+    rotateCurrent: currentBytes !== null && currentBytes > SERVE_LOG_ROTATE_BYTES,
+    truncatePrevious: previousBytes !== null && previousBytes > SERVE_PREVIOUS_LOG_TRUNCATE_BYTES,
+  };
+}
+
+function fileSize(path: string): number | null {
+  try {
+    return statSync(path).size;
+  } catch {
+    return null;
+  }
+}
+
+export function prepareServeLog(logPath: string): void {
+  mkdirSync(dirname(logPath), { recursive: true });
+  const previousLog = `${logPath}.prev`;
+  const decision = decideServeLogRotation(fileSize(logPath), fileSize(previousLog));
+  if (decision.truncatePrevious) truncateSync(previousLog, 0);
+  if (decision.rotateCurrent) {
+    rmSync(previousLog, { force: true });
+    renameSync(logPath, previousLog);
+  }
+}
+
+function requireLaunchctl(): { domain: string; plistPath: string; target: string } {
+  if (process.platform !== 'darwin' || typeof process.getuid !== 'function') {
+    throw new CliError(
+      'serve_agent_unsupported',
+      'The o8 serve launch agent is available only on macOS.',
+      EXIT.INVALID_ARGS,
+    );
+  }
+  const domain = `gui/${process.getuid()}`;
+  return {
+    domain,
+    plistPath: join(homedir(), 'Library', 'LaunchAgents', `${SERVE_LAUNCH_AGENT_LABEL}.plist`),
+    target: `${domain}/${SERVE_LAUNCH_AGENT_LABEL}`,
+  };
+}
+
+function launchctl(args: string[], allowFailure = false): boolean {
+  const result = spawnSync('/bin/launchctl', args, { encoding: 'utf8' });
+  if (result.status === 0) return true;
+  if (allowFailure) return false;
+  const detail = result.stderr.trim() || result.stdout.trim() || `exit ${String(result.status)}`;
+  throw new CliError('serve_agent_launchctl_failed', `launchctl ${args[0]} failed: ${detail}`, EXIT.CONFLICT);
+}
+
+function serveAgentStatus(): { installed: boolean; label: string; loaded: boolean; plistPath: string } {
+  const paths = requireLaunchctl();
+  return {
+    installed: existsSync(paths.plistPath),
+    label: SERVE_LAUNCH_AGENT_LABEL,
+    loaded: launchctl(['print', paths.target], true),
+    plistPath: paths.plistPath,
+  };
+}
+
+function outputAgentStatus(
+  mode: OutputMode,
+  action: 'install' | 'uninstall' | 'status',
+): number {
+  const status = serveAgentStatus();
+  const payload = { schema: 'o8/cli/serve-agent/v1', action, ...status };
+  if (mode.human) {
+    printHumanKv([
+      ['action', action],
+      ['label', status.label],
+      ['installed', String(status.installed)],
+      ['loaded', String(status.loaded)],
+      ['plist', status.plistPath],
+    ]);
+  } else {
+    printJson(payload);
+  }
+  return EXIT.OK;
+}
+
+export async function runServeAgentCommand(
+  mode: OutputMode,
+  action: string | undefined,
+  rest: string[],
+  options: ServeAgentCommandOptions,
+): Promise<number> {
+  if (!action || rest.length > 0 || !['install', 'uninstall', 'status'].includes(action)) {
+    throw new CliError(
+      'invalid_serve_agent_args',
+      `Unknown serve agent action: ${action ?? '(none)'}`,
+      EXIT.INVALID_ARGS,
+      'Use `o8 serve agent install`, `o8 serve agent uninstall`, or `o8 serve agent status`.',
+    );
+  }
+  const typedAction = action as 'install' | 'uninstall' | 'status';
+  if (typedAction === 'status') return outputAgentStatus(mode, typedAction);
+
+  const paths = requireLaunchctl();
+  if (typedAction === 'install') {
+    await options.assertDataDirAvailable();
+    mkdirSync(dirname(paths.plistPath), { recursive: true });
+    mkdirSync(dirname(options.logPath), { recursive: true });
+    writeFileSync(paths.plistPath, buildServeLaunchAgentPlist(options), { mode: 0o600 });
+    launchctl(['bootout', paths.target], true);
+    launchctl(['bootstrap', paths.domain, paths.plistPath]);
+  } else {
+    launchctl(['bootout', paths.target], true);
+    rmSync(paths.plistPath, { force: true });
+  }
+  return outputAgentStatus(mode, typedAction);
+}
+
+export async function superviseServeDaemon(options: SuperviseServeDaemonOptions): Promise<number> {
+  prepareServeLog(options.logPath);
+  const logFd = openSync(options.logPath, 'a', 0o600);
+  const child = spawn(process.execPath, [options.cliEntry, 'serve', '__daemon'], {
+    cwd: options.workingDirectory,
+    detached: true,
+    env: {
+      ...process.env,
+      O8_SERVE_ROOT: options.workingDirectory,
+      O8_SERVE_LAUNCH_MODE: options.launchMode,
+    },
+    stdio: ['ignore', logFd, logFd],
+  });
+  closeSync(logFd);
+  if (!child.pid) {
+    throw new CliError('serve_spawn_failed', 'Failed to spawn the headless daemon.', EXIT.CONNECTION_REFUSED);
+  }
+  try {
+    writeFileSync(options.pidFile, String(child.pid), { flag: 'wx', mode: 0o600 });
+  } catch (error) {
+    try { child.kill('SIGTERM'); } catch {}
+    throw error;
+  }
+
+  let stopping = false;
+  const stopChild = (): void => {
+    stopping = true;
+    try { child.kill('SIGTERM'); } catch {}
+  };
+  process.once('SIGTERM', stopChild);
+  process.once('SIGINT', stopChild);
+  return await new Promise<number>((resolve) => {
+    child.once('exit', (code, signal) => {
+      try {
+        if (readFileSync(options.pidFile, 'utf8').trim() === String(child.pid)) {
+          rmSync(options.pidFile, { force: true });
+        }
+      } catch {}
+      if (stopping) resolve(EXIT.OK);
+      else resolve(code ?? (signal ? EXIT.CONNECTION_REFUSED : EXIT.OK));
+    });
+  });
+}

--- a/cli/src/commands/serve-lifecycle.ts
+++ b/cli/src/commands/serve-lifecycle.ts
@@ -1,5 +1,6 @@
-import { spawn, spawnSync } from 'node:child_process';
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import {
+  appendFileSync,
   closeSync,
   existsSync,
   mkdirSync,
@@ -20,10 +21,19 @@ import { printHumanKv, printJson, type OutputMode } from '../output.js';
 export const SERVE_LAUNCH_AGENT_LABEL = 'ai.o8.serve';
 export const SERVE_LOG_ROTATE_BYTES = 20 * 1024 * 1024;
 export const SERVE_PREVIOUS_LOG_TRUNCATE_BYTES = 5 * 1024 * 1024;
+export const SERVE_SUPERVISOR_MAX_FAST_FAILURES = 5;
+export const SERVE_SUPERVISOR_BACKOFF_CAP_MS = 30_000;
+const SERVE_SUPERVISOR_BACKOFF_BASE_MS = 1_000;
+const SERVE_SUPERVISOR_READY_POLL_MS = 100;
 
 export interface ServeLogRotationDecision {
   rotateCurrent: boolean;
   truncatePrevious: boolean;
+}
+
+export interface ServeSupervisorRetryDecision {
+  delayMs: number;
+  exhausted: boolean;
 }
 
 export interface ServeLaunchAgentPlistOptions {
@@ -136,6 +146,20 @@ export function formatServeLogSessionBoundary(
   return `\n=== o8 serve session ${startedAt} version=${version} pid=${pid} ===\n`;
 }
 
+export function decideServeSupervisorRetry(failureCount: number): ServeSupervisorRetryDecision {
+  const exhausted = failureCount >= SERVE_SUPERVISOR_MAX_FAST_FAILURES;
+  return {
+    delayMs: exhausted
+      ? 0
+      : Math.min(SERVE_SUPERVISOR_BACKOFF_BASE_MS * (2 ** Math.max(0, failureCount - 1)), SERVE_SUPERVISOR_BACKOFF_CAP_MS),
+    exhausted,
+  };
+}
+
+export function formatServeSupervisorFailure(timestamp: string, failureCount: number): string {
+  return `=== o8 serve supervisor ${timestamp} exiting after ${failureCount} consecutive daemon failures before ready; launchd will retry ===\n`;
+}
+
 function fileSize(path: string): number | null {
   try {
     return statSync(path).size;
@@ -189,6 +213,33 @@ function clearSupervisorPid(stateFile: string): void {
 export function readServeSupervisorPid(stateFile: string): number | null {
   const pid = readServeStateDocument(stateFile)?.supervisorPid;
   return Number.isInteger(pid) && Number(pid) > 0 ? Number(pid) : null;
+}
+
+function waitForChildExit(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+  return new Promise((resolve) => { child.once('exit', () => resolve()); });
+}
+
+async function daemonReachedReadyBeforeExit(
+  child: ChildProcess,
+  stateFile: string,
+  leafPid: number,
+): Promise<boolean> {
+  const exited = waitForChildExit(child);
+  let reachedReady = false;
+  while (child.exitCode === null && child.signalCode === null) {
+    const state = readServeStateDocument(stateFile);
+    if (state?.pid === leafPid && state.status === 'ready') {
+      reachedReady = true;
+      break;
+    }
+    await Promise.race([
+      exited,
+      new Promise((resolve) => { setTimeout(resolve, SERVE_SUPERVISOR_READY_POLL_MS); }),
+    ]);
+  }
+  await exited;
+  return reachedReady;
 }
 
 export async function waitForSupervisorRestart<T>(
@@ -300,14 +351,30 @@ export async function superviseServeDaemon(options: SuperviseServeDaemonOptions)
   let child: ReturnType<typeof spawn> | null = null;
   let stopping = false;
   let restartRequested = false;
+  let consecutiveFastFailures = 0;
+  let resolveDelay: (() => void) | null = null;
+  const wakeDelay = (): void => { resolveDelay?.(); };
+  const waitForDelay = async (delayMs: number): Promise<void> => {
+    await new Promise<void>((resolve) => {
+      const finish = (): void => {
+        clearTimeout(timer);
+        resolveDelay = null;
+        resolve();
+      };
+      const timer = setTimeout(finish, delayMs);
+      resolveDelay = finish;
+    });
+  };
   const stopSupervisor = (): void => {
     stopping = true;
     try { child?.kill('SIGTERM'); } catch {}
+    wakeDelay();
   };
   const restartChild = (): void => {
     if (stopping) return;
     restartRequested = true;
     try { child?.kill('SIGTERM'); } catch {}
+    wakeDelay();
   };
   process.once('SIGTERM', stopSupervisor);
   process.once('SIGINT', stopSupervisor);
@@ -335,6 +402,13 @@ export async function superviseServeDaemon(options: SuperviseServeDaemonOptions)
       if (!child.pid) {
         throw new CliError('serve_spawn_failed', 'Failed to spawn the headless daemon.', EXIT.CONNECTION_REFUSED);
       }
+      if (stopping) {
+        try { child.kill('SIGTERM'); } catch {}
+        await waitForChildExit(child);
+        child = null;
+        break;
+      }
+      if (restartRequested) restartRequested = false;
       try {
         writeFileSync(options.pidFile, String(child.pid), { flag: 'wx', mode: 0o600 });
       } catch (error) {
@@ -343,22 +417,42 @@ export async function superviseServeDaemon(options: SuperviseServeDaemonOptions)
       }
 
       const leafPid = child.pid;
-      await new Promise<void>((resolve) => { child?.once('exit', () => resolve()); });
+      const reachedReady = await daemonReachedReadyBeforeExit(child, options.stateFile, leafPid);
       try {
         if (readFileSync(options.pidFile, 'utf8').trim() === String(leafPid)) {
           rmSync(options.pidFile, { force: true });
         }
       } catch {}
       child = null;
+      if (reachedReady) consecutiveFastFailures = 0;
       if (stopping) break;
-      if (!restartRequested && process.platform !== 'win32') {
+      if (restartRequested) continue;
+      if (process.platform !== 'win32') {
         try { process.kill(-leafPid, 'SIGTERM'); } catch {}
-        await new Promise((resolve) => { setTimeout(resolve, 1_000); });
+        await waitForDelay(1_000);
         try { process.kill(-leafPid, 'SIGKILL'); } catch {}
       }
+      if (stopping) break;
+      if (restartRequested) continue;
+      if (reachedReady) continue;
+
+      consecutiveFastFailures += 1;
+      const retry = decideServeSupervisorRetry(consecutiveFastFailures);
+      if (retry.exhausted) {
+        appendFileSync(
+          options.logPath,
+          formatServeSupervisorFailure(new Date().toISOString(), consecutiveFastFailures),
+          { mode: 0o600 },
+        );
+        return EXIT.CONNECTION_REFUSED;
+      }
+      await waitForDelay(retry.delayMs);
     }
     return EXIT.OK;
   } finally {
+    wakeDelay();
+    process.removeListener('SIGTERM', stopSupervisor);
+    process.removeListener('SIGINT', stopSupervisor);
     process.removeListener('SIGHUP', restartChild);
     clearSupervisorPid(options.stateFile);
   }

--- a/cli/src/commands/serve-lifecycle.ts
+++ b/cli/src/commands/serve-lifecycle.ts
@@ -35,7 +35,7 @@ export interface ServeLaunchAgentPlistOptions {
 }
 
 interface ServeAgentCommandOptions extends ServeLaunchAgentPlistOptions {
-  assertDataDirAvailable: () => Promise<void>;
+  assertInstallAvailable: () => Promise<void>;
 }
 
 interface SuperviseServeDaemonOptions {
@@ -43,7 +43,23 @@ interface SuperviseServeDaemonOptions {
   launchMode: 'development' | 'packaged';
   logPath: string;
   pidFile: string;
+  stateFile: string;
   workingDirectory: string;
+}
+
+interface ServeStateDocument {
+  schema: 'o8/serve-state/v1';
+  supervisorPid?: number;
+  [key: string]: unknown;
+}
+
+interface WaitForSupervisorRestartOptions<T> {
+  supervisorPid: number;
+  timeoutMs: number;
+  pollMs: number;
+  logPath: string;
+  processAlive: (pid: number) => boolean;
+  readReadyState: () => Promise<T | null>;
 }
 
 function escapePlistValue(value: string): string {
@@ -112,6 +128,14 @@ export function decideServeLogRotation(
   };
 }
 
+export function formatServeLogSessionBoundary(
+  startedAt: string,
+  version: string,
+  pid: number,
+): string {
+  return `\n=== o8 serve session ${startedAt} version=${version} pid=${pid} ===\n`;
+}
+
 function fileSize(path: string): number | null {
   try {
     return statSync(path).size;
@@ -129,6 +153,59 @@ export function prepareServeLog(logPath: string): void {
     rmSync(previousLog, { force: true });
     renameSync(logPath, previousLog);
   }
+}
+
+function readServeStateDocument(stateFile: string): ServeStateDocument | null {
+  try {
+    const parsed = JSON.parse(readFileSync(stateFile, 'utf8')) as ServeStateDocument;
+    return parsed?.schema === 'o8/serve-state/v1' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeServeStateDocument(stateFile: string, state: ServeStateDocument): void {
+  const temporary = `${stateFile}.${process.pid}.tmp`;
+  writeFileSync(temporary, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+  renameSync(temporary, stateFile);
+}
+
+function persistSupervisorPid(stateFile: string, reset: boolean): void {
+  const current = reset ? null : readServeStateDocument(stateFile);
+  writeServeStateDocument(stateFile, {
+    ...(current ?? { schema: 'o8/serve-state/v1' }),
+    supervisorPid: process.pid,
+  });
+}
+
+function clearSupervisorPid(stateFile: string): void {
+  const current = readServeStateDocument(stateFile);
+  if (!current || current.supervisorPid !== process.pid) return;
+  const { supervisorPid: _supervisorPid, ...remaining } = current;
+  if (Object.keys(remaining).length === 1) rmSync(stateFile, { force: true });
+  else writeServeStateDocument(stateFile, remaining as ServeStateDocument);
+}
+
+export function readServeSupervisorPid(stateFile: string): number | null {
+  const pid = readServeStateDocument(stateFile)?.supervisorPid;
+  return Number.isInteger(pid) && Number(pid) > 0 ? Number(pid) : null;
+}
+
+export async function waitForSupervisorRestart<T>(
+  options: WaitForSupervisorRestartOptions<T>,
+): Promise<T> {
+  const deadline = Date.now() + options.timeoutMs;
+  while (Date.now() < deadline && options.processAlive(options.supervisorPid)) {
+    const state = await options.readReadyState();
+    if (state) return state;
+    await new Promise((resolve) => { setTimeout(resolve, options.pollMs); });
+  }
+  throw new CliError(
+    'serve_start_failed',
+    'The launch-agent supervisor did not replace the headless daemon before the startup deadline.',
+    EXIT.CONNECTION_REFUSED,
+    `Inspect ${options.logPath}.`,
+  );
 }
 
 function requireLaunchctl(): { domain: string; plistPath: string; target: string } {
@@ -202,9 +279,11 @@ export async function runServeAgentCommand(
   const typedAction = action as 'install' | 'uninstall' | 'status';
   if (typedAction === 'status') return outputAgentStatus(mode, typedAction);
 
+  if (typedAction === 'install') {
+    await options.assertInstallAvailable();
+  }
   const paths = requireLaunchctl();
   if (typedAction === 'install') {
-    await options.assertDataDirAvailable();
     mkdirSync(dirname(paths.plistPath), { recursive: true });
     mkdirSync(dirname(options.logPath), { recursive: true });
     writeFileSync(paths.plistPath, buildServeLaunchAgentPlist(options), { mode: 0o600 });
@@ -218,45 +297,69 @@ export async function runServeAgentCommand(
 }
 
 export async function superviseServeDaemon(options: SuperviseServeDaemonOptions): Promise<number> {
-  prepareServeLog(options.logPath);
-  const logFd = openSync(options.logPath, 'a', 0o600);
-  const child = spawn(process.execPath, [options.cliEntry, 'serve', '__daemon'], {
-    cwd: options.workingDirectory,
-    detached: true,
-    env: {
-      ...process.env,
-      O8_SERVE_ROOT: options.workingDirectory,
-      O8_SERVE_LAUNCH_MODE: options.launchMode,
-    },
-    stdio: ['ignore', logFd, logFd],
-  });
-  closeSync(logFd);
-  if (!child.pid) {
-    throw new CliError('serve_spawn_failed', 'Failed to spawn the headless daemon.', EXIT.CONNECTION_REFUSED);
-  }
-  try {
-    writeFileSync(options.pidFile, String(child.pid), { flag: 'wx', mode: 0o600 });
-  } catch (error) {
-    try { child.kill('SIGTERM'); } catch {}
-    throw error;
-  }
-
+  let child: ReturnType<typeof spawn> | null = null;
   let stopping = false;
-  const stopChild = (): void => {
+  let restartRequested = false;
+  const stopSupervisor = (): void => {
     stopping = true;
-    try { child.kill('SIGTERM'); } catch {}
+    try { child?.kill('SIGTERM'); } catch {}
   };
-  process.once('SIGTERM', stopChild);
-  process.once('SIGINT', stopChild);
-  return await new Promise<number>((resolve) => {
-    child.once('exit', (code, signal) => {
+  const restartChild = (): void => {
+    if (stopping) return;
+    restartRequested = true;
+    try { child?.kill('SIGTERM'); } catch {}
+  };
+  process.once('SIGTERM', stopSupervisor);
+  process.once('SIGINT', stopSupervisor);
+  process.on('SIGHUP', restartChild);
+  persistSupervisorPid(options.stateFile, true);
+
+  try {
+    while (!stopping) {
+      restartRequested = false;
+      persistSupervisorPid(options.stateFile, true);
+      prepareServeLog(options.logPath);
+      const logFd = openSync(options.logPath, 'a', 0o600);
+      child = spawn(process.execPath, [options.cliEntry, 'serve', '__daemon'], {
+        cwd: options.workingDirectory,
+        detached: true,
+        env: {
+          ...process.env,
+          O8_SERVE_ROOT: options.workingDirectory,
+          O8_SERVE_LAUNCH_MODE: options.launchMode,
+          O8_SERVE_SUPERVISOR_PID: String(process.pid),
+        },
+        stdio: ['ignore', logFd, logFd],
+      });
+      closeSync(logFd);
+      if (!child.pid) {
+        throw new CliError('serve_spawn_failed', 'Failed to spawn the headless daemon.', EXIT.CONNECTION_REFUSED);
+      }
       try {
-        if (readFileSync(options.pidFile, 'utf8').trim() === String(child.pid)) {
+        writeFileSync(options.pidFile, String(child.pid), { flag: 'wx', mode: 0o600 });
+      } catch (error) {
+        try { child.kill('SIGTERM'); } catch {}
+        throw error;
+      }
+
+      const leafPid = child.pid;
+      await new Promise<void>((resolve) => { child?.once('exit', () => resolve()); });
+      try {
+        if (readFileSync(options.pidFile, 'utf8').trim() === String(leafPid)) {
           rmSync(options.pidFile, { force: true });
         }
       } catch {}
-      if (stopping) resolve(EXIT.OK);
-      else resolve(code ?? (signal ? EXIT.CONNECTION_REFUSED : EXIT.OK));
-    });
-  });
+      child = null;
+      if (stopping) break;
+      if (!restartRequested && process.platform !== 'win32') {
+        try { process.kill(-leafPid, 'SIGTERM'); } catch {}
+        await new Promise((resolve) => { setTimeout(resolve, 1_000); });
+        try { process.kill(-leafPid, 'SIGKILL'); } catch {}
+      }
+    }
+    return EXIT.OK;
+  } finally {
+    process.removeListener('SIGHUP', restartChild);
+    clearSupervisorPid(options.stateFile);
+  }
 }

--- a/cli/src/commands/serve-output.ts
+++ b/cli/src/commands/serve-output.ts
@@ -12,6 +12,7 @@ interface ServeOutputState {
   pid: number;
   startedAt: string;
   status: 'starting' | 'ready' | 'stopping' | 'failed';
+  supervisorPid?: number;
   version?: string;
   wsPort: number;
 }
@@ -39,6 +40,7 @@ export function outputServeState(
     status: state.status,
     children: state.children,
     startedAt: state.startedAt,
+    supervisorPid: state.supervisorPid ?? null,
     cliVersion: CLI_VERSION,
     daemonVersion,
     versionMismatch,
@@ -58,6 +60,7 @@ export function outputServeState(
     ['ws', String(state.wsPort)],
     ['mode', state.mode],
     ['status', state.status],
+    ['supervisor pid', state.supervisorPid ? String(state.supervisorPid) : '(none)'],
     ['cli version', CLI_VERSION],
     ['daemon version', daemonVersion ?? '(unknown)'],
     ['version mismatch', String(versionMismatch)],

--- a/cli/src/commands/serve-output.ts
+++ b/cli/src/commands/serve-output.ts
@@ -1,0 +1,99 @@
+import { EXIT } from '../api.js';
+import { printHumanKv, printJson, type OutputMode } from '../output.js';
+import { CLI_VERSION } from './version.js';
+
+export const SERVE_STATUS_NOTE = 'The desktop app uses the next available API and WebSocket port block entries, so both can coexist. App auto-update does not update a running daemon; run `o8 serve restart` to pick up the new code.';
+
+interface ServeOutputState {
+  apiPort: number;
+  children: Array<{ role: 'api' | 'ws'; pid: number }>;
+  mode: 'development' | 'packaged';
+  pgid: number;
+  pid: number;
+  startedAt: string;
+  status: 'starting' | 'ready' | 'stopping' | 'failed';
+  version?: string;
+  wsPort: number;
+}
+
+export function outputServeState(
+  mode: OutputMode,
+  state: ServeOutputState,
+  running: boolean,
+  healthy: boolean,
+): void {
+  const daemonVersion = state.version ?? null;
+  const versionMismatch = daemonVersion !== null && daemonVersion !== CLI_VERSION;
+  const warning = versionMismatch
+    ? `Invoking CLI version ${CLI_VERSION} differs from running daemon version ${daemonVersion}. Run \`o8 serve restart\` to pick up the new code.`
+    : null;
+  const payload = {
+    schema: 'o8/cli/serve-status/v1',
+    running,
+    healthy,
+    pid: state.pid,
+    pgid: state.pgid,
+    apiPort: state.apiPort,
+    wsPort: state.wsPort,
+    mode: state.mode,
+    status: state.status,
+    children: state.children,
+    startedAt: state.startedAt,
+    cliVersion: CLI_VERSION,
+    daemonVersion,
+    versionMismatch,
+    warning,
+    note: SERVE_STATUS_NOTE,
+  };
+  if (!mode.human) {
+    printJson(payload);
+    return;
+  }
+  printHumanKv([
+    ['running', String(running)],
+    ['healthy', String(healthy)],
+    ['pid', String(state.pid)],
+    ['pgid', String(state.pgid)],
+    ['api', String(state.apiPort)],
+    ['ws', String(state.wsPort)],
+    ['mode', state.mode],
+    ['status', state.status],
+    ['cli version', CLI_VERSION],
+    ['daemon version', daemonVersion ?? '(unknown)'],
+    ['version mismatch', String(versionMismatch)],
+    ...(warning ? [['warning', warning] as [string, string]] : []),
+    ['note', SERVE_STATUS_NOTE],
+  ]);
+}
+
+export function outputServeNotRunning(mode: OutputMode): number {
+  const payload = {
+    schema: 'o8/cli/serve-status/v1',
+    running: false,
+    healthy: false,
+    cliVersion: CLI_VERSION,
+    daemonVersion: null,
+    versionMismatch: false,
+    warning: null,
+    note: SERVE_STATUS_NOTE,
+  };
+  if (mode.human) {
+    printHumanKv([
+      ['running', 'false'],
+      ['healthy', 'false'],
+      ['cli version', CLI_VERSION],
+      ['daemon version', '(not running)'],
+      ['note', SERVE_STATUS_NOTE],
+    ]);
+  } else {
+    printJson(payload);
+  }
+  return EXIT.OK;
+}
+
+export function outputServeStopped(mode: OutputMode, pid: number): number {
+  const payload = { schema: 'o8/cli/serve-stop/v1', stopped: true, pid };
+  if (mode.human) printHumanKv([['stopped', 'true'], ['pid', String(pid)]]);
+  else printJson(payload);
+  return EXIT.OK;
+}

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -17,6 +17,11 @@ import { fileURLToPath } from 'node:url';
 import { CliError, EXIT } from '../api.js';
 import { resolveCliDataDir } from '../config.js';
 import { printHumanKv, printJson, type OutputMode } from '../output.js';
+import {
+  prepareServeLog,
+  runServeAgentCommand,
+  superviseServeDaemon,
+} from './serve-lifecycle.js';
 
 const PROD_API_PORT_BLOCK = [47100, 47101, 47102, 47103, 47104] as const;
 const PROD_WS_PORT_BLOCK = [47105, 47106, 47107, 47108, 47109] as const;
@@ -459,9 +464,7 @@ async function startServe(mode: OutputMode): Promise<number> {
   await assertDataDirAvailableForServe(paths);
 
   const plan = resolveLaunchPlan();
-  const previousLog = `${paths.logFile}.prev`;
-  rmSync(previousLog, { force: true });
-  if (existsSync(paths.logFile)) renameSync(paths.logFile, previousLog);
+  prepareServeLog(paths.logFile);
   const logFd = openSync(paths.logFile, 'a', 0o600);
   const cliEntry = process.argv[1];
   const child = spawn(process.execPath, [cliEntry, 'serve', '__daemon'], {
@@ -496,6 +499,25 @@ async function startServe(mode: OutputMode): Promise<number> {
   const state = await waitForDaemonReady(paths, child.pid);
   outputState(mode, state, true, true);
   return EXIT.OK;
+}
+
+async function runLaunchAgent(): Promise<number> {
+  const paths = servePaths();
+  mkdirSync(paths.dataDir, { recursive: true });
+  cleanStaleOwner(paths);
+  await assertDataDirAvailableForServe(paths);
+  const ownerPid = readOwnerPid(paths);
+  if (ownerPid && processAlive(ownerPid)) {
+    throw new CliError('serve_already_running', `Headless o8 is already running with pid ${ownerPid}.`, EXIT.CONFLICT);
+  }
+  const plan = resolveLaunchPlan();
+  return superviseServeDaemon({
+    cliEntry: process.argv[1],
+    launchMode: plan.mode,
+    logPath: paths.logFile,
+    pidFile: paths.pidFile,
+    workingDirectory: plan.root,
+  });
 }
 
 async function statusServe(mode: OutputMode): Promise<number> {
@@ -735,17 +757,30 @@ export async function runServe(
   subcommand: string | undefined,
   rest: string[],
 ): Promise<number> {
+  if (subcommand === 'agent') {
+    const paths = servePaths();
+    const plan = resolveLaunchPlan();
+    return runServeAgentCommand(mode, rest[0], rest.slice(1), {
+      cliEntry: process.argv[1],
+      dataDir: paths.dataDir,
+      logPath: paths.logFile,
+      nodePath: process.execPath,
+      workingDirectory: plan.root,
+      assertDataDirAvailable: () => assertDataDirAvailableForServe(paths),
+    });
+  }
   if (rest.length > 0) {
     throw new CliError('invalid_serve_args', `Unexpected serve arguments: ${rest.join(' ')}`, EXIT.INVALID_ARGS);
   }
   if (!subcommand) return startServe(mode);
   if (subcommand === 'status') return statusServe(mode);
   if (subcommand === 'stop') return stopServe(mode);
+  if (subcommand === '__launch_agent') return runLaunchAgent();
   if (subcommand === '__daemon') return runDaemon();
   throw new CliError(
     'unknown_serve_subcommand',
     `Unknown serve subcommand: ${subcommand}`,
     EXIT.INVALID_ARGS,
-    'Use `o8 serve`, `o8 serve status`, or `o8 serve stop`.',
+    'Use `o8 serve`, `o8 serve status`, `o8 serve stop`, or `o8 serve agent status`.',
   );
 }

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -16,19 +16,24 @@ import { fileURLToPath } from 'node:url';
 
 import { CliError, EXIT } from '../api.js';
 import { resolveCliDataDir } from '../config.js';
-import { printHumanKv, printJson, type OutputMode } from '../output.js';
+import { type OutputMode } from '../output.js';
 import {
   prepareServeLog,
   runServeAgentCommand,
   superviseServeDaemon,
 } from './serve-lifecycle.js';
+import { CLI_VERSION } from './version.js';
+import {
+  outputServeNotRunning,
+  outputServeState,
+  outputServeStopped,
+} from './serve-output.js';
 
 const PROD_API_PORT_BLOCK = [47100, 47101, 47102, 47103, 47104] as const;
 const PROD_WS_PORT_BLOCK = [47105, 47106, 47107, 47108, 47109] as const;
 const START_TIMEOUT_MS = 60_000;
 const STOP_TIMEOUT_MS = 8_000;
 const POLL_MS = 100;
-const DESKTOP_COEXISTENCE_NOTE = 'The desktop app uses the next available API and WebSocket port block entries, so both can coexist.';
 
 type ServeMode = 'development' | 'packaged';
 type ServeStatus = 'starting' | 'ready' | 'stopping' | 'failed';
@@ -49,6 +54,7 @@ interface ServeState {
   startedAt: string;
   status: ServeStatus;
   children: ServeChildState[];
+  version?: string;
   error?: string;
 }
 
@@ -409,45 +415,6 @@ async function waitForDaemonReady(paths: ServePaths, pid: number): Promise<Serve
   );
 }
 
-function outputState(mode: OutputMode, state: ServeState, running: boolean, healthy: boolean): void {
-  const payload = {
-    schema: 'o8/cli/serve-status/v1',
-    running,
-    healthy,
-    pid: state.pid,
-    pgid: state.pgid,
-    apiPort: state.apiPort,
-    wsPort: state.wsPort,
-    mode: state.mode,
-    status: state.status,
-    children: state.children,
-    startedAt: state.startedAt,
-    note: DESKTOP_COEXISTENCE_NOTE,
-  };
-  if (!mode.human) {
-    printJson(payload);
-    return;
-  }
-  printHumanKv([
-    ['running', String(running)],
-    ['healthy', String(healthy)],
-    ['pid', String(state.pid)],
-    ['pgid', String(state.pgid)],
-    ['api', String(state.apiPort)],
-    ['ws', String(state.wsPort)],
-    ['mode', state.mode],
-    ['status', state.status],
-    ['note', DESKTOP_COEXISTENCE_NOTE],
-  ]);
-}
-
-function outputStopped(mode: OutputMode, pid: number): number {
-  const payload = { schema: 'o8/cli/serve-stop/v1', stopped: true, pid };
-  if (mode.human) printHumanKv([['stopped', 'true'], ['pid', String(pid)]]);
-  else printJson(payload);
-  return EXIT.OK;
-}
-
 async function startServe(mode: OutputMode): Promise<number> {
   const paths = servePaths();
   mkdirSync(dirname(paths.logFile), { recursive: true });
@@ -497,7 +464,7 @@ async function startServe(mode: OutputMode): Promise<number> {
   }
   child.unref();
   const state = await waitForDaemonReady(paths, child.pid);
-  outputState(mode, state, true, true);
+  outputServeState(mode, state, true, true);
   return EXIT.OK;
 }
 
@@ -527,30 +494,16 @@ async function statusServe(mode: OutputMode): Promise<number> {
   if (!pid || !state || state.pid !== pid || !processAlive(pid)) {
     const hasRecoverableChildren = Boolean(state?.children.some((child) => processAlive(child.pid)));
     if (!hasRecoverableChildren) cleanStaleOwner(paths);
-    const payload = {
-      schema: 'o8/cli/serve-status/v1',
-      running: false,
-      healthy: false,
-      note: DESKTOP_COEXISTENCE_NOTE,
-    };
-    if (mode.human) {
-      printHumanKv([
-        ['running', 'false'],
-        ['healthy', 'false'],
-        ['note', DESKTOP_COEXISTENCE_NOTE],
-      ]);
-    }
-    else printJson(payload);
-    return EXIT.OK;
+    return outputServeNotRunning(mode);
   }
   const healthy = state.status === 'ready'
     && await apiIsReady(state.apiPort)
     && await portAcceptsConnections(state.wsPort);
-  outputState(mode, state, true, healthy);
+  outputServeState(mode, state, true, healthy);
   return healthy ? EXIT.OK : EXIT.CONNECTION_REFUSED;
 }
 
-async function stopServe(mode: OutputMode): Promise<number> {
+async function stopServe(mode: OutputMode, report = true): Promise<number> {
   const paths = servePaths();
   const pid = readOwnerPid(paths);
   const state = readState(paths);
@@ -566,7 +519,7 @@ async function stopServe(mode: OutputMode): Promise<number> {
     const stopped = await terminateTrackedPids(childPids, stateMatchesOwner?.pgid, 1_000);
     cleanStaleOwner(paths);
     if (stopped && trackedPids.every((trackedPid) => !processAlive(trackedPid)) && !existsSync(paths.pidFile)) {
-      return outputStopped(mode, leaderPid);
+      return report ? outputServeStopped(mode, leaderPid) : EXIT.OK;
     }
     throw new CliError(
       'serve_stop_failed',
@@ -592,7 +545,7 @@ async function stopServe(mode: OutputMode): Promise<number> {
       && !processGroupAlive(stateMatchesOwner?.pgid)
       && !existsSync(paths.pidFile)
     ) {
-      return outputStopped(mode, leaderPid);
+      return report ? outputServeStopped(mode, leaderPid) : EXIT.OK;
     }
     await wait(POLL_MS);
   }
@@ -603,7 +556,7 @@ async function stopServe(mode: OutputMode): Promise<number> {
     && !processGroupAlive(stateMatchesOwner?.pgid);
   if (allProcessesStopped) cleanStaleOwner(paths);
   if (allProcessesStopped && !existsSync(paths.pidFile)) {
-    return outputStopped(mode, leaderPid);
+    return report ? outputServeStopped(mode, leaderPid) : EXIT.OK;
   }
   throw new CliError(
     'serve_stop_failed',
@@ -611,6 +564,11 @@ async function stopServe(mode: OutputMode): Promise<number> {
     EXIT.CONFLICT,
     `Inspect ${paths.logFile}.`,
   );
+}
+
+async function restartServe(mode: OutputMode): Promise<number> {
+  await stopServe(mode, false);
+  return startServe(mode);
 }
 
 async function runDaemon(): Promise<number> {
@@ -672,6 +630,7 @@ async function runDaemon(): Promise<number> {
     startedAt: new Date().toISOString(),
     status: 'starting',
     children: [],
+    version: CLI_VERSION,
   };
   writeState(paths, state);
 
@@ -775,12 +734,13 @@ export async function runServe(
   if (!subcommand) return startServe(mode);
   if (subcommand === 'status') return statusServe(mode);
   if (subcommand === 'stop') return stopServe(mode);
+  if (subcommand === 'restart') return restartServe(mode);
   if (subcommand === '__launch_agent') return runLaunchAgent();
   if (subcommand === '__daemon') return runDaemon();
   throw new CliError(
     'unknown_serve_subcommand',
     `Unknown serve subcommand: ${subcommand}`,
     EXIT.INVALID_ARGS,
-    'Use `o8 serve`, `o8 serve status`, `o8 serve stop`, or `o8 serve agent status`.',
+    'Use `o8 serve`, `o8 serve status`, `o8 serve stop`, `o8 serve restart`, or `o8 serve agent status`.',
   );
 }

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1,14 +1,8 @@
 import { randomBytes, randomUUID } from 'node:crypto';
 import { spawn, type ChildProcess } from 'node:child_process';
 import {
-  closeSync,
-  existsSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  renameSync,
-  rmSync,
-  writeFileSync,
+  appendFileSync, closeSync, existsSync, mkdirSync, openSync, readFileSync,
+  renameSync, rmSync, writeFileSync,
 } from 'node:fs';
 import { createServer, Socket } from 'node:net';
 import { dirname, join, parse } from 'node:path';
@@ -18,16 +12,15 @@ import { CliError, EXIT } from '../api.js';
 import { resolveCliDataDir } from '../config.js';
 import { type OutputMode } from '../output.js';
 import {
+  formatServeLogSessionBoundary,
   prepareServeLog,
+  readServeSupervisorPid,
   runServeAgentCommand,
   superviseServeDaemon,
+  waitForSupervisorRestart,
 } from './serve-lifecycle.js';
 import { CLI_VERSION } from './version.js';
-import {
-  outputServeNotRunning,
-  outputServeState,
-  outputServeStopped,
-} from './serve-output.js';
+import { outputServeNotRunning, outputServeState, outputServeStopped } from './serve-output.js';
 
 const PROD_API_PORT_BLOCK = [47100, 47101, 47102, 47103, 47104] as const;
 const PROD_WS_PORT_BLOCK = [47105, 47106, 47107, 47108, 47109] as const;
@@ -54,6 +47,7 @@ interface ServeState {
   startedAt: string;
   status: ServeStatus;
   children: ServeChildState[];
+  supervisorPid?: number;
   version?: string;
   error?: string;
 }
@@ -152,10 +146,30 @@ function writeState(paths: ServePaths, state: ServeState): void {
 }
 
 function cleanStaleOwner(paths: ServePaths): void {
+  const supervisorPid = readServeSupervisorPid(paths.stateFile);
+  if (supervisorPid && processAlive(supervisorPid)) return;
   const pid = readOwnerPid(paths);
   if (pid && processAlive(pid)) return;
   rmSync(paths.pidFile, { force: true });
   rmSync(paths.stateFile, { force: true });
+}
+
+async function assertServeAgentInstallAvailable(paths: ServePaths): Promise<void> {
+  cleanStaleOwner(paths);
+  const supervisorPid = readServeSupervisorPid(paths.stateFile);
+  const ownerPid = readOwnerPid(paths);
+  const runningPid = supervisorPid && processAlive(supervisorPid)
+    ? supervisorPid
+    : ownerPid && processAlive(ownerPid) ? ownerPid : null;
+  if (runningPid) {
+    throw new CliError(
+      'serve_already_running',
+      `Cannot install the launch agent while headless o8 is already running with pid ${runningPid}.`,
+      EXIT.CONFLICT,
+      'Run `o8 serve stop`, then retry `o8 serve agent install`.',
+    );
+  }
+  await assertDataDirAvailableForServe(paths);
 }
 
 function wait(ms: number): Promise<void> {
@@ -420,10 +434,12 @@ async function startServe(mode: OutputMode): Promise<number> {
   mkdirSync(dirname(paths.logFile), { recursive: true });
   cleanStaleOwner(paths);
   const existingPid = readOwnerPid(paths);
-  if (existingPid && processAlive(existingPid)) {
+  const supervisorPid = readServeSupervisorPid(paths.stateFile);
+  const runningPid = supervisorPid && processAlive(supervisorPid) ? supervisorPid : existingPid;
+  if (runningPid && processAlive(runningPid)) {
     throw new CliError(
       'serve_already_running',
-      `Headless o8 is already running with pid ${existingPid}.`,
+      `Headless o8 is already running with pid ${runningPid}.`,
       EXIT.CONFLICT,
       'Run `o8 serve status` or `o8 serve stop`.',
     );
@@ -483,6 +499,7 @@ async function runLaunchAgent(): Promise<number> {
     launchMode: plan.mode,
     logPath: paths.logFile,
     pidFile: paths.pidFile,
+    stateFile: paths.stateFile,
     workingDirectory: plan.root,
   });
 }
@@ -507,37 +524,38 @@ async function stopServe(mode: OutputMode, report = true): Promise<number> {
   const paths = servePaths();
   const pid = readOwnerPid(paths);
   const state = readState(paths);
+  const supervisorPid = readServeSupervisorPid(paths.stateFile);
   const stateMatchesOwner = state && (!pid || state.pid === pid) ? state : null;
   const leaderPid = pid ?? stateMatchesOwner?.pid ?? null;
-  if (!leaderPid) {
+  const liveSupervisorPid = supervisorPid && processAlive(supervisorPid) ? supervisorPid : null;
+  const resultPid = leaderPid ?? liveSupervisorPid;
+  if (!resultPid) {
     cleanStaleOwner(paths);
     throw new CliError('serve_not_running', 'Headless o8 is not running.', EXIT.NOT_FOUND);
   }
   const childPids = stateMatchesOwner?.children.map((child) => child.pid) ?? [];
-  const trackedPids = uniquePids([leaderPid, ...childPids]);
-  if (!processAlive(leaderPid)) {
+  const trackedPids = uniquePids([liveSupervisorPid ?? 0, leaderPid ?? 0, ...childPids]);
+  if (!liveSupervisorPid && (!leaderPid || !processAlive(leaderPid))) {
     const stopped = await terminateTrackedPids(childPids, stateMatchesOwner?.pgid, 1_000);
     cleanStaleOwner(paths);
     if (stopped && trackedPids.every((trackedPid) => !processAlive(trackedPid)) && !existsSync(paths.pidFile)) {
-      return report ? outputServeStopped(mode, leaderPid) : EXIT.OK;
+      return report ? outputServeStopped(mode, resultPid) : EXIT.OK;
     }
     throw new CliError(
       'serve_stop_failed',
-      `Headless o8 pid ${leaderPid} died, but one or more recorded children could not be stopped.`,
+      `Headless o8 pid ${resultPid} died, but one or more recorded children could not be stopped.`,
       EXIT.CONFLICT,
       `Inspect ${paths.logFile}.`,
     );
   }
-  try {
-    process.kill(leaderPid, 'SIGTERM');
-  } catch {}
+  signalPids([liveSupervisorPid ?? leaderPid ?? 0], 'SIGTERM');
   const startedAt = Date.now();
   const deadline = startedAt + STOP_TIMEOUT_MS;
   const escalationAt = startedAt + Math.floor(STOP_TIMEOUT_MS / 2);
   let childrenSignaled = false;
   while (Date.now() < deadline) {
     if (!childrenSignaled && Date.now() >= escalationAt) {
-      signalPids(childPids, 'SIGTERM');
+      signalPids(trackedPids, 'SIGTERM');
       childrenSignaled = true;
     }
     if (
@@ -545,7 +563,7 @@ async function stopServe(mode: OutputMode, report = true): Promise<number> {
       && !processGroupAlive(stateMatchesOwner?.pgid)
       && !existsSync(paths.pidFile)
     ) {
-      return report ? outputServeStopped(mode, leaderPid) : EXIT.OK;
+      return report ? outputServeStopped(mode, resultPid) : EXIT.OK;
     }
     await wait(POLL_MS);
   }
@@ -556,17 +574,46 @@ async function stopServe(mode: OutputMode, report = true): Promise<number> {
     && !processGroupAlive(stateMatchesOwner?.pgid);
   if (allProcessesStopped) cleanStaleOwner(paths);
   if (allProcessesStopped && !existsSync(paths.pidFile)) {
-    return report ? outputServeStopped(mode, leaderPid) : EXIT.OK;
+    return report ? outputServeStopped(mode, resultPid) : EXIT.OK;
   }
   throw new CliError(
     'serve_stop_failed',
-    `Headless o8 pid ${leaderPid} did not stop before the shutdown deadline.`,
+    `Headless o8 pid ${resultPid} did not stop before the shutdown deadline.`,
     EXIT.CONFLICT,
     `Inspect ${paths.logFile}.`,
   );
 }
 
 async function restartServe(mode: OutputMode): Promise<number> {
+  const paths = servePaths();
+  const state = readState(paths);
+  const supervisorPid = readServeSupervisorPid(paths.stateFile);
+  if (supervisorPid && processAlive(supervisorPid)) {
+    const previousPid = readOwnerPid(paths) ?? state?.pid ?? null;
+    process.kill(supervisorPid, 'SIGHUP');
+    const restarted = await waitForSupervisorRestart({
+      supervisorPid,
+      timeoutMs: START_TIMEOUT_MS,
+      pollMs: POLL_MS,
+      logPath: paths.logFile,
+      processAlive,
+      readReadyState: async () => {
+        const pid = readOwnerPid(paths);
+        const current = readState(paths);
+        if (!pid || pid === previousPid || current?.pid !== pid) return null;
+        if (current.supervisorPid !== supervisorPid || current.status !== 'ready') return null;
+        return await apiIsReady(current.apiPort) && await portAcceptsConnections(current.wsPort) ? current : null;
+      },
+    });
+    outputServeState(mode, restarted, true, true);
+    return EXIT.OK;
+  }
+  const ownerPid = readOwnerPid(paths);
+  const recoverableChildren = state?.children.some((child) => processAlive(child.pid)) ?? false;
+  if ((!ownerPid || !processAlive(ownerPid)) && !recoverableChildren) {
+    cleanStaleOwner(paths);
+    return startServe(mode);
+  }
   await stopServe(mode, false);
   return startServe(mode);
 }
@@ -577,6 +624,8 @@ async function runDaemon(): Promise<number> {
   const ownerDeadline = Date.now() + 2_000;
   while (readOwnerPid(paths) !== process.pid && Date.now() < ownerDeadline) await wait(10);
   if (readOwnerPid(paths) !== process.pid) return EXIT.CONFLICT;
+  const startedAt = new Date().toISOString();
+  appendFileSync(paths.logFile, formatServeLogSessionBoundary(startedAt, CLI_VERSION, process.pid), { mode: 0o600 });
 
   const plan = resolveLaunchPlan();
   const requestedMode = process.env.O8_SERVE_LAUNCH_MODE;
@@ -591,6 +640,7 @@ async function runDaemon(): Promise<number> {
   writeFileSync(paths.apiPortFile, String(apiPort), { mode: 0o600 });
   writeFileSync(paths.wsPortFile, String(wsPort), { mode: 0o600 });
   const token = getOrCreateToken(paths);
+  const supervisorPid = parsePid(process.env.O8_SERVE_SUPERVISOR_PID ?? '');
 
   const env: NodeJS.ProcessEnv = {
     ...process.env,
@@ -627,9 +677,10 @@ async function runDaemon(): Promise<number> {
     wsPort,
     mode: plan.mode,
     root: plan.root,
-    startedAt: new Date().toISOString(),
+    startedAt,
     status: 'starting',
     children: [],
+    ...(supervisorPid ? { supervisorPid } : {}),
     version: CLI_VERSION,
   };
   writeState(paths, state);
@@ -725,7 +776,7 @@ export async function runServe(
       logPath: paths.logFile,
       nodePath: process.execPath,
       workingDirectory: plan.root,
-      assertDataDirAvailable: () => assertDataDirAvailableForServe(paths),
+      assertInstallAvailable: () => assertServeAgentInstallAvailable(paths),
     });
   }
   if (rest.length > 0) {

--- a/cli/src/commands/version.ts
+++ b/cli/src/commands/version.ts
@@ -15,7 +15,7 @@ import { printHumanKv, printJson, type OutputMode } from '../output.js';
 // Replaced by esbuild --define at build time (cli/esbuild.config.mjs). Falls
 // back to a dev marker when run unbundled (e.g. via tsx during development).
 declare const __O8_CLI_VERSION__: string | undefined;
-const CLI_VERSION = typeof __O8_CLI_VERSION__ !== 'undefined' ? __O8_CLI_VERSION__ : '0.0.0-dev';
+export const CLI_VERSION = typeof __O8_CLI_VERSION__ !== 'undefined' ? __O8_CLI_VERSION__ : '0.0.0-dev';
 
 interface PanelStatus {
   version: string | null;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -218,6 +218,9 @@ commands:
   serve                start the headless API, WebSocket layer, and supervisor daemon
   serve status         report the daemon pid, ports, health, and launch mode
   serve stop           stop the daemon and reap its server children
+  serve agent install  install and load the per-user headless service
+  serve agent uninstall  unload and remove the per-user headless service
+  serve agent status   report whether the per-user headless service is loaded
   ask [--terse] "<question>"  ask the Engineering Brain about this repo (answer + cited sources)
   feature list|next|add|verify  durable repo-scoped feature ledger
   ground "<task>"      persist a real-path impact map before execution

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -218,6 +218,7 @@ commands:
   serve                start the headless API, WebSocket layer, and supervisor daemon
   serve status         report the daemon pid, ports, health, and launch mode
   serve stop           stop the daemon and reap its server children
+  serve restart        stop and restart the daemon with the invoking CLI version
   serve agent install  install and load the per-user headless service
   serve agent uninstall  unload and remove the per-user headless service
   serve agent status   report whether the per-user headless service is loaded

--- a/tests/o8-serve-real-path.test.ts
+++ b/tests/o8-serve-real-path.test.ts
@@ -30,6 +30,10 @@ interface ServeStatus {
   apiPort: number;
   wsPort: number;
   mode: 'development' | 'packaged';
+  cliVersion: string;
+  daemonVersion: string | null;
+  versionMismatch: boolean;
+  warning: string | null;
   children: Array<{ role: string; pid: number }>;
   note: string;
 }
@@ -142,6 +146,10 @@ describe.sequential('o8 serve real CLI path', () => {
     expect(startStatus.apiPort).toBeGreaterThan(0);
     expect(startStatus.wsPort).toBeGreaterThan(0);
     expect(startStatus.note).toContain('both can coexist');
+    expect(startStatus.note).toContain('auto-update does not update a running daemon');
+    expect(startStatus.cliVersion).toBe(startStatus.daemonVersion);
+    expect(startStatus.versionMismatch).toBe(false);
+    expect(startStatus.warning).toBeNull();
     expect(existsSync(join(dataDir, 'serve.pid'))).toBe(true);
     expect(readFileSync(join(dataDir, 'instance-id'), 'utf8')).toBe(desktopInstanceId);
     expect(readFileSync(join(dataDir, 'serve-instance-id'), 'utf8').trim()).not.toBe(desktopInstanceId);
@@ -163,8 +171,41 @@ describe.sequential('o8 serve real CLI path', () => {
       wsPort: startStatus.wsPort,
       mode: 'development',
       pgid: startStatus.pid,
+      cliVersion: startStatus.cliVersion,
+      daemonVersion: startStatus.daemonVersion,
+      versionMismatch: false,
+      warning: null,
       note: startStatus.note,
     });
+
+    const statePath = join(dataDir, 'serve-state.json');
+    const persistedState = JSON.parse(readFileSync(statePath, 'utf8')) as Record<string, unknown>;
+    expect(persistedState.version).toBe(startStatus.cliVersion);
+    writeFileSync(statePath, `${JSON.stringify({ ...persistedState, version: '0.0.0-stale' }, null, 2)}\n`, { mode: 0o600 });
+    const mismatchedStatus = await runCli(['serve', 'status'], dataDir);
+    expect(mismatchedStatus.code, mismatchedStatus.stderr).toBe(0);
+    expect(JSON.parse(mismatchedStatus.stdout)).toMatchObject({
+      cliVersion: startStatus.cliVersion,
+      daemonVersion: '0.0.0-stale',
+      versionMismatch: true,
+      warning: expect.stringContaining('o8 serve restart'),
+    });
+
+    const initialOwnedPids = [startStatus.pid, ...descendantPids(startStatus.pid)];
+    const restarted = await runCli(['serve', 'restart'], dataDir);
+    expect(restarted.code, `${restarted.stderr}\n${readServeLog(dataDir)}`).toBe(0);
+    const restartedStatus = JSON.parse(restarted.stdout) as ServeStatus;
+    expect(restartedStatus).toMatchObject({
+      running: true,
+      healthy: true,
+      mode: 'development',
+      cliVersion: startStatus.cliVersion,
+      daemonVersion: startStatus.cliVersion,
+      versionMismatch: false,
+      warning: null,
+    });
+    expect(restartedStatus.pid).not.toBe(startStatus.pid);
+    expect(initialOwnedPids.filter(processAlive)).toEqual([]);
 
     const secondStart = await runCli(['serve'], dataDir);
     expect(secondStart.code).toBe(5);
@@ -172,11 +213,11 @@ describe.sequential('o8 serve real CLI path', () => {
       error: { code: 'serve_already_running', ambiguous: false },
     });
 
-    const ownedPids = [startStatus.pid, ...descendantPids(startStatus.pid)];
+    const ownedPids = [restartedStatus.pid, ...descendantPids(restartedStatus.pid)];
     expect(ownedPids.length).toBeGreaterThanOrEqual(3);
     const stopped = await runCli(['serve', 'stop'], dataDir, 15_000);
     expect(stopped.code, stopped.stderr).toBe(0);
-    expect(JSON.parse(stopped.stdout)).toMatchObject({ stopped: true, pid: startStatus.pid });
+    expect(JSON.parse(stopped.stdout)).toMatchObject({ stopped: true, pid: restartedStatus.pid });
     expect(existsSync(join(dataDir, 'serve.pid'))).toBe(false);
     expect(ownedPids.filter(processAlive)).toEqual([]);
   }, 120_000);

--- a/tests/o8-serve-real-path.test.ts
+++ b/tests/o8-serve-real-path.test.ts
@@ -55,6 +55,18 @@ function makePackagedLayout(): { cliEntrypoint: string; serverRoot: string } {
   return { cliEntrypoint: packagedCli, serverRoot };
 }
 
+function makeFailingPackagedLayout(): { cliEntrypoint: string; serverRoot: string } {
+  const layoutRoot = mkdtempSync(join(tmpdir(), 'o8-failing-serve-layout-'));
+  tempDirs.add(layoutRoot);
+  const serverRoot = join(layoutRoot, 'o8.app', 'Contents', 'Resources', 'server');
+  mkdirSync(join(serverRoot, 'bin'), { recursive: true });
+  const packagedCli = join(serverRoot, 'bin', 'o8.mjs');
+  copyFileSync(cliEntrypoint, packagedCli);
+  writeFileSync(join(serverRoot, 'server.js'), 'process.exit(2);\n');
+  writeFileSync(join(serverRoot, 'ws-server.mjs'), 'process.exit(2);\n');
+  return { cliEntrypoint: packagedCli, serverRoot };
+}
+
 interface CliResult {
   code: number;
   stdout: string;
@@ -118,10 +130,13 @@ function runCli(
   });
 }
 
-function startLaunchAgentSupervisor(dataDir: string): SupervisedProcess {
-  const child = spawn(process.execPath, [cliEntrypoint, 'serve', '__launch_agent'], {
-    cwd: root,
-    env: cliEnv(dataDir),
+function startLaunchAgentSupervisor(
+  dataDir: string,
+  options: { cliEntrypoint?: string; cwd?: string; serveRoot?: string } = {},
+): SupervisedProcess {
+  const child = spawn(process.execPath, [options.cliEntrypoint ?? cliEntrypoint, 'serve', '__launch_agent'], {
+    cwd: options.cwd ?? root,
+    env: cliEnv(dataDir, options.serveRoot),
     stdio: ['ignore', 'ignore', 'pipe'],
   });
   supervisorProcesses.add(child);
@@ -441,6 +456,22 @@ describe.sequential('o8 serve real CLI path', () => {
     expect(existsSync(join(dataDir, 'serve-state.json'))).toBe(false);
     expect(processAlive(respawnedStatus.pid)).toBe(false);
   }, 120_000);
+
+  it('hands persistent pre-ready failures back to launchd after bounded retries', async () => {
+    const dataDir = makeDataDir();
+    const packaged = makeFailingPackagedLayout();
+    const supervisor = startLaunchAgentSupervisor(dataDir, {
+      cliEntrypoint: packaged.cliEntrypoint,
+      cwd: packaged.serverRoot,
+      serveRoot: join(packaged.serverRoot, 'missing-source-checkout'),
+    });
+    expect(await waitForProcessExit(supervisor.child, 45_000)).toEqual({ code: 2, signal: null });
+    const log = readServeLog(dataDir);
+    expect(log.match(/=== o8 serve session /g)).toHaveLength(5);
+    expect(log).toContain('exiting after 5 consecutive daemon failures before ready; launchd will retry');
+    expect(existsSync(join(dataDir, 'serve.pid'))).toBe(false);
+    expect(existsSync(join(dataDir, 'serve-state.json'))).toBe(false);
+  }, 60_000);
 
   it.skipIf(!packagedServeEnabled)(
     'starts from the packaged resource layout, authenticates, and reaps every child (set O8_TEST_PACKAGED_SERVE=1 to enable)',

--- a/tests/o8-serve-real-path.test.ts
+++ b/tests/o8-serve-real-path.test.ts
@@ -1,5 +1,15 @@
 import { execFile, execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { createServer as createHttpServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -8,11 +18,35 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 const root = resolve(import.meta.dirname, '..');
 const cliEntrypoint = join(root, 'cli', 'dist', 'o8.mjs');
 const dataDirs = new Set<string>();
+const tempDirs = new Set<string>();
 
 function makeDataDir(): string {
   const dataDir = mkdtempSync(join(tmpdir(), 'o8-serve-real-path-'));
   dataDirs.add(dataDir);
+  tempDirs.add(dataDir);
   return dataDir;
+}
+
+function makePackagedLayout(): { cliEntrypoint: string; serverRoot: string } {
+  const exportedServer = join(root, 'out', 'server');
+  for (const relativePath of ['server.js', 'ws-server.mjs', join('bin', 'o8.mjs')]) {
+    expect(existsSync(join(exportedServer, relativePath)), `Missing out/server/${relativePath}; run npm run build and node scripts/tauri-export.mjs.`).toBe(true);
+  }
+  const layoutRoot = mkdtempSync(join(tmpdir(), 'o8-packaged-serve-layout-'));
+  tempDirs.add(layoutRoot);
+  const serverRoot = join(layoutRoot, 'o8.app', 'Contents', 'Resources', 'server');
+  mkdirSync(join(serverRoot, 'bin'), { recursive: true });
+  for (const entry of readdirSync(exportedServer, { withFileTypes: true })) {
+    if (entry.name === 'bin') continue;
+    symlinkSync(
+      join(exportedServer, entry.name),
+      join(serverRoot, entry.name),
+      entry.isDirectory() ? 'dir' : 'file',
+    );
+  }
+  const packagedCli = join(serverRoot, 'bin', 'o8.mjs');
+  copyFileSync(join(exportedServer, 'bin', 'o8.mjs'), packagedCli);
+  return { cliEntrypoint: packagedCli, serverRoot };
 }
 
 interface CliResult {
@@ -38,12 +72,12 @@ interface ServeStatus {
   note: string;
 }
 
-function cliEnv(dataDir: string): NodeJS.ProcessEnv {
+function cliEnv(dataDir: string, serveRoot = root): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     O8_DATA_DIR: dataDir,
     CORTEX_IDE_DATA_DIR: dataDir,
-    O8_SERVE_ROOT: root,
+    O8_SERVE_ROOT: serveRoot,
     O8_WORKER_TOKEN: '',
     O8_WORKER_PACKET_ID: '',
   };
@@ -51,11 +85,16 @@ function cliEnv(dataDir: string): NodeJS.ProcessEnv {
   return env;
 }
 
-function runCli(args: string[], dataDir: string, timeout = 75_000): Promise<CliResult> {
+function runCli(
+  args: string[],
+  dataDir: string,
+  timeout = 75_000,
+  options: { cliEntrypoint?: string; cwd?: string; serveRoot?: string } = {},
+): Promise<CliResult> {
   return new Promise((resolveResult) => {
-    execFile(process.execPath, [cliEntrypoint, ...args], {
-      cwd: root,
-      env: cliEnv(dataDir),
+    execFile(process.execPath, [options.cliEntrypoint ?? cliEntrypoint, ...args], {
+      cwd: options.cwd ?? root,
+      env: cliEnv(dataDir, options.serveRoot),
       timeout,
     }, (error, stdout, stderr) => {
       resolveResult({
@@ -124,8 +163,8 @@ describe.sequential('o8 serve real CLI path', () => {
   afterAll(async () => {
     for (const dataDir of dataDirs) {
       await runCli(['serve', 'stop'], dataDir, 15_000);
-      rmSync(dataDir, { recursive: true, force: true });
     }
+    for (const tempDir of tempDirs) rmSync(tempDir, { recursive: true, force: true });
   });
 
   it('starts, authenticates, reports, refuses a second owner, and reaps every child', async () => {
@@ -278,4 +317,50 @@ describe.sequential('o8 serve real CLI path', () => {
       await new Promise<void>((resolveClose) => { server.close(() => resolveClose()); });
     }
   }, 30_000);
+
+  it.runIf(process.env.O8_TEST_PACKAGED_SERVE === '1')(
+    'starts from the packaged resource layout, authenticates, and reaps every child',
+    async () => {
+      const dataDir = makeDataDir();
+      const packaged = makePackagedLayout();
+      const runOptions = {
+        cliEntrypoint: packaged.cliEntrypoint,
+        cwd: packaged.serverRoot,
+        serveRoot: join(packaged.serverRoot, 'missing-source-checkout'),
+      };
+      const started = await runCli(['serve'], dataDir, 75_000, runOptions);
+      expect(started.code, `${started.stderr}\n${readServeLog(dataDir)}`).toBe(0);
+      const status = JSON.parse(started.stdout) as ServeStatus;
+      expect(status).toMatchObject({
+        running: true,
+        healthy: true,
+        mode: 'packaged',
+      });
+
+      const token = readFileSync(join(dataDir, 'ws-token'), 'utf8').trim();
+      const gatedResponse = await fetch(`http://127.0.0.1:${status.apiPort}/api/panel/repos`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(60_000),
+      });
+      expect(gatedResponse.status, await gatedResponse.text()).toBe(200);
+
+      const ownedPids = [status.pid, ...descendantPids(status.pid)];
+      expect(ownedPids.length).toBeGreaterThanOrEqual(3);
+      const statusResult = await runCli(['serve', 'status'], dataDir, 75_000, runOptions);
+      expect(statusResult.code, statusResult.stderr).toBe(0);
+      expect(JSON.parse(statusResult.stdout)).toMatchObject({
+        running: true,
+        healthy: true,
+        mode: 'packaged',
+        pid: status.pid,
+      });
+
+      const stopped = await runCli(['serve', 'stop'], dataDir, 15_000, runOptions);
+      expect(stopped.code, stopped.stderr).toBe(0);
+      expect(JSON.parse(stopped.stdout)).toMatchObject({ stopped: true, pid: status.pid });
+      expect(ownedPids.filter(processAlive)).toEqual([]);
+      expect(existsSync(join(dataDir, 'serve.pid'))).toBe(false);
+    },
+    120_000,
+  );
 });

--- a/tests/o8-serve-real-path.test.ts
+++ b/tests/o8-serve-real-path.test.ts
@@ -1,4 +1,4 @@
-import { execFile, execFileSync } from 'node:child_process';
+import { execFile, execFileSync, spawn, type ChildProcess } from 'node:child_process';
 import {
   copyFileSync,
   existsSync,
@@ -19,6 +19,12 @@ const root = resolve(import.meta.dirname, '..');
 const cliEntrypoint = join(root, 'cli', 'dist', 'o8.mjs');
 const dataDirs = new Set<string>();
 const tempDirs = new Set<string>();
+const supervisorProcesses = new Set<ChildProcess>();
+const packagedServeEnabled = process.env.O8_TEST_PACKAGED_SERVE === '1';
+
+if (!packagedServeEnabled) {
+  process.stdout.write('[o8-serve-real-path] packaged proof skipped; set O8_TEST_PACKAGED_SERVE=1 to enable\n');
+}
 
 function makeDataDir(): string {
   const dataDir = mkdtempSync(join(tmpdir(), 'o8-serve-real-path-'));
@@ -64,12 +70,18 @@ interface ServeStatus {
   apiPort: number;
   wsPort: number;
   mode: 'development' | 'packaged';
+  supervisorPid: number | null;
   cliVersion: string;
   daemonVersion: string | null;
   versionMismatch: boolean;
   warning: string | null;
   children: Array<{ role: string; pid: number }>;
   note: string;
+}
+
+interface SupervisedProcess {
+  child: ChildProcess;
+  stderr: () => string;
 }
 
 function cliEnv(dataDir: string, serveRoot = root): NodeJS.ProcessEnv {
@@ -104,6 +116,19 @@ function runCli(
       });
     });
   });
+}
+
+function startLaunchAgentSupervisor(dataDir: string): SupervisedProcess {
+  const child = spawn(process.execPath, [cliEntrypoint, 'serve', '__launch_agent'], {
+    cwd: root,
+    env: cliEnv(dataDir),
+    stdio: ['ignore', 'ignore', 'pipe'],
+  });
+  supervisorProcesses.add(child);
+  let stderr = '';
+  child.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+  child.once('exit', () => { supervisorProcesses.delete(child); });
+  return { child, stderr: () => stderr };
 }
 
 function processAlive(pid: number): boolean {
@@ -146,6 +171,43 @@ async function waitForPidsToExit(pids: number[], timeoutMs: number): Promise<boo
   return pids.every((pid) => !processAlive(pid));
 }
 
+async function waitForProcessExit(
+  child: ChildProcess,
+  timeoutMs: number,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return { code: child.exitCode, signal: child.signalCode };
+  }
+  return await new Promise((resolveExit, rejectExit) => {
+    const timeout = setTimeout(() => { rejectExit(new Error(`Process ${String(child.pid)} did not exit.`)); }, timeoutMs);
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout);
+      resolveExit({ code, signal });
+    });
+  });
+}
+
+async function waitForHealthyServe(
+  dataDir: string,
+  predicate: (status: ServeStatus) => boolean = () => true,
+  supervisor?: SupervisedProcess,
+): Promise<ServeStatus> {
+  const deadline = Date.now() + 75_000;
+  let lastResult: CliResult | null = null;
+  while (Date.now() < deadline) {
+    if (supervisor?.child.pid && !processAlive(supervisor.child.pid)) {
+      throw new Error(`Launch-agent supervisor exited before readiness.\n${supervisor.stderr()}\n${readServeLog(dataDir)}`);
+    }
+    lastResult = await runCli(['serve', 'status'], dataDir, 15_000);
+    if (lastResult.code === 0) {
+      const status = JSON.parse(lastResult.stdout) as ServeStatus;
+      if (status.running && status.healthy && predicate(status)) return status;
+    }
+    await new Promise((resolveWait) => { setTimeout(resolveWait, 100); });
+  }
+  throw new Error(`Headless serve did not become healthy.\n${lastResult?.stderr ?? ''}\n${readServeLog(dataDir)}`);
+}
+
 function readServeLog(dataDir: string): string {
   const logPath = join(dataDir, 'logs', 'serve.log');
   return existsSync(logPath) ? readFileSync(logPath, 'utf8') : '';
@@ -163,6 +225,9 @@ describe.sequential('o8 serve real CLI path', () => {
   afterAll(async () => {
     for (const dataDir of dataDirs) {
       await runCli(['serve', 'stop'], dataDir, 15_000);
+    }
+    for (const supervisor of supervisorProcesses) {
+      try { supervisor.kill('SIGTERM'); } catch {}
     }
     for (const tempDir of tempDirs) rmSync(tempDir, { recursive: true, force: true });
   });
@@ -251,6 +316,15 @@ describe.sequential('o8 serve real CLI path', () => {
     expect(JSON.parse(secondStart.stderr)).toMatchObject({
       error: { code: 'serve_already_running', ambiguous: false },
     });
+    const installWhileRunning = await runCli(['serve', 'agent', 'install'], dataDir);
+    expect(installWhileRunning.code).toBe(5);
+    expect(JSON.parse(installWhileRunning.stderr)).toMatchObject({
+      error: {
+        code: 'serve_already_running',
+        hint: expect.stringContaining('o8 serve stop'),
+        ambiguous: false,
+      },
+    });
 
     const ownedPids = [restartedStatus.pid, ...descendantPids(restartedStatus.pid)];
     expect(ownedPids.length).toBeGreaterThanOrEqual(3);
@@ -259,6 +333,20 @@ describe.sequential('o8 serve real CLI path', () => {
     expect(JSON.parse(stopped.stdout)).toMatchObject({ stopped: true, pid: restartedStatus.pid });
     expect(existsSync(join(dataDir, 'serve.pid'))).toBe(false);
     expect(ownedPids.filter(processAlive)).toEqual([]);
+
+    const restartedFromStopped = await runCli(['serve', 'restart'], dataDir);
+    expect(restartedFromStopped.code, `${restartedFromStopped.stderr}\n${readServeLog(dataDir)}`).toBe(0);
+    const restartedFromStoppedStatus = JSON.parse(restartedFromStopped.stdout) as ServeStatus;
+    expect(restartedFromStoppedStatus).toMatchObject({
+      running: true,
+      healthy: true,
+      mode: 'development',
+      supervisorPid: null,
+    });
+    expect(readServeLog(dataDir).match(/=== o8 serve session /g)).toHaveLength(3);
+    const stoppedAgain = await runCli(['serve', 'stop'], dataDir, 15_000);
+    expect(stoppedAgain.code, stoppedAgain.stderr).toBe(0);
+    expect(processAlive(restartedFromStoppedStatus.pid)).toBe(false);
   }, 120_000);
 
   it('reaps recorded children and stale ownership after the daemon leader is killed', async () => {
@@ -318,8 +406,44 @@ describe.sequential('o8 serve real CLI path', () => {
     }
   }, 30_000);
 
-  it.runIf(process.env.O8_TEST_PACKAGED_SERVE === '1')(
-    'starts from the packaged resource layout, authenticates, and reaps every child',
+  it('keeps supervisor ownership across restart and crash respawn, then exits cleanly on stop', async () => {
+    const dataDir = makeDataDir();
+    const supervisor = startLaunchAgentSupervisor(dataDir);
+    expect(supervisor.child.pid).toBeGreaterThan(0);
+    const supervisorPid = supervisor.child.pid!;
+    const initialStatus = await waitForHealthyServe(dataDir, undefined, supervisor);
+    expect(initialStatus.supervisorPid).toBe(supervisorPid);
+
+    const restarted = await runCli(['serve', 'restart'], dataDir);
+    expect(restarted.code, `${restarted.stderr}\n${supervisor.stderr()}\n${readServeLog(dataDir)}`).toBe(0);
+    const restartedStatus = JSON.parse(restarted.stdout) as ServeStatus;
+    expect(restartedStatus.supervisorPid).toBe(supervisorPid);
+    expect(restartedStatus.pid).not.toBe(initialStatus.pid);
+    expect(processAlive(supervisorPid)).toBe(true);
+    expect(processAlive(restartedStatus.pid)).toBe(true);
+    expect(processAlive(initialStatus.pid)).toBe(false);
+
+    process.kill(restartedStatus.pid, 'SIGKILL');
+    expect(await waitForPidsToExit([restartedStatus.pid], 5_000)).toBe(true);
+    const respawnedStatus = await waitForHealthyServe(
+      dataDir,
+      (status) => status.pid !== restartedStatus.pid,
+      supervisor,
+    );
+    expect(respawnedStatus.supervisorPid).toBe(supervisorPid);
+    expect(processAlive(respawnedStatus.pid)).toBe(true);
+
+    const stopped = await runCli(['serve', 'stop'], dataDir, 15_000);
+    expect(stopped.code, `${stopped.stderr}\n${supervisor.stderr()}\n${readServeLog(dataDir)}`).toBe(0);
+    expect(JSON.parse(stopped.stdout)).toMatchObject({ stopped: true, pid: respawnedStatus.pid });
+    expect(await waitForProcessExit(supervisor.child, 5_000)).toEqual({ code: 0, signal: null });
+    expect(existsSync(join(dataDir, 'serve.pid'))).toBe(false);
+    expect(existsSync(join(dataDir, 'serve-state.json'))).toBe(false);
+    expect(processAlive(respawnedStatus.pid)).toBe(false);
+  }, 120_000);
+
+  it.skipIf(!packagedServeEnabled)(
+    'starts from the packaged resource layout, authenticates, and reaps every child (set O8_TEST_PACKAGED_SERVE=1 to enable)',
     async () => {
       const dataDir = makeDataDir();
       const packaged = makePackagedLayout();

--- a/tests/serve-port-constant-drift.test.ts
+++ b/tests/serve-port-constant-drift.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { PROD_API_PORT_BLOCK, PROD_WS_PORT_BLOCK } from '@/lib/panel/port-constants';
+
+const root = resolve(import.meta.dirname, '..');
+const PANEL_PATH = 'src/lib/panel/port-constants.ts';
+const CLI_PATH = 'cli/src/commands/serve.ts';
+const RUST_PATH = 'src-tauri/src/lib.rs';
+const SOURCE_PATHS = [PANEL_PATH, CLI_PATH, RUST_PATH] as const;
+
+interface PortBlocks {
+  api: number[];
+  ws: number[];
+}
+
+function parseTypeScriptBlock(source: string, name: string): number[] {
+  const match = source.match(new RegExp(`const ${name} = \\[([^\\]]+)\\] as const;`));
+  if (!match) throw new Error(`Could not parse ${name} from ${CLI_PATH}.`);
+  return match[1].split(',').map((value) => Number.parseInt(value.trim(), 10));
+}
+
+function parseRustRange(source: string, name: string): number[] {
+  const match = source.match(new RegExp(`const ${name}: std::ops::Range<u16> = (\\d+)\\.\\.(\\d+);`));
+  if (!match) throw new Error(`Could not parse ${name} from ${RUST_PATH}.`);
+  const start = Number.parseInt(match[1], 10);
+  const end = Number.parseInt(match[2], 10);
+  return Array.from({ length: end - start }, (_, index) => start + index);
+}
+
+describe('headless serve production port constants', () => {
+  it('keeps the panel, CLI bundle copy, and native shell blocks equal', () => {
+    const cliSource = readFileSync(join(root, CLI_PATH), 'utf8');
+    const rustSource = readFileSync(join(root, RUST_PATH), 'utf8');
+    const blocks: Record<(typeof SOURCE_PATHS)[number], PortBlocks> = {
+      [PANEL_PATH]: {
+        api: [...PROD_API_PORT_BLOCK],
+        ws: [...PROD_WS_PORT_BLOCK],
+      },
+      [CLI_PATH]: {
+        api: parseTypeScriptBlock(cliSource, 'PROD_API_PORT_BLOCK'),
+        ws: parseTypeScriptBlock(cliSource, 'PROD_WS_PORT_BLOCK'),
+      },
+      [RUST_PATH]: {
+        api: parseRustRange(rustSource, 'PROD_API_PORT_RANGE'),
+        ws: parseRustRange(rustSource, 'PROD_WS_PORT_RANGE'),
+      },
+    };
+    const expected = JSON.stringify(blocks[PANEL_PATH]);
+    const equal = SOURCE_PATHS.every((path) => JSON.stringify(blocks[path]) === expected);
+    const evidence = SOURCE_PATHS.map((path) => `${path}: ${JSON.stringify(blocks[path])}`).join('\n');
+
+    expect(equal, `Production port blocks drifted across ${SOURCE_PATHS.join(', ')}.\n${evidence}`).toBe(true);
+  });
+});


### PR DESCRIPTION
#2029, four checklist items: service lifecycle, the minimal update story, the port-constant drift guard, and the packaged-mode proof.

## Service lifecycle
`o8 serve agent install|uninstall|status` manages a per-user launch agent (`ai.o8.serve`): `bootstrap`/`bootout` via launchctl, plist written 0600 with XML-escaped paths, `RunAtLoad`, and `KeepAlive.SuccessfulExit=false` — so a crashed daemon respawns (5s throttle) while a clean `o8 serve stop` exits 0 and launchd leaves it down; `bootout` SIGTERMs the supervising process, which forwards to the daemon and reaps. Install refuses when the desktop app owns the data dir. Serve logs now rotate at 20 MB with the previous log truncated past 5 MB, decided at daemon start only (never under a live writer). Plist generation and the rotation decision are pure functions with unit tests; tests never touch launchctl.

## Update story (minimal)
The daemon stamps its version into `serve-state.json`; `serve status` reports cliVersion/daemonVersion, flags a mismatch, and the note states plainly that app auto-update does not update a running daemon. `o8 serve restart` stops and restarts under the invoking CLI's code in one command.

## Drift guard
A hermetic test asserts the production API/WS port blocks are identical across their three copies — the panel constants (imported), the CLI bundle copy (parsed), and the native shell range (parsed) — failing with all three files and their parsed values named.

## Packaged-mode proof
The serve suite gains a packaged-layout case: the exported server tree arranged as the app bundle lays it out, `serve` reporting `mode: packaged`, the gated API answering with the written token, and full child reaping on stop. Opt-in via `O8_TEST_PACKAGED_SERVE=1` because generating clean artifacts takes ~8 minutes; it was run once here end-to-end (4/4, ~36s once artifacts exist). The always-on suite additionally covers the version-mismatch warning and the restart flow (old pids fully reaped, new daemon healthy).

## Supervisor lifecycle correctness

`stop` and `restart` are supervisor-aware: the daemon leaf's pid and the supervising process's pid are both tracked, so `o8 serve stop` signals the supervisor (which drains the daemon and exits **0**, leaving launchd satisfied rather than respawning), and `o8 serve restart` uses SIGHUP so the supervisor survives and swaps the daemon underneath itself — the launch agent's crash protection is never silently disarmed. A crashed daemon is respawned by the supervisor after its process group is cleaned up, and a daemon that never reaches ready backs off (1s, 2s, 4s, 8s) before the supervisor gives up after five consecutive pre-ready failures, logs why, and exits nonzero so launchd's throttle owns further retries. A stop signal arriving between loop iterations terminates the just-spawned daemon instead of stranding it.

## Verification
`npx tsc --noEmit` clean, `npm run lint` exit 0 at cap, rule-check clean, classification check exit 0, serve + drift suites green, lifecycle unit tests green.
