### PR TITLE
fix: surface storage reclaim candidates in hold messages (#2046)

### DIFF
--- a/src/lib/orchestrator/packet-storage-admission-normalize.ts
+++ b/src/lib/orchestrator/packet-storage-admission-normalize.ts
@@ -104,8 +104,13 @@ function normalizePressureCandidate(value: unknown) {
   );
   const measured = nullableInteger(row.measuredAllocatedBytes);
   const reclaimed = nullableInteger(row.verifiedReclaimedAvailableBytes);
+  // Receipts persisted before the path was recorded stay readable as an unknown path.
+  const workspacePath = row.workspacePath === undefined || row.workspacePath === null
+    ? null
+    : typeof row.workspacePath === 'string' ? row.workspacePath : undefined;
   if (
-    typeof row.packetId !== 'string'
+    workspacePath === undefined
+    || typeof row.packetId !== 'string'
     || typeof row.laneId !== 'string'
     || typeof row.operationId !== 'string'
     || (row.repositoryUuid !== null && typeof row.repositoryUuid !== 'string')
@@ -119,6 +124,7 @@ function normalizePressureCandidate(value: unknown) {
     repositoryUuid: row.repositoryUuid as string | null,
     laneId: row.laneId,
     operationId: row.operationId,
+    workspacePath,
     measuredAllocatedBytes: measured,
     verifiedReclaimedAvailableBytes: reclaimed,
     outcome: row.outcome as 'candidate' | 'parked' | 'already_parked' | 'refused',

--- a/src/lib/orchestrator/storage-admission-held-message.ts
+++ b/src/lib/orchestrator/storage-admission-held-message.ts
@@ -5,10 +5,14 @@ import type Database from 'better-sqlite3';
 import { listLanes } from '@/lib/lane/registry';
 import { listMissionRegistryEntries } from '@/lib/orchestrator/mission-registry';
 import { packetTerminalState } from '@/lib/orchestrator/packet-state';
-import type { OrchestratorPacketStorageAdmission } from '@/lib/orchestrator/types';
+import type {
+  OrchestratorPacketStorageAdmission,
+  OrchestratorStoragePressureReceipt,
+} from '@/lib/orchestrator/types';
 import type { StorageAdmissionPolicy } from '@/lib/workspace/storage-admission';
 
 const GIB = 1024 * 1024 * 1024;
+const MAX_LISTED_RECLAIM_CANDIDATES = 3;
 
 interface ReservedOwnerRow {
   owner_id: string;
@@ -82,6 +86,32 @@ function reserveBreachExplanation(
     ? ` The volume is ${formatStorageGigabytes(reserveShortfall)} below that reserve.`
     : '';
   return `${policySummary} This volume requires ${formatStorageGigabytes(requiredReserve)} free; ${formatStorageGigabytes(available)} is available.${reservationSummary}${reserveSummary} Free ${formatStorageGigabytes(dispatchShortfall)} more to dispatch this packet's ${formatStorageGigabytes(receipt.estimateBytes)} estimate while preserving the reserve.`;
+}
+
+/**
+ * Names the workspaces an operator can reclaim, largest estimate first. The
+ * coordinator persists these candidates on every manual-mode hold; without this
+ * sentence the operator only sees a byte shortfall and no place to act on it.
+ */
+export function storagePressureCandidateSummary(
+  pressure: OrchestratorStoragePressureReceipt,
+): string | null {
+  const reclaimable = pressure.candidates
+    .filter((candidate) => candidate.outcome === 'candidate')
+    .sort((left, right) => (
+      (right.measuredAllocatedBytes ?? 0) - (left.measuredAllocatedBytes ?? 0)
+      || left.packetId.localeCompare(right.packetId)
+    ));
+  if (reclaimable.length === 0) return null;
+  const listed = reclaimable.slice(0, MAX_LISTED_RECLAIM_CANDIDATES).map((candidate) => {
+    const label = candidate.workspacePath ?? candidate.packetId;
+    return candidate.measuredAllocatedBytes === null
+      ? `${label} (size unknown)`
+      : `${label} (${formatStorageGigabytes(candidate.measuredAllocatedBytes)})`;
+  });
+  const remaining = reclaimable.length - listed.length;
+  const tail = remaining > 0 ? `, and ${remaining} more` : '';
+  return `Reclaim candidates, largest first: ${listed.join(', ')}${tail}.`;
 }
 
 export function storageAdmissionHeldMessage(

--- a/src/lib/orchestrator/storage-admission.ts
+++ b/src/lib/orchestrator/storage-admission.ts
@@ -378,9 +378,12 @@ export function createPacketStorageAdmissionCoordinator(
             recordedAt: decisionClockValid ? decisionAt : replay.recordedAt,
           };
           throw new PacketStorageAdmissionError(
+            // Same policy the first hold explained with, so a replayed hold
+            // reads identically instead of degrading to the vague summary.
             storageAdmissionHeldMessage(
               receipt,
               sqlite,
+              resolvePolicy(),
             ),
             receipt,
           );

--- a/src/lib/orchestrator/storage-pressure-policy.ts
+++ b/src/lib/orchestrator/storage-pressure-policy.ts
@@ -29,6 +29,7 @@ import {
   type PacketStorageAdmissionLease,
   type PacketStorageAdmissionReceipt,
 } from './storage-admission';
+import { storagePressureCandidateSummary } from './storage-admission-held-message';
 import { withStoragePressurePolicyLock } from './storage-pressure-policy-lock';
 
 export interface StoragePressureProjection {
@@ -127,6 +128,7 @@ function candidateReceipt(
     repositoryUuid: candidate.repo?.id ?? null,
     laneId: candidate.lane.id,
     operationId: candidate.operationId,
+    workspacePath: candidate.volumePath,
     measuredAllocatedBytes: candidate.measuredAllocatedBytes,
     verifiedReclaimedAvailableBytes,
     outcome,
@@ -344,11 +346,13 @@ export function createStoragePressureAdmissionCoordinator(
             ? candidateReceipt(candidate, 'refused', candidate.refusal)
             : candidateReceipt(candidate, 'candidate', 'manual_action_required')
         ));
+        const pressure = pressureReceipt(
+          'manual', 'manual_review', packet, held.receipt.ownerGeneration, receipts, now(),
+        );
+        const candidateSummary = storagePressureCandidateSummary(pressure);
         throw new PacketStorageAdmissionError(
-          held.message,
-          withPressure(held.receipt, pressureReceipt(
-            'manual', 'manual_review', packet, held.receipt.ownerGeneration, receipts, now(),
-          )),
+          candidateSummary ? `${held.message} ${candidateSummary}` : held.message,
+          withPressure(held.receipt, pressure),
         );
       }
       const receipts: OrchestratorStoragePressureCandidateReceipt[] = [];

--- a/src/lib/orchestrator/types.ts
+++ b/src/lib/orchestrator/types.ts
@@ -253,6 +253,8 @@ export interface OrchestratorStoragePressureCandidateReceipt {
   repositoryUuid: string | null;
   laneId: string;
   operationId: string;
+  /** Workspace path the operator would reclaim; null when the lane never proved one. */
+  workspacePath: string | null;
   measuredAllocatedBytes: number | null;
   verifiedReclaimedAvailableBytes: number | null;
   outcome: 'candidate' | 'parked' | 'already_parked' | 'refused';

--- a/tests/mission-status-storage-pressure-real-path.test.ts
+++ b/tests/mission-status-storage-pressure-real-path.test.ts
@@ -62,6 +62,7 @@ describe('mission status storage-pressure projection', () => {
             repositoryUuid: 'repo-status',
             laneId: 'lane-status',
             operationId: 'pressure-operation-status',
+            workspacePath: '/tmp/o8-status-candidate',
             measuredAllocatedBytes: 4_096,
             verifiedReclaimedAvailableBytes: 4_096,
             outcome: 'parked',

--- a/tests/storage-admission-dispatch-real-path.test.ts
+++ b/tests/storage-admission-dispatch-real-path.test.ts
@@ -45,7 +45,9 @@ const { createStoragePressureAdmissionCoordinator } = await import(
 );
 const { StorageAdmissionStore } = await import('@/lib/workspace/storage-admission');
 const statusRoute = await import('@/app/api/orchestrator/status/route');
+import type { Lane } from '@/lib/lane/types';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import type { RepoRegistryEntry } from '@/lib/repos/types';
 
 beforeAll(() => {
   mkdirSync(repoPath);
@@ -70,9 +72,9 @@ afterAll(() => {
   rmSync(testRoot, { recursive: true, force: true });
 });
 
-function packet(): OrchestratorPacket {
+function packet(id = 'packet-storage-retry'): OrchestratorPacket {
   return {
-    id: 'packet-storage-retry',
+    id,
     referenceLabel: 'PKT-STORAGE-RETRY',
     title: 'storage retry',
     summary: 'storage retry',
@@ -87,6 +89,65 @@ function packet(): OrchestratorPacket {
     blockedReason: null,
     lane: null,
   };
+}
+
+const POLICY_SENTENCE = 'Storage policy keeps 10% of disk or 10.0 GB, whichever is greater, unallocated.';
+
+function reviewingLane(): Lane {
+  return {
+    id: 'lane-storage-review',
+    projectId: null,
+    label: 'storage review candidate',
+    repoPath,
+    worktreePath: repoPath,
+    branch: 'inline/storage-review-candidate',
+    baseBranch: 'main',
+    runtime: 'codex',
+    sessionKey: 'owned:storage-review-candidate',
+    packetId: 'packet-storage-review-candidate',
+    prNumber: null,
+    status: 'reviewing',
+    ownership: 'managed',
+    writerToken: null,
+    lastHeartbeatAt: null,
+    createdAt: '2026-08-20T12:00:00.000Z',
+    updatedAt: '2026-08-20T12:00:00.000Z',
+    lastEventAt: '2026-08-20T12:00:00.000Z',
+    lastEventLabel: 'review_ready',
+  };
+}
+
+function reviewRepo(): RepoRegistryEntry {
+  return {
+    id: 'repo-storage-review',
+    name: 'storage review repo',
+    localPath: repoPath,
+    remoteUrl: null,
+    defaultBranch: 'main',
+    addedAt: '2026-08-20T12:00:00.000Z',
+    lastOpenedAt: null,
+    storagePressureParkingDisabled: false,
+    setup: {
+      envMode: 'copy',
+      envFiles: [],
+      installCommand: null,
+      installOnCreateWorkspace: false,
+      buildCommand: null,
+      runBuildOnCreateWorkspace: false,
+      devCommand: null,
+      defaultPort: null,
+      workspaceIsolationPreference: 'auto',
+    },
+  };
+}
+
+async function readStatusPacket(missionId: string): Promise<OrchestratorPacket> {
+  const response = await statusRoute.GET(new NextRequest(
+    `http://127.0.0.1/api/orchestrator/status?missionId=${missionId}`,
+    { headers: { Host: '127.0.0.1' } },
+  ));
+  const body = await response.json() as { result: { packets: OrchestratorPacket[] } };
+  return body.result.packets[0]!;
 }
 
 describe('storage admission dispatch real path', () => {
@@ -129,48 +190,8 @@ describe('storage admission dispatch real path', () => {
     });
     const park = vi.fn();
     const pressureAdmission = createStoragePressureAdmissionCoordinator(admission, {
-      listLanes: () => [{
-        id: 'lane-storage-review',
-        projectId: null,
-        label: 'storage review candidate',
-        repoPath,
-        worktreePath: repoPath,
-        branch: 'inline/storage-review-candidate',
-        baseBranch: 'main',
-        runtime: 'codex',
-        sessionKey: 'owned:storage-review-candidate',
-        packetId: 'packet-storage-review-candidate',
-        prNumber: null,
-        status: 'reviewing',
-        ownership: 'managed',
-        writerToken: null,
-        lastHeartbeatAt: null,
-        createdAt: '2026-08-20T12:00:00.000Z',
-        updatedAt: '2026-08-20T12:00:00.000Z',
-        lastEventAt: '2026-08-20T12:00:00.000Z',
-        lastEventLabel: 'review_ready',
-      }],
-      listRepos: async () => [{
-        id: 'repo-storage-review',
-        name: 'storage review repo',
-        localPath: repoPath,
-        remoteUrl: null,
-        defaultBranch: 'main',
-        addedAt: '2026-08-20T12:00:00.000Z',
-        lastOpenedAt: null,
-        storagePressureParkingDisabled: false,
-        setup: {
-          envMode: 'copy',
-          envFiles: [],
-          installCommand: null,
-          installOnCreateWorkspace: false,
-          buildCommand: null,
-          runBuildOnCreateWorkspace: false,
-          devCommand: null,
-          defaultPort: null,
-          workspaceIsolationPreference: 'auto',
-        },
-      }],
+      listLanes: () => [reviewingLane()],
+      listRepos: async () => [reviewRepo()],
       measureAllocatedBytes: async () => 4 * 1024 * 1024 * 1024,
       observeVolume,
       getSnapshot: () => null,
@@ -259,5 +280,98 @@ describe('storage admission dispatch real path', () => {
       storageAdmission: { state: 'committed', estimateBytes: 8 * 1024 * 1024 * 1024 },
     });
     expect(launchCalls).toEqual(['packet-storage-retry']);
+  }, 30_000);
+
+  it('names reclaim candidates in the hold message on the first hold and on the replayed hold', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-24T12:00:00.000Z'));
+    vi.stubEnv('O8_WORKSPACE_PARKING_MODE', 'manual');
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200 })));
+    const availableBytes = 12 * 1024 * 1024 * 1024;
+    const observeVolume = async (targetPath: string) => ({
+      status: 'observed' as const,
+      targetPath,
+      probePath: worktreeRoot,
+      volumeId: 'device:test',
+      availableBytes,
+      freeBytes: availableBytes,
+      totalBytes: 100 * 1024 * 1024 * 1024,
+      observedAt: Date.now(),
+      error: null,
+    });
+    const store = new StorageAdmissionStore(getSqlite(), { now: Date.now, observeVolume });
+    const admission = createPacketStorageAdmissionCoordinator({
+      sqlite: getSqlite(),
+      store,
+      now: Date.now,
+      observeEstimate: (targetPath) => observeRepoStorageEstimate(targetPath, {
+        readCachedMeasurement: () => null,
+        refreshMeasurement: async () => {
+          throw Object.assign(new Error('du timed out'), { code: 'ETIMEDOUT' });
+        },
+        defer: (task) => task(),
+      }),
+      observeReservationVolume: observeVolume,
+      resolvePolicy: () => ({
+        reserveRatio: 0.1,
+        absoluteFloorBytes: 10 * 1024 * 1024 * 1024,
+      }),
+    });
+    const pressureAdmission = createStoragePressureAdmissionCoordinator(admission, {
+      listLanes: () => [reviewingLane()],
+      listRepos: async () => [reviewRepo()],
+      measureAllocatedBytes: async () => 4 * 1024 * 1024 * 1024,
+      observeVolume,
+      getSnapshot: () => null,
+      parkWorkspace: vi.fn(),
+    });
+    const initial = {
+      ...createEmptyOrchestratorMissionState(),
+      missionId: 'mission-storage-candidates',
+      repoPath,
+      runtime: 'codex' as const,
+      packets: [packet('packet-storage-candidates')],
+    };
+
+    const held = await runDispatchTick(initial, {
+      launchBudget: { maxLaunches: 1 },
+      storageAdmission: pressureAdmission,
+    });
+    expect(launchCalls).toEqual([]);
+    expect(held.packets[0]?.storageAdmission?.pressure?.candidates[0]).toMatchObject({
+      outcome: 'candidate',
+      workspacePath: repoPath,
+      measuredAllocatedBytes: 4 * 1024 * 1024 * 1024,
+    });
+    writeOrchestratorControlPlaneState(held);
+
+    const firstStatus = await readStatusPacket('mission-storage-candidates');
+    expect(firstStatus.blockedReason).toContain(POLICY_SENTENCE);
+    expect(firstStatus.blockedReason).toContain(`Reclaim candidates, largest first: ${repoPath} (4.0 GB).`);
+    expect(firstStatus.storageAdmission?.pressure?.candidates[0]?.workspacePath).toBe(repoPath);
+
+    // Drop the receipt the way a control-plane row written before the hold
+    // persisted would: the next tick recomputes the same launch generation and
+    // replays the recorded reserve mutation instead of taking a fresh one.
+    writeOrchestratorControlPlaneState({
+      ...held,
+      packets: [{ ...held.packets[0]!, storageAdmission: null }],
+    });
+    const replayed = await runDispatchTick(readOrchestratorControlPlaneState(), {
+      launchBudget: { maxLaunches: 1 },
+      storageAdmission: pressureAdmission,
+    });
+    expect(launchCalls).toEqual([]);
+    expect(replayed.packets[0]?.storageAdmission).toMatchObject({
+      state: 'held',
+      reason: 'reserve_breached',
+      mutationId: 'packet-storage-reserve:packet-storage-candidates:1',
+    });
+    writeOrchestratorControlPlaneState(replayed);
+
+    const replayStatus = await readStatusPacket('mission-storage-candidates');
+    expect(replayStatus.blockedReason).toContain(POLICY_SENTENCE);
+    expect(replayStatus.blockedReason).toContain(`Reclaim candidates, largest first: ${repoPath} (4.0 GB).`);
+    expect(replayStatus.storageAdmission?.pressure?.candidates[0]?.workspacePath).toBe(repoPath);
   }, 30_000);
 });


### PR DESCRIPTION
## Mechanic

A manual-mode `reserve_breached` hold already computed and persisted reclaim candidates (`outcome: 'candidate'`, `manual_review`), but nothing read `pressure.candidates` — the operator got a byte shortfall with no workspace named.

- `OrchestratorStoragePressureCandidateReceipt` gains `workspacePath`, filled from the candidate's resolved volume path, so a candidate can be named as a directory rather than a packet id. The normalizer reads receipts persisted before the field existed back as an unknown path instead of rejecting them.
- New `storagePressureCandidateSummary` lists the top three candidates, largest estimate first, as path plus estimated reclaim bytes. The manual-mode hold appends it to the message that already states the shortfall.
- The replay branch passed no `policy` to `storageAdmissionHeldMessage`, so a hold recovered from a recorded reserve mutation fell back to "Storage policy requires the reported reserve to remain unallocated" instead of naming the ratio and floor. It now passes the resolved policy.

No new component: the existing hold message carries the list.

## Test

`tests/storage-admission-dispatch-real-path.test.ts` gains a second real-path case driving `runDispatchTick` and the real `/api/orchestrator/status` route. It asserts the candidate path and reclaim bytes appear in `blockedReason` on the first hold, then drops the packet receipt so the next tick recomputes the same launch generation and replays the recorded mutation, and asserts the replayed hold returns the same policy sentence and the same named candidate. Reverting either change fails it (checked both ways).

Gates: `npx tsc --noEmit` 0, `npm run lint` 0, target suite 2/2, `npm run test:classification:check` 0, `npm run rule-check` 0.

Closes #2046

🤖 Generated with [Claude Code](https://claude.com/claude-code)