### PR TITLE
fix: derive merged review state from receipts

### DIFF
--- a/src/lib/orchestrator/derive-review-state.test.ts
+++ b/src/lib/orchestrator/derive-review-state.test.ts
@@ -54,9 +54,28 @@ function lane(overrides: Partial<Lane> = {}): Lane {
 }
 
 describe('derivePacketReviewState', () => {
+  it('reports a released packet with a rejected review as needs-revision', () => {
+    const result = derivePacketReviewState({
+      packet: packet({ releaseState: 'released' }),
+      lane: lane({ status: 'reviewing', outcome: null }),
+      orchestratorReview: {
+        verdict: 'rejected',
+        ts: '2026-07-07T01:40:00.000Z',
+        summary: 'Changes requested',
+      },
+      mergeGate: {
+        verdict: 'failing',
+        ts: '2026-07-07T01:40:31.000Z',
+        checks: ['merge-preview'],
+      },
+    });
+
+    expect(result.state).toBe('needs-revision');
+  });
+
   it('keeps an approved passing verdict ready-to-merge while the lane is merging', () => {
     const result = derivePacketReviewState({
-      packet: packet(),
+      packet: packet({ releaseState: 'released' }),
       lane: lane(),
       orchestratorReview: {
         verdict: 'approved',
@@ -74,5 +93,41 @@ describe('derivePacketReviewState', () => {
       state: 'ready-to-merge',
       stateChangedAt: '2026-07-07T01:40:00.000Z',
     });
+  });
+
+  it('reports a released packet without a review decision as working', () => {
+    const result = derivePacketReviewState({
+      packet: packet({ releaseState: 'released', review: null }),
+      lane: lane({ status: 'reviewing', outcome: null }),
+      orchestratorReview: null,
+      mergeGate: null,
+    });
+
+    expect(result.state).toBe('working');
+  });
+
+  it('reports a lane completed with the merged outcome as merged', () => {
+    const result = derivePacketReviewState({
+      packet: packet({ releaseState: 'pending' }),
+      lane: lane({ status: 'completed', outcome: 'merged' }),
+      orchestratorReview: null,
+      mergeGate: null,
+    });
+
+    expect(result.state).toBe('merged');
+  });
+
+  it('reports a packet with a merge receipt as merged', () => {
+    const result = derivePacketReviewState({
+      packet: packet({
+        releaseState: 'released',
+        releaseStatePayload: { mergeCommit: '0123456789012345678901234567890123456789' },
+      }),
+      lane: lane({ status: 'reviewing', outcome: null }),
+      orchestratorReview: null,
+      mergeGate: null,
+    });
+
+    expect(result.state).toBe('merged');
   });
 });

--- a/src/lib/orchestrator/derive-review-state.ts
+++ b/src/lib/orchestrator/derive-review-state.ts
@@ -9,7 +9,6 @@
  */
 import type { Lane } from '@/lib/lane/types';
 import type { PacketDiffBaseResolution } from '@/lib/diff/base-resolution';
-import { isPacketReleased } from '@/lib/orchestrator/packet-state';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 
 export type PacketReviewState =
@@ -70,9 +69,8 @@ function pickLatestTimestamp(candidates: Array<string | null | undefined>): stri
 /**
  * Deterministic state machine. Order matters — the first matching rule wins.
  *
- *   1. `merged`          — packet release flipped to `released`, the packet
- *                          is already `released`, or the lane reached the
- *                          terminal merged outcome.
+ *   1. `merged`          — the lane reached the terminal merged outcome, or
+ *                          the packet carries a merge receipt.
  *   2. `failed`          — lane or packet status is `failed`.
  *   3. `needs-revision`  — orchestrator rejected the diff OR the merge gate
  *                          flagged any blocking violation.
@@ -86,7 +84,10 @@ export function derivePacketReviewState(input: DeriveReviewStateInput): DeriveRe
   const now = new Date().toISOString();
 
   // 1. merged
-  if (isPacketReleased(packet) || (lane?.status === 'completed' && lane.outcome === 'merged')) {
+  if (
+    (lane?.status === 'completed' && lane.outcome === 'merged')
+    || Boolean(packet.releaseStatePayload?.mergeCommit?.trim())
+  ) {
     const ts = pickLatestTimestamp([
       orchestratorReview?.ts,
       mergeGate?.ts,

--- a/tests/review-state-released-real-path.test.ts
+++ b/tests/review-state-released-real-path.test.ts
@@ -1,0 +1,131 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+
+const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-review-state-released-'));
+const operatorToken = 'operator-review-state-released-0123456789';
+process.env.O8_DATA_DIR = dataDir;
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+writeFileSync(join(dataDir, 'ws-token'), `${operatorToken}\n`, 'utf8');
+
+const reviewStateRoute = await import('@/app/api/orchestrator/review-state/route');
+const { closeDb } = await import('@/lib/db');
+const { createLane, getLane, setLaneStatus } = await import('@/lib/lane/registry');
+const {
+  readOrchestratorControlPlaneState,
+  writeOrchestratorControlPlaneState,
+} = await import('@/lib/orchestrator/control-plane');
+const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+
+const roots: string[] = [dataDir];
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+afterAll(() => {
+  closeDb();
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+describe('review state for released but unmerged packets through the real route', () => {
+  it('reports needs-revision for the persisted rejected review instead of merged', async () => {
+    const root = mkdtempSync(join(os.tmpdir(), 'o8-review-state-route-'));
+    roots.push(root);
+    const repoPath = join(root, 'repo');
+    const worktreePath = join(root, 'worktree');
+    const branch = 'fix/review-state-released';
+    const packetId = 'pkt-review-state-released';
+
+    git(root, ['init', '--initial-branch=main', repoPath]);
+    git(repoPath, ['config', 'user.name', 'o8-test']);
+    git(repoPath, ['config', 'user.email', 'o8@example.test']);
+    writeFileSync(join(repoPath, 'base.txt'), 'base\n');
+    git(repoPath, ['add', 'base.txt']);
+    git(repoPath, ['commit', '-m', 'base']);
+    git(repoPath, ['worktree', 'add', '-b', branch, worktreePath]);
+    writeFileSync(join(worktreePath, 'feature.txt'), 'reviewed change\n');
+    git(worktreePath, ['add', 'feature.txt']);
+    git(worktreePath, ['commit', '-m', 'test fixture change']);
+    writeFileSync(join(worktreePath, 'dirty.txt'), 'merge gate must fail\n');
+
+    const lane = createLane({
+      repoPath,
+      worktreePath,
+      branch,
+      baseBranch: 'main',
+      runtime: 'codex',
+      packetId,
+      label: 'Released review state',
+    });
+    setLaneStatus(lane.id, 'reviewing', 'system', 'review_requested');
+
+    writeOrchestratorControlPlaneState({
+      ...createEmptyOrchestratorMissionState(),
+      missionId: 'mission-review-state-released',
+      repoPath,
+      runtime: 'codex',
+      packets: [{
+        id: packetId,
+        referenceLabel: '#2083',
+        title: 'Released review state',
+        summary: 'Keep released distinct from merged.',
+        workspaceTargetPath: repoPath,
+        branchTarget: branch,
+        runtime: 'codex',
+        dependencyLabels: [],
+        dependencyPacketIds: [],
+        queueState: 'held',
+        releaseState: 'released',
+        releaseStatePayload: {
+          source: 'headless_released',
+          evidenceKind: 'headless_loop',
+          mergeCommit: null,
+          releasedAt: '2026-09-06T12:00:00.000Z',
+        },
+        status: 'released',
+        blockedReason: null,
+        lane: null,
+        review: {
+          approved: false,
+          findings: [],
+          summary: 'Changes requested',
+          recordedAt: '2026-09-06T12:01:00.000Z',
+        },
+      } as OrchestratorPacket],
+      updatedAt: '2026-09-06T12:01:00.000Z',
+    });
+
+    expect(getLane(lane.id)).toMatchObject({ status: 'reviewing', outcome: null });
+
+    const response = await reviewStateRoute.GET(new NextRequest(
+      `http://localhost:3001/api/orchestrator/review-state?packetId=${packetId}`,
+      { headers: { host: 'localhost:3001', authorization: `Bearer ${operatorToken}` } },
+    ));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      packetId,
+      state: 'needs-revision',
+      orchestratorReview: { verdict: 'rejected' },
+      mergeGate: { verdict: 'failing' },
+      lane: lane.id,
+      outcome: null,
+    });
+    expect(readOrchestratorControlPlaneState().packets[0]).toMatchObject({
+      id: packetId,
+      releaseState: 'released',
+      releaseStatePayload: { mergeCommit: null },
+    });
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2288,6 +2288,14 @@
       ]
     },
     {
+      "path": "tests/review-state-released-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/review-supersede-retry-real-path.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
## Summary

- `derivePacketReviewState` no longer treats `releaseState: 'released'` as merged. A worker that finishes its turn is stamped released whether or not anything merged, so every completed-but-unmerged packet read as merged to the review-state tool, the API route, and the UI.
- `merged` now derives from the lane reaching the terminal merged outcome or the packet carrying a merge receipt. A released packet with a rejected review falls through to `needs-revision`, with an approved review and a passing gate to `ready-to-merge`, otherwise `working`.
- Adds a real-path regression through the review-state route with a persisted lane and packet using the observed payload from the issue (released, verdict rejected, merge gate failing, lane reviewing, outcome null).

Closes #2083

## Verification

- `npx tsc --noEmit`
- `npx vitest run src/lib/orchestrator/derive-review-state.test.ts tests/review-state-released-real-path.test.ts` (6 passed, rerun independently by the reviewer)
- `npm run rule-check -- --base=origin/main`
- `npx eslint` on touched files
- `npm run test:classification:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dVxFgHWcYwiMja5oBxySH