### PR TITLE
fix: retain managed run post-mortems

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,7 @@ o8 project delete <id|name>
 o8 run <cmd...>                            # stream in an o8-owned terminal visible to the operator
 o8 run --detach <cmd...>                   # register a server/daemon and return immediately
 o8 run --list                              # managed runs with recent exit codes
+o8 run --last                              # latest command, exit receipt, and retained log
 o8 run stop <run-id>                       # stop a managed run
 o8 run -- <cmd...>                         # use -- when the wrapped command has flags
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -29,6 +29,7 @@ JSON to stdout is the default; pass `--human` for ANSI-formatted output.
 | `o8 packet stop <id>` | Interrupt the worker and hold the packet; resume with `packet reset` or `packet rerun`; `packet cancel` is an alias |
 | `o8 mission stop --mission <id>` | Interrupt and hold every packet in a mission, then print per-packet results |
 | `o8 run stop <runId>` | Stop an o8-managed run listed by `o8 run --list` |
+| `o8 run --last` | Show the latest run's command, start time, durable exit receipt, and retained log path |
 | `o8 packet log <event>` | (Phase-1 stub) — will append a structured lane event once the backend route lands |
 
 ## Configuration

--- a/cli/src/commands/run-receipts.ts
+++ b/cli/src/commands/run-receipts.ts
@@ -1,0 +1,123 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { resolveCliDataDir } from '../config.js';
+
+const RECEIPT_RETENTION = 50;
+
+export interface ManagedRunReceiptMetadata {
+  schema: 'o8/cli/run-receipt/v1';
+  id: string;
+  session: string;
+  command: string;
+  cwd: string;
+  startedAt: string;
+  mode: 'stream' | 'detach';
+}
+
+export interface LastManagedRunReceipt extends ManagedRunReceiptMetadata {
+  exitStatus: string | null;
+  logPath: string;
+}
+
+export function managedRunReceiptPaths(id: string, dataDir = resolveCliDataDir()) {
+  const directory = join(dataDir, 'logs', 'run');
+  return {
+    directory,
+    logFile: join(directory, `${id}.log`),
+    exitFile: join(directory, `${id}.exit`),
+    metadataFile: join(directory, `${id}.json`),
+  };
+}
+
+function isManagedRunReceiptMetadata(value: unknown): value is ManagedRunReceiptMetadata {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Record<string, unknown>;
+  return candidate.schema === 'o8/cli/run-receipt/v1'
+    && typeof candidate.id === 'string'
+    && /^[a-f0-9]{8}$/.test(candidate.id)
+    && candidate.session === `cortex-run-${candidate.id}`
+    && typeof candidate.command === 'string'
+    && typeof candidate.cwd === 'string'
+    && typeof candidate.startedAt === 'string'
+    && (candidate.mode === 'stream' || candidate.mode === 'detach');
+}
+
+function readReceiptMetadata(directory: string): ManagedRunReceiptMetadata[] {
+  if (!existsSync(directory)) return [];
+  return readdirSync(directory)
+    .filter((name) => name.endsWith('.json'))
+    .flatMap((name) => {
+      try {
+        const parsed = JSON.parse(readFileSync(join(directory, name), 'utf8')) as unknown;
+        return isManagedRunReceiptMetadata(parsed) ? [parsed] : [];
+      } catch {
+        return [];
+      }
+    })
+    .sort((left, right) => right.startedAt.localeCompare(left.startedAt)
+      || right.id.localeCompare(left.id));
+}
+
+function pruneRunReceipts(directory: string): void {
+  for (const receipt of readReceiptMetadata(directory).slice(RECEIPT_RETENTION)) {
+    const exitFile = join(directory, `${receipt.id}.exit`);
+    if (!existsSync(exitFile)) continue;
+    for (const path of [
+      join(directory, `${receipt.id}.log`),
+      exitFile,
+      join(directory, `${receipt.id}.json`),
+    ]) {
+      try { rmSync(path, { force: true }); } catch {}
+    }
+  }
+}
+
+export function initializeManagedRunReceipt(
+  metadata: ManagedRunReceiptMetadata,
+  dataDir = resolveCliDataDir(),
+) {
+  const paths = managedRunReceiptPaths(metadata.id, dataDir);
+  try {
+    mkdirSync(paths.directory, { recursive: true, mode: 0o700 });
+    rmSync(paths.exitFile, { force: true });
+    writeFileSync(paths.logFile, '', { mode: 0o600 });
+    writeFileSync(paths.metadataFile, `${JSON.stringify(metadata)}\n`, { mode: 0o600 });
+  } catch (error) {
+    for (const path of [paths.logFile, paths.exitFile, paths.metadataFile]) {
+      try { rmSync(path, { force: true }); } catch {}
+    }
+    throw error;
+  }
+  pruneRunReceipts(paths.directory);
+  return paths;
+}
+
+export function readLastManagedRunReceipt(
+  dataDir = resolveCliDataDir(),
+): LastManagedRunReceipt | null {
+  const directory = join(dataDir, 'logs', 'run');
+  const latest = readReceiptMetadata(directory)[0];
+  if (!latest) return null;
+  const { logFile, exitFile } = managedRunReceiptPaths(latest.id, dataDir);
+  let exitStatus: string | null = null;
+  try {
+    const value = readFileSync(exitFile, 'utf8').trim();
+    if (value) exitStatus = value;
+  } catch { /* a live run has no exit receipt yet */ }
+  return { ...latest, exitStatus, logPath: logFile };
+}
+
+export function exitCodeFromStatus(status: string): number | null {
+  if (/^\d+$/.test(status)) return Number.parseInt(status, 10);
+  const signal = status.match(/^signal:(HUP|INT|QUIT|KILL|TERM)$/)?.[1];
+  if (!signal) return null;
+  const number = { HUP: 1, INT: 2, QUIT: 3, KILL: 9, TERM: 15 }[signal];
+  return number === undefined ? null : 128 + number;
+}

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -32,12 +32,19 @@ import { pathToFileURL } from 'node:url';
 import { apiFetch, CliError, EXIT } from '../api.js';
 import { resolveConfig } from '../config.js';
 import { resolveLaneFromCwd } from './packet/worktree-resolve.js';
+import {
+  exitCodeFromStatus,
+  initializeManagedRunReceipt,
+  readLastManagedRunReceipt,
+  type ManagedRunReceiptMetadata,
+} from './run-receipts.js';
 import { printJson, printHumanHeading, printHumanKv, type OutputMode } from '../output.js';
 
 /** Flags consumed by `o8 run` itself (everything else is the command). */
 const RUN_LEADING_FLAGS = new Set([
   '--detach',
   '--list',
+  '--last',
   '--human',
   '--json',
   '--verbose',
@@ -182,7 +189,7 @@ async function settleOwnedSessionLocally(
  * arbitrary command — re-parse from process.argv. Supports both
  * `o8 run <cmd...>` and `o8 run [--detach] -- <cmd...>`.
  */
-function extractRunCommand(): { detach: boolean; list: boolean; command: string[] } {
+function extractRunCommand(): { detach: boolean; list: boolean; last: boolean; command: string[] } {
   const argv = process.argv.slice(2);
   const runIdx = argv.indexOf('run');
   const after = runIdx >= 0 ? argv.slice(runIdx + 1) : [];
@@ -202,7 +209,12 @@ function extractRunCommand(): { detach: boolean; list: boolean; command: string[
     }
     command = after.slice(i);
   }
-  return { detach: flags.includes('--detach'), list: flags.includes('--list'), command };
+  return {
+    detach: flags.includes('--detach'),
+    list: flags.includes('--list'),
+    last: flags.includes('--last'),
+    command,
+  };
 }
 
 interface ManagedRunRow {
@@ -260,6 +272,27 @@ async function runRunList(mode: OutputMode): Promise<number> {
   return 0;
 }
 
+function runRunLast(mode: OutputMode): number {
+  const run = readLastManagedRunReceipt();
+  if (mode.human) {
+    printHumanHeading('last o8 run');
+    if (!run) {
+      process.stdout.write('  (no retained runs)\n');
+    } else {
+      printHumanKv([
+        ['id', run.id],
+        ['command', run.command],
+        ['started', run.startedAt],
+        ['exit', run.exitStatus ?? 'running or not yet reconciled'],
+        ['log', run.logPath],
+      ]);
+    }
+  } else {
+    printJson({ schema: 'o8/cli/run.last/v1', run });
+  }
+  return 0;
+}
+
 async function runRunStop(mode: OutputMode, command: string[]): Promise<number> {
   const { runId } = parseRunStopArgs(command);
   const cfg = resolveConfig();
@@ -304,9 +337,10 @@ async function runRunStop(mode: OutputMode, command: string[]): Promise<number> 
 
 export async function runRun(mode: OutputMode, _rest: string[]): Promise<number> {
   void _rest; // the command comes from raw argv, not the dispatcher's parse
-  const { detach, list, command } = extractRunCommand();
+  const { detach, list, last, command } = extractRunCommand();
 
   if (list) return runRunList(mode);
+  if (last) return runRunLast(mode);
   if (command[0] === 'stop') return runRunStop(mode, command);
 
   if (command.length === 0) {
@@ -326,13 +360,32 @@ export async function runRun(mode: OutputMode, _rest: string[]): Promise<number>
   const processMarker = randomUUID().replace(/-/g, '');
 
   const base = join(tmpdir(), `o8-run-${id}`);
-  const logFile = `${base}.log`;
-  const exitFile = `${base}.exit`;
   const goFile = `${base}.go`;
   const envFile = `${base}.env`;
-  for (const f of [logFile, exitFile, goFile, envFile]) {
+  for (const f of [goFile, envFile]) {
     try { rmSync(f, { force: true }); } catch { /* fresh paths */ }
   }
+  const metadata: ManagedRunReceiptMetadata = {
+    schema: 'o8/cli/run-receipt/v1',
+    id,
+    session,
+    command: cmd,
+    cwd,
+    startedAt,
+    mode: detach ? 'detach' : 'stream',
+  };
+  let receiptPaths: ReturnType<typeof initializeManagedRunReceipt>;
+  try {
+    receiptPaths = initializeManagedRunReceipt(metadata);
+  } catch (error) {
+    throw new CliError(
+      'run_receipt_init_failed',
+      `Could not create the durable run receipt: ${error instanceof Error ? error.message : String(error)}`,
+      EXIT.INVALID_ARGS,
+      'Check write access to the configured o8 data directory.',
+    );
+  }
+  const { logFile, exitFile, metadataFile } = receiptPaths;
 
   // Mirror the agent's full env into the pane (the tmux server may have stale
   // env — at minimum PATH would be wrong → "command not found").
@@ -346,18 +399,28 @@ export async function runRun(mode: OutputMode, _rest: string[]): Promise<number>
   // so nothing is missed (matters for short commands). The command runs via
   // `"$@"` (tokens passed as positional args) so quoting survives intact — a
   // joined-and-reshelled string would mangle anything with shell metachars.
-  // A `trap ... EXIT` removes the secret-bearing env-file + go-file
-  // unconditionally — even if `cd` fails or the command is killed mid-run.
+  // EXIT removes only the secret-bearing temp files. Signal handlers retain
+  // the log and exit receipt, then forward the signal to the direct child.
   const wrapper = [
-    `trap 'rm -f ${sq(goFile)} ${sq(envFile)}' EXIT`,
+    'umask 077',
+    `__o8_child=''`,
+    `__o8_signal() { __o8_name="$1"; __o8_code="$2"; printf 'signal:%s' "$__o8_name" > ${sq(exitFile)}; if [ -n "$__o8_child" ]; then kill -s "$__o8_name" "$__o8_child" 2>/dev/null || true; fi; exit "$__o8_code"; }`,
+    `__o8_cleanup() { __o8_ec=$?; if [ ! -e ${sq(exitFile)} ]; then printf '%s' "$__o8_ec" > ${sq(exitFile)}; fi; rm -f ${sq(goFile)} ${sq(envFile)}; }`,
+    `trap '__o8_cleanup' EXIT`,
+    `trap '__o8_signal HUP 129' HUP`,
+    `trap '__o8_signal INT 130' INT`,
+    `trap '__o8_signal QUIT 131' QUIT`,
+    `trap '__o8_signal TERM 143' TERM`,
     `cd ${sq(cwd)} || exit 1`,
     `[ -e ${sq(envFile)} ] && . ${sq(envFile)}`,
     `rm -f ${sq(envFile)}`,
-    `printf '$ %s\\nstarted-at %s\\n\\n' "$*" ${sq(startedAt)}`,
     `while [ ! -e ${sq(goFile)} ]; do sleep 0.02; done`,
-    `"$@"`,
+    `printf '$ %s\\nstarted-at %s\\n\\n' "$*" ${sq(startedAt)}`,
+    `"$@" & __o8_child=$!`,
+    `wait "$__o8_child"`,
     `__o8_ec=$?`,
-    `printf '%s' "$__o8_ec" > ${sq(exitFile)}`,
+    `__o8_child=''`,
+    `case "$__o8_ec" in 129) printf 'signal:HUP' > ${sq(exitFile)} ;; 130) printf 'signal:INT' > ${sq(exitFile)} ;; 131) printf 'signal:QUIT' > ${sq(exitFile)} ;; 137) printf 'signal:KILL' > ${sq(exitFile)} ;; 143) printf 'signal:TERM' > ${sq(exitFile)} ;; *) printf '%s' "$__o8_ec" > ${sq(exitFile)} ;; esac`,
     `exit $__o8_ec`,
   ].join('; ');
 
@@ -368,6 +431,9 @@ export async function runRun(mode: OutputMode, _rest: string[]): Promise<number>
       { windowsHide: true, timeout: 10_000, stdio: 'ignore' },
     );
   } catch (err) {
+    for (const f of [logFile, exitFile, metadataFile, goFile, envFile]) {
+      try { rmSync(f, { force: true }); } catch {}
+    }
     const msg = err instanceof Error ? err.message : String(err);
     throw new CliError(
       'tmux_spawn_failed',
@@ -406,17 +472,30 @@ export async function runRun(mode: OutputMode, _rest: string[]): Promise<number>
   };
   if (!detach) process.on('SIGINT', onSigint);
 
-  // Only stream mode needs the pane teed to a log file (we tail it to stdout).
-  // Detached runs are watched by attaching the tmux session directly, so piping
-  // would just grow an unbounded /tmp log nobody reads.
-  if (!detach) {
+  // Every run keeps a post-mortem log. The go-gate means the command cannot
+  // emit until pipe-pane is attached successfully.
+  try {
+    execFileSync('tmux', ['pipe-pane', '-o', '-t', session, `cat >> ${sq(logFile)}`], {
+      windowsHide: true,
+      timeout: 5_000,
+      stdio: 'ignore',
+    });
+  } catch (error) {
     try {
-      execFileSync('tmux', ['pipe-pane', '-o', '-t', session, `cat >> ${sq(logFile)}`], {
+      execFileSync('tmux', ['kill-session', '-t', session], {
         windowsHide: true,
         timeout: 5_000,
         stdio: 'ignore',
       });
-    } catch { /* without pipe-pane the operator can still attach live; agent just won't see stream */ }
+    } catch {}
+    for (const f of [logFile, exitFile, metadataFile, goFile, envFile]) {
+      try { rmSync(f, { force: true }); } catch {}
+    }
+    throw new CliError(
+      'run_log_capture_failed',
+      `Could not attach the durable run log: ${error instanceof Error ? error.message : String(error)}`,
+      EXIT.INVALID_ARGS,
+    );
   }
 
   try {
@@ -430,7 +509,7 @@ export async function runRun(mode: OutputMode, _rest: string[]): Promise<number>
         stdio: 'ignore',
       });
     } catch {}
-    for (const f of [logFile, exitFile, goFile, envFile]) {
+    for (const f of [logFile, exitFile, metadataFile, goFile, envFile]) {
       try { rmSync(f, { force: true }); } catch {}
     }
     throw error;
@@ -614,11 +693,11 @@ export async function runRun(mode: OutputMode, _rest: string[]): Promise<number>
     if (!interruptRequested) {
       if (exitFound) {
         try {
-          const parsed = Number.parseInt(readFileSync(exitFile, 'utf-8').trim(), 10);
-          exitCode = Number.isNaN(parsed) ? 0 : parsed;
-        } catch { exitCode = 0; }
+          exitCode = exitCodeFromStatus(readFileSync(exitFile, 'utf-8').trim()) ?? 1;
+        } catch { exitCode = 1; }
       } else {
         exitCode = 130; // session killed out from under us
+        try { writeFileSync(exitFile, 'signal:UNKNOWN', { mode: 0o600 }); } catch {}
       }
       try {
         await apiFetch(cfg, '/api/panel/managed-runs', {
@@ -633,7 +712,10 @@ export async function runRun(mode: OutputMode, _rest: string[]): Promise<number>
   } finally {
     process.off('SIGINT', onSigint);
     if (fd !== null) { try { closeSync(fd); } catch { /* noop */ } }
-    for (const f of [logFile, exitFile, goFile, envFile]) {
+    if (interruptRequested && !existsSync(exitFile)) {
+      try { writeFileSync(exitFile, 'signal:INT', { mode: 0o600 }); } catch {}
+    }
+    for (const f of [goFile, envFile]) {
       try { rmSync(f, { force: true }); } catch { /* noop */ }
     }
   }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -214,6 +214,7 @@ commands:
   disconnect           remove this machine from the operator's connected devices
   run [--detach] <cmd> run a process in an o8-owned terminal the operator can watch
   run --list           list managed runs (running + recent, with exit codes)
+  run --last           show the latest command, start, exit receipt, and retained log
   run stop <runId>     stop a managed run from o8 run --list
   serve                start the headless API, WebSocket layer, and supervisor daemon
   serve status         report the daemon pid, ports, health, and launch mode

--- a/docs/user/persistent-terminals.md
+++ b/docs/user/persistent-terminals.md
@@ -16,6 +16,7 @@ tmux must be available on the host for a terminal to survive the owning process.
 
 - `tmux ls` shows the live terminal sessions independently of the app.
 - `o8 run --list` shows long-running commands launched through the managed-run surface.
+- `o8 run --last` shows the latest command, start time, durable exit receipt, and retained log path.
 - `o8 doctor` checks the local control plane when tabs do not reconnect.
 
 If a restored tab has no live tmux session, o8 treats it as dead and starts a fresh shell only through the normal restore path. It never represents a missing session as recovered.

--- a/src/lib/runtimes/managed-runs/registry.ts
+++ b/src/lib/runtimes/managed-runs/registry.ts
@@ -12,8 +12,7 @@
  */
 
 import { join } from 'node:path';
-import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from 'node:fs';
 import { listCortexTmuxSessions } from '@/lib/terminal/tmux';
 import { getDataDir } from '@/lib/data-dir-migration';
 import type {
@@ -92,21 +91,33 @@ function persist(): void {
 }
 
 /**
- * Recover a run's exit code from the pane wrapper's exit-file (written on normal
- * exit). Detached runs leave it in tmpdir; we read it once on reconcile then
- * delete it. Returns null when absent (killed mid-command / never wrote).
+ * Recover a run's exit code from the pane wrapper's durable exit receipt.
+ * Signal receipts map to their conventional shell exit codes. Returns null
+ * while a live run has not written its receipt or for an unknown signal.
  */
 function readExitCode(id: string): number | null {
   try {
-    const path = join(tmpdir(), `o8-run-${id}.exit`);
+    const path = join(getDataDir(), 'logs', 'run', `${id}.exit`);
     if (!existsSync(path)) return null;
     const raw = readFileSync(path, 'utf8').trim();
-    try { rmSync(path, { force: true }); } catch { /* best effort cleanup */ }
-    const code = Number.parseInt(raw, 10);
-    return Number.isNaN(code) ? null : code;
+    if (/^\d+$/.test(raw)) return Number.parseInt(raw, 10);
+    const signal = raw.match(/^signal:(HUP|INT|QUIT|KILL|TERM)$/)?.[1];
+    if (!signal) return null;
+    const number = { HUP: 1, INT: 2, QUIT: 3, KILL: 9, TERM: 15 }[signal];
+    return number === undefined ? null : 128 + number;
   } catch {
     return null;
   }
+}
+
+function retainUnknownExitReceipt(id: string): void {
+  try {
+    const directory = join(getDataDir(), 'logs', 'run');
+    const path = join(directory, `${id}.exit`);
+    if (existsSync(path)) return;
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    writeFileSync(path, 'signal:UNKNOWN', { flag: 'wx', mode: 0o600 });
+  } catch { /* best effort after an untrappable wrapper exit */ }
 }
 
 /** Load persisted records on first module init (per process), validating each. */
@@ -204,6 +215,7 @@ export async function listManagedRuns(): Promise<ManagedRunRecord[]> {
       // own read+delete. A detach run's exit-file (when present) gives the real
       // code → finished; absent (killed mid-command / app was down) → gone.
       const code = rec.mode === 'detach' ? readExitCode(rec.id) : null;
+      if (rec.mode === 'detach' && code === null) retainUnknownExitReceipt(rec.id);
       rec.status = code === null ? 'gone' : 'finished';
       rec.exitCode = code;
       rec.finishedAt = rec.finishedAt ?? now;

--- a/tests/cli-stop-parsing.test.ts
+++ b/tests/cli-stop-parsing.test.ts
@@ -1,14 +1,24 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { CliError, EXIT } from '../cli/src/api';
 import { parseMissionStopArgs, runMission } from '../cli/src/commands/mission';
 import { parsePacketStopArgs } from '../cli/src/commands/packet/stop';
 import { managedRunEnvironmentLines, parseRunStopArgs } from '../cli/src/commands/run';
+import {
+  initializeManagedRunReceipt,
+  readLastManagedRunReceipt,
+} from '../cli/src/commands/run-receipts';
+
+const receiptRoots: string[] = [];
 
 describe('CLI stop command parsing', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
+    while (receiptRoots.length > 0) rmSync(receiptRoots.pop()!, { recursive: true, force: true });
   });
 
   it('packet stop treats positional and --packet ids identically', () => {
@@ -117,5 +127,31 @@ describe('CLI stop command parsing', () => {
       'unset NODE_OPTIONS',
       `export NODE_OPTIONS='--trace-warnings --import=${stubUrl}'`,
     ]);
+  });
+
+  it('retains only the newest 50 completed local run receipts', () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'o8-run-receipts-'));
+    receiptRoots.push(dataDir);
+    for (let index = 0; index <= 50; index += 1) {
+      const id = index.toString(16).padStart(8, '0');
+      const paths = initializeManagedRunReceipt({
+        schema: 'o8/cli/run-receipt/v1',
+        id,
+        session: `cortex-run-${id}`,
+        command: `command-${index}`,
+        cwd: dataDir,
+        startedAt: new Date(index * 1_000).toISOString(),
+        mode: 'stream',
+      }, dataDir);
+      writeFileSync(paths.exitFile, '0');
+    }
+
+    const oldest = join(dataDir, 'logs', 'run', '00000000.json');
+    expect(existsSync(oldest)).toBe(false);
+    expect(readLastManagedRunReceipt(dataDir)).toMatchObject({
+      id: '00000032',
+      command: 'command-50',
+      exitStatus: '0',
+    });
   });
 });

--- a/tests/managed-run-cli-interrupt-real-path.test.ts
+++ b/tests/managed-run-cli-interrupt-real-path.test.ts
@@ -1,6 +1,6 @@
 import { spawn, spawnSync, execFileSync, type ChildProcess } from 'node:child_process';
 import { createServer, type Server } from 'node:http';
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -49,7 +49,42 @@ afterEach(async () => {
 });
 
 describe.skipIf(!tmuxAvailable)('streamed o8 run Ctrl-C real entry point', () => {
-  it('forwards SIGINT, proves the parent and grandchild dead, records exit 130, and cleans temp files', async () => {
+  it('retains the log and numeric exit receipt after a normal command exit', () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'o8-run-cli-normal-'));
+    roots.push(dataDir);
+    const harnessPath = join(dataDir, 'run-harness.mts');
+    const runCommandModule = new URL('../cli/src/commands/run.ts', import.meta.url).href;
+    writeFileSync(harnessPath, `
+import { runRun } from ${JSON.stringify(runCommandModule)};
+const code = await runRun({ human: false, verbose: false }, []);
+process.exit(code);
+`);
+    const result = spawnSync(process.execPath, [
+      '--import', 'tsx',
+      harnessPath,
+      'run', '--', process.execPath, '-e', 'console.log("normal-receipt"); process.exit(7)',
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        O8_API_PORT: '1',
+        O8_API_TOKEN: 'test-token',
+        CORTEX_IDE_DATA_DIR: dataDir,
+      },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(7);
+    expect(result.stdout).toContain('normal-receipt');
+
+    const receiptDir = join(dataDir, 'logs', 'run');
+    const metadataFile = readdirSync(receiptDir).find((name) => name.endsWith('.json'));
+    if (!metadataFile) throw new Error('managed run did not retain metadata');
+    const metadata = JSON.parse(readFileSync(join(receiptDir, metadataFile), 'utf8')) as { id: string };
+    expect(readFileSync(join(receiptDir, `${metadata.id}.exit`), 'utf8')).toBe('7');
+    expect(readFileSync(join(receiptDir, `${metadata.id}.log`), 'utf8')).toContain('normal-receipt');
+  }, 15_000);
+
+  it('forwards SIGINT, proves the process tree dead, and retains the post-mortem receipt', async () => {
     let run: ManagedRunRecord | null = null;
     let killCalls = 0;
     const server = createServer(async (request, response) => {
@@ -153,11 +188,124 @@ process.exit(code);
     expect(markerPids(registered.processMarker!)).toEqual([]);
     expect(() => execFileSync('tmux', ['has-session', '-t', registered.session], { stdio: 'ignore' }))
       .toThrow();
-    const base = join(tmpdir(), `o8-run-${registered.id}`);
-    for (const suffix of ['.log', '.exit', '.go', '.env']) {
-      expect(existsSync(`${base}${suffix}`)).toBe(false);
+    const receiptDir = join(dataDir, 'logs', 'run');
+    expect(readFileSync(join(receiptDir, `${registered.id}.exit`), 'utf8')).toBe('signal:INT');
+    expect(readFileSync(join(receiptDir, `${registered.id}.log`), 'utf8')).toContain('started-at');
+    expect(JSON.parse(readFileSync(join(receiptDir, `${registered.id}.json`), 'utf8')))
+      .toMatchObject({ id: registered.id, command: expect.any(String), mode: 'stream' });
+    const tempBase = join(tmpdir(), `o8-run-${registered.id}`);
+    for (const suffix of ['.go', '.env']) {
+      expect(existsSync(`${tempBase}${suffix}`)).toBe(false);
     }
     sessions.pop();
     children.pop();
+  }, 25_000);
+
+  it('records SIGTERM from the wrapper and exposes it through run --last', async () => {
+    let run: ManagedRunRecord | null = null;
+    const server = createServer(async (request, response) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) chunks.push(Buffer.from(chunk));
+      const body = chunks.length > 0 ? JSON.parse(Buffer.concat(chunks).toString('utf8')) : {};
+      response.setHeader('Content-Type', 'application/json');
+      if (request.url === '/api/panel/managed-runs' && request.method === 'POST' && body.action === 'register') {
+        run = {
+          ...body,
+          status: 'running',
+          finishedAt: null,
+          exitCode: null,
+          termination: null,
+        } as ManagedRunRecord;
+        sessions.push(run.session);
+        response.end(JSON.stringify({ ok: true, run }));
+        return;
+      }
+      response.statusCode = 404;
+      response.end(JSON.stringify({ error: 'not_found' }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('fixture server did not bind');
+    const dataDir = mkdtempSync(join(tmpdir(), 'o8-run-cli-sigterm-'));
+    roots.push(dataDir);
+    const harnessPath = join(dataDir, 'run-harness.mts');
+    const runCommandModule = new URL('../cli/src/commands/run.ts', import.meta.url).href;
+    writeFileSync(harnessPath, `
+import { runRun } from ${JSON.stringify(runCommandModule)};
+const code = await runRun({ human: false, verbose: false }, []);
+process.exit(code);
+`);
+    const command = 'process.stdout.write("before-term\\n"); setInterval(() => {}, 1000)';
+    const cli = spawn(process.execPath, [
+      '--import', 'tsx',
+      harnessPath,
+      'run', '--detach', '--', process.execPath, '-e', command,
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        O8_API_PORT: String(address.port),
+        O8_API_TOKEN: 'test-token',
+        CORTEX_IDE_DATA_DIR: dataDir,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let cliStdout = '';
+    let cliStderr = '';
+    let cliExitState: { code: number | null } | null = null;
+    cli.stdout?.on('data', (chunk) => { cliStdout += String(chunk); });
+    cli.stderr?.on('data', (chunk) => { cliStderr += String(chunk); });
+    cli.once('exit', (code) => { cliExitState = { code }; });
+    children.push(cli);
+    const registered = await waitFor(() => run).catch((error) => {
+      throw new Error(`${error instanceof Error ? error.message : String(error)}\nstdout=${cliStdout}\nstderr=${cliStderr}`);
+    });
+    const cliExit = await waitFor(() => cliExitState);
+    expect(cliExit.code).toBe(0);
+    children.pop();
+
+    const receiptDir = join(dataDir, 'logs', 'run');
+    const logFile = join(receiptDir, `${registered.id}.log`);
+    const exitFile = join(receiptDir, `${registered.id}.exit`);
+    await waitFor(() => existsSync(logFile) && readFileSync(logFile, 'utf8').includes('before-term')
+      ? true
+      : null);
+    if (!registered.panePid) throw new Error('managed run did not register a pane pid');
+    process.kill(registered.panePid, 'SIGTERM');
+
+    const exitReceipt = await waitFor(() => existsSync(exitFile) ? readFileSync(exitFile, 'utf8') : null);
+    expect(exitReceipt).toBe('signal:TERM');
+    await waitFor(() => markerPids(registered.processMarker!).length === 0 ? true : null);
+    await waitFor(() => {
+      try {
+        execFileSync('tmux', ['has-session', '-t', registered.session], { stdio: 'ignore' });
+        return null;
+      } catch {
+        return true;
+      }
+    });
+
+    const last = spawnSync(process.execPath, [
+      '--import', 'tsx',
+      harnessPath,
+      'run', '--last',
+    ], {
+      cwd: process.cwd(),
+      env: { ...process.env, CORTEX_IDE_DATA_DIR: dataDir },
+      encoding: 'utf8',
+    });
+    expect(last.status).toBe(0);
+    expect(JSON.parse(last.stdout)).toMatchObject({
+      schema: 'o8/cli/run.last/v1',
+      run: {
+        id: registered.id,
+        command: expect.stringContaining('before-term'),
+        startedAt: expect.any(String),
+        exitStatus: 'signal:TERM',
+        logPath: logFile,
+      },
+    });
+    sessions.pop();
   }, 25_000);
 });

--- a/tests/managed-run-registry-termination.test.ts
+++ b/tests/managed-run-registry-termination.test.ts
@@ -3,11 +3,33 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   killManagedRun,
+  listManagedRuns,
   registerManagedRun,
 } from '@/lib/runtimes/managed-runs/registry';
 import type { ManagedRunTerminationReceipt } from '@/lib/runtimes/managed-runs/types';
 
 describe('managed-run durable termination receipt', () => {
+  it('retains an unknown-signal receipt after a detached wrapper disappears', async () => {
+    const id = `missing${Date.now()}`;
+    const session = `cortex-run-${id}`;
+    registerManagedRun({
+      id,
+      session,
+      command: 'node detached-build.mjs',
+      cwd: process.cwd(),
+      mode: 'detach',
+      startedAt: new Date().toISOString(),
+      status: 'running',
+    });
+
+    const reconciled = (await listManagedRuns()).find((run) => run.id === id);
+    expect(reconciled).toMatchObject({ status: 'gone', exitCode: null });
+    expect(readFileSync(
+      join(process.env.CORTEX_IDE_DATA_DIR!, 'logs', 'run', `${id}.exit`),
+      'utf8',
+    )).toBe('signal:UNKNOWN');
+  });
+
   it('persists exit 130 only with confirmed process-tree settlement evidence', () => {
     const id = `receipt${Date.now()}`;
     const session = `cortex-run-${id}`;


### PR DESCRIPTION
## Outcome

Managed runs now retain enough local evidence to diagnose normal exits and wrapper termination after the live terminal is gone.

- keeps each log, exit receipt, and private metadata under the configured o8 data directory at `logs/run/`
- records numeric exits and named signal exits
- captures detached runs as well as streamed runs
- adds `o8 run --last` for the latest command, start time, exit status, and log path without requiring the app server
- retains the newest 50 completed receipts so post-mortems cannot grow without bound
- reconciles an untrappable detached-wrapper disappearance as `signal:UNKNOWN`

Closes #2054.

## Verification

- real tmux entry-path test: normal exit, streamed SIGINT, direct wrapper SIGTERM (3 passed)
- focused CLI and registry tests (10 passed)
- `npx tsc --noEmit`
- touched-file ESLint
- `npm run test:classification:check`
- `npm run rule-check -- --base=origin/main`
- `npm run build:cli`
- `npm test` (655 files passed, 3 skipped; 3932 tests passed, 3 skipped)
- `git diff --check origin/main...HEAD`