### PR TITLE
fix: complete retirement for absent directories

### DIFF
--- a/src/lib/workspace/exact-managed-directory-retirement.ts
+++ b/src/lib/workspace/exact-managed-directory-retirement.ts
@@ -92,7 +92,7 @@ function verifyClaimInput(
 
 async function prepareRetirement(
   input: ExactManagedDirectoryRetirementInput,
-): Promise<ExactWorkspaceClaimRecord> {
+): Promise<ExactWorkspaceClaimRecord | null> {
   const requestedDirectoryPath = path.resolve(input.directoryPath);
   const parentIdentity = await captureParentIdentity(requestedDirectoryPath);
   const directoryPath = path.join(
@@ -115,6 +115,7 @@ async function prepareRetirement(
     verifyClaimInput(existing, input, parentIdentity);
     return existing;
   }
+  if (!(await directoryIdentity(directoryPath))) return null;
   await assertWorktreeMaterializationIdentity(directoryPath, input.identity);
   const operationId = randomUUID();
   const claimPath = path.join(parentIdentity.canonicalPath, `.o8-retired-managed-${operationId}`);
@@ -211,6 +212,7 @@ export async function retireExactManagedDirectory(
   input: ExactManagedDirectoryRetirementInput,
 ): Promise<void> {
   const claim = await prepareRetirement(input);
+  if (!claim) return;
   await finishClaim(claim, input.beforeRetirementRename, input.afterRetirementRename);
 }
 

--- a/tests/managed-creation-crash-recovery-real-path.test.ts
+++ b/tests/managed-creation-crash-recovery-real-path.test.ts
@@ -98,7 +98,7 @@ it.each(['git-worktree', 'apfs-cow-clone'] as const)(
   90_000,
 );
 
-it('reclaims an already absent managed directory once and preserves mismatch refusal', async () => {
+it('retires a claim-free absent directory once and preserves mismatch refusal', async () => {
   const root = mkdtempSync(path.join(os.tmpdir(), 'o8-cleanup-absent-replay-'));
   const repoRoot = makeRepo(root);
   const dataDir = process.env.CORTEX_IDE_DATA_DIR!;
@@ -109,6 +109,7 @@ it('reclaims an already absent managed directory once and preserves mismatch ref
   const { captureWorktreeMaterializationIdentity } = await import('@/lib/worktree/materialization-identity');
   const { withWorktreeMetaTransaction } = await import('@/lib/worktree/metadata-store');
   const { resolveWorktreeRootLayout } = await import('@/lib/worktree/root-layout');
+  const { readExactWorkspaceClaim } = await import('@/lib/workspace/exact-workspace-claim-state');
   const { closeDb } = await import('@/lib/db');
   const layout = resolveWorktreeRootLayout(repoRoot);
   mkdirSync(layout.primaryBase, { recursive: true });
@@ -137,6 +138,7 @@ it('reclaims an already absent managed directory once and preserves mismatch ref
   writeFileSync(path.join(absentPath, 'owned.txt'), 'owned bytes');
   await saveEntry(absentId, absentPath);
   rmSync(absentPath, { recursive: true });
+  expect(readExactWorkspaceClaim('managed-retirement', repoRoot, absentId)).toBeNull();
 
   const mismatchId = 'packet-mismatched-retirement';
   const mismatchPath = path.join(layout.primaryBase, mismatchId);
@@ -149,14 +151,22 @@ it('reclaims an already absent managed directory once and preserves mismatch ref
   writeFileSync(path.join(mismatchPath, 'replacement.txt'), 'replacement bytes');
 
   const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  const manager = new WorktreeManager(repoRoot);
+  const cleanupSpy = vi.spyOn(manager, 'cleanup');
   try {
-    const manager = new WorktreeManager(repoRoot);
     const firstSweep = await manager.prune(0);
+    const absentSelectionsAfterFirst = cleanupSpy.mock.calls.filter(
+      ([worktreeId]) => worktreeId === absentId,
+    ).length;
     const metadataAfterFirst = await withWorktreeMetaTransaction(
       repoRoot,
       async (transaction) => (await transaction.readAll())[absentId],
     );
+    const claimAfterFirst = readExactWorkspaceClaim('managed-retirement', repoRoot, absentId);
     const secondSweep = await manager.prune(0);
+    const absentSelectionsAfterSecond = cleanupSpy.mock.calls.filter(
+      ([worktreeId]) => worktreeId === absentId,
+    ).length;
     const metadataAfterSecond = await withWorktreeMetaTransaction(
       repoRoot,
       async (transaction) => (await transaction.readAll())[absentId],
@@ -170,14 +180,20 @@ it('reclaims an already absent managed directory once and preserves mismatch ref
 
     expect({
       firstSweep,
+      absentSelectionsAfterFirst,
       metadataAfterFirst: Boolean(metadataAfterFirst),
+      claimAfterFirst,
       secondSweep,
+      absentSelectionsAfterSecond,
       metadataAfterSecond: Boolean(metadataAfterSecond),
       absentRefusals: absentRefusals.length,
     }).toEqual({
       firstSweep: [absentId],
+      absentSelectionsAfterFirst: 1,
       metadataAfterFirst: false,
+      claimAfterFirst: null,
       secondSweep: [],
+      absentSelectionsAfterSecond: 1,
       metadataAfterSecond: false,
       absentRefusals: 0,
     });
@@ -187,6 +203,7 @@ it('reclaims an already absent managed directory once and preserves mismatch ref
     expect(readFileSync(path.join(retainedMismatchPath, 'owned.txt'), 'utf8'))
       .toBe('owned bytes');
   } finally {
+    cleanupSpy.mockRestore();
     errorSpy.mockRestore();
     closeDb();
   }

--- a/tests/managed-creation-crash-recovery-real-path.test.ts
+++ b/tests/managed-creation-crash-recovery-real-path.test.ts
@@ -1,10 +1,19 @@
 import { spawn } from 'node:child_process';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { expect, it } from 'vitest';
+import { expect, it, vi } from 'vitest';
 
 function makeRepo(root: string): string {
   const repoRoot = path.join(root, 'repo');
@@ -88,6 +97,100 @@ it.each(['git-worktree', 'apfs-cow-clone'] as const)(
   },
   90_000,
 );
+
+it('reclaims an already absent managed directory once and preserves mismatch refusal', async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'o8-cleanup-absent-replay-'));
+  const repoRoot = makeRepo(root);
+  const dataDir = process.env.CORTEX_IDE_DATA_DIR!;
+  const worktreeRoot = path.join(root, 'worktrees');
+  process.env.CORTEX_IDE_DATA_DIR = dataDir;
+  process.env.O8_WORKTREE_ROOT = worktreeRoot;
+  const { WorktreeManager } = await import('@/lib/worktree/manager');
+  const { captureWorktreeMaterializationIdentity } = await import('@/lib/worktree/materialization-identity');
+  const { withWorktreeMetaTransaction } = await import('@/lib/worktree/metadata-store');
+  const { resolveWorktreeRootLayout } = await import('@/lib/worktree/root-layout');
+  const { closeDb } = await import('@/lib/db');
+  const layout = resolveWorktreeRootLayout(repoRoot);
+  mkdirSync(layout.primaryBase, { recursive: true });
+  const parentIdentity = await captureWorktreeMaterializationIdentity(layout.primaryBase);
+
+  const saveEntry = async (id: string, workspacePath: string) => {
+    const materializationIdentity = await captureWorktreeMaterializationIdentity(workspacePath);
+    await withWorktreeMetaTransaction(repoRoot, (transaction) => transaction.save(id, {
+      id,
+      agentType: 'worker',
+      baseBranch: 'main',
+      createdAt: Date.now(),
+      claudeManaged: false,
+      taskName: id,
+      branchName: `inline/${id}`,
+      status: 'ready',
+      isolationKind: 'apfs-cow-clone',
+      materializationIdentity,
+      materializationParentIdentity: parentIdentity,
+    }));
+  };
+
+  const absentId = 'packet-absent-retirement';
+  const absentPath = path.join(layout.primaryBase, absentId);
+  mkdirSync(absentPath);
+  writeFileSync(path.join(absentPath, 'owned.txt'), 'owned bytes');
+  await saveEntry(absentId, absentPath);
+  rmSync(absentPath, { recursive: true });
+
+  const mismatchId = 'packet-mismatched-retirement';
+  const mismatchPath = path.join(layout.primaryBase, mismatchId);
+  const retainedMismatchPath = path.join(root, 'retained-mismatched-retirement');
+  mkdirSync(mismatchPath);
+  writeFileSync(path.join(mismatchPath, 'owned.txt'), 'owned bytes');
+  await saveEntry(mismatchId, mismatchPath);
+  renameSync(mismatchPath, retainedMismatchPath);
+  mkdirSync(mismatchPath);
+  writeFileSync(path.join(mismatchPath, 'replacement.txt'), 'replacement bytes');
+
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  try {
+    const manager = new WorktreeManager(repoRoot);
+    const firstSweep = await manager.prune(0);
+    const metadataAfterFirst = await withWorktreeMetaTransaction(
+      repoRoot,
+      async (transaction) => (await transaction.readAll())[absentId],
+    );
+    const secondSweep = await manager.prune(0);
+    const metadataAfterSecond = await withWorktreeMetaTransaction(
+      repoRoot,
+      async (transaction) => (await transaction.readAll())[absentId],
+    );
+    const mismatchRemoved = await manager.cleanup(
+      mismatchId, { force: true, overrideLiveGuard: true },
+    );
+    const absentRefusals = errorSpy.mock.calls.filter((args) => (
+      args.some((argument) => String(argument).includes(absentId))
+    ));
+
+    expect({
+      firstSweep,
+      metadataAfterFirst: Boolean(metadataAfterFirst),
+      secondSweep,
+      metadataAfterSecond: Boolean(metadataAfterSecond),
+      absentRefusals: absentRefusals.length,
+    }).toEqual({
+      firstSweep: [absentId],
+      metadataAfterFirst: false,
+      secondSweep: [],
+      metadataAfterSecond: false,
+      absentRefusals: 0,
+    });
+    expect(mismatchRemoved).toBe(false);
+    expect(readFileSync(path.join(mismatchPath, 'replacement.txt'), 'utf8'))
+      .toBe('replacement bytes');
+    expect(readFileSync(path.join(retainedMismatchPath, 'owned.txt'), 'utf8'))
+      .toBe('owned bytes');
+  } finally {
+    errorSpy.mockRestore();
+    closeDb();
+  }
+}, 30_000);
 
 it.each(['pr', 'merge'] as const)('replays %s cleanup after a crash following the exact retirement rename', async (action) => {
   const root = mkdtempSync(path.join(os.tmpdir(), `o8-cleanup-${action}-crash-replay-`));


### PR DESCRIPTION
## Summary

The crash-replay sweep selects retirement entries whose managed directory is already gone, then `prepareRetirement` asserted materialization identity on that missing path, threw `ENOENT`, threw again in recovery, and refused. The refusal never removed the metadata entry, so every sweep replayed the same entries: about 2,400 refusal lines across 14 stale packet worktrees on one installed 0.1.737, a permanent leak and log flood on every start.

- `prepareRetirement` now returns `null` when the directory is absent and no claim exists, and the caller completes the retirement, removing the metadata entry, instead of asserting identity on a path that no longer exists.
- Identity assertion is unchanged for directories that still exist; a present directory with mismatched identity is still refused.

Closes #2093

## Verification

- `npx tsc --noEmit`
- `npx vitest run tests/managed-creation-crash-recovery-real-path.test.ts src/lib/workspace/exact-managed-directory-retirement.test.ts` (10 passed, rerun independently by the reviewer)
- `npm run rule-check -- --base=origin/main`
- `npx eslint` on touched files
- `npm run test:classification:check`

Regression `reclaims an already absent managed directory once and preserves mismatch refusal` first reproduces two consecutive refusals on the old code through the real sweep, then proves one-sweep metadata removal, no replay, and continued refusal of a present mismatched directory. It does not seed a claim, so it reaches the identity assert the previous test skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dVxFgHWcYwiMja5oBxySH