### PR TITLE
feat: declare Linux nodejs dependency and document unsupported surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Free tier uses on-device Apple transcription or your own Whisper key. An optiona
 
 ## Quickstart
 
-macOS has signed releases today. Windows 11 is runtime-verified and produces MSI and NSIS installers. Linux produces deb, rpm, and AppImage packages; public signing, update channels, and Linux desktop verification remain open.
+macOS has signed releases today. Windows 11 is runtime-verified and produces MSI and NSIS installers. Linux produces deb, rpm, and AppImage packages; public signing, update channels, and Linux desktop verification remain open. The deb/rpm packages declare a `nodejs (>= 22)` dependency so a clean install has the system Node the app's sidecar requires; voice dictation, the native browser pane, and the native folder/file picker are macOS-only — see the [Linux surface support table](./docs/internals/port-audit-linux.md#linux-surface-support-table) for the fallback each one uses.
 
 **Easiest:** download the latest signed build from [Releases](https://github.com/hurttlocker/o8/releases) — auto-updates included.
 

--- a/docs/internals/port-audit-linux.md
+++ b/docs/internals/port-audit-linux.md
@@ -2,6 +2,16 @@
 
 Scope: greenfield Linux blockers and structural seams in the current o8 implementation.
 
+## Linux surface support table
+
+Three surfaces are macOS-native code paths with no Linux implementation. Each has an in-app fallback rather than a crash — the feature reads as unavailable, not broken.
+
+| Surface | Status on Linux | Why | Fallback |
+| --- | --- | --- | --- |
+| Voice dictation (Symon push-to-talk, `Fn`/right-`Option` hotkeys, on-device Apple transcription) | Unsupported | The Symon capture stack is a native macOS Swift binary driven through the Accessibility API; it is not built for Linux at all. The composer's own mic-button dictation path (`useDictation.ts`) additionally depends on WebKitGTK's `MediaRecorder`/`getUserMedia`/`SpeechRecognition` support, which is unverified on this platform (see "Web mic and recorder APIs need Linux WebKitGTK validation" below). | Type directly into the composer; there is no voice input path today on Linux. |
+| Native browser pane (embedded Browser tab / canvas browser cards, agent-grab) | Unsupported | `src-tauri/src/browser_view.rs` builds the pane as a native AppKit child window; the `#[cfg(not(target_os = "macos"))]` stubs for `open`/`eval`/`navigate` compile to no-ops (`open` returns `Ok(())` with no window ever created, `eval` returns `false`, `eval_result` returns the literal error `"native browser-view is macOS-only"`). | The pane's own "Open in Browser tab" / external-open control (`openExternal` in `src/components/desktop/O8BrowserPane.tsx`, backed by `openExternalUrl`) opens the same URL in the system default browser instead of the embedded webview. |
+| Folder/file picker (`osascript`-backed native chooser) | Unsupported | `src/app/api/panel/browse-folder/route.ts` and the `pick` action in `src/app/api/panel/file-io/route.ts` shell out to `osascript`/AppleScript. On Linux `osascript` does not exist, so the `execSync`/`execFileAsync` call throws `ENOENT`; both routes catch that and return `{ path: null }` — the same shape as a user cancelling. | Callers (`pickRepoFolder.ts`, `AddRepoDialog.tsx`, `OnboardingReposStep.tsx`) treat a null path as "no native picker available" and fall through to a manual path-entry prompt (`requestPrompt`) — the operator types the absolute folder/file path directly. |
+
 ## Executive Top 10 Greenfield Findings
 
 The remaining open Linux blockers are release artifacts ([#1898](https://github.com/hurttlocker/o8/issues/1898)), installed deep-link and bundle registration ([#1899](https://github.com/hurttlocker/o8/issues/1899)), and stale-listener reclaim ([#1926](https://github.com/hurttlocker/o8/issues/1926)).

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -22,5 +22,15 @@
         "schemes": ["o8"]
       }
     }
+  },
+  "bundle": {
+    "linux": {
+      "deb": {
+        "depends": ["nodejs (>= 22)"]
+      },
+      "rpm": {
+        "depends": ["nodejs >= 22.0.0"]
+      }
+    }
   }
 }

--- a/tests/linux-packaging-deps.test.ts
+++ b/tests/linux-packaging-deps.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// #2055 — a clean Linux install launched straight to the Node pre-flight
+// dialog because the deb/rpm bundler config declared no nodejs dependency.
+// `bundle.externalBin` stays null on Linux (the Tauri sidecar wants a
+// SYSTEM Node), so the packaging config is the only thing standing between
+// a fresh `apt install ./o8.deb` and a broken first launch. This test reads
+// the real config the build merges (`src-tauri/tauri.linux.conf.json`,
+// auto-merged by the Tauri CLI for Linux targets per tauri-utils'
+// `BundleConfig.linux` — see `LinuxConfig` / `DebConfig.depends` /
+// `RpmConfig.depends` in the vendored tauri-utils crate) so a future edit
+// cannot silently drop the dependency without failing CI.
+const CONFIG_PATH = join(__dirname, '..', 'src-tauri', 'tauri.linux.conf.json');
+
+function readLinuxConfig(): {
+  bundle?: { linux?: { deb?: { depends?: string[] }; rpm?: { depends?: string[] } } };
+} {
+  return JSON.parse(readFileSync(CONFIG_PATH, 'utf-8'));
+}
+
+describe('Linux packaging nodejs dependency (#2055)', () => {
+  it('declares a nodejs >= 22 dependency for the deb bundle', () => {
+    const config = readLinuxConfig();
+    const depends = config.bundle?.linux?.deb?.depends ?? [];
+    const nodejsEntry = depends.find((d) => /^nodejs\b/.test(d));
+    expect(nodejsEntry).toBeDefined();
+    expect(nodejsEntry).toMatch(/>=\s*22/);
+  });
+
+  it('declares a nodejs >= 22 dependency for the rpm bundle', () => {
+    const config = readLinuxConfig();
+    const depends = config.bundle?.linux?.rpm?.depends ?? [];
+    const nodejsEntry = depends.find((d) => /^nodejs\b/.test(d));
+    expect(nodejsEntry).toBeDefined();
+    expect(nodejsEntry).toMatch(/>=\s*22/);
+  });
+});


### PR DESCRIPTION
Closes #2055

## Summary

- `src-tauri/tauri.linux.conf.json` now declares `bundle.linux.deb.depends: ["nodejs (>= 22)"]` and `bundle.linux.rpm.depends: ["nodejs >= 22.0.0"]` — verified against the `DebConfig`/`RpmConfig` field names and version-string conventions in the vendored `tauri-utils` crate (`~/.cargo/registry/.../tauri-utils-2.9.3/src/config.rs`). This file is auto-merged by the Tauri CLI for Linux targets alongside the explicit `--config src-tauri/tauri.portci.conf.json` override that `port-build.yml` already passes, so both apply together on a Linux build.
- `docs/internals/port-audit-linux.md` gets a new "Linux surface support table" marking voice dictation, the native browser pane, and the `osascript` folder/file picker as unsupported, with the fallback each one actually falls through to in code (traced through `useDictation.ts`, `browser_view.rs`'s non-macOS stubs, and `pickRepoFolder.ts`/`AddRepoDialog.tsx`'s three-tier fallback chain).
- `README.md`'s Linux quickstart line now points at that table and mentions the new dependency.
- `tests/linux-packaging-deps.test.ts` reads the real `tauri.linux.conf.json` and asserts both `depends` arrays carry a `nodejs >= 22` entry, so a future edit can't silently drop it.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — exit 0 (54 pre-existing warnings, unrelated to this change)
- `npx vitest run tests/linux-packaging-deps.test.ts` — 2/2 passed
- `npm run test:classify` then `npm run test:classification:check` — manifest already matched, no diff needed
- `npm run rule-check` — clean

**Not run here:** this sandbox cannot build the actual `.deb`/`.rpm` artifacts (no Linux Tauri toolchain), so `dpkg-deb -f <deb> Depends` / the rpm spec `Requires` were not verified against a real build — only against the config schema. The `port-build.yml` workflow build is the real proof; worth a manual `workflow_dispatch` run to confirm the packaged artifacts actually carry the dependency.

## Test plan

- [x] Config change verified against the tauri-bundler schema (not guessed)
- [x] New unit test passes and fails if the depends entries are removed
- [ ] Manual `port-build.yml` dispatch to confirm `dpkg-deb -f` / rpm spec show the dependency on a real build (not done in this sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuwAJQVFhKFmL7C1RWDx1T