### PR TITLE
fix: consume one-time huddle alignment

### DIFF
--- a/src/lib/lane/commands.ts
+++ b/src/lib/lane/commands.ts
@@ -453,6 +453,15 @@ async function dispatchUnlocked(
               lane: huddlePark.lane ?? undefined,
             };
           }
+          if (huddlePark.operatorBlocked) {
+            const blockedLane = huddlePark.lane ?? getLane(command.laneId) ?? lane;
+            return {
+              ok: false,
+              laneId: command.laneId,
+              note: blockedLane.lastEventLabel ?? 'worker_blocked',
+              lane: blockedLane,
+            };
+          }
           const { shouldDeferCompletionForLiveRuntime } = await import('@/lib/supervisor/completion-liveness');
           if (await shouldDeferCompletionForLiveRuntime(lane)) {
             console.warn(`[lane] request_review: ${command.laneId} has no diff yet, but its owned runtime is still live. Keeping it running.`);

--- a/src/lib/orchestrator/alignment-access.ts
+++ b/src/lib/orchestrator/alignment-access.ts
@@ -32,9 +32,12 @@ export interface PacketAlignment {
 }
 
 export type PacketAlignmentInput = HuddleAccessInput
-  & Pick<OrchestratorPacket, 'runtime' | 'assignedModel' | 'workerRouting' | 'huddle'>;
+  & Pick<OrchestratorPacket, 'runtime' | 'assignedModel' | 'workerRouting' | 'huddle' | 'alignmentResolvedAt'>;
 
 export function resolvePacketAlignment(packet: PacketAlignmentInput): PacketAlignment {
+  if (typeof packet.alignmentResolvedAt === 'string' && packet.alignmentResolvedAt.trim()) {
+    return { armed: false, source: null, promptSection: null };
+  }
   if (resolvePacketHuddleEnabled(packet)) {
     return { armed: true, source: 'huddle', promptSection: HUDDLE_PROMPT_SECTION };
   }

--- a/src/lib/orchestrator/huddle-zero-diff.test.ts
+++ b/src/lib/orchestrator/huddle-zero-diff.test.ts
@@ -57,6 +57,15 @@ function seedHuddleLane(packetId: string, huddle: boolean | undefined, runtime: 
   return getLane(lane.id)!;
 }
 
+function resolveSeededAlignment(packetId: string) {
+  const state = createEmptyOrchestratorMissionState();
+  state.packets = [{
+    ...huddlePacket(packetId, '/tmp/o8-huddle-zero-diff-test-repo', true),
+    alignmentResolvedAt: '2026-09-01T02:00:00.000Z',
+  }];
+  writeOrchestratorControlPlaneState(state);
+}
+
 describe('parkHuddleReadyZeroDiffLane (#1496)', () => {
   it('parks a huddle packet on zero-diff exit WITHOUT any plan/report signal (steer stays reachable)', async () => {
     // No agent_report huddle event and no transcript — the exact #1502/#1496
@@ -82,6 +91,32 @@ describe('parkHuddleReadyZeroDiffLane (#1496)', () => {
     expect(result.parked).toBe(false);
     // Left untouched — the caller falls through to its zero_diff_failed path.
     expect(getLane(lane.id)?.status).toBe('running');
+  });
+
+  it('does NOT classify a later zero-diff exit as huddle after alignment was resolved', async () => {
+    const lane = seedHuddleLane('pkt-huddle-resolved', true);
+    resolveSeededAlignment('pkt-huddle-resolved');
+
+    const result = await parkHuddleReadyZeroDiffLane(lane);
+
+    expect(result.parked).toBe(false);
+    expect(result.operatorBlocked).not.toBe(true);
+    expect(getLane(lane.id)?.status).toBe('running');
+  });
+
+  it('preserves a typed operator blocker instead of relabeling it as huddle-ready', async () => {
+    const lane = seedHuddleLane('pkt-huddle-typed-blocker', true);
+    resolveSeededAlignment('pkt-huddle-typed-blocker');
+    const blocked = setLaneStatus(lane.id, 'awaiting_orchestrator', 'system', 'nondeterministic_test');
+
+    const result = await parkHuddleReadyZeroDiffLane(lane);
+
+    expect(result).toMatchObject({
+      parked: false,
+      operatorBlocked: true,
+      lane: { id: lane.id, status: 'awaiting_orchestrator', lastEventLabel: 'nondeterministic_test' },
+    });
+    expect(getLane(blocked!.id)?.lastEventLabel).toBe('nondeterministic_test');
   });
 
   it('parks an adaptive legacy packet without an explicit huddle choice', async () => {

--- a/src/lib/orchestrator/huddle-zero-diff.ts
+++ b/src/lib/orchestrator/huddle-zero-diff.ts
@@ -1,4 +1,4 @@
-import { getLaneEvents, setLaneStatus } from '@/lib/lane/registry';
+import { getLane, getLaneEvents, setLaneStatus } from '@/lib/lane/registry';
 import type { Lane } from '@/lib/lane/types';
 import { resolvePacketAlignment } from '@/lib/orchestrator/alignment-access';
 import { readOrchestratorControlPlaneState, withLockedState } from '@/lib/orchestrator/control-plane';
@@ -33,13 +33,54 @@ async function transcriptEndsWithPlan(lane: Lane): Promise<boolean> {
   }
 }
 
-export async function parkHuddleReadyZeroDiffLane(lane: Lane): Promise<{ parked: boolean; lane?: Lane }> {
+export interface HuddleZeroDiffResult {
+  parked: boolean;
+  operatorBlocked?: boolean;
+  lane?: Lane;
+}
+
+export async function parkHuddleReadyZeroDiffLane(lane: Lane): Promise<HuddleZeroDiffResult> {
   const packetId = lane.packetId?.trim();
   if (!packetId) return { parked: false };
 
   const state = readOrchestratorControlPlaneState();
   const packet = state.packets.find((candidate) => candidate.id === packetId);
   if (!packet) return { parked: false };
+
+  // A worker can intentionally end an implementation turn with a typed
+  // blocker after restoring a clean tree. That operator-facing reason is more
+  // specific than generic zero-diff classification and must survive process
+  // completion. Read the current lane rather than the supervisor's possibly
+  // stale snapshot; huddle/huddle_ready still flow through the alignment path
+  // below, while every other awaiting-orchestrator report is preserved.
+  const currentLane = getLane(lane.id) ?? lane;
+  const currentLabel = currentLane.lastEventLabel?.trim();
+  if (
+    currentLane.status === 'awaiting_orchestrator'
+    && currentLabel
+    && currentLabel !== 'huddle'
+    && currentLabel !== HUDDLE_READY_EVENT_LABEL
+  ) {
+    const blockedAt = currentLane.lastEventAt ?? new Date().toISOString();
+    await withLockedState((current) => {
+      const currentPacket = current.packets.find((candidate) => candidate.id === packetId);
+      if (!currentPacket) return;
+      currentPacket.status = 'blocked';
+      currentPacket.blockedReason = currentLabel;
+      currentPacket.lastEventAt = blockedAt;
+      currentPacket.lastEventLabel = currentLabel;
+      if (currentPacket.lane) {
+        currentPacket.lane = {
+          ...currentPacket.lane,
+          laneId: currentLane.id,
+          sessionKey: currentLane.sessionKey ?? lane.sessionKey ?? null,
+          lastEventAt: blockedAt,
+          lastEventLabel: currentLabel,
+        };
+      }
+    });
+    return { parked: false, operatorBlocked: true, lane: currentLane };
+  }
 
   // An explicit huddle packet is DESIGNED to produce a zero-diff alignment turn.
   // So is a single-sub cheap-tier worker: it's auto-armed with the SAME

--- a/src/lib/orchestrator/operator-mission-service/rerun-with-feedback.ts
+++ b/src/lib/orchestrator/operator-mission-service/rerun-with-feedback.ts
@@ -23,6 +23,7 @@ import { cleanupResetPacketTargets, type ResetCleanupTarget } from './reset-clea
 import { unregisterWatchedAgent } from '@/lib/supervisor/agent-supervisor';
 import { storageOwnerGenerationForLane } from '@/lib/orchestrator/terminal-storage-release';
 import { archiveWorkspaceManifestRunForReset } from '@/lib/workspace/manifest/lifecycle';
+import { resolvePacketAlignment } from '@/lib/orchestrator/alignment-access';
 
 /**
  * #662 — One-click rerun-with-feedback.
@@ -79,6 +80,20 @@ function appendFeedback(base: string, feedback: string) {
   const trimmedFeedback = feedback.trim();
   if (!stripped) return `${FEEDBACK_HEADING}\n${trimmedFeedback}`;
   return `${stripped}\n\n${FEEDBACK_HEADING}\n${trimmedFeedback}`;
+}
+
+const ALIGNMENT_WAIT_LABELS = new Set([
+  'huddle',
+  'huddle_ready',
+  'needs_clarification',
+  'question',
+  'worker_question',
+]);
+
+function packetAwaitsAlignmentFeedback(packet: OrchestratorPacket): boolean {
+  if (!resolvePacketAlignment(packet).armed) return false;
+  return [packet.blockedReason, packet.lastEventLabel, packet.lane?.lastEventLabel]
+    .some((label) => typeof label === 'string' && ALIGNMENT_WAIT_LABELS.has(label));
 }
 
 function buildEscalationSuggestion(packet: OrchestratorPacket, nextAttemptCount: number): RerunEscalationSuggestion | null {
@@ -344,6 +359,7 @@ async function rerunWithFeedbackUnlocked(input: RerunWithFeedbackInput): Promise
 
   const guard = await holdPacketLifecycleMutation({ packetId, kind: 'rerun' });
   if (!guard) throw new Error(`Packet ${packetId} not found.`);
+  const resolvesAlignment = packetAwaitsAlignmentFeedback(guard.previousPacket);
   const worktreePruned = await retireRerunGeneration(guard);
   const originalSummary = guard.previousPacket.summary;
   const originalPrompt = guard.previousPacket.prompt?.trim()
@@ -353,6 +369,9 @@ async function rerunWithFeedbackUnlocked(input: RerunWithFeedbackInput): Promise
   try {
     await supersedeDurableApprovedReviews(packetId, 'Superseded by rerun_with_feedback.');
     relaunched = await mutatePacketLifecycleGuard(guard, async (packet, current) => {
+      if (resolvesAlignment && !packet.alignmentResolvedAt) {
+        packet.alignmentResolvedAt = new Date().toISOString();
+      }
       resetPacketFields(packet);
       const nextAttemptCount = (packet.attemptCount ?? 0) + 1;
       escalationSuggestion = buildEscalationSuggestion(packet, nextAttemptCount);

--- a/src/lib/orchestrator/operator-mission-service/steer.ts
+++ b/src/lib/orchestrator/operator-mission-service/steer.ts
@@ -18,7 +18,13 @@ import { findLaneByPacket, setLaneStatus } from '@/lib/lane/registry';
 import type { Lane } from '@/lib/lane/types';
 import { recordLaneEvent } from '@/lib/lane/events';
 import { rebindLaneSessionIfChanged } from '@/lib/lane/session-rebind';
-import { findMissionRegistryEntryByPacketId } from '@/lib/orchestrator/mission-registry';
+import {
+  findMissionRegistryEntryByPacketId,
+  withMissionRegistryState,
+} from '@/lib/orchestrator/mission-registry';
+import { resolvePacketAlignment } from '@/lib/orchestrator/alignment-access';
+import { withLockedState } from '@/lib/orchestrator/control-plane';
+import { withMissionHandoffBarrier } from '@/lib/orchestrator/lifecycle-mutation-lock';
 import { performRuntimeAction } from '@/lib/runtime/actions';
 import { currentMissionState } from './shared';
 import { continueOwnedCodexSession, getOwnedCodexRuntimeTail, getOwnedCodexTelemetrySources } from '@/lib/codex/owned';
@@ -126,6 +132,35 @@ async function resumeExitedOwnedCodexSession(surfaceId: string, message: string)
   }
 }
 
+async function markAlignmentResolved(packetId: string): Promise<void> {
+  await withMissionHandoffBarrier(async () => {
+    let currentMissionId = '';
+    const { result: foundCurrent } = await withLockedState((current) => {
+      currentMissionId = current.missionId?.trim() ?? '';
+      const packet = current.packets.find((candidate) => candidate.id === packetId);
+      if (!packet) return false;
+      if (resolvePacketAlignment(packet).armed) {
+        packet.alignmentResolvedAt = new Date().toISOString();
+      }
+      return true;
+    });
+    if (foundCurrent) return;
+
+    const entry = findMissionRegistryEntryByPacketId(packetId, {
+      includeArchived: true,
+      excludeMissionId: currentMissionId || undefined,
+    });
+    if (!entry) return;
+    await withMissionRegistryState(entry.id, (state) => {
+      const packet = state.packets.find((candidate) => candidate.id === packetId);
+      if (packet && resolvePacketAlignment(packet).armed) {
+        packet.alignmentResolvedAt = new Date().toISOString();
+      }
+      return { state, result: undefined };
+    });
+  });
+}
+
 export async function steerPacket({
   packetId,
   message,
@@ -215,6 +250,11 @@ export async function steerPacket({
       });
       throw new SteerPacketUnavailableError(`Steer failed to start: ${startupFailure}`, 'terminal');
     }
+
+    // Huddle/advisor alignment is a one-time turn. Only consume it after the
+    // warm resume (or cold owned-session fallback) has actually started; an
+    // unavailable steer must leave the alignment prompt armed for recovery.
+    await markAlignmentResolved(packetId);
 
     const updated = setLaneStatus(lane.id, 'running', 'orchestrator', 'steered_packet');
     if (!updated || updated.status !== 'running') {

--- a/src/lib/orchestrator/packet-alignment-normalize.ts
+++ b/src/lib/orchestrator/packet-alignment-normalize.ts
@@ -1,0 +1,11 @@
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+
+// Alignment state lives only on the packet. Normalizing both the original
+// huddle intent and its one-time resolution receipt keeps reruns honest.
+export function normalizePacketAlignmentResolvedAt(
+  value: unknown,
+): OrchestratorPacket['alignmentResolvedAt'] {
+  return typeof value === 'string' && Number.isFinite(Date.parse(value))
+    ? value
+    : undefined;
+}

--- a/src/lib/orchestrator/packet-prompt-alignment.test.ts
+++ b/src/lib/orchestrator/packet-prompt-alignment.test.ts
@@ -86,6 +86,22 @@ describe('buildPacketPrompt alignment de-dup', () => {
     });
   });
 
+  it('does not re-arm an alignment turn after the operator resolved it', async () => {
+    await withCheapTierProfile(async () => {
+      const prompt = await buildPacketPrompt(
+        minimalPacket({
+          huddle: true,
+          alignmentResolvedAt: '2026-09-01T02:00:00.000Z',
+          runtime: 'claude-code',
+          assignedModel: null,
+        }),
+        [],
+      );
+      expect(prompt).not.toContain(HUDDLE_PROMPT_SECTION);
+      expect(prompt).not.toContain(ADVISOR_PROMPT_SECTION);
+    });
+  });
+
   it('read-only work gets an inspection contract without write, alignment, or commit instructions', async () => {
     await withCheapTierProfile(async () => {
       const prompt = await buildPacketPrompt(

--- a/src/lib/orchestrator/store.ts
+++ b/src/lib/orchestrator/store.ts
@@ -7,6 +7,7 @@ import { normalizePacketContextTelemetry, reconcilePacketContextTelemetry } from
 import type { DomainLaneSummary } from '@/lib/orchestrator/domain-lane-summary';
 import { normalizeQualitySearchPacketState } from '@/lib/orchestrator/quality-search';
 import { normalizePacketStorageAdmission, normalizePacketStorageAdmissionEpoch } from '@/lib/orchestrator/packet-storage-admission-normalize';
+import { normalizePacketAlignmentResolvedAt } from '@/lib/orchestrator/packet-alignment-normalize';
 import { normalizeLaneBinding } from '@/lib/orchestrator/lane-binding';
 import { normalizeTerminalStatusEvidenceField } from '@/lib/terminal-status/normalize';
 import { hydrateOrchestratorTurnPinEntry, installOrchestratorTurnPinFetchPatch, persistOrchestratorTurnPin, readCachedOrchestratorTurnPin, stageOrchestratorTurnPin } from '@/lib/orchestrator/turn-pins';
@@ -363,9 +364,8 @@ function normalizePacket(raw: unknown, index: number, existing: Array<Pick<Orche
     operatorStopped: packet.operatorStopped === true ? true : undefined,
     spendCap: normalizePacketSpendCap(packet.spendCap), spendTelemetry: normalizePacketSpendTelemetry(packet.spendTelemetry),
     contextTelemetry: normalizePacketContextTelemetry(packet.contextTelemetry),
-    // Huddle mode (per-mission alignment turn) lives only on the packet — drop
-    // it here and a rerun/re-read would silently disarm the huddle.
     huddle: typeof packet.huddle === 'boolean' ? packet.huddle : undefined,
+    alignmentResolvedAt: normalizePacketAlignmentResolvedAt(packet.alignmentResolvedAt),
     blockedReason: typeof packet.blockedReason === 'string' ? packet.blockedReason : null, completionSummary: typeof packet.completionSummary === 'string' && packet.completionSummary.trim() ? packet.completionSummary.trim() : null, ...normalizeTerminalStatusEvidenceField(packet.statusEvidence),
     storageAdmission: normalizePacketStorageAdmission(packet.storageAdmission), storageAdmissionEpoch: normalizePacketStorageAdmissionEpoch(packet.storageAdmissionEpoch),
     recovery: normalizePacketRecovery(packet.recovery),

--- a/src/lib/orchestrator/types.ts
+++ b/src/lib/orchestrator/types.ts
@@ -406,6 +406,13 @@ export interface OrchestratorPacket {
    */
   huddle?: boolean;
   /**
+   * Timestamp of the first operator response that released this packet from
+   * its one-time alignment turn. The original huddle flag stays intact as
+   * historical intent, while prompt assembly and zero-diff classification use
+   * this marker to avoid re-arming alignment on later generations.
+   */
+  alignmentResolvedAt?: string;
+  /**
    * Provider/runtime routing decision. Production currently enforces Codex as
    * the selected runtime while preserving requested future providers.
    */

--- a/src/lib/supervisor/silent-exit-detector.ts
+++ b/src/lib/supervisor/silent-exit-detector.ts
@@ -477,6 +477,10 @@ async function triageSilentExit(lane: Lane): Promise<boolean> {
       console.log(`[silent-exit] Lane ${lane.id} completed its huddle turn with no changes; parked for orchestrator.`);
       return true;
     }
+    if (huddlePark.operatorBlocked) {
+      console.log(`[silent-exit] Lane ${lane.id} already carries operator blocker ${huddlePark.lane?.lastEventLabel ?? 'worker_blocked'}; preserving it.`);
+      return true;
+    }
     setLaneStatus(lane.id, 'awaiting_input', 'system', 'silent_exit_no_work');
     enqueueSilentExitInbox(
       lane,

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -9262,6 +9262,16 @@ async function bootstrapWsServer() {
                     detail,
                   };
                 }
+                if (huddlePark.operatorBlocked) {
+                  const blockedLane = huddlePark.lane ?? lane;
+                  const label = packetId ? `Packet ${packetId}` : `Lane ${lane.id}`;
+                  const detail = `${label} stopped for operator input: ${blockedLane.lastEventLabel ?? 'worker_blocked'}.`;
+                  console.warn(`[supervisor] ${detail}`);
+                  return {
+                    block: true,
+                    detail,
+                  };
+                }
                 const failedLane = setLaneStatus(lane.id, 'failed', 'system', 'zero_diff_failed');
 
                 if (packetId) {

--- a/tests/huddle-zero-diff-classification.test.ts
+++ b/tests/huddle-zero-diff-classification.test.ts
@@ -3,7 +3,13 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const performRuntimeActionMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/runtime/actions', () => ({
+  performRuntimeAction: performRuntimeActionMock,
+}));
 
 process.env.CORTEX_IDE_DATA_DIR = mkdtempSync(join(tmpdir(), 'o8-huddle-zero-diff-data-'));
 process.env.O8_DATA_DIR = process.env.CORTEX_IDE_DATA_DIR;
@@ -12,12 +18,22 @@ const { dispatch } = await import('@/lib/lane/commands');
 const { reportAgentEvent } = await import('@/lib/lane/agent-report');
 const { createLane, getLane, listLanes } = await import('@/lib/lane/registry');
 const { readOrchestratorControlPlaneState, writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+const { buildPacketPrompt } = await import('@/lib/orchestrator/packet-prompt');
+const { steerPacket } = await import('@/lib/orchestrator/operator-mission-service/steer');
+const { getMissionStatus } = await import('@/lib/orchestrator/operator-mission-service');
 const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+const { readMissionRegistryEntry } = await import('@/lib/orchestrator/mission-registry');
 const { HUDDLE_READY_EVENT_LABEL } = await import('@/lib/orchestrator/huddle-zero-diff');
+const { HUDDLE_PROMPT_SECTION } = await import('@/lib/orchestrator/huddle-access');
+const { getSqlite } = await import('@/lib/db');
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 
 afterAll(() => {
   rmSync(process.env.CORTEX_IDE_DATA_DIR as string, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  performRuntimeActionMock.mockReset();
 });
 
 function git(cwd: string, args: string[]): string {
@@ -36,9 +52,9 @@ function makeCleanWorktree(): string {
   return dir;
 }
 
-function packetFor(worktreePath: string, laneId: string): OrchestratorPacket {
+function packetFor(packetId: string, worktreePath: string, laneId: string, sessionKey: string): OrchestratorPacket {
   return {
-    id: 'pkt-huddle-zero-diff',
+    id: packetId,
     referenceLabel: 'P1',
     title: 'Plan before editing',
     summary: 'Huddle turn should not produce a diff.',
@@ -61,7 +77,7 @@ function packetFor(worktreePath: string, laneId: string): OrchestratorPacket {
       repoPath: worktreePath,
       worktreePath,
       runtime: 'codex',
-      sessionKey: 'codex-owned:huddle-zero-diff',
+      sessionKey,
       laneId,
       lastHeartbeatAt: null,
       lastEventAt: null,
@@ -73,6 +89,8 @@ function packetFor(worktreePath: string, laneId: string): OrchestratorPacket {
 
 describe('huddle zero-diff classification', () => {
   it('parks a huddle-armed lane with a persisted huddle report instead of failing zero-diff', async () => {
+    const packetId = 'pkt-huddle-zero-diff';
+    const sessionKey = 'codex-owned:huddle-zero-diff';
     const worktreePath = makeCleanWorktree();
     const lane = createLane({
       repoPath: worktreePath,
@@ -80,8 +98,8 @@ describe('huddle zero-diff classification', () => {
       branch: 'pkt/huddle-zero-diff',
       baseBranch: 'main',
       runtime: 'codex',
-      sessionKey: 'codex-owned:huddle-zero-diff',
-      packetId: 'pkt-huddle-zero-diff',
+      sessionKey,
+      packetId,
     });
 
     writeOrchestratorControlPlaneState({
@@ -89,7 +107,7 @@ describe('huddle zero-diff classification', () => {
       missionId: 'mission-huddle-zero-diff',
       repoPath: worktreePath,
       runtime: 'codex',
-      packets: [packetFor(worktreePath, lane.id)],
+      packets: [packetFor(packetId, worktreePath, lane.id, sessionKey)],
       updatedAt: new Date().toISOString(),
     });
 
@@ -120,5 +138,127 @@ describe('huddle zero-diff classification', () => {
     expect(packet?.lastEventLabel).toBe(HUDDLE_READY_EVENT_LABEL);
     expect(packet?.status).not.toBe('failed');
     expect(listLanes()).toHaveLength(1);
+  });
+
+  it('consumes alignment on steer and preserves a later typed blocker through zero-diff completion', async () => {
+    const packetId = 'pkt-huddle-consumed-real-path';
+    const sessionKey = 'test-runtime:huddle-consumed';
+    const missionId = 'mission-huddle-consumed-real-path';
+    const worktreePath = makeCleanWorktree();
+    const lane = createLane({
+      repoPath: worktreePath,
+      worktreePath,
+      branch: 'pkt/huddle-consumed-real-path',
+      baseBranch: 'main',
+      runtime: 'codex',
+      sessionKey,
+      packetId,
+    });
+
+    writeOrchestratorControlPlaneState({
+      ...createEmptyOrchestratorMissionState(),
+      missionId,
+      repoPath: worktreePath,
+      runtime: 'codex',
+      packets: [packetFor(packetId, worktreePath, lane.id, sessionKey)],
+      updatedAt: new Date().toISOString(),
+    });
+
+    reportAgentEvent({
+      laneId: lane.id,
+      actor: 'system',
+      event: 'huddle',
+      message: 'Plan: align once, implement, and preserve a causal blocker if bounded verification fails.',
+    });
+    await dispatch({ verb: 'request_review', laneId: lane.id, actor: 'system' });
+
+    performRuntimeActionMock.mockResolvedValue({
+      ok: true,
+      action: 'steer',
+      surfaceId: sessionKey,
+      sessionKey,
+      runtime: 'codex',
+      status: 'running',
+      note: 'Steered test runtime.',
+    });
+    await steerPacket({ packetId, message: 'Plan approved. Implement now.' });
+
+    const resolvedPacket = readOrchestratorControlPlaneState().packets
+      .find((candidate) => candidate.id === packetId)!;
+    expect(resolvedPacket.alignmentResolvedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    const freshPrompt = await buildPacketPrompt(resolvedPacket, []);
+    expect(freshPrompt).not.toContain(HUDDLE_PROMPT_SECTION);
+
+    reportAgentEvent({
+      laneId: lane.id,
+      actor: 'system',
+      event: 'blocked',
+      reason: 'nondeterministic_test',
+      message: 'Stopped after the bounded test failed repeatedly; the clean tree is intentional.',
+    });
+    const completion = await dispatch({ verb: 'request_review', laneId: lane.id, actor: 'system' });
+
+    expect(completion).toMatchObject({ ok: false, note: 'nondeterministic_test' });
+    expect(getLane(lane.id)).toMatchObject({
+      status: 'awaiting_orchestrator',
+      lastEventLabel: 'nondeterministic_test',
+    });
+    const status = await getMissionStatus({ missionId, includeCost: false });
+    expect(status.packets.find((candidate) => candidate.id === packetId)).toMatchObject({
+      status: 'blocked',
+      blockedReason: 'nondeterministic_test',
+      lane: { status: 'awaiting_orchestrator', lastEventLabel: 'nondeterministic_test' },
+    });
+  });
+
+  it('persists consumed alignment when a steerable packet lives in the mission registry', async () => {
+    const packetId = 'pkt-huddle-registry-consumed';
+    const missionId = 'mission-huddle-registry-consumed';
+    const sessionKey = 'test-runtime:huddle-registry-consumed';
+    const worktreePath = makeCleanWorktree();
+    createLane({
+      repoPath: worktreePath,
+      worktreePath,
+      branch: 'pkt/huddle-registry-consumed',
+      baseBranch: 'main',
+      runtime: 'codex',
+      sessionKey,
+      packetId,
+    });
+    const registryState = {
+      ...createEmptyOrchestratorMissionState(),
+      missionId,
+      repoPath: worktreePath,
+      runtime: 'codex' as const,
+      packets: [packetFor(packetId, worktreePath, 'lane-registry-consumed', sessionKey)],
+    };
+    const now = Date.now();
+    getSqlite().prepare(
+      `INSERT INTO missions (
+         id, repo_path, runtime, prompt, summary, constraints, packet_meta_json,
+         total_waves, created_at, updated_at, archived_at, mission_state_json
+       ) VALUES (?, ?, 'codex', '', '', '', '[]', 1, ?, ?, NULL, ?)`,
+    ).run(missionId, worktreePath, now, now, JSON.stringify(registryState));
+    writeOrchestratorControlPlaneState({
+      ...createEmptyOrchestratorMissionState(),
+      missionId: 'mission-current-unrelated',
+      packets: [],
+    });
+
+    performRuntimeActionMock.mockResolvedValue({
+      ok: true,
+      action: 'steer',
+      surfaceId: sessionKey,
+      sessionKey,
+      runtime: 'codex',
+      status: 'running',
+      note: 'Steered test runtime.',
+    });
+    await steerPacket({ packetId, message: 'Plan approved. Implement now.' });
+
+    const persisted = readMissionRegistryEntry(missionId, { includeArchived: true })
+      ?.mission.packets.find((candidate) => candidate.id === packetId);
+    expect(persisted?.alignmentResolvedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(persisted?.huddle).toBe(true);
   });
 });

--- a/tests/packet-control-fields-survive-normalize.test.ts
+++ b/tests/packet-control-fields-survive-normalize.test.ts
@@ -159,6 +159,7 @@ function fullPacketFixture() {
     workerIntent: 'reviewer',
     useBrain: true,
     huddle: true,
+    alignmentResolvedAt: '2026-01-01T00:07:30.000Z',
     workerRouting: resolveWorkerRouting({
       workerIntent: 'reviewer',
       requestedProvider: 'codex',
@@ -273,6 +274,7 @@ describe('packet fields survive normalize', () => {
       taskContractSource: undefined,
       storageAdmissionEpoch: undefined,
       statusEvidence: undefined,
+      alignmentResolvedAt: undefined,
     }));
 
     expect(normalized.packets[0].operatorStopped).toBeUndefined();
@@ -283,6 +285,7 @@ describe('packet fields survive normalize', () => {
     expect(normalized.packets[0].taskContractSource).toBeUndefined();
     expect(normalized.packets[0].storageAdmissionEpoch).toBe(1);
     expect(normalized.packets[0].statusEvidence).toBeUndefined();
+    expect(normalized.packets[0].alignmentResolvedAt).toBeUndefined();
   });
 
   it('preserves an explicit disabled task-contract gate', () => {

--- a/tests/single-sub-token-ladder.test.ts
+++ b/tests/single-sub-token-ladder.test.ts
@@ -134,4 +134,30 @@ describe('single-subscription token ladder rerun escalation', () => {
     expect(persisted?.tierEscalated).toBe(true);
     expect(persisted?.workerRouting?.selectedModel).toBe('claude-sonnet-5');
   });
+
+  it('consumes a resolved huddle before a fresh rerun generation is dispatched', async () => {
+    const packet = packetFixture({
+      status: 'blocked',
+      blockedReason: 'huddle_ready',
+      lastEventLabel: 'huddle_ready',
+      huddle: true,
+      alignmentResolvedAt: undefined,
+      attemptCount: 0,
+    });
+    writeOrchestratorControlPlaneState({
+      ...createEmptyOrchestratorMissionState(),
+      missionId: 'mission-huddle-rerun',
+      packets: [packet],
+    });
+
+    await rerunWithFeedback({
+      packetId: packet.id,
+      feedback: 'The plan is approved. Implement without another alignment turn.',
+    });
+
+    const { currentMissionState } = await import('@/lib/orchestrator/operator-mission-service/shared');
+    const persisted = currentMissionState().packets.find((candidate) => candidate.id === packet.id);
+    expect(persisted?.alignmentResolvedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(persisted?.huddle).toBe(true);
+  });
 });


### PR DESCRIPTION
## Outcome

- Treat huddle/advisor alignment as a one-time packet turn while retaining the original intent as history.
- Persist the alignment receipt after a successful warm steer or an alignment-feedback rerun, including packets stored in the multi-mission registry.
- Preserve a worker's typed operator blocker on an intentional zero-diff stop instead of rewriting it to `huddle_ready`.
- Make the request-review, WebSocket supervisor, and silent-exit paths honor that preserved blocker.

## Real-path regression

The regression drives the production report, review, steer, prompt, blocker, and mission-status paths:

1. huddle report parks for operator review;
2. successful steer records the one-time alignment receipt;
3. a fresh prompt omits the huddle section;
4. a typed `nondeterministic_test` stop with a clean tree remains the packet's visible blocker.

It also proves the receipt persists when the packet is in the multi-mission registry and that a fresh rerun generation does not re-arm the huddle.

## Verification

- `env -u NODE_OPTIONS npm test` (3,908 passed, 3 skipped)
- focused dispatch regression suite (20 passed)
- `npx tsc --noEmit`
- touched-file ESLint
- `npm run rule-check -- --base=origin/main`
- `npm run test:classification:check`
- `git diff --check`

No visual proof applies because this is dispatch-state logic.

Closes #2043
