### PR TITLE
fix: settle abandoned review turns

### DIFF
--- a/src/lib/lane/commands.ts
+++ b/src/lib/lane/commands.ts
@@ -57,6 +57,7 @@ import {
 import { commitDirtyWorktree, readHeadSha } from '@/lib/lane/worktree-merge-git';
 import { withRepoActionRecovery } from '@/lib/lane/repo-action-lock';
 import { materializationAwareExecFile } from '@/lib/worktree/materialization-execution';
+import { enqueueLaneReview } from '@/lib/lane/review-queue';
 import { persistLanePacketHold } from '@/lib/lane/packet-stop-hold';
 import { killLaneSessionsConfirmed } from '@/lib/lane/reap-sessions';
 import { liveWorkerSessionLanes } from '@/lib/lane/worker-session-state';
@@ -569,6 +570,7 @@ async function dispatchUnlocked(
       }
 
       const updated = setLaneStatus(command.laneId, 'reviewing', actor, 'review_requested');
+      if (updated) enqueueLaneReview(updated);
       return { ok: true, laneId: command.laneId, note: 'Review requested.', lane: updated ?? undefined };
     }
 

--- a/src/lib/lane/review-attempt-head.ts
+++ b/src/lib/lane/review-attempt-head.ts
@@ -209,6 +209,7 @@ export function reclaimAbandonedReviewAttempts(options: {
         leaseMs,
         attempts,
       });
+      stopActiveReviewTurn({ laneId: row.lane_id, reason: 'abandoned' });
       if (status === 'failed') {
         surfaceReviewQueueBlocker({
           laneId: row.lane_id,

--- a/src/lib/lane/review-turn-state.ts
+++ b/src/lib/lane/review-turn-state.ts
@@ -12,6 +12,10 @@ interface ReviewTurnEventPayload {
   expectedHeadSha?: unknown;
 }
 
+interface ReviewAttemptStatusRow {
+  status: string;
+}
+
 export interface ActiveReviewTurn {
   id: string;
   threadId: string | null;
@@ -47,7 +51,7 @@ export function startReviewTurn(input: {
   return reviewTurnId;
 }
 
-export function findActiveReviewTurn(laneId: string): ActiveReviewTurn | null {
+function findUnsettledReviewTurn(laneId: string): ActiveReviewTurn | null {
   const row = getSqlite().prepare(`
     SELECT verb, payload_json
     FROM lane_events
@@ -75,6 +79,34 @@ export function findActiveReviewTurn(laneId: string): ActiveReviewTurn | null {
   }
 }
 
+function reviewAttemptStatus(
+  laneId: string,
+  active: ActiveReviewTurn,
+): string | null {
+  if (active.surface !== 'auto-review' || !active.threadId) return null;
+  const prefix = `auto-review-${laneId}-`;
+  if (!active.threadId.startsWith(prefix)) return null;
+  const reviewId = active.threadId
+    .slice(prefix.length)
+    .replace(/-verdict-retry$/, '');
+  if (!reviewId) return null;
+  try {
+    const row = getSqlite().prepare(
+      'SELECT status FROM review_queue WHERE id = ? AND lane_id = ? LIMIT 1',
+    ).get(reviewId, laneId) as ReviewAttemptStatusRow | undefined;
+    return row?.status ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function findActiveReviewTurn(laneId: string): ActiveReviewTurn | null {
+  const active = findUnsettledReviewTurn(laneId);
+  if (!active) return null;
+  const attemptStatus = reviewAttemptStatus(laneId, active);
+  return attemptStatus && attemptStatus !== 'in_progress' ? null : active;
+}
+
 export function findActiveReviewTurnId(laneId: string): string | null {
   return findActiveReviewTurn(laneId)?.id ?? null;
 }
@@ -95,16 +127,18 @@ export function bindReviewTurnAbortController(
 
 export function stopActiveReviewTurn(input: {
   laneId: string;
-  reason: 'packet_discarded' | 'packet_stopped' | 'superseded';
+  reason: 'abandoned' | 'packet_discarded' | 'packet_stopped' | 'superseded';
 }): ReviewTurnStopResult | null {
-  const active = findActiveReviewTurn(input.laneId);
-  if (!active) return null;
-  const binding = reviewTurnAbortControllers.get(active.id);
-  const abortRequested = binding?.laneId === input.laneId;
-  if (abortRequested) {
+  const abortedTurnIds = new Set<string>();
+  for (const [reviewTurnId, binding] of reviewTurnAbortControllers) {
+    if (binding.laneId !== input.laneId) continue;
     binding.controller.abort(input.reason);
-    reviewTurnAbortControllers.delete(active.id);
+    reviewTurnAbortControllers.delete(reviewTurnId);
+    abortedTurnIds.add(reviewTurnId);
   }
+  const active = findUnsettledReviewTurn(input.laneId);
+  if (!active) return null;
+  const abortRequested = abortedTurnIds.has(active.id);
   recordLaneEvent(input.laneId, 'review_turn_stopped', 'system', {
     reviewTurnId: active.id,
     threadId: active.threadId,

--- a/tests/close-packet-unmerged.test.ts
+++ b/tests/close-packet-unmerged.test.ts
@@ -18,9 +18,10 @@ process.env.CORTEX_IDE_DATA_DIR = dataDir;
 writeFileSync(join(dataDir, 'ws-token'), `${wsToken}\n`, 'utf-8');
 
 const closeRoute = await import('@/app/api/orchestrator/discard-packet/route');
-const { getDb, closeDb } = await import('@/lib/db');
+const { getDb, getSqlite, closeDb } = await import('@/lib/db');
 const { sessionOutcomes } = await import('@/lib/db/schema');
 const { createLane, getLane, getLaneEvents, setLaneStatus } = await import('@/lib/lane/registry');
+const { startReviewTurn } = await import('@/lib/lane/review-turn-state');
 const { recordMission } = await import('@/lib/db/missions-store');
 const { readMissionRegistryEntry } = await import('@/lib/orchestrator/mission-registry');
 const { readOrchestratorControlPlaneState, writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
@@ -111,7 +112,7 @@ function persistOpenCodeClosePacket(input: {
 }
 
 describe('close_packet_unmerged real path (#1570)', () => {
-  it('archives an awaiting-review packet and writes the explicit disposition to durable state', async () => {
+  it('archives an awaiting-review packet and stops its dangling terminal-attempt review turn', async () => {
     const packetId = 'pkt-close-unmerged-real-path';
     const repoPath = join(dataDir, 'repo');
     const lane = createLane({
@@ -158,6 +159,20 @@ describe('close_packet_unmerged real path (#1570)', () => {
 
     const db = getDb();
     expect(db).not.toBeNull();
+    const reviewId = 'review-close-terminal-attempt';
+    const reviewedHeadSha = 'a'.repeat(40);
+    getSqlite().prepare(
+      `INSERT INTO review_queue (
+         id, lane_id, repo_path, status, attempts, head_sha, created_at, updated_at
+       ) VALUES (?, ?, ?, 'completed', 0, ?, datetime('now'), datetime('now'))`,
+    ).run(reviewId, lane.id, repoPath, reviewedHeadSha);
+    const reviewTurnId = startReviewTurn({
+      laneId: lane.id,
+      threadId: `auto-review-${lane.id}-${reviewId}`,
+      backend: 'codex',
+      surface: 'auto-review',
+      expectedHeadSha: reviewedHeadSha,
+    });
 
     const response = await closeRoute.POST(operatorRequest({
       packetId,
@@ -171,6 +186,16 @@ describe('close_packet_unmerged real path (#1570)', () => {
         closed: true,
         disposition: 'adopted_elsewhere',
         packetId,
+        stoppedReviewTurns: 1,
+      },
+    });
+    expect(getLaneEvents(lane.id, 100).find((event) => (
+      event.verb === 'review_turn_stopped'
+      && event.payload.reviewTurnId === reviewTurnId
+    ))).toMatchObject({
+      payload: {
+        reason: 'packet_discarded',
+        abortRequested: false,
       },
     });
 

--- a/tests/review-supersede-retry-real-path.test.ts
+++ b/tests/review-supersede-retry-real-path.test.ts
@@ -97,6 +97,14 @@ const { closeDb, getSqlite } = await import('@/lib/db');
 const reviewRoute = await import('@/app/api/orchestrator/review/route');
 const resetRoute = await import('@/app/api/orchestrator/reset-packet/route');
 const { drainReviewQueue, triggerAutoReview } = await import('@/lib/lane/auto-review');
+const { dispatch: dispatchLaneCommand } = await import('@/lib/lane/commands');
+const { reclaimAbandonedReviewAttempts } = await import('@/lib/lane/review-attempt-head');
+const { enqueueLaneReview } = await import('@/lib/lane/review-queue');
+const {
+  findActiveReviewTurn,
+  startReviewTurn,
+  stopActiveReviewTurn,
+} = await import('@/lib/lane/review-turn-state');
 const {
   createLane,
   getLane,
@@ -301,6 +309,163 @@ describe('superseded active reviewer turn (#2003)', () => {
     ))).toHaveLength(0);
     expect(reviewer.ensureStatuses).toEqual(['ready', 'ready']);
   });
+
+  it('accepts HEAD D after lease expiry abandons the HEAD A reviewer turn (#2084)', async () => {
+    const packetId = 'pkt-abandoned-review-turn-2084';
+    const branch = 'inline/abandoned-review-turn-2084';
+    const repoDir = createRepo(branch);
+    const lane = createLane({
+      repoPath: repoDir,
+      worktreePath: repoDir,
+      branch,
+      baseBranch: 'main',
+      runtime: 'codex',
+      label: 'abandoned review turn fixture',
+      packetId,
+    });
+    const headA = commitFile(repoDir, 'result-a.txt', 'head A\n', 'head A');
+    setLaneStatus(lane.id, 'reviewing', 'system', 'review_requested');
+    persistCurrentMission(repoDir, packetFixture({ packetId, repoPath: repoDir, branch, laneId: lane.id }));
+
+    triggerAutoReview(getLane(lane.id)!);
+    reviewer.holdNextTurn = true;
+    const firstDrain = drainReviewQueue();
+    await vi.waitFor(() => {
+      expect(queueRows(lane.id)).toContainEqual(expect.objectContaining({
+        status: 'in_progress',
+        head_sha: headA,
+      }));
+      expect(reviewer.signals).toHaveLength(1);
+    });
+    const headATurn = getLaneEvents(lane.id, 100).find((event) => (
+      event.verb === 'review_turn_started' && event.payload.expectedHeadSha === headA
+    ));
+    expect(headATurn?.payload.reviewTurnId).toEqual(expect.any(String));
+
+    const rejected = await reviewRoute.POST(operatorPost('/api/orchestrator/review', {
+      packetId,
+      findings: [{
+        file: 'result-a.txt',
+        severity: 'warning',
+        description: 'The first review requires a successor commit.',
+        status: 'deferred',
+      }],
+      approved: false,
+      reviewedHeadSha: headA,
+      clientMutationId: 'reject-head-a-before-abandon-2084',
+    }));
+    expect(rejected.status).toBe(200);
+    await expect(rejected.json()).resolves.toMatchObject({
+      ok: true,
+      result: { recorded: true, reviewedHeadSha: headA },
+    });
+
+    setLaneStatus(lane.id, 'running', 'orchestrator', 'turn_sent');
+    getSqlite().prepare(
+      `UPDATE review_queue SET claimed_at = datetime('now', '-2 hours')
+       WHERE lane_id = ? AND status = 'in_progress'`,
+    ).run(lane.id);
+    expect(reclaimAbandonedReviewAttempts()).toBe(1);
+    expect(reviewer.signals[0]?.aborted).toBe(true);
+    expect(reviewer.signals[0]?.reason).toBe('abandoned');
+    await firstDrain;
+    expect(findActiveReviewTurn(lane.id)).toBeNull();
+
+    commitFile(repoDir, 'result-b.txt', 'head B\n', 'head B');
+    commitFile(repoDir, 'result-c.txt', 'head C\n', 'head C');
+    const headD = commitFile(repoDir, 'result-d.txt', 'head D\n', 'head D');
+    const reviewRequest = await dispatchLaneCommand({
+      verb: 'request_review',
+      laneId: lane.id,
+      actor: 'orchestrator',
+    });
+    expect(reviewRequest.ok).toBe(true);
+    expect(queueRows(lane.id)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ status: 'completed', head_sha: headA }),
+      expect.objectContaining({ status: 'pending', head_sha: headD }),
+    ]));
+
+    const response = await reviewRoute.POST(operatorPost('/api/orchestrator/review', {
+      packetId,
+      findings: [],
+      approved: true,
+      reviewedHeadSha: headD,
+      clientMutationId: 'review-head-d-after-abandon-2084',
+    }));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      result: {
+        recorded: true,
+        reviewedHeadSha: headD,
+      },
+    });
+    expect(readOrchestratorControlPlaneState().packets.find((packet) => (
+      packet.id === packetId
+    ))?.review).toMatchObject({ approved: true, reviewedHeadSha: headD });
+
+    const events = getLaneEvents(lane.id, 200);
+    expect(events.find((event) => event.verb === 'review_turn_stopped')).toMatchObject({
+      payload: {
+        reviewTurnId: headATurn?.payload.reviewTurnId,
+        reason: 'abandoned',
+        abortRequested: true,
+      },
+    });
+    expect(events.find((event) => (
+      event.verb === 'review_turn_finished'
+      && event.payload.reviewTurnId === headATurn?.payload.reviewTurnId
+    ))).toMatchObject({ payload: { outcome: 'failed' } });
+    expect(events.filter((event) => event.verb === 'review_head_drift_rejected')).toHaveLength(0);
+  });
+
+  it('does not let a terminal auto-review attempt pin an operator submission to its old HEAD', async () => {
+    const packetId = 'pkt-terminal-review-attempt-2084';
+    const branch = 'inline/terminal-review-attempt-2084';
+    const repoDir = createRepo(branch);
+    const lane = createLane({
+      repoPath: repoDir,
+      worktreePath: repoDir,
+      branch,
+      baseBranch: 'main',
+      runtime: 'codex',
+      label: 'terminal review attempt fixture',
+      packetId,
+    });
+    const headA = commitFile(repoDir, 'head-a.txt', 'head A\n', 'head A');
+    setLaneStatus(lane.id, 'reviewing', 'system', 'review_requested');
+    const queued = enqueueLaneReview(getLane(lane.id)!, { headSha: headA });
+    getSqlite().prepare(
+      `UPDATE review_queue SET status = 'completed' WHERE id = ?`,
+    ).run(queued.reviewId);
+    startReviewTurn({
+      laneId: lane.id,
+      threadId: `auto-review-${lane.id}-${queued.reviewId}`,
+      backend: 'codex',
+      surface: 'auto-review',
+      expectedHeadSha: headA,
+    });
+    const headD = commitFile(repoDir, 'head-d.txt', 'head D\n', 'head D');
+    persistCurrentMission(repoDir, packetFixture({ packetId, repoPath: repoDir, branch, laneId: lane.id }));
+
+    const response = await reviewRoute.POST(operatorPost('/api/orchestrator/review', {
+      packetId,
+      findings: [],
+      approved: true,
+      reviewedHeadSha: headD,
+      clientMutationId: 'review-current-head-after-terminal-attempt-2084',
+    }));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      result: { recorded: true, reviewedHeadSha: headD },
+    });
+    expect(getLaneEvents(lane.id, 100).filter((event) => (
+      event.verb === 'review_head_drift_rejected'
+    ))).toHaveLength(0);
+    stopActiveReviewTurn({ laneId: lane.id, reason: 'abandoned' });
+  });
+
 });
 
 describe('retry_packet awaiting-input salvage (#2003)', () => {


### PR DESCRIPTION
## Summary

An auto-review turn whose claim lease expired while the reviewer was still running was reclaimed without ever being settled: no `review_turn_finished` or `review_turn_stopped` was recorded, so its pinned `expectedHeadSha` gated every later operator `submit_review` as `review_head_drift`, `approve_and_merge` refused on the stale verdict, and `steer_packet` and `close_packet_unmerged` left the dangling turn in place. The packet could only land through a PR outside o8.

- Reclaiming an abandoned attempt now stops its review turn with a new `abandoned` reason, aborting every reviewer controller still bound to the lane, so an aborted reviewer always reaches `finishReviewTurn`.
- `findActiveReviewTurn` no longer returns an auto-review turn whose attempt row is no longer `in_progress`, so a dangling turn cannot pin an operator submission to its old HEAD. An operator `submit_review` for the packet's current HEAD is accepted.
- `request_review` enqueues a fresh attempt row when a lane returns to `reviewing`, so a new HEAD gets reviewed instead of being skipped behind stale rows.
- The server-side close path settles the dangling turn through the existing stop logic and reports `stoppedReviewTurns: 1`.

Closes #2084

## Verification

- `npx tsc --noEmit`
- `npx vitest run` on the review-supersede, close-packet, and review-attempt suites (39 passed)
- `npm run rule-check -- --base=origin/main`
- `npx eslint` on touched files
- `npm run test:classification:check`

Regressions: `accepts HEAD D after lease expiry abandons the HEAD A reviewer turn` reproduces the issue timeline end to end through the authenticated review route with persisted state; `archives an awaiting-review packet and stops its dangling terminal-attempt review turn` goes through the real close route.

Out of scope: `tests/steered-review-settlement-real-path.test.ts` fails five tests identically on current `main` (verified side by side at 6902f0646); this change does not alter that result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dVxFgHWcYwiMja5oBxySH