### PR TITLE
ci: schedule weekly integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,14 @@ name: CI
 # direct pushes/day × ~17 job-minutes that was the entire Actions bill for
 # zero new signal. PRs are the un-gated lanes (PR agents), so event-driven CI
 # stays there.
-# A weekly run keeps dependency audits current; workflow_dispatch remains the
-# on-demand path for a full remote check against main.
+# A weekly run keeps integration coverage and dependency audits current;
+# workflow_dispatch remains the on-demand path for a full remote check against
+# main.
 on:
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '17 5 * * 0'
   workflow_dispatch:
 
 permissions:
@@ -23,6 +26,7 @@ concurrency:
 jobs:
   typecheck:
     name: Type Check
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -45,6 +49,7 @@ jobs:
   # being linted). Warnings don't fail the job; errors do.
   lint:
     name: Lint
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -143,6 +148,7 @@ jobs:
 
   governance-smoke:
     name: Governance Smoke
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     # timeout is load-bearing: this job hung at the 6h GitHub ceiling 3x on
     # 2026-07-11 (open handle keeps node alive after the smoke passes) —


### PR DESCRIPTION
## Summary

The `Resource-owning Integration Tests` job was gated on `schedule` or `workflow_dispatch`, and the header comment promised a weekly run, but the workflow had no `schedule:` trigger. Every one of the last 40 CI runs was a pull request, so the job reported `skipped` each time and the whole `npm run test:integration` lane never ran in CI.

- Adds one weekly cron (Sunday 05:17 UTC) so the integration lane runs against `main` without a human dispatching it.
- Cost-bounded: on the scheduled event only the hermetic unit tests (the integration job's dependency), the integration lane, and the security audit run, all on Linux. Type check, lint, and governance smoke are gated off the schedule; the Windows Rust gate and the build were already dispatch or PR only.
- Pull request and dispatch behaviour is unchanged. `concurrency: cancel-in-progress` is intact.
- Header comment now matches the trigger.

Closes #2089

## Verification

- YAML parses; per-job trigger table derived from the file:

| Job | Runner | PR | Dispatch | Schedule |
|---|---|---|---|---|
| Type Check | Linux | Y | Y | N |
| Lint | Linux | Y | Y | N |
| Hermetic Unit Tests | Linux | Y | Y | Y |
| Resource-owning Integration Tests | Linux | N | Y | Y |
| Security Audit | Linux | Y | Y | Y |
| Governance Smoke | Linux | Y | Y | N |
| Build | Linux | N | Y | N |
| Rust Compile Gate (Windows) | Windows | Y | Y | N |
| Rust Compile Gate (Linux) | Linux | Y | Y | N |

- The live receipt (a run with `event=schedule` whose integration job is not `skipped`) can only exist after this reaches `main` and the first Sunday cron fires. #2088 is expected to make that first run red; that is the signal this change exists to produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dVxFgHWcYwiMja5oBxySH