### PR TITLE
fix: surface manual storage remediation

### DIFF
--- a/src/lib/orchestrator/packet-storage-admission-normalize.ts
+++ b/src/lib/orchestrator/packet-storage-admission-normalize.ts
@@ -75,7 +75,7 @@ function normalizePressureReceipt(
   if (
     row.schema !== 'o8/storage-pressure-decision/v1'
     || (row.mode !== 'manual' && row.mode !== 'pressure')
-    || !['disabled', 'admitted_after_parking', 'exhausted'].includes(String(row.status))
+    || !['disabled', 'manual_review', 'admitted_after_parking', 'exhausted'].includes(String(row.status))
     || row.trigger !== 'reserve_breached'
     || !Number.isSafeInteger(row.launchGeneration)
     || !Number.isSafeInteger(row.recordedAt)
@@ -86,7 +86,7 @@ function normalizePressureReceipt(
   return {
     schema: 'o8/storage-pressure-decision/v1',
     mode: row.mode,
-    status: row.status as 'disabled' | 'admitted_after_parking' | 'exhausted',
+    status: row.status as 'disabled' | 'manual_review' | 'admitted_after_parking' | 'exhausted',
     trigger: 'reserve_breached',
     launchGeneration: row.launchGeneration as number,
     candidates: candidates as NonNullable<NonNullable<OrchestratorPacket['storageAdmission']>['pressure']>['candidates'],
@@ -111,7 +111,7 @@ function normalizePressureCandidate(value: unknown) {
     || (row.repositoryUuid !== null && typeof row.repositoryUuid !== 'string')
     || measured === undefined
     || reclaimed === undefined
-    || !['parked', 'already_parked', 'refused'].includes(String(row.outcome))
+    || !['candidate', 'parked', 'already_parked', 'refused'].includes(String(row.outcome))
     || typeof row.reason !== 'string'
   ) return null;
   return {
@@ -121,7 +121,7 @@ function normalizePressureCandidate(value: unknown) {
     operationId: row.operationId,
     measuredAllocatedBytes: measured,
     verifiedReclaimedAvailableBytes: reclaimed,
-    outcome: row.outcome as 'parked' | 'already_parked' | 'refused',
+    outcome: row.outcome as 'candidate' | 'parked' | 'already_parked' | 'refused',
     reason: row.reason,
   };
 }

--- a/src/lib/orchestrator/storage-admission-held-message.ts
+++ b/src/lib/orchestrator/storage-admission-held-message.ts
@@ -1,0 +1,106 @@
+import 'server-only';
+
+import type Database from 'better-sqlite3';
+
+import { listLanes } from '@/lib/lane/registry';
+import { listMissionRegistryEntries } from '@/lib/orchestrator/mission-registry';
+import { packetTerminalState } from '@/lib/orchestrator/packet-state';
+import type { OrchestratorPacketStorageAdmission } from '@/lib/orchestrator/types';
+import type { StorageAdmissionPolicy } from '@/lib/workspace/storage-admission';
+
+const GIB = 1024 * 1024 * 1024;
+
+interface ReservedOwnerRow {
+  owner_id: string;
+  exact_bytes: number;
+}
+
+function terminalReservationHoldSummary(
+  sqlite: Database.Database,
+  volumeId: string,
+): { bytes: number; packets: number } {
+  const terminalOwners = new Set<string>();
+  for (const entry of listMissionRegistryEntries({ includeArchived: true })) {
+    for (const packet of entry.mission.packets) {
+      const terminal = packetTerminalState(packet);
+      if (terminal === 'released' || terminal === 'archived') {
+        terminalOwners.add(packet.id);
+      }
+    }
+  }
+  for (const lane of listLanes()) {
+    if (lane.packetId && (lane.status === 'completed' || lane.status === 'archived')) {
+      terminalOwners.add(lane.packetId);
+    }
+  }
+  const rows = sqlite.prepare(`
+    SELECT owner_id, exact_bytes FROM storage_admission_reservations
+    WHERE volume_id = ? AND state = 'reserved'
+  `).all(volumeId) as ReservedOwnerRow[];
+  const held = rows.filter((row) => terminalOwners.has(row.owner_id));
+  return {
+    bytes: held.reduce((sum, row) => sum + row.exact_bytes, 0),
+    packets: new Set(held.map((row) => row.owner_id)).size,
+  };
+}
+
+function formatStorageGigabytes(bytes: number): string {
+  return `${(bytes / GIB).toFixed(1)} GB`;
+}
+
+function formatStorageReservePercent(ratio: number): string {
+  const percent = ratio * 100;
+  return Number.isInteger(percent) ? String(percent) : percent.toFixed(1);
+}
+
+function reserveBreachExplanation(
+  receipt: OrchestratorPacketStorageAdmission,
+  policy?: StorageAdmissionPolicy,
+): string | null {
+  const available = receipt.physicalAvailableBytes;
+  const requiredReserve = receipt.requiredReserveBytes;
+  const headroom = receipt.dispatchHeadroomBytes;
+  if (
+    available === null
+    || requiredReserve === null
+    || headroom === null
+    || !Number.isSafeInteger(available)
+    || !Number.isSafeInteger(requiredReserve)
+    || !Number.isSafeInteger(headroom)
+  ) return null;
+  const reserveShortfall = Math.max(0, -headroom);
+  const dispatchShortfall = Math.max(0, receipt.estimateBytes - headroom);
+  const activeReserved = receipt.reservedBeforeBytes ?? 0;
+  const policySummary = policy?.reserveRatio !== undefined
+    && policy.absoluteFloorBytes !== undefined
+    ? `Storage policy keeps ${formatStorageReservePercent(policy.reserveRatio)}% of disk or ${formatStorageGigabytes(policy.absoluteFloorBytes)}, whichever is greater, unallocated.`
+    : 'Storage policy requires the reported reserve to remain unallocated.';
+  const reservationSummary = activeReserved > 0
+    ? ` ${formatStorageGigabytes(activeReserved)} is already reserved for other launches.`
+    : '';
+  const reserveSummary = reserveShortfall > 0
+    ? ` The volume is ${formatStorageGigabytes(reserveShortfall)} below that reserve.`
+    : '';
+  return `${policySummary} This volume requires ${formatStorageGigabytes(requiredReserve)} free; ${formatStorageGigabytes(available)} is available.${reservationSummary}${reserveSummary} Free ${formatStorageGigabytes(dispatchShortfall)} more to dispatch this packet's ${formatStorageGigabytes(receipt.estimateBytes)} estimate while preserving the reserve.`;
+}
+
+export function storageAdmissionHeldMessage(
+  receipt: OrchestratorPacketStorageAdmission,
+  sqlite: Database.Database,
+  policy?: StorageAdmissionPolicy,
+): string {
+  const base = `Dispatch held by storage admission (${receipt.reason}).`;
+  if (receipt.reason !== 'reserve_breached') return base;
+  const capacity = reserveBreachExplanation(receipt, policy);
+  const explained = capacity ? `${base} ${capacity}` : base;
+  if (!receipt.volumeId) return explained;
+  let terminal: ReturnType<typeof terminalReservationHoldSummary>;
+  try {
+    terminal = terminalReservationHoldSummary(sqlite, receipt.volumeId);
+  } catch {
+    return explained;
+  }
+  if (terminal.packets === 0) return explained;
+  const gib = (terminal.bytes / GIB).toFixed(2);
+  return `${explained} ${gib} GB held by ${terminal.packets} terminal packet${terminal.packets === 1 ? '' : 's'}.`;
+}

--- a/src/lib/orchestrator/storage-admission.ts
+++ b/src/lib/orchestrator/storage-admission.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import type Database from 'better-sqlite3';
 
 import { getSqlite } from '@/lib/db';
-import { findLaneByPacket, listLanes } from '@/lib/lane/registry';
+import { findLaneByPacket } from '@/lib/lane/registry';
 import { getOperatorDefaultsSync } from '@/lib/operator/defaults';
 import { listMissionRegistryEntries } from '@/lib/orchestrator/mission-registry';
 import type {
@@ -38,6 +38,7 @@ import {
   observeRepoWorkspacePaths,
   type RepoStorageEstimate,
 } from './storage-estimate';
+import { storageAdmissionHeldMessage } from './storage-admission-held-message';
 
 export { observeRepoStorageEstimate } from './storage-estimate';
 export type { RepoStorageEstimate } from './storage-estimate';
@@ -91,11 +92,6 @@ export interface AdmissionCoordinatorDependencies {
 
 interface StoredMutationRow {
   result_json: string;
-}
-
-interface ReservedOwnerRow {
-  owner_id: string;
-  exact_bytes: number;
 }
 
 export class PacketStorageAdmissionError extends Error {
@@ -183,53 +179,6 @@ function priorMutationResult(sqlite: Database.Database, mutationId: string): Sto
     'SELECT result_json FROM storage_admission_mutations WHERE mutation_id = ?',
   ).get(mutationId) as StoredMutationRow | undefined;
   return row ? { ...(JSON.parse(row.result_json) as Omit<StorageAdmissionResult, 'idempotent'>), idempotent: true } : null;
-}
-
-function terminalReservationHoldSummary(
-  sqlite: Database.Database,
-  volumeId: string,
-): { bytes: number; packets: number } {
-  const terminalOwners = new Set<string>();
-  for (const entry of listMissionRegistryEntries({ includeArchived: true })) {
-    for (const packet of entry.mission.packets) {
-      const terminal = packetTerminalState(packet);
-      if (terminal === 'released' || terminal === 'archived') {
-        terminalOwners.add(packet.id);
-      }
-    }
-  }
-  for (const lane of listLanes()) {
-    if (lane.packetId && (lane.status === 'completed' || lane.status === 'archived')) {
-      terminalOwners.add(lane.packetId);
-    }
-  }
-  const rows = sqlite.prepare(`
-    SELECT owner_id, exact_bytes FROM storage_admission_reservations
-    WHERE volume_id = ? AND state = 'reserved'
-  `).all(volumeId) as ReservedOwnerRow[];
-  const held = rows.filter((row) => terminalOwners.has(row.owner_id));
-  return {
-    bytes: held.reduce((sum, row) => sum + row.exact_bytes, 0),
-    packets: new Set(held.map((row) => row.owner_id)).size,
-  };
-}
-
-function storageAdmissionHeldMessage(
-  reason: string,
-  volumeId: string | null,
-  sqlite: Database.Database,
-): string {
-  const base = `Dispatch held by storage admission (${reason}).`;
-  if (reason !== 'reserve_breached' || !volumeId) return base;
-  let terminal: ReturnType<typeof terminalReservationHoldSummary>;
-  try {
-    terminal = terminalReservationHoldSummary(sqlite, volumeId);
-  } catch {
-    return base;
-  }
-  if (terminal.packets === 0) return base;
-  const gib = (terminal.bytes / GIB).toFixed(2);
-  return `${base} ${gib} GB held by ${terminal.packets} terminal packet${terminal.packets === 1 ? '' : 's'}.`;
 }
 
 function reserveReplayIdentityFailure(
@@ -430,8 +379,7 @@ export function createPacketStorageAdmissionCoordinator(
           };
           throw new PacketStorageAdmissionError(
             storageAdmissionHeldMessage(
-              disposition.reason,
-              currentReservation?.volumeId ?? replay.observation?.volumeId ?? null,
+              receipt,
               sqlite,
             ),
             receipt,
@@ -483,6 +431,7 @@ export function createPacketStorageAdmissionCoordinator(
           ),
         );
       }
+      const policy = resolvePolicy();
       const result = await store.reserve({
         mutationId,
         reservationId,
@@ -492,7 +441,7 @@ export function createPacketStorageAdmissionCoordinator(
         ownerId: packet.id,
         ownerGeneration: launchGeneration,
         leaseExpiresAt: now() + LAUNCH_RESERVATION_LEASE_MS,
-        policy: resolvePolicy(),
+        policy,
       });
       const receipt = receiptFromResult(result, {
         ownerId: packet.id,
@@ -505,9 +454,9 @@ export function createPacketStorageAdmissionCoordinator(
       if (result.decision !== 'reserved' || !result.reservation) {
         throw new PacketStorageAdmissionError(
           storageAdmissionHeldMessage(
-            result.reason,
-            result.observation?.volumeId ?? null,
+            receipt,
             sqlite,
+            policy,
           ),
           receipt,
         );

--- a/src/lib/orchestrator/storage-pressure-policy.test.ts
+++ b/src/lib/orchestrator/storage-pressure-policy.test.ts
@@ -168,14 +168,33 @@ function lane(
 }
 
 describe('storage pressure admission policy', () => {
-  it('keeps the default manual-only and never parks for non-capacity holds', async () => {
+  it('surfaces manual remediation candidates without parking and ignores non-capacity holds', async () => {
     const park = vi.fn();
     const manual = pressureCoordinator(
       baseCoordinator(async () => { throw held('target'); }),
-      { mode: () => 'manual', parkWorkspace: park },
+      {
+        mode: () => 'manual',
+        listLanes: () => [lane('review', '/repos/review', '2026-01-01T00:00:00.000Z')],
+        listRepos: async () => [repo('repo-review', '/repos/review')],
+        measureAllocatedBytes: async () => 400,
+        getSnapshot: () => null,
+        parkWorkspace: park,
+      },
     );
     await expect(manual.reserveForLaunch(packet('target'))).rejects.toMatchObject({
-      receipt: { reason: 'reserve_breached', pressure: { mode: 'manual', status: 'disabled' } },
+      receipt: {
+        reason: 'reserve_breached',
+        pressure: {
+          mode: 'manual',
+          status: 'manual_review',
+          candidates: [{
+            packetId: 'review',
+            measuredAllocatedBytes: 400,
+            outcome: 'candidate',
+            reason: 'manual_action_required',
+          }],
+        },
+      },
     });
 
     const unknown = pressureCoordinator(

--- a/src/lib/orchestrator/storage-pressure-policy.ts
+++ b/src/lib/orchestrator/storage-pressure-policy.ts
@@ -320,15 +320,6 @@ export function createStoragePressureAdmissionCoordinator(
       }
 
       const selectedMode = mode();
-      if (selectedMode !== 'pressure') {
-        throw new PacketStorageAdmissionError(
-          held.message,
-          withPressure(held.receipt, pressureReceipt(
-            'manual', 'disabled', packet, held.receipt.ownerGeneration, [], now(),
-          )),
-        );
-      }
-
       let candidates: PressureCandidate[];
       try {
         candidates = await buildCandidates(
@@ -342,7 +333,21 @@ export function createStoragePressureAdmissionCoordinator(
         throw new PacketStorageAdmissionError(
           'Dispatch held because storage-pressure candidate accounting is unknown.',
           withPressure(held.receipt, pressureReceipt(
-            'pressure', 'exhausted', packet, held.receipt.ownerGeneration, [], now(),
+            selectedMode, selectedMode === 'manual' ? 'manual_review' : 'exhausted',
+            packet, held.receipt.ownerGeneration, [], now(),
+          )),
+        );
+      }
+      if (selectedMode === 'manual') {
+        const receipts = candidates.map((candidate) => (
+          candidate.refusal
+            ? candidateReceipt(candidate, 'refused', candidate.refusal)
+            : candidateReceipt(candidate, 'candidate', 'manual_action_required')
+        ));
+        throw new PacketStorageAdmissionError(
+          held.message,
+          withPressure(held.receipt, pressureReceipt(
+            'manual', 'manual_review', packet, held.receipt.ownerGeneration, receipts, now(),
           )),
         );
       }

--- a/src/lib/orchestrator/types.ts
+++ b/src/lib/orchestrator/types.ts
@@ -255,14 +255,14 @@ export interface OrchestratorStoragePressureCandidateReceipt {
   operationId: string;
   measuredAllocatedBytes: number | null;
   verifiedReclaimedAvailableBytes: number | null;
-  outcome: 'parked' | 'already_parked' | 'refused';
+  outcome: 'candidate' | 'parked' | 'already_parked' | 'refused';
   reason: string;
 }
 
 export interface OrchestratorStoragePressureReceipt {
   schema: 'o8/storage-pressure-decision/v1';
   mode: 'manual' | 'pressure';
-  status: 'disabled' | 'admitted_after_parking' | 'exhausted';
+  status: 'disabled' | 'manual_review' | 'admitted_after_parking' | 'exhausted';
   trigger: 'reserve_breached';
   launchGeneration: number;
   candidates: OrchestratorStoragePressureCandidateReceipt[];

--- a/tests/storage-admission-dispatch-real-path.test.ts
+++ b/tests/storage-admission-dispatch-real-path.test.ts
@@ -40,6 +40,9 @@ const {
   createPacketStorageAdmissionCoordinator,
   observeRepoStorageEstimate,
 } = await import('@/lib/orchestrator/storage-admission');
+const { createStoragePressureAdmissionCoordinator } = await import(
+  '@/lib/orchestrator/storage-pressure-policy'
+);
 const { StorageAdmissionStore } = await import('@/lib/workspace/storage-admission');
 const statusRoute = await import('@/app/api/orchestrator/status/route');
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
@@ -58,6 +61,7 @@ beforeAll(() => {
 afterEach(() => {
   vi.useRealTimers();
   launchCalls.length = 0;
+  vi.unstubAllEnvs();
   vi.unstubAllGlobals();
 });
 
@@ -89,6 +93,7 @@ describe('storage admission dispatch real path', () => {
   it('uses timeout fallback, surfaces a capacity hold, and retries it from persisted state', async () => {
     vi.useFakeTimers({ toFake: ['Date'] });
     vi.setSystemTime(new Date('2026-08-22T12:00:00.000Z'));
+    vi.stubEnv('O8_WORKSPACE_PARKING_MODE', 'manual');
     vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200 })));
     let availableBytes = 12 * 1024 * 1024 * 1024;
     let refreshCalls = 0;
@@ -117,7 +122,59 @@ describe('storage admission dispatch real path', () => {
         defer: (task) => task(),
       }),
       observeReservationVolume: observeVolume,
-      resolvePolicy: () => ({ reserveRatio: 0.1, absoluteFloorBytes: 1024 * 1024 * 1024 }),
+      resolvePolicy: () => ({
+        reserveRatio: 0.1,
+        absoluteFloorBytes: 10 * 1024 * 1024 * 1024,
+      }),
+    });
+    const park = vi.fn();
+    const pressureAdmission = createStoragePressureAdmissionCoordinator(admission, {
+      listLanes: () => [{
+        id: 'lane-storage-review',
+        projectId: null,
+        label: 'storage review candidate',
+        repoPath,
+        worktreePath: repoPath,
+        branch: 'inline/storage-review-candidate',
+        baseBranch: 'main',
+        runtime: 'codex',
+        sessionKey: 'owned:storage-review-candidate',
+        packetId: 'packet-storage-review-candidate',
+        prNumber: null,
+        status: 'reviewing',
+        ownership: 'managed',
+        writerToken: null,
+        lastHeartbeatAt: null,
+        createdAt: '2026-08-20T12:00:00.000Z',
+        updatedAt: '2026-08-20T12:00:00.000Z',
+        lastEventAt: '2026-08-20T12:00:00.000Z',
+        lastEventLabel: 'review_ready',
+      }],
+      listRepos: async () => [{
+        id: 'repo-storage-review',
+        name: 'storage review repo',
+        localPath: repoPath,
+        remoteUrl: null,
+        defaultBranch: 'main',
+        addedAt: '2026-08-20T12:00:00.000Z',
+        lastOpenedAt: null,
+        storagePressureParkingDisabled: false,
+        setup: {
+          envMode: 'copy',
+          envFiles: [],
+          installCommand: null,
+          installOnCreateWorkspace: false,
+          buildCommand: null,
+          runBuildOnCreateWorkspace: false,
+          devCommand: null,
+          defaultPort: null,
+          workspaceIsolationPreference: 'auto',
+        },
+      }],
+      measureAllocatedBytes: async () => 4 * 1024 * 1024 * 1024,
+      observeVolume,
+      getSnapshot: () => null,
+      parkWorkspace: park,
     });
     const initial = {
       ...createEmptyOrchestratorMissionState(),
@@ -129,7 +186,7 @@ describe('storage admission dispatch real path', () => {
 
     const held = await runDispatchTick(initial, {
       launchBudget: { maxLaunches: 1 },
-      storageAdmission: admission,
+      storageAdmission: pressureAdmission,
     });
     expect(refreshCalls).toBeGreaterThan(0);
     expect(launchCalls).toEqual([]);
@@ -141,8 +198,25 @@ describe('storage admission dispatch real path', () => {
         state: 'held',
         reason: 'reserve_breached',
         estimateBytes: 8 * 1024 * 1024 * 1024,
+        pressure: {
+          mode: 'manual',
+          status: 'manual_review',
+          candidates: [{
+            packetId: 'packet-storage-review-candidate',
+            measuredAllocatedBytes: 4 * 1024 * 1024 * 1024,
+            outcome: 'candidate',
+            reason: 'manual_action_required',
+          }],
+        },
       },
     });
+    expect(held.packets[0]?.blockedReason).toContain(
+      'Storage policy keeps 10% of disk or 10.0 GB, whichever is greater, unallocated.',
+    );
+    expect(held.packets[0]?.blockedReason).toContain(
+      "Free 6.0 GB more to dispatch this packet's 8.0 GB estimate",
+    );
+    expect(park).not.toHaveBeenCalled();
     writeOrchestratorControlPlaneState(held);
 
     const response = await statusRoute.GET(new NextRequest(
@@ -155,12 +229,20 @@ describe('storage admission dispatch real path', () => {
     expect(body.result.packets[0]).toMatchObject({
       status: 'queued',
       blockedReason: expect.stringContaining('reserve_breached'),
-      storageAdmission: { state: 'held', reason: 'reserve_breached' },
+      storageAdmission: {
+        state: 'held',
+        reason: 'reserve_breached',
+        pressure: {
+          mode: 'manual',
+          status: 'manual_review',
+          candidates: [{ outcome: 'candidate' }],
+        },
+      },
     });
 
     const duringBackoff = await runDispatchTick(readOrchestratorControlPlaneState(), {
       launchBudget: { maxLaunches: 1 },
-      storageAdmission: admission,
+      storageAdmission: pressureAdmission,
     });
     expect(duringBackoff.packets[0]?.status).toBe('queued');
     expect(launchCalls).toEqual([]);
@@ -169,7 +251,7 @@ describe('storage admission dispatch real path', () => {
     vi.advanceTimersByTime(10_001);
     const retried = await runDispatchTick(duringBackoff, {
       launchBudget: { maxLaunches: 1 },
-      storageAdmission: admission,
+      storageAdmission: pressureAdmission,
     });
     expect(retried.packets[0]).toMatchObject({
       status: 'launching',


### PR DESCRIPTION
## Outcome

Turn a manual-mode storage hold into an actionable operator decision without weakening the reserve policy or parking any workspace automatically.

## Changes

- Explain the reserve policy, available capacity, active reservations, and exact dispatch shortfall in the held reason.
- Build reclaim candidates in manual mode and persist them as manual-review receipts.
- Keep every parking mutation gated to pressure mode. Manual mode only reports candidates.
- Preserve and normalize candidate receipts through the persisted packet state.
- Drive a real held dispatch through the coordinator, status route, retry path, and persisted state.

## Verification

- Focused Vitest: 2 files, 14 tests passed
- TypeScript: passed
- ESLint: passed with the accepted baseline
- Rule check: passed
- Test classification: passed
- Hermetic unit suite: passed

## Residual

This does not change the disk reserve itself and does not introduce automatic cleanup. The operator still owns every parking decision in manual mode.

Closes #2035
