### PR TITLE
fix: keep active lanes visible in operator status

### DIFF
--- a/src/app/api/operator/status/route.ts
+++ b/src/app/api/operator/status/route.ts
@@ -3,10 +3,33 @@ import { getRuntimeInventorySnapshot } from '@/lib/runtime/inventory';
 import { listApprovals, listUnsettledApprovalContinuations } from '@/lib/approvals/store';
 import { getLaneEvents, listLanes } from '@/lib/lane/registry';
 import { buildOperatorStatusAgents, summarizeOperatorStatus } from '@/lib/orchestrator/operator-status-model';
+import { readTranscriptActivityBySession } from '@/lib/orchestrator/operator-mission-service/mission-status-transcript';
 import { listTerminalReviewQueueEvidence } from '@/lib/terminal-status/store';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+
+interface OperatorActivityCandidate {
+  action: string;
+  target: string;
+  timestamp: string;
+  laneId: string | null;
+  packetId: string | null;
+  sessionKey: string;
+}
+
+function relativeActivityAge(timestamp: string): string {
+  const parsed = Date.parse(timestamp);
+  if (!Number.isFinite(parsed)) return 'just now';
+  const ageMs = Math.max(0, Date.now() - parsed);
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (ageMs < minute) return 'just now';
+  if (ageMs < hour) return `${Math.max(1, Math.round(ageMs / minute))}m ago`;
+  if (ageMs < day) return `${Math.max(1, Math.round(ageMs / hour))}h ago`;
+  return `${Math.max(1, Math.round(ageMs / day))}d ago`;
+}
 
 export async function GET(request: NextRequest) {
   try {
@@ -30,6 +53,16 @@ export async function GET(request: NextRequest) {
       approvals: pendingApprovals,
       reviewQueue: listTerminalReviewQueueEvidence(),
     });
+    const laneBySessionKey = new Map(
+      lanes
+        .filter((lane) => lane.sessionKey)
+        .map((lane) => [lane.sessionKey as string, lane]),
+    );
+    const transcriptActivityBySession = await readTranscriptActivityBySession(
+      agents
+        .filter((agent) => laneBySessionKey.has(agent.sessionKey))
+        .map((agent) => agent.sessionKey),
+    );
     const spendCapHits = lanes.flatMap((lane) => getLaneEvents(lane.id, 200)
       .filter((event) => event.verb === 'spend_cap_hit')
       .map((event) => ({
@@ -61,13 +94,55 @@ export async function GET(request: NextRequest) {
     };
 
     // ── Timeline ──
-    const events: Array<Record<string, unknown>> = [];
-
-    const recentActivity = events.slice(0, 5).map((e) => ({
-      action: (e.action as string) || (e.type as string) || '',
-      target: (e.title as string) || (e.target as string) || '',
-      timeAgo: (e.age as string) || (e.timeAgo as string) || '',
-    }));
+    // Keep runtime transcript activity and durable lane lifecycle activity as
+    // separate candidates. A steer writes both in close succession; collapsing
+    // to only the newest timestamp would hide the transcript signal that proves
+    // the worker is still advancing.
+    const activityCandidates: OperatorActivityCandidate[] = agents.flatMap((agent) => {
+      const lane = laneBySessionKey.get(agent.sessionKey);
+      const target = lane?.label || agent.name;
+      const candidates: OperatorActivityCandidate[] = [];
+      const lastTranscriptAt = transcriptActivityBySession.get(agent.sessionKey)?.lastTranscriptAt;
+      if (lastTranscriptAt) {
+        candidates.push({
+          action: 'transcript_activity',
+          target,
+          timestamp: lastTranscriptAt,
+          laneId: lane?.id ?? null,
+          packetId: lane?.packetId ?? null,
+          sessionKey: agent.sessionKey,
+        });
+      }
+      const laneActivityAt = lane?.lastEventAt || lane?.updatedAt;
+      if (lane && laneActivityAt) {
+        candidates.push({
+          action: lane.lastEventLabel || lane.status,
+          target,
+          timestamp: laneActivityAt,
+          laneId: lane.id,
+          packetId: lane.packetId,
+          sessionKey: agent.sessionKey,
+        });
+      } else if (agent.observedAt) {
+        candidates.push({
+          action: agent.status,
+          target,
+          timestamp: agent.observedAt,
+          laneId: null,
+          packetId: null,
+          sessionKey: agent.sessionKey,
+        });
+      }
+      return candidates;
+    });
+    const recentActivity = activityCandidates
+      .filter((candidate) => Number.isFinite(Date.parse(candidate.timestamp)))
+      .sort((left, right) => right.timestamp.localeCompare(left.timestamp))
+      .slice(0, 5)
+      .map((candidate) => ({
+        ...candidate,
+        timeAgo: relativeActivityAge(candidate.timestamp),
+      }));
 
     // ── Summary ──
     const summary = summarizeOperatorStatus({

--- a/src/lib/orchestrator/operator-status-model.test.ts
+++ b/src/lib/orchestrator/operator-status-model.test.ts
@@ -69,6 +69,30 @@ function lane(overrides: Partial<Lane>): Lane {
 }
 
 describe('operator status model', () => {
+  it('uses an active persisted lane when runtime discovery misses its session', () => {
+    const agents = buildOperatorStatusAgents([], [lane({ status: 'running' })]);
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0]).toMatchObject({
+      name: 'packet worker',
+      sessionKey: 'codex-owned:1',
+      status: 'running',
+      authority: 'lane-state',
+      task: 'session_running',
+    });
+    expect(agents[0].statusEvidence).toMatchObject({
+      state: 'working',
+      authority: 'lane-state',
+    });
+  });
+
+  it.each(['idle', 'paused', 'completed', 'archived'] as const)(
+    'does not resurrect a lane-only %s session as an agent',
+    (status) => {
+      expect(buildOperatorStatusAgents([], [lane({ status })])).toEqual([]);
+    },
+  );
+
   it('keeps runtime failure authoritative when the lane still says running', () => {
     const agents = buildOperatorStatusAgents([agent({ status: 'failed' })], [lane({ status: 'running' })]);
 

--- a/src/lib/orchestrator/operator-status-model.ts
+++ b/src/lib/orchestrator/operator-status-model.ts
@@ -72,7 +72,11 @@ function observedAtForAgent(agent: AgentSummary, lane: Lane | undefined): string
 
 function approvalMatchesAgent(approval: ApprovalRecord, agent: AgentSummary, lane: Lane | undefined): boolean {
   if (approval.sessionKey === agent.sessionKey) return true;
-  if (!lane) return false;
+  return Boolean(lane && approvalMatchesLane(approval, lane));
+}
+
+function approvalMatchesLane(approval: ApprovalRecord, lane: Lane): boolean {
+  if (lane.sessionKey && approval.sessionKey === lane.sessionKey) return true;
   if (approval.continuation?.kind === 'lane' && approval.continuation.laneId === lane.id) return true;
   return approval.metadata?.laneId === lane.id || approval.metadata?.LaneId === lane.id;
 }
@@ -197,6 +201,66 @@ function canonicalAgentStatus(
   return operatorStatusFromTerminalState(statusEvidence.state, agent.status || 'idle');
 }
 
+const LANE_ONLY_OPERATOR_STATUSES = new Set<Lane['status']>([
+  'launching',
+  'running',
+  'awaiting_input',
+  'awaiting_orchestrator',
+  'awaiting_human',
+  'recovering',
+  'reviewing',
+  'merging',
+  'failed',
+]);
+
+function safeResolveLaneOnlyStatusEvidence(
+  lane: Lane,
+  context: OperatorStatusEvidenceContext,
+): TerminalStatusEvidence {
+  try {
+    return resolveTerminalStatusEvidence({
+      lane,
+      laneEvents: context.laneEventsByLaneId?.get(lane.id) ?? [],
+      approvals: (context.approvals ?? []).filter((approval) => (
+        approval.status === 'pending' && approvalMatchesLane(approval, lane)
+      )),
+      reviewQueue: (context.reviewQueue ?? []).filter((review) => review.laneId === lane.id),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[terminal-status] Failed to resolve lane-only status for ${lane.id}: ${message}`);
+    return unknownTerminalStatusEvidence({
+      sessionId: lane.sessionKey || lane.id,
+      runtime: lane.runtime,
+      observedAt: lane.lastEventAt ?? lane.updatedAt,
+      summary: 'Terminal status evidence could not be resolved for this lane.',
+      fallbackReason: `Status resolution failed for this lane: ${message}`,
+    });
+  }
+}
+
+function operatorStatusAgentFromLane(
+  lane: Lane & { sessionKey: string },
+  context: OperatorStatusEvidenceContext,
+): OperatorStatusAgent {
+  const statusEvidence = safeResolveLaneOnlyStatusEvidence(lane, context);
+  return {
+    name: lane.label || lane.sessionKey,
+    repo: repoFromWorkspace(lane.worktreePath || lane.repoPath),
+    runtime: lane.runtime,
+    model: lane.model ?? null,
+    status: operatorStatusFromTerminalState(statusEvidence.state, lane.status),
+    branch: lane.branch,
+    elapsed: lane.lastEventAt || lane.updatedAt,
+    sessionKey: lane.sessionKey,
+    task: lane.lastEventLabel,
+    authority: statusEvidence.authority,
+    summary: statusEvidence.summary,
+    observedAt: statusEvidence.observedAt,
+    statusEvidence,
+  };
+}
+
 export function buildOperatorStatusAgents(
   sessions: AgentSummary[],
   lanes: Lane[],
@@ -213,7 +277,7 @@ export function buildOperatorStatusAgents(
     ? sessions.filter((session) => session.sessionKey === sessionKeyFilter)
     : sessions;
 
-  return filtered.map((session) => {
+  const inventoryAgents = filtered.map((session) => {
     const lane = laneBySession.get(session.sessionKey);
     const statusEvidence = safeResolveAgentSummaryStatusEvidence(session, lane, context);
     return {
@@ -232,6 +296,23 @@ export function buildOperatorStatusAgents(
       statusEvidence,
     };
   });
+
+  // Runtime discovery is observational and can briefly return no session while
+  // a warm worker is still advancing. The lane registry is the durable
+  // lifecycle record, so an active lane must remain visible even during that
+  // discovery gap. Only synthesize a lane-backed row when inventory did not
+  // already provide the same session, and never resurrect idle/archived lanes.
+  const representedSessionKeys = new Set(inventoryAgents.map((agent) => agent.sessionKey));
+  const laneOnlyAgents = [...laneBySession.values()]
+    .filter((lane): lane is Lane & { sessionKey: string } => Boolean(
+      lane.sessionKey
+      && LANE_ONLY_OPERATOR_STATUSES.has(lane.status)
+      && !representedSessionKeys.has(lane.sessionKey)
+      && (!sessionKeyFilter || lane.sessionKey === sessionKeyFilter),
+    ))
+    .map((lane) => operatorStatusAgentFromLane(lane, context));
+
+  return [...inventoryAgents, ...laneOnlyAgents];
 }
 
 const ACTIVE_STATUSES = new Set(['launching', 'running', 'working', 'recovering']);

--- a/tests/steer-idempotency-real-path.test.ts
+++ b/tests/steer-idempotency-real-path.test.ts
@@ -16,6 +16,9 @@ vi.mock('@/lib/runtime/actions', async (importOriginal) => {
 vi.mock('@/lib/realtime/publisher', () => ({ publishRealtimeMutation: h.publish }));
 vi.mock('@/lib/command-center/snapshot', () => ({ invalidateCommandCenterSnapshotCaches: vi.fn() }));
 vi.mock('@/lib/mobile/inbox', () => ({ invalidateInboxCache: vi.fn() }));
+vi.mock('@/lib/runtime/inventory', () => ({
+  getRuntimeInventorySnapshot: vi.fn(async () => ({ agents: [] })),
+}));
 
 const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-steer-idempotency-'));
 const operatorToken = 'operator-steer-idempotency-0123456789abcdef';
@@ -24,10 +27,12 @@ process.env.O8_DATA_DIR = dataDir;
 process.env.CORTEX_IDE_DATA_DIR = dataDir;
 
 const legacyRoute = await import('@/app/api/orchestrator/steer-packet/route');
+const operatorStatusRoute = await import('@/app/api/operator/status/route');
+const { handleStatus } = await import('@/lib/mcp/operator-handlers/status');
 const agentControlRoute = await import('@/app/api/agent-control/action/route');
 const idempotency = await import('@/lib/orchestrator/idempotency-store');
 const { closeDb, getSqlite } = await import('@/lib/db');
-const { createLane, deleteLane } = await import('@/lib/lane/registry');
+const { createLane, deleteLane, getLane } = await import('@/lib/lane/registry');
 
 const createdLaneIds: string[] = [];
 
@@ -43,13 +48,13 @@ function post(pathname: string, body: unknown) {
   });
 }
 
-function createSteerLane(label: string) {
+function createSteerLane(label: string, sessionKey = `codex-owned:${label}`) {
   const lane = createLane({
     repoPath: dataDir,
     branch: `inline/${label}`,
     runtime: 'codex',
     packetId: `packet-${label}`,
-    sessionKey: `codex-owned:${label}`,
+    sessionKey,
   });
   createdLaneIds.push(lane.id);
   return lane;
@@ -69,6 +74,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const laneId of createdLaneIds.splice(0)) deleteLane(laneId);
 });
 
@@ -78,6 +84,59 @@ afterAll(() => {
 });
 
 describe('packet steer post-effect idempotency through real routes', () => {
+  it('real o8_status keeps a successfully steered lane visible when runtime discovery is empty', async () => {
+    const lane = createSteerLane(
+      'operator-status-lane-truth',
+      'test-runtime:operator-status-lane-truth',
+    );
+    h.perform.mockResolvedValueOnce({
+      ok: true,
+      action: 'steer',
+      surfaceId: lane.sessionKey,
+      sessionKey: lane.sessionKey,
+      runtime: lane.runtime,
+      status: 'sent',
+      note: 'steered',
+    });
+
+    const steer = await legacyRoute.POST(post('/api/orchestrator/steer-packet', {
+      packetId: lane.packetId,
+      message: 'continue the live packet',
+      idempotencyKey: 'operator-status-lane-truth',
+    }));
+    expect(steer.status).toBe(200);
+    expect(getLane(lane.id)?.status).toBe('running');
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const request = new NextRequest(String(input));
+      if (request.nextUrl.pathname === '/api/operator/status') {
+        return operatorStatusRoute.GET(request);
+      }
+      throw new Error(`Unexpected fetch: ${request.nextUrl.pathname}`);
+    });
+
+    const result = await handleStatus({});
+    const text = result.content.find((block) => block.type === 'text')?.text ?? '{}';
+    const payload = JSON.parse(text) as {
+      summary: string;
+      data: {
+        agents: Array<{ sessionKey: string; status: string; authority: string }>;
+        recentActivity: Array<{ action: string; target: string }>;
+      };
+    };
+
+    expect(payload.summary).toContain('1 agent running');
+    expect(payload.data.agents).toContainEqual(expect.objectContaining({
+      sessionKey: lane.sessionKey,
+      status: 'running',
+      authority: 'lane-state',
+    }));
+    expect(payload.data.recentActivity).toContainEqual(expect.objectContaining({
+      action: 'transcript_activity',
+      target: lane.label,
+    }));
+  });
+
   it('legacy steer replays an outcome-unknown throw after the event/send boundary', async () => {
     const lane = createSteerLane('legacy-outcome-unknown');
     h.perform.mockImplementationOnce(async () => {


### PR DESCRIPTION
## Outcome

Keep a live lane visible in operator status when runtime inventory briefly misses its session, including after a successful steer leaves the packet wrapper blocked while the lane is running.

## Changes

- Synthesize an operator-status agent from active persisted lane state only when inventory has no matching session.
- Keep runtime failure evidence authoritative when inventory does report the session.
- Exclude idle, paused, completed, and archived lanes so stale rows are not resurrected.
- Populate recent activity from transcript and lane lifecycle evidence.
- Drive a real steer through the persisted lane, operator-status route, and o8_status handler.

## Verification

- Focused Vitest: 2 files, 16 tests passed
- TypeScript: passed
- ESLint: passed with the accepted baseline
- Rule check: passed
- Test classification: passed
- Hermetic unit suite: passed

## Residual

Lane state is used only as the durable fallback for active lifecycle states. It does not override a discovered runtime failure and does not revive terminal sessions.

Closes #2036
