### PR TITLE
fix: strengthen native auth preflight evidence

### DIFF
--- a/src/lib/runtimes/shared/auth-detect-claude.test.ts
+++ b/src/lib/runtimes/shared/auth-detect-claude.test.ts
@@ -282,7 +282,7 @@ describe.skipIf(process.platform === 'win32')('Claude Code native sign-in verifi
 
     const startedAt = Date.now();
     const status = await claudeStatus();
-    expect(Date.now() - startedAt).toBeLessThan(10_000);
+    expect(Date.now() - startedAt).toBeLessThan(15_000);
     expect(status).toMatchObject({
       ready: false,
       authenticated: false,

--- a/src/lib/runtimes/shared/auth-detect.ts
+++ b/src/lib/runtimes/shared/auth-detect.ts
@@ -41,6 +41,7 @@ import { suggestMachineAuthProfile } from './auth-profile-suggestion';
 
 const execFileAsync = promisify(execFile);
 const CACHE_TTL_MS = 60_000;
+const UNKNOWN_CLAUDE_CACHE_TTL_MS = 5_000;
 const PROBE_TIMEOUT_MS = 1_500;
 const TRUSTED_KEYLESS_OPENCODE_MODELS = new Set([
   'opencode/deepseek-v4-flash-free',
@@ -636,7 +637,10 @@ export async function getRuntimeAuthSnapshot(): Promise<RuntimeAuthSnapshot> {
   while (true) {
     const generation = cacheGeneration;
     const cached = cache;
-    if (cached && Date.now() - cached.cachedAt < CACHE_TTL_MS) {
+    const cacheTtlMs = cached?.snapshot.statuses.claude.nativeLoginState === 'unknown'
+      ? UNKNOWN_CLAUDE_CACHE_TTL_MS
+      : CACHE_TTL_MS;
+    if (cached && Date.now() - cached.cachedAt < cacheTtlMs) {
       const opencode = await refreshOpencodeStatus();
       if (generation !== cacheGeneration || cache !== cached) continue;
       const snapshot = {

--- a/src/lib/runtimes/shared/claude-login-probe.ts
+++ b/src/lib/runtimes/shared/claude-login-probe.ts
@@ -11,8 +11,8 @@ import { cliInvocation } from '@/lib/runtimes/shared/cli-spawn';
 
 const execFileAsync = promisify(execFile);
 
-/** Matches the general CLI probe budget in auth-detect.ts. */
-export const CLAUDE_PROBE_TIMEOUT_MS = 1_500;
+/** Covers a cold Claude Code CLI start in a Finder-launched app process. */
+export const CLAUDE_PROBE_TIMEOUT_MS = 5_000;
 
 /**
  * Three-state answer to "is this Claude Code CLI signed in?".
@@ -23,6 +23,12 @@ export const CLAUDE_PROBE_TIMEOUT_MS = 1_500;
  * evidence, but must not treat the inconclusive probe itself as authentication.
  */
 export type ClaudeLoginState = 'logged_in' | 'logged_out' | 'unknown';
+
+function probeTimedOut(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const record = error as { code?: unknown; killed?: unknown };
+  return record.killed === true || record.code === 'ETIMEDOUT';
+}
 
 /**
  * Runs `claude auth status --json` under a bounded timeout and buffer.
@@ -35,18 +41,22 @@ export async function probeClaudeLoginState(
   binaryPath: string,
   timeoutMs = CLAUDE_PROBE_TIMEOUT_MS,
 ): Promise<ClaudeLoginState> {
-  let stdout: string;
-  try {
-    const probe = cliInvocation(binaryPath, ['auth', 'status', '--json']);
-    ({ stdout } = await execFileAsync(probe.command, probe.args, {
-      windowsHide: true,
-      timeout: Math.max(1, Math.min(timeoutMs, CLAUDE_PROBE_TIMEOUT_MS)),
-      env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
-      maxBuffer: 64 * 1024,
-    }));
-  } catch {
-    // Timeout, killed process, non-zero exit, missing/unexecutable binary.
-    return 'unknown';
+  let stdout = '';
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const probe = cliInvocation(binaryPath, ['auth', 'status', '--json']);
+      ({ stdout } = await execFileAsync(probe.command, probe.args, {
+        windowsHide: true,
+        timeout: Math.max(1, Math.min(timeoutMs, CLAUDE_PROBE_TIMEOUT_MS)),
+        env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
+        maxBuffer: 64 * 1024,
+      }));
+      break;
+    } catch (error) {
+      if (attempt === 0 && probeTimedOut(error)) continue;
+      // Timeout, killed process, non-zero exit, missing/unexecutable binary.
+      return 'unknown';
+    }
   }
   try {
     const parsed = JSON.parse(stdout.trim()) as { loggedIn?: unknown };
@@ -67,14 +77,27 @@ export async function probeClaudeLoginState(
 export { hasClaudeEnvCredential } from '@/lib/claude-code/oauth-credential';
 
 /**
- * On-disk OAuth evidence for the operator's own config dir.
+ * File-based native login evidence for the operator's own account.
  *
- * Deliberately file-only: the macOS Keychain also holds this credential, but
- * `security find-generic-password` can raise an ACL prompt, and readiness is polled.
+ * Deliberately does not read the macOS Keychain: `security find-generic-password`
+ * can raise an ACL prompt, and readiness is polled. A live token in the config dir
+ * or the account email Claude writes to ~/.claude.json is sufficient evidence.
  * The Keychain remains the seeding path's concern (seedNativeWorkerCredentials).
  */
 export async function hasStoredClaudeOAuthCredential(): Promise<boolean> {
   const configDir = process.env.CLAUDE_CONFIG_DIR?.trim() || path.join(os.homedir(), '.claude');
-  const raw = await readFile(path.join(configDir, '.credentials.json'), 'utf-8').catch(() => '');
-  return hasLiveClaudeOAuth(raw);
+  const [credentialRaw, userConfigRaw] = await Promise.all([
+    readFile(path.join(configDir, '.credentials.json'), 'utf-8').catch(() => ''),
+    readFile(path.join(os.homedir(), '.claude.json'), 'utf-8').catch(() => ''),
+  ]);
+  if (hasLiveClaudeOAuth(credentialRaw)) return true;
+  try {
+    const parsed = JSON.parse(userConfigRaw) as { oauthAccount?: unknown };
+    const account = parsed?.oauthAccount;
+    if (!account || typeof account !== 'object' || Array.isArray(account)) return false;
+    const emailAddress = (account as Record<string, unknown>).emailAddress;
+    return typeof emailAddress === 'string' && emailAddress.trim().length > 0;
+  } catch {
+    return false;
+  }
 }

--- a/tests/claude-auth-preflight-real-path.test.ts
+++ b/tests/claude-auth-preflight-real-path.test.ts
@@ -1,0 +1,173 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const cliFixture = vi.hoisted(() => ({ claudeBinary: '' }));
+
+vi.mock('@/lib/runtimes/shared/cli-locate', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/runtimes/shared/cli-locate')>(),
+  scanAndLink: vi.fn((binaryName: string) => (
+    binaryName === 'claude' ? cliFixture.claudeBinary : null
+  )),
+}));
+
+const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), 'o8-claude-auth-preflight-'));
+const fixtureHome = path.join(fixtureRoot, 'home');
+const fixtureBinDir = path.join(fixtureHome, '.local', 'bin');
+const fixtureDataDir = path.join(fixtureRoot, 'data');
+const fixtureClaudeConfigDir = path.join(fixtureRoot, 'claude-config');
+const retryCountPath = path.join(fixtureRoot, 'retry-count');
+const controlledEnvKeys = [
+  'ANTHROPIC_API_KEY',
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  'CLAUDE_CONFIG_DIR',
+  'CORTEX_IDE_DATA_DIR',
+  'HOME',
+  'O8_DATA_DIR',
+  'O8_TEST_CLAUDE_MODE',
+  'O8_TEST_CLAUDE_RETRY_COUNT',
+  'PATH',
+] as const;
+const priorEnv = Object.fromEntries(
+  controlledEnvKeys.map((key) => [key, process.env[key]]),
+) as Record<(typeof controlledEnvKeys)[number], string | undefined>;
+
+let authDetect: typeof import('@/lib/runtimes/shared/auth-detect');
+
+function writeAccountEvidence(emailAddress = 'operator@example.test') {
+  writeFileSync(
+    path.join(fixtureHome, '.claude.json'),
+    JSON.stringify({ oauthAccount: { emailAddress } }),
+  );
+}
+
+function clearStoredEvidence() {
+  rmSync(path.join(fixtureHome, '.claude.json'), { force: true });
+  rmSync(path.join(fixtureClaudeConfigDir, '.credentials.json'), { force: true });
+}
+
+beforeAll(async () => {
+  mkdirSync(fixtureBinDir, { recursive: true });
+  mkdirSync(fixtureDataDir, { recursive: true });
+  mkdirSync(fixtureClaudeConfigDir, { recursive: true });
+  cliFixture.claudeBinary = path.join(fixtureBinDir, 'claude');
+  writeFileSync(cliFixture.claudeBinary, [
+    '#!/bin/sh',
+    'case "${O8_TEST_CLAUDE_MODE:-logged_out}" in',
+    '  slow_logged_in) /bin/sleep 2; printf \'%s\\n\' \'{"loggedIn":true}\' ;;',
+    '  logged_in) printf \'%s\\n\' \'{"loggedIn":true}\' ;;',
+    '  logged_out) printf \'%s\\n\' \'{"loggedIn":false}\' ;;',
+    '  malformed) printf \'%s\\n\' \'not-json\' ;;',
+    '  timeout) exec /bin/sleep 20 ;;',
+    '  timeout_once)',
+    '    count=0',
+    '    if [ -f "$O8_TEST_CLAUDE_RETRY_COUNT" ]; then IFS= read -r count < "$O8_TEST_CLAUDE_RETRY_COUNT"; fi',
+    '    count=$((count + 1))',
+    '    printf \'%s\\n\' "$count" > "$O8_TEST_CLAUDE_RETRY_COUNT"',
+    '    if [ "$count" -eq 1 ]; then exec /bin/sleep 20; fi',
+    '    printf \'%s\\n\' \'{"loggedIn":true}\'',
+    '    ;;',
+    'esac',
+  ].join('\n'));
+  chmodSync(cliFixture.claudeBinary, 0o755);
+
+  process.env.HOME = fixtureHome;
+  process.env.CLAUDE_CONFIG_DIR = fixtureClaudeConfigDir;
+  process.env.CORTEX_IDE_DATA_DIR = fixtureDataDir;
+  process.env.O8_DATA_DIR = fixtureDataDir;
+  process.env.PATH = `${fixtureBinDir}${path.delimiter}${priorEnv.PATH ?? ''}`;
+  process.env.ANTHROPIC_API_KEY = '';
+  process.env.CLAUDE_CODE_OAUTH_TOKEN = '';
+  process.env.O8_TEST_CLAUDE_RETRY_COUNT = retryCountPath;
+
+  authDetect = await import('@/lib/runtimes/shared/auth-detect');
+});
+
+beforeEach(() => {
+  clearStoredEvidence();
+  rmSync(retryCountPath, { force: true });
+  process.env.O8_TEST_CLAUDE_MODE = 'logged_out';
+  authDetect.invalidateRuntimeAuthCache();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  authDetect.invalidateRuntimeAuthCache();
+});
+
+afterAll(() => {
+  for (const key of controlledEnvKeys) {
+    const prior = priorEnv[key];
+    if (prior === undefined) delete process.env[key];
+    else process.env[key] = prior;
+  }
+  rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+describe.skipIf(process.platform === 'win32')('Claude auth dispatch preflight real path', () => {
+  it('allows a cold CLI probe that answers within five seconds', async () => {
+    process.env.O8_TEST_CLAUDE_MODE = 'slow_logged_in';
+
+    await expect(authDetect.assertRuntimeDispatchable('claude-code')).resolves.toBeUndefined();
+  }, 15_000);
+
+  it('allows file-based account evidence when both probe attempts time out', async () => {
+    process.env.O8_TEST_CLAUDE_MODE = 'timeout';
+    writeAccountEvidence();
+
+    await expect(authDetect.assertRuntimeDispatchable('claude-code')).resolves.toBeUndefined();
+  }, 20_000);
+
+  it('fails closed when the probe times out without file-based evidence', async () => {
+    process.env.O8_TEST_CLAUDE_MODE = 'timeout';
+
+    const rejection = await authDetect.assertRuntimeDispatchable('claude-code').catch((error) => error);
+    expect(rejection).toBeInstanceOf(authDetect.DispatchPreflightError);
+    expect(rejection).toMatchObject({
+      code: 'dispatch_cli_auth_unavailable',
+      status: {
+        authenticated: false,
+        unavailableReason: 'needs_auth',
+        detail: 'Claude Code CLI is installed but its sign-in state could not be verified.',
+      },
+    });
+  }, 20_000);
+
+  it('keeps explicit sign-out decisive when file-based account evidence exists', async () => {
+    process.env.O8_TEST_CLAUDE_MODE = 'logged_out';
+    writeAccountEvidence();
+
+    await expect(authDetect.assertRuntimeDispatchable('claude-code')).rejects.toMatchObject({
+      code: 'dispatch_cli_auth_unavailable',
+      status: {
+        authenticated: false,
+        unavailableReason: 'needs_auth',
+        detail: 'Claude Code CLI is installed but not signed in.',
+      },
+    });
+  });
+
+  it('refreshes an unknown verdict after its five-second cache lifetime', async () => {
+    process.env.O8_TEST_CLAUDE_MODE = 'malformed';
+    await expect(authDetect.assertRuntimeDispatchable('claude-code')).rejects.toMatchObject({
+      status: { nativeLoginState: 'unknown', unavailableReason: 'needs_auth' },
+    });
+
+    const refreshedAt = Date.now() + 5_001;
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(refreshedAt);
+    process.env.O8_TEST_CLAUDE_MODE = 'logged_in';
+
+    await expect(authDetect.assertRuntimeDispatchable('claude-code')).resolves.toBeUndefined();
+  });
+
+  it('retries once when the first probe attempt times out', async () => {
+    process.env.O8_TEST_CLAUDE_MODE = 'timeout_once';
+
+    await expect(authDetect.assertRuntimeDispatchable('claude-code')).resolves.toBeUndefined();
+    expect(existsSync(retryCountPath)).toBe(true);
+    expect(readFileSync(retryCountPath, 'utf-8').trim()).toBe('2');
+  }, 15_000);
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1136,6 +1136,13 @@
       ]
     },
     {
+      "path": "tests/claude-auth-preflight-real-path.test.ts",
+      "reasons": [
+        "executable-fixture",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/claude-code-codex-orchestrator-live-smoke.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
Closes #2078.

## What

`create_mission` with a `claude-code` worker was refused with `dispatch_cli_auth_unavailable` while `claude auth status --json` on the same machine reported `loggedIn: true`. The preflight is fail-closed by design; its evidence set missed the macOS default sign-in shape.

## Mechanic

- The login probe ran `claude auth status --json` under a 1.5 s budget. A cold CLI start inside the Finder-launched app process crosses it, and any timeout mapped to `unknown`.
- The fallback read only `~/.claude/.credentials.json` for a live `claudeAiOauth` token. On macOS that token lives in the login keychain, so the file check returned false.
- `unknown` plus no file token meant `authenticated: false`, and the verdict was cached for 60 s.

## Fix

- Probe budget raised to 5 s with one retry after a timeout.
- After an inconclusive probe, `~/.claude.json` `oauthAccount.emailAddress` counts as stored login evidence (file only, no keychain read, no ACL prompt). Explicit `loggedIn: false` still wins.
- An `unknown` verdict is cached for 5 s instead of 60 s.
- User-facing wording unchanged.

## Tests

`tests/claude-auth-preflight-real-path.test.ts` drives the real `assertRuntimeDispatchable('claude-code')` with a fake `claude` binary on `PATH` and `HOME`/`CLAUDE_CONFIG_DIR` pointed at fixtures: slow probe within budget → dispatchable; both attempts time out with account evidence → dispatchable; time out without evidence → refused `needs_auth`; explicit sign-out with evidence present → refused; timeout-then-success retry; `unknown` verdict not pinned by the cache. Existing `auth-detect-claude.test.ts` cases stay green (one latency bound widened for the larger budget).

Local gates: `npx tsc --noEmit` clean, scoped eslint clean, `npm run rule-check` zero violations, 18 + 6 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7GZg4LTAf7odUF7nYaXBa
