### PR TITLE
fix: log unpinned recovery skips once and guard git on missing worktrees (#2048)

### DIFF
--- a/src/lib/lane/repo-preflight.ts
+++ b/src/lib/lane/repo-preflight.ts
@@ -13,12 +13,21 @@ import { isOrchestratorHomePath } from '@/lib/orchestrator/repo-path';
  * tool-side error mid-turn. Fail with the truth, before any spawn work.
  */
 export function isGitWorkTreeSync(repoPath: string): boolean {
+  // #2048 — probe the path BEFORE spawning git. A packet whose repo folder was
+  // moved or deleted made the headless recovery tick re-run this every tick, and
+  // execFileSync inherits the parent's stderr by default, so each miss printed a
+  // bare `fatal: not a git repository` into serve.log with nothing naming the
+  // caller. The existence check answers the missing-folder case without a spawn;
+  // the explicit `stdio` keeps git's stderr piped (and discarded) for the
+  // folder-exists-but-isn't-a-repo case, which the catch below already handles.
+  if (!repoPath || !existsSync(repoPath)) return false;
   try {
     return execFileSync('git', ['-C', repoPath, 'rev-parse', '--is-inside-work-tree'], {
       windowsHide: true,
       encoding: 'utf-8',
       timeout: 5_000,
       maxBuffer: 128 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe'],
     }).trim() === 'true';
   } catch {
     return false;

--- a/src/lib/orchestrator/dispatch.ts
+++ b/src/lib/orchestrator/dispatch.ts
@@ -21,3 +21,9 @@ export {
   mergeDispatchTickOutcome,
   runDispatchTick,
 } from './scheduling';
+
+export {
+  forgetRecoverySkip,
+  resetRecoverySkipMemo,
+  shouldLogRecoverySkip,
+} from './recovery-skip-log';

--- a/src/lib/orchestrator/recovery-skip-log.ts
+++ b/src/lib/orchestrator/recovery-skip-log.ts
@@ -1,0 +1,43 @@
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+
+// #2048 — the headless loop is a long-lived process that re-runs the recovery
+// gate every tick (10s). A packet blocked on a condition only the operator can
+// clear ("runtime is not pinned") is re-evaluated forever, and logging every
+// evaluation flooded serve.log with 38,008 identical lines in 27 hours. Remember
+// the last blocker we PRINTED per packet, fingerprinted by reason + pinned
+// runtime: the same reason under the same runtime stays silent, and a changed
+// runtime (or a different blocker) prints once more.
+const loggedRecoverySkips = new Map<string, string>();
+
+function recoverySkipFingerprint(reason: string, pinnedRuntime: OrchestratorRuntime | null): string {
+  return `${reason}::${pinnedRuntime ?? 'unpinned'}`;
+}
+
+/** True the first time this packet is skipped for this reason+runtime pair. */
+export function shouldLogRecoverySkip(
+  packetId: string,
+  reason: string,
+  pinnedRuntime: OrchestratorRuntime | null,
+): boolean {
+  const fingerprint = recoverySkipFingerprint(reason, pinnedRuntime);
+  if (loggedRecoverySkips.get(packetId) === fingerprint) return false;
+  loggedRecoverySkips.set(packetId, fingerprint);
+  return true;
+}
+
+/** Forget a packet's memoized skip so its next block logs again. */
+export function forgetRecoverySkip(packetId: string): void {
+  loggedRecoverySkips.delete(packetId);
+}
+
+/** Test seam — drop every memoized skip. */
+export function resetRecoverySkipMemo(): void {
+  loggedRecoverySkips.clear();
+}
+
+/** Keep the memo bounded by the live packet set — a daemon runs for weeks. */
+export function pruneRecoverySkipMemo(livePacketIds: Set<string>): void {
+  for (const packetId of loggedRecoverySkips.keys()) {
+    if (!livePacketIds.has(packetId)) loggedRecoverySkips.delete(packetId);
+  }
+}

--- a/src/lib/orchestrator/scheduling.ts
+++ b/src/lib/orchestrator/scheduling.ts
@@ -31,6 +31,7 @@ import {
 } from '@/lib/orchestrator/storage-admission';
 import { getStoragePressureAdmissionCoordinator } from '@/lib/orchestrator/storage-pressure-policy';
 import { isDispatchHalted } from './dispatch-halt';
+import { forgetRecoverySkip, pruneRecoverySkipMemo, shouldLogRecoverySkip } from './recovery-skip-log';
 
 import { computePredictedFiles, filterOverlappingPackets } from './preservation-envelope';
 import { applyPacketScopePolicy, packetScopeDispatchBlocker } from './packet-scope-policy';
@@ -519,24 +520,31 @@ export async function runDispatchTick(
     }
   }
 
+  pruneRecoverySkipMemo(new Set(nextState.packets.map((packet) => packet.id)));
+
   const dispatchablePackets = overlapFiltered
     .map((packet) => ({
       packet,
       recoveryContext: recoveryContextByPacketId.get(packet.id) ?? null,
     }))
     .filter(({ packet, recoveryContext }) => {
+      const pinnedRuntime = recoveryContext?.runtime ?? packet.dispatchRuntimePin ?? null;
       const recoveryBlocker = options.enforceBootRecoveryGuard
         ? getBootRecoveryLaunchBlocker({
             missionArchived: options.missionArchived,
             missionLive: !nextState.packets.every((candidate) => candidate.archivedAt || candidate.releaseState === 'released'),
             packet,
-            pinnedRuntime: recoveryContext?.runtime ?? packet.dispatchRuntimePin ?? null,
+            pinnedRuntime,
           })
         : null;
       if (recoveryBlocker) {
-        console.log(`[recovery] Packet ${packet.id} skipped — ${recoveryBlocker}`);
+        // #2048 — print once per reason+runtime, not once per tick.
+        if (shouldLogRecoverySkip(packet.id, recoveryBlocker, pinnedRuntime)) {
+          console.log(`[recovery] Packet ${packet.id} skipped — ${recoveryBlocker}`);
+        }
         return false;
       }
+      forgetRecoverySkip(packet.id);
       if (getDispatchBlocker(packet, nextState.packets) !== null) {
         return false;
       }

--- a/tests/recovery-tick-log-flood-real-path.test.ts
+++ b/tests/recovery-tick-log-flood-real-path.test.ts
@@ -1,0 +1,164 @@
+/**
+ * #2048 — the headless recovery tick must not flood serve.log.
+ *
+ * Both cases drive the REAL entry point (`runDispatchTick` with the boot
+ * recovery guard on) against PERSISTED control-plane state, because the guard
+ * and the git probe were each already covered in isolation while the flood ran
+ * for 27 hours (38,008 lines) in production:
+ *
+ *   A. A decompose packet with no pinned runtime is skipped on every tick. The
+ *      skip must be LOGGED once, not once per tick. Two real ticks, one line.
+ *
+ *   B. A packet whose workspace target no longer exists must not spawn git at
+ *      all — `execFileSync` inherits the parent's stderr, so every miss printed
+ *      a bare `fatal: not a git repository` with nothing naming the caller.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const gitCalls = vi.hoisted(() => [] as string[][]);
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    default: actual,
+    execFileSync: ((file: string, args?: readonly string[], options?: unknown) => {
+      if (file === 'git') gitCalls.push([...(args ?? [])]);
+      return (actual.execFileSync as unknown as (...a: unknown[]) => unknown)(file, args, options);
+    }) as typeof actual.execFileSync,
+  };
+});
+
+const {
+  readOrchestratorControlPlaneState,
+  writeOrchestratorControlPlaneState,
+} = await import('@/lib/orchestrator/control-plane');
+const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+const { runDispatchTick } = await import('@/lib/orchestrator/scheduling');
+const { resetRecoverySkipMemo } = await import('@/lib/orchestrator/recovery-skip-log');
+import type { OrchestratorMissionState, OrchestratorPacket } from '@/lib/orchestrator/types';
+
+const testRoot = mkdtempSync(join(tmpdir(), 'o8-recovery-log-flood-'));
+const repoPath = join(testRoot, 'repo');
+const missingRepoPath = join(testRoot, 'repo-that-was-deleted');
+
+beforeAll(() => {
+  mkdirSync(repoPath, { recursive: true });
+  execFileSync('git', ['init', '--initial-branch=main'], { cwd: repoPath });
+  writeFileSync(join(repoPath, 'README.md'), 'recovery tick flood\n');
+  execFileSync('git', ['add', 'README.md'], { cwd: repoPath });
+  execFileSync('git', ['-c', 'user.email=test@o8.local', '-c', 'user.name=o8-test', 'commit', '-m', 'init'], {
+    cwd: repoPath,
+  });
+  gitCalls.length = 0;
+});
+
+beforeEach(() => {
+  resetRecoverySkipMemo();
+  gitCalls.length = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterAll(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+function persistPacket(packet: OrchestratorPacket): OrchestratorMissionState {
+  const state = createEmptyOrchestratorMissionState();
+  return writeOrchestratorControlPlaneState({ ...state, packets: [packet] });
+}
+
+function decomposePacket(overrides: Partial<OrchestratorPacket> = {}): OrchestratorPacket {
+  return {
+    id: 'decompose-2048-stale',
+    referenceLabel: 'PKT-DECOMPOSE-2048',
+    title: 'decompose stale work',
+    summary: 'decompose stale work',
+    workspaceTargetPath: repoPath,
+    branchTarget: 'issue/2048-decompose',
+    runtime: 'codex',
+    dependencyLabels: [],
+    dependencyPacketIds: [],
+    queueState: 'queued',
+    releaseState: 'pending',
+    status: 'queued',
+    blockedReason: null,
+    lane: null,
+    ...overrides,
+  };
+}
+
+async function tickPersistedState(): Promise<string[]> {
+  const logs: string[] = [];
+  const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    logs.push(args.map((arg) => String(arg)).join(' '));
+  });
+  try {
+    // Read back from disk each tick — the daemon does exactly this, so the
+    // memo cannot be smuggled in on the in-memory packet object.
+    const persisted = readOrchestratorControlPlaneState();
+    const dispatched = await runDispatchTick(persisted, {
+      enforceBootRecoveryGuard: true,
+      missionArchived: false,
+    });
+    writeOrchestratorControlPlaneState(dispatched);
+  } finally {
+    spy.mockRestore();
+  }
+  return logs;
+}
+
+describe('#2048 headless recovery tick logging', () => {
+  it('logs an unpinned decompose packet skip once across two real ticks', async () => {
+    persistPacket(decomposePacket({ dispatchRuntimePin: null }));
+
+    const firstTick = await tickPersistedState();
+    const secondTick = await tickPersistedState();
+
+    const skipLines = [...firstTick, ...secondTick].filter((line) => line.includes('runtime is not pinned'));
+    expect(skipLines).toHaveLength(1);
+    expect(skipLines[0]).toContain('decompose-2048-stale');
+    // The second tick still skipped the packet — it just stayed quiet.
+    expect(secondTick.some((line) => line.includes('runtime is not pinned'))).toBe(false);
+  });
+
+  it('logs again once the packet stops being blocked on an unpinned runtime', async () => {
+    persistPacket(decomposePacket({ dispatchRuntimePin: null }));
+    const firstTick = await tickPersistedState();
+    expect(firstTick.filter((line) => line.includes('runtime is not pinned'))).toHaveLength(1);
+
+    // Operator pins a runtime, then the packet is archived — a different
+    // blocker, so the memo must not swallow it.
+    persistPacket(decomposePacket({
+      dispatchRuntimePin: 'codex',
+      archivedAt: new Date().toISOString(),
+    }));
+    const secondTick = await tickPersistedState();
+
+    const skipLines = secondTick.filter((line) => line.includes('[recovery] Packet decompose-2048-stale skipped'));
+    expect(skipLines).toHaveLength(1);
+    expect(skipLines[0]).toContain('mission is not live');
+  });
+
+  it('spawns no git process for a workspace target that no longer exists', async () => {
+    persistPacket(decomposePacket({
+      id: 'decompose-2048-missing-repo',
+      workspaceTargetPath: missingRepoPath,
+      dispatchRuntimePin: 'codex',
+    }));
+
+    const logs = await tickPersistedState();
+
+    const probedMissingPath = gitCalls.some((args) => args.includes(missingRepoPath));
+    expect(probedMissingPath).toBe(false);
+    expect(logs.some((line) => line.includes('fatal:'))).toBe(false);
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2060,6 +2060,14 @@
       ]
     },
     {
+      "path": "tests/recovery-tick-log-flood-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/release-broadcast-real-path.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
## Mechanic

The headless loop re-runs the boot-recovery gate every 10s. A packet blocked on a condition only the operator can clear — `runtime is not pinned` — is re-evaluated forever, and the gate logged every evaluation: **38,008 identical lines** for four stale decompose packets in 27 hours.

`src/lib/orchestrator/recovery-skip-log.ts` remembers the blocker we last *printed* per packet, fingerprinted by reason + pinned runtime. A module-level map is enough because the loop is a long-lived process. The same reason under the same runtime stays silent; a pinned runtime — or a different blocker — prints once more. The memo is pruned against the live packet set each tick, and cleared for any packet that reaches the gate unblocked, so it cannot go stale on a daemon that runs for weeks.

The interleaved `fatal: not a git repository` came from the shared work-tree probe (`isGitWorkTreeSync`): `execFileSync` inherits the parent's stderr by default, so every miss on a repo folder that had been moved or deleted printed git's own error into `serve.log` with nothing naming the caller. The probe now checks the path with `existsSync` before spawning, and pipes git's stderr for the folder-exists-but-isn't-a-repo case the `catch` already handled.

## Tests

`tests/recovery-tick-log-flood-real-path.test.ts` drives the REAL entry point — `runDispatchTick` with the boot recovery guard on — against persisted control-plane state re-read from disk on each tick, so the memo cannot be smuggled in on an in-memory packet object:

- two ticks over a persisted unpinned decompose packet produce exactly one log line, and the second tick still skips the packet;
- a later tick under a changed blocker prints again (the memo is not a permanent mute);
- a packet whose workspace target no longer exists records no git spawn against that path and no `fatal:` output.

Both fixes were falsified: with the memo guard and the `existsSync` check reverted, tests 1 and 3 fail.

Gates: `npx tsc --noEmit` 0 · `npm run lint` 0 (54 pre-existing warnings, 0 errors) · `npm test` 0 (3902 passed) · related integration files 0 (46 passed) · `npm run test:classification:check` 0 · `npm run rule-check` 0.

## Out of scope

The issue's third acceptance bullet — surfacing stale unpinned decompose packets in operator status as needing a decision — is deliberately **not** in this PR. It is a product surface change rather than a log-volume fix, and belongs in its own change against the status surface.

Closes #2048

🤖 Generated with [Claude Code](https://claude.com/claude-code)