### PR TITLE
fix: recognize cursor-addressed terminal freshness

### DIFF
--- a/src/lib/ws-server/terminal-resync-barrier.test.ts
+++ b/src/lib/ws-server/terminal-resync-barrier.test.ts
@@ -100,4 +100,10 @@ describe('terminal resync barrier', () => {
     expect(terminalResyncFreshnessLine(['old\r\n\x1b]0;title\x07\x1b[31m newest line \x1b[0m\r\n']))
       .toBe('newest line');
   });
+
+  it('extracts the last cursor-addressed row without spanning painted rows', () => {
+    expect(terminalResyncFreshnessLine([
+      '\x1b[2J\x1b[H\x1b[1;1Hfirst painted row\x1b[2Hsecond painted row',
+    ])).toBe('second painted row');
+  });
 });

--- a/src/lib/ws-server/terminal-resync-barrier.ts
+++ b/src/lib/ws-server/terminal-resync-barrier.ts
@@ -56,8 +56,13 @@ function scrollbackTail(chunks: readonly string[], maxBytes: number): string {
   return Buffer.concat(retained.reverse()).toString('utf8');
 }
 
+function splitCursorAddressedRows(value: string): string {
+  return value.replace(/\x1b\[[\d;]*[Hf]/gu, '\n');
+}
+
 export function terminalResyncFreshnessLine(chunks: readonly string[]): string | null {
-  const lines = stripTerminalControlSequences(scrollbackTail(chunks, 512)).split('\n');
+  const tail = splitCursorAddressedRows(scrollbackTail(chunks, 512));
+  const lines = stripTerminalControlSequences(tail).split('\n');
   for (let index = lines.length - 1; index >= 0; index -= 1) {
     const line = lines[index].trim();
     if (line) return line.slice(-80);

--- a/tests/terminal-visibility-real-path.test.ts
+++ b/tests/terminal-visibility-real-path.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { WebSocket } from 'ws';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { dashSessionNameForOwnerKey } from '@/lib/ws-server/dash-terminal-persistence';
+import { dashSessionNameForOwnerKey, dashTmuxArgs } from '@/lib/ws-server/dash-terminal-persistence';
 import { renderTerminalBytes } from './helpers/headless-terminal';
 
 type WireFrame = {
@@ -141,7 +141,7 @@ function terminalText(received: ReceivedFrame[], startIndex = 0, targetSession =
 }
 
 function capturePane(targetSession = sessionName) {
-  return execFileSync('tmux', ['capture-pane', '-p', '-t', targetSession], { encoding: 'utf8' });
+  return execFileSync('tmux', dashTmuxArgs('capture-pane', '-p', '-t', targetSession), { encoding: 'utf8' });
 }
 
 function normalizeTerminalLines(lines: string[]) {
@@ -247,8 +247,8 @@ afterAll(async () => {
   for (const socket of sockets) socket.close();
   await stopWsServer().catch(() => undefined);
   if (apiServer?.listening) await new Promise<void>((resolve) => apiServer.close(() => resolve()));
-  try { execFileSync('tmux', ['kill-session', '-t', sessionName], { stdio: 'ignore' }); } catch { /* not created */ }
-  try { execFileSync('tmux', ['kill-session', '-t', duplicateSessionName], { stdio: 'ignore' }); } catch { /* not created */ }
+  try { execFileSync('tmux', dashTmuxArgs('kill-session', '-t', sessionName), { stdio: 'ignore' }); } catch { /* not created */ }
+  try { execFileSync('tmux', dashTmuxArgs('kill-session', '-t', duplicateSessionName), { stdio: 'ignore' }); } catch { /* not created */ }
   rmSync(dataDir, { recursive: true, force: true });
 });
 
@@ -295,7 +295,9 @@ describe.runIf(tmuxAvailable)('terminal visibility through the real WebSocket an
     const paintedRows = Array.from({ length: OVERFLOW_TERMINAL.rows }, (_, index) => (
       `O8_RESYNC_ROW_${String(index).padStart(2, '0')}${index === OVERFLOW_TERMINAL.rows - 1 ? ' O8_OVERFLOW_DONE' : ''}`
     ));
-    const paintedScreen = `${paintedRows.join('\n')}\n`;
+    const paintedScreen = `\x1b[2J\x1b[H${paintedRows
+      .map((line, index) => `\x1b[${index + 1};1H${line}`)
+      .join('')}`;
     const overflowScript = `const line='Z'.repeat(4095)+'\\n';let elapsed=0;const timer=setInterval(()=>{process.stdout.write(line);elapsed+=5;if(elapsed>=400){clearInterval(timer);process.stdout.write(Buffer.from('${Buffer.from(paintedScreen).toString('base64')}','base64'));}},5)`;
     visible.socket.send(JSON.stringify({
       type: 'terminal-input',


### PR DESCRIPTION
## Outcome

Cursor-addressed terminal paints now derive their freshness token from the last addressed row instead of a control-stripped byte line that can span several screen rows. Hidden TUI reveals can therefore accept a current tmux snapshot instead of falling back to truncated scrollback.

The real-path test now paints all rows with cursor positioning and addresses the same isolated tmux server used by production, including cleanup.

## Evidence

- Reproduced before the fix: source was scrollback instead of tmux
- Terminal resync barrier: 8/8 passed
- Real WebSocket, PTY, and tmux visibility path: 3/3 passed
- Hermetic suite: 655 files passed, 3 skipped; 3933 tests passed, 3 skipped
- TypeScript, touched ESLint, test classification, repository rule check, and diff check passed

Closes #1981