### PR TITLE
fix: consume huddle alignment on packet reset (#2045)

### DIFF
--- a/src/lib/orchestrator/operator-mission-service/reset.ts
+++ b/src/lib/orchestrator/operator-mission-service/reset.ts
@@ -23,6 +23,7 @@ import {
   withMissionRegistryState,
 } from '@/lib/orchestrator/mission-registry';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import { resolvePacketAlignment } from '@/lib/orchestrator/alignment-access';
 import { advancePacketStorageAdmissionEpoch } from '@/lib/orchestrator/packet-storage-admission-normalize';
 import { managedPacketWorktreeId, resolveWorktreeRootLayout } from '@/lib/worktree/root-layout';
 import { archiveWorkspaceManifestRunForReset } from '@/lib/workspace/manifest/lifecycle';
@@ -93,6 +94,17 @@ function markPacketResetHeld(packet: OrchestratorPacket) {
   packet.launchAttempts = 0;
   packet.operatorStopped = false;
   packet.tierEscalated = undefined;
+  // #2045 — reset CONSUMES a still-armed alignment (stamps `alignmentResolvedAt`)
+  // rather than clearing `huddle`: the operator's reset IS the alignment
+  // decision, and stamping keeps the audit trail that the packet was armed and
+  // when the alignment closed. Without this, reset_packet -> dispatch_mission
+  // re-armed the huddle block in `buildPacketPrompt` (#2044 only consumed it on
+  // steer / rerun_with_feedback), so the fresh worker spent a whole session
+  // planning again and produced no code. Only stamps while armed, so a packet
+  // that already consumed its alignment keeps the original timestamp.
+  if (resolvePacketAlignment(packet).armed) {
+    packet.alignmentResolvedAt = new Date().toISOString();
+  }
 }
 
 function markPacketResetPending(packet: OrchestratorPacket) {

--- a/tests/huddle-zero-diff-classification.test.ts
+++ b/tests/huddle-zero-diff-classification.test.ts
@@ -20,6 +20,7 @@ const { createLane, getLane, listLanes } = await import('@/lib/lane/registry');
 const { readOrchestratorControlPlaneState, writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
 const { buildPacketPrompt } = await import('@/lib/orchestrator/packet-prompt');
 const { steerPacket } = await import('@/lib/orchestrator/operator-mission-service/steer');
+const { resetPacket } = await import('@/lib/orchestrator/operator-mission-service/reset');
 const { getMissionStatus } = await import('@/lib/orchestrator/operator-mission-service');
 const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
 const { readMissionRegistryEntry } = await import('@/lib/orchestrator/mission-registry');
@@ -209,6 +210,48 @@ describe('huddle zero-diff classification', () => {
       blockedReason: 'nondeterministic_test',
       lane: { status: 'awaiting_orchestrator', lastEventLabel: 'nondeterministic_test' },
     });
+  });
+
+  it('consumes alignment on reset so the redispatch prompt no longer arms the huddle turn', async () => {
+    const packetId = 'pkt-huddle-consumed-on-reset';
+    const missionId = 'mission-huddle-consumed-on-reset';
+    const worktreePath = makeCleanWorktree();
+    // The documented reset recovery: the worker's session is already gone, so
+    // the lane carries no session key to kill.
+    const lane = createLane({
+      repoPath: worktreePath,
+      worktreePath,
+      branch: 'pkt/huddle-consumed-on-reset',
+      baseBranch: 'main',
+      runtime: 'codex',
+      packetId,
+    });
+
+    const armed = packetFor(packetId, worktreePath, lane.id, '');
+    armed.lane!.sessionKey = '';
+    writeOrchestratorControlPlaneState({
+      ...createEmptyOrchestratorMissionState(),
+      missionId,
+      repoPath: worktreePath,
+      runtime: 'codex',
+      packets: [armed],
+      updatedAt: new Date().toISOString(),
+    });
+
+    const armedPacket = readOrchestratorControlPlaneState().packets
+      .find((candidate) => candidate.id === packetId)!;
+    expect(await buildPacketPrompt(armedPacket, [])).toContain(HUDDLE_PROMPT_SECTION);
+
+    const reset = await resetPacket({ packetId, reason: 'session_lost', clearWorktree: false });
+    expect(reset).toMatchObject({ reset: true, packetId });
+
+    const resetPersisted = readOrchestratorControlPlaneState().packets
+      .find((candidate) => candidate.id === packetId)!;
+    expect(resetPersisted.queueState).toBe('held');
+    expect(resetPersisted.alignmentResolvedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    const redispatchPrompt = await buildPacketPrompt(resetPersisted, []);
+    expect(redispatchPrompt).not.toContain(HUDDLE_PROMPT_SECTION);
   });
 
   it('persists consumed alignment when a steerable packet lives in the mission registry', async () => {


### PR DESCRIPTION
## Mechanic

The one-time huddle alignment is consumed by stamping `alignmentResolvedAt`, and that stamp was written only on the steer and rerun-with-feedback paths. `reset_packet` -> `dispatch_mission` — the documented recovery for a dead session — therefore left the alignment unconsumed, so `buildPacketPrompt` re-armed the huddle block and the fresh worker spent a whole session planning again instead of implementing (#2043's loop).

`markPacketResetHeld` now **consumes** a still-armed alignment rather than clearing the `huddle` flag: the operator's reset is itself the alignment decision, and stamping keeps the audit trail that the packet was armed and when its alignment closed. It only stamps while armed, so a packet that already consumed its alignment keeps the original timestamp. The comment in the handler states the choice and the reason.

That single chokepoint covers both reset paths (current control-plane state and the mission registry). `retry_packet` was audited: it shares the same `resetPacket` implementation and differs only in the `clearWorktree` default, so it inherits the fix — no second change needed.

## Test

`tests/huddle-zero-diff-classification.test.ts` gains a real-path case: persist a huddle-armed packet whose session is already gone, assert the assembled prompt arms the huddle block, drive the real `resetPacket` handler, then rebuild the prompt from the persisted packet and assert the huddle block is gone. Verified falsifiable — the case fails on the unpatched handler.

Gates: `npx tsc --noEmit` 0, `npm run lint` 0, `npm run rule-check` 0, `npm run test:classification:check` 0, huddle suite 4/4 passing.

Closes #2045

🤖 Generated with [Claude Code](https://claude.com/claude-code)
