### PR TITLE
feat: add typed execution carriers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ For contributors who are reading the code, extending o8, or maintaining a cross-
 | [Loopback API security](internals/loopback-api.md) | How socket identity, bearer tokens, origins, and public-route exceptions are enforced. |
 | [Connect contract](internals/connect-contract.md) | The desktop-to-relay wire protocol, ownership rules, and web-surface behavior. |
 | [Runtime adapter contract](internals/runtime-adapter-contract.md) | The supported runtime model and the recipe for adding another agent CLI. |
+| [Execution carriers](internals/execution-carriers.md) | Typed argv and credential wrappers that preserve the underlying runtime identity. |
 | [Local-model coverage](internals/local-model-coverage.md) | Which orchestrators, workers, and support surfaces can use local inference today. |
 | [Task-pool control plane](internals/agent-task-pool-control-plane.md) | How tasks project onto packets, lanes, locks, CLI commands, and MCP tools. |
 | [Fleet state model](internals/fleet-state-model.md) | The canonical status vocabulary for agents, packets, squads, and review. |

--- a/docs/internals/execution-carriers.md
+++ b/docs/internals/execution-carriers.md
@@ -1,0 +1,51 @@
+# Execution carriers
+
+An execution carrier is an allowlisted argv and credential wrapper around an existing worker runtime. It is not a runtime adapter. The runtime still owns capabilities, session identity, transcript parsing, cost attribution, review, resume, and cleanup.
+
+The first supported pair is Ori with Codex:
+
+```text
+runtime = codex, execution carrier = ori
+codex exec --json ...
+        becomes
+ori codex exec --json ...
+```
+
+o8 constructs that command as an executable plus an argument array. It does not accept an operator-supplied shell string. Ori's `codex` subcommand comes from the closed carrier catalog, and the existing Codex adapter still produces every argument after it. The concrete Ori contract and installation provenance are documented by [OpenRouter's announcement](https://openrouter.ai/blog/announcements/ori-harness/) and its [official install skill](https://github.com/OpenRouterTeam/skills/blob/main/skills/install-ori-harness/SKILL.md). Do not install the unrelated npm package named `ori`.
+
+On Windows, the selected carrier must resolve to a native `.exe` or `.com` executable. o8 refuses `.cmd` and `.bat` carrier shims because prompt argv would otherwise pass through `cmd.exe`. When `O8_CODEX_BIN` resolves Codex outside the inherited `PATH`, o8 prepends that executable's directory only for the carried child so Ori launches the same underlying CLI that passed preflight.
+
+## Configure the carrier
+
+Set the persisted operator default in `~/.o8/settings.toml`:
+
+```toml
+[models]
+worker_execution_carrier = "ori"
+```
+
+Use an empty string to restore direct runtime launch. The same setting is available through `o8_operator_defaults` as `workerExecutionCarrier`; pass `"ori"` to enable it or `""` to clear it. Mission creation snapshots the resolved value onto every packet, so a later settings change cannot silently reroute a retry or resume.
+
+Ori currently supports only Codex in o8. A mission that resolves any packet to an incompatible runtime is rejected before branch or worktree preparation.
+
+## Identity and authentication precedence
+
+| Concern | Owner when Ori is selected |
+| --- | --- |
+| Runtime and lane identity | Codex |
+| Capability evidence | Codex adapter |
+| Session key and resume protocol | Codex adapter |
+| Transcript and cost parser | Codex adapter |
+| Review and cleanup | Codex adapter |
+| Credential path used to reach the provider | Ori |
+| Launch display | `Codex via Ori` |
+
+Carrier authentication takes precedence for the carried launch, including create-mission and one-step spawn preflight. Preflight runs `ori auth` with all output discarded and records only its boolean result, `authSource: execution-carrier`, binary identities, and resolution sources; it never stores a token, secret, or credential value. Selecting a carrier disables native-runtime auth gating for that launch, but it does not make the underlying CLI optional: both `ori` and `codex` must resolve. A macOS sandboxed worker receives read-only access to Ori's `~/.ori` state; the carrier credential tree is not writable.
+
+A missing Ori binary is a `missing-carrier` failure with `O8_ORI_BIN` guidance. A missing Codex binary is a separate `missing-runtime` failure with `O8_CODEX_BIN` guidance. Neither case falls back to an unwrapped launch.
+
+## Process ownership
+
+The spawned root command is Ori, so the durable run records the resolved Ori executable path as its command identity, even when `sandbox-exec` wraps it. The Ori child inherits the owned-run marker and belongs to the same detached process tree or process group. Interrupt and orphan cleanup validate the exact wrapper path as an argv token, then stop the whole tree. All operator-facing lifecycle and review records continue to attribute that tree to Codex.
+
+This design is the bounded follow-up to [issue #2034](https://github.com/hurttlocker/o8/issues/2034). It does not change the Copilot CLI or Crush runtime adapters landed there.

--- a/src/app/api/orchestrator/create-mission/route.ts
+++ b/src/app/api/orchestrator/create-mission/route.ts
@@ -20,6 +20,10 @@ import {
   resolveRuntimePreset,
 } from '@/lib/orchestrator/runtime-capabilities';
 import { assertRuntimeDispatchable, DispatchPreflightError } from '@/lib/runtimes/shared/auth-detect';
+import {
+  assertExecutionCarrierDispatchable,
+  ExecutionCarrierPreflightError,
+} from '@/lib/runtimes/shared/execution-carrier-preflight';
 import { ControlPlaneLockTimeoutError } from '@/lib/orchestrator/control-plane';
 import { resolveRequestPrincipalContext } from '@/lib/auth/principal';
 import type { PacketDispatcherAttribution } from '@/lib/orchestrator/types';
@@ -262,13 +266,18 @@ export async function POST(request: NextRequest) {
     // stored worker profile: a mission pinned to openrouter / codex-subscription never
     // touches the native CLI login, so a logged-out native CLI must not refuse it.
     const preflightCarrier = { claudeCodeCarrier };
-    await assertRuntimeDispatchable(
-      workerRouting.selectedRuntime, workerRouting.selectedModel, repoPath, preflightCarrier,
-    );
-    for (const issueRouting of issueRoutings) {
+    const preflightRuntime = async (routing: typeof workerRouting) => {
+      if (defaults.workerExecutionCarrier) {
+        await assertExecutionCarrierDispatchable(routing.selectedRuntime, defaults.workerExecutionCarrier);
+        return;
+      }
       await assertRuntimeDispatchable(
-        issueRouting.selectedRuntime, issueRouting.selectedModel, repoPath, preflightCarrier,
+        routing.selectedRuntime, routing.selectedModel, repoPath, preflightCarrier,
       );
+    };
+    await preflightRuntime(workerRouting);
+    for (const issueRouting of issueRoutings) {
+      await preflightRuntime(issueRouting);
     }
   } catch (error) {
     if (error instanceof DispatchPreflightError) {
@@ -278,6 +287,12 @@ export async function POST(request: NextRequest) {
         installed: error.status.installed,
         authenticated: error.status.authenticated,
         unavailableReason: error.status.unavailableReason,
+      });
+    }
+    if (error instanceof ExecutionCarrierPreflightError) {
+      return operatorError(error.failure, error.message, 400, {
+        runtime: workerRouting.selectedRuntime,
+        executionCarrier: defaults.workerExecutionCarrier,
       });
     }
     const message = error instanceof Error ? error.message : 'Runtime readiness check failed.';

--- a/src/app/api/orchestrator/spawn-prompt/route.ts
+++ b/src/app/api/orchestrator/spawn-prompt/route.ts
@@ -15,6 +15,7 @@ import {
   isDispatchableRuntime,
 } from '@/lib/orchestrator/runtime-capabilities';
 import { assertRuntimeDispatchable, DispatchPreflightError } from '@/lib/runtimes/shared/auth-detect';
+import { assertExecutionCarrierDispatchable, ExecutionCarrierPreflightError } from '@/lib/runtimes/shared/execution-carrier-preflight';
 import { findMissionByCreationMutationId } from '@/lib/orchestrator/create-mission-receipt';
 import {
   bindIdempotencyClientMutation,
@@ -100,7 +101,11 @@ export async function POST(request: NextRequest) {
     model: workerRouting.selectedModel,
   });
   try {
-    await assertRuntimeDispatchable(workerRouting.selectedRuntime, workerRouting.selectedModel, repoPath);
+    if (defaults.workerExecutionCarrier) {
+      await assertExecutionCarrierDispatchable(workerRouting.selectedRuntime, defaults.workerExecutionCarrier);
+    } else {
+      await assertRuntimeDispatchable(workerRouting.selectedRuntime, workerRouting.selectedModel, repoPath);
+    }
   } catch (error) {
     if (error instanceof DispatchPreflightError) {
       return operatorError(error.code, `${error.status.detail} ${error.status.fix}`, 400, {
@@ -109,6 +114,12 @@ export async function POST(request: NextRequest) {
         installed: error.status.installed,
         authenticated: error.status.authenticated,
         unavailableReason: error.status.unavailableReason,
+      });
+    }
+    if (error instanceof ExecutionCarrierPreflightError) {
+      return operatorError(error.failure, error.message, 400, {
+        runtime: workerRouting.selectedRuntime,
+        executionCarrier: defaults.workerExecutionCarrier,
       });
     }
     const message = error instanceof Error ? error.message : 'Runtime readiness check failed.';

--- a/src/app/api/panel/operator-defaults/route.ts
+++ b/src/app/api/panel/operator-defaults/route.ts
@@ -29,6 +29,7 @@ import {
 } from '@/lib/operator/broadcast-commentary-defaults';
 import { isDispatchRuntime } from '@/lib/operator/defaults-env';
 import { isWorkerStartMode } from '@/lib/operator/worker-start-mode';
+import { isExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 import { projectAgentRoleRoutes } from '@/lib/operator/role-routing';
 import { listRoleRoutingReceipts } from '@/lib/operator/role-routing-ledger';
 import {
@@ -310,6 +311,13 @@ function normalizeUpdate(body: Record<string, unknown>): Partial<OperatorDefault
       throw new Error('defaultDispatchRuntime must name a dispatchable runtime.');
     }
     update.defaultDispatchRuntime = body.defaultDispatchRuntime;
+  }
+
+  if (body.workerExecutionCarrier !== undefined) {
+    if (body.workerExecutionCarrier !== null && !isExecutionCarrierId(body.workerExecutionCarrier)) {
+      throw new Error('workerExecutionCarrier must be "ori" or null.');
+    }
+    update.workerExecutionCarrier = body.workerExecutionCarrier;
   }
 
   if (body.workerStartMode !== undefined) {

--- a/src/components/desktop/settings/OperatorDefaultsTab.tsx
+++ b/src/components/desktop/settings/OperatorDefaultsTab.tsx
@@ -53,6 +53,11 @@ const PARALLEL_CAP_PRESETS: Array<{ key: string; label: string; value: number }>
 ];
 
 const DEFAULT_WORKER_RUNTIME_OPTIONS = DISPATCH_RUNTIME_OPTIONS;
+type ExecutionCarrierSelection = 'direct' | 'ori';
+const EXECUTION_CARRIER_OPTIONS: Array<{ value: ExecutionCarrierSelection; label: string; detail: string }> = [
+  { value: 'direct', label: 'Direct', detail: 'Launch the selected runtime CLI directly.' },
+  { value: 'ori', label: 'Ori', detail: 'Use Ori credentials and routing while Codex keeps session ownership.' },
+];
 
 type CliHouseStatus = NonNullable<OperatorDefaultsResponse['cliAuth']>['statuses']['codex'];
 
@@ -317,6 +322,9 @@ export function OperatorDefaultsTab() {
     }
     return 'Codex is the default worker — pick any available runtime to override';
   })();
+  const carrierCompatibilityReason = values.defaultDispatchRuntime === 'codex'
+    ? null
+    : 'Ori is available when the effective default worker is Codex.';
   const profileHint = cliAuth?.suggestedSubscriptionProfile.profile
     && cliAuth.suggestedSubscriptionProfile.profile !== activeProfile
     ? cliAuth.suggestedSubscriptionProfile
@@ -637,6 +645,24 @@ export function OperatorDefaultsTab() {
               />
             }
             disabled={Boolean(profileOverrideReason) || envLocked('defaultDispatchRuntime') || busyField === 'defaultDispatchRuntime'}
+            divider
+          />
+          <SettingsRow
+            icon={<RocketIcon />}
+            label="Execution carrier"
+            subtitle={carrierCompatibilityReason ?? 'Optional typed argv and credential wrapper. The runtime still owns sessions, transcripts, costs, and review.'}
+            accessory={
+              <PickerMenu<ExecutionCarrierSelection>
+                value={values.workerExecutionCarrier ?? 'direct'}
+                options={carrierCompatibilityReason ? EXECUTION_CARRIER_OPTIONS.slice(0, 1) : EXECUTION_CARRIER_OPTIONS}
+                onChange={(next) => { updateField('workerExecutionCarrier', next === 'direct' ? null : next); }}
+                disabled={busyField === 'workerExecutionCarrier'}
+                minWidth={150}
+                open={openDispatchPicker === 'execution-carrier'}
+                onOpenChange={(open) => setOpenDispatchPicker((current) => resolvePickerGroupOpen(current, 'execution-carrier', open))}
+              />
+            }
+            disabled={busyField === 'workerExecutionCarrier'}
             divider
           />
           <SettingsRow

--- a/src/components/desktop/settings/dispatch-shared.tsx
+++ b/src/components/desktop/settings/dispatch-shared.tsx
@@ -82,6 +82,7 @@ export interface OperatorDefaults {
   opencodeOrchestratorModel: string | null;
   opencodeWorkerModel: string | null;
   defaultDispatchRuntime: DispatchRuntime;
+  workerExecutionCarrier: 'ori' | null;
   workerRuntimes: DispatchRuntime[];
   codexWorkerEffort: ThinkingEffort;
   claudeWorkerEffort: ThinkingEffort;

--- a/src/lib/codex/owned.ts
+++ b/src/lib/codex/owned.ts
@@ -51,10 +51,9 @@ import { getDataDir } from '@/lib/data-dir-migration';
 import { codexSandboxLaunchArgs, codexSandboxResumeArgs } from '@/lib/codex/read-only-args';
 import type { WorkerWorkMode } from '@/lib/orchestrator/types';
 import { isReadOnlyRuntimeConfig, workModeRuntimeConfig } from '@/lib/runtimes/shared/owned-session/work-mode';
-
+import { executionCarrierRuntimeConfig, type ExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 // Re-export the fleet additions shape under its original Codex name.
 export type { OwnedCodexFleetAdditions } from '@/lib/runtimes/shared/owned-session';
-
 // ── Codex-specific types (preserved signatures) ──────────────────────────────
 
 export type OwnedCodexLaunchRequest = {
@@ -67,6 +66,7 @@ export type OwnedCodexLaunchRequest = {
   packetId?: string;
   /** Durable packet work mode; 'read-only' hardens argv and the OS sandbox. */
   workMode?: WorkerWorkMode;
+  executionCarrier?: ExecutionCarrierId;
 };
 
 export type OwnedCodexLaunchResponse = {
@@ -77,7 +77,6 @@ export type OwnedCodexLaunchResponse = {
 };
 
 type OwnedReviewDisposition = 'watching' | 'resolved';
-
 // ── Codex JSONL helpers ──────────────────────────────────────────────────────
 
 function safeObject(value: unknown): Record<string, unknown> | null {
@@ -85,7 +84,6 @@ function safeObject(value: unknown): Record<string, unknown> | null {
     ? value as Record<string, unknown>
     : null;
 }
-
 function parseJsonObject(value: unknown): Record<string, unknown> | null {
   if (typeof value === 'string') {
     try {
@@ -96,7 +94,6 @@ function parseJsonObject(value: unknown): Record<string, unknown> | null {
   }
   return safeObject(value);
 }
-
 function readStringField(source: Record<string, unknown> | null, ...keys: string[]) {
   if (!source) return undefined;
   for (const key of keys) {
@@ -751,7 +748,10 @@ export async function launchOwnedCodexSession(
     ...request,
     // Pinned like the model/carrier pins, so retry/resume/rerun of a read-only
     // packet stays read-only even if the caller omits the mode.
-    runtimeConfig: workModeRuntimeConfig(request.workMode),
+    runtimeConfig: {
+      ...workModeRuntimeConfig(request.workMode),
+      ...executionCarrierRuntimeConfig(request.executionCarrier),
+    },
   });
   return {
     ok: result.ok,

--- a/src/lib/lane/commands-launch.ts
+++ b/src/lib/lane/commands-launch.ts
@@ -222,6 +222,7 @@ export async function launchSession(
       model: command.model,
       claudeCodeModel: command.claudeCodeModel,
       claudeCodeCarrier: command.claudeCodeCarrier,
+      executionCarrier: command.executionCarrier,
       effort: command.effort,
       clientMutationId: command.clientMutationId,
       isolate: !lane.worktreePath,

--- a/src/lib/lane/types.ts
+++ b/src/lib/lane/types.ts
@@ -18,6 +18,7 @@ import type { MergeCheckResult } from '@/lib/lane/preview-merge';
 import type { ClaudeCodeModelSource } from '@/lib/claude-code/worker-profile-types';
 import type { OrchestratorRuntime, WorkerLaunchContext } from '@/lib/orchestrator/types';
 import type { PacketSpendCap } from '@/lib/orchestrator/metered-spend';
+import type { ExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 import { isWorkerTerminal } from '@/lib/lane/terminal-states';
 
 // ── Lane Status ──
@@ -160,6 +161,7 @@ export type LaneCommand =
       model?: string;
       claudeCodeModel?: string;
       claudeCodeCarrier?: ClaudeCodeModelSource;
+      executionCarrier?: ExecutionCarrierId;
       spendCap?: PacketSpendCap;
       effort?: ThinkingEffort;
       /** Stable for one packet launch attempt so a crash can reconcile the owned session. */
@@ -287,6 +289,7 @@ export type LaneEventVerb =
   | 'explainer_completed'
   | 'explainer_failed'
   | 'runtime_drift'
+  | 'execution_carrier_preflight'
   | 'capacity_snapshot'
   | 'pr_merged_reconciled'
   | 'merged_by_ancestry_reconciled'

--- a/src/lib/mcp/operator-handlers/status.ts
+++ b/src/lib/mcp/operator-handlers/status.ts
@@ -294,6 +294,11 @@ export const STATUS_TOOLS: McpTool[] = [
           enum: listDispatchableRuntimes(),
           description: 'Default worker runtime for dispatches.',
         },
+        workerExecutionCarrier: {
+          type: 'string',
+          enum: ['ori', ''],
+          description: 'Allowlisted worker execution carrier. Use "ori" for Ori or an empty string for direct runtime launch.',
+        },
         defaultDispatchModel: {
           type: 'string',
           description: 'Default worker model id. Pass an empty string to restore the selected runtime default.',
@@ -383,6 +388,7 @@ const OPERATOR_DEFAULTS_KEYS = [
   'uiLoopMaxDiffFiles',
   'uiLoopPreviewTimeoutMs',
   'defaultDispatchRuntime',
+  'workerExecutionCarrier',
   'defaultDispatchModel',
   'opencodeOrchestratorModel',
   'opencodeWorkerModel',
@@ -420,7 +426,7 @@ export async function handleOperatorDefaults(args: Record<string, unknown>): Pro
     for (const key of OPERATOR_DEFAULTS_KEYS) {
       if (args[key] !== undefined) update[key] = args[key];
     }
-    const EMPTY_STRING_MEANS_NULL = new Set(['opencodeOrchestratorModel', 'opencodeWorkerModel']);
+    const EMPTY_STRING_MEANS_NULL = new Set(['opencodeOrchestratorModel', 'opencodeWorkerModel', 'workerExecutionCarrier']);
     for (const key of EMPTY_STRING_MEANS_NULL) {
       if (update[key] === '') update[key] = null;
     }

--- a/src/lib/operator/defaults-roundtrip.test.ts
+++ b/src/lib/operator/defaults-roundtrip.test.ts
@@ -10,9 +10,11 @@ process.env.CORTEX_IDE_DATA_DIR = dataDir;
 const {
   getOperatorDefaults,
   getOperatorDefaultsTomlPath,
+  OPERATOR_DEFAULTS_FALLBACK,
   updateOperatorDefaults,
 } = await import('./defaults');
 const { parseOperatorDefaultsToml } = await import('@/lib/settings/toml');
+const { assertRoutingTomlCompatibility } = await import('./routing-compatibility');
 
 /**
  * Evaporation guard: updateOperatorDefaults copies each field from the update
@@ -111,6 +113,38 @@ describe('updateOperatorDefaults round-trip', () => {
     await updateOperatorDefaults({ reviewerBackend: 'codex' });
     const after = await updateOperatorDefaults({ parallelCap: 5 });
     expect(after.values.reviewerBackend).toBe('codex');
+  });
+
+  it('clears the persisted execution carrier back to direct launch', async () => {
+    await updateOperatorDefaults({ defaultDispatchRuntime: 'codex', workerExecutionCarrier: 'ori' });
+    const cleared = await updateOperatorDefaults({ workerExecutionCarrier: null });
+    expect(cleared.values.workerExecutionCarrier).toBeNull();
+    expect(parseOperatorDefaultsToml(readFileSync(getOperatorDefaultsTomlPath(), 'utf8')).workerExecutionCarrier).toBeNull();
+  });
+
+  it('rejects an execution carrier that is incompatible with the effective default runtime', async () => {
+    await updateOperatorDefaults({ defaultDispatchRuntime: 'claude-code' });
+    await expect(updateOperatorDefaults({ workerExecutionCarrier: 'ori' })).rejects.toThrow(/incompatible/);
+  });
+
+  it('honors environment-selected runtime precedence when validating updates and TOML', async () => {
+    const priorRuntime = process.env.O8_DEFAULT_DISPATCH_RUNTIME;
+    const priorProfile = process.env.O8_SUBSCRIPTION_PROFILE;
+    process.env.O8_DEFAULT_DISPATCH_RUNTIME = 'claude-code';
+    process.env.O8_SUBSCRIPTION_PROFILE = 'both';
+    try {
+      await expect(updateOperatorDefaults({ defaultDispatchRuntime: 'codex', workerExecutionCarrier: 'ori' }))
+        .rejects.toThrow(/effective default runtime 'claude-code'/);
+      expect(() => assertRoutingTomlCompatibility(
+        '[models]\ndefault_dispatch_runtime = "codex"\nworker_execution_carrier = "ori"\n',
+        OPERATOR_DEFAULTS_FALLBACK,
+      )).toThrow(/effective default runtime 'claude-code'/);
+    } finally {
+      if (priorRuntime === undefined) delete process.env.O8_DEFAULT_DISPATCH_RUNTIME;
+      else process.env.O8_DEFAULT_DISPATCH_RUNTIME = priorRuntime;
+      if (priorProfile === undefined) delete process.env.O8_SUBSCRIPTION_PROFILE;
+      else process.env.O8_SUBSCRIPTION_PROFILE = priorProfile;
+    }
   });
 
   it('subscriptionProfile persists and flips the effective house defaults', async () => {

--- a/src/lib/operator/defaults.ts
+++ b/src/lib/operator/defaults.ts
@@ -2,6 +2,7 @@ import 'server-only';
 import { CODEX_MODEL_IDS, isCodexModelId, isSupportedModelId, MODEL_IDS, SUPPORTED_MODEL_IDS } from '@/lib/models';
 import { isThinkingEffort, type ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+import { isExecutionCarrierId, type ExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 import type { UpdateAutoApply } from '@/lib/app-update/types';
 import { validateCredentialSafeUrl } from '@/lib/settings/credential-safe-url';
 import { applyApfsDependencyImagesUpdate, APFS_DEPENDENCY_IMAGES_FALLBACK, resolveStoredApfsDependencyImages, type ApfsDependencyImagesDefaults } from './apfs-dependency-images-default';
@@ -16,7 +17,7 @@ import {
 import { resolveWorkerEffortDefault } from './worker-effort-default';
 import { isWorkerStartMode, type WorkerStartMode } from './worker-start-mode';
 import { parseStoredJson } from './stored-json';
-import { assertRoutingCompatibility, routingUpdateTouchesCompatibility } from './routing-compatibility';
+import { assertExecutionCarrierRoutingCompatibility, assertRoutingCompatibility, routingUpdateTouchesCompatibility } from './routing-compatibility';
 import {
   coerceStoredTier,
   envTargetingTier,
@@ -24,9 +25,7 @@ import {
   mergeTier,
   type TargetingTier,
 } from './targeting-tier';
-
 export { isSubscriptionProfile };
-
 import { normalizeAcpModelId, isPlausibleAcpModelId } from '@/lib/orchestrator/acp-model-id';
 
 import { isOrchestratorBackendSetting, isReviewerBackendSetting, isCollideAggregator, isPrLinkDestination, sanitizeBranchPrefix, type OrchestratorBackendSetting, type ReviewerBackendSetting, type CollideAggregator, type PrLinkDestination } from './defaults-env';
@@ -107,18 +106,9 @@ export {
   ORCHESTRATOR_MODEL_OPTIONS,
   PARALLEL_CAP_PRESETS,
 } from './default-options';
-/**
- * Operator defaults — the dispatch/supervision knobs exposed in Settings
- * (one field per knob in {@link OperatorDefaults}; the count grows, don't
- * hardcode it in docs).
- * Resolution order (every knob): env var > persisted file > hardcoded fallback.
- * Canonical file: `~/.o8/settings.toml`. The legacy
- * `operator-defaults.json` remains a synchronized last-good fallback so an
- * invalid hand edit never prevents startup.
- * (override root with CORTEX_IDE_DATA_DIR). NOTE: `~/.cortex-ide/` is NOT
- * read — a stale copy of this file there silently does nothing (bit the
- * operator flow 2026-07-07; always verify against getOperatorDefaultsPath()).
- */
+/** Operator defaults exposed in Settings. Resolution: env > persisted file > fallback.
+ * Canonical file: `~/.o8/settings.toml`; the legacy JSON remains a last-good fallback.
+ * Override root with CORTEX_IDE_DATA_DIR. `~/.cortex-ide/` is not read. */
 export type SettingSource = 'env' | 'file' | 'profile' | 'default';
 export type RequireApproval = 'high-risk' | 'surface' | 'always' | 'never';
 
@@ -147,6 +137,7 @@ export interface OperatorDefaults extends StorageReserveDefaults, WorkspaceParki
   /** Model for dispatched opencode workers. Null = the adapter default. */
   opencodeWorkerModel: string | null;
   defaultDispatchRuntime: OrchestratorRuntime;
+  workerExecutionCarrier: ExecutionCarrierId | null;
   workerStartMode: WorkerStartMode;
   workerRuntimes: OrchestratorRuntime[];
   /** Default Codex worker effort. 'adaptive' preserves runtime default behavior. */
@@ -329,9 +320,7 @@ export const OPERATOR_DEFAULTS_FALLBACK: OperatorDefaults = {
   ...REVIEW_CONTINUATION_FALLBACK,
   ...BROADCAST_COMMENTARY_FALLBACK,
   ...APFS_DEPENDENCY_IMAGES_FALLBACK,
-  // Operator-pinned: Opus 4.8 with max thinking is the default orchestrator
-  // brain. Subscription-billed via the REPL migration, so cost is the user's
-  // existing Claude Code MAX plan — not a per-token API charge.
+  // Operator-pinned subscription model; not a per-token API charge.
   thinkingEffort: 'max',
   promptCachingEnabled: true,
   mergeTestReplayEnabled: false,
@@ -340,6 +329,7 @@ export const OPERATOR_DEFAULTS_FALLBACK: OperatorDefaults = {
   opencodeOrchestratorModel: null,
   opencodeWorkerModel: null,
   defaultDispatchRuntime: 'codex',
+  workerExecutionCarrier: null,
   workerStartMode: 'autonomous',
   workerRuntimes: ['codex'],
   codexWorkerEffort: 'adaptive',
@@ -356,11 +346,9 @@ export const OPERATOR_DEFAULTS_FALLBACK: OperatorDefaults = {
   experimentalCanvas: false,
   nativeBrowserView: true,
   classAComposer: 'auto',
-  // ON by default post-#1097. Subscription pool, not Agent SDK pool. See the
-  // docstring above on the field for the rationale.
+  // ON by default post-#1097; subscription pool, not Agent SDK pool.
   inAppOrchestratorEnabled: true,
-  // ON by default — the free, fast (~2.7s warm), subscription-billed Brain for
-  // anyone with a Claude sub. Independent of the orchestrator toggle (2026-06-22).
+  // Subscription-billed Brain, independent of the orchestrator toggle.
   brainUseClaudeCli: true,
   workersUseBrain: 'auto',
   ...WORKSPACE_MANIFEST_POLICY_FALLBACK,
@@ -375,9 +363,7 @@ export const OPERATOR_DEFAULTS_FALLBACK: OperatorDefaults = {
   quizGateEnabled: false,
   // Buy-in doc generation OFF by default — opt-in narrative for external sharing.
   buyinDocEnabled: false,
-  // Targeting Machine tiers. Both default to Codex (the shipping dispatch worker),
-  // differentiated by effort — cheap triage at low, premium action at high. The
-  // operator can point triage at a cheaper runtime/model (gemini, a local model).
+  // Targeting tiers default to Codex and differ by effort.
   targetingTriage: { runtime: 'codex', model: '', effort: 'low' },
   targetingAction: { runtime: 'codex', model: '', effort: 'high' },
   updateAutoApply: 'off',
@@ -410,6 +396,7 @@ interface StoredOperatorDefaults extends Partial<StorageReserveDefaults>, Partia
   opencodeOrchestratorModel?: string | null;
   opencodeWorkerModel?: string | null;
   defaultDispatchRuntime?: OrchestratorRuntime;
+  workerExecutionCarrier?: ExecutionCarrierId | null;
   defaultDispatchRuntimeExplicit?: boolean;
   workerStartMode?: WorkerStartMode;
   workerRuntimes?: OrchestratorRuntime[];
@@ -503,6 +490,9 @@ function resolveFromFile(stored: StoredOperatorDefaults): FileOperatorDefaults {
   if (isDispatchRuntime(stored.defaultDispatchRuntime)) {
     result.defaultDispatchRuntime = stored.defaultDispatchRuntime;
     result.defaultDispatchRuntimeExplicit = stored.defaultDispatchRuntimeExplicit !== false;
+  }
+  if (stored.workerExecutionCarrier === null || isExecutionCarrierId(stored.workerExecutionCarrier)) {
+    result.workerExecutionCarrier = stored.workerExecutionCarrier;
   }
   if (isWorkerStartMode(stored.workerStartMode)) result.workerStartMode = stored.workerStartMode;
   if (Array.isArray(stored.workerRuntimes)) {
@@ -706,6 +696,7 @@ function resolveDefaults(fileValues: FileOperatorDefaults): OperatorDefaultsWith
       fileValues.opencodeOrchestratorModel ?? OPERATOR_DEFAULTS_FALLBACK.opencodeOrchestratorModel,
     opencodeWorkerModel: fileValues.opencodeWorkerModel ?? OPERATOR_DEFAULTS_FALLBACK.opencodeWorkerModel,
     defaultDispatchRuntime,
+    workerExecutionCarrier: fileValues.workerExecutionCarrier !== undefined ? fileValues.workerExecutionCarrier : OPERATOR_DEFAULTS_FALLBACK.workerExecutionCarrier,
     workerStartMode: fileValues.workerStartMode ?? OPERATOR_DEFAULTS_FALLBACK.workerStartMode,
     workerRuntimes: fileValues.workerRuntimes ?? OPERATOR_DEFAULTS_FALLBACK.workerRuntimes,
     codexWorkerEffort:
@@ -777,6 +768,7 @@ function resolveDefaults(fileValues: FileOperatorDefaults): OperatorDefaultsWith
     opencodeOrchestratorModel: fileValues.opencodeOrchestratorModel !== undefined ? 'file' : 'default',
     opencodeWorkerModel: fileValues.opencodeWorkerModel !== undefined ? 'file' : 'default',
     defaultDispatchRuntime: profileDefaults ? 'profile' : envRuntime !== null ? 'env' : fileValues.defaultDispatchRuntimeExplicit ? 'file' : 'default',
+    workerExecutionCarrier: fileValues.workerExecutionCarrier !== undefined ? 'file' : 'default',
     workerStartMode: fileValues.workerStartMode !== undefined ? 'file' : 'default',
     workerRuntimes: fileValues.workerRuntimes !== undefined ? 'file' : 'default',
     codexWorkerEffort:
@@ -932,6 +924,12 @@ async function updateOperatorDefaultsOnce(update: Partial<OperatorDefaults>): Pr
     }
     stored.defaultDispatchRuntime = update.defaultDispatchRuntime;
     stored.defaultDispatchRuntimeExplicit = true;
+  }
+  if (update.workerExecutionCarrier !== undefined) {
+    if (update.workerExecutionCarrier !== null && !isExecutionCarrierId(update.workerExecutionCarrier)) {
+      throw new Error('workerExecutionCarrier must be "ori" or null.');
+    }
+    stored.workerExecutionCarrier = update.workerExecutionCarrier;
   }
   if (update.workerStartMode !== undefined) {
     if (!isWorkerStartMode(update.workerStartMode)) throw new Error('workerStartMode must be one of "autonomous", "huddle", or "adaptive".');
@@ -1118,7 +1116,7 @@ async function updateOperatorDefaultsOnce(update: Partial<OperatorDefaults>): Pr
     ...OPERATOR_DEFAULTS_FALLBACK,
     ...fileValues,
   };
-  if (routingUpdateTouchesCompatibility(update)) assertRoutingCompatibility(canonicalValues);
+  if (routingUpdateTouchesCompatibility(update)) { assertRoutingCompatibility(canonicalValues); assertExecutionCarrierRoutingCompatibility(resolveDefaults(fileValues).values); }
   await persistOperatorDefaults(canonicalValues, stored, existingToml, revision);
 
   return getOperatorDefaults();

--- a/src/lib/operator/routing-compatibility.ts
+++ b/src/lib/operator/routing-compatibility.ts
@@ -1,10 +1,14 @@
 import { validateRuntimeModelSelection } from '@/lib/runtimes/shared/model-compatibility';
+import { assertExecutionCarrierCompatible } from '@/lib/runtimes/shared/execution-carrier';
 import { parseOperatorDefaultsToml } from '@/lib/settings/toml';
 import type { OperatorDefaults } from './defaults';
+import { isSubscriptionProfile, resolveSubscriptionProfileHouseDefaults } from './subscription-profile';
+import { isDispatchRuntime } from './defaults-env';
 
 type RoutingCompatibilityValues = Pick<
   OperatorDefaults,
-  'defaultDispatchRuntime' | 'defaultDispatchModel' | 'targetingTriage' | 'targetingAction'
+  'subscriptionProfile' | 'defaultDispatchRuntime' | 'workerExecutionCarrier'
+    | 'defaultDispatchModel' | 'targetingTriage' | 'targetingAction'
 >;
 
 function assertRuntimeModelCompatibility(
@@ -20,19 +24,43 @@ function assertRuntimeModelCompatibility(
 
 export function assertRoutingCompatibility(values: RoutingCompatibilityValues): void {
   assertRuntimeModelCompatibility(values.defaultDispatchRuntime, values.defaultDispatchModel, 'Default worker');
+  assertExecutionCarrierRoutingCompatibility(values);
   assertRuntimeModelCompatibility(values.targetingTriage.runtime, values.targetingTriage.model, 'Triage');
   assertRuntimeModelCompatibility(values.targetingAction.runtime, values.targetingAction.model, 'Action tier');
+}
+
+export function assertExecutionCarrierRoutingCompatibility(values: RoutingCompatibilityValues): void {
+  const effectiveRuntime = resolveSubscriptionProfileHouseDefaults(values.subscriptionProfile)?.defaultDispatchRuntime
+    ?? values.defaultDispatchRuntime;
+  if (values.workerExecutionCarrier) {
+    try {
+      assertExecutionCarrierCompatible(values.workerExecutionCarrier, effectiveRuntime);
+    } catch {
+      throw new Error(
+        `Execution carrier '${values.workerExecutionCarrier}' is incompatible with the effective default runtime '${effectiveRuntime}'. Select a compatible runtime or use Direct.`,
+      );
+    }
+  }
 }
 
 export function assertRoutingTomlCompatibility(
   raw: string,
   fallback: OperatorDefaults,
 ): void {
-  assertRoutingCompatibility({ ...fallback, ...parseOperatorDefaultsToml(raw) });
+  const values = { ...fallback, ...parseOperatorDefaultsToml(raw) };
+  if (isSubscriptionProfile(process.env.O8_SUBSCRIPTION_PROFILE)) {
+    values.subscriptionProfile = process.env.O8_SUBSCRIPTION_PROFILE;
+  }
+  if (isDispatchRuntime(process.env.O8_DEFAULT_DISPATCH_RUNTIME)) {
+    values.defaultDispatchRuntime = process.env.O8_DEFAULT_DISPATCH_RUNTIME;
+  }
+  assertRoutingCompatibility(values);
 }
 
 export function routingUpdateTouchesCompatibility(update: Partial<OperatorDefaults>): boolean {
-  return update.defaultDispatchRuntime !== undefined
+  return update.subscriptionProfile !== undefined
+    || update.defaultDispatchRuntime !== undefined
+    || update.workerExecutionCarrier !== undefined
     || update.defaultDispatchModel !== undefined
     || update.targetingTriage !== undefined
     || update.targetingAction !== undefined;

--- a/src/lib/orchestrator/dispatch-packet-launch.ts
+++ b/src/lib/orchestrator/dispatch-packet-launch.ts
@@ -18,6 +18,8 @@ import type { PacketSpendCap } from './metered-spend';
 import { getProjectContext } from '@/lib/projects/context';
 import { resolveDefaultBranch } from '@/lib/repos/registry';
 import { assertRuntimeDispatchable } from '@/lib/runtimes/shared/auth-detect';
+import { assertExecutionCarrierDispatchable, type ExecutionCarrierPreflightEvidence } from '@/lib/runtimes/shared/execution-carrier-preflight';
+import { executionCarrierDefinition } from '@/lib/runtimes/shared/execution-carrier';
 import type {
   OrchestratorPacket,
   OrchestratorRuntime,
@@ -155,6 +157,12 @@ function recordPacketRouting(input: {
   });
 }
 
+function carrierAuditReason(packet: OrchestratorPacket, routing: WorkerRouting, reason: string): string {
+  return packet.executionCarrier
+    ? `${reason} Effective runtime: ${getRuntimeCapability(routing.selectedRuntime).label} via ${executionCarrierDefinition(packet.executionCarrier).label}; auth source: execution-carrier.`
+    : reason;
+}
+
 export async function launchPacketWithStorageAdmission(input: {
   packet: OrchestratorPacket;
   allPackets: OrchestratorPacket[];
@@ -169,15 +177,20 @@ export async function launchPacketWithStorageAdmission(input: {
   });
   const projectContext = await getProjectContext({ repoPath: packet.workspaceTargetPath });
   const baseBranch = await resolveDefaultBranch(packet.workspaceTargetPath!);
+  let carrierPreflight: ExecutionCarrierPreflightEvidence | null = null;
   try {
-    await assertRuntimeDispatchable(
-      workerRouting.selectedRuntime,
-      workerRouting.selectedModel,
-      packet.workspaceTargetPath,
-      // Retry / rerun relaunches a persisted packet, whose pinned carrier can differ
-      // from the stored worker profile the auth snapshot was computed against.
-      { claudeCodeCarrier: packet.claudeCodeCarrier ?? null },
-    );
+    if (packet.executionCarrier) {
+      carrierPreflight = await assertExecutionCarrierDispatchable(workerRouting.selectedRuntime, packet.executionCarrier);
+    } else {
+      await assertRuntimeDispatchable(
+        workerRouting.selectedRuntime,
+        workerRouting.selectedModel,
+        packet.workspaceTargetPath,
+        // Retry / rerun relaunches a persisted packet, whose pinned carrier can differ
+        // from the stored worker profile the auth snapshot was computed against.
+        { claudeCodeCarrier: packet.claudeCodeCarrier ?? null },
+      );
+    }
   } catch (error) {
     recordPacketRouting({
       packet,
@@ -225,7 +238,7 @@ export async function launchPacketWithStorageAdmission(input: {
       receiptKey: `packet-storage-launch:${admissionLease.receipt.reservationId}`,
       contextId: packet.id,
       status: fallback ? 'fallback' : 'selected',
-      reason: workerRouting.reason,
+      reason: carrierAuditReason(packet, workerRouting, workerRouting.reason),
       fallbackReason: fallback ? workerRouting.reason : null,
     });
     return result;
@@ -278,6 +291,18 @@ export async function launchPacketWithStorageAdmission(input: {
         storageAdmissionOwnerGeneration: launchGeneration,
         storageAdmissionReservationId: admissionLease.receipt.reservationId,
       });
+      if (carrierPreflight) {
+        recordLaneEvent(laneResult.laneId, 'execution_carrier_preflight', 'orchestrator', {
+          runtime: carrierPreflight.runtime,
+          runtimeBinary: carrierPreflight.runtimeBinaryName,
+          runtimeBinarySource: carrierPreflight.runtimeCli.source,
+          executionCarrier: carrierPreflight.executionCarrier,
+          carrierBinary: carrierPreflight.carrierBinaryName,
+          carrierBinarySource: carrierPreflight.carrierCli.source,
+          authSource: carrierPreflight.authSource,
+          authenticated: carrierPreflight.authenticated,
+        });
+      }
       launchResult = await dispatchLaneCommand({
         verb: 'launch_session',
         laneId: laneResult.laneId,
@@ -290,6 +315,7 @@ export async function launchPacketWithStorageAdmission(input: {
         model: workerRouting.selectedModel ?? undefined,
         claudeCodeModel: packet.claudeCodeModel ?? undefined,
         claudeCodeCarrier: packet.claudeCodeCarrier ?? undefined,
+        executionCarrier: packet.executionCarrier ?? undefined,
         spendCap,
         effort: workerRouting.selectedEffort ?? undefined,
         clientMutationId: `packet-launch:${packet.id}:${launchGeneration}`,
@@ -345,7 +371,7 @@ export async function launchPacketWithStorageAdmission(input: {
       receiptKey: claimKey,
       contextId: packet.id,
       status: fallback ? 'fallback' : 'selected',
-      reason: outcome.result.workerRouting.reason,
+      reason: carrierAuditReason(packet, outcome.result.workerRouting, outcome.result.workerRouting.reason),
       fallbackReason: fallback ? outcome.result.workerRouting.reason : null,
     });
     return outcome.result;

--- a/src/lib/orchestrator/normalize/decomposition.ts
+++ b/src/lib/orchestrator/normalize/decomposition.ts
@@ -1,6 +1,7 @@
 import type { OrchestratorPacket, OrchestratorPacketType } from '@/lib/orchestrator/types';
 import { normalizePacketTaskContract } from '@/lib/orchestrator/packet-task-contract';
 import { normalizeWorkerLaunchContext } from '@/lib/orchestrator/worker-launch-context';
+import { isExecutionCarrierId, UnknownExecutionCarrierError } from '@/lib/runtimes/shared/execution-carrier';
 
 /**
  * Narrow an arbitrary value to a known packet type tag. Only `decompose` is
@@ -48,6 +49,12 @@ export function normalizeClaudeCodePacketPins(
       ? carrier
       : null,
   };
+}
+
+export function normalizePacketExecutionCarrier(value: unknown): OrchestratorPacket['executionCarrier'] {
+  if (value === null || value === undefined) return null;
+  if (isExecutionCarrierId(value)) return value;
+  throw new UnknownExecutionCarrierError(value);
 }
 
 /**

--- a/src/lib/orchestrator/operator-mission-service/mission.ts
+++ b/src/lib/orchestrator/operator-mission-service/mission.ts
@@ -6,7 +6,7 @@ import { buildDagMetadata, buildDependencyGraph } from '@/lib/orchestrator/dag';
 import { applyPacketScopePolicy, buildRemainingLaunchBudget, computePredictedFiles, runDispatchTick } from '@/lib/orchestrator/dispatch';
 import { findLaneByPacket, getLaneEvents, listLanes } from '@/lib/lane/registry';
 import { recoveryInfoFromLaneEvents } from '@/lib/lane/recovery-info';
-import { resolveBranchPrefixSync } from '@/lib/operator/defaults';
+import { getOperatorDefaultsSync, resolveBranchPrefixSync } from '@/lib/operator/defaults';
 import { currentLaneMergePolicy } from '@/lib/lane/dogfood-guard';
 import { listArtifacts, toArtifactRef } from '@/lib/artifacts/store';
 import { normalizeOrchestratorMissionState } from '@/lib/orchestrator/store';
@@ -21,6 +21,7 @@ import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 import { bindWorkerLaunchParent } from '@/lib/orchestrator/worker-launch-context';
 import { assertQualitySearchMissionCompatibility, resolveTaskContractRequired } from '@/lib/orchestrator/task-contract-required';
 import { withMissionHandoffBarrier } from '@/lib/orchestrator/lifecycle-mutation-lock';
+import { assertExecutionCarrierCompatible, isExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 import { releaseAbandonedMissionLifecycleHold } from '@/lib/orchestrator/mission-lifecycle-hold';
 import { getTopRulesForPacket, readRepoScopedRules } from '@/lib/dispatch/rules-store';
 import { prepareMissionBranches, type MissionBranchDecision } from './branch-cleanup';
@@ -141,6 +142,25 @@ export async function createMission(input: CreateMissionInput) {
     requestedEffort: input.requestedEffort,
     source: 'mission-create',
   });
+  const executionCarrier = input.executionCarrier === undefined
+    ? getOperatorDefaultsSync().values.workerExecutionCarrier
+    : input.executionCarrier;
+  if (executionCarrier !== null && !isExecutionCarrierId(executionCarrier)) {
+    throw new Error('executionCarrier must be "ori" or null.');
+  }
+  const packetRoutings = loadedIssues.map((issue) => issue.runtime
+    ? resolveWorkerRouting({
+        workerIntent: input.workerIntent,
+        requestedProvider: input.requestedProvider,
+        requestedRuntime: issue.runtime,
+        requestedModel: resolveRuntimePresetModel(input.runtimePreset, issue.runtime, input.requestedModel, input.claudeCodeCarrier),
+        requestedEffort: input.requestedEffort,
+        source: 'mission-create-packet',
+      })
+    : workerRouting);
+  if (executionCarrier) {
+    for (const routing of packetRoutings) assertExecutionCarrierCompatible(executionCarrier, routing.selectedRuntime);
+  }
   const branchPreparation = await prepareMissionBranches({
     repoPath,
     candidates: loadedIssues.map((issue, index) => ({
@@ -168,16 +188,7 @@ export async function createMission(input: CreateMissionInput) {
     // Per-issue runtime — a mission can mix Codex + Gemini packets (the swarm
     // "split coding/thinking" path). When the issue pins its own runtime, route
     // that packet through it; otherwise inherit the mission-level routing.
-    const packetRouting = issue.runtime
-      ? resolveWorkerRouting({
-          workerIntent: input.workerIntent,
-          requestedProvider: input.requestedProvider,
-          requestedRuntime: issue.runtime,
-          requestedModel: resolveRuntimePresetModel(input.runtimePreset, issue.runtime, input.requestedModel, input.claudeCodeCarrier),
-          requestedEffort: input.requestedEffort,
-          source: 'mission-create-packet',
-        })
-      : workerRouting;
+    const packetRouting = packetRoutings[index]!;
 
     // #453/#inline-branch-hardening — Inline tasks carry their unique issue
     // number in the branch to avoid same-title mission collisions.
@@ -236,6 +247,7 @@ export async function createMission(input: CreateMissionInput) {
       lane: null,
       assignedModel: packetRouting.selectedModel,
       ...(packetRouting.selectedRuntime === 'claude-code' ? { claudeCodeModel: input.claudeCodeModel?.trim() || null, claudeCodeCarrier: input.claudeCodeCarrier ?? null } : {}),
+      ...(executionCarrier ? { executionCarrier } : {}),
       workerIntent: packetRouting.workerIntent,
       workerRouting: packetRouting,
       dispatchRuntimePin: packetRouting.requestedRuntime ?? packetRouting.selectedRuntime,

--- a/src/lib/orchestrator/operator-mission-service/types.ts
+++ b/src/lib/orchestrator/operator-mission-service/types.ts
@@ -12,6 +12,7 @@ import type {
 import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import type { ClaudeCodeModelSource } from '@/lib/claude-code/worker-profile-types';
 import type { RuntimePresetId } from '@/lib/orchestrator/runtime-capabilities';
+import type { ExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 
 export interface LoadedIssue {
   number: number;
@@ -44,6 +45,8 @@ export interface CreateMissionInput {
   claudeCodeModel?: string | null;
   /** Explicit per-packet carrier pin for Claude Code workers. */
   claudeCodeCarrier?: ClaudeCodeModelSource | null;
+  /** Optional execution wrapper. Omit to inherit the persisted operator setting. */
+  executionCarrier?: ExecutionCarrierId | null;
   /** Requested worker reasoning effort. Applied at launch only for runtimes with
    *  a reasoning-effort surface (codex/claude-code); a no-op elsewhere. Omit for
    *  today's behavior (runtime default). */

--- a/src/lib/orchestrator/store.ts
+++ b/src/lib/orchestrator/store.ts
@@ -1,4 +1,4 @@
-import { normalizeClaudeCodePacketPins, normalizeDecompositionMetadata, normalizePacketDispatcher, normalizePacketLaunchContext, normalizePacketTaskContractFields, normalizePacketType } from '@/lib/orchestrator/normalize/decomposition';
+import { normalizeClaudeCodePacketPins, normalizeDecompositionMetadata, normalizePacketDispatcher, normalizePacketExecutionCarrier, normalizePacketLaunchContext, normalizePacketTaskContractFields, normalizePacketType } from '@/lib/orchestrator/normalize/decomposition';
 import { normalizeRuntimeStatusToOrchestratorStatus } from '@/lib/orchestrator/runtime-status';
 import { runtimeTruthHasActiveWriter } from '@/lib/orchestrator/runtime-truth';
 import { normalizePacketRecovery } from '@/lib/lane/recovery-info';
@@ -383,7 +383,7 @@ function normalizePacket(raw: unknown, index: number, existing: Array<Pick<Orche
     comparisonIndex: typeof packet.comparisonIndex === 'number' && Number.isFinite(packet.comparisonIndex) && packet.comparisonIndex >= 0
       ? Math.floor(packet.comparisonIndex)
       : undefined,
-    assignedModel: (typeof packet.assignedModel === 'string' && packet.assignedModel.trim()) || null, ...normalizeClaudeCodePacketPins(packet),
+    assignedModel: (typeof packet.assignedModel === 'string' && packet.assignedModel.trim()) || null, ...normalizeClaudeCodePacketPins(packet), executionCarrier: normalizePacketExecutionCarrier(packet.executionCarrier),
     qualitySearch: normalizeQualitySearchPacketState(packet.qualitySearch),
     tierEscalated: packet.tierEscalated === true ? true : undefined,
     predictedFiles: Array.isArray(packet.predictedFiles)

--- a/src/lib/orchestrator/types.ts
+++ b/src/lib/orchestrator/types.ts
@@ -9,6 +9,7 @@ import type { PacketSpendCap, PacketSpendTelemetry } from '@/lib/orchestrator/me
 import type { PacketContextTelemetry } from '@/lib/orchestrator/packet-context-telemetry';
 import type { AgentSummary } from '@/lib/fleet/types';
 import type { TerminalStatusEvidence } from '@/lib/terminal-status/resolve';
+import type { ExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 
 export type { OrchestratorRuntime } from '@/lib/orchestrator/runtime-capabilities';
 export type OrchestratorExecutionMode = 'fleet' | 'single' | 'fusion';
@@ -381,6 +382,8 @@ export interface OrchestratorPacket {
   claudeCodeModel?: string | null;
   /** Explicit carrier pin for a Claude Code packet. It wins over the global worker profile. */
   claudeCodeCarrier?: ClaudeCodeModelSource | null;
+  /** Optional argv/credential wrapper. The runtime remains the session identity owner. */
+  executionCarrier?: ExecutionCarrierId | null;
   /** Opt-in two-candidate search state. The seed has a null role; fan-out
    * assigns one bounded role to each isolated candidate. */
   qualitySearch?: QualitySearchPacketState;

--- a/src/lib/runtime/actions.ts
+++ b/src/lib/runtime/actions.ts
@@ -5,6 +5,7 @@ import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import type { ClaudeCodeModelSource } from '@/lib/claude-code/worker-profile-types';
 import type { OrchestratorRuntime, WorkerWorkMode } from '@/lib/orchestrator/types';
 import type { PacketSpendCap } from '@/lib/orchestrator/metered-spend';
+import type { ExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 import {
   listDeclarativeRuntimes,
 } from '@/lib/orchestrator/runtime-capabilities';
@@ -75,6 +76,7 @@ export interface RuntimeLaunchRequest {
   model?: string;
   claudeCodeModel?: string;
   claudeCodeCarrier?: ClaudeCodeModelSource;
+  executionCarrier?: ExecutionCarrierId;
   /** Requested reasoning effort — passed to the runtime's launch; per-runtime no-op. */
   effort?: ThinkingEffort;
   clientMutationId?: string;
@@ -365,6 +367,7 @@ export async function launchRuntimeSurface(payload: RuntimeLaunchRequest): Promi
     model: payload.model,
     claudeCodeModel: payload.claudeCodeModel,
     claudeCodeCarrier: payload.claudeCodeCarrier,
+    executionCarrier: payload.executionCarrier,
     effort: payload.effort,
     worktreeFlag: launchWorktree?.claudeWorktreeFlag,
     worktreePath: launchWorktree?.worktree?.path,

--- a/src/lib/runtimes/codex.ts
+++ b/src/lib/runtimes/codex.ts
@@ -348,6 +348,7 @@ export const codexRuntime: AgentRuntime = {
       effort,
       laneId: opts.laneId,
       packetId: opts.packetId,
+      executionCarrier: opts.executionCarrier,
       // Codex is the DEFAULT worker runtime, so a read-only packet that skipped
       // this thread was read-only in prompt only for almost every dispatch.
       workMode: opts.workMode,

--- a/src/lib/runtimes/shared/execution-carrier-launch.ts
+++ b/src/lib/runtimes/shared/execution-carrier-launch.ts
@@ -1,0 +1,84 @@
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveCli, type CliResolverSpec } from './cli-resolver';
+import {
+  composeExecutionCarrierInvocation,
+  executionCarrierDefinition,
+  executionCarrierFromRuntimeConfig,
+} from './execution-carrier';
+
+type ResolveCli = (spec: CliResolverSpec) => ReturnType<typeof resolveCli>;
+
+export interface ExecutionCarrierInvocation {
+  command: string;
+  args: string[];
+  carried: boolean;
+  runtimeBinDir?: string;
+}
+
+export async function resolveExecutionCarrierInvocation(input: {
+  runtime: OrchestratorRuntime;
+  runtimeConfig: Record<string, string> | undefined;
+  runtimeBinary: string;
+  runtimeArgs: readonly string[];
+  resolve?: ResolveCli;
+}): Promise<ExecutionCarrierInvocation> {
+  const carrier = executionCarrierFromRuntimeConfig(input.runtimeConfig);
+  if (!carrier) {
+    const invocation = composeExecutionCarrierInvocation({
+      carrier: null,
+      runtime: input.runtime,
+      runtimeBinary: input.runtimeBinary,
+      runtimeArgs: input.runtimeArgs,
+    });
+    return { ...invocation, carried: false };
+  }
+
+  const definition = executionCarrierDefinition(carrier);
+  const carrierCli = await (input.resolve ?? resolveCli)({
+    runtimeId: `execution-carrier:${carrier}`,
+    binaryName: definition.binaryName,
+    envOverride: definition.binaryEnvOverride,
+  });
+  if (process.platform === 'win32' && !/\.(?:exe|com)$/i.test(carrierCli.path)) {
+    throw new Error(
+      `Execution carrier '${carrier}' resolved to a script wrapper; Windows carrier launches require a native .exe or .com binary.`,
+    );
+  }
+  const invocation = composeExecutionCarrierInvocation({
+    carrier,
+    runtime: input.runtime,
+    runtimeBinary: input.runtimeBinary,
+    runtimeArgs: input.runtimeArgs,
+    carrierBinary: carrierCli.path,
+  });
+  return {
+    ...invocation,
+    carried: true,
+    ...(path.isAbsolute(input.runtimeBinary) ? { runtimeBinDir: path.dirname(input.runtimeBinary) } : {}),
+  };
+}
+
+export function executionCarrierSpawnPath(
+  basePath: string,
+  launch: ExecutionCarrierInvocation,
+): string {
+  return launch.runtimeBinDir ? `${launch.runtimeBinDir}${path.delimiter}${basePath}` : basePath;
+}
+
+export function executionCarrierSandboxReadPaths(
+  basePaths: readonly string[],
+  launch: ExecutionCarrierInvocation,
+): string[] {
+  return launch.carried
+    ? [...basePaths, path.join(os.homedir(), '.ori'), ...(launch.runtimeBinDir ? [launch.runtimeBinDir] : [])]
+    : [...basePaths];
+}
+
+export function executionCarrierCommandIdentity(
+  launch: ExecutionCarrierInvocation,
+  spawnBinary: string,
+): string {
+  return launch.carried ? launch.command : path.basename(spawnBinary);
+}

--- a/src/lib/runtimes/shared/execution-carrier-preflight.ts
+++ b/src/lib/runtimes/shared/execution-carrier-preflight.ts
@@ -1,0 +1,147 @@
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+import { spawn } from 'node:child_process';
+import { CliNotFoundError, resolveCli, type ResolvedCli } from './cli-resolver';
+import { cliInvocation } from './cli-spawn';
+import {
+  assertExecutionCarrierCompatible,
+  executionCarrierDefinition,
+  type ExecutionCarrierId,
+} from './execution-carrier';
+
+export type ExecutionCarrierPreflightFailure =
+  | 'unsupported-pair'
+  | 'missing-carrier'
+  | 'missing-runtime'
+  | 'unsafe-carrier-binary'
+  | 'carrier-auth-unavailable';
+
+export class ExecutionCarrierPreflightError extends Error {
+  constructor(
+    public readonly failure: ExecutionCarrierPreflightFailure,
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'ExecutionCarrierPreflightError';
+  }
+}
+
+type ResolveCli = typeof resolveCli;
+
+const RUNTIME_CLI: Partial<Record<OrchestratorRuntime, {
+  binaryName: string;
+  envOverride: string;
+}>> = {
+  codex: { binaryName: 'codex', envOverride: 'O8_CODEX_BIN' },
+};
+
+export interface ExecutionCarrierPreflightEvidence {
+  runtime: OrchestratorRuntime;
+  runtimeBinaryName: string;
+  runtimeCli: ResolvedCli;
+  executionCarrier: ExecutionCarrierId;
+  carrierBinaryName: string;
+  carrierCli: ResolvedCli;
+  authSource: 'execution-carrier';
+  authenticated: true;
+}
+
+export async function probeExecutionCarrierAuth(binary: string): Promise<boolean> {
+  const invocation = cliInvocation(binary, ['auth']);
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve(result);
+    };
+    const child = spawn(invocation.command, invocation.args, {
+      windowsHide: true,
+      stdio: 'ignore',
+      env: process.env,
+    });
+    const timeout = setTimeout(() => { child.kill(); finish(false); }, 10_000);
+    child.once('error', () => finish(false));
+    child.once('exit', (code) => finish(code === 0));
+  });
+}
+
+export async function assertExecutionCarrierDispatchable(
+  runtime: OrchestratorRuntime,
+  carrier: ExecutionCarrierId,
+  resolve: ResolveCli = resolveCli,
+  probeAuth: (binary: string) => Promise<boolean> = probeExecutionCarrierAuth,
+): Promise<ExecutionCarrierPreflightEvidence> {
+  try {
+    assertExecutionCarrierCompatible(carrier, runtime);
+  } catch (error) {
+    throw new ExecutionCarrierPreflightError(
+      'unsupported-pair',
+      `Execution carrier '${carrier}' cannot dispatch the '${runtime}' runtime.`,
+      error,
+    );
+  }
+
+  const runtimeSpec = RUNTIME_CLI[runtime];
+  if (!runtimeSpec) {
+    throw new ExecutionCarrierPreflightError(
+      'missing-runtime',
+      `The '${runtime}' runtime does not expose an underlying CLI contract for execution carriers.`,
+    );
+  }
+
+  let carrierCli: ResolvedCli;
+  const definition = executionCarrierDefinition(carrier);
+  try {
+    carrierCli = await resolve({
+      runtimeId: `execution-carrier:${carrier}`,
+      binaryName: definition.binaryName,
+      envOverride: definition.binaryEnvOverride,
+    });
+  } catch (error) {
+    if (!(error instanceof CliNotFoundError)) throw error;
+    throw new ExecutionCarrierPreflightError(
+      'missing-carrier',
+      `Execution carrier '${carrier}' is selected, but '${definition.binaryName}' was not found. Install it or set ${definition.binaryEnvOverride}.`,
+      error,
+    );
+  }
+
+  if (process.platform === 'win32' && !/\.(?:exe|com)$/i.test(carrierCli.path)) {
+    throw new ExecutionCarrierPreflightError(
+      'unsafe-carrier-binary',
+      `Execution carrier '${carrier}' resolved to a script wrapper. On Windows, ${definition.binaryEnvOverride} must name a native .exe or .com binary so worker argv never passes through cmd.exe.`,
+    );
+  }
+
+  if (!await probeAuth(carrierCli.path)) {
+    throw new ExecutionCarrierPreflightError(
+      'carrier-auth-unavailable',
+      `Execution carrier '${carrier}' could not resolve credentials. Run '${definition.binaryName} login'; if '${definition.binaryName} auth' is unknown, upgrade Ori to 0.3.0 or newer.`,
+    );
+  }
+
+  let runtimeCli: ResolvedCli;
+  try {
+    runtimeCli = await resolve({ runtimeId: runtime, ...runtimeSpec });
+  } catch (error) {
+    if (!(error instanceof CliNotFoundError)) throw error;
+    throw new ExecutionCarrierPreflightError(
+      'missing-runtime',
+      `Execution carrier '${carrier}' is available, but the underlying '${runtimeSpec.binaryName}' CLI was not found. Install it or set ${runtimeSpec.envOverride}.`,
+      error,
+    );
+  }
+
+  return {
+    runtime,
+    runtimeBinaryName: runtimeSpec.binaryName,
+    runtimeCli,
+    executionCarrier: carrier,
+    carrierBinaryName: definition.binaryName,
+    carrierCli,
+    authSource: 'execution-carrier',
+    authenticated: true,
+  };
+}

--- a/src/lib/runtimes/shared/execution-carrier.test.ts
+++ b/src/lib/runtimes/shared/execution-carrier.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { CliNotFoundError, type CliResolverSpec, type ResolvedCli } from './cli-resolver';
+import {
+  composeExecutionCarrierInvocation,
+  executionCarrierFromRuntimeConfig,
+  executionCarrierRuntimeConfig,
+  UnknownExecutionCarrierError,
+  UnsupportedExecutionCarrierRuntimeError,
+} from './execution-carrier';
+import {
+  executionCarrierCommandIdentity,
+  executionCarrierSandboxReadPaths,
+  executionCarrierSpawnPath,
+  resolveExecutionCarrierInvocation,
+} from './execution-carrier-launch';
+import { assertExecutionCarrierDispatchable, ExecutionCarrierPreflightError } from './execution-carrier-preflight';
+
+function resolved(path: string): ResolvedCli {
+  return { path, source: 'env', detectedAt: 1, envHint: 'test' };
+}
+
+const carrierBinary = process.platform === 'win32' ? 'C:\\tools\\ori.exe' : '/tools/ori';
+
+describe('typed execution carriers', () => {
+  it('composes Ori and Codex as structured argv without a shell string', () => {
+    expect(composeExecutionCarrierInvocation({
+      carrier: 'ori', runtime: 'codex', carrierBinary: '/bin/ori',
+      runtimeBinary: '/bin/codex', runtimeArgs: ['exec', '--json', 'hello; echo unsafe'],
+    })).toEqual({ command: '/bin/ori', args: ['codex', 'exec', '--json', 'hello; echo unsafe'] });
+  });
+
+  it('keeps the no-carrier invocation unchanged', async () => {
+    const resolve = vi.fn();
+    await expect(resolveExecutionCarrierInvocation({
+      runtime: 'codex', runtimeConfig: undefined, runtimeBinary: '/bin/codex',
+      runtimeArgs: ['exec', '--json'], resolve,
+    })).resolves.toEqual({ command: '/bin/codex', args: ['exec', '--json'], carried: false });
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it('exposes an off-PATH underlying runtime to the carrier and keeps Ori state read-only', async () => {
+    const runtimeBinary = process.platform === 'win32' ? 'C:\\private\\codex.exe' : '/private/codex';
+    const launch = await resolveExecutionCarrierInvocation({
+      runtime: 'codex', runtimeConfig: { executionCarrier: 'ori' }, runtimeBinary,
+      runtimeArgs: ['exec', '--json'], resolve: async () => resolved(carrierBinary),
+    });
+    expect(launch).toMatchObject({ command: carrierBinary, args: ['codex', 'exec', '--json'], carried: true });
+    expect(executionCarrierSpawnPath('base-path', launch).split(process.platform === 'win32' ? ';' : ':')[0])
+      .toBe(process.platform === 'win32' ? 'C:\\private' : '/private');
+    expect(executionCarrierSandboxReadPaths(['/mcp'], launch)).toEqual(expect.arrayContaining([
+      '/mcp', expect.stringMatching(/[\\/]\.ori$/), process.platform === 'win32' ? 'C:\\private' : '/private',
+    ]));
+    expect(executionCarrierCommandIdentity(launch, '/usr/bin/sandbox-exec')).toBe(carrierBinary);
+  });
+
+  it('rejects unsupported carrier/runtime pairs', () => {
+    expect(() => composeExecutionCarrierInvocation({
+      carrier: 'ori', runtime: 'claude-code', carrierBinary: '/bin/ori',
+      runtimeBinary: '/bin/claude', runtimeArgs: ['--print'],
+    })).toThrow(UnsupportedExecutionCarrierRuntimeError);
+  });
+
+  it('round-trips the credential-free runtime config pin', () => {
+    expect(executionCarrierRuntimeConfig('ori')).toEqual({ executionCarrier: 'ori' });
+    expect(executionCarrierFromRuntimeConfig({ executionCarrier: 'ori' })).toBe('ori');
+    expect(executionCarrierRuntimeConfig(null)).toEqual({});
+    expect(() => executionCarrierFromRuntimeConfig({ executionCarrier: 'future-carrier' }))
+      .toThrow(UnknownExecutionCarrierError);
+  });
+
+  it('reports a missing carrier separately from a missing underlying runtime', async () => {
+    const missingCarrier = vi.fn(async (spec: CliResolverSpec) => {
+      throw new CliNotFoundError(spec.binaryName, []);
+    });
+    await expect(assertExecutionCarrierDispatchable('codex', 'ori', missingCarrier, async () => true))
+      .rejects.toMatchObject({ failure: 'missing-carrier' } satisfies Partial<ExecutionCarrierPreflightError>);
+
+    const missingRuntime = vi.fn(async (spec: CliResolverSpec) => {
+      if (spec.runtimeId === 'execution-carrier:ori') return resolved(carrierBinary);
+      throw new CliNotFoundError(spec.binaryName, []);
+    });
+    await expect(assertExecutionCarrierDispatchable('codex', 'ori', missingRuntime, async () => true))
+      .rejects.toMatchObject({ failure: 'missing-runtime' } satisfies Partial<ExecutionCarrierPreflightError>);
+  });
+
+  it('fails closed when the carrier cannot resolve credentials', async () => {
+    const resolve = vi.fn(async (spec: CliResolverSpec) => resolved(
+      spec.runtimeId === 'execution-carrier:ori' ? carrierBinary : `/bin/${spec.binaryName}`,
+    ));
+    await expect(assertExecutionCarrierDispatchable('codex', 'ori', resolve, async () => false))
+      .rejects.toMatchObject({ failure: 'carrier-auth-unavailable' } satisfies Partial<ExecutionCarrierPreflightError>);
+  });
+
+  it('reports carrier auth evidence without credentials', async () => {
+    const resolve = vi.fn(async (spec: CliResolverSpec) => resolved(
+      spec.runtimeId === 'execution-carrier:ori' ? carrierBinary : `/bin/${spec.binaryName}`,
+    ));
+    const evidence = await assertExecutionCarrierDispatchable('codex', 'ori', resolve, async () => true);
+    expect(evidence).toMatchObject({ runtime: 'codex', executionCarrier: 'ori', authSource: 'execution-carrier', authenticated: true });
+    expect(JSON.stringify(evidence)).not.toMatch(/token|secret|credential/i);
+  });
+
+  it.skipIf(process.platform !== 'win32')('rejects Windows script carriers before prompt argv can reach cmd.exe', async () => {
+    const resolve = vi.fn(async (spec: CliResolverSpec) => resolved(
+      spec.runtimeId === 'execution-carrier:ori' ? 'C:\\tools\\ori.cmd' : 'C:\\tools\\codex.exe',
+    ));
+    await expect(assertExecutionCarrierDispatchable('codex', 'ori', resolve, async () => true))
+      .rejects.toMatchObject({ failure: 'unsafe-carrier-binary' });
+  });
+});

--- a/src/lib/runtimes/shared/execution-carrier.ts
+++ b/src/lib/runtimes/shared/execution-carrier.ts
@@ -1,0 +1,92 @@
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+
+export type ExecutionCarrierId = 'ori';
+
+export interface ExecutionCarrierDefinition {
+  id: ExecutionCarrierId;
+  label: string;
+  binaryName: string;
+  binaryEnvOverride: string;
+  runtimeSubcommands: Readonly<Partial<Record<OrchestratorRuntime, readonly string[]>>>;
+}
+
+const EXECUTION_CARRIERS: Readonly<Record<ExecutionCarrierId, ExecutionCarrierDefinition>> = {
+  ori: {
+    id: 'ori',
+    label: 'Ori',
+    binaryName: 'ori',
+    binaryEnvOverride: 'O8_ORI_BIN',
+    runtimeSubcommands: { codex: ['codex'] },
+  },
+};
+
+export const EXECUTION_CARRIER_RUNTIME_CONFIG_KEY = 'executionCarrier';
+
+export class UnsupportedExecutionCarrierRuntimeError extends Error {
+  constructor(carrier: ExecutionCarrierId, runtime: OrchestratorRuntime) {
+    super(`Execution carrier '${carrier}' does not support runtime '${runtime}'.`);
+    this.name = 'UnsupportedExecutionCarrierRuntimeError';
+  }
+}
+
+export class UnknownExecutionCarrierError extends Error {
+  constructor(value: unknown) {
+    super(`Unknown execution carrier ${JSON.stringify(value)}; refusing to fall back to direct runtime credentials.`);
+    this.name = 'UnknownExecutionCarrierError';
+  }
+}
+
+export function isExecutionCarrierId(value: unknown): value is ExecutionCarrierId {
+  return value === 'ori';
+}
+
+export function executionCarrierDefinition(id: ExecutionCarrierId): ExecutionCarrierDefinition {
+  return EXECUTION_CARRIERS[id];
+}
+
+export function assertExecutionCarrierCompatible(
+  carrier: ExecutionCarrierId,
+  runtime: OrchestratorRuntime,
+): readonly string[] {
+  const subcommand = executionCarrierDefinition(carrier).runtimeSubcommands[runtime];
+  if (!subcommand) throw new UnsupportedExecutionCarrierRuntimeError(carrier, runtime);
+  return subcommand;
+}
+
+export function composeExecutionCarrierInvocation(input: {
+  carrier: ExecutionCarrierId | null | undefined;
+  runtime: OrchestratorRuntime;
+  runtimeBinary: string;
+  runtimeArgs: readonly string[];
+  carrierBinary?: string;
+}): { command: string; args: string[] } {
+  if (!input.carrier) {
+    return { command: input.runtimeBinary, args: [...input.runtimeArgs] };
+  }
+  const subcommand = assertExecutionCarrierCompatible(input.carrier, input.runtime);
+  if (!input.carrierBinary) throw new Error(`Resolved binary is required for execution carrier '${input.carrier}'.`);
+  return { command: input.carrierBinary, args: [...subcommand, ...input.runtimeArgs] };
+}
+
+export function executionCarrierRuntimeConfig(
+  carrier: ExecutionCarrierId | null | undefined,
+): Record<string, string> {
+  return carrier ? { [EXECUTION_CARRIER_RUNTIME_CONFIG_KEY]: carrier } : {};
+}
+
+export function executionCarrierFromRuntimeConfig(
+  runtimeConfig: Record<string, string> | undefined,
+): ExecutionCarrierId | null {
+  const value = runtimeConfig?.[EXECUTION_CARRIER_RUNTIME_CONFIG_KEY];
+  if (value === undefined) return null;
+  if (isExecutionCarrierId(value)) return value;
+  throw new UnknownExecutionCarrierError(value);
+}
+
+export function executionCarrierRuntimeLabel(
+  runtimeLabel: string,
+  runtimeConfig: Record<string, string> | undefined,
+): string {
+  const carrier = executionCarrierFromRuntimeConfig(runtimeConfig);
+  return carrier ? `${runtimeLabel} via ${executionCarrierDefinition(carrier).label}` : runtimeLabel;
+}

--- a/src/lib/runtimes/shared/owned-session/fleet.ts
+++ b/src/lib/runtimes/shared/owned-session/fleet.ts
@@ -5,6 +5,7 @@ import {
 } from './archive';
 import {
   OWNED_STALE_WINDOW_MS,
+  commandLineMatchesOwnedRun,
   isOwnedRunAlive,
   metadataPath,
   nowIso,
@@ -231,7 +232,7 @@ export function createFleetComputer({
           await signalBridgeTerminalSession(activeRun.tmuxSession, 'SIGINT');
         } else {
           const cmd = await pidCommandLine(activeRun.pid);
-          if (cmd && cmd.includes(adapter.binaryName)) {
+          if (commandLineMatchesOwnedRun(cmd, activeRun.commandIdentity, adapter.binaryName)) {
             if (process.platform === 'win32') {
               // A failed kill must NOT return early here: the orphan record and
               // saveSession below are the only trace this session ever existed,

--- a/src/lib/runtimes/shared/owned-session/helpers.test.ts
+++ b/src/lib/runtimes/shared/owned-session/helpers.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
 
 import {
+  commandLineMatchesOwnedRun,
   filterStderrNoise,
   isOwnedRunAlive,
   relativeAge,
@@ -38,6 +39,21 @@ describe('repoSlugFromOrigin', () => {
     expect(repoSlugFromOrigin('https://gitlab.com/team/repo.git')).toBeUndefined();
     expect(repoSlugFromOrigin('')).toBeUndefined();
     expect(repoSlugFromOrigin(undefined)).toBeUndefined();
+  });
+});
+
+describe('commandLineMatchesOwnedRun', () => {
+  it('recognizes a persisted carrier wrapper instead of requiring the runtime binary name', () => {
+    expect(commandLineMatchesOwnedRun('/usr/bin/ori codex exec --json', '/usr/bin/ori', 'codex')).toBe(true);
+    expect(commandLineMatchesOwnedRun('/Users/J Doe/.local/bin/ori codex exec --json', '/Users/J Doe/.local/bin/ori', 'codex')).toBe(true);
+    expect(commandLineMatchesOwnedRun('"/Users/J Doe/.local/bin/ori" codex exec --json', '/Users/J Doe/.local/bin/ori', 'codex')).toBe(true);
+    expect(commandLineMatchesOwnedRun('/Users/J Doe/.local/bin/original codex exec --json', '/Users/J Doe/.local/bin/ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('/bin/sh -c "echo /usr/bin/ori"', '/usr/bin/ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('/usr/bin/ori codex exec --json', undefined, 'codex')).toBe(true);
+    expect(commandLineMatchesOwnedRun('/usr/bin/node unrelated.js', 'ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('/usr/bin/origami codexical', 'ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('git fetch origin', 'ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('/Users/victoria/bin/node task.js', 'ori', 'codex')).toBe(false);
   });
 });
 

--- a/src/lib/runtimes/shared/owned-session/helpers.ts
+++ b/src/lib/runtimes/shared/owned-session/helpers.ts
@@ -300,6 +300,39 @@ export function isPidAlive(pid?: number) {
   }
 }
 
+export function commandLineMatchesOwnedRun(
+  commandLine: string | null,
+  commandIdentity: string | undefined,
+  fallbackBinaryName: string,
+): boolean {
+  const identity = commandIdentity?.trim() || fallbackBinaryName;
+  if (!commandLine) return false;
+  const normalizedIdentity = identity.toLowerCase();
+  const identityIsPath = identity.includes('/') || identity.includes('\\');
+  if (identityIsPath) {
+    const normalizedCommandLine = commandLine.toLowerCase();
+    const quotedTokens = commandLine.match(/"[^"]*"|'[^']*'/g) ?? [];
+    if (quotedTokens.some((token) => token.slice(1, -1).toLowerCase() === normalizedIdentity)) return true;
+    let offset = normalizedCommandLine.indexOf(normalizedIdentity);
+    while (offset >= 0) {
+      const before = normalizedCommandLine[offset - 1];
+      const after = normalizedCommandLine[offset + normalizedIdentity.length];
+      const prefix = normalizedCommandLine.slice(0, offset);
+      const insideSingleQuotes = (prefix.match(/'/g)?.length ?? 0) % 2 === 1;
+      const insideDoubleQuotes = (prefix.match(/"/g)?.length ?? 0) % 2 === 1;
+      if (!insideSingleQuotes && !insideDoubleQuotes
+        && (!before || /\s/.test(before)) && (!after || /\s/.test(after))) return true;
+      offset = normalizedCommandLine.indexOf(normalizedIdentity, offset + 1);
+    }
+    return false;
+  }
+  const tokens = commandLine.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
+  return tokens.some((rawToken) => {
+    const token = rawToken.replace(/^["']|["']$/g, '').toLowerCase();
+    return path.basename(token) === normalizedIdentity || path.win32.basename(token) === normalizedIdentity;
+  });
+}
+
 export async function isOwnedRunAlive(run?: OwnedRunRecord | null): Promise<boolean> {
   if (!run) return false;
   // A run that already recorded a finish is terminal — never probe it (#1293).

--- a/src/lib/runtimes/shared/owned-session/lifecycle.ts
+++ b/src/lib/runtimes/shared/owned-session/lifecycle.ts
@@ -19,6 +19,7 @@ import type {
   OwnedRuntimeAdapter,
   OwnedSessionRecord,
 } from './types';
+import { executionCarrierRuntimeLabel } from '@/lib/runtimes/shared/execution-carrier';
 
 export interface OwnedLifecycleContext {
   adapter: OwnedRuntimeAdapter;
@@ -100,6 +101,7 @@ export function buildRuntimeSurface(
   running: boolean,
 ): RuntimeSurfaceSummary {
   const { adapter, runtimeId } = context;
+  const runtimeLabel = executionCarrierRuntimeLabel(adapter.squadShortName, session.runtimeConfig);
   const lifecycle = deriveLifecycle(context, session);
   const lastOutcomeLabel = lifecycle.lastOutcome ? ` • last ${lifecycle.lastOutcome}` : '';
 
@@ -112,8 +114,8 @@ export function buildRuntimeSurface(
     cwd: shortHome(session.repoPath),
     branch: session.branch,
     sourceLabel: running
-      ? `IDE-owned ${adapter.squadShortName} registry • active pid ${session.activeRun?.pid ?? 'unknown'}${lastOutcomeLabel}`
-      : `IDE-owned ${adapter.squadShortName} registry • ${lifecycleAvailabilityLabel(lifecycle.availability)}${lastOutcomeLabel}`,
+      ? `IDE-owned ${runtimeLabel} registry • active pid ${session.activeRun?.pid ?? 'unknown'}${lastOutcomeLabel}`
+      : `IDE-owned ${runtimeLabel} registry • ${lifecycleAvailabilityLabel(lifecycle.availability)}${lastOutcomeLabel}`,
     tailSourceLabel: `${shortHome(session.sessionDir)}/${RUNS_DIR}/*.jsonl`,
     capabilities: {
       attach: true,
@@ -158,26 +160,27 @@ export function buildCurrentTask(
   running: boolean,
 ) {
   const { adapter } = context;
+  const runtimeLabel = executionCarrierRuntimeLabel(adapter.squadShortName, session.runtimeConfig);
   const lifecycle = deriveLifecycle(context, session);
   if (running) {
-    return `IDE-launched ${adapter.squadShortName} run active. ${session.latestSummary}`;
+    return `IDE-launched ${runtimeLabel} run active. ${session.latestSummary}`;
   }
   if (lifecycle.availability === 'awaiting-thread') {
-    return `IDE-owned ${adapter.squadShortName} session launched and waiting for its first thread id. ${session.latestSummary}`;
+    return `IDE-owned ${runtimeLabel} session launched and waiting for its first thread id. ${session.latestSummary}`;
   }
   if (reviewDisposition(session) === 'resolved') {
     return `Operator marked this owned result resolved. Keep watching only if new evidence appears. ${session.latestSummary}`;
   }
   if (lifecycle.lastOutcome === 'interrupted') {
-    return `IDE-owned ${adapter.squadShortName} session is ready for resume after an interrupted run. ${session.latestSummary}`;
+    return `IDE-owned ${runtimeLabel} session is ready for resume after an interrupted run. ${session.latestSummary}`;
   }
   if (lifecycle.lastOutcome === 'failed') {
-    return `IDE-owned ${adapter.squadShortName} session is ready for a corrective follow-up after a failed run. ${session.latestSummary}`;
+    return `IDE-owned ${runtimeLabel} session is ready for a corrective follow-up after a failed run. ${session.latestSummary}`;
   }
   if (session.threadId) {
-    return `IDE-owned ${adapter.squadShortName} session ready for the next input via resume. ${session.latestSummary}`;
+    return `IDE-owned ${runtimeLabel} session ready for the next input via resume. ${session.latestSummary}`;
   }
-  return `IDE-owned ${adapter.squadShortName} session is idle. ${session.latestSummary}`;
+  return `IDE-owned ${runtimeLabel} session is idle. ${session.latestSummary}`;
 }
 
 export function formatChildExit(outcome: OwnedChildExitOutcome | undefined) {

--- a/src/lib/runtimes/shared/owned-session/run-controller.ts
+++ b/src/lib/runtimes/shared/owned-session/run-controller.ts
@@ -3,7 +3,6 @@ import { closeSync, openSync } from 'node:fs';
 import { readFile, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
-
 import { getOrCreateLocalWorkerToken } from '@/lib/auth/worker-token';
 import {
   bindPacketWorkerTokenProcess,
@@ -16,10 +15,10 @@ import { spawnBridgeTerminalSession } from '@/lib/runtime/pty-bridge';
 import { ensureDispatchBackendReady } from '@/lib/runtimes/shared/dispatch-readiness';
 import { CliNotFoundError, resolveCli } from '@/lib/runtimes/shared/cli-resolver';
 import { cliInvocation } from '@/lib/runtimes/shared/cli-spawn';
+import { executionCarrierCommandIdentity, executionCarrierSandboxReadPaths, executionCarrierSpawnPath, resolveExecutionCarrierInvocation } from '@/lib/runtimes/shared/execution-carrier-launch';
 import { guardedWorkspaceInvocation } from '@/lib/worktree/materialization-execution';
 import { tmuxSessionName } from '@/lib/terminal/tmux';
 import { pathWithNodeRuntime } from '@/lib/util/node-on-path';
-
 import { crashSurvivableWorkersEnabled } from './crash-survival';
 import { observeChildExit, readAbnormalStderrTail } from './exit-outcome';
 import { prepareOwnedLaunchArgs } from './launch-args';
@@ -535,8 +534,9 @@ export function createOwnedRunController({
       humanLabel,
     });
 
-    let spawnBinary = binary;
-    let spawnArgs = args;
+    const carrierLaunch = await resolveExecutionCarrierInvocation({ runtime: runtimeId as OrchestratorRuntime, runtimeConfig: session.runtimeConfig, runtimeBinary: binary, runtimeArgs: args });
+    let spawnBinary = carrierLaunch.command;
+    let spawnArgs = carrierLaunch.args;
     const sandboxEnvExtra: Record<string, string> = {};
     if (sandboxEnabled) {
       try {
@@ -545,9 +545,9 @@ export function createOwnedRunController({
           profileDir: path.join(session.sessionDir, RUNS_DIR),
           cwd: session.repoPath,
           repoPath: session.repoPath,
-          binary,
-          args,
-          extraReadPaths: workerMcp.sandboxReadPaths,
+          binary: spawnBinary,
+          args: spawnArgs,
+          extraReadPaths: executionCarrierSandboxReadPaths(workerMcp.sandboxReadPaths, carrierLaunch),
           finalAllowReadPaths: workerMcp.configPath ? [workerMcp.configPath] : undefined,
           // Read-only: repo stays readable, kernel refuses every write. Deny
           // paths come from the SAME git probe prepareWorkerSandbox uses to
@@ -627,7 +627,7 @@ export function createOwnedRunController({
       // the spawned process cwd. Keep both values aligned so a worker cannot
       // silently operate in the o8 server's own checkout.
       PWD: session.repoPath,
-      PATH: pathWithNodeRuntime(),
+      PATH: executionCarrierSpawnPath(pathWithNodeRuntime(), carrierLaunch),
       FORCE_COLOR: '0',
       NO_COLOR: '1',
       // Workers must never pop an OS browser: dev servers (CRA, storybook)
@@ -660,7 +660,7 @@ export function createOwnedRunController({
       prompt,
       startedAt: nowIso(),
       pid: 0,
-      commandIdentity: path.basename(spawnBinary),
+      commandIdentity: executionCarrierCommandIdentity(carrierLaunch, spawnBinary),
       processMarker: runId,
       spawnState: 'prepared',
       stdoutPath,
@@ -677,7 +677,7 @@ export function createOwnedRunController({
     await io.saveSession(session);
 
     try {
-      if (!crashSurvivableWorkersEnabled()) {
+      if (!carrierLaunch.carried && !crashSurvivableWorkersEnabled()) {
         try {
           const result = await spawnBridgeTerminalSession({
             sessionName: bridgeSessionName,

--- a/src/lib/runtimes/shared/owned-session/sandbox.test.ts
+++ b/src/lib/runtimes/shared/owned-session/sandbox.test.ts
@@ -128,6 +128,20 @@ describe('buildSeatbeltProfile — policy shape', () => {
     expect(profile).toContain('(subpath "/Users/op/.codex")');
   });
 
+  it('can grant Ori state read access without making the credential tree writable', () => {
+    const oriProfile = buildSeatbeltProfile({
+      worktreePath: '/tmp/wt',
+      repoPath: '/tmp/repo',
+      homeDir: '/Users/op',
+      tmpDir: '/tmp/T',
+      extraReadPaths: ['/Users/op/.ori'],
+    });
+    const readAllow = oriProfile.indexOf(';; --- read: system + toolchain roots ---');
+    const writeAllow = oriProfile.indexOf(';; --- read+write: packet, Git metadata, TMPDIR, and tool state ---');
+    expect(oriProfile.indexOf('(subpath "/Users/op/.ori")', readAllow)).toBeGreaterThan(readAllow);
+    expect(oriProfile.indexOf('(subpath "/Users/op/.ori")', writeAllow)).toBe(-1);
+  });
+
   it('can deny protected executable paths and keep launch policy immutable', () => {
     expect(profile).toContain('(deny process-exec\n  (literal "/opt/codex/bin/codex")');
     expect(profile).toContain('(regex #"(^|/)codex(?:$|[-.])")');

--- a/src/lib/runtimes/shared/owned-session/store.ts
+++ b/src/lib/runtimes/shared/owned-session/store.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_AUTO_RETRY_DELAY_MS,
   OWNED_FLEET_TTL_MS,
   compactText,
+  commandLineMatchesOwnedRun,
   ensureDir,
   isPidAlive,
   nowIso,
@@ -345,7 +346,8 @@ export function createOwnedSessionStore(
         await signalBridgeTerminalSession(session.activeRun.tmuxSession, 'SIGINT');
       } else {
         const cmd = await pidCommandLine(session.activeRun.pid);
-        if (cmd && cmd.includes(adapter.binaryName)) {
+        const commandIdentity = session.activeRun.commandIdentity ?? adapter.binaryName;
+        if (commandLineMatchesOwnedRun(cmd, session.activeRun.commandIdentity, adapter.binaryName)) {
           // Windows has no process groups addressed by negative pid and no
           // SIGINT delivery to another tree; the CLI is also a grandchild of
           // the interpreter, so a single-pid kill would leave it running.
@@ -365,7 +367,7 @@ export function createOwnedSessionStore(
           }
         } else {
           console.warn(
-            `[owned-store] Skipping interrupt signal for ${surfaceId}: pid ${session.activeRun.pid} no longer matches an owned ${adapter.binaryName} run (${cmd ?? 'process gone'})`,
+            `[owned-store] Skipping interrupt signal for ${surfaceId}: pid ${session.activeRun.pid} no longer matches owned command ${commandIdentity} (${cmd ?? 'process gone'})`,
           );
         }
       }

--- a/src/lib/runtimes/types.ts
+++ b/src/lib/runtimes/types.ts
@@ -5,6 +5,7 @@ import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import type { ClaudeCodeModelSource } from '@/lib/claude-code/worker-profile-types';
 import type { PacketCostSource, PacketSpendCap } from '@/lib/orchestrator/metered-spend';
 import type { WorkerWorkMode } from '@/lib/orchestrator/types';
+import type { ExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 
 /**
  * Universal Agent Runtime Contract
@@ -272,6 +273,7 @@ export interface LaunchOptions {
   /** Explicit packet-only model/carrier pins for the Claude Code adapter. */
   claudeCodeModel?: string;
   claudeCodeCarrier?: ClaudeCodeModelSource;
+  executionCarrier?: ExecutionCarrierId;
   /** Requested reasoning effort — applied per-runtime (codex today); a no-op elsewhere. */
   effort?: ThinkingEffort;
   worktreeFlag?: string;

--- a/src/lib/settings/toml.ts
+++ b/src/lib/settings/toml.ts
@@ -30,6 +30,7 @@ import { isTargetingTier } from '@/lib/operator/targeting-tier';
 import { isWorkerStartMode } from '@/lib/operator/worker-start-mode';
 import { isThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import { AUTHENTICATED_ENDPOINT_GUIDANCE, credentialBearingUrlPart } from './credential-safe-url';
+import { isExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 
 type TomlRecord = Record<string, unknown>;
 
@@ -123,6 +124,16 @@ function acpModelIdField(section: string, key: string): TomlField<string | null>
         ? trimmed
         : invalid(tomlKey, `a model id shaped provider/model, optionally with a /low or /high suffix; received ${JSON.stringify(trimmed)}`);
     },
+  };
+}
+
+function executionCarrierField(section: string, key: string): TomlField<OperatorDefaults['workerExecutionCarrier']> {
+  return {
+    path: [section, key],
+    serialize: (value) => value ?? '',
+    parse: (value, tomlKey) => value === '' || value === null
+      ? null
+      : isExecutionCarrierId(value) ? value : invalid(tomlKey, '"ori" or an empty string'),
   };
 }
 
@@ -244,6 +255,7 @@ export const OPERATOR_DEFAULTS_TOML_MAPPING = {
   opencodeOrchestratorModel: acpModelIdField('models', 'opencode_orchestrator_model'),
   opencodeWorkerModel: acpModelIdField('models', 'opencode_worker_model'),
   defaultDispatchRuntime: enumField('models', 'default_dispatch_runtime', 'a dispatchable runtime name', isDispatchRuntime),
+  workerExecutionCarrier: executionCarrierField('models', 'worker_execution_carrier'),
   workerStartMode: enumField('operator', 'worker_start_mode', 'one of "autonomous", "huddle", or "adaptive"', isWorkerStartMode),
   workerRuntimes: dispatchRuntimeListField('models', 'worker_runtimes'),
   codexWorkerEffort: enumField('models', 'codex_worker_effort', 'a valid thinking effort', isThinkingEffort),

--- a/tests/execution-carrier-real-path.test.ts
+++ b/tests/execution-carrier-real-path.test.ts
@@ -3,7 +3,39 @@ import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterAll, describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+const ensureDispatchBackendReadyMock = vi.hoisted(() => vi.fn(async () => ({
+  ready: true,
+  reason: 'test',
+  waitedMs: 0,
+  attempts: 1,
+  lastCheck: {
+    ready: true,
+    reason: 'test',
+    apiBase: 'http://127.0.0.1:1',
+    portSource: 'default' as const,
+    apiPortFilePresent: false,
+  },
+})));
+const measureHostVolumeMock = vi.hoisted(() => vi.fn(async () => ({
+  accountingStatus: 'observed' as const,
+  probePath: '/',
+  availableBytes: 90_000_000_000,
+  freeBytes: 90_000_000_000,
+  totalBytes: 100_000_000_000,
+  error: null,
+})));
+
+vi.mock('@/lib/runtimes/shared/dispatch-readiness', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/runtimes/shared/dispatch-readiness')>(),
+  ensureDispatchBackendReady: ensureDispatchBackendReadyMock,
+}));
+
+vi.mock('@/lib/worktree/storage-telemetry', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/worktree/storage-telemetry')>(),
+  measureHostVolume: measureHostVolumeMock,
+}));
 
 const testRoot = mkdtempSync(path.join(os.tmpdir(), 'o8-execution-carrier-'));
 const dataDir = path.join(testRoot, 'data');
@@ -13,10 +45,17 @@ const carrierPidFile = path.join(testRoot, 'carrier.pid');
 const childPidFile = path.join(testRoot, 'child.pid');
 const carrierArgsFile = path.join(testRoot, 'carrier.args');
 const shellInjectionSentinel = path.join(testRoot, 'argv-was-interpreted');
+const testStorageReserveRatio = 0.000001;
+const testStorageReserveFloorGb = 0.001;
 const priorEnv = new Map<string, string | undefined>();
 const controlledEnv = [
   'CORTEX_IDE_DATA_DIR', 'O8_DATA_DIR', 'CORTEX_IDE_OWNED_CODEX_ROOT',
   'O8_CODEX_BIN', 'O8_ORI_BIN', 'O8_CRASH_SURVIVABLE_WORKERS',
+  'O8_SUBSCRIPTION_PROFILE', 'O8_DEFAULT_DISPATCH_RUNTIME',
+  'O8_WORKER_SANDBOX', 'O8_WORKTREE_ROOT',
+  'O8_APFS_COW_WORKSPACES', 'O8_APFS_DEPENDENCY_IMAGES',
+  'O8_PACKAGED_APP', 'O8_DISPATCH_MODEL',
+  'O8_STORAGE_RESERVE_RATIO', 'O8_STORAGE_RESERVE_FLOOR_GB',
   'O8_SKIP_PRELAUNCH_TYPECHECK', 'O8_TEST_CARRIER_PID_FILE',
   'O8_TEST_CHILD_PID_FILE', 'O8_TEST_CARRIER_ARGS_FILE',
 ] as const;
@@ -119,6 +158,16 @@ wait "$child"
     process.env.O8_CODEX_BIN = fakeCodex;
     process.env.O8_ORI_BIN = fakeOri;
     process.env.O8_CRASH_SURVIVABLE_WORKERS = '1';
+    process.env.O8_SUBSCRIPTION_PROFILE = 'both';
+    process.env.O8_DEFAULT_DISPATCH_RUNTIME = 'codex';
+    process.env.O8_WORKER_SANDBOX = '0';
+    process.env.O8_WORKTREE_ROOT = path.join(testRoot, 'worktrees');
+    process.env.O8_APFS_COW_WORKSPACES = '0';
+    process.env.O8_APFS_DEPENDENCY_IMAGES = '0';
+    process.env.O8_PACKAGED_APP = '0';
+    delete process.env.O8_DISPATCH_MODEL;
+    process.env.O8_STORAGE_RESERVE_RATIO = String(testStorageReserveRatio);
+    process.env.O8_STORAGE_RESERVE_FLOOR_GB = String(testStorageReserveFloorGb);
     process.env.O8_SKIP_PRELAUNCH_TYPECHECK = '1';
     process.env.O8_TEST_CARRIER_PID_FILE = carrierPidFile;
     process.env.O8_TEST_CHILD_PID_FILE = childPidFile;
@@ -128,7 +177,15 @@ wait "$child"
     const { addRepo } = await import('@/lib/repos/registry');
     await addRepo(repoPath);
     const { updateOperatorDefaults } = await import('@/lib/operator/defaults');
-    await updateOperatorDefaults({ defaultDispatchRuntime: 'codex', workerExecutionCarrier: 'ori' });
+    const defaults = await updateOperatorDefaults({ defaultDispatchRuntime: 'codex', workerExecutionCarrier: 'ori' });
+    expect(defaults.values).toMatchObject({
+      storageReserveRatio: testStorageReserveRatio,
+      storageReserveFloorGb: testStorageReserveFloorGb,
+    });
+    expect(defaults.sources).toMatchObject({
+      storageReserveRatio: 'env',
+      storageReserveFloorGb: 'env',
+    });
     const { createMission, dispatchMission } = await import('@/lib/orchestrator/operator-mission-service');
     const mission = await createMission({
       issues: [{ number: 2037, title: 'Prove execution carriers', body: '', url: '' }],
@@ -142,10 +199,19 @@ wait "$child"
     expect(packet.executionCarrier).toBe('ori');
     expect((await dispatchMission({ missionId: mission.missionId })).dispatched).toBe(1);
 
+    const dispatchedPacket = readOrchestratorControlPlaneState().packets
+      .find((candidate) => candidate.id === packetId)!;
+    expect(dispatchedPacket.storageAdmission).toMatchObject({
+      ownerId: packetId,
+      state: 'committed',
+    });
+
     const { findLaneByPacket, getLaneEvents } = await import('@/lib/lane/registry');
     const lane = findLaneByPacket(packet.id)!;
     expect(lane.worktreePath).toBeTruthy();
     expect(lane.worktreePath).not.toBe(repoPath);
+    expect(measureHostVolumeMock).toHaveBeenCalled();
+    expect(ensureDispatchBackendReadyMock).toHaveBeenCalledWith('codex', 'launch');
     const runtime = (await import('@/lib/runtimes')).getRuntime('codex')!;
     await waitUntil(async () => {
       const surface = (await runtime.discoverSessions()).find((candidate) => candidate.sessionKey === lane.sessionKey);
@@ -170,6 +236,7 @@ wait "$child"
     rmSync(childPidFile, { force: true });
     rmSync(carrierArgsFile, { force: true });
     expect((await runtime.resume(lane.sessionKey!, maliciousLookingPrompt)).ok).toBe(true);
+    expect(ensureDispatchBackendReadyMock).toHaveBeenCalledWith('codex', 'resume');
     await waitUntil(() => existsSync(carrierPidFile) && existsSync(childPidFile), 'carried resume processes did not start');
     const carrierPid = Number(readFileSync(carrierPidFile, 'utf8'));
     const childPid = Number(readFileSync(childPidFile, 'utf8'));

--- a/tests/execution-carrier-real-path.test.ts
+++ b/tests/execution-carrier-real-path.test.ts
@@ -85,9 +85,11 @@ async function waitUntil(predicate: () => boolean | Promise<boolean>, message: s
 }
 
 function createRemoteRepo() {
-  const origin = path.join(testRoot, 'origin.git');
-  const seed = path.join(testRoot, 'seed');
-  const repo = path.join(testRoot, 'repo');
+  // Owned-runtime launches are restricted to paths under the home or data
+  // directory, so the fixture repo and worktrees live under the fixture data dir.
+  const origin = path.join(dataDir, 'origin.git');
+  const seed = path.join(dataDir, 'seed');
+  const repo = path.join(dataDir, 'repo');
   execFileSync('git', ['init', '--bare', origin], { stdio: 'pipe' });
   execFileSync('git', ['clone', origin, seed], { stdio: 'pipe' });
   git(seed, 'checkout', '-b', 'main');
@@ -127,6 +129,7 @@ describe.skipIf(process.platform === 'win32')('execution carrier isolated worktr
     const fakeCodex = path.join(runtimeDir, 'codex');
     const fakeOri = path.join(carrierDir, 'ori');
     writeExecutable(fakeCodex, `#!/bin/sh
+case "$1" in --version|-V) printf '%s\n' '0.0.0-test'; exit 0;; esac
 printf '%s\n' '{"type":"thread.started","thread_id":"carrier-thread"}'
 printf '%s\n' '{"type":"item.completed","item":{"id":"proof","type":"agent_message","text":"carrier transcript proof"}}'
 printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":5}}'
@@ -140,6 +143,7 @@ case " $* " in
 esac
 `);
     writeExecutable(fakeOri, `#!/bin/sh
+case "$1" in --version|-V) printf '%s\n' '0.0.0-test'; exit 0;; esac
 if [ "$1" = "auth" ]; then exit 0; fi
 printf '%s\n' "$$" > "$O8_TEST_CARRIER_PID_FILE"
 printf '%s\n' "$@" > "$O8_TEST_CARRIER_ARGS_FILE"
@@ -161,7 +165,7 @@ wait "$child"
     process.env.O8_SUBSCRIPTION_PROFILE = 'both';
     process.env.O8_DEFAULT_DISPATCH_RUNTIME = 'codex';
     process.env.O8_WORKER_SANDBOX = '0';
-    process.env.O8_WORKTREE_ROOT = path.join(testRoot, 'worktrees');
+    process.env.O8_WORKTREE_ROOT = path.join(dataDir, 'worktrees');
     process.env.O8_APFS_COW_WORKSPACES = '0';
     process.env.O8_APFS_DEPENDENCY_IMAGES = '0';
     delete process.env.O8_PACKAGED_APP;
@@ -219,7 +223,7 @@ wait "$child"
     }, 'initial carried Codex run did not reach ready-for-resume');
 
     const surface = (await runtime.discoverSessions()).find((candidate) => candidate.sessionKey === lane.sessionKey);
-    expect(surface).toMatchObject({ runtimeId: 'codex', ownership: 'o8-owned' });
+    expect(surface).toMatchObject({ runtimeId: 'codex', ownership: 'owned' });
     expect(await runtime.readTranscript(lane.sessionKey!)).toEqual(expect.arrayContaining([
       expect.objectContaining({ role: 'assistant', text: 'carrier transcript proof' }),
     ]));

--- a/tests/execution-carrier-real-path.test.ts
+++ b/tests/execution-carrier-real-path.test.ts
@@ -1,0 +1,188 @@
+import { execFileSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const testRoot = mkdtempSync(path.join(os.tmpdir(), 'o8-execution-carrier-'));
+const dataDir = path.join(testRoot, 'data');
+const runtimeDir = path.join(testRoot, 'runtime-bin');
+const carrierDir = path.join(testRoot, 'carrier-bin');
+const carrierPidFile = path.join(testRoot, 'carrier.pid');
+const childPidFile = path.join(testRoot, 'child.pid');
+const carrierArgsFile = path.join(testRoot, 'carrier.args');
+const shellInjectionSentinel = path.join(testRoot, 'argv-was-interpreted');
+const priorEnv = new Map<string, string | undefined>();
+const controlledEnv = [
+  'CORTEX_IDE_DATA_DIR', 'O8_DATA_DIR', 'CORTEX_IDE_OWNED_CODEX_ROOT',
+  'O8_CODEX_BIN', 'O8_ORI_BIN', 'O8_CRASH_SURVIVABLE_WORKERS',
+  'O8_SKIP_PRELAUNCH_TYPECHECK', 'O8_TEST_CARRIER_PID_FILE',
+  'O8_TEST_CHILD_PID_FILE', 'O8_TEST_CARRIER_ARGS_FILE',
+] as const;
+
+for (const key of controlledEnv) priorEnv.set(key, process.env[key]);
+
+function git(cwd: string, ...args: string[]) {
+  return execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+function writeExecutable(file: string, source: string) {
+  writeFileSync(file, source, 'utf8');
+  chmodSync(file, 0o755);
+}
+
+function isPidAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+async function waitUntil(predicate: () => boolean | Promise<boolean>, message: string, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(message);
+}
+
+function createRemoteRepo() {
+  const origin = path.join(testRoot, 'origin.git');
+  const seed = path.join(testRoot, 'seed');
+  const repo = path.join(testRoot, 'repo');
+  execFileSync('git', ['init', '--bare', origin], { stdio: 'pipe' });
+  execFileSync('git', ['clone', origin, seed], { stdio: 'pipe' });
+  git(seed, 'checkout', '-b', 'main');
+  writeFileSync(path.join(seed, 'README.md'), 'execution carrier real-path fixture\n');
+  git(seed, 'add', 'README.md');
+  git(seed, '-c', 'user.email=test@o8.test', '-c', 'user.name=o8-test', 'commit', '-m', 'init');
+  git(seed, 'push', '-u', 'origin', 'main');
+  git(origin, 'symbolic-ref', 'HEAD', 'refs/heads/main');
+  execFileSync('git', ['clone', origin, repo], { stdio: 'pipe' });
+  return repo;
+}
+
+afterAll(async () => {
+  for (const pidFile of [carrierPidFile, childPidFile]) {
+    if (!existsSync(pidFile)) continue;
+    const pid = Number(readFileSync(pidFile, 'utf8'));
+    if (Number.isInteger(pid) && isPidAlive(pid)) {
+      try { process.kill(pid, 'SIGKILL'); } catch {}
+    }
+  }
+  if (process.platform !== 'win32') {
+    await import('@/lib/db').then(({ closeDb }) => closeDb()).catch(() => {});
+  }
+  for (const [key, value] of priorEnv) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+describe.skipIf(process.platform === 'win32')('execution carrier isolated worktree real path', () => {
+  it('routes launch and resume through Ori while Codex retains identity, evidence, and cleanup', async () => {
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(runtimeDir, { recursive: true });
+    mkdirSync(carrierDir, { recursive: true });
+    const fakeCodex = path.join(runtimeDir, 'codex');
+    const fakeOri = path.join(carrierDir, 'ori');
+    writeExecutable(fakeCodex, `#!/bin/sh
+printf '%s\n' '{"type":"thread.started","thread_id":"carrier-thread"}'
+printf '%s\n' '{"type":"item.completed","item":{"id":"proof","type":"agent_message","text":"carrier transcript proof"}}'
+printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":5}}'
+printf '%s\n' 'carrier review proof' > carrier-proof.txt
+case " $* " in
+  *" resume "*)
+    printf '%s\n' "$$" > "$O8_TEST_CHILD_PID_FILE"
+    trap 'exit 0' INT TERM
+    while :; do sleep 1; done
+    ;;
+esac
+`);
+    writeExecutable(fakeOri, `#!/bin/sh
+if [ "$1" = "auth" ]; then exit 0; fi
+printf '%s\n' "$$" > "$O8_TEST_CARRIER_PID_FILE"
+printf '%s\n' "$@" > "$O8_TEST_CARRIER_ARGS_FILE"
+if [ "$1" != "codex" ]; then exit 64; fi
+shift
+codex "$@" &
+child=$!
+printf '%s\n' "$child" > "$O8_TEST_CHILD_PID_FILE"
+trap 'kill -TERM "$child" 2>/dev/null; wait "$child"; exit 0' INT TERM
+wait "$child"
+`);
+
+    process.env.CORTEX_IDE_DATA_DIR = dataDir;
+    process.env.O8_DATA_DIR = dataDir;
+    process.env.CORTEX_IDE_OWNED_CODEX_ROOT = path.join(testRoot, 'owned-codex');
+    process.env.O8_CODEX_BIN = fakeCodex;
+    process.env.O8_ORI_BIN = fakeOri;
+    process.env.O8_CRASH_SURVIVABLE_WORKERS = '1';
+    process.env.O8_SKIP_PRELAUNCH_TYPECHECK = '1';
+    process.env.O8_TEST_CARRIER_PID_FILE = carrierPidFile;
+    process.env.O8_TEST_CHILD_PID_FILE = childPidFile;
+    process.env.O8_TEST_CARRIER_ARGS_FILE = carrierArgsFile;
+
+    const repoPath = createRemoteRepo();
+    const { addRepo } = await import('@/lib/repos/registry');
+    await addRepo(repoPath);
+    const { updateOperatorDefaults } = await import('@/lib/operator/defaults');
+    await updateOperatorDefaults({ defaultDispatchRuntime: 'codex', workerExecutionCarrier: 'ori' });
+    const { createMission, dispatchMission } = await import('@/lib/orchestrator/operator-mission-service');
+    const mission = await createMission({
+      issues: [{ number: 2037, title: 'Prove execution carriers', body: '', url: '' }],
+      repoPath,
+      runtime: 'codex',
+      constraints: '',
+    });
+    const packetId = mission.packets[0]!.id;
+    const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+    const packet = readOrchestratorControlPlaneState().packets.find((candidate) => candidate.id === packetId)!;
+    expect(packet.executionCarrier).toBe('ori');
+    expect((await dispatchMission({ missionId: mission.missionId })).dispatched).toBe(1);
+
+    const { findLaneByPacket, getLaneEvents } = await import('@/lib/lane/registry');
+    const lane = findLaneByPacket(packet.id)!;
+    expect(lane.worktreePath).toBeTruthy();
+    expect(lane.worktreePath).not.toBe(repoPath);
+    const runtime = (await import('@/lib/runtimes')).getRuntime('codex')!;
+    await waitUntil(async () => {
+      const surface = (await runtime.discoverSessions()).find((candidate) => candidate.sessionKey === lane.sessionKey);
+      return surface?.lifecycle?.availability === 'ready-for-resume';
+    }, 'initial carried Codex run did not reach ready-for-resume');
+
+    const surface = (await runtime.discoverSessions()).find((candidate) => candidate.sessionKey === lane.sessionKey);
+    expect(surface).toMatchObject({ runtimeId: 'codex', ownership: 'o8-owned' });
+    expect(await runtime.readTranscript(lane.sessionKey!)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ role: 'assistant', text: 'carrier transcript proof' }),
+    ]));
+    expect(await runtime.getTelemetry?.(lane.sessionKey!)).toMatchObject({ totalTokens: 15, inputTokens: 10, outputTokens: 5 });
+    expect(await runtime.getChangedFiles(lane.sessionKey!)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: 'carrier-proof.txt' }),
+    ]));
+    expect(getLaneEvents(lane.id, 200)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ verb: 'execution_carrier_preflight', payload: expect.objectContaining({ runtime: 'codex', executionCarrier: 'ori' }) }),
+    ]));
+
+    const maliciousLookingPrompt = `resume; touch ${shellInjectionSentinel}`;
+    rmSync(carrierPidFile, { force: true });
+    rmSync(childPidFile, { force: true });
+    rmSync(carrierArgsFile, { force: true });
+    expect((await runtime.resume(lane.sessionKey!, maliciousLookingPrompt)).ok).toBe(true);
+    await waitUntil(() => existsSync(carrierPidFile) && existsSync(childPidFile), 'carried resume processes did not start');
+    const carrierPid = Number(readFileSync(carrierPidFile, 'utf8'));
+    const childPid = Number(readFileSync(childPidFile, 'utf8'));
+    expect(isPidAlive(carrierPid)).toBe(true);
+    expect(isPidAlive(childPid)).toBe(true);
+    expect(readFileSync(carrierArgsFile, 'utf8')).toContain('resume');
+    expect(existsSync(shellInjectionSentinel)).toBe(false);
+
+    const worktreePath = lane.worktreePath!;
+    const { stopPacket } = await import('@/lib/orchestrator/stop-packet');
+    const stopped = await stopPacket(packet.id);
+    expect(stopped).toMatchObject({ ok: true, killConfirmed: true, interruptedSessions: 1 });
+    await waitUntil(() => !isPidAlive(carrierPid) && !isPidAlive(childPid), 'carrier wrapper or runtime child survived stop');
+    await waitUntil(() => !existsSync(worktreePath), 'isolated worktree was not reclaimed after stop');
+  }, 45_000);
+});

--- a/tests/execution-carrier-real-path.test.ts
+++ b/tests/execution-carrier-real-path.test.ts
@@ -164,7 +164,7 @@ wait "$child"
     process.env.O8_WORKTREE_ROOT = path.join(testRoot, 'worktrees');
     process.env.O8_APFS_COW_WORKSPACES = '0';
     process.env.O8_APFS_DEPENDENCY_IMAGES = '0';
-    process.env.O8_PACKAGED_APP = '0';
+    delete process.env.O8_PACKAGED_APP;
     delete process.env.O8_DISPATCH_MODEL;
     process.env.O8_STORAGE_RESERVE_RATIO = String(testStorageReserveRatio);
     process.env.O8_STORAGE_RESERVE_FLOOR_GB = String(testStorageReserveFloorGb);

--- a/tests/operator-defaults-mcp-routing.test.ts
+++ b/tests/operator-defaults-mcp-routing.test.ts
@@ -7,6 +7,17 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import { MODEL_IDS } from '@/lib/models';
 
 const spawnMock = vi.hoisted(() => vi.fn());
+const nativePreflightMock = vi.hoisted(() => vi.fn(async () => undefined));
+const carrierPreflightMock = vi.hoisted(() => vi.fn(async () => ({
+  runtime: 'codex' as const,
+  runtimeBinaryName: 'codex',
+  runtimeCli: { path: '/test/codex', source: 'path' as const, detectedAt: 1 },
+  executionCarrier: 'ori' as const,
+  carrierBinaryName: 'ori',
+  carrierCli: { path: '/test/ori', source: 'path' as const, detectedAt: 1 },
+  authSource: 'execution-carrier' as const,
+  authenticated: true as const,
+})));
 const ensureDispatchBackendReadyMock = vi.hoisted(() => vi.fn(async () => ({
   ready: true,
   reason: 'http_200',
@@ -91,9 +102,14 @@ vi.mock('@/lib/runtimes/shared/auth-detect', async (importOriginal) => {
       },
       suggestedSubscriptionProfile: { profile: null, detail: null },
     })),
-    assertRuntimeDispatchable: vi.fn(async () => undefined),
+    assertRuntimeDispatchable: nativePreflightMock,
   };
 });
+
+vi.mock('@/lib/runtimes/shared/execution-carrier-preflight', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/runtimes/shared/execution-carrier-preflight')>(),
+  assertExecutionCarrierDispatchable: carrierPreflightMock,
+}));
 
 vi.mock('@/lib/usage-log', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/usage-log')>();
@@ -252,6 +268,8 @@ beforeEach(() => {
   vi.resetModules();
 
   spawnMock.mockReset();
+  nativePreflightMock.mockClear();
+  carrierPreflightMock.mockClear();
   spawnMock.mockReturnValue({
     pid: 987_654,
     stdin: { end: vi.fn() },
@@ -310,6 +328,7 @@ describe('MCP operator defaults and dispatch routing', () => {
       broadcastCommentaryMaxPerHour: expect.any(Object),
       brainUseClaudeCli: expect.any(Object),
       defaultDispatchModel: expect.any(Object),
+      workerExecutionCarrier: expect.objectContaining({ enum: ['ori', ''] }),
       meteredPacketCostCapUsd: expect.any(Object),
       meteredPacketInputTokenCap: expect.any(Object),
       uiLoopMaxIterations: expect.any(Object),
@@ -409,6 +428,19 @@ describe('MCP operator defaults and dispatch routing', () => {
     });
     expect(fetchMock).not.toHaveBeenCalled();
     expect((await getOperatorDefaults()).values.codexWorkerEffort).toBe(before);
+  });
+
+  it.skipIf(process.platform === 'win32')('uses execution-carrier auth instead of native auth at the create-mission route', async () => {
+    const { handleOperatorDefaults } = await import('@/lib/mcp/operator-handlers/status');
+    await handleOperatorDefaults({ defaultDispatchRuntime: 'codex', workerExecutionCarrier: 'ori' });
+
+    await expect(createMissionThroughRoute({
+      repoPath: await createRegisteredTempRepo(),
+      issueNumber: 2037,
+      requestedRuntime: 'codex',
+    })).resolves.toMatchObject({ missionId: expect.any(String) });
+    expect(carrierPreflightMock).toHaveBeenCalledWith('codex', 'ori');
+    expect(nativePreflightMock).not.toHaveBeenCalled();
   });
 
   it('carries defaultDispatchModel through mission creation into the Codex spawn argv', async () => {

--- a/tests/packet-control-fields-survive-normalize.test.ts
+++ b/tests/packet-control-fields-survive-normalize.test.ts
@@ -16,6 +16,7 @@ import {
   normalizeOrchestratorMissionState,
 } from '@/lib/orchestrator/store';
 import { normalizeOrchestratorMissionStateForPersistence } from '@/lib/orchestrator/persisted-mission';
+import { normalizePacketExecutionCarrier } from '@/lib/orchestrator/normalize/decomposition';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 
 const NOW = new Date('2026-01-01T00:00:00.000Z');
@@ -148,6 +149,7 @@ function fullPacketFixture() {
     assignedModel: 'gpt-5.5',
     claudeCodeModel: 'gateway/model-y',
     claudeCodeCarrier: 'openrouter',
+    executionCarrier: null,
     qualitySearch: {
       version: 1,
       role: 'robustness_complete',
@@ -250,6 +252,10 @@ function stateWithPacket(packet: OrchestratorPacket) {
 }
 
 describe('packet fields survive normalize', () => {
+  it('refuses an unknown persisted execution carrier instead of falling back to direct credentials', () => {
+    expect(() => normalizePacketExecutionCarrier('future-carrier')).toThrow(/refusing to fall back/i);
+  });
+
   it('preserves every packet key across a normalize round-trip', () => {
     vi.useFakeTimers();
     try {

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1412,6 +1412,16 @@
       ]
     },
     {
+      "path": "tests/execution-carrier-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "executable-fixture",
+        "git-cli",
+        "process-signal",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/feedback-sync-reports.test.ts",
       "reasons": [
         "executable-fixture"


### PR DESCRIPTION
## Summary

- add a persisted, allowlisted execution-carrier setting and snapshot it onto mission packets
- launch Codex through Ori as structured executable/argv while Codex remains the sole runtime, session, transcript, cost, review, resume, and cleanup identity
- add carrier-first auth preflight with distinct missing-carrier, missing-runtime, unsupported-pair, and unsafe-Windows-wrapper failures
- preserve the direct/no-carrier path and document configuration, identity/auth precedence, and process ownership

This is intentionally the bounded follow-up extracted from #2034. It does not reopen or expand the Copilot CLI or Crush runtime work landed there.

## Verification

- `npm run typecheck`
- `npm run lint` (passes at the repository's existing 54-warning budget)
- `npm run test:classification:check`
- post-completion rule check against `upstream/main` (29 changed files, zero violations)
- focused carrier/settings/packet tests: 33 passed; the dedicated POSIX real-path test is skipped on Windows

The real-path test creates an isolated git worktree and fake off-PATH Codex/Ori executables, then exercises launch, resume, transcript and token evidence, changed-file review, no-shell prompt handling, exact wrapper/child termination, and worktree reclamation. It will execute on POSIX CI. A full local Windows unit run also exposed the repository's existing POSIX-path, process-identity, and locked-SQLite fixture failures; no carrier-focused test failed.

Closes #2037
