### PR TITLE
fix: run the test-classification check in the ship preflight (#2053)

### DIFF
--- a/scripts/lib/ship-preflight.mjs
+++ b/scripts/lib/ship-preflight.mjs
@@ -163,6 +163,23 @@ export function performShipPreflight(options) {
   if (dirty.length > 0) {
     throw new Error(`release worktree contains ${dirty.length} non-operator change${dirty.length === 1 ? '' : 's'}`);
   }
+  // A test file that lands on main without a PR (a direct-pushed release fix)
+  // never runs `npm run test:classification:check` — that gate is PR-CI-only —
+  // so a stale manifest reaches the tag unnoticed and turns every open PR's
+  // Hermetic Unit Tests job red for a reason unrelated to its diff (#2053).
+  // Reuse the exact same script + remedy text CI prints on failure.
+  const classification = run(process.execPath, ['scripts/classify-tests.mjs', '--check'], {
+    cwd: root,
+    env,
+    timeoutMs: 15_000,
+  });
+  if (classification.status !== 0) {
+    throw new Error(
+      classification.stderr.trim()
+        || classification.stdout.trim()
+        || `test classification check exited ${classification.status}`,
+    );
+  }
   const repo = env.O8_RELEASE_REPO?.trim() || repositoryFromRemote(requireSuccess(
     run('git', ['remote', 'get-url', 'origin'], { cwd: root, env }),
     'could not resolve the release repository',

--- a/tests/release-preflight.test.ts
+++ b/tests/release-preflight.test.ts
@@ -162,6 +162,53 @@ describe('ship preflight', () => {
     expect(receipt.message).toContain('browser unavailable');
   });
 
+  it('aborts the ship when the test classification manifest is stale, with the same remedy CI prints', () => {
+    const { root, head, env } = fixture();
+    const remedy = '[test-classification] manifest drifted; run npm run test:classify';
+    const calls: string[] = [];
+    const run = (command: string, args: string[]) => {
+      calls.push(`${command} ${args.join(' ')}`);
+      if (command === 'git' && args[0] === 'rev-parse') return { status: 0, stdout: head, stderr: '' };
+      if (command === 'git' && args[0] === 'rev-list') return { status: 0, stdout: head, stderr: '' };
+      if (command === 'git' && args[0] === 'status') return { status: 0, stdout: '', stderr: '' };
+      if (args[0] === 'scripts/classify-tests.mjs') return { status: 1, stdout: '', stderr: `${remedy}\n` };
+      return { status: 0, stdout: `${command} test-version\n`, stderr: '' };
+    };
+
+    expect(() => performShipPreflight({ root, version: '0.1.999', env, run })).toThrow(remedy);
+    expect(calls).toContain(`${process.execPath} scripts/classify-tests.mjs --check`);
+    // No real build ran — the stub above never spawns node/npm/cargo for a build.
+    expect(calls.some((call) => call.includes('build'))).toBe(false);
+  });
+
+  it('passes the ship preflight when the test classification manifest is current', () => {
+    const { root, head, env } = fixture();
+    const calls: string[] = [];
+    const run = (command: string, args: string[]) => {
+      calls.push(`${command} ${args.join(' ')}`);
+      if (command === 'git' && args[0] === 'rev-parse') return { status: 0, stdout: head, stderr: '' };
+      if (command === 'git' && args[0] === 'rev-list') return { status: 0, stdout: head, stderr: '' };
+      if (command === 'git' && args[0] === 'status') return { status: 0, stdout: '', stderr: '' };
+      if (command === 'git' && args[0] === 'remote') {
+        return { status: 0, stdout: 'https://github.com/example/release-repo.git\n', stderr: '' };
+      }
+      if (command === 'git' && args[0] === 'ls-remote') {
+        return { status: 0, stdout: `${head}\trefs/tags/v0.1.999^{}\n`, stderr: '' };
+      }
+      if (command === 'gh' && args[0] === 'release') return { status: 1, stdout: '', stderr: 'not found' };
+      if (args[0] === 'scripts/classify-tests.mjs') {
+        return { status: 0, stdout: '[test-classification] manifest matches resource-owning source markers\n', stderr: '' };
+      }
+      if (command === 'ps') return { status: 0, stdout: '', stderr: '' };
+      return { status: 0, stdout: `${command} test-version\n`, stderr: '' };
+    };
+
+    const receipt = performShipPreflight({ root, version: '0.1.999', env, run });
+
+    expect(receipt.head).toBe(head);
+    expect(calls).toContain(`${process.execPath} scripts/classify-tests.mjs --check`);
+  });
+
   it('keeps an intentionally disabled intake independent from ship readiness', () => {
     const { root, head, env } = fixture();
     env.O8_INTAKE_RECONCILIATION = 'disabled';


### PR DESCRIPTION
## Mechanic

`test:classification:check` only ran in PR CI. A test file that reached main outside a PR (a direct-pushed release fix) could skip it and land with a stale `tests/test-classification.json`. Because CI evaluates each PR as a merge with main, every open PR's Hermetic Unit Tests job then failed on a manifest drift unrelated to its own diff.

## Fix

`performShipPreflight()` (`scripts/lib/ship-preflight.mjs`) now runs `node scripts/classify-tests.mjs --check` alongside its existing local-state checks (dirty tree, disk space, credentials, competing builds) and aborts the ship with the exact stderr remedy CI prints on failure. This gates `npm run ship` before a tag with a drifted manifest can go out.

`sync-version.mjs` (the `npm version` hook) is left untouched — it only validates the semver string it's about to write into the manifests; it runs no test/build steps of its own, so there is nothing analogous to hook the check into there.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint` — 0 errors (54 pre-existing warnings, unrelated files)
- [x] Two new `tests/release-preflight.test.ts` cases stub the classify invocation through the existing injected `run` dependency — exit 0 passes, exit 1 aborts with the remedy text — without running a real build
- [x] `npm run test:classify` / `npm run test:classification:check` — manifest current, exit 0
- [x] `npm run rule-check` — clean

Closes #2053

🤖 Generated with [Claude Code](https://claude.com/claude-code)