### PR TITLE
fix: guard external release build cache

### DIFF
--- a/docs/operations/release-build-cache.md
+++ b/docs/operations/release-build-cache.md
@@ -31,6 +31,18 @@ This verification detects corruption and metadata mismatch. It does not turn an 
 
 Set `O8_RELEASE_BUILD_CACHE_DIR` to isolate a canary or move the cache to another local volume. Set `O8_RELEASE_BUILD_CACHE=off` to bypass restore and capture without changing the build command.
 
+For a macOS external volume, create a private marker at the volume root whose contents are a stable operator-chosen identity, then configure both the cache directory and that identity:
+
+```bash
+export O8_RELEASE_BUILD_CACHE_VOLUME_ID="<stable-volume-identity>"
+printf '%s\n' "$O8_RELEASE_BUILD_CACHE_VOLUME_ID" > "/Volumes/<volume>/.o8-release-cache-volume"
+export O8_RELEASE_BUILD_CACHE_DIR="/Volumes/<volume>/o8/release-cache"
+```
+
+Create the marker while the intended volume is mounted. Do not pre-create `/Volumes/<volume>` when it is absent. Before every restore or capture, the wrapper reads the marker and requires its contents to exactly match `O8_RELEASE_BUILD_CACHE_VOLUME_ID`. A missing marker, missing identity, or changed marker causes one warning and selects the local default instead; the wrapper never creates the configured `/Volumes/...` path in that state. `O8_RELEASE_BUILD_CACHE_LOCAL_DIR` can override the fallback for a hermetic canary.
+
+The cache-entry budget defaults to 4 GiB on the local root and 20 GiB on a validated external root. Set `O8_RELEASE_BUILD_CACHE_MAX_BYTES` to a non-negative integer byte count to override it. Capture prunes whole compatibility entries oldest-first, with relative path as the deterministic tie-breaker. Receipts are outside the budget and are not pruned.
+
 The cache retains one source entry for each compatibility identity and the two newest compatibility identities for each phase. This bounds the large native and web intermediates while preserving the most useful rollback point.
 
 ## Receipts

--- a/scripts/lib/release-build-cache.d.mts
+++ b/scripts/lib/release-build-cache.d.mts
@@ -24,7 +24,10 @@ export interface ReleaseBuildCacheAction {
   estimatedSavedMs?: number | null;
 }
 
-export function resolveReleaseBuildCacheRoot(env?: NodeJS.ProcessEnv): string;
+export function resolveReleaseBuildCacheRoot(
+  env?: NodeJS.ProcessEnv,
+  options?: { warn?: (line: string) => void },
+): string;
 export function isReleaseBuildCacheSafetyError(error: unknown): boolean;
 export function collectReleaseBuildCacheIdentity(
   root: string,
@@ -74,6 +77,11 @@ export const releaseBuildCacheInternals: {
   collectWebEnvironmentFiles(root: string): Array<{ path: string; sha256: string }>;
   normalizeArchivePath(value: string): string | null;
   pathAllowed(candidate: string, targets: string[], excludes: string[]): boolean;
+  pruneCacheToBudget(
+    cacheRoot: string,
+    budgetBytes: number,
+    projectRoot: string,
+  ): { removedBytes: number; remainingBytes: number; removedEntries: number };
   sha256File(path: string): Promise<string>;
   stableJson(value: unknown): string;
 };

--- a/scripts/lib/release-build-cache.mjs
+++ b/scripts/lib/release-build-cache.mjs
@@ -577,6 +577,16 @@ function pruneCacheToBudget(cacheRoot, budgetBytes, projectRoot) {
   const entriesRoot = join(cacheRoot, 'entries');
   if (!existsSync(entriesRoot)) return { removedBytes: 0, remainingBytes: 0, removedEntries: 0 };
   assertOutsideProjectNodeModules(entriesRoot, projectRoot);
+  const entriesMetadata = lstatSync(entriesRoot);
+  const resolvedCacheRoot = realpathWithMissingSegments(cacheRoot);
+  const resolvedEntriesRoot = realpathWithMissingSegments(entriesRoot);
+  if (entriesMetadata.isSymbolicLink()
+    || !resolvedPathInside(resolvedEntriesRoot, resolvedCacheRoot)) {
+    throw new Error('release cache budget refused entries root outside the cache root');
+  }
+  if (!entriesMetadata.isDirectory()) {
+    throw new Error('release cache budget refused non-directory entries root');
+  }
   const candidates = [];
   for (const phase of readdirSync(entriesRoot).sort()) {
     const phaseRoot = join(entriesRoot, phase);

--- a/scripts/lib/release-build-cache.mjs
+++ b/scripts/lib/release-build-cache.mjs
@@ -23,6 +23,9 @@ export const RELEASE_BUILD_CACHE_RECEIPT_SCHEMA = 'o8/release-build-cache-receip
 export const RELEASE_BUILD_CACHE_PHASES = Object.freeze(['web', 'speech', 'native']);
 
 const CACHE_VERSION_DIR = 'release-v1';
+const EXTERNAL_VOLUME_MARKER = '.o8-release-cache-volume';
+const LOCAL_CACHE_BUDGET_BYTES = 4 * 1024 * 1024 * 1024;
+const EXTERNAL_CACHE_BUDGET_BYTES = 20 * 1024 * 1024 * 1024;
 const ENTRY_LIMIT = 1;
 const COMPATIBILITY_LIMIT = 2;
 const UNSAFE_PATH_ERROR_CODE = 'O8_RELEASE_CACHE_UNSAFE_PATH';
@@ -171,8 +174,69 @@ function collectWebEnvironmentFiles(root) {
   });
 }
 
-export function resolveReleaseBuildCacheRoot(env = process.env) {
-  return resolve(env.O8_RELEASE_BUILD_CACHE_DIR?.trim() || join(homedir(), '.o8-build-cache', CACHE_VERSION_DIR));
+function localCacheRoot(env) {
+  return resolve(env.O8_RELEASE_BUILD_CACHE_LOCAL_DIR?.trim()
+    || join(homedir(), '.o8-build-cache', CACHE_VERSION_DIR));
+}
+
+function externalVolumeRoot(configuredRoot, env) {
+  const explicit = env.O8_RELEASE_BUILD_CACHE_EXTERNAL_ROOT?.trim();
+  if (explicit) return resolve(explicit);
+  const match = configuredRoot.match(/^\/Volumes\/[^/]+(?:\/|$)/);
+  return match ? match[0].replace(/\/$/, '') : null;
+}
+
+export function resolveReleaseBuildCacheRoot(env = process.env, options = {}) {
+  const configured = env.O8_RELEASE_BUILD_CACHE_DIR?.trim();
+  if (!configured) return localCacheRoot(env);
+  const configuredRoot = resolve(configured);
+  const volumeRoot = externalVolumeRoot(configuredRoot, env);
+  if (!volumeRoot) return configuredRoot;
+  const expectedVolumeId = env.O8_RELEASE_BUILD_CACHE_VOLUME_ID?.trim();
+  const markerPath = join(volumeRoot, EXTERNAL_VOLUME_MARKER);
+  let actualVolumeId = null;
+  try {
+    const markerMetadata = lstatSync(markerPath);
+    if (markerMetadata.isFile() && !markerMetadata.isSymbolicLink()) {
+      actualVolumeId = readFileSync(markerPath, 'utf8').trim();
+    }
+  } catch {}
+  if (expectedVolumeId && actualVolumeId === expectedVolumeId
+    && resolvedPathInside(realpathWithMissingSegments(configuredRoot), realpathWithMissingSegments(volumeRoot))) {
+    return configuredRoot;
+  }
+  const fallback = localCacheRoot(env);
+  const reason = !expectedVolumeId ? 'volume identity is not configured'
+    : actualVolumeId === null ? 'mount marker is missing'
+      : actualVolumeId !== expectedVolumeId ? 'mount identity changed'
+        : 'cache directory is outside the external root';
+  (options.warn ?? console.warn)(
+    `[release-cache] external cache unavailable (${reason}); using local cache`,
+  );
+  return fallback;
+}
+
+function cacheBudgetBytes(env, cacheRoot) {
+  const configured = env.O8_RELEASE_BUILD_CACHE_MAX_BYTES?.trim();
+  if (configured) {
+    const parsed = Number(configured);
+    if (!Number.isSafeInteger(parsed) || parsed < 0) {
+      throw new Error('O8_RELEASE_BUILD_CACHE_MAX_BYTES must be a non-negative integer');
+    }
+    return parsed;
+  }
+  const configuredRoot = env.O8_RELEASE_BUILD_CACHE_DIR?.trim()
+    ? resolve(env.O8_RELEASE_BUILD_CACHE_DIR.trim())
+    : null;
+  return configuredRoot === cacheRoot && externalVolumeRoot(cacheRoot, env)
+    ? EXTERNAL_CACHE_BUDGET_BYTES
+    : LOCAL_CACHE_BUDGET_BYTES;
+}
+
+function operationCacheRoot(options) {
+  const env = options.env ?? process.env;
+  if (env.O8_RELEASE_BUILD_CACHE_DIR?.trim()) return resolveReleaseBuildCacheRoot(env);
+  return options.cacheRoot ?? resolveReleaseBuildCacheRoot(env);
 }
 
 export function collectReleaseBuildCacheIdentity(root, phase, options = {}) {
@@ -385,7 +449,7 @@ export async function restoreReleaseBuildCache(root, phase, options = {}) {
     return { phase, status: 'bypass', reason: 'disabled', durationMs: Date.now() - started };
   }
   const identity = options.identity ?? collectReleaseBuildCacheIdentity(root, phase, options);
-  const cacheRoot = options.cacheRoot ?? resolveReleaseBuildCacheRoot(options.env);
+  const cacheRoot = operationCacheRoot(options);
   if (identity.source.worktreeClean === false) {
     return { phase, status: 'bypass', reason: 'dirty_worktree', durationMs: Date.now() - started };
   }
@@ -492,13 +556,63 @@ function pruneCompatibilityDirectories(cacheRoot, phase, keepCompatibility, proj
   }
 }
 
+function directoryUsage(path, root = path) {
+  const metadata = lstatSync(path);
+  if (metadata.isSymbolicLink()) {
+    throw new Error(`release cache budget refused symbolic link: ${relative(root, path) || '.'}`);
+  }
+  if (metadata.isFile()) return { bytes: metadata.size, oldestMtimeMs: metadata.mtimeMs };
+  if (!metadata.isDirectory()) return { bytes: 0, oldestMtimeMs: metadata.mtimeMs };
+  let bytes = 0;
+  let oldestMtimeMs = metadata.mtimeMs;
+  for (const name of readdirSync(path).sort()) {
+    const usage = directoryUsage(join(path, name), root);
+    bytes += usage.bytes;
+    oldestMtimeMs = Math.min(oldestMtimeMs, usage.oldestMtimeMs);
+  }
+  return { bytes, oldestMtimeMs };
+}
+
+function pruneCacheToBudget(cacheRoot, budgetBytes, projectRoot) {
+  const entriesRoot = join(cacheRoot, 'entries');
+  if (!existsSync(entriesRoot)) return { removedBytes: 0, remainingBytes: 0, removedEntries: 0 };
+  assertOutsideProjectNodeModules(entriesRoot, projectRoot);
+  const candidates = [];
+  for (const phase of readdirSync(entriesRoot).sort()) {
+    const phaseRoot = join(entriesRoot, phase);
+    const phaseMetadata = lstatSync(phaseRoot);
+    if (phaseMetadata.isSymbolicLink()) {
+      throw new Error(`release cache budget refused symbolic link: ${relative(entriesRoot, phaseRoot)}`);
+    }
+    if (!phaseMetadata.isDirectory()) continue;
+    for (const name of readdirSync(phaseRoot).sort()) {
+      const path = join(phaseRoot, name);
+      const usage = directoryUsage(path, entriesRoot);
+      candidates.push({ path, relativePath: relative(entriesRoot, path), ...usage });
+    }
+  }
+  let remainingBytes = candidates.reduce((sum, entry) => sum + entry.bytes, 0);
+  let removedBytes = 0;
+  let removedEntries = 0;
+  candidates.sort((left, right) => left.oldestMtimeMs - right.oldestMtimeMs
+    || left.relativePath.localeCompare(right.relativePath));
+  for (const entry of candidates) {
+    if (remainingBytes <= budgetBytes) break;
+    removeCachePath(entry.path, { recursive: true, force: true }, projectRoot);
+    remainingBytes -= entry.bytes;
+    removedBytes += entry.bytes;
+    removedEntries += 1;
+  }
+  return { removedBytes, remainingBytes, removedEntries };
+}
+
 export async function captureReleaseBuildCache(root, phase, options = {}) {
   const started = Date.now();
   if ((options.env ?? process.env).O8_RELEASE_BUILD_CACHE === 'off') {
     return { phase, status: 'bypass', reason: 'disabled', durationMs: Date.now() - started };
   }
   const identity = options.identity ?? collectReleaseBuildCacheIdentity(root, phase, options);
-  const cacheRoot = options.cacheRoot ?? resolveReleaseBuildCacheRoot(options.env);
+  const cacheRoot = operationCacheRoot(options);
   if (identity.source.worktreeClean === false) {
     return { phase, status: 'bypass', reason: 'dirty_worktree', durationMs: Date.now() - started };
   }
@@ -559,6 +673,14 @@ export async function captureReleaseBuildCache(root, phase, options = {}) {
     renameCachePath(temporaryManifest, finalManifestPath, root);
     pruneEntries(directory, identity.entrySha256, root);
     pruneCompatibilityDirectories(cacheRoot, phase, identity.compatibilitySha256, root);
+    const pruned = pruneCacheToBudget(
+      cacheRoot,
+      cacheBudgetBytes(options.env ?? process.env, cacheRoot),
+      root,
+    );
+    if (pruned.removedEntries > 0) {
+      console.log(`[release-cache] budget pruned=${pruned.removedEntries} bytes=${pruned.removedBytes}`);
+    }
     return {
       phase,
       status: 'captured',
@@ -629,6 +751,7 @@ export const releaseBuildCacheInternals = {
   collectWebEnvironmentFiles,
   normalizeArchivePath,
   pathAllowed,
+  pruneCacheToBudget,
   sha256File,
   stableJson,
 };

--- a/tests/release-build-cache.test.ts
+++ b/tests/release-build-cache.test.ts
@@ -6,6 +6,7 @@ import {
   readdirSync,
   rmSync,
   symlinkSync,
+  utimesSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -16,6 +17,7 @@ import {
   collectReleaseBuildCacheIdentity,
   finalizeReleaseBuildCacheReceipt,
   releaseBuildCacheInternals,
+  resolveReleaseBuildCacheRoot,
   restoreReleaseBuildCache,
   writeReleaseBuildCachePhaseReceipt,
   type ReleaseBuildCacheIdentity,
@@ -56,6 +58,111 @@ function nativeIdentity(source: string): ReleaseBuildCacheIdentity {
 }
 
 describe('shared release build cache', () => {
+  it('uses a configured external root only while its mount marker identity matches', async () => {
+    const { root } = fixture();
+    const volumeRoot = mkdtempSync(join(tmpdir(), 'o8-release-cache-volume-'));
+    roots.push(volumeRoot);
+    const cacheRoot = join(volumeRoot, 'cache');
+    const marker = join(volumeRoot, '.o8-release-cache-volume');
+    const localRoot = join(root, 'local-fallback');
+    const warnings: string[] = [];
+    const env = {
+      NODE_ENV: 'test' as const,
+      O8_RELEASE_BUILD_CACHE_DIR: cacheRoot,
+      O8_RELEASE_BUILD_CACHE_EXTERNAL_ROOT: volumeRoot,
+      O8_RELEASE_BUILD_CACHE_VOLUME_ID: 'archive-a',
+      O8_RELEASE_BUILD_CACHE_LOCAL_DIR: localRoot,
+    };
+
+    expect(resolveReleaseBuildCacheRoot(env, { warn: (line) => warnings.push(line) })).toBe(localRoot);
+    expect(existsSync(cacheRoot)).toBe(false);
+    expect(warnings).toHaveLength(1);
+
+    writeFileSync(marker, 'archive-a\n');
+    expect(resolveReleaseBuildCacheRoot(env)).toBe(cacheRoot);
+    expect(await captureReleaseBuildCache(root, 'web', { env, identity: identity('a') }))
+      .toMatchObject({ status: 'captured' });
+
+    writeFileSync(marker, 'archive-b\n');
+    expect(resolveReleaseBuildCacheRoot(env, { warn: () => {} })).toBe(localRoot);
+    expect(await captureReleaseBuildCache(root, 'web', { env, identity: identity('b') }))
+      .toMatchObject({ status: 'captured' });
+    expect(existsSync(join(cacheRoot, 'entries', 'web', 'compatibility-a', 'entry-b.tar'))).toBe(false);
+    expect(existsSync(join(localRoot, 'entries', 'web', 'compatibility-a', 'entry-b.tar'))).toBe(true);
+  });
+
+  it('rejects a symlinked external-volume marker', () => {
+    const { root } = fixture();
+    const volumeRoot = mkdtempSync(join(tmpdir(), 'o8-release-cache-volume-'));
+    roots.push(volumeRoot);
+    const identityFile = join(root, 'identity');
+    writeFileSync(identityFile, 'archive-a\n');
+    symlinkSync(identityFile, join(volumeRoot, '.o8-release-cache-volume'));
+
+    expect(resolveReleaseBuildCacheRoot({
+      NODE_ENV: 'test' as const,
+      O8_RELEASE_BUILD_CACHE_DIR: join(volumeRoot, 'cache'),
+      O8_RELEASE_BUILD_CACHE_EXTERNAL_ROOT: volumeRoot,
+      O8_RELEASE_BUILD_CACHE_VOLUME_ID: 'archive-a',
+      O8_RELEASE_BUILD_CACHE_LOCAL_DIR: join(root, 'fallback'),
+    }, { warn: () => {} })).toBe(join(root, 'fallback'));
+    expect(existsSync(join(volumeRoot, 'cache'))).toBe(false);
+  });
+
+  it('prunes oldest cache entries to a deterministic byte budget without touching receipts', async () => {
+    const { root, cacheRoot } = fixture();
+    const entries = join(cacheRoot, 'entries', 'web');
+    const oldEntry = join(entries, 'old', 'old.tar');
+    const tiedEntry = join(entries, 'tied', 'tied.tar');
+    const newEntry = join(entries, 'new', 'new.tar');
+    const receipt = join(cacheRoot, 'receipts', 'keep.json');
+    for (const path of [oldEntry, tiedEntry, newEntry, receipt]) {
+      mkdirSync(join(path, '..'), { recursive: true });
+      writeFileSync(path, '12345');
+    }
+    utimesSync(oldEntry, 1, 1);
+    utimesSync(tiedEntry, 2, 2);
+    utimesSync(newEntry, 2, 2);
+
+    const result = releaseBuildCacheInternals.pruneCacheToBudget(cacheRoot, 5, root);
+    expect(result).toMatchObject({ removedBytes: 10, remainingBytes: 5 });
+    expect(existsSync(oldEntry)).toBe(false);
+    expect(existsSync(newEntry)).toBe(false);
+    expect(existsSync(tiedEntry)).toBe(true);
+    expect(readFileSync(receipt, 'utf8')).toBe('12345');
+  });
+
+  it('enforces the configured budget through capture', async () => {
+    const { root, cacheRoot } = fixture();
+    const receipt = join(cacheRoot, 'receipts', 'keep.json');
+    mkdirSync(join(cacheRoot, 'receipts'), { recursive: true });
+    writeFileSync(receipt, 'keep');
+
+    expect(await captureReleaseBuildCache(root, 'web', {
+      env: {
+        NODE_ENV: 'test' as const,
+        O8_RELEASE_BUILD_CACHE_DIR: cacheRoot,
+        O8_RELEASE_BUILD_CACHE_MAX_BYTES: '0',
+      },
+      identity: identity('budget'),
+    })).toMatchObject({ status: 'captured' });
+    expect(readdirSync(join(cacheRoot, 'entries', 'web'))).toEqual([]);
+    expect(readFileSync(receipt, 'utf8')).toBe('keep');
+  });
+
+  it('refuses budget pruning when entries escape the cache root through a symlink', () => {
+    const { root, cacheRoot } = fixture();
+    const outside = mkdtempSync(join(tmpdir(), 'o8-release-cache-outside-'));
+    roots.push(outside);
+    const marker = join(outside, 'must-survive');
+    writeFileSync(marker, 'safe');
+    mkdirSync(join(cacheRoot, 'entries'), { recursive: true });
+    symlinkSync(outside, join(cacheRoot, 'entries', 'escape'), 'dir');
+
+    expect(() => releaseBuildCacheInternals.pruneCacheToBudget(cacheRoot, 0, root)).toThrow('symbolic link');
+    expect(readFileSync(marker, 'utf8')).toBe('safe');
+  });
+
   it('hashes local production environment files without recording their values', () => {
     const { root } = fixture();
     writeFileSync(join(root, '.env.local'), 'NEXT_PUBLIC_CACHE_CANARY=secret-one\n');

--- a/tests/release-build-cache.test.ts
+++ b/tests/release-build-cache.test.ts
@@ -163,6 +163,20 @@ describe('shared release build cache', () => {
     expect(readFileSync(marker, 'utf8')).toBe('safe');
   });
 
+  it('refuses budget pruning when the entries root is a symlink', () => {
+    const { root, cacheRoot } = fixture();
+    const outside = mkdtempSync(join(tmpdir(), 'o8-release-cache-outside-'));
+    roots.push(outside);
+    const marker = join(outside, 'must-survive');
+    writeFileSync(marker, 'safe');
+    mkdirSync(cacheRoot, { recursive: true });
+    symlinkSync(outside, join(cacheRoot, 'entries'), 'dir');
+
+    expect(() => releaseBuildCacheInternals.pruneCacheToBudget(cacheRoot, 0, root))
+      .toThrow('entries root outside the cache root');
+    expect(readFileSync(marker, 'utf8')).toBe('safe');
+  });
+
   it('hashes local production environment files without recording their values', () => {
     const { root } = fixture();
     writeFileSync(join(root, '.env.local'), 'NEXT_PUBLIC_CACHE_CANARY=secret-one\n');


### PR DESCRIPTION
## Outcome

Adopts the complete cache-budget implementation from #1988 onto current `main` while preserving that pull request as the attribution record.

- validates the configured external volume before reuse
- falls back to the local cache when validation fails
- enforces deterministic local and external byte budgets
- records the operating contract and tests the real cache path
- rejects a top-level `entries` symlink before any budget pruning can escape the cache root

Closes #1940. Supersedes #1988.

## Verification

- `npx vitest run tests/release-build-cache.test.ts` (16 passed)
- `npx tsc --noEmit`
- touched-file ESLint
- `npm run test:classification:check`
- `npm run rule-check -- --base=origin/main`
- `npm test` (655 files passed, 3 skipped; 3932 tests passed, 3 skipped)
- `git diff --check origin/main...HEAD`