### PR TITLE
feat: operator step to sign and manifest the Linux AppImage (#2057)

### DIFF
--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -48,3 +48,13 @@ External report reconciliation has its own [configuration and recovery runbook](
 A local build or commit is not a release. Publishing uses the repository’s guarded ship workflow and requires explicit operator authorization in the current session. Keep signing material out of the repository, never run concurrent ship processes, and verify the published version and installer after notarization completes.
 
 Linux release artifacts are produced on a Linux build host. Before `npm run ship`, copy the resulting `bundle/appimage/*.AppImage`, matching `.sig`, and any `bundle/deb/*.deb` files into the corresponding directories under `src-tauri/target/release/bundle/` on the release host. The release script detects them automatically, uploads them with the macOS assets, and adds the signed AppImage to the `linux-x86_64` updater entry.
+
+### Linux signature
+
+When the AppImage was built by the port-build workflow instead, it is published unsigned — that build disables updater artifacts, and the updater signing key never reaches a CI runner. Sign the published asset afterwards, from the release host:
+
+```bash
+npm run ship:linux-sig -- --tag v0.1.724
+```
+
+The step verifies the tag's release is published (never a draft) and holds the expected `o8_<version>_linux_amd64_preview.AppImage` in every target repository, downloads that asset, signs it with the same updater key and invocation the macOS artifact uses, then uploads `<asset>.sig` beside it along with a regenerated `latest.json` that gains exactly one `linux-x86_64` entry. The macOS entries are carried across untouched. Any missing asset, version mismatch, draft release, or absent signing key aborts before anything is published. Repositories default to the source repo and the public updater mirror; override with repeated `--repo owner/name`.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "gate:webview": "node scripts/preship-webview-gate.mjs",
     "release": "node scripts/release.mjs",
     "ship": "node scripts/release.mjs --ship",
+    "ship:linux-sig": "node scripts/sign-linux-appimage.mjs",
     "postinstall": "node scripts/postinstall.mjs",
     "tauri:prebuild": "node scripts/tauri-prebuild.mjs",
     "version": "node scripts/sync-version.mjs",

--- a/scripts/lib/linux-appimage-signature.d.mts
+++ b/scripts/lib/linux-appimage-signature.d.mts
@@ -1,0 +1,70 @@
+import type { ReleaseUpdaterManifest, ReleaseUpdaterPlatform } from './release-manifest.d.mts';
+
+export const SIGNER_COMMAND: string;
+export const SIGNER_ARGS: string[];
+export const GH_COMMAND: string;
+export const SIGNING_KEY_ENV: string;
+export const SIGNING_KEY_PASSWORD_ENV: string;
+export const SIGNING_KEY_RELATIVE_PATH: string[];
+export const DARWIN_UPDATER_ASSET: string;
+export const LATEST_JSON_ASSET: string;
+export const DEFAULT_REPOS: string[];
+
+export function versionFromTag(tag: string): string;
+
+export function resolveSigningKey(options?: {
+  env?: Record<string, string | undefined>;
+  fileExists?: (path: string) => boolean;
+  readFile?: (path: string) => string;
+}): string;
+
+export function withLinuxPlatform(options: {
+  latest: ReleaseUpdaterManifest;
+  version: string;
+  signature: string;
+}): ReleaseUpdaterManifest;
+
+export interface LinuxSignatureRunOptions {
+  capture?: boolean;
+  env?: Record<string, string | undefined>;
+}
+
+export interface LinuxSignatureDeps {
+  resolveSigningKey: () => string | Promise<string>;
+  fetchRelease: (options: { repo: string; tag: string }) =>
+    | { isDraft: boolean; assets: string[] }
+    | null
+    | Promise<{ isDraft: boolean; assets: string[] } | null>;
+  downloadAsset: (options: { repo: string; tag: string; assetName: string; destDir: string }) => string | Promise<string>;
+  signAppImage: (options: { filePath: string; signingKey: string }) => string | Promise<string>;
+  readSignature: (options: { sigPath: string }) => string | Promise<string>;
+  fetchLatestJson: (options: { repo: string; tag: string; destDir: string }) =>
+    | ReleaseUpdaterManifest
+    | Promise<ReleaseUpdaterManifest>;
+  writeLatestJson: (options: { path: string; latest: ReleaseUpdaterManifest }) => void | Promise<void>;
+  uploadAssets: (options: { repo: string; tag: string; files: string[] }) => void | Promise<void>;
+}
+
+export function createLinuxSignatureDeps(options?: {
+  run?: (command: string, args: string[], options?: LinuxSignatureRunOptions) => string;
+  env?: Record<string, string | undefined>;
+  readFile?: (path: string) => string;
+  writeFile?: (path: string, contents: string) => void;
+}): LinuxSignatureDeps;
+
+export function signLinuxAppImage(options: {
+  tag: string;
+  repos?: string[];
+  workDir: string;
+  deps: LinuxSignatureDeps;
+  log?: (message: string) => void;
+}): Promise<{
+  version: string;
+  assetName: string;
+  sigPath: string;
+  latestJsonPath: string;
+  latest: ReleaseUpdaterManifest;
+  repos: string[];
+}>;
+
+export type { ReleaseUpdaterManifest, ReleaseUpdaterPlatform };

--- a/scripts/lib/linux-appimage-signature.mjs
+++ b/scripts/lib/linux-appimage-signature.mjs
@@ -1,0 +1,183 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { linuxUpdaterPlatform, publishedLinuxAssetName } from './release-manifest.mjs';
+
+// The updater signing key never leaves the ship machine, so this step is
+// operator-invoked: CI builds the AppImage with `createUpdaterArtifacts: false`
+// and publishes it unsigned, and the operator signs the published asset here
+// with the same minisign key the macOS updater artifact is signed with.
+export const SIGNER_COMMAND = 'cargo';
+export const SIGNER_ARGS = ['tauri', 'signer', 'sign'];
+export const GH_COMMAND = 'gh';
+export const SIGNING_KEY_ENV = 'TAURI_SIGNING_PRIVATE_KEY';
+export const SIGNING_KEY_PASSWORD_ENV = 'TAURI_SIGNING_PRIVATE_KEY_PASSWORD';
+export const SIGNING_KEY_RELATIVE_PATH = ['.tauri', 'cortex-ide.key'];
+export const DARWIN_UPDATER_ASSET = 'o8.app.tar.gz';
+export const LATEST_JSON_ASSET = 'latest.json';
+export const DEFAULT_REPOS = ['hurttlocker/o8', 'hurttlocker/o8-releases'];
+
+const TAG_PATTERN = /^v(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$/;
+
+export function versionFromTag(tag) {
+  const match = TAG_PATTERN.exec(String(tag ?? '').trim());
+  if (!match) {
+    throw new Error(`release tag must look like v0.1.724 (received ${JSON.stringify(String(tag ?? ''))})`);
+  }
+  return match[1];
+}
+
+/**
+ * The key is read from the same place the signed macOS build reads it: the
+ * TAURI_SIGNING_PRIVATE_KEY env var, else the operator key file the
+ * `tauri:build:signed` script already points at. Absent → fail closed; the
+ * value is never logged.
+ */
+export function resolveSigningKey({
+  env = process.env,
+  fileExists = existsSync,
+  readFile = (path) => readFileSync(path, 'utf8'),
+} = {}) {
+  const fromEnv = env[SIGNING_KEY_ENV]?.trim();
+  if (fromEnv) return fromEnv;
+  const home = env.HOME?.trim();
+  const keyPath = home ? join(home, ...SIGNING_KEY_RELATIVE_PATH) : null;
+  if (!keyPath || !fileExists(keyPath)) {
+    throw new Error(
+      `updater signing key unavailable: set ${SIGNING_KEY_ENV}, or run this on the ship machine where the operator key lives. Signing never runs on a CI runner.`,
+    );
+  }
+  const key = readFile(keyPath).trim();
+  if (!key) throw new Error(`updater signing key at ${keyPath} is empty`);
+  return key;
+}
+
+/**
+ * Adds the linux-x86_64 platform to an already-published latest.json. Darwin
+ * entries are carried across by reference so they stay byte-for-byte identical.
+ */
+export function withLinuxPlatform({ latest, version, signature }) {
+  const platforms = latest?.platforms;
+  const darwin = platforms?.['darwin-x86_64'];
+  if (!darwin || typeof darwin.url !== 'string') {
+    throw new Error('published latest.json has no darwin-x86_64 url to anchor the download base on');
+  }
+  if (!darwin.url.endsWith(`/${DARWIN_UPDATER_ASSET}`)) {
+    throw new Error(`published latest.json darwin-x86_64 url does not end in /${DARWIN_UPDATER_ASSET}: ${darwin.url}`);
+  }
+  if (latest.version !== version) {
+    throw new Error(`published latest.json is version ${latest.version}, not ${version}`);
+  }
+  const downloadBase = darwin.url.slice(0, -(DARWIN_UPDATER_ASSET.length + 1));
+  return {
+    ...latest,
+    platforms: {
+      ...platforms,
+      'linux-x86_64': linuxUpdaterPlatform({ version, signature, downloadBase }),
+    },
+  };
+}
+
+function defaultRun(command, args, options = {}) {
+  return execFileSync(command, args, {
+    encoding: 'utf8',
+    stdio: options.capture ? ['ignore', 'pipe', 'inherit'] : ['ignore', 'inherit', 'inherit'],
+    env: options.env,
+  });
+}
+
+export function createLinuxSignatureDeps({
+  run = defaultRun,
+  env = process.env,
+  readFile = (path) => readFileSync(path, 'utf8'),
+  writeFile = (path, contents) => writeFileSync(path, contents),
+} = {}) {
+  return {
+    resolveSigningKey: () => resolveSigningKey({ env }),
+    fetchRelease: ({ repo, tag }) => {
+      let stdout;
+      try {
+        stdout = run(GH_COMMAND, ['release', 'view', tag, '--repo', repo, '--json', 'isDraft,assets'], { capture: true });
+      } catch {
+        return null;
+      }
+      const parsed = JSON.parse(stdout);
+      return {
+        isDraft: parsed.isDraft === true,
+        assets: (parsed.assets ?? []).map((asset) => asset.name),
+      };
+    },
+    downloadAsset: ({ repo, tag, assetName, destDir }) => {
+      run(GH_COMMAND, ['release', 'download', tag, '--repo', repo, '--pattern', assetName, '--dir', destDir, '--clobber']);
+      return join(destDir, assetName);
+    },
+    signAppImage: ({ filePath, signingKey }) => {
+      // Same invocation the macOS updater artifact is signed with: the key
+      // rides the env var (newer tauri-cli rejects --private-key-path when the
+      // env var is set too) with an empty password and stdin closed.
+      run(SIGNER_COMMAND, [...SIGNER_ARGS, filePath], {
+        env: { ...env, [SIGNING_KEY_ENV]: signingKey, [SIGNING_KEY_PASSWORD_ENV]: '' },
+      });
+      return `${filePath}.sig`;
+    },
+    readSignature: ({ sigPath }) => readFile(sigPath),
+    fetchLatestJson: ({ repo, tag, destDir }) => {
+      run(GH_COMMAND, ['release', 'download', tag, '--repo', repo, '--pattern', LATEST_JSON_ASSET, '--dir', destDir, '--clobber']);
+      return JSON.parse(readFile(join(destDir, LATEST_JSON_ASSET)));
+    },
+    writeLatestJson: ({ path, latest }) => writeFile(path, `${JSON.stringify(latest, null, 2)}\n`),
+    uploadAssets: ({ repo, tag, files }) => {
+      run(GH_COMMAND, ['release', 'upload', tag, ...files, '--clobber', '--repo', repo]);
+    },
+  };
+}
+
+/**
+ * Downloads the tag's published AppImage, signs it with the updater key, and
+ * republishes the signature plus a latest.json that gains exactly one
+ * linux-x86_64 entry. Every precondition fails closed before the key is used.
+ */
+export async function signLinuxAppImage({ tag, repos = DEFAULT_REPOS, workDir, deps, log = () => {} }) {
+  const version = versionFromTag(tag);
+  if (!Array.isArray(repos) || repos.length === 0) throw new Error('at least one target repository is required');
+  if (!workDir) throw new Error('a work directory is required');
+  const assetName = publishedLinuxAssetName(version);
+
+  const signingKey = await deps.resolveSigningKey();
+
+  // Every repo that will carry the manifest must already hold the AppImage the
+  // manifest url points at, or the updater would resolve to a 404.
+  for (const repo of repos) {
+    const release = await deps.fetchRelease({ repo, tag });
+    if (!release) throw new Error(`release ${tag} was not found in ${repo}`);
+    if (release.isDraft) throw new Error(`release ${tag} in ${repo} is a draft — publish it before signing the Linux AppImage`);
+    if (!release.assets.includes(assetName)) {
+      const present = release.assets.filter((name) => name.endsWith('.AppImage'));
+      throw new Error(
+        `release ${tag} in ${repo} has no ${assetName} asset`
+        + (present.length > 0 ? ` (AppImage assets present: ${present.join(', ')})` : ''),
+      );
+    }
+  }
+
+  const [primary] = repos;
+  log(`downloading ${assetName} from ${primary}`);
+  const appImagePath = await deps.downloadAsset({ repo: primary, tag, assetName, destDir: workDir });
+
+  log(`signing ${assetName}`);
+  const sigPath = await deps.signAppImage({ filePath: appImagePath, signingKey });
+  const signature = (await deps.readSignature({ sigPath }))?.trim();
+  if (!signature) throw new Error(`the signer produced no signature at ${sigPath}`);
+
+  const publishedLatest = await deps.fetchLatestJson({ repo: primary, tag, destDir: workDir });
+  const latest = withLinuxPlatform({ latest: publishedLatest, version, signature });
+  const latestJsonPath = join(workDir, LATEST_JSON_ASSET);
+  await deps.writeLatestJson({ path: latestJsonPath, latest });
+
+  for (const repo of repos) {
+    log(`uploading ${assetName}.sig + ${LATEST_JSON_ASSET} to ${repo}`);
+    await deps.uploadAssets({ repo, tag, files: [sigPath, latestJsonPath] });
+  }
+
+  return { version, assetName, sigPath, latestJsonPath, latest, repos: [...repos] };
+}

--- a/scripts/lib/release-manifest.d.mts
+++ b/scripts/lib/release-manifest.d.mts
@@ -14,6 +14,14 @@ export interface ReleaseUpdaterManifest {
   };
 }
 
+export function publishedLinuxAssetName(version: string): string;
+
+export function linuxUpdaterPlatform(options: {
+  version: string;
+  signature: string;
+  downloadBase: string;
+}): ReleaseUpdaterPlatform;
+
 export interface BuildReleaseManifestOptions {
   bundleDir: string;
   version: string;

--- a/scripts/lib/release-manifest.mjs
+++ b/scripts/lib/release-manifest.mjs
@@ -21,6 +21,16 @@ export function publishedLinuxAssetName(version) {
   return `o8_${version}_linux_amd64_preview.AppImage`;
 }
 
+// Single definition of the linux-x86_64 updater entry, shared by the local
+// ship path (which discovers a locally built + signed AppImage) and the
+// operator-invoked signing step for a CI-published AppImage.
+export function linuxUpdaterPlatform({ version, signature, downloadBase }) {
+  return {
+    signature,
+    url: `${downloadBase}/${publishedLinuxAssetName(version)}`,
+  };
+}
+
 function assertLinuxAppImageVersionMatches(artifactPath, version) {
   const name = basename(artifactPath);
   const match = name.match(LINUX_APPIMAGE_NAME_PATTERN);
@@ -85,10 +95,11 @@ export function buildReleaseManifest({
 
   if (linux.updater) {
     assertLinuxAppImageVersionMatches(linux.updater.artifactPath, version);
-    platforms['linux-x86_64'] = {
+    platforms['linux-x86_64'] = linuxUpdaterPlatform({
+      version,
       signature: readFileSync(linux.updater.signaturePath, 'utf8').trim(),
-      url: `${downloadBase}/${publishedLinuxAssetName(version)}`,
-    };
+      downloadBase,
+    });
   }
 
   return {

--- a/scripts/sign-linux-appimage.mjs
+++ b/scripts/sign-linux-appimage.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Operator step: sign a CI-published Linux AppImage and put it in the updater
+ * manifest.
+ *
+ * `tauri.portci.conf.json` sets `createUpdaterArtifacts: false`, so the Linux
+ * build published by the port-build workflow carries no `.AppImage.sig` and the
+ * updater cannot accept it. The minisign key never leaves the ship machine, so
+ * the signature is produced here, by hand, against an already-published tag:
+ *
+ *   1. Verify the tag's release is published (not a draft) and actually holds
+ *      the expected `o8_<version>_linux_amd64_preview.AppImage`
+ *   2. Download that asset
+ *   3. Sign it with the same key + invocation the macOS updater artifact uses
+ *   4. Upload `<asset>.sig` next to it, and a regenerated `latest.json` that
+ *      gains exactly one `linux-x86_64` entry (darwin entries untouched)
+ *
+ * Usage:
+ *   npm run ship:linux-sig -- --tag v0.1.724
+ *   npm run ship:linux-sig -- --tag v0.1.724 --repo hurttlocker/o8 --repo hurttlocker/o8-releases
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  DEFAULT_REPOS,
+  createLinuxSignatureDeps,
+  signLinuxAppImage,
+} from './lib/linux-appimage-signature.mjs';
+
+const LOG = '[sign-linux-appimage]';
+
+function parseArgs(argv) {
+  const options = { tag: null, repos: [], help: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--help' || arg === '-h') options.help = true;
+    else if (arg === '--tag') options.tag = argv[++index] ?? null;
+    else if (arg.startsWith('--tag=')) options.tag = arg.slice('--tag='.length);
+    else if (arg === '--repo') options.repos.push(argv[++index] ?? '');
+    else if (arg.startsWith('--repo=')) options.repos.push(arg.slice('--repo='.length));
+    else throw new Error(`unrecognized argument: ${arg}`);
+  }
+  if (options.repos.length === 0) options.repos = [...DEFAULT_REPOS];
+  return options;
+}
+
+function usage() {
+  console.log([
+    'Usage: npm run ship:linux-sig -- --tag <vX.Y.Z> [--repo <owner/name> ...]',
+    '',
+    'Signs the tag\'s published Linux AppImage with the operator updater key and',
+    'republishes the signature plus a latest.json carrying the linux-x86_64 entry.',
+    '',
+    `Default repositories: ${DEFAULT_REPOS.join(', ')}`,
+    '',
+    'Requires the updater signing key on this machine. Never runs on CI.',
+  ].join('\n'));
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    usage();
+    return;
+  }
+  if (!options.tag) throw new Error('--tag is required (for example --tag v0.1.724)');
+  // The key is an operator secret; a CI runner must never reach the signer.
+  if (process.env.CI) throw new Error('refusing to run on CI — the updater signing key stays on the ship machine');
+
+  const workDir = mkdtempSync(join(tmpdir(), 'o8-linux-appimage-sig-'));
+  try {
+    const result = await signLinuxAppImage({
+      tag: options.tag,
+      repos: options.repos,
+      workDir,
+      deps: createLinuxSignatureDeps(),
+      log: (message) => console.log(`${LOG} ${message}`),
+    });
+    console.log(`${LOG} published ${result.assetName}.sig and latest.json for ${options.tag}`);
+    console.log(`${LOG} linux-x86_64 url: ${result.latest.platforms['linux-x86_64'].url}`);
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(`${LOG} FATAL: ${error?.message ?? error}`);
+  process.exit(1);
+});

--- a/tests/linux-appimage-signature.test.ts
+++ b/tests/linux-appimage-signature.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DARWIN_UPDATER_ASSET,
+  GH_COMMAND,
+  LATEST_JSON_ASSET,
+  SIGNER_ARGS,
+  SIGNER_COMMAND,
+  SIGNING_KEY_ENV,
+  SIGNING_KEY_PASSWORD_ENV,
+  createLinuxSignatureDeps,
+  resolveSigningKey,
+  signLinuxAppImage,
+  versionFromTag,
+  withLinuxPlatform,
+  type LinuxSignatureDeps,
+  type ReleaseUpdaterManifest,
+} from '../scripts/lib/linux-appimage-signature.mjs';
+import { publishedLinuxAssetName } from '../scripts/lib/release-manifest.mjs';
+
+const TAG = 'v0.1.724';
+const VERSION = '0.1.724';
+const ASSET = publishedLinuxAssetName(VERSION);
+const BASE = 'https://github.com/hurttlocker/o8-releases/releases/download/v0.1.724';
+
+function publishedLatest(): ReleaseUpdaterManifest {
+  return {
+    version: VERSION,
+    notes: 'o8 v0.1.724',
+    pub_date: '2026-09-01T00:00:00.000Z',
+    platforms: {
+      'darwin-x86_64': { signature: 'darwin-sig', url: `${BASE}/${DARWIN_UPDATER_ASSET}` },
+      'darwin-aarch64': { signature: 'darwin-sig', url: `${BASE}/${DARWIN_UPDATER_ASSET}` },
+    },
+  };
+}
+
+type Call = { name: string; args: Record<string, unknown> };
+
+function harness(overrides: Partial<LinuxSignatureDeps> = {}) {
+  const calls: Call[] = [];
+  const record = (name: string, args: Record<string, unknown>) => calls.push({ name, args });
+  const deps: LinuxSignatureDeps = {
+    resolveSigningKey: () => 'operator-key',
+    fetchRelease: ({ repo, tag }) => {
+      record('fetchRelease', { repo, tag });
+      return { isDraft: false, assets: [ASSET, 'o8.app.tar.gz', LATEST_JSON_ASSET] };
+    },
+    downloadAsset: ({ repo, tag, assetName, destDir }) => {
+      record('downloadAsset', { repo, tag, assetName, destDir });
+      return `${destDir}/${assetName}`;
+    },
+    signAppImage: ({ filePath, signingKey }) => {
+      record('signAppImage', { filePath, signingKey });
+      return `${filePath}.sig`;
+    },
+    readSignature: ({ sigPath }) => {
+      record('readSignature', { sigPath });
+      return 'linux-sig\n';
+    },
+    fetchLatestJson: ({ repo, tag, destDir }) => {
+      record('fetchLatestJson', { repo, tag, destDir });
+      return publishedLatest();
+    },
+    writeLatestJson: ({ path, latest }) => { record('writeLatestJson', { path, latest }); },
+    uploadAssets: ({ repo, tag, files }) => { record('uploadAssets', { repo, tag, files }); },
+    ...overrides,
+  };
+  return { calls, deps };
+}
+
+describe('linux AppImage updater signature', () => {
+  it('signs the published asset and publishes the signature plus manifest', async () => {
+    const { calls, deps } = harness();
+    const result = await signLinuxAppImage({
+      tag: TAG,
+      repos: ['hurttlocker/o8', 'hurttlocker/o8-releases'],
+      workDir: '/work',
+      deps,
+    });
+
+    expect(result.assetName).toBe(ASSET);
+    expect(calls.filter((call) => call.name === 'fetchRelease').map((call) => call.args.repo))
+      .toEqual(['hurttlocker/o8', 'hurttlocker/o8-releases']);
+    expect(calls.find((call) => call.name === 'downloadAsset')?.args)
+      .toMatchObject({ repo: 'hurttlocker/o8', assetName: ASSET, destDir: '/work' });
+    expect(calls.find((call) => call.name === 'signAppImage')?.args)
+      .toEqual({ filePath: `/work/${ASSET}`, signingKey: 'operator-key' });
+
+    const uploads = calls.filter((call) => call.name === 'uploadAssets');
+    expect(uploads.map((call) => call.args.repo)).toEqual(['hurttlocker/o8', 'hurttlocker/o8-releases']);
+    for (const upload of uploads) {
+      expect(upload.args.files).toEqual([`/work/${ASSET}.sig`, `/work/${LATEST_JSON_ASSET}`]);
+    }
+  });
+
+  it('adds exactly one linux entry and leaves the darwin entries byte-for-byte', () => {
+    const latest = publishedLatest();
+    const next = withLinuxPlatform({ latest, version: VERSION, signature: 'linux-sig' });
+
+    expect(Object.keys(next.platforms)).toEqual(['darwin-x86_64', 'darwin-aarch64', 'linux-x86_64']);
+    expect(JSON.stringify(next.platforms['darwin-x86_64'])).toBe(JSON.stringify(latest.platforms['darwin-x86_64']));
+    expect(JSON.stringify(next.platforms['darwin-aarch64'])).toBe(JSON.stringify(latest.platforms['darwin-aarch64']));
+    expect(next.platforms['linux-x86_64']).toEqual({ signature: 'linux-sig', url: `${BASE}/${ASSET}` });
+    expect(latest.platforms['linux-x86_64']).toBeUndefined();
+  });
+
+  it('fails closed when the release is missing, a draft, or has no AppImage', async () => {
+    const missing = harness({ fetchRelease: () => null });
+    await expect(signLinuxAppImage({ tag: TAG, repos: ['o/r'], workDir: '/work', deps: missing.deps }))
+      .rejects.toThrow(/was not found in o\/r/);
+
+    const draft = harness({ fetchRelease: () => ({ isDraft: true, assets: [ASSET] }) });
+    await expect(signLinuxAppImage({ tag: TAG, repos: ['o/r'], workDir: '/work', deps: draft.deps }))
+      .rejects.toThrow(/is a draft/);
+
+    const wrongVersion = harness({
+      fetchRelease: () => ({ isDraft: false, assets: [publishedLinuxAssetName('0.1.723')] }),
+    });
+    await expect(signLinuxAppImage({ tag: TAG, repos: ['o/r'], workDir: '/work', deps: wrongVersion.deps }))
+      .rejects.toThrow(/has no o8_0\.1\.724_linux_amd64_preview\.AppImage asset/);
+
+    expect(missing.calls.some((call) => call.name === 'downloadAsset')).toBe(false);
+    expect(draft.calls.some((call) => call.name === 'signAppImage')).toBe(false);
+    expect(wrongVersion.calls.some((call) => call.name === 'uploadAssets')).toBe(false);
+  });
+
+  it('fails closed on a malformed tag, an empty signature, and a mismatched manifest version', async () => {
+    expect(() => versionFromTag('0.1.724')).toThrow(/must look like/);
+
+    const empty = harness({ readSignature: () => '  \n' });
+    await expect(signLinuxAppImage({ tag: TAG, repos: ['o/r'], workDir: '/work', deps: empty.deps }))
+      .rejects.toThrow(/produced no signature/);
+    expect(empty.calls.some((call) => call.name === 'uploadAssets')).toBe(false);
+
+    const stale = harness({ fetchLatestJson: () => ({ ...publishedLatest(), version: '0.1.723' }) });
+    await expect(signLinuxAppImage({ tag: TAG, repos: ['o/r'], workDir: '/work', deps: stale.deps }))
+      .rejects.toThrow(/is version 0\.1\.723, not 0\.1\.724/);
+    expect(stale.calls.some((call) => call.name === 'uploadAssets')).toBe(false);
+  });
+
+  it('fails closed when the signing key is absent from the env and the ship machine', () => {
+    expect(() => resolveSigningKey({ env: { HOME: '/home/nobody' }, fileExists: () => false }))
+      .toThrow(/signing key unavailable/);
+    expect(resolveSigningKey({ env: { [SIGNING_KEY_ENV]: ' env-key ' }, fileExists: () => false }))
+      .toBe('env-key');
+    expect(resolveSigningKey({
+      env: { HOME: '/home/ship' },
+      fileExists: (path) => path === '/home/ship/.tauri/cortex-ide.key',
+      readFile: () => 'file-key\n',
+    })).toBe('file-key');
+  });
+
+  it('builds the download, signer, and upload argv the operator expects', () => {
+    const invocations: Array<{ command: string; args: string[]; env?: Record<string, string | undefined> }> = [];
+    const deps = createLinuxSignatureDeps({
+      env: { PATH: '/usr/bin' },
+      readFile: () => '{"version":"0.1.724"}',
+      run: (command, args, options) => {
+        invocations.push({ command, args, env: options?.env });
+        return '{"isDraft":false,"assets":[{"name":"a"}]}';
+      },
+    });
+
+    deps.fetchRelease({ repo: 'o/r', tag: TAG });
+    deps.downloadAsset({ repo: 'o/r', tag: TAG, assetName: ASSET, destDir: '/work' });
+    deps.signAppImage({ filePath: `/work/${ASSET}`, signingKey: 'operator-key' });
+    deps.uploadAssets({ repo: 'o/r', tag: TAG, files: [`/work/${ASSET}.sig`, `/work/${LATEST_JSON_ASSET}`] });
+
+    expect(invocations[0]).toMatchObject({
+      command: GH_COMMAND,
+      args: ['release', 'view', TAG, '--repo', 'o/r', '--json', 'isDraft,assets'],
+    });
+    expect(invocations[1]).toMatchObject({
+      command: GH_COMMAND,
+      args: ['release', 'download', TAG, '--repo', 'o/r', '--pattern', ASSET, '--dir', '/work', '--clobber'],
+    });
+    expect(invocations[2].command).toBe(SIGNER_COMMAND);
+    expect(invocations[2].args).toEqual([...SIGNER_ARGS, `/work/${ASSET}`]);
+    expect(invocations[2].env?.[SIGNING_KEY_ENV]).toBe('operator-key');
+    expect(invocations[2].env?.[SIGNING_KEY_PASSWORD_ENV]).toBe('');
+    expect(invocations[3]).toMatchObject({
+      command: GH_COMMAND,
+      args: [
+        'release', 'upload', TAG,
+        `/work/${ASSET}.sig`, `/work/${LATEST_JSON_ASSET}`,
+        '--clobber', '--repo', 'o/r',
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Closes #2057

The port-build workflow builds Linux with `createUpdaterArtifacts: false`, so the AppImage it publishes has no `.sig` and the updater cannot accept it. The updater signing key never reaches a CI runner, so the signature has to be produced afterwards, by hand, on the release host.

## The step

```bash
npm run ship:linux-sig -- --tag v0.1.724
```

`scripts/sign-linux-appimage.mjs` (logic in `scripts/lib/linux-appimage-signature.mjs`):

1. Parses the tag into a version and refuses to run when `CI` is set.
2. Resolves the key exactly the way the signed macOS build does — `TAURI_SIGNING_PRIVATE_KEY`, else the operator key file `tauri:build:signed` already points at. No new signing path, no key material logged.
3. Requires every target repository to hold a published (non-draft) release carrying `publishedLinuxAssetName(version)` — the version gate from #2062, applied to the published asset name.
4. Downloads that asset, signs it with the same signer invocation `sign-and-notarize.mjs` uses for the macOS updater artifact.
5. Uploads `<asset>.sig` beside it, plus a regenerated `latest.json`.

`latest.json` is the published one with a single `linux-x86_64` entry added through `linuxUpdaterPlatform()`, a helper extracted from `buildReleaseManifest` so both paths share one definition of that entry. Darwin entries are carried across by reference, so they stay byte-for-byte identical.

Fail-closed before the key is used or anything is published: malformed tag, absent key, missing release, draft release, missing or version-mismatched AppImage, empty signature, `latest.json` whose version does not match the tag.

## Verification

`tests/linux-appimage-signature.test.ts` injects the download, sign, and upload functions — the real signer never runs. It asserts the argv of each invocation, every fail-closed branch (including that nothing downloads, signs, or uploads once a precondition trips), and that the manifest gains exactly one linux entry with the darwin entries unchanged.

`npx tsc --noEmit` 0 · `npm run lint` 0 · new + `tests/release-artifacts.test.ts` 13 passed · `npm run test:classification:check` 0 (test is hermetic, no manifest entry) · `npm run rule-check` 0.

Docs: "Linux signature" subsection under the release boundary in `docs/operations/deployment.md`.

Not run for real against a release — that is the operator's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuwAJQVFhKFmL7C1RWDx1T
