### PR TITLE
fix: point the Linux updater manifest at the published asset and gate on version (#2056)

### DIFF
--- a/scripts/lib/release-manifest.mjs
+++ b/scripts/lib/release-manifest.mjs
@@ -9,6 +9,34 @@ function listFiles(directory, suffix) {
     .sort();
 }
 
+// The Linux build produces a local AppImage named "o8_<version>_amd64.AppImage"
+// (see tests/release-artifacts.test.ts fixtures), but the publish-preview job
+// in .github/workflows/port-build.yml re-uploads it under a different name:
+// "o8_<version>_linux_amd64_preview.AppImage". The updater manifest url must
+// point at the name the asset is actually published under, not the local
+// build's basename.
+const LINUX_APPIMAGE_NAME_PATTERN = /^o8_(.+)_amd64\.AppImage$/;
+
+function publishedLinuxAssetName(version) {
+  return `o8_${version}_linux_amd64_preview.AppImage`;
+}
+
+function assertLinuxAppImageVersionMatches(artifactPath, version) {
+  const name = basename(artifactPath);
+  const match = name.match(LINUX_APPIMAGE_NAME_PATTERN);
+  if (!match) {
+    throw new Error(
+      `Linux AppImage release artifact "${name}" does not match the expected "o8_<version>_amd64.AppImage" naming pattern`,
+    );
+  }
+  const [, appImageVersion] = match;
+  if (appImageVersion !== version) {
+    throw new Error(
+      `Linux AppImage version "${appImageVersion}" (from "${name}") does not match release version "${version}"`,
+    );
+  }
+}
+
 function discoverLinuxArtifacts(bundleDir) {
   const appImageDir = join(bundleDir, 'appimage');
   const appImages = listFiles(appImageDir, '.AppImage');
@@ -56,9 +84,10 @@ export function buildReleaseManifest({
   };
 
   if (linux.updater) {
+    assertLinuxAppImageVersionMatches(linux.updater.artifactPath, version);
     platforms['linux-x86_64'] = {
       signature: readFileSync(linux.updater.signaturePath, 'utf8').trim(),
-      url: `${downloadBase}/${basename(linux.updater.artifactPath)}`,
+      url: `${downloadBase}/${publishedLinuxAssetName(version)}`,
     };
   }
 

--- a/tests/release-artifacts.test.ts
+++ b/tests/release-artifacts.test.ts
@@ -76,7 +76,7 @@ describe('release artifact provenance', () => {
   });
 });
 
-function makeReleaseBundle(includeLinux: boolean) {
+function makeReleaseBundle(includeLinux: boolean, linuxAppImageVersion = '0.1.999') {
   const bundleDir = mkdtempSync(join(tmpdir(), 'o8-release-bundle-'));
   roots.push(bundleDir);
   const macosDir = join(bundleDir, 'macos');
@@ -101,8 +101,8 @@ function makeReleaseBundle(includeLinux: boolean) {
     mkdirSync(appImageDir, { recursive: true });
     mkdirSync(debDir, { recursive: true });
     linuxAssets.push(
-      join(appImageDir, 'o8_0.1.999_amd64.AppImage'),
-      join(appImageDir, 'o8_0.1.999_amd64.AppImage.sig'),
+      join(appImageDir, `o8_${linuxAppImageVersion}_amd64.AppImage`),
+      join(appImageDir, `o8_${linuxAppImageVersion}_amd64.AppImage.sig`),
       join(debDir, 'o8_0.1.999_amd64.deb'),
     );
     writeFileSync(linuxAssets[0], 'appimage');
@@ -144,18 +144,48 @@ describe('release updater manifest', () => {
     expect(plan.uploadArgs).toEqual([...bundle.macosAssets, ...bundle.trailingAssets]);
   });
 
-  it('adds signed Linux artifacts to the updater manifest and upload list', () => {
+  it('adds signed Linux artifacts to the updater manifest and upload list, using the published asset name', () => {
     const bundle = makeReleaseBundle(true);
     const plan = releasePlan(bundle);
 
+    // publish-preview (.github/workflows/port-build.yml) re-uploads the local
+    // "o8_<version>_amd64.AppImage" build output under
+    // "o8_<version>_linux_amd64_preview.AppImage" — the manifest url must
+    // match the published name, not the local build's basename, or the
+    // updater 404s.
     expect(plan.latestJson.platforms['linux-x86_64']).toEqual({
       signature: 'linux-fixture-signature',
-      url: 'https://github.com/example/releases/download/v0.1.999/o8_0.1.999_amd64.AppImage',
+      url: 'https://github.com/example/releases/download/v0.1.999/o8_0.1.999_linux_amd64_preview.AppImage',
     });
     expect(plan.uploadArgs).toEqual([
       ...bundle.macosAssets,
       ...bundle.linuxAssets,
       ...bundle.trailingAssets,
     ]);
+  });
+
+  it('throws before upload when the Linux AppImage version does not match the release version', () => {
+    const bundle = makeReleaseBundle(true, '0.1.998');
+    expect(() => releasePlan(bundle)).toThrow(/does not match release version "0\.1\.999"/);
+  });
+
+  it('throws when the Linux AppImage filename does not match the expected naming pattern', () => {
+    const bundleDir = mkdtempSync(join(tmpdir(), 'o8-release-bundle-'));
+    roots.push(bundleDir);
+    const appImageDir = join(bundleDir, 'appimage');
+    mkdirSync(appImageDir, { recursive: true });
+    writeFileSync(join(appImageDir, 'o8-unexpected-name.AppImage'), 'appimage');
+    writeFileSync(join(appImageDir, 'o8-unexpected-name.AppImage.sig'), 'sig\n');
+
+    expect(() =>
+      buildReleaseManifest({
+        bundleDir,
+        version: '0.1.999',
+        notes: 'o8 v0.1.999',
+        pubDate: '2026-08-27T12:00:00.000Z',
+        downloadBase: 'https://github.com/example/releases/download/v0.1.999',
+        darwinSignature: 'darwin-fixture-signature',
+      }),
+    ).toThrow(/does not match the expected "o8_<version>_amd64\.AppImage" naming pattern/);
   });
 });


### PR DESCRIPTION
## Summary

- `buildReleaseManifest` (`scripts/lib/release-manifest.mjs`) wrote the `linux-x86_64` updater url from the local AppImage build's basename (`o8_<version>_amd64.AppImage`), but `publish-preview` in `.github/workflows/port-build.yml` re-uploads that artifact under `o8_<version>_linux_amd64_preview.AppImage`. Any published `latest.json` with a linux entry 404s the updater download.
- The url is now derived from the release `version` argument using the published naming pattern, matching the workflow's `copy_one` rename.
- Added a version gate: `assertLinuxAppImageVersionMatches` parses the AppImage filename's embedded version and throws before upload if it doesn't equal the release version being manifested, or if the filename doesn't match the expected `o8_<version>_amd64.AppImage` pattern.
- Darwin platform entries are untouched — a dedicated test asserts the macOS-only manifest and upload list are unchanged.

## Test plan

- [x] `npx tsc --noEmit` — exit 0
- [x] `npm run lint` — exit 0 (54 pre-existing warnings unrelated to this change, 0 errors)
- [x] `npx vitest run tests/release-artifacts.test.ts` — 7/7 passing, including the new published-name assertion and two new version-gate tests (mismatch, malformed filename)
- [x] `npm run rule-check` — exit 0

Closes #2056

🤖 Generated with [Claude Code](https://claude.com/claude-code)