### PR TITLE
fix: offer a download instead of restart-to-install on non-AppImage Linux installs (#2059)

### DIFF
--- a/scripts/lib/release-manifest.mjs
+++ b/scripts/lib/release-manifest.mjs
@@ -17,7 +17,7 @@ function listFiles(directory, suffix) {
 // build's basename.
 const LINUX_APPIMAGE_NAME_PATTERN = /^o8_(.+)_amd64\.AppImage$/;
 
-function publishedLinuxAssetName(version) {
+export function publishedLinuxAssetName(version) {
   return `o8_${version}_linux_amd64_preview.AppImage`;
 }
 

--- a/src/app/api/panel/app/install-info/route.ts
+++ b/src/app/api/panel/app/install-info/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+
+import { isSelfUpdatableInstall, normalizeInstallPlatform } from '@/lib/app-update/install-target';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * What kind of install is running. The bundled server is spawned by the Tauri
+ * shell, so it inherits the app process env — including `APPIMAGE`, which the
+ * AppImage runtime sets to the path the app was started from. The webview has
+ * no way to read either value on its own.
+ */
+export async function GET() {
+  const platform = normalizeInstallPlatform(process.platform);
+  const appImagePath = typeof process.env.APPIMAGE === 'string' && process.env.APPIMAGE.trim()
+    ? process.env.APPIMAGE.trim()
+    : null;
+  const info = {
+    platform,
+    arch: process.arch || null,
+    appImagePath,
+    updaterSelfUpdatable: null,
+  };
+
+  return NextResponse.json(
+    { ...info, selfUpdatable: isSelfUpdatableInstall(info) },
+    { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+  );
+}

--- a/src/components/desktop/UpdateCard.tsx
+++ b/src/components/desktop/UpdateCard.tsx
@@ -12,6 +12,9 @@
  *   [•] Update available                 [Restart] [×]
  *       v0.1.172
  *
+ * The action reads [Download] instead on an install that cannot replace
+ * itself (a deb/rpm Linux install — see `isSelfUpdatableInstall`).
+ *
  * Click anywhere on the body to expand. The expanded section calls
  * /api/panel/o8-update-summary (free OpenRouter pool) to render a
  * 1-paragraph professional summary from the actual GitHub release body
@@ -32,6 +35,11 @@ import {
   relaunchInstalledUpdate,
   RELEASE_URL,
 } from '@/lib/app-update/client-restart';
+import {
+  normalizeInstallInfo,
+  resolveUpdateAction,
+  type InstallInfo,
+} from '@/lib/app-update/install-target';
 
 interface UpdateInfo {
   version: string;
@@ -54,6 +62,8 @@ let updateInstallInFlight = false;
 
 interface InstallRequest {
   requireIdle?: boolean;
+  /** True only for the operator pressing the card's action button. */
+  userInitiated?: boolean;
 }
 
 interface UpdateIdleResponse {
@@ -147,7 +157,9 @@ export function UpdateCard() {
   const [blockedNote, setBlockedNote] = useState<string | null>(null);
   const [installError, setInstallError] = useState<string | null>(null);
   const [bundleIntegrity, setBundleIntegrity] = useState<BundleIntegrityStatus | null>(null);
+  const [installInfo, setInstallInfo] = useState<InstallInfo | null>(null);
   const updateRef = useRef<UpdateInfo | null>(null);
+  const installInfoRef = useRef<InstallInfo | null>(null);
   const installingRef = useRef(false);
   const autoApplyingRef = useRef(false);
   const restartDeferredRef = useRef(false);
@@ -159,6 +171,23 @@ export function UpdateCard() {
   useEffect(() => {
     installingRef.current = installing;
   }, [installing]);
+
+  useEffect(() => {
+    installInfoRef.current = installInfo;
+  }, [installInfo]);
+
+  // What the running install is capable of. Only the server can read
+  // process.platform + APPIMAGE; a deb/rpm Linux install can never
+  // restart-to-install, so the card offers the release download instead.
+  useEffect(() => {
+    fetch('/api/panel/app/install-info', { cache: 'no-store' })
+      .then(async (response) => {
+        if (!response.ok) return;
+        const next = normalizeInstallInfo(await response.json());
+        if (next) setInstallInfo(next);
+      })
+      .catch(() => { /* unknown install stays on the existing restart path */ });
+  }, []);
 
   const handleDismiss = useCallback(() => {
     const version = update?.version ?? '';
@@ -328,17 +357,24 @@ export function UpdateCard() {
 
   const handleInstall = useCallback(async (request: InstallRequest = {}) => {
     if (installingRef.current || updateInstallInFlight) return;
+    const action = resolveUpdateAction(installInfoRef.current, updateRef.current?.version ?? null);
+    if (action.kind === 'download' && !request.userInitiated) {
+      // Background applies (idle auto-apply, remote apply mutation) never open
+      // a browser on the operator's behalf.
+      setBlockedNote('This install updates by download. o8 cannot replace a deb or rpm install in place.');
+      return;
+    }
     updateInstallInFlight = true;
     installingRef.current = true;
     try {
       setInstalling(true);
       setBlockedNote(null);
       setInstallError(null);
-      if (request.requireIdle && !(await checkUpdateIdle())) {
+      if (action.kind === 'restart' && request.requireIdle && !(await checkUpdateIdle())) {
         setBlockedNote('Update ready. Restart is waiting for lanes and terminals to become idle.');
         return;
       }
-      if (restartDeferredRef.current) {
+      if (action.kind === 'restart' && restartDeferredRef.current) {
         const restarted = await relaunchInstalledUpdate({
           beforeRestart: request.requireIdle ? checkUpdateIdle : undefined,
         });
@@ -348,9 +384,13 @@ export function UpdateCard() {
         return;
       }
       const outcome = await installUpdateAndRestart(
-        updateRef.current?.releaseUrl ?? RELEASE_URL,
-        { beforeRestart: request.requireIdle ? checkUpdateIdle : undefined },
+        action.kind === 'download' ? action.url : updateRef.current?.releaseUrl ?? RELEASE_URL,
+        {
+          beforeRestart: request.requireIdle ? checkUpdateIdle : undefined,
+          selfUpdatable: action.kind === 'restart',
+        },
       );
+      if (outcome.downloadOpened) return;
       if (outcome.blocked) {
         // Kill-switch: this version was pulled post-release. Surface a quiet
         // note instead of restarting; the operator waits for the next build.
@@ -430,6 +470,11 @@ export function UpdateCard() {
   }
   if (!update) return null;
   if (dismissed && dismissed === update.version) return null;
+
+  // A deb/rpm Linux install cannot replace itself, so the same slot carries a
+  // download link to the release asset instead of restart-to-install.
+  const action = resolveUpdateAction(installInfo, update.version);
+  const actionLabel = action.kind === 'download' ? 'Download' : 'Restart';
 
   const cardStyle: CSSProperties = {
     flexShrink: 0,
@@ -557,12 +602,15 @@ export function UpdateCard() {
           type="button"
           onClick={(e) => {
             e.stopPropagation();
-            void handleInstall();
+            void handleInstall({ userInitiated: true });
           }}
           disabled={installing}
+          aria-label={action.kind === 'download'
+            ? `Download o8 v${update.version}`
+            : `Restart to install o8 v${update.version}`}
           style={restartStyle}
         >
-          {installing ? 'Installing…' : 'Restart'}
+          {installing && action.kind === 'restart' ? 'Installing…' : actionLabel}
         </button>
         <button
           type="button"

--- a/src/lib/app-update/client-restart.ts
+++ b/src/lib/app-update/client-restart.ts
@@ -12,10 +12,18 @@ export interface InstallUpdateOutcome {
   restartDeferred?: boolean;
   /** Set when the update was skipped because the version is pulled (kill-switch). */
   blocked?: { version: string; note?: string };
+  /** The install cannot self-update, so the release download was opened instead. */
+  downloadOpened?: boolean;
 }
 
 export interface InstallUpdateOptions {
   beforeRestart?: () => Promise<boolean>;
+  /**
+   * False when the running install cannot replace itself (a deb/rpm Linux
+   * install — see `isSelfUpdatableInstall`). Such a call opens the release
+   * download instead of ever reaching restart-to-install.
+   */
+  selfUpdatable?: boolean;
 }
 
 async function releaseCloudJobLeasesForRestart(): Promise<void> {
@@ -73,6 +81,11 @@ export async function installUpdateAndRestart(
   releaseUrl?: string,
   options: InstallUpdateOptions = {},
 ): Promise<InstallUpdateOutcome> {
+  if (options.selfUpdatable === false) {
+    openExternalUrl(releaseUrl ?? RELEASE_URL);
+    return { installed: false, downloadOpened: true };
+  }
+
   if (!isTauri()) {
     openExternalUrl(releaseUrl ?? RELEASE_URL);
     return { installed: false };

--- a/src/lib/app-update/install-target.test.ts
+++ b/src/lib/app-update/install-target.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isSelfUpdatableInstall,
+  normalizeInstallInfo,
+  releaseDownloadUrl,
+  resolveUpdateAction,
+  type InstallInfo,
+} from './install-target';
+
+function info(overrides: Partial<InstallInfo> = {}): InstallInfo {
+  return {
+    platform: 'darwin',
+    arch: 'arm64',
+    appImagePath: null,
+    updaterSelfUpdatable: null,
+    ...overrides,
+  };
+}
+
+describe('isSelfUpdatableInstall', () => {
+  it('keeps macOS and Windows bundles on the restart-to-install path', () => {
+    expect(isSelfUpdatableInstall(info({ platform: 'darwin' }))).toBe(true);
+    expect(isSelfUpdatableInstall(info({ platform: 'darwin', arch: 'x64' }))).toBe(true);
+    expect(isSelfUpdatableInstall(info({ platform: 'win32', arch: 'x64' }))).toBe(true);
+  });
+
+  it('treats a Linux install as self-updatable only when it is an AppImage', () => {
+    expect(isSelfUpdatableInstall(info({
+      platform: 'linux',
+      arch: 'x64',
+      appImagePath: '/home/o8/Apps/o8_0.1.726_amd64.AppImage',
+    }))).toBe(true);
+    // deb/rpm: no APPIMAGE in the app env.
+    expect(isSelfUpdatableInstall(info({ platform: 'linux', arch: 'x64' }))).toBe(false);
+    expect(isSelfUpdatableInstall(info({ platform: 'linux', arch: 'arm64' }))).toBe(false);
+  });
+
+  it('honours an explicit updater verdict on every platform', () => {
+    expect(isSelfUpdatableInstall(info({ updaterSelfUpdatable: false }))).toBe(false);
+    expect(isSelfUpdatableInstall(info({
+      platform: 'linux',
+      appImagePath: '/tmp/o8.AppImage',
+      updaterSelfUpdatable: false,
+    }))).toBe(false);
+  });
+
+  it('fails open on an unknown platform so the shipped path is unchanged', () => {
+    expect(isSelfUpdatableInstall(info({ platform: 'unknown', arch: null }))).toBe(true);
+  });
+});
+
+describe('releaseDownloadUrl', () => {
+  it('points x86_64 Linux at the published AppImage asset', () => {
+    expect(releaseDownloadUrl(info({ platform: 'linux', arch: 'x64' }), '0.1.726'))
+      .toBe('https://github.com/hurttlocker/o8/releases/download/v0.1.726/o8_0.1.726_linux_amd64_preview.AppImage');
+    expect(releaseDownloadUrl(info({ platform: 'linux', arch: 'x86_64' }), 'v0.1.726'))
+      .toBe('https://github.com/hurttlocker/o8/releases/download/v0.1.726/o8_0.1.726_linux_amd64_preview.AppImage');
+  });
+
+  it('falls back to the release page for an arch with no published asset', () => {
+    expect(releaseDownloadUrl(info({ platform: 'linux', arch: 'arm64' }), '0.1.726'))
+      .toBe('https://github.com/hurttlocker/o8/releases/tag/v0.1.726');
+    expect(releaseDownloadUrl(info({ platform: 'linux', arch: null }), '0.1.726'))
+      .toBe('https://github.com/hurttlocker/o8/releases/tag/v0.1.726');
+  });
+
+  it('falls back to the latest release when the version is unknown', () => {
+    expect(releaseDownloadUrl(info({ platform: 'linux', arch: 'x64' }), null))
+      .toBe('https://github.com/hurttlocker/o8/releases/latest');
+  });
+});
+
+describe('resolveUpdateAction', () => {
+  it('renders restart-to-install wherever the install can self-update', () => {
+    expect(resolveUpdateAction(info({ platform: 'darwin' }), '0.1.726')).toEqual({ kind: 'restart' });
+    expect(resolveUpdateAction(info({
+      platform: 'linux',
+      arch: 'x64',
+      appImagePath: '/home/o8/Apps/o8.AppImage',
+    }), '0.1.726')).toEqual({ kind: 'restart' });
+  });
+
+  it('renders a download link on a deb/rpm Linux install', () => {
+    expect(resolveUpdateAction(info({ platform: 'linux', arch: 'x64' }), '0.1.726')).toEqual({
+      kind: 'download',
+      url: 'https://github.com/hurttlocker/o8/releases/download/v0.1.726/o8_0.1.726_linux_amd64_preview.AppImage',
+    });
+  });
+
+  it('renders restart-to-install while the install is still unknown', () => {
+    expect(resolveUpdateAction(null, '0.1.726')).toEqual({ kind: 'restart' });
+  });
+});
+
+describe('normalizeInstallInfo', () => {
+  it('reads the route payload and rejects junk', () => {
+    expect(normalizeInstallInfo({
+      platform: 'linux',
+      arch: 'x64',
+      appImagePath: '  /home/o8/o8.AppImage  ',
+      updaterSelfUpdatable: false,
+    })).toEqual({
+      platform: 'linux',
+      arch: 'x64',
+      appImagePath: '/home/o8/o8.AppImage',
+      updaterSelfUpdatable: false,
+    });
+    expect(normalizeInstallInfo({ platform: 'plan9', arch: '', appImagePath: '  ' })).toEqual({
+      platform: 'unknown',
+      arch: null,
+      appImagePath: null,
+      updaterSelfUpdatable: null,
+    });
+    expect(normalizeInstallInfo(null)).toBeNull();
+    expect(normalizeInstallInfo('linux')).toBeNull();
+  });
+});

--- a/src/lib/app-update/install-target.ts
+++ b/src/lib/app-update/install-target.ts
@@ -1,0 +1,100 @@
+/**
+ * Which update action an install can actually perform.
+ *
+ * Tauri v2 replaces a Linux binary in place only when the running app is an
+ * AppImage: the AppImage runtime exports `APPIMAGE` with the path it was
+ * started from, and the updater rewrites that file. A deb/rpm install has no
+ * `APPIMAGE`, its binary sits under a root-owned prefix, and
+ * `downloadAndInstall()` cannot land — restart-to-install is a dead end there.
+ * macOS and Windows bundles keep the existing self-update path.
+ *
+ * One predicate (`isSelfUpdatableInstall`) decides that for every surface, so
+ * the card, the background idle-apply loop, and the restart helper cannot
+ * disagree about what an install is capable of.
+ */
+
+export type InstallPlatform = 'darwin' | 'linux' | 'win32' | 'unknown';
+
+export interface InstallInfo {
+  platform: InstallPlatform;
+  /** Node-style arch of the running app ('x64', 'arm64', …), null when unknown. */
+  arch: string | null;
+  /** Path the AppImage was started from; null on every non-AppImage install. */
+  appImagePath: string | null;
+  /** Updater verdict when the shell knows it; null when it has no opinion. */
+  updaterSelfUpdatable: boolean | null;
+}
+
+export type UpdateAction =
+  | { kind: 'restart' }
+  | { kind: 'download'; url: string };
+
+const RELEASES_BASE = 'https://github.com/hurttlocker/o8/releases';
+
+export const RELEASES_LATEST_URL = `${RELEASES_BASE}/latest`;
+
+export function normalizeInstallPlatform(value: unknown): InstallPlatform {
+  if (value === 'darwin' || value === 'linux' || value === 'win32') return value;
+  return 'unknown';
+}
+
+/** Release artifacts are named by package arch, not by the Node arch string. */
+function packageArch(arch: string | null): 'amd64' | 'arm64' | null {
+  if (!arch) return null;
+  const normalized = arch.trim().toLowerCase();
+  if (normalized === 'x64' || normalized === 'x86_64' || normalized === 'amd64') return 'amd64';
+  if (normalized === 'arm64' || normalized === 'aarch64') return 'arm64';
+  return null;
+}
+
+export function normalizeInstallInfo(payload: unknown): InstallInfo | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const record = payload as Record<string, unknown>;
+  const arch = typeof record.arch === 'string' && record.arch.trim() ? record.arch.trim() : null;
+  const appImagePath = typeof record.appImagePath === 'string' && record.appImagePath.trim()
+    ? record.appImagePath.trim()
+    : null;
+  return {
+    platform: normalizeInstallPlatform(record.platform),
+    arch,
+    appImagePath,
+    updaterSelfUpdatable: typeof record.updaterSelfUpdatable === 'boolean'
+      ? record.updaterSelfUpdatable
+      : null,
+  };
+}
+
+/**
+ * True when the running install can replace itself and relaunch. Unknown
+ * platforms fail OPEN (true) so a missing/failed install-info probe leaves the
+ * shipped macOS behaviour exactly as it was.
+ */
+export function isSelfUpdatableInstall(info: InstallInfo): boolean {
+  if (info.updaterSelfUpdatable === false) return false;
+  if (info.platform === 'linux') return Boolean(info.appImagePath);
+  return true;
+}
+
+/**
+ * Where a non-self-updatable install sends the operator. The release pipeline
+ * publishes one signed x86_64 AppImage per release, and the publish-preview
+ * job re-uploads it under a name that differs from the local build's basename
+ * — `publishedLinuxAssetName` in `scripts/lib/release-manifest.mjs` is the one
+ * source of that name, and `tests/linux-update-download.test.ts` pins this
+ * helper to the url that builder emits. Any other arch gets the release page,
+ * which lists whatever that build actually produced.
+ */
+export function releaseDownloadUrl(info: InstallInfo, version: string | null): string {
+  const bare = version?.trim().replace(/^v/, '') ?? '';
+  if (!bare) return RELEASES_LATEST_URL;
+  if (info.platform === 'linux' && packageArch(info.arch) === 'amd64') {
+    return `${RELEASES_BASE}/download/v${bare}/o8_${bare}_linux_amd64_preview.AppImage`;
+  }
+  return `${RELEASES_BASE}/tag/v${bare}`;
+}
+
+/** The single decision every update surface renders and acts on. */
+export function resolveUpdateAction(info: InstallInfo | null, version: string | null): UpdateAction {
+  if (!info || isSelfUpdatableInstall(info)) return { kind: 'restart' };
+  return { kind: 'download', url: releaseDownloadUrl(info, version) };
+}

--- a/tests/linux-update-download.test.ts
+++ b/tests/linux-update-download.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Real-path seam for #2059: the update card's action is decided by what the
+ * RUNNING install can do, not by what the card assumes.
+ *
+ * Seam A drives the real `/api/panel/app/install-info` route handler with the
+ * platform stubbed, feeds its JSON through the same normalizer the card uses,
+ * and asserts which action the card would render.
+ * Seam B drives the real `installUpdateAndRestart` chokepoint every surface
+ * (button, idle auto-apply, remote apply mutation) funnels into, and asserts a
+ * non-self-updatable install opens the download and never reaches the updater.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { normalizeInstallInfo, releaseDownloadUrl, resolveUpdateAction } from '@/lib/app-update/install-target';
+import { buildReleaseManifest } from '../scripts/lib/release-manifest.mjs';
+
+const { openExternalUrl, updaterCheck, invoke, relaunch } = vi.hoisted(() => ({
+  openExternalUrl: vi.fn(),
+  updaterCheck: vi.fn(async () => null),
+  invoke: vi.fn(async () => undefined),
+  relaunch: vi.fn(async () => undefined),
+}));
+
+vi.mock('@/lib/desktop/open-external', () => ({ openExternalUrl }));
+vi.mock('@tauri-apps/plugin-updater', () => ({ check: updaterCheck }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke }));
+vi.mock('@tauri-apps/plugin-process', () => ({ relaunch }));
+
+const { GET } = await import('@/app/api/panel/app/install-info/route');
+const { installUpdateAndRestart } = await import('@/lib/app-update/client-restart');
+
+const realPlatform = process.platform;
+const realArch = process.arch;
+const realAppImage = process.env.APPIMAGE;
+
+function stubInstall(platform: NodeJS.Platform, arch: string, appImage: string | null) {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  Object.defineProperty(process, 'arch', { value: arch, configurable: true });
+  if (appImage) process.env.APPIMAGE = appImage;
+  else delete process.env.APPIMAGE;
+}
+
+async function actionForRunningInstall(version: string) {
+  const response = await GET();
+  expect(response.status).toBe(200);
+  const info = normalizeInstallInfo(await response.json());
+  expect(info).not.toBeNull();
+  return resolveUpdateAction(info, version);
+}
+
+describe('install-info route decides the update action (seam A)', () => {
+  beforeEach(() => {
+    openExternalUrl.mockClear();
+    updaterCheck.mockClear();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true });
+    Object.defineProperty(process, 'arch', { value: realArch, configurable: true });
+    if (realAppImage === undefined) delete process.env.APPIMAGE;
+    else process.env.APPIMAGE = realAppImage;
+  });
+
+  it('offers a download on a Linux install with no AppImage path (deb/rpm)', async () => {
+    stubInstall('linux', 'x64', null);
+    await expect(actionForRunningInstall('0.1.726')).resolves.toEqual({
+      kind: 'download',
+      url: 'https://github.com/hurttlocker/o8/releases/download/v0.1.726/o8_0.1.726_linux_amd64_preview.AppImage',
+    });
+  });
+
+  it('keeps restart-to-install on a Linux AppImage', async () => {
+    stubInstall('linux', 'x64', '/home/o8/Apps/o8_0.1.726_amd64.AppImage');
+    await expect(actionForRunningInstall('0.1.726')).resolves.toEqual({ kind: 'restart' });
+  });
+
+  it('keeps macOS behaviour unchanged', async () => {
+    stubInstall('darwin', 'arm64', null);
+    await expect(actionForRunningInstall('0.1.726')).resolves.toEqual({ kind: 'restart' });
+  });
+});
+
+describe('install chokepoint honours the install verdict (seam B)', () => {
+  beforeEach(() => {
+    openExternalUrl.mockClear();
+    updaterCheck.mockClear();
+    invoke.mockClear();
+    relaunch.mockClear();
+  });
+
+  it('opens the release download and never runs the updater when the install cannot self-update', async () => {
+    const url = 'https://github.com/hurttlocker/o8/releases/download/v0.1.726/o8_0.1.726_linux_amd64_preview.AppImage';
+    await expect(installUpdateAndRestart(url, { selfUpdatable: false })).resolves.toEqual({
+      installed: false,
+      downloadOpened: true,
+    });
+    expect(openExternalUrl).toHaveBeenCalledWith(url);
+    expect(updaterCheck).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(relaunch).not.toHaveBeenCalled();
+  });
+});
+
+describe('the download url matches what the release pipeline publishes (seam C)', () => {
+  const bundles: string[] = [];
+
+  afterEach(() => {
+    while (bundles.length) rmSync(bundles.pop() as string, { recursive: true, force: true });
+  });
+
+  it('resolves the same linux-x86_64 asset url the updater manifest emits', () => {
+    const version = '0.1.999';
+    const bundleDir = mkdtempSync(join(tmpdir(), 'o8-release-manifest-'));
+    bundles.push(bundleDir);
+    const appImageDir = join(bundleDir, 'appimage');
+    mkdirSync(appImageDir, { recursive: true });
+    writeFileSync(join(appImageDir, `o8_${version}_amd64.AppImage`), 'appimage');
+    writeFileSync(join(appImageDir, `o8_${version}_amd64.AppImage.sig`), 'linux-fixture-signature\n');
+
+    const downloadBase = 'https://github.com/hurttlocker/o8/releases/download/v0.1.999';
+    const { latestJson } = buildReleaseManifest({
+      bundleDir,
+      version,
+      notes: `o8 v${version}`,
+      pubDate: '2026-09-02T12:00:00.000Z',
+      downloadBase,
+      darwinSignature: 'darwin-fixture-signature',
+    });
+
+    // The local build name and the published asset name differ; the card must
+    // link the published one or every Linux download 404s.
+    const linuxUrl = latestJson.platforms['linux-x86_64']?.url;
+    expect(typeof linuxUrl).toBe('string');
+    expect(releaseDownloadUrl(
+      { platform: 'linux', arch: 'x64', appImagePath: null, updaterSelfUpdatable: null },
+      version,
+    )).toBe(linuxUrl);
+    expect(latestJson.platforms['darwin-x86_64']?.url).toBe(`${downloadBase}/o8.app.tar.gz`);
+  });
+});


### PR DESCRIPTION
Tauri v2 can only replace a Linux binary in place when the running app is an AppImage — the AppImage runtime exports `APPIMAGE` with the path it was started from, and the updater rewrites that file. A deb or rpm install has no `APPIMAGE` and its binary sits under a root-owned prefix, so `downloadAndInstall()` cannot land and restart-to-install is a dead end.

## Mechanic

- `src/lib/app-update/install-target.ts` — one predicate, `isSelfUpdatableInstall({ platform, arch, appImagePath, updaterSelfUpdatable })`, plus `resolveUpdateAction` which turns it into the action a surface renders: restart, or a download link to the release asset for the detected arch. x86_64 gets the published AppImage asset; any other arch gets the release page, since the pipeline publishes no asset for it. Unknown platforms fail open to restart, so macOS and Windows behave exactly as before.
- `src/app/api/panel/app/install-info/route.ts` — the webview cannot read `process.platform` or `APPIMAGE`, so the bundled server (a child of the Tauri shell, inheriting its env) reports them through this gated GET.
- `UpdateCard` fetches it once and falls back to the existing path if the probe fails. The action button carries the download and never restart-to-install on such an install; background applies (idle auto-apply, remote apply mutation) surface a note instead of opening a browser on the operator's behalf. No new component — the same card slot carries the link, opened through the existing external-open helper.
- `client-restart.ts` takes `selfUpdatable`, so a caller that bypasses the card still cannot reach the updater.

## Tests

- `src/lib/app-update/install-target.test.ts` — the predicate over the platform matrix (darwin/win32/linux × AppImage/none × arch), URL resolution, payload normalization.
- `tests/linux-update-download.test.ts` — real-path seams: drives the actual `GET` route handler with the platform stubbed, feeds its JSON through the normalizer the card uses, and asserts which action results; then drives the real `installUpdateAndRestart` chokepoint and asserts a non-self-updatable install opens the download and never calls the updater, `restart_app`, or `relaunch`.

Gates: `npx tsc --noEmit` 0, `npm run lint` 0, `npm test` 0 (3918 passed), `npm run test:classification:check` 0, `npm run rule-check` 0.

Not visually verified on Linux — no Linux machine was available in this environment.

Closes #2059

🤖 Generated with [Claude Code](https://claude.com/claude-code)