### PR TITLE
chore: classify cli-stop-parsing test in the manifest

### DIFF
--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1171,6 +1171,12 @@
       ]
     },
     {
+      "path": "tests/cli-stop-parsing.test.ts",
+      "reasons": [
+        "terminal-tool"
+      ]
+    },
+    {
       "path": "tests/cli-usage-api-real-path.test.ts",
       "reasons": [
         "real-path"


### PR DESCRIPTION
## What

Adds the missing `tests/cli-stop-parsing.test.ts` entry to `tests/test-classification.json` via `npm run test:classify`.

## Why

The test file reached main without a manifest entry, so `npm run test:classification:check` fails on main at cc80e3a76 and the Hermetic Unit Tests job fails on every open PR (#2049, #2050, #2051) for a reason unrelated to their changes.

## Verification

`npm run test:classification:check` exits 0 on this branch. No other files change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuwAJQVFhKFmL7C1RWDx1T