### PR TITLE
docs(user): local PII MCP on tool-spine + workers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ For operators who want to understand the product and run governed agent work wit
 | [Orchestration playbook](user/orchestration-playbook.md) | How to brief, monitor, review, recover, and close agent work well. |
 | [Claude Code model carriers](user/claude-code-model-carriers.md) | How native, API-billed, and Codex subscription model sources work behind the Claude Code harness. |
 | [Operator MCP bridge](user/operator-mcp-bridge.md) | How terminal and MCP clients drive the same governed control plane as the app. |
+| [Local PII MCP](user/local-pii-mcp.md) | Attach an on-device PII detect/redact MCP to the tool-spine and workers. |
 | [Persistent terminals](user/persistent-terminals.md) | How terminal sessions survive restarts and recover their scrollback. |
 | [Telemetry privacy](user/product-telemetry-privacy.md) | What optional product telemetry can contain and how consent is enforced. |
 | [Vocabulary](user/vocabulary.md) | The precise meanings of runtime, agent, session, packet, lane, mission, review, and approval. |

--- a/docs/user/local-pii-mcp.md
+++ b/docs/user/local-pii-mcp.md
@@ -1,0 +1,66 @@
+# Local PII MCP (on-device redaction)
+
+o8 can attach a **local** PII detect/redact MCP so orchestrators and supported workers call `detect_pii` / `redact_pii` without sending text to a cloud NER service.
+
+This uses the existing **external MCP** + optional **worker injection** path (tool-spine). It does **not** replace broadcast/token redaction in `src/lib/broadcast/redaction.ts`.
+
+Upstream model and adapters: [programasweights/pii](https://github.com/programasweights/pii) · harness package [kvnloo/pii](https://github.com/kvnloo/pii).
+
+## Install the Python side
+
+```bash
+git clone https://github.com/kvnloo/pii
+cd pii
+pip install -e .
+pip install programasweights --extra-index-url https://pypi.programasweights.com/simple/
+python -m paw_pii.mcp_server   # stdio MCP: detect_pii, redact_pii
+```
+
+## Register in Settings
+
+1. **Settings → MCP → Add external server**
+2. Fields:
+   - **Name:** `paw-pii` (pattern `^[A-Za-z0-9_-]+$`)
+   - **Transport:** stdio
+   - **Command:** absolute path to your venv/`python3`
+   - **Args:** `-m` `paw_pii.mcp_server`
+   - **Env (optional):** `PAW_PII_PLACEHOLDER=[PII]`, `PAW_PII_PROGRAM_ID=…`
+3. Enable the server.
+4. Toggle **Attach to supported workers** so codex/claude-code packet workers receive the same stdio MCP (`workerInjection`).
+
+Enabled externals are assembled into the tool-spine for Claude/Codex orchestrator surfaces automatically (`src/lib/mcp/tool-spine/build.ts`).
+
+## Register via API
+
+```bash
+curl -sS -X POST "http://127.0.0.1:3000/api/setup/mcp-servers" \
+  -H "Authorization: Bearer $O8_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "paw-pii",
+    "transport": "stdio",
+    "command": "/usr/bin/python3",
+    "args": ["-m", "paw_pii.mcp_server"],
+    "env": {"PAW_PII_PLACEHOLDER": "[PII]"},
+    "enabled": true,
+    "workerInjection": true
+  }'
+```
+
+## What this covers
+
+| Goal | Supported |
+|------|-----------|
+| Orchestrator can call redact tools | Yes — external MCP on tool-spine |
+| Workers (codex / claude-code) can call redact tools | Yes — `workerInjection` |
+| Always scrub every LLM egress without a tool call | No — needs a new middleware seam (open an issue first) |
+| Credential / path scrub on Broadcast | Existing `broadcast/redaction.ts` (not NER) |
+
+## Related code
+
+- `src/lib/mcp/external-servers.ts` — persistence/CRUD
+- `src/lib/mcp/worker-injection.ts` — attach to supported runtimes
+- `src/lib/mcp/tool-spine/build.ts` — catalog assembly
+- `docs/user/operator-mcp-bridge.md` — operator MCP
+- `docs/internals/runtime-adapter-contract.md` — worker MCP injection
+- Issue tracking first-class follow-ups: see the linked GitHub issue on this PR

--- a/docs/user/local-pii-mcp.md
+++ b/docs/user/local-pii-mcp.md
@@ -16,9 +16,11 @@ pip install programasweights --extra-index-url https://pypi.programasweights.com
 python -m paw_pii.mcp_server   # stdio MCP: detect_pii, redact_pii
 ```
 
+The model package comes from an index run by its authors, not PyPI. Pin the version you tested and review that index before installing. The server is meant to run inference on-device; confirm it makes no network calls in your environment before trusting it with real transcripts.
+
 ## Register in Settings
 
-1. **Settings → MCP → Add external server**
+1. **Settings → MCP → add a server**
 2. Fields:
    - **Name:** `paw-pii` (pattern `^[A-Za-z0-9_-]+$`)
    - **Transport:** stdio
@@ -32,9 +34,11 @@ Enabled externals are assembled into the tool-spine for Claude/Codex orchestrato
 
 ## Register via API
 
+o8 picks its API port at launch and writes it to `~/.o8/api-port`. Calls from loopback need no bearer token. A non-loopback client must send `Authorization: Bearer $(cat ~/.o8/ws-token)`.
+
 ```bash
-curl -sS -X POST "http://127.0.0.1:3000/api/setup/mcp-servers" \
-  -H "Authorization: Bearer $O8_TOKEN" \
+O8_PORT=$(cat ~/.o8/api-port)
+curl -sS -X POST "http://127.0.0.1:${O8_PORT}/api/setup/mcp-servers" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "paw-pii",
@@ -63,4 +67,4 @@ curl -sS -X POST "http://127.0.0.1:3000/api/setup/mcp-servers" \
 - `src/lib/mcp/tool-spine/build.ts` — catalog assembly
 - `docs/user/operator-mcp-bridge.md` — operator MCP
 - `docs/internals/runtime-adapter-contract.md` — worker MCP injection
-- Issue tracking first-class follow-ups: see the linked GitHub issue on this PR
+- Follow-ups (builtin promotion, automatic pre-LLM scrub): [#2074](https://github.com/hurttlocker/o8/issues/2074)


### PR DESCRIPTION
## Summary

Docs-only follow-up for #2074 (issue-first).

- Adds `docs/user/local-pii-mcp.md` — Settings + API recipe for stdio `python -m paw_pii.mcp_server`, including `workerInjection`
- Indexes it in `docs/README.md`

No runtime/backend changes. Automatic pre-LLM scrub remains out of scope pending maintainer design OK (Phase C on the issue).

## Test plan

- [ ] Doc links resolve
- [ ] Recipe matches `external-servers` field names (`workerInjection`, stdio args)
- [ ] Optional smoke: register MCP and see `detect_pii` / `redact_pii` on tools/list