### PR TITLE
fix: authorize packet-bound merge previews

### DIFF
--- a/src/app/api/orchestrator/merge-preview/route.ts
+++ b/src/app/api/orchestrator/merge-preview/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requirePanelAuth } from '@/lib/panel/auth';
 import { resolveRequestPrincipalContext, workerPacketRefusal } from '@/lib/auth/principal';
 import { previewPacketMerge } from '@/lib/lane/preview-merge';
 import { branchUnresolvedPayload, LaneBranchUnresolvedError } from '@/lib/lane/review-target';
@@ -7,6 +6,7 @@ import {
   ImmutableReviewUnavailableError,
   immutableReviewUnavailablePayload,
 } from '@/lib/lane/review-source';
+import { operatorError } from '@/app/api/orchestrator/_utils';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -22,16 +22,22 @@ export const dynamic = 'force-dynamic';
  * Gated by the global middleware (loopback + token under /api/orchestrator/).
  */
 export async function GET(request: NextRequest) {
-  const denied = requirePanelAuth(request);
-  if (denied) return denied;
+  const principal = resolveRequestPrincipalContext(request);
+  if (principal.role !== 'operator' && principal.role !== 'device' && principal.role !== 'worker') {
+    return operatorError(
+      'unauthorized',
+      'Merge preview requires the operator credential, an enrolled device, or a packet-bound worker credential.',
+      401,
+    );
+  }
 
   const packetId = request.nextUrl.searchParams.get('packetId')?.trim();
-  if (!packetId) {
-    return NextResponse.json({ error: 'packetId is required.' }, { status: 400 });
-  }
-  const ownershipRefusal = workerPacketRefusal(resolveRequestPrincipalContext(request), packetId);
+  const ownershipRefusal = workerPacketRefusal(principal, packetId);
   if (ownershipRefusal) {
     return NextResponse.json({ ok: false, error: ownershipRefusal }, { status: 403 });
+  }
+  if (!packetId) {
+    return NextResponse.json({ error: 'packetId is required.' }, { status: 400 });
   }
 
   try {

--- a/src/lib/lane/review-source.test.ts
+++ b/src/lib/lane/review-source.test.ts
@@ -155,11 +155,15 @@ const diffRoute = await import('@/app/api/lanes/[id]/diff/route');
 const mergePreviewRoute = await import('@/app/api/orchestrator/merge-preview/route');
 const reviewStateRoute = await import('@/app/api/orchestrator/review-state/route');
 const { closeDb } = await import('@/lib/db');
+const { getOrCreateWsToken } = await import('@/lib/ws-auth');
 
 function operatorGet(url: string) {
   return new NextRequest(url, {
     method: 'GET',
-    headers: { host: 'localhost:3001' },
+    headers: {
+      host: 'localhost:3001',
+      authorization: `Bearer ${getOrCreateWsToken()}`,
+    },
   });
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -130,6 +130,7 @@ const DEVICE_CAPABILITIES: Array<{ methods: ReadonlySet<string>; path: RegExp }>
   // gated per-principal, never loopback-trusted; its handler accepts operator +
   // device and still 403s a worker. Real-path coverage: tests/principal-authz.
   { methods: new Set(['POST']), path: /^\/api\/orchestrator\/steer-packet\/?$/ },
+  { methods: new Set(['GET']), path: /^\/api\/orchestrator\/merge-preview\/?$/ },
   // Phone-facing surfaces reached OUTSIDE /api/mobile/* (the app grew into these
   // and each failed closed until named). All device-safe: repo o8.md notes (read
   // + autosave write), fleet runtime inventory, review diffs, dictation + TTS.
@@ -170,6 +171,8 @@ const WORKER_CAPABILITIES: Array<{ methods: ReadonlySet<string>; path: RegExp }>
   { methods: new Set(['GET', 'POST', 'PATCH', 'DELETE']), path: /^\/api\/repo-spec(?:\/|$)/ },
   { methods: new Set(['GET']), path: /^\/api\/tasks(?:\/[^/]+)?\/?$/ },
   { methods: new Set(['POST']), path: /^\/api\/tasks\/[^/]+\/(?:report|block)\/?$/ },
+  // Read-only admission is packet-bound again in the route handler.
+  { methods: new Set(['GET']), path: /^\/api\/orchestrator\/merge-preview\/?$/ },
 ];
 
 const SPECTATOR_CAPABILITIES: Array<{ methods: ReadonlySet<string>; path: RegExp }> = [

--- a/tests/implementation-notes-artifact-real-path.test.ts
+++ b/tests/implementation-notes-artifact-real-path.test.ts
@@ -8,9 +8,10 @@ import { NextRequest } from 'next/server';
 
 const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-notes-real-path-data-'));
 const tempDirs: string[] = [];
+const WS_TOKEN = 'operator-notes-real-path-token';
 process.env.O8_DATA_DIR = dataDir;
 process.env.CORTEX_IDE_DATA_DIR = dataDir;
-writeFileSync(join(dataDir, 'ws-token'), 'operator-notes-real-path-token\n', 'utf8');
+writeFileSync(join(dataDir, 'ws-token'), `${WS_TOKEN}\n`, 'utf8');
 
 const mergePreviewRoute = await import('@/app/api/orchestrator/merge-preview/route');
 const { createLane, setLaneStatus } = await import('@/lib/lane/registry');
@@ -21,7 +22,10 @@ function git(cwd: string, args: string[]): void {
 }
 
 function operatorGet(url: string): NextRequest {
-  return new NextRequest(url, { method: 'GET', headers: { host: 'localhost:3001' } });
+  return new NextRequest(url, {
+    method: 'GET',
+    headers: { host: 'localhost:3001', authorization: `Bearer ${WS_TOKEN}` },
+  });
 }
 
 afterEach(() => {

--- a/tests/lane-branch-binding-diff.test.ts
+++ b/tests/lane-branch-binding-diff.test.ts
@@ -134,9 +134,13 @@ describe('lane branch binding and governance diff targets', () => {
     const { NextRequest } = await import('next/server');
     const diffRoute = await import('@/app/api/lanes/[id]/diff/route');
     const previewRoute = await import('@/app/api/orchestrator/merge-preview/route');
+    const { getOrCreateWsToken } = await import('@/lib/ws-auth');
     const operatorGet = (url: string) => new NextRequest(url, {
       method: 'GET',
-      headers: { host: 'localhost:3001' },
+      headers: {
+        host: 'localhost:3001',
+        authorization: `Bearer ${getOrCreateWsToken()}`,
+      },
     });
 
     const diffResponse = await diffRoute.GET(

--- a/tests/principal-authz.test.ts
+++ b/tests/principal-authz.test.ts
@@ -19,7 +19,8 @@
  * The worker-token file + ws-token file are written to a temp data dir BEFORE any
  * import, because worker-token.ts and the DB resolve their dir at module load.
  */
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import os from 'node:os';
 import { join } from 'node:path';
@@ -65,6 +66,7 @@ const reset = await import('@/app/api/orchestrator/reset-packet/route');
 const rerun = await import('@/app/api/orchestrator/rerun-with-feedback/route');
 const sessionRules = await import('@/app/api/orchestrator/session-rules/route');
 const merge = await import('@/app/api/orchestrator/merge/route');
+const mergePreview = await import('@/app/api/orchestrator/merge-preview/route');
 const workspace = await import('@/app/api/orchestrator/workspace/route');
 const devServer = await import('@/app/api/panel/dev-server/route');
 const fileIo = await import('@/app/api/panel/file-io/route');
@@ -545,6 +547,116 @@ describe('principal-authz — workspace reads stay packet-bound', () => {
       error: { code: 'worker_packet_mismatch' },
     });
   });
+});
+
+describe('principal-authz — merge preview admits only the owning worker packet', () => {
+  it('keeps operator and device output unchanged while enforcing worker packet ownership', async () => {
+    const repoPath = mkdtempSync(join(os.tmpdir(), 'o8-merge-preview-authz-'));
+    const packetId = `pkt-merge-preview-owner-${Date.now()}`;
+    const otherPacketId = `${packetId}-other`;
+    const branch = `inline/${packetId}`;
+    const git = (...args: string[]) => execFileSync('git', args, {
+      cwd: repoPath,
+      stdio: 'pipe',
+    });
+
+    try {
+      git('init', '-q', '-b', 'main');
+      git('config', 'user.email', 'test@o8.dev');
+      git('config', 'user.name', 'o8 test');
+      writeFileSync(join(repoPath, 'README.md'), 'base\n');
+      git('add', 'README.md');
+      git('commit', '-q', '-m', 'base');
+      git('checkout', '-q', '-b', branch);
+      writeFileSync(join(repoPath, 'README.md'), 'base\npacket change\n');
+      git('add', 'README.md');
+      git('commit', '-q', '-m', 'packet change');
+
+      const { createLane } = await import('@/lib/lane/registry');
+      createLane({
+        label: 'merge preview authorization',
+        repoPath,
+        worktreePath: repoPath,
+        branch,
+        baseBranch: 'main',
+        runtime: 'codex',
+        packetId,
+      });
+
+      const ownedUrl = `http://localhost:3001/api/orchestrator/merge-preview?packetId=${packetId}`;
+      const otherUrl = `http://localhost:3001/api/orchestrator/merge-preview?packetId=${otherPacketId}`;
+      const operatorRequest = req(ownedUrl, { principal: 'operator', method: 'GET' });
+      expect(panelGateMiddleware(operatorRequest).status).toBe(200);
+      const operatorResponse = await mergePreview.GET(operatorRequest);
+      expect(operatorResponse.status).toBe(200);
+      const operatorBody = await operatorResponse.text();
+      expect(JSON.parse(operatorBody)).toMatchObject({
+        packetId,
+        checks: expect.any(Array),
+        blockers: expect.any(Array),
+        branch,
+      });
+
+      const workerToken = mintPacketWorkerToken(packetId);
+      const ownedWorkerRequest = req(ownedUrl, {
+        principal: 'worker',
+        method: 'GET',
+        workerToken,
+      });
+      expect(panelGateMiddleware(ownedWorkerRequest).status).toBe(200);
+      const ownedWorkerResponse = await mergePreview.GET(ownedWorkerRequest);
+      expect(ownedWorkerResponse.status).toBe(200);
+      expect(await ownedWorkerResponse.text()).toBe(operatorBody);
+
+      const deviceRequest = new NextRequest(ownedUrl, {
+        method: 'GET',
+        headers: { host: 'localhost:3001', authorization: `Bearer ${DEVICE_TOKEN}` },
+      });
+      expect(panelGateMiddleware(deviceRequest).status).toBe(200);
+      const deviceResponse = await mergePreview.GET(deviceRequest);
+      expect(deviceResponse.status).toBe(200);
+      expect(await deviceResponse.text()).toBe(operatorBody);
+
+      const mismatchRequest = req(otherUrl, {
+        principal: 'worker',
+        method: 'GET',
+        workerToken,
+      });
+      expect(panelGateMiddleware(mismatchRequest).status).toBe(200);
+      const mismatchResponse = await mergePreview.GET(mismatchRequest);
+      expect(mismatchResponse.status).toBe(403);
+      await expect(mismatchResponse.json()).resolves.toMatchObject({
+        ok: false,
+        error: { code: 'worker_packet_mismatch' },
+      });
+
+      const legacyWorkerRequest = req(ownedUrl, {
+        principal: 'worker',
+        method: 'GET',
+      });
+      expect(panelGateMiddleware(legacyWorkerRequest).status).toBe(200);
+      const legacyWorkerResponse = await mergePreview.GET(legacyWorkerRequest);
+      expect(legacyWorkerResponse.status).toBe(403);
+      await expect(legacyWorkerResponse.json()).resolves.toMatchObject({
+        ok: false,
+        error: { code: 'worker_packet_mismatch' },
+      });
+
+      const anonymousRequest = new NextRequest(ownedUrl, {
+        method: 'GET',
+        headers: { host: 'localhost:3001' },
+      });
+      expect(panelGateMiddleware(anonymousRequest).status).toBe(401);
+      const anonymousResponse = await mergePreview.GET(anonymousRequest);
+      expect(anonymousResponse.status).toBe(401);
+      await expect(anonymousResponse.json()).resolves.toMatchObject({
+        ok: false,
+        error: { code: 'unauthorized' },
+      });
+    } finally {
+      rmSync(repoPath, { recursive: true, force: true });
+    }
+  }, 20_000);
 });
 
 describe('principal-authz — worker credentials are bound to their persisted packet owner (#1644)', () => {

--- a/tests/real-path-seams.test.ts
+++ b/tests/real-path-seams.test.ts
@@ -268,7 +268,10 @@ function operatorReq(url: string, body: unknown): NextRequest {
   });
 }
 function operatorGet(url: string): NextRequest {
-  return new NextRequest(url, { method: 'GET', headers: { host: 'localhost:3001' } });
+  return new NextRequest(url, {
+    method: 'GET',
+    headers: { host: 'localhost:3001', authorization: `Bearer ${WS_TOKEN}` },
+  });
 }
 
 describe('seam B — a dispatched worker approve_and_merge raises an operator card (CRIT-1/HIGH-4)', () => {

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2068,6 +2068,8 @@
     {
       "path": "tests/principal-authz.test.ts",
       "reasons": [
+        "child-process",
+        "git-cli",
         "terminal-tool"
       ]
     },


### PR DESCRIPTION
## Summary

- `GET /api/orchestrator/merge-preview` ran the operator-only panel gate before packet ownership was ever evaluated, so a dispatched worker presenting its packet-bound credential was rejected with a misleading "token did not match" hint and could never run the read-only merge preview that AGENTS.md tells it to run before reporting.
- The route now resolves the principal first: operator and device are admitted, a worker is admitted only when `workerPacketRefusal` passes for the requested packet, everything else gets a structured 401. Operator and device responses are byte-identical to before.
- Middleware allowlists gain the matching read-only entries for device and worker principals; ownership is still enforced in the handler.
- Existing merge-preview test callers now present the operator credential, since the handler no longer inherits loopback trust from the old panel gate.

Closes #2081

## Verification

- `npx tsc --noEmit`
- `npx vitest run` on the principal-authz real-path suite plus the merge-preview callers (7 files, 229 tests)
- `npm run rule-check -- --base=origin/main`
- `npx eslint` on touched files
- `npm run test:classification:check`

Regression `keeps operator and device output unchanged while enforcing worker packet ownership` runs through the middleware gate and the real route: owning worker 200 with the operator's exact body, mismatched or unbound worker 403 `worker_packet_mismatch`, anonymous 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dVxFgHWcYwiMja5oBxySH