### PR TITLE
fix: retire failed lanes from operator status and sort activity by epoch

### DIFF
--- a/src/app/api/operator/status/route.ts
+++ b/src/app/api/operator/status/route.ts
@@ -18,6 +18,18 @@ interface OperatorActivityCandidate {
   sessionKey: string;
 }
 
+// Sources are mixed formats — `lane.lastEventAt` (Date#toISOString, always
+// `.mmmZ`) and transcript `lastTranscriptAt` (provider-controlled, may come
+// through as `+00:00`). `localeCompare` on the raw string only agrees with
+// real chronological order when both sides share the same offset/fraction
+// shape, so two entries at the same moment written differently can sort
+// backwards (#2047). Compare parsed epoch milliseconds instead; a timestamp
+// that fails to parse sorts as oldest so a bad value never jumps the queue.
+function timestampEpochOrOldest(timestamp: string): number {
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+}
+
 function relativeActivityAge(timestamp: string): string {
   const parsed = Date.parse(timestamp);
   if (!Number.isFinite(parsed)) return 'just now';
@@ -137,7 +149,7 @@ export async function GET(request: NextRequest) {
     });
     const recentActivity = activityCandidates
       .filter((candidate) => Number.isFinite(Date.parse(candidate.timestamp)))
-      .sort((left, right) => right.timestamp.localeCompare(left.timestamp))
+      .sort((left, right) => timestampEpochOrOldest(right.timestamp) - timestampEpochOrOldest(left.timestamp))
       .slice(0, 5)
       .map((candidate) => ({
         ...candidate,

--- a/src/lib/orchestrator/operator-status-model.ts
+++ b/src/lib/orchestrator/operator-status-model.ts
@@ -1,5 +1,6 @@
 import type { ApprovalRecord } from '@/lib/approvals/types';
 import type { AgentStatus, AgentSummary } from '@/lib/fleet/types';
+import { isLaneTerminal } from '@/lib/lane/terminal-states';
 import type { Lane, LaneEvent } from '@/lib/lane/types';
 import type { RuntimeId, RuntimeSessionStatus } from '@/lib/runtimes/types';
 import {
@@ -213,6 +214,27 @@ const LANE_ONLY_OPERATOR_STATUSES = new Set<Lane['status']>([
   'failed',
 ]);
 
+// A `failed` lane never transitions on its own — only an operator redispatch
+// or archive moves it forward — so keeping it in LANE_ONLY_OPERATOR_STATUSES
+// without a bound means `o8_status` reports an agent for work that ended
+// hours or days ago (#2047). Bound how long a lane-terminal status (today
+// just `failed`; `isLaneTerminal` also covers `completed`/`archived` should
+// either land in the set later) keeps synthesizing an agent row: 30 minutes
+// is long enough for the operator to notice a fresh failure in the status
+// feed during the same session, short enough that a stale failure doesn't
+// linger indefinitely. A lane with no session key carries no live-session
+// evidence at all, so it drops immediately regardless of age.
+const TERMINAL_LANE_ONLY_STALE_WINDOW_MS = 30 * 60_000;
+
+function isStaleTerminalLaneOnlyAgent(lane: Lane, nowMs: number): boolean {
+  if (!isLaneTerminal(lane.status)) return false;
+  if (!lane.sessionKey) return true;
+  const observedAt = lane.lastEventAt || lane.updatedAt;
+  const parsed = observedAt ? Date.parse(observedAt) : NaN;
+  if (!Number.isFinite(parsed)) return true;
+  return nowMs - parsed > TERMINAL_LANE_ONLY_STALE_WINDOW_MS;
+}
+
 function safeResolveLaneOnlyStatusEvidence(
   lane: Lane,
   context: OperatorStatusEvidenceContext,
@@ -303,12 +325,14 @@ export function buildOperatorStatusAgents(
   // discovery gap. Only synthesize a lane-backed row when inventory did not
   // already provide the same session, and never resurrect idle/archived lanes.
   const representedSessionKeys = new Set(inventoryAgents.map((agent) => agent.sessionKey));
+  const nowMs = Date.now();
   const laneOnlyAgents = [...laneBySession.values()]
     .filter((lane): lane is Lane & { sessionKey: string } => Boolean(
       lane.sessionKey
       && LANE_ONLY_OPERATOR_STATUSES.has(lane.status)
       && !representedSessionKeys.has(lane.sessionKey)
-      && (!sessionKeyFilter || lane.sessionKey === sessionKeyFilter),
+      && (!sessionKeyFilter || lane.sessionKey === sessionKeyFilter)
+      && !isStaleTerminalLaneOnlyAgent(lane, nowMs),
     ))
     .map((lane) => operatorStatusAgentFromLane(lane, context));
 

--- a/tests/real-path-seams.test.ts
+++ b/tests/real-path-seams.test.ts
@@ -1004,11 +1004,25 @@ describe('seam E — orchestrator state projects one terminal status authority',
     expect(response.status).toBe(200);
     const json = await response.json();
 
-    expect(json.agents.map((candidate: { runtime: string }) => candidate.runtime)).toEqual([
+    // Real-path lane-only synthesis (#2042) is unscoped by design: an
+    // unarchived active lane (reviewing / awaiting_orchestrator / running)
+    // stays visible in a global /api/operator/status call even without a
+    // matching runtime-inventory session, so an operator does not lose sight
+    // of live work during a brief discovery gap. This file persists real
+    // lanes in one shared in-process DB across every test without deleting
+    // them, so earlier seam tests above legitimately leave their own active
+    // lanes behind — those correctly keep showing up here too; asserting an
+    // exhaustive agent list would make this test depend on unrelated seams'
+    // lane litter rather than on what it actually verifies.
+    // `buildOperatorStatusAgents` always orders inventory-sourced agents
+    // ahead of lane-only fallback rows, so the two mocked sessions are
+    // deterministically the first two entries regardless of what else has
+    // accumulated in the shared DB.
+    expect(json.agents.slice(0, 2).map((candidate: { runtime: string }) => candidate.runtime)).toEqual([
       'cloud',
       'remote-customer',
     ]);
-    expect(json.agents.map((candidate: { statusEvidence: { runtime: string } }) => (
+    expect(json.agents.slice(0, 2).map((candidate: { statusEvidence: { runtime: string } }) => (
       candidate.statusEvidence.runtime
     ))).toEqual(['cloud', 'remote-customer']);
   });

--- a/tests/steer-idempotency-real-path.test.ts
+++ b/tests/steer-idempotency-real-path.test.ts
@@ -32,7 +32,7 @@ const { handleStatus } = await import('@/lib/mcp/operator-handlers/status');
 const agentControlRoute = await import('@/app/api/agent-control/action/route');
 const idempotency = await import('@/lib/orchestrator/idempotency-store');
 const { closeDb, getSqlite } = await import('@/lib/db');
-const { createLane, deleteLane, getLane } = await import('@/lib/lane/registry');
+const { createLane, deleteLane, getLane, setLaneStatus, updateLane } = await import('@/lib/lane/registry');
 
 const createdLaneIds: string[] = [];
 
@@ -45,6 +45,16 @@ function post(pathname: string, body: unknown) {
       'content-type': 'application/json',
     },
     body: JSON.stringify(body),
+  });
+}
+
+function get(pathname: string) {
+  return new NextRequest(`http://localhost:3001${pathname}`, {
+    method: 'GET',
+    headers: {
+      host: 'localhost:3001',
+      authorization: `Bearer ${operatorToken}`,
+    },
   });
 }
 
@@ -256,5 +266,60 @@ describe('packet steer post-effect idempotency through real routes', () => {
     ).get() as { count: number };
     expect(executionRows.count).toBe(0);
     expect(h.perform).not.toHaveBeenCalled();
+  });
+
+  it('real o8_status drops a stale failed lane but keeps a fresh one (#2047)', async () => {
+    const staleLane = createSteerLane('failed-lane-stale');
+    setLaneStatus(staleLane.id, 'failed', 'system', 'worker_failed');
+    updateLane(staleLane.id, {
+      lastEventAt: new Date(Date.now() - 60 * 60_000).toISOString(),
+    }, 'system');
+
+    const freshLane = createSteerLane('failed-lane-fresh');
+    setLaneStatus(freshLane.id, 'failed', 'system', 'worker_failed');
+
+    const response = await operatorStatusRoute.GET(get('/api/operator/status'));
+    expect(response.status).toBe(200);
+    const payload = await response.json() as {
+      agents: Array<{ sessionKey: string; status: string }>;
+    };
+
+    expect(payload.agents.some((agent) => agent.sessionKey === staleLane.sessionKey)).toBe(false);
+    expect(payload.agents).toContainEqual(expect.objectContaining({
+      sessionKey: freshLane.sessionKey,
+      status: 'failed',
+    }));
+  });
+
+  it('real o8_status sorts recent activity by parsed epoch, not raw timestamp string', async () => {
+    // Same real instant deliberately written with a fractional-Z suffix vs an
+    // offset suffix, so the earlier suffix character ('.' before Z) would
+    // outrank a later real timestamp under a naive string compare.
+    const olderStringGreaterLane = createSteerLane('sort-z-older');
+    setLaneStatus(olderStringGreaterLane.id, 'running', 'system', 'session_launched');
+    updateLane(olderStringGreaterLane.id, {
+      lastEventAt: '2026-01-01T00:00:00Z',
+    }, 'system');
+
+    const newerStringLesserLane = createSteerLane('sort-offset-newer');
+    setLaneStatus(newerStringLesserLane.id, 'running', 'system', 'session_launched');
+    updateLane(newerStringLesserLane.id, {
+      lastEventAt: '2026-01-01T00:00:00.500+00:00',
+    }, 'system');
+
+    const response = await operatorStatusRoute.GET(get('/api/operator/status'));
+    expect(response.status).toBe(200);
+    const payload = await response.json() as {
+      recentActivity: Array<{ target: string; timestamp: string }>;
+    };
+
+    const targets = new Set([olderStringGreaterLane.label, newerStringLesserLane.label]);
+    const ordered = payload.recentActivity.filter((entry) => targets.has(entry.target));
+    expect(ordered.length).toBeGreaterThanOrEqual(2);
+    const newerIndex = ordered.findIndex((entry) => entry.target === newerStringLesserLane.label);
+    const olderIndex = ordered.findIndex((entry) => entry.target === olderStringGreaterLane.label);
+    expect(newerIndex).toBeGreaterThanOrEqual(0);
+    expect(olderIndex).toBeGreaterThanOrEqual(0);
+    expect(newerIndex).toBeLessThan(olderIndex);
   });
 });


### PR DESCRIPTION
## Mechanic

Follow-up to #2042. Two residuals in operator status:

- `LANE_ONLY_OPERATOR_STATUSES` includes `failed`, and a failed-but-unarchived lane never transitions on its own (only an operator redispatch or archive moves it), so it was synthesized as an agent row forever. Added `isStaleTerminalLaneOnlyAgent()`: a lane-terminal status (`isLaneTerminal` — `failed`/`completed`/`archived`) drops out of the synthesized agent list once its `lastEventAt` is older than a 30-minute bounded window, or immediately if it has no session key.
- The recent-activity merge sorted candidates with `localeCompare` on raw timestamp strings while mixing `lane.lastEventAt` (always `Date#toISOString`, `.mmmZ`) with transcript `lastTranscriptAt` (provider-controlled, may come through as a `+00:00` offset). Two entries at the same real instant written in different formats could sort backwards. Replaced with a comparator over parsed epoch milliseconds; an unparseable timestamp sorts as oldest.

## Scope addition found during verification

Running the full gate list surfaced a pre-existing failure in `tests/real-path-seams.test.ts` seam E ("real operator status GET keeps cloud and remote-customer sessions"), reproducible on `origin/main` with no local changes. Root cause: that test pins an exact two-agent list from a global (unscoped) `/api/operator/status` call. That assumption predates #2042 — lane-only synthesis correctly surfaces every unarchived active lane persisted in the shared in-process test DB, including lanes left behind by earlier seam tests in the same file that never delete their lanes (by design, for real-DB-state assertions elsewhere in the file). This is genuine, intended production behavior (a live lane stays visible in a global status view even without a live runtime session), not a regression to suppress. Fixed the test rather than the production code: kept the real assertion (the two mocked runtime-inventory sessions are present) but scoped it to the deterministic inventory-first two entries (`buildOperatorStatusAgents` always orders inventory-sourced agents ahead of lane-only fallback rows), with a comment explaining why extra entries can legitimately appear.

## Test

Extends `tests/steer-idempotency-real-path.test.ts`, driving the real `/api/operator/status` route against persisted lane state:
- a stale failed lane (`lastEventAt` backdated past the window) is absent from `agents`; a fresh failed lane stays visible
- a sort test with one `Z` timestamp and one `+00:00` timestamp representing the same instant, which only orders correctly under epoch comparison

## Verification

- `npx tsc --noEmit`: exit 0
- `npm run lint`: exit 0 (0 errors, pre-existing unrelated warnings)
- `npx vitest run --config config/vitest/vitest.unit.config.ts src/lib/orchestrator/operator-status-model.test.ts`: 11/11 passed
- `npm run test:integration -- tests/steer-idempotency-real-path.test.ts`: 7/7 passed (5 existing + 2 new)
- `npm run test:integration -- tests/real-path-seams.test.ts`: 47/47 passed (including seam E)
- `npm run test:classification:check`: passed
- `npm run rule-check`: passed

Closes #2047

🤖 Generated with [Claude Code](https://claude.com/claude-code)