### PR TITLE
fix: harden native worker startup and terminal outcomes

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "packageManager": "npm@11.8.0",
   "scripts": {
+    "worker:login": "node --import ./scripts/register-server-only-stub.mjs --import tsx scripts/connect-native-worker.ts",
     "predev:cleanup": "node scripts/dev.mjs cleanup",
     "dev": "node scripts/dev.mjs all",
     "dev:next": "node scripts/dev.mjs next",

--- a/scripts/connect-native-worker.ts
+++ b/scripts/connect-native-worker.ts
@@ -1,0 +1,90 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { stripVTControlCharacters } from 'node:util';
+
+import { resolveCli } from '../src/lib/runtimes/shared/cli-resolver';
+import { saveNativeWorkerToken } from '../src/lib/claude-code/worker-token';
+import { extractSetupWorkerToken, workerTokenSetupNeedsBrowser } from '../src/lib/claude-code/worker-token-output';
+
+// Run only as the operator. Never put the raw setup-token command in a managed
+// terminal: it prints the credential. This wrapper retains output in memory only.
+async function main(): Promise<void> {
+  if (process.platform !== 'darwin') throw new Error('Mac acceptance required.');
+  if (process.env.O8_WORKER_TOKEN || process.env.O8_WORKER_PACKET_ID) throw new Error('Operator context required.');
+  const binary = await resolveCli({ runtimeId: 'claude-code', binaryName: 'claude', envOverride: 'O8_CLAUDE_CODE_BIN' });
+  const { spawn } = createRequire(import.meta.url)('node-pty') as typeof import('node-pty');
+  const configDir = await mkdtemp(path.join(os.tmpdir(), 'o8-worker-login-'));
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (/^(ANTHROPIC_|CLAUDE_|O8_WORKER_)/.test(key)) delete env[key];
+  }
+  Object.assign(env, {
+    CLAUDE_CONFIG_DIR: configDir,
+    CLAUDE_SECURESTORAGE_CONFIG_DIR: configDir,
+    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+    FORCE_COLOR: '0', NO_COLOR: '1',
+  });
+  delete env.BROWSER;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn(binary.path, ['setup-token'], { cwd: configDir, env, cols: 1000, rows: 40 });
+      let raw = '';
+      let browserReported = false;
+      let saving: Promise<void> | undefined;
+      let settled = false;
+      const finish = (ok: boolean) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        process.off('SIGINT', cancel);
+        process.off('SIGTERM', cancel);
+        try { child.kill(); } catch { /* The CLI can exit before encrypted storage finishes. */ }
+        raw = '';
+        if (ok) resolve(); else reject(new Error('Worker login did not finish.'));
+      };
+      const cancel = () => finish(false);
+      const timer = setTimeout(cancel, 10 * 60_000);
+      process.once('SIGINT', cancel);
+      process.once('SIGTERM', cancel);
+      child.onData((chunk) => {
+        if (settled) return;
+        // Interactive redraws can repeat for minutes during browser approval.
+        // Retain a bounded tail rather than treating those redraws as a failure.
+        raw = (raw + chunk).slice(-128 * 1024);
+        if (!browserReported && workerTokenSetupNeedsBrowser(raw)) {
+          browserReported = true;
+          console.log('Approve the dedicated worker login in your browser. No token will be printed here.');
+        }
+      });
+      child.onExit(({ exitCode }) => {
+        const token = extractSetupWorkerToken(raw, exitCode === 0);
+        if (token) saving = saveNativeWorkerToken(token);
+        if (saving) void saving.then(() => finish(true), () => finish(false));
+        else {
+          const clean = stripVTControlCharacters(raw);
+          console.error(JSON.stringify({
+            event: 'setup_exit_without_capture', exitCode,
+            browserReported,
+            successMarker: clean.includes('Long-lived authentication token created successfully'),
+            footerMarker: clean.includes('Store this token securely.'),
+            tokenPrefixPresent: clean.includes('sk-ant-oat01-'),
+            tokenLengths: [...clean.matchAll(/sk-ant-oat01-([A-Za-z0-9_-]+)/g)].map((match) => match[0].length),
+            authError: /authentication failed|invalid code|expired|revoked/i.test(clean),
+          }));
+          finish(false);
+        }
+      });
+      console.log('Starting a dedicated subscription worker login. Raw CLI output is suppressed.');
+    });
+    console.log('Worker token encrypted and saved. A real worker request is still required to verify authentication.');
+  } finally {
+    await rm(configDir, { recursive: true, force: true });
+  }
+}
+
+void main().catch(() => {
+  console.error('Dedicated worker login stopped without a success receipt. No credential details were logged.');
+  process.exitCode = 1;
+});

--- a/src/app/api/runtime/launch/route.ts
+++ b/src/app/api/runtime/launch/route.ts
@@ -15,6 +15,8 @@ import {
 import { RuntimeLaunchPostEffectError } from '@/lib/runtime/launch-governance';
 import { listLanes } from '@/lib/lane/registry';
 import { findOwnedLaunchByMutationId } from '@/lib/runtimes/shared/owned-session-index';
+import { isClaudeCodeModelSource } from '@/lib/claude-code/worker-profile-types';
+import { normalizePacketSpendCap } from '@/lib/orchestrator/metered-spend';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -33,7 +35,11 @@ function canonicalLaunchRequest(
     runtime: runtimeName as RuntimeLaunchRequest['runtime'],
     prompt: payload.prompt?.trim() ?? '',
     model: trimmed(payload.model),
+    claudeCodeModel: trimmed(payload.claudeCodeModel),
+    claudeCodeCarrier: payload.claudeCodeCarrier,
     effort: payload.effort,
+    workMode: payload.workMode,
+    spendCap: normalizePacketSpendCap(payload.spendCap),
     clientMutationId,
     cwd: payload.cwd?.trim() ?? '',
     repoPath: trimmed(payload.repoPath),
@@ -59,6 +65,12 @@ export async function POST(request: NextRequest) {
   }
   if (!payload || !clientMutationId) {
     return NextResponse.json({ error: 'clientMutationId is required for this launch route' }, { status: 400 });
+  }
+  if ((payload.claudeCodeModel !== undefined && typeof payload.claudeCodeModel !== 'string')
+    || (payload.claudeCodeCarrier !== undefined && !isClaudeCodeModelSource(payload.claudeCodeCarrier))
+    || (payload.workMode !== undefined && payload.workMode !== 'edit' && payload.workMode !== 'read-only')
+    || (payload.spendCap !== undefined && !normalizePacketSpendCap(payload.spendCap))) {
+    return NextResponse.json({ error: 'Invalid carrier, work mode, or spend cap for this launch.' }, { status: 400 });
   }
 
   const launchRequest = canonicalLaunchRequest(payload, runtimeName, clientMutationId);

--- a/src/lib/claude-code/codex-subscription-proxy.ts
+++ b/src/lib/claude-code/codex-subscription-proxy.ts
@@ -19,6 +19,7 @@ import { getDataDir } from '@/lib/data-dir-migration';
 import { CliNotFoundError, resolveCli } from '@/lib/runtimes/shared/cli-resolver';
 import { browserOpenInvocation, findLatestCodexOAuthUrl } from './codex-subscription-oauth';
 import { hasClaudeEnvCredential, hasLiveClaudeOAuth } from './oauth-credential';
+import { nativeWorkerTokenEnv, WORKER_TOKEN_SETUP_HINT } from './worker-token';
 import type { ClaudeCodeModelSource } from './worker-profile-types';
 
 const DEFAULT_PORT = 8317;
@@ -336,49 +337,67 @@ export async function ensureCodexSubscriptionClaudeConfigDir(sessionDir: string)
   return ensureClaudeCodeWorkerConfigDir(sessionDir);
 }
 
+/** Workers use a dedicated inference token, never the operator's refresh store. */
+export async function claudeCodeWorkerCredentialEnv(
+  configDir: string,
+  source?: ClaudeCodeModelSource,
+): Promise<Record<string, string>> {
+  return {
+    CLAUDE_SECURESTORAGE_CONFIG_DIR: configDir,
+    ...(process.platform === 'darwin' && source === 'native' ? await nativeWorkerTokenEnv() : {}),
+  };
+}
+
 export async function ensureClaudeCodeWorkerConfigDir(
   sessionDir: string,
   source?: ClaudeCodeModelSource,
 ): Promise<string> {
+  return (await prepareClaudeCodeWorkerConfig(sessionDir, source)).configDir;
+}
+
+export async function prepareClaudeCodeWorkerConfig(
+  sessionDir: string,
+  source?: ClaudeCodeModelSource,
+): Promise<{ configDir: string; credentialEnv: Record<string, string> }> {
   const configDir = path.join(sessionDir, 'claude-code-worker-config');
+  const credentialEnv = await claudeCodeWorkerCredentialEnv(configDir, source);
   await mkdir(configDir, { recursive: true, mode: 0o700 });
   await chmod(configDir, 0o700);
   await rm(path.join(configDir, 'skills'), { recursive: true, force: true });
+  if (process.platform === 'darwin') {
+    // Remove only this session's obsolete snapshot; never touch the source store.
+    await rm(path.join(configDir, '.credentials.json'), { force: true });
+  }
   if (source === 'native') {
     // A non-empty ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN is decisive for the
     // native carrier at the readiness seam (detectNativeClaudeAuth skips the CLI probe
     // for it), and the spawned worker inherits this same environment. Demanding an
-    // OAuth snapshot on top of it would refuse a launch that preflight just approved,
-    // so on that path the snapshot is best-effort and the CLI assertion is skipped.
-    const envCredential = hasClaudeEnvCredential();
-    await seedNativeWorkerCredentials(configDir, { required: !envCredential });
-    if (!envCredential) await assertNativeWorkerAuthenticated(configDir);
+    // OAuth credential on top of it would refuse a launch that preflight approved.
+    const envCredential = hasClaudeEnvCredential({ ...process.env, ...credentialEnv });
+    if (process.platform === 'darwin') {
+      if (!envCredential) {
+        throw new ClaudeCodeWorkerAuthenticationError(`No dedicated worker credential is configured. ${WORKER_TOKEN_SETUP_HINT}`);
+      }
+    } else {
+      await seedNativeWorkerCredentials(configDir, { required: !envCredential });
+    }
+    if (!envCredential) {
+      await assertNativeWorkerAuthenticated(configDir, credentialEnv);
+    }
   }
-  return configDir;
+  return { configDir, credentialEnv };
 }
 
-// On the native carrier, the isolated config dir replaces the operator's real
-// CLAUDE_CONFIG_DIR (or ~/.claude), so a worker that spawns there is otherwise
-// logged out. Current macOS Claude Code stores the live OAuth object in the
-// "Claude Code-credentials" Keychain item, and that lookup does not survive a
-// config-dir swap. Other platforms store it at <config dir>/.credentials.json.
-// Snapshot the live credential into the isolated dir for this worker.
-// Never symlink — a symlink would let a worker rewrite the operator's file.
+// Non-Mac behavior is unchanged pending its own platform acceptance.
+// Mac workers do not copy the operator's refreshable credential.
 async function seedNativeWorkerCredentials(
   configDir: string,
   options: { required: boolean },
 ): Promise<void> {
   const sourceConfigDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
   const sourceCredentialsPath = path.join(sourceConfigDir, '.credentials.json');
-  const keychainCredentials = process.platform === 'darwin'
-    ? await execFileUtf8('/usr/bin/security', [
-        'find-generic-password', '-s', 'Claude Code-credentials', '-w',
-      ]).catch(() => '')
-    : '';
   const fileCredentials = await readFile(sourceCredentialsPath, 'utf8').catch(() => '');
-  const credentials = hasLiveClaudeOAuth(keychainCredentials)
-    ? keychainCredentials
-    : hasLiveClaudeOAuth(fileCredentials) ? fileCredentials : '';
+  const credentials = hasLiveClaudeOAuth(fileCredentials) ? fileCredentials : '';
   if (!credentials) {
     if (!options.required) return;
     throw new ClaudeCodeWorkerAuthenticationError('No live Claude OAuth credential was available to seed.');
@@ -388,7 +407,10 @@ async function seedNativeWorkerCredentials(
   await chmod(destCredentialsPath, 0o600);
 }
 
-async function assertNativeWorkerAuthenticated(configDir: string): Promise<void> {
+async function assertNativeWorkerAuthenticated(
+  configDir: string,
+  credentialEnv: Record<string, string>,
+): Promise<void> {
   let binary: string;
   try {
     binary = (await resolveCli({
@@ -402,10 +424,12 @@ async function assertNativeWorkerAuthenticated(configDir: string): Promise<void>
   }
   const raw = await execFileUtf8(binary, ['auth', 'status', '--json'], {
     ...process.env,
+    ...credentialEnv,
     CLAUDE_CONFIG_DIR: configDir,
   }).catch(() => '');
   try {
     if ((JSON.parse(raw) as { loggedIn?: boolean }).loggedIn === true) return;
   } catch {}
-  throw new ClaudeCodeWorkerAuthenticationError('Claude Code rejected the seeded credential.');
+  // This is local credential presence, not server-side token validation.
+  throw new ClaudeCodeWorkerAuthenticationError('The native CLI reports no login in the selected credential store.');
 }

--- a/src/lib/claude-code/interactive-session.ts
+++ b/src/lib/claude-code/interactive-session.ts
@@ -268,21 +268,9 @@ function settleTurn(
 
 function flushActiveTurn(
   session: InternalClaudeCodeInteractiveSession,
-): boolean {
+): void {
   const turn = session.activeTurn;
-  if (!turn) return false;
-
-  let emittedDone = false;
-  for (const event of turn.parser.flush()) {
-    if (event.type === 'done' && event.sessionId) {
-      session.sessionId = event.sessionId;
-    }
-    if (event.type === 'done') {
-      emittedDone = true;
-    }
-    turn.onEvent(event);
-  }
-  return emittedDone;
+  if (turn) handleParserEvents(session, turn.parser.flush());
 }
 
 function handleParserEvents(
@@ -296,9 +284,16 @@ function handleParserEvents(
     if (event.type === 'done' && event.sessionId) {
       session.sessionId = event.sessionId;
     }
+    if (event.type === 'done' && event.isError) {
+      // Consumers use done to render success. Reject before forwarding it so
+      // the streaming route emits an error instead of a successful close.
+      settleTurn(session, new Error('Worker returned a failed result.'));
+      return;
+    }
     turn.onEvent(event);
     if (event.type === 'done') {
       settleTurn(session, null);
+      return;
     }
   }
 }
@@ -346,12 +341,8 @@ function attachProcessHandlers(session: InternalClaudeCodeInteractiveSession): v
 
   proc.on('close', (code, signal) => {
     markDead(session);
-    const emittedDone = flushActiveTurn(session);
+    flushActiveTurn(session);
     if (!session.activeTurn) return;
-    if (emittedDone) {
-      settleTurn(session, null);
-      return;
-    }
 
     const suffix = signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`;
     const stderr = session.stderrBuffer.trim();

--- a/src/lib/claude-code/one-shot-repl.ts
+++ b/src/lib/claude-code/one-shot-repl.ts
@@ -78,7 +78,7 @@ export function buildOneShotArgs(model: string, effort?: string): string[] {
 /**
  * One-shot turn against the REPL. Spawns, sends one user message, reads
  * stream-json until `result`, resolves with the assistant text. Rejects on
- * exit-without-result, timeout, or spawn error.
+ * a failed result, exit-without-result, timeout, or spawn error.
  */
 export async function askClaudeOneShot(
   prompt: string,
@@ -120,7 +120,7 @@ export async function askClaudeOneShot(
       for (const evt of events) {
         if (evt.type === 'done') {
           resultText = evt.text ?? resultText;
-          finish(null, resultText.trim());
+          finish(evt.isError ? new Error('Worker returned a failed result.') : null, resultText.trim());
           return;
         }
       }
@@ -141,7 +141,7 @@ export async function askClaudeOneShot(
       for (const evt of trailing) {
         if (evt.type === 'done') {
           resultText = evt.text ?? resultText;
-          finish(null, resultText.trim());
+          finish(evt.isError ? new Error('Worker returned a failed result.') : null, resultText.trim());
           return;
         }
       }

--- a/src/lib/claude-code/owned.ts
+++ b/src/lib/claude-code/owned.ts
@@ -1,3 +1,4 @@
+import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
 
 import {
@@ -36,7 +37,7 @@ import { getOperatorDefaultsSync } from '@/lib/operator/defaults';
 import { recordLaneEvent } from '@/lib/lane/events';
 import {
   ClaudeCodeWorkerAuthenticationError,
-  ensureClaudeCodeWorkerConfigDir,
+  prepareClaudeCodeWorkerConfig,
   ensureCodexSubscriptionProxyReady,
 } from '@/lib/claude-code/codex-subscription-proxy';
 
@@ -90,12 +91,24 @@ function parseClaudeOwnedRunLog(raw: string, run: OwnedRunRecord): ParsedRunLog 
   const inputTokens = done?.inputTokens ?? usage?.inputTokens ?? 0;
   const cacheReadTokens = done?.cacheReadTokens ?? usage?.cacheReadTokens ?? 0;
   const contextTokens = inputTokens + cacheReadTokens;
+  const terminalMissing = !done && Boolean(run.childExit || run.finishedAt)
+    && run.outcome !== 'interrupted' && !run.interruptRequestedAt;
+  const providerFailed = done?.isError === true || terminalMissing;
 
   return {
     threadId: done?.sessionId,
     entries,
-    outcome: done ? 'finished' : 'running',
-    completedTurn: Boolean(done),
+    outcome: providerFailed ? 'failed' : done ? 'finished' : 'running',
+    completedTurn: Boolean(done && !providerFailed),
+    ...(providerFailed ? {
+      providerFailure: terminalMissing ? {
+        subtype: 'missing_result',
+        message: 'Worker exited without a terminal result.',
+      } : {
+        ...(done?.subtype ? { subtype: done.subtype } : {}),
+        ...(done?.text.trim() ? { message: done.text.trim() } : {}),
+      },
+    } : {}),
     ...(contextTokens > 0 ? {
       turnContextUsage: { inputTokens, cacheReadTokens, contextTokens },
     } : {}),
@@ -117,7 +130,11 @@ export const claudeCodeOwnedAdapter: OwnedRuntimeAdapter = {
     const source = configuredSource === 'openrouter' || configuredSource === 'codex-subscription'
       ? configuredSource
       : 'native';
-    const isolatedConfigDir = await ensureClaudeCodeWorkerConfigDir(session.sessionDir, source);
+    const { configDir: isolatedConfigDir, credentialEnv } = await prepareClaudeCodeWorkerConfig(session.sessionDir, source);
+    // Shell scratch must use the same private grant as other runtime state,
+    // not a shared system-temp directory outside the worker sandbox.
+    const isolatedScratchDir = path.join(isolatedConfigDir, 'tmp');
+    await mkdir(isolatedScratchDir, { recursive: true, mode: 0o700 });
     const key = source === 'openrouter' ? await resolveClaudeCodeWorkerGatewayKey() : null;
     if (source === 'openrouter' && !key) {
       throw new Error('This Claude Code worker is pinned to OpenRouter, but its API key is no longer configured. Add the key in Settings > Models > API keys before resuming it.');
@@ -132,6 +149,8 @@ export const claudeCodeOwnedAdapter: OwnedRuntimeAdapter = {
           connection.baseUrl,
         ),
         CLAUDE_CONFIG_DIR: isolatedConfigDir,
+        CLAUDE_CODE_TMPDIR: isolatedScratchDir,
+        ...credentialEnv,
       };
     }
     const env = buildClaudeCodeWorkerSpawnEnv(source, session.model, key);
@@ -149,7 +168,8 @@ export const claudeCodeOwnedAdapter: OwnedRuntimeAdapter = {
       );
     }
     env.CLAUDE_CONFIG_DIR = isolatedConfigDir;
-    return env;
+    env.CLAUDE_CODE_TMPDIR = isolatedScratchDir;
+    return { ...env, ...credentialEnv };
   },
   humanLabel: 'Owned Claude Code',
   squadShortName: 'Claude',

--- a/src/lib/claude-code/read-only-worker-launch.test.ts
+++ b/src/lib/claude-code/read-only-worker-launch.test.ts
@@ -28,13 +28,16 @@ vi.mock('@/lib/runtimes/shared/dispatch-readiness', async (importOriginal) => {
   return { ...actual, ensureDispatchBackendReady: vi.fn(async () => ({ ready: true, reason: 'http_200' })) };
 });
 
-// The worker config dir seeds real operator credentials; the argv contract does
-// not depend on it, so keep the fixture credential-free.
+// Keep config preparation real. Only the external subscription proxy is a fixture.
 vi.mock('@/lib/claude-code/codex-subscription-proxy', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/claude-code/codex-subscription-proxy')>();
   return {
     ...actual,
-    ensureClaudeCodeWorkerConfigDir: vi.fn(async (sessionDir: string) => sessionDir),
+    ensureCodexSubscriptionProxyReady: vi.fn(async () => ({
+      baseUrl: 'http://127.0.0.1:8317',
+      clientToken: 'test-token',
+      models: ['gpt-5.6-sol'],
+    })),
   };
 });
 
@@ -81,11 +84,15 @@ const { CLAUDE_READ_ONLY_DISALLOWED_TOOLS, CLAUDE_STRICT_MCP_CONFIG_FLAG } = awa
 const { SANDBOX_EXEC_PATH } = await import('@/lib/runtimes/shared/owned-session/sandbox');
 
 beforeEach(() => {
+  // An explicit synthetic credential avoids reading any operator login store.
+  vi.stubEnv('ANTHROPIC_API_KEY', '');
+  vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', 'synthetic-argv-fixture');
   spawnMock.mockReturnValue({ pid: 4242, unref: vi.fn(), once: vi.fn() });
   spawnBridgeMock.mockRejectedValue(new Error('bridge unavailable'));
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   spawnMock.mockReset();
   spawnBridgeMock.mockReset();
 });
@@ -103,6 +110,17 @@ async function spawnedArgs(workMode?: 'read-only'): Promise<string[]> {
   expect(result, result.note).toMatchObject({ ok: true });
   expect(spawnMock).toHaveBeenCalled();
   return spawnMock.mock.calls[spawnMock.mock.calls.length - 1]?.[1] as string[];
+}
+
+async function spawnedCall(carrier: 'native' | 'codex-subscription') {
+  const result = await launchOwnedClaudeCodeSession({
+    cwd: repoPath,
+    prompt: 'inspect the repository',
+    claudeCodeCarrier: carrier,
+    workMode: 'read-only',
+  });
+  expect(result, result.note).toMatchObject({ ok: true });
+  return spawnMock.mock.calls[spawnMock.mock.calls.length - 1]!;
 }
 
 describe('owned Claude Code read-only argv', () => {
@@ -194,6 +212,40 @@ describe('owned Claude Code read-only argv', () => {
     },
   );
 
+  it.skipIf(process.platform !== 'darwin').each(['native', 'codex-subscription'] as const)(
+    'prepares and narrowly re-opens mutable Claude state for the %s carrier',
+    async (carrier) => {
+      const [, args, options] = await spawnedCall(carrier);
+      const configDir = options.env.CLAUDE_CONFIG_DIR as string;
+      const sandboxIdx = (args as string[]).indexOf(SANDBOX_EXEC_PATH);
+      const profilePath = (args as string[])[sandboxIdx + 2]!;
+      const profile = readFileSync(profilePath, 'utf8');
+
+      expect(profile.lastIndexOf(`(subpath "${realpathSync(configDir)}")`))
+        .toBeGreaterThan(profile.indexOf(`(subpath "${realpathSync(tempRoot)}")`));
+      expect(profile.lastIndexOf(`(literal "${path.join(configDir, '.credentials.json')}")`))
+        .toBeGreaterThan(profile.lastIndexOf(`(subpath "${configDir}")`));
+      expect(existsSync(path.join(configDir, 'hooks'))).toBe(false);
+      expect(existsSync(path.join(configDir, 'skills'))).toBe(false);
+      expect(existsSync(path.join(configDir, '.credentials.json'))).toBe(false);
+
+      const projectsState = path.join(configDir, 'projects', 'repo', 'compaction.json');
+      execFileSync(SANDBOX_EXEC_PATH, [
+        '-f', profilePath, '/bin/sh', '-c',
+        `mkdir -p ${JSON.stringify(path.dirname(projectsState))} && printf compacted > ${JSON.stringify(projectsState)}`,
+      ], { stdio: 'ignore' });
+      expect(readFileSync(projectsState, 'utf8')).toBe('compacted');
+
+      expect(() => execFileSync(SANDBOX_EXEC_PATH, [
+        '-f', profilePath, '/bin/sh', '-c',
+        `printf replaced > ${JSON.stringify(path.join(configDir, '.credentials.json'))}`,
+      ], { stdio: 'ignore' })).toThrow();
+      expect(() => execFileSync(SANDBOX_EXEC_PATH, [
+        '-f', profilePath, '/bin/cat', path.join(path.dirname(configDir), 'session.json'),
+      ], { stdio: 'ignore' })).toThrow();
+    },
+  );
+
   it('builds the deny rule from the session runtimeConfig pin, not the caller', () => {
     const base = { cwd: repoPath, prompt: 'inspect' };
     expect(claudeCodeOwnedAdapter.launchArgs({ ...base, runtimeConfig: { workMode: 'read-only' } }))
@@ -206,3 +258,57 @@ describe('owned Claude Code read-only argv', () => {
       .not.toContain(CLAUDE_STRICT_MCP_CONFIG_FLAG);
   });
 });
+
+describe('owned Claude Code provider terminal outcome', () => {
+  const run = {
+    id: 'provider-result',
+    mode: 'launch' as const,
+    prompt: 'inspect',
+    startedAt: new Date(0).toISOString(),
+    pid: 0,
+    stdoutPath: '/tmp/provider-result.jsonl',
+    stderrPath: '/tmp/provider-result.stderr',
+    outcome: 'running' as const,
+  };
+
+  it('treats a zero-exit-shaped provider error result as a failed incomplete turn', () => {
+    const parsed = claudeCodeOwnedAdapter.parseRunLog(lines({
+      type: 'result',
+      subtype: 'success',
+      is_error: true,
+      result: 'Not logged in',
+      session_id: 'failed-provider-session',
+    }), run);
+
+    expect(parsed).toMatchObject({
+      threadId: 'failed-provider-session',
+      outcome: 'failed',
+      completedTurn: false,
+      providerFailure: { subtype: 'success', message: 'Not logged in' },
+    });
+  });
+
+  it('treats a clean provider result as a completed turn', () => {
+    expect(claudeCodeOwnedAdapter.parseRunLog(lines({
+      type: 'result', subtype: 'success', result: 'done',
+    }), run)).toMatchObject({ outcome: 'finished', completedTurn: true });
+  });
+
+  it('requires a terminal result only once the owned run has ended', () => {
+    const partial = lines({ type: 'message_stop' }, { type: 'system', subtype: 'compact_boundary' });
+    expect(claudeCodeOwnedAdapter.parseRunLog(partial, run)).toMatchObject({
+      outcome: 'running', completedTurn: false,
+    });
+    const exited = { ...run, childExit: { code: 0, signal: null, classification: 'clean-exit' as const } };
+    expect(claudeCodeOwnedAdapter.parseRunLog(partial, exited)).toMatchObject({
+      outcome: 'failed', completedTurn: false, providerFailure: { subtype: 'missing_result' },
+    });
+    expect(claudeCodeOwnedAdapter.parseRunLog(partial, {
+      ...exited, outcome: 'interrupted', interruptRequestedAt: new Date().toISOString(),
+    })).not.toHaveProperty('providerFailure');
+  });
+});
+
+function lines(...events: unknown[]): string {
+  return events.map((event) => `${JSON.stringify(event)}\n`).join('');
+}

--- a/src/lib/claude-code/stream-json-parser.test.ts
+++ b/src/lib/claude-code/stream-json-parser.test.ts
@@ -99,3 +99,80 @@ describe('stream-json parser usage truth', () => {
     }));
   });
 });
+
+describe('stream-json parser provider terminal truth', () => {
+  it.each([true, false])('waits past message stops for the outer result (failure: %s)', (failed) => {
+    const parser = createClaudeCodeStreamJsonParser();
+    const intermediate = parser.pushChunk(lines(
+      wrap({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Reading context.' } }),
+      wrap({ type: 'message_stop' }),
+      { type: 'message_stop' },
+      { type: 'system', subtype: 'compact_boundary', compact_metadata: { trigger: 'auto', pre_tokens: 58_671 } },
+      wrap({ type: 'message_stop' }),
+    ));
+    expect(intermediate.filter((event) => event.type === 'done')).toEqual([]);
+    expect(parser.flush().filter((event) => event.type === 'done')).toEqual([]);
+    const terminal = parser.pushChunk(lines({
+      type: 'result', subtype: 'success', is_error: failed,
+      result: failed ? 'Context refill limit reached' : 'Complete finding',
+      session_id: 'streamed-terminal',
+    })).filter((event) => event.type === 'done');
+    expect(terminal).toHaveLength(1);
+    expect(terminal[0]).toMatchObject({
+      type: 'done', subtype: 'success', sessionId: 'streamed-terminal',
+      text: failed ? 'Context refill limit reached' : 'Complete finding',
+      ...(failed ? { isError: true } : {}),
+    });
+    if (!failed) expect(terminal[0]).not.toHaveProperty('isError');
+  });
+
+  it.each([
+    {
+      name: 'is_error with an empty result',
+      event: { type: 'result', subtype: 'success', is_error: true, result: '' },
+      expectedText: '',
+    },
+    {
+      name: 'a non-success result subtype',
+      event: { type: 'result', subtype: 'error_during_execution', result: 'provider failed' },
+      expectedText: 'provider failed',
+    },
+  ])('marks $name as failed', ({ event, expectedText }) => {
+    const parser = createClaudeCodeStreamJsonParser();
+    const done = parser.pushChunk(lines(event)).find((entry) => entry.type === 'done');
+
+    expect(done).toMatchObject({ type: 'done', isError: true, text: expectedText });
+  });
+
+  it('preserves partial assistant text when the provider error result is empty', () => {
+    const parser = createClaudeCodeStreamJsonParser();
+    const events = parser.pushChunk(lines(
+      wrap({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'partial finding' } }),
+      { type: 'result', subtype: 'error_during_execution', is_error: true, result: '' },
+    ));
+
+    expect(events.find((entry) => entry.type === 'done')).toMatchObject({
+      type: 'done',
+      isError: true,
+      subtype: 'error_during_execution',
+      text: 'partial finding',
+    });
+  });
+
+  it('keeps a clean success successful', () => {
+    const parser = createClaudeCodeStreamJsonParser();
+    const done = parser.pushChunk(lines({
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: 'complete',
+    })).find((entry) => entry.type === 'done');
+
+    expect(done).toEqual(expect.objectContaining({
+      type: 'done',
+      subtype: 'success',
+      text: 'complete',
+    }));
+    expect(done).not.toHaveProperty('isError');
+  });
+});

--- a/src/lib/claude-code/stream-json-parser.ts
+++ b/src/lib/claude-code/stream-json-parser.ts
@@ -19,6 +19,8 @@ export type ClaudeCodeStreamJsonParserEvent =
   | {
       type: 'done';
       text: string;
+      isError?: boolean;
+      subtype?: string;
       sessionId?: string;
       inputTokens?: number;
       outputTokens?: number;
@@ -300,10 +302,17 @@ export function createClaudeCodeStreamJsonParser(
     const sessionId = asString(event.session_id) ?? state.sessionId ?? undefined;
     if (sessionId) state.sessionId = sessionId;
     if (state.emittedDone) return;
-    const resultText = asString(event.result) ?? state.fullResponse;
+    const subtype = asString(event.subtype);
+    const isResult = event.type === 'result';
+    const isError = event.is_error === true
+      || (isResult && subtype !== undefined && subtype !== 'success');
+    const explicitResult = asString(event.result);
+    const resultText = explicitResult?.trim() ? explicitResult : state.fullResponse;
     const doneEvent: ClaudeCodeStreamJsonParserEvent = {
       type: 'done',
       text: resultText,
+      ...(isError ? { isError: true } : {}),
+      ...(subtype ? { subtype } : {}),
       ...(sessionId ? { sessionId } : {}),
       ...(typeof usage?.inputTokens === 'number' ? { inputTokens: usage.inputTokens } : {}),
       ...(typeof usage?.outputTokens === 'number' ? { outputTokens: usage.outputTokens } : {}),
@@ -465,7 +474,10 @@ export function createClaudeCodeStreamJsonParser(
       return events;
     }
 
-    if (type === 'message_stop' || type === 'result') {
+    // A streamed message_stop ends one model message, not the worker turn.
+    // Tool calls and compaction can follow it. Only the outer result carries
+    // terminal success/failure; consuming the first stop masks later errors.
+    if (type === 'result') {
       emitDone(event, events);
     }
 

--- a/src/lib/claude-code/warm-repl-pool.ts
+++ b/src/lib/claude-code/warm-repl-pool.ts
@@ -306,7 +306,7 @@ function runTurn(
         deltaText += evt.text;
         onDelta?.(evt.text);
       } else if (evt.type === 'done') {
-        finish(null, evt.text || deltaText);
+        finish(evt.isError ? new Error('Worker returned a failed result.') : null, evt.text || deltaText);
       }
     };
 

--- a/src/lib/claude-code/worker-token-output.ts
+++ b/src/lib/claude-code/worker-token-output.ts
@@ -1,0 +1,15 @@
+import { stripVTControlCharacters } from 'node:util';
+
+import { isNativeWorkerToken } from './worker-token';
+
+/** Raw setup output is secret-bearing. Callers must never forward it to a log. */
+export function extractSetupWorkerToken(raw: string, successfulExit = false): string | null {
+  if (!successfulExit) return null;
+  const text = stripVTControlCharacters(raw);
+  const matches = [...new Set(text.match(/sk-ant-oat01-[A-Za-z0-9_-]+/g) ?? [])];
+  return matches.length === 1 && isNativeWorkerToken(matches[0]) ? matches[0] : null;
+}
+
+export function workerTokenSetupNeedsBrowser(raw: string): boolean {
+  return stripVTControlCharacters(raw).includes('Browser didn\'t open?');
+}

--- a/src/lib/claude-code/worker-token.test.ts
+++ b/src/lib/claude-code/worker-token.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearMasterKeyCache } from '@/lib/db/master-key';
+import { nativeWorkerTokenEnv, readNativeWorkerToken, saveNativeWorkerToken } from './worker-token';
+import { extractSetupWorkerToken } from './worker-token-output';
+
+const token = `sk-ant-oat01-${'synthetic'.repeat(12)}`;
+let directory: string;
+beforeEach(() => {
+  directory = mkdtempSync(path.join(os.tmpdir(), 'o8-worker-token-test-'));
+  vi.stubEnv('CORTEX_IDE_DATA_DIR', directory);
+  vi.stubEnv('O8_DATA_DIR', directory);
+  vi.stubEnv('O8_MASTER_KEY', Buffer.alloc(32, 7).toString('base64url'));
+  vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', '');
+  vi.stubEnv('ANTHROPIC_API_KEY', '');
+  clearMasterKeyCache();
+});
+afterEach(() => {
+  clearMasterKeyCache();
+  vi.unstubAllEnvs();
+  rmSync(directory, { recursive: true, force: true });
+});
+
+describe('dedicated worker credential boundary', () => {
+  it('round-trips through encrypted private storage without changing the parent environment', async () => {
+    await saveNativeWorkerToken(token);
+    const filename = path.join(directory, 'native-worker-token.json');
+    expect(readFileSync(filename, 'utf8')).not.toContain(token);
+    expect(statSync(filename).mode & 0o777).toBe(0o600);
+    expect(await readNativeWorkerToken()).toBe(token);
+    expect(await nativeWorkerTokenEnv()).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: token });
+    expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe('');
+  });
+
+  it('fails closed for missing, corrupt, and wrong-key storage', async () => {
+    expect(await readNativeWorkerToken()).toBeNull();
+    writeFileSync(path.join(directory, 'native-worker-token.json'), 'broken');
+    expect(await readNativeWorkerToken()).toBeNull();
+    await saveNativeWorkerToken(token);
+    clearMasterKeyCache();
+    vi.stubEnv('O8_MASTER_KEY', Buffer.alloc(32, 8).toString('base64url'));
+    expect(await readNativeWorkerToken()).toBeNull();
+  });
+
+  it.each(['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN'])('does not replace an explicit %s', async (key) => {
+    await saveNativeWorkerToken(token);
+    vi.stubEnv(key, 'explicit-synthetic');
+    expect(await nativeWorkerTokenEnv()).toEqual({});
+  });
+
+  it('rejects a login refresh blob and incomplete setup output', async () => {
+    await expect(saveNativeWorkerToken('{"refreshToken":"synthetic"}')).rejects.toThrow('Invalid worker token format');
+    expect(extractSetupWorkerToken(`Long-lived authentication token created successfully!\n${token}`)).toBeNull();
+    expect(extractSetupWorkerToken(`\x1b[32m${token}\x1b[0m\n`, true)).toBe(token);
+    expect(extractSetupWorkerToken(`${token}\n${token}`, true)).toBe(token);
+    expect(extractSetupWorkerToken(`${token}\n${token}other`, true)).toBeNull();
+  });
+});

--- a/src/lib/claude-code/worker-token.ts
+++ b/src/lib/claude-code/worker-token.ts
@@ -1,0 +1,54 @@
+import 'server-only';
+
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { getDataDir } from '@/lib/data-dir-migration';
+import { decryptValue, encryptValue } from '@/lib/db/master-key';
+import { hasClaudeEnvCredential } from './oauth-credential';
+
+const TOKEN_FILE = 'native-worker-token.json';
+export const WORKER_TOKEN_SETUP_HINT = 'Run `npm run worker:login` from the application source checkout to connect a dedicated worker token.';
+export const requiresNativeWorkerToken = (): boolean => process.platform === 'darwin';
+
+/** An inference token, never the operator login's refresh credential. */
+export function isNativeWorkerToken(value: unknown): value is string {
+  return typeof value === 'string' && /^sk-ant-oat01-[A-Za-z0-9_-]{40,256}$/.test(value);
+}
+
+export async function saveNativeWorkerToken(token: string): Promise<void> {
+  if (!isNativeWorkerToken(token)) throw new Error('Invalid worker token format.');
+  const encrypted = await encryptValue(token);
+  const directory = getDataDir();
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const destination = path.join(directory, TOKEN_FILE);
+  const temporary = `${destination}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(temporary, JSON.stringify({ version: 1, ...encrypted }), { mode: 0o600, flag: 'wx' });
+    await rename(temporary, destination);
+  } finally {
+    await rm(temporary, { force: true });
+  }
+}
+
+/** Parent-only decryption. Nothing is added to global env, run records, or argv. */
+export async function readNativeWorkerToken(): Promise<string | null> {
+  try {
+    const stored = JSON.parse(await readFile(path.join(getDataDir(), TOKEN_FILE), 'utf8')) as {
+      version?: unknown; ciphertext?: unknown; iv?: unknown;
+    };
+    if (stored.version !== 1 || typeof stored.ciphertext !== 'string' || typeof stored.iv !== 'string') return null;
+    const token = await decryptValue(stored.ciphertext, stored.iv);
+    return isNativeWorkerToken(token) ? token : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function nativeWorkerTokenEnv(): Promise<Record<string, string>> {
+  // An explicitly configured credential keeps its existing precedence and billing route.
+  if (hasClaudeEnvCredential()) return {};
+  const token = await readNativeWorkerToken();
+  return token ? { CLAUDE_CODE_OAUTH_TOKEN: token } : {};
+}

--- a/src/lib/codex/read-only-worker-launch.test.ts
+++ b/src/lib/codex/read-only-worker-launch.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, realpathSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -86,6 +86,52 @@ function indexOfSequence(args: string[], sequence: readonly string[]): number {
 }
 
 describe('owned Codex read-only argv', () => {
+  it.skipIf(process.platform !== 'darwin').each(['read-only', 'edit'] as const)(
+    'reads only the backing project config without reopening its checkout (%s)',
+    async (workMode) => {
+      // HOME placement is deliberate: the system-temp read grant would hide
+      // the real linked-worktree startup denial this test must reproduce.
+      const project = mkdtempSync(path.join(os.homedir(), '.o8-project-config-test-'));
+      const packet = path.join(tempRoot, `config-packet-${workMode}`);
+      const priorSandbox = process.env.O8_WORKER_SANDBOX;
+      try {
+        execFileSync('git', ['init', '-q', project]);
+        mkdirSync(path.join(project, '.codex'));
+        const config = path.join(project, '.codex', 'config.toml');
+        const neighboring = path.join(project, 'private-note.txt');
+        writeFileSync(config, '# project startup fixture\n');
+        writeFileSync(neighboring, 'not a worker input');
+        execFileSync('git', ['-C', project, 'add', '--', '.codex/config.toml']);
+        execFileSync('git', ['-C', project, '-c', 'user.name=Fixture', '-c', 'user.email=fixture@example.test',
+          'commit', '-qm', 'fixture']);
+        execFileSync('git', ['-C', project, 'worktree', 'add', '--detach', packet], { stdio: 'ignore' });
+        process.env.O8_WORKER_SANDBOX = 'on';
+        const result = await launchOwnedCodexSession({
+          cwd: packet, prompt: 'inspect the project configuration', workMode,
+        });
+        expect(result, result.note).toMatchObject({ ok: true });
+        const args = spawnMock.mock.calls[spawnMock.mock.calls.length - 1]![1] as string[];
+        const profile = args[args.indexOf(SANDBOX_EXEC_PATH) + 2]!;
+        expect(execFileSync(SANDBOX_EXEC_PATH, ['-f', profile, '/bin/cat', config], {
+          encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+        })).toBe('# project startup fixture\n');
+        expect(() => execFileSync(SANDBOX_EXEC_PATH, ['-f', profile, '/bin/cat', neighboring], {
+          stdio: 'ignore',
+        })).toThrow();
+        expect(() => execFileSync(SANDBOX_EXEC_PATH, ['-f', profile, process.execPath, '-e',
+          'require("node:fs").writeFileSync(process.argv[1], "changed")', config,
+        ], { stdio: 'ignore' })).toThrow();
+        expect(readFileSync(config, 'utf8')).toBe('# project startup fixture\n');
+        expect(execFileSync('git', ['-C', packet, 'status', '--porcelain'], { encoding: 'utf8' })).toBe('');
+      } finally {
+        if (priorSandbox === undefined) delete process.env.O8_WORKER_SANDBOX;
+        else process.env.O8_WORKER_SANDBOX = priorSandbox;
+        rmSync(packet, { recursive: true, force: true });
+        rmSync(project, { recursive: true, force: true });
+      }
+    },
+  );
+
   it('launches a read-only packet with approvals off and no nested inner sandbox', async () => {
     const args = await spawnedArgs('read-only');
     expect(indexOfSequence(args, CODEX_READ_ONLY_LAUNCH_FLAGS)).toBeGreaterThan(-1);

--- a/src/lib/lane/worker-session-state.ts
+++ b/src/lib/lane/worker-session-state.ts
@@ -24,7 +24,8 @@ export function hasRecordedWorkerExit(lane: Lane): boolean {
 export function hasRecordedCleanWorkerExit(lane: Lane): boolean {
   const event = newestWorkerProcessExit(lane);
   if (!event) return false;
-  const { classification, exitCode, signal } = event.payload;
+  const { classification, exitCode, runtimeOutcome, signal } = event.payload;
+  if (runtimeOutcome === 'failed') return false;
   return classification === 'clean-exit'
     || (exitCode === 0 && (signal === null || signal === undefined));
 }

--- a/src/lib/orchestrator/control-plane.ts
+++ b/src/lib/orchestrator/control-plane.ts
@@ -183,16 +183,20 @@ function hasUnreconciledRuntimeExit(lane: Lane, events: LaneEvent[]): boolean {
   if (!RUNTIME_EXIT_OVERRIDE_STATUSES.has(lane.status)) return false;
   const runtimeExit = events.findLast((event) => event.verb === 'runtime_process_exit');
   if (!runtimeExit) return false;
+  const exitSurfaceId = runtimeExit.payload.surfaceId;
+  if (typeof exitSurfaceId === 'string' && lane.sessionKey && exitSurfaceId !== lane.sessionKey) return false;
+  const exitAt = Date.parse(runtimeExit.timestamp);
+  const laneEventAt = lane.lastEventAt ? Date.parse(lane.lastEventAt) : 0;
+  if (!Number.isFinite(exitAt) || (Number.isFinite(laneEventAt) && exitAt < laneEventAt)) return false;
   const classification = runtimeExit.payload.classification;
   const exitCode = runtimeExit.payload.exitCode;
+  const runtimeOutcome = runtimeExit.payload.runtimeOutcome;
   const signal = runtimeExit.payload.signal;
+  if (runtimeOutcome === 'failed') return true;
   if (classification === 'clean-exit' || (exitCode === 0 && (signal === null || signal === undefined))) {
     return false;
   }
-  const exitAt = Date.parse(runtimeExit.timestamp);
-  const laneEventAt = lane.lastEventAt ? Date.parse(lane.lastEventAt) : 0;
-  if (!Number.isFinite(exitAt)) return false;
-  return !Number.isFinite(laneEventAt) || exitAt >= laneEventAt;
+  return true;
 }
 
 export function buildDomainLaneSummaries(): DomainLaneSummary[] {

--- a/src/lib/runtime/interrupt-escalation.ts
+++ b/src/lib/runtime/interrupt-escalation.ts
@@ -5,6 +5,10 @@ import { isBridgeSessionAlive, signalBridgeTerminalSession } from '@/lib/runtime
 import { lookupOwnedActiveRunFresh } from '@/lib/runtimes/shared/owned-session-index';
 import { isPidAlive, pidCommandLine } from '@/lib/runtimes/shared/owned-session/helpers';
 import { getOwnedSessionLifecycle } from '@/lib/runtimes/shared/owned-session-lifecycle';
+import {
+  probeOwnedRunProcessClaim,
+  resolveSpawnedProcessGroupId,
+} from '@/lib/runtimes/shared/owned-session/run-process-proof';
 
 export type InterruptEscalationSignal = 'SIGINT' | 'SIGTERM' | 'SIGKILL';
 
@@ -555,8 +559,28 @@ export async function escalateInterruptOwnedSurface(surfaceId: string): Promise<
     : false;
   if (activeRun.pid && !bridgeAlive) {
     const expectedCommand = activeRun.commandIdentity ?? commandLabel;
-    const commandLine = await pidCommandLine(activeRun.pid);
-    if (commandLine && !commandLine.includes(expectedCommand)) {
+    let identityMatches: boolean;
+    if (process.platform !== 'win32' && isPidAlive(activeRun.pid)) {
+      // A launcher can exec the runtime without changing PID. The persisted
+      // run marker survives that transition; a binary name does not. Require
+      // both the exact PID's marker and its recorded group before signaling.
+      // Missing/unknown proof must never fall back to a matching command name.
+      const claim = activeRun.processMarker ? await probeOwnedRunProcessClaim({
+        pid: activeRun.pid, marker: activeRun.processMarker, rootPid: activeRun.pid,
+      }) : null;
+      const group = claim?.state === 'match'
+        ? await resolveSpawnedProcessGroupId(activeRun.pid)
+        : undefined;
+      identityMatches = claim?.state === 'match'
+        && group !== undefined
+        && group === (activeRun.processGroupId ?? activeRun.pid);
+    } else {
+      const commandLine = await pidCommandLine(activeRun.pid);
+      identityMatches = commandLine
+        ? commandLine.includes(expectedCommand)
+        : !isPidAlive(activeRun.pid);
+    }
+    if (!identityMatches) {
       return {
         attempted: false,
         confirmedDead: false,
@@ -564,7 +588,7 @@ export async function escalateInterruptOwnedSurface(surfaceId: string): Promise<
         steps: [],
         pid: activeRun.pid,
         tmuxSession: activeRun.tmuxSession,
-        note: `Stored pid ${activeRun.pid} no longer matches the owned ${expectedCommand} run, so its process tree was not signaled or confirmed stopped.`,
+        note: `Stored pid ${activeRun.pid} could not be verified as the owned ${expectedCommand} run, so its process tree was not signaled or confirmed stopped. Legacy runs require an owner-verified stop before retry.`,
       };
     }
   }

--- a/src/lib/runtime/owned-surface-interrupt.test.ts
+++ b/src/lib/runtime/owned-surface-interrupt.test.ts
@@ -5,6 +5,9 @@ const mocks = vi.hoisted(() => ({
   signalBridge: vi.fn(),
   lookupRun: vi.fn(),
   pidCommandLine: vi.fn(),
+  pidAlive: vi.fn(),
+  claim: vi.fn(),
+  processGroup: vi.fn(),
 }));
 
 vi.mock('@/lib/runtime/pty-bridge', () => ({
@@ -15,19 +18,24 @@ vi.mock('@/lib/runtimes/shared/owned-session-index', () => ({
   lookupOwnedActiveRunFresh: mocks.lookupRun,
 }));
 vi.mock('@/lib/runtimes/shared/owned-session/helpers', () => ({
-  isPidAlive: vi.fn(() => false),
+  isPidAlive: mocks.pidAlive,
   pidCommandLine: mocks.pidCommandLine,
 }));
 vi.mock('@/lib/runtimes/shared/owned-session-lifecycle', () => ({
   getOwnedSessionLifecycle: vi.fn(() => undefined),
 }));
 vi.mock('@/lib/runtimes', () => ({}));
+vi.mock('@/lib/runtimes/shared/owned-session/run-process-proof', () => ({
+  probeOwnedRunProcessClaim: mocks.claim,
+  resolveSpawnedProcessGroupId: mocks.processGroup,
+}));
 
 const { escalateInterruptOwnedSurface } = await import('./interrupt-escalation');
 
 describe('owned surface interrupt authority', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.pidAlive.mockReturnValue(false);
   });
 
   it('trusts and stops a live bridge even when the stored wrapper pid was reused', async () => {
@@ -49,5 +57,48 @@ describe('owned surface interrupt authority', () => {
       alreadyDead: false,
       tmuxSession: 'owned-live-bridge',
     });
+  });
+
+  it.each(['mismatch', 'unknown'])('refuses %s run-marker evidence even with a matching binary', async (state) => {
+    mocks.lookupRun.mockResolvedValue({
+      pid: 4242, processGroupId: 4242, commandIdentity: 'claude', processMarker: 'owned-run',
+    });
+    mocks.pidAlive.mockReturnValue(true);
+    mocks.pidCommandLine.mockResolvedValue('/usr/local/bin/claude');
+    mocks.claim.mockResolvedValue({ state });
+    const result = await escalateInterruptOwnedSurface('claude-code-owned:marker-authority');
+    expect(result).toMatchObject({ attempted: false, confirmedDead: false, steps: [] });
+    expect(mocks.claim).toHaveBeenCalledWith({ pid: 4242, marker: 'owned-run', rootPid: 4242 });
+    expect(mocks.pidCommandLine).not.toHaveBeenCalled();
+    expect(mocks.processGroup).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, 9999])('refuses missing or changed process-group proof (%s)', async (group) => {
+    mocks.lookupRun.mockResolvedValue({
+      pid: 4242, processGroupId: 4242, commandIdentity: 'sandbox-exec', processMarker: 'owned-run',
+    });
+    mocks.pidAlive.mockReturnValue(true);
+    mocks.claim.mockResolvedValue({ state: 'match' });
+    mocks.processGroup.mockResolvedValue(group);
+    const result = await escalateInterruptOwnedSurface('claude-code-owned:group-authority');
+    expect(result).toMatchObject({ attempted: false, confirmedDead: false, steps: [] });
+  });
+
+  it('does not interpret a failed legacy command probe as proof of death', async () => {
+    mocks.lookupRun.mockResolvedValue({ pid: 4242, commandIdentity: 'claude' });
+    mocks.pidAlive.mockReturnValue(true);
+    mocks.pidCommandLine.mockResolvedValue(null);
+    expect(await escalateInterruptOwnedSurface('claude-code-owned:legacy-unknown'))
+      .toMatchObject({ attempted: false, confirmedDead: false, steps: [] });
+  });
+
+  it('refuses a live unmarked legacy PID even when its executable matches', async () => {
+    mocks.lookupRun.mockResolvedValue({ pid: 4242, commandIdentity: 'claude' });
+    mocks.pidAlive.mockReturnValue(true);
+    mocks.pidCommandLine.mockResolvedValue('/usr/local/bin/claude');
+    expect(await escalateInterruptOwnedSurface('claude-code-owned:legacy-same-binary'))
+      .toMatchObject({ attempted: false, confirmedDead: false, steps: [] });
+    expect(mocks.claim).not.toHaveBeenCalled();
+    expect(mocks.pidCommandLine).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/runtimes/shared/auth-detect-claude.test.ts
+++ b/src/lib/runtimes/shared/auth-detect-claude.test.ts
@@ -10,9 +10,14 @@ const authFixture = vi.hoisted(() => ({
   home: '',
   claudeBinary: '',
   installed: true,
+  dedicatedTokenRequired: false,
 }));
 const symonBridgeFixture = vi.hoisted(() => ({
   selections: [] as Array<{ engine: string; model: string; effort: string } | undefined>,
+}));
+vi.mock('@/lib/claude-code/worker-token', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/claude-code/worker-token')>(),
+  requiresNativeWorkerToken: () => authFixture.dedicatedTokenRequired,
 }));
 
 vi.mock('node:os', async (importOriginal) => {
@@ -134,6 +139,8 @@ function createMissionRequest(issueNumber: number, overrides: {
 }
 
 beforeEach(async () => {
+  // Preserve coverage of the file-backed native path independently of the host.
+  authFixture.dedicatedTokenRequired = false;
   authFixture.installed = true;
   vi.stubEnv('ANTHROPIC_API_KEY', '');
   vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', '');
@@ -149,6 +156,8 @@ afterEach(() => {
   vi.unstubAllEnvs();
   invalidateRuntimeAuthCache();
   rmSync(claudeConfigDir, { recursive: true, force: true });
+  rmSync(path.join(authFixture.home, '.claude.json'), { force: true });
+  rmSync(path.join(dataRoot, 'native-worker-token.json'), { force: true });
 });
 
 afterAll(() => {
@@ -161,6 +170,35 @@ afterAll(() => {
 });
 
 describe.skipIf(process.platform === 'win32')('Claude Code native sign-in verification', () => {
+  it('refuses an ordinary Mac login through mission creation until a dedicated token is configured', async () => {
+    authFixture.dedicatedTokenRequired = true;
+    vi.stubEnv('O8_TEST_CLAUDE_MODE', 'logged_in');
+    // Main's account-metadata fallback must not bypass worker credentials.
+    writeFileSync(path.join(authFixture.home, '.claude.json'), JSON.stringify({
+      oauthAccount: { emailAddress: 'synthetic@example.invalid' },
+    }));
+    expect(await claudeStatus()).toMatchObject({
+      ready: false, authenticated: false, unavailableReason: 'needs_auth',
+      fix: expect.stringContaining('npm run worker:login'),
+    });
+    const response = await createMissionRoute.POST(createMissionRequest(91_762_030));
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ ok: false, error: { code: 'dispatch_cli_auth_unavailable' } });
+  });
+
+  it('recognizes an encrypted Mac worker token without claiming live provider validation', async () => {
+    authFixture.dedicatedTokenRequired = true;
+    vi.stubEnv('O8_MASTER_KEY', Buffer.alloc(32, 7).toString('base64url'));
+    const { saveNativeWorkerToken } = await import('@/lib/claude-code/worker-token');
+    await saveNativeWorkerToken(`sk-ant-oat01-${'synthetic'.repeat(12)}`);
+    const status = await claudeStatus();
+    expect(status).toMatchObject({
+      ready: true, authenticated: true, unavailableReason: null,
+      detail: expect.stringContaining('provider acceptance is checked on launch'),
+    });
+    await expect(assertRuntimeDispatchable('claude-code')).resolves.toBeUndefined();
+  });
+
   it('refuses stale marker files and empty OAuth fields as sign-in evidence', async () => {
     writeStaleMarkers();
 
@@ -298,8 +336,9 @@ describe.skipIf(process.platform === 'win32')('Claude Code native sign-in verifi
     });
   }, 20_000);
 
-  it('falls back to real stored OAuth material when the probe is inconclusive', async () => {
+  it.each(['', '   ', 'padded'])('finds stored OAuth with config override %j when the probe is inconclusive', async (override) => {
     vi.stubEnv('O8_TEST_CLAUDE_MODE', 'malformed');
+    vi.stubEnv('CLAUDE_CONFIG_DIR', override === 'padded' ? `  ${claudeConfigDir}  ` : override);
     writeStaleMarkers({ claudeAiOauth: { accessToken: 'sk-ant-oat-live', refreshToken: '' } });
 
     expect(await claudeStatus()).toMatchObject({
@@ -309,6 +348,34 @@ describe.skipIf(process.platform === 'win32')('Claude Code native sign-in verifi
       unavailableReason: null,
       detail: 'Claude Code CLI is installed and signed in.',
     });
+  });
+
+  it('preserves ordinary account evidence when dedicated worker credentials are not required', async () => {
+    vi.stubEnv('O8_TEST_CLAUDE_MODE', 'malformed');
+    writeFileSync(path.join(authFixture.home, '.claude.json'), JSON.stringify({
+      oauthAccount: { emailAddress: 'synthetic@example.invalid' },
+    }));
+    expect(await claudeStatus()).toMatchObject({ ready: true, authenticated: true });
+  });
+
+  it('rechecks an unknown login after five seconds without manual invalidation', async () => {
+    vi.stubEnv('O8_TEST_CLAUDE_MODE', 'malformed');
+    let now = Date.now();
+    const clock = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    try {
+      invalidateRuntimeAuthCache();
+      expect((await getRuntimeAuthSnapshot()).statuses.claude).toMatchObject({
+        ready: false, nativeLoginState: 'unknown',
+      });
+      vi.stubEnv('O8_TEST_CLAUDE_MODE', 'logged_in');
+      expect((await getRuntimeAuthSnapshot()).statuses.claude.nativeLoginState).toBe('unknown');
+      now += 5_001;
+      expect((await getRuntimeAuthSnapshot()).statuses.claude).toMatchObject({
+        ready: true, nativeLoginState: 'logged_in',
+      });
+    } finally {
+      clock.mockRestore();
+    }
   });
 
   it('reports not_installed without probing when the CLI is absent', async () => {

--- a/src/lib/runtimes/shared/auth-detect.ts
+++ b/src/lib/runtimes/shared/auth-detect.ts
@@ -18,9 +18,7 @@ import type { ClaudeCodeModelSource } from '@/lib/claude-code/worker-profile-typ
 import { claudeCarrierPresentation } from './claude-carrier-presentation';
 import { scanAndLink } from './cli-locate';
 import {
-  hasClaudeEnvCredential,
-  hasStoredClaudeOAuthCredential,
-  probeClaudeLoginState,
+  detectNativeClaudeAuth,
   type ClaudeLoginState,
 } from './claude-login-probe';
 import { cliInvocation } from '@/lib/runtimes/shared/cli-spawn';
@@ -257,26 +255,6 @@ function claudeWorkerCarrier(): ClaudeCodeModelSource {
   } catch {
     return 'native';
   }
-}
-
-/**
- * Native sign-in evidence, in decisiveness order.
- *
- * A non-empty env credential is decisive positive evidence and skips the subprocess.
- * Otherwise the installed CLI is asked directly; only an explicit `loggedIn:false`
- * is treated as decisive negative. An inconclusive probe falls back to real stored
- * OAuth material — never to marker files like ~/.claude/settings.json or
- * ~/.claude/projects, which survive a sign-out and used to fake authentication here.
- */
-async function detectNativeClaudeAuth(binaryPath: string): Promise<{
-  authenticated: boolean;
-  loginState: ClaudeLoginState;
-}> {
-  if (hasClaudeEnvCredential()) return { authenticated: true, loginState: 'logged_in' };
-  const loginState = await probeClaudeLoginState(binaryPath);
-  if (loginState === 'logged_in') return { authenticated: true, loginState };
-  if (loginState === 'logged_out') return { authenticated: false, loginState };
-  return { authenticated: await hasStoredClaudeOAuthCredential(), loginState };
 }
 
 async function detectClaude(): Promise<RuntimeAuthStatus> {

--- a/src/lib/runtimes/shared/claude-carrier-presentation.ts
+++ b/src/lib/runtimes/shared/claude-carrier-presentation.ts
@@ -1,5 +1,6 @@
 import type { ClaudeCodeModelSource } from '@/lib/claude-code/worker-profile-types';
 import type { ClaudeLoginState } from './claude-login-probe';
+import { requiresNativeWorkerToken, WORKER_TOKEN_SETUP_HINT } from '@/lib/claude-code/worker-token';
 
 const CARRIER_LABELS: Record<ClaudeCodeModelSource, string> = {
   native: 'native Claude Code',
@@ -14,18 +15,20 @@ export function claudeCarrierPresentation(
   nativeLoginState: ClaudeLoginState = 'unknown',
 ): { ready: boolean; detail: string; fix: string } {
   const blocked = carrier === 'native' && nativeSignInBlocked;
-  const nativeAuthDetail = nativeLoginState === 'logged_out'
+  const nativeAuthDetail = requiresNativeWorkerToken()
+    ? 'The native worker needs a dedicated inference credential.'
+    : nativeLoginState === 'logged_out'
     ? 'Claude Code CLI is installed but not signed in.'
     : 'Claude Code CLI is installed but its sign-in state could not be verified.';
   return {
     ready: !blocked,
     detail: authenticated
-      ? 'Claude Code CLI is installed and signed in.'
+      ? requiresNativeWorkerToken() ? 'Native worker credentials are configured; provider acceptance is checked on launch.' : 'Claude Code CLI is installed and signed in.'
       : nativeSignInBlocked
         ? carrier === 'native'
           ? nativeAuthDetail
           : `${nativeAuthDetail.slice(0, -1)}; workers use the ${CARRIER_LABELS[carrier]} carrier.`
         : 'Claude Code CLI is installed but its sign-in state could not be verified.',
-    fix: blocked ? 'Run `claude` once to sign in.' : 'No action needed.',
+    fix: blocked ? requiresNativeWorkerToken() ? WORKER_TOKEN_SETUP_HINT : 'Run `claude` once to sign in.' : 'No action needed.',
   };
 }

--- a/src/lib/runtimes/shared/claude-login-probe.ts
+++ b/src/lib/runtimes/shared/claude-login-probe.ts
@@ -6,7 +6,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
-import { hasLiveClaudeOAuth } from '@/lib/claude-code/oauth-credential';
+import { hasClaudeEnvCredential, hasLiveClaudeOAuth } from '@/lib/claude-code/oauth-credential';
+import { readNativeWorkerToken, requiresNativeWorkerToken } from '@/lib/claude-code/worker-token';
 import { cliInvocation } from '@/lib/runtimes/shared/cli-spawn';
 
 const execFileAsync = promisify(execFile);
@@ -82,7 +83,7 @@ export { hasClaudeEnvCredential } from '@/lib/claude-code/oauth-credential';
  * Deliberately does not read the macOS Keychain: `security find-generic-password`
  * can raise an ACL prompt, and readiness is polled. A live token in the config dir
  * or the account email Claude writes to ~/.claude.json is sufficient evidence.
- * The Keychain remains the seeding path's concern (seedNativeWorkerCredentials).
+ * Required worker credentials are checked separately before this fallback.
  */
 export async function hasStoredClaudeOAuthCredential(): Promise<boolean> {
   const configDir = process.env.CLAUDE_CONFIG_DIR?.trim() || path.join(os.homedir(), '.claude');
@@ -100,4 +101,20 @@ export async function hasStoredClaudeOAuthCredential(): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/** Required worker credentials take precedence over ordinary account metadata. */
+export async function detectNativeClaudeAuth(binaryPath: string): Promise<{
+  authenticated: boolean;
+  loginState: ClaudeLoginState;
+}> {
+  if (hasClaudeEnvCredential()) return { authenticated: true, loginState: 'logged_in' };
+  if (requiresNativeWorkerToken()) {
+    const authenticated = Boolean(await readNativeWorkerToken());
+    return { authenticated, loginState: authenticated ? 'logged_in' : 'logged_out' };
+  }
+  const loginState = await probeClaudeLoginState(binaryPath);
+  if (loginState === 'logged_in') return { authenticated: true, loginState };
+  if (loginState === 'logged_out') return { authenticated: false, loginState };
+  return { authenticated: await hasStoredClaudeOAuthCredential(), loginState };
 }

--- a/src/lib/runtimes/shared/owned-session-index.test.ts
+++ b/src/lib/runtimes/shared/owned-session-index.test.ts
@@ -118,4 +118,16 @@ describe('lookupOwnedActiveRun', () => {
 
     expect(await lookupOwnedActiveRunFresh('pi-owned:new')).toEqual({ pid: 8, tmuxSession: undefined });
   });
+
+  it('preserves the latest exact run marker through a fresh stop lookup', async () => {
+    const surfaceId = 'claude-code-owned:marker';
+    writeSession('marker', surfaceId, { pid: 8, processMarker: 'old-run' });
+    expect(await lookupOwnedActiveRun(surfaceId)).toMatchObject({ processMarker: 'old-run' });
+    writeSession('marker', surfaceId, {
+      pid: 9, processGroupId: 9, commandIdentity: 'sandbox-exec', processMarker: 'new-run',
+    });
+    expect(await lookupOwnedActiveRunFresh(surfaceId)).toMatchObject({
+      pid: 9, processGroupId: 9, commandIdentity: 'sandbox-exec', processMarker: 'new-run',
+    });
+  });
 });

--- a/src/lib/runtimes/shared/owned-session-index.ts
+++ b/src/lib/runtimes/shared/owned-session-index.ts
@@ -27,6 +27,7 @@ export interface OwnedActiveRun {
   processGroupId?: number;
   tmuxSession?: string;
   commandIdentity?: string;
+  processMarker?: string;
 }
 
 export interface IndexedOwnedActiveRun extends OwnedActiveRun {
@@ -127,6 +128,9 @@ async function buildRootIndex(root: string): Promise<RootIndex> {
           tmuxSession: typeof parsed.activeRun.tmuxSession === 'string' ? parsed.activeRun.tmuxSession : undefined,
           commandIdentity: typeof parsed.activeRun.commandIdentity === 'string'
             ? parsed.activeRun.commandIdentity
+            : undefined,
+          processMarker: typeof parsed.activeRun.processMarker === 'string'
+            ? parsed.activeRun.processMarker
             : undefined,
         }
       : {});

--- a/src/lib/runtimes/shared/owned-session/helpers.ts
+++ b/src/lib/runtimes/shared/owned-session/helpers.ts
@@ -18,7 +18,7 @@ import type { RuntimeSurfaceLifecycle } from '@/lib/fleet/types';
 import { truncateText } from '@/lib/util/text';
 import { getDataDir } from '@/lib/data-dir-migration';
 
-import type { OwnedRunOutcome, OwnedRunRecord, ParsedRunLog } from './types';
+import type { OwnedChildExitOutcome, OwnedRunOutcome, OwnedRunRecord, ParsedRunLog } from './types';
 
 const execFileAsync = promisify(execFile);
 
@@ -334,6 +334,7 @@ export function deriveRunOutcome(
   if (run.outcome === 'interrupted' || run.interruptRequestedAt) {
     return 'interrupted';
   }
+  if (parsed.outcome === 'failed') return 'failed';
   if (parsed.completedTurn) {
     return 'finished';
   }
@@ -342,4 +343,28 @@ export function deriveRunOutcome(
     return 'failed';
   }
   return run.outcome === 'running' ? 'failed' : run.outcome;
+}
+
+/** Keep process exit and provider outcome distinct in the durable exit event. */
+export function ownedProcessExitPayload(
+  runtime: string,
+  surfaceId: string,
+  run: OwnedRunRecord,
+  childExit: OwnedChildExitOutcome,
+  parsed: ParsedRunLog | undefined,
+  stderr: string,
+) {
+  return {
+    runtime,
+    surfaceId,
+    runId: run.id,
+    exitCode: childExit.code,
+    signal: childExit.signal,
+    classification: childExit.classification,
+    runtimeOutcome: run.outcome,
+    stderr,
+    completedTurn: parsed?.completedTurn ?? false,
+    ...(parsed?.providerFailure ? { providerFailure: parsed.providerFailure } : {}),
+    ...(parsed?.turnContextUsage ?? {}),
+  };
 }

--- a/src/lib/runtimes/shared/owned-session/project-config.test.ts
+++ b/src/lib/runtimes/shared/owned-session/project-config.test.ts
@@ -1,0 +1,52 @@
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { backingProjectConfigPaths } from './project-config';
+
+const fixtures: string[] = [];
+async function fixture() {
+  const root = await realpath(await mkdtemp(path.join(os.tmpdir(), 'o8-project-config-')));
+  fixtures.push(root);
+  const project = path.join(root, 'project');
+  const configDir = path.join(project, '.codex');
+  await mkdir(configDir, { recursive: true });
+  return { root, project, configDir, config: path.join(configDir, 'config.toml'),
+    gitPaths: [path.join(project, '.git', 'worktrees', 'packet'), path.join(project, '.git')] };
+}
+afterEach(async () => {
+  await Promise.all(fixtures.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('backing project configuration is an exact read-only input', () => {
+  it('does not infer a project from a separate Git directory or reopen the current checkout', async () => {
+    const f = await fixture();
+    await expect(backingProjectConfigPaths([path.join(f.root, 'bare.git')], 'packet', []))
+      .resolves.toEqual([]);
+    await expect(backingProjectConfigPaths(f.gitPaths, f.project, [])).resolves.toEqual([]);
+  });
+
+  it('grants only an existing regular config and refuses protected project roots', async () => {
+    const f = await fixture();
+    await expect(backingProjectConfigPaths(f.gitPaths, 'packet', [])).resolves.toEqual([]);
+    await writeFile(f.config, '# synthetic config');
+    await expect(backingProjectConfigPaths(f.gitPaths, 'packet', [])).resolves.toEqual([f.config]);
+    await expect(backingProjectConfigPaths(f.gitPaths, 'packet', [f.project])).rejects.toThrow('protected');
+  });
+
+  it.each(['file', 'parent', 'directory'] as const)('refuses a %s alias or directory grant', async (kind) => {
+    const f = await fixture();
+    const outside = path.join(f.root, 'outside');
+    await mkdir(outside);
+    await writeFile(path.join(outside, 'config.toml'), '# synthetic private config');
+    if (kind === 'parent') {
+      await rm(f.configDir, { recursive: true });
+      await symlink(outside, f.configDir);
+    } else if (kind === 'file') {
+      await symlink(path.join(outside, 'config.toml'), f.config);
+    } else {
+      await mkdir(f.config);
+    }
+    await expect(backingProjectConfigPaths(f.gitPaths, 'packet', [])).rejects.toThrow('non-aliased');
+  });
+});

--- a/src/lib/runtimes/shared/owned-session/project-config.ts
+++ b/src/lib/runtimes/shared/owned-session/project-config.ts
@@ -1,0 +1,30 @@
+import { lstat, realpath } from 'node:fs/promises';
+import path from 'node:path';
+
+/** A linked checkout can load hooks from its backing project's config file. */
+export async function backingProjectConfigPaths(
+  gitPaths: string[],
+  worktreeRoot: string,
+  protectedRoots: string[],
+): Promise<string[]> {
+  const commonDir = gitPaths.at(-1);
+  // A bare or separately located Git directory does not identify a checkout.
+  if (!commonDir || path.basename(commonDir) !== '.git') return [];
+  const projectRoot = await realpath(path.dirname(commonDir));
+  if (projectRoot === worktreeRoot) return [];
+  if (protectedRoots.includes(projectRoot)) {
+    throw new Error('A backing project cannot re-open a protected root configuration.');
+  }
+  const config = path.join(projectRoot, '.codex', 'config.toml');
+  const entry = await lstat(config).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === 'ENOENT') return null;
+    throw error;
+  });
+  if (!entry) return [];
+  // Do not turn a repository symlink into a grant on an operator's config or
+  // credential store. Only this regular file at its canonical path is eligible.
+  if (!entry.isFile() || await realpath(config) !== config) {
+    throw new Error('Backing project configuration must be a regular, non-aliased file.');
+  }
+  return [config];
+}

--- a/src/lib/runtimes/shared/owned-session/run-controller.ts
+++ b/src/lib/runtimes/shared/owned-session/run-controller.ts
@@ -23,7 +23,7 @@ import { pathWithNodeRuntime } from '@/lib/util/node-on-path';
 import { crashSurvivableWorkersEnabled } from './crash-survival';
 import { observeChildExit, readAbnormalStderrTail } from './exit-outcome';
 import { prepareOwnedLaunchArgs } from './launch-args';
-import { detectSandboxDenial, sandboxDenialOperatorMessage } from './sandbox-denial';
+import { detectSandboxDenial, detectRunSandboxDenial, sandboxDenialOperatorMessage } from './sandbox-denial';
 import {
   AUTO_RETRY_FRESHNESS_MS,
   MAX_AUTO_RETRIES,
@@ -33,6 +33,7 @@ import {
   ensureDir,
   isOwnedRunAlive,
   nowIso,
+  ownedProcessExitPayload,
   pathExists,
 } from './helpers';
 import { stageMissingCliRun } from './missing-cli';
@@ -45,6 +46,7 @@ import {
   workerSandboxEnabled,
 } from './sandbox';
 import { resolveReadOnlySandboxPlan } from './work-mode';
+import { preparedRuntimeStateSandboxPolicy } from './runtime-state-sandbox';
 import type { OwnedSessionIo } from './session-io';
 import type {
   OwnedChildExitOutcome,
@@ -94,8 +96,7 @@ export function createOwnedRunController({
 }): OwnedRunController {
   const pendingAutoRetries = new Set<string>();
   const runArtifactCache = new Map<string, {
-    stdoutKey: string;
-    stderrKey: string;
+    key: string;
     /** null = raw exceeded RAW_RETENTION_MAX_BYTES; re-read from disk on hit. */
     stdoutRaw: string | null;
     stderrRaw: string | null;
@@ -139,8 +140,11 @@ export function createOwnedRunController({
       statKey(run.stdoutPath),
       statKey(run.stderrPath),
     ]);
+    const key = JSON.stringify([
+      stdoutKey, stderrKey, run.outcome, run.finishedAt, run.interruptRequestedAt, run.childExit,
+    ]);
     const cached = runArtifactCache.get(run.id);
-    if (cached && cached.stdoutKey === stdoutKey && cached.stderrKey === stderrKey) {
+    if (cached?.key === key) {
       runArtifactCache.delete(run.id);
       runArtifactCache.set(run.id, cached);
       if (cached.stdoutRaw !== null && cached.stderrRaw !== null) {
@@ -160,8 +164,7 @@ export function createOwnedRunController({
 
     const withinRawCap = stdoutRaw.length + stderrRaw.length <= RAW_RETENTION_MAX_BYTES;
     const entry = {
-      stdoutKey,
-      stderrKey,
+      key,
       stdoutRaw: withinRawCap ? stdoutRaw : null,
       stderrRaw: withinRawCap ? stderrRaw : null,
       parsed: adapter.parseRunLog(
@@ -211,12 +214,15 @@ export function createOwnedRunController({
     let model: string | undefined;
     let latestPrompt = '';
     let sandboxDenial: OwnedRunRecord['sandboxDenial'];
+    let artifacts: Awaited<ReturnType<typeof readRunArtifacts>> | null = null;
     await withSurfaceLock(surfaceId, async () => {
       const current = await io.findSession(surfaceId);
       if (!current) return;
       laneId = current.laneId;
       model = current.model;
       latestPrompt = current.latestPrompt;
+      const currentRun = current.recentRuns.find((run) => run.id === runId);
+      artifacts = currentRun ? await readRunArtifacts({ ...currentRun, childExit }).catch(() => null) : null;
       let dirty = false;
       const finishedAt = nowIso();
       const applyExit = (run: OwnedRunRecord): OwnedRunRecord => {
@@ -224,6 +230,8 @@ export function createOwnedRunController({
         dirty = true;
         const nextOutcome = run.outcome === 'interrupted'
           ? 'interrupted'
+          : artifacts?.parsed.outcome === 'failed'
+            ? 'failed'
           : childExit.classification === 'clean-exit'
             ? 'finished'
             : 'failed';
@@ -254,22 +262,15 @@ export function createOwnedRunController({
     });
     invalidateFleetCache();
 
-    if (laneId && exitedRun) {
-      const artifacts = await readRunArtifacts(exitedRun).catch(() => null);
-      const stderr = compactText(artifacts?.stderrRaw || childExit.stderrTail || '', 4_000);
-      const rawFailure = `${artifacts?.stdoutRaw ?? ''}\n${artifacts?.stderrRaw ?? childExit.stderrTail ?? ''}`;
+    const recordedRun = exitedRun as OwnedRunRecord | null;
+    const recordedArtifacts = artifacts as Awaited<ReturnType<typeof readRunArtifacts>> | null;
+    if (laneId && recordedRun) {
+      const stderr = compactText(recordedArtifacts?.stderrRaw || childExit.stderrTail || '', 4_000);
+      const rawFailure = `${recordedArtifacts?.stdoutRaw ?? ''}\n${recordedArtifacts?.stderrRaw ?? childExit.stderrTail ?? ''}`;
       try {
-        recordLaneEvent(laneId, 'runtime_process_exit', 'system', {
-          runtime: runtimeId,
-          surfaceId,
-          runId,
-          exitCode: childExit.code,
-          signal: childExit.signal,
-          classification: childExit.classification,
-          stderr,
-          completedTurn: artifacts?.parsed.completedTurn ?? false,
-          ...(artifacts?.parsed.turnContextUsage ?? {}),
-        });
+        recordLaneEvent(laneId, 'runtime_process_exit', 'system', ownedProcessExitPayload(
+          runtimeId, surfaceId, recordedRun, childExit, recordedArtifacts?.parsed, stderr,
+        ));
       } catch (error) {
         console.warn(`[owned-store] Failed to record runtime_process_exit for lane ${laneId}:`, error);
       }
@@ -397,7 +398,7 @@ export function createOwnedRunController({
       }
 
       if (run.sandboxed && !run.sandboxDenial) {
-        const denial = detectSandboxDenial(`${stdoutRaw}\n${stderrRaw}`);
+        const denial = detectRunSandboxDenial(runtimeId, stdoutRaw, stderrRaw);
         if (denial) {
           run.sandboxDenial = denial;
           session.latestSummary = sandboxDenialOperatorMessage(runtimeId, denial);
@@ -534,6 +535,11 @@ export function createOwnedRunController({
       sandboxEnabled,
       humanLabel,
     });
+    // Prepare the exact isolated config root before Seatbelt is built.
+    const adapterEnv: Record<string, string> = adapter.extraSpawnEnv
+      ? await adapter.extraSpawnEnv(session)
+      : {};
+    const runtimeState = preparedRuntimeStateSandboxPolicy(adapter, session, adapterEnv);
 
     let spawnBinary = binary;
     let spawnArgs = args;
@@ -548,25 +554,16 @@ export function createOwnedRunController({
           binary,
           args,
           extraReadPaths: workerMcp.sandboxReadPaths,
+          readBackingProjectConfig: runtimeId === 'codex',
           finalAllowReadPaths: workerMcp.configPath ? [workerMcp.configPath] : undefined,
           // Read-only: repo stays readable, kernel refuses every write. Deny
           // paths come from the SAME git probe prepareWorkerSandbox uses to
           // grant access, and it throws if that probe resolves nothing.
           enforceReadOnly: readOnlySandbox.enforced,
-          finalAllowReadWritePaths: session.identity?.configHomeRef
-            ? [session.identity.configHomeRef]
+          finalAllowReadWritePaths: runtimeState.configHome
+            ? [runtimeState.configHome]
             : undefined,
-          finalImmutableWritePaths: session.identity?.configHomeRef
-            ? [
-                path.join(session.identity.configHomeRef, 'auth.json'),
-                path.join(session.identity.configHomeRef, 'config.toml'),
-                path.join(session.identity.configHomeRef, 'AGENTS.md'),
-                path.join(session.identity.configHomeRef, 'agents'),
-                path.join(session.identity.configHomeRef, 'plugins'),
-                path.join(session.identity.configHomeRef, 'rules'),
-                path.join(session.identity.configHomeRef, 'skills'),
-              ]
-            : undefined,
+          finalImmutableWritePaths: runtimeState.immutablePaths,
         });
         spawnBinary = prepared.binary;
         spawnArgs = prepared.args;
@@ -612,12 +609,6 @@ export function createOwnedRunController({
     let pendingDetachedExit: OwnedChildExitOutcome | undefined;
 
     const bridgeSessionName = tmuxSessionName(runtimeId, runId);
-    const adapterEnv: Record<string, string> = adapter.extraSpawnEnv
-      ? await adapter.extraSpawnEnv(session)
-      : {};
-    if (adapter.isolatedConfigHomeEnv && session.identity?.configHomeRef) {
-      adapterEnv[adapter.isolatedConfigHomeEnv] = session.identity.configHomeRef;
-    }
     const workerToken = session.packetId
       ? mintPacketWorkerToken(session.packetId, { processMarker: runId })
       : getOrCreateLocalWorkerToken();

--- a/src/lib/runtimes/shared/owned-session/run-process-proof.ts
+++ b/src/lib/runtimes/shared/owned-session/run-process-proof.ts
@@ -106,7 +106,7 @@ export async function probeOwnedRunProcessClaim(input: {
       windowsHide: true,
     });
     const marker = `O8_OWNED_RUN_MARKER=${input.marker}`;
-    return stdout.includes(marker)
+    return stdout.split(/\s+/).includes(marker)
       ? { state: 'match' }
       : { state: 'mismatch', detail: 'The claimed PID does not carry the authenticated worker process marker.' };
   } catch (error) {

--- a/src/lib/runtimes/shared/owned-session/runtime-state-sandbox.ts
+++ b/src/lib/runtimes/shared/owned-session/runtime-state-sandbox.ts
@@ -1,0 +1,28 @@
+import path from 'node:path';
+
+import type { OwnedRuntimeAdapter, OwnedSessionRecord } from './types';
+
+const IMMUTABLE_CONFIG_ENTRIES = [
+  'auth.json', 'config.toml', 'AGENTS.md', 'agents', 'plugins', 'rules', 'skills',
+  '.credentials.json', 'settings.json', 'settings.local.json', 'hooks',
+  'mcp-servers', 'statusline.sh',
+];
+
+export function preparedRuntimeStateSandboxPolicy(
+  adapter: OwnedRuntimeAdapter,
+  session: OwnedSessionRecord,
+  adapterEnv: Record<string, string>,
+): { configHome?: string; immutablePaths?: string[] } {
+  if (adapter.isolatedConfigHomeEnv && session.identity?.configHomeRef) {
+    adapterEnv[adapter.isolatedConfigHomeEnv] = session.identity.configHomeRef;
+  }
+  const configHome = adapter.isolatedConfigHomeEnv
+    ? adapterEnv[adapter.isolatedConfigHomeEnv]?.trim()
+    : undefined;
+  return configHome
+    ? {
+        configHome,
+        immutablePaths: IMMUTABLE_CONFIG_ENTRIES.map((entry) => path.join(configHome, entry)),
+      }
+    : {};
+}

--- a/src/lib/runtimes/shared/owned-session/sandbox-denial.test.ts
+++ b/src/lib/runtimes/shared/owned-session/sandbox-denial.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { detectRunSandboxDenial, detectSandboxDenial } from './sandbox-denial';
+
+describe('sandbox denial diagnostic text', () => {
+  it.each([
+    '(deny file-read* file-write* (subpath "/example"))',
+    JSON.stringify({ output: 'deny file-read-data /example/secret' }),
+    'The example says: cat: /example/secret: Operation not permitted',
+  ])('ignores quoted policy and diagnostic examples: %s', (text) => {
+    expect(detectSandboxDenial(text)).toBeNull();
+  });
+
+  it.each([
+    ['Sandbox: cat(42) deny(1) file-read-data /example/secret', 'file-read'],
+    ['deny(1) process-exec /example/tool', 'process-exec'],
+    ['cat: /example/secret: Operation not permitted', 'file-read'],
+    ['cat: relative-file: Operation not permitted', 'file-read'],
+    ['sandbox-exec: execvp() of "/example/tool" failed: Operation not permitted', 'process-exec'],
+    ['chmod: Unable to change file mode on /example/secret: Operation not permitted', 'file-write'],
+    ['sandbox-exec: sandbox_apply: Operation not permitted', 'sandbox-apply'],
+  ])('recognizes anchored diagnostics: %s', (text, operation) => {
+    expect(detectSandboxDenial(text)?.operation).toBe(operation);
+  });
+
+  it('bounds diagnostic fields before they enter persisted events', () => {
+    const denial = detectSandboxDenial('cat: /' + 'x'.repeat(20000) + ': Operation not permitted');
+    expect(denial).not.toBeNull();
+    expect(denial!.resource.length).toBeLessThanOrEqual(512);
+    expect(denial!.line.length).toBeLessThanOrEqual(1024);
+  });
+
+  it.each([false, true])('uses explicit tool failure identity: %s', (failed) => {
+    const text = 'cat: /example/secret: Operation not permitted';
+    const stream = JSON.stringify({ type: 'user', message: { content: [
+      { type: 'tool_result', is_error: failed, content: [{ type: 'text', text }] },
+    ] } });
+    expect(Boolean(detectRunSandboxDenial('claude-code', stream, ''))).toBe(failed);
+    expect(detectRunSandboxDenial('codex', stream, '')).toBeNull();
+    const command = JSON.stringify({ type: 'item.completed', item: { type: 'command_execution',
+      exit_code: failed ? 1 : 0, aggregated_output: text } });
+    expect(Boolean(detectRunSandboxDenial('codex', command, ''))).toBe(failed);
+  });
+
+  it('ignores prose, partial JSON, null and nested example envelopes', () => {
+    const example = { type: 'user', message: { content: [{ type: 'tool_result', is_error: true,
+      content: 'cat: /example/secret: Operation not permitted' }] } };
+    expect(detectRunSandboxDenial('claude-code', ['null', '{', 'deny(1) file-read-data /example',
+      JSON.stringify({ type: 'assistant', message: { content: JSON.stringify(example) } }),
+    ].join('\n'), '')).toBeNull();
+  });
+});

--- a/src/lib/runtimes/shared/owned-session/sandbox-denial.ts
+++ b/src/lib/runtimes/shared/owned-session/sandbox-denial.ts
@@ -7,7 +7,7 @@ export interface SandboxDenial {
 const OPERATION_NOT_PERMITTED = /operation not permitted/i;
 
 function trimResource(value: string): string {
-  return value.trim().replace(/^['"]|['"]$/g, '').replace(/[.,;]$/, '');
+  return value.trim().replace(/^['"]|['"]$/g, '').replace(/[.,;]$/, '').slice(0, 512);
 }
 
 function operationForCommand(command: string): SandboxDenial['operation'] {
@@ -21,10 +21,12 @@ function operationForCommand(command: string): SandboxDenial['operation'] {
 /** Parse the stderr forms emitted by macOS sandbox-exec and denied children. */
 export function detectSandboxDenial(raw: string): SandboxDenial | null {
   for (const originalLine of raw.split(/\r?\n/)) {
-    const line = originalLine.trim();
-    if (!line) continue;
+    const diagnostic = originalLine.trim();
+    if (!diagnostic || diagnostic.startsWith('{') || diagnostic.startsWith('[')) continue;
+    const line = diagnostic.slice(0, 1024);
 
-    const sandboxLog = line.match(/\bdeny(?:\(\d+\))?\s+(file-read[^ ]*|file-write[^ ]*|process-exec)\s+(.+)$/i);
+    // A policy expression or quoted source line is not a kernel diagnostic.
+    const sandboxLog = diagnostic.match(/^(?:Sandbox:\s+\S+\(\d+\)\s+)?deny(?:\(\d+\))?\s+(file-read(?:-[a-z-]+)?|file-write(?:-[a-z-]+)?|process-exec)\s+(\/.+)$/i);
     if (sandboxLog) {
       const operation = sandboxLog[1]?.toLowerCase().startsWith('file-read')
         ? 'file-read'
@@ -34,21 +36,21 @@ export function detectSandboxDenial(raw: string): SandboxDenial | null {
       return { operation, resource: trimResource(sandboxLog[2] ?? 'unknown resource'), line };
     }
 
-    const execFailure = line.match(/execvp\(\) of ['"](.+?)['"] failed:\s*Operation not permitted/i);
+    const execFailure = diagnostic.match(/^(?:sandbox-exec:\s*)?execvp\(\) of ['"](.+?)['"] failed:\s*Operation not permitted\s*$/i);
     if (execFailure) {
       return { operation: 'process-exec', resource: trimResource(execFailure[1] ?? ''), line };
     }
 
-    const modeFailure = line.match(/Unable to change file mode on (.+?):\s*Operation not permitted/i);
+    const modeFailure = diagnostic.match(/^(?:chmod:\s*)?Unable to change file mode on (.+?):\s*Operation not permitted\s*$/i);
     if (modeFailure) {
       return { operation: 'file-write', resource: trimResource(modeFailure[1] ?? ''), line };
     }
 
-    if (/sandbox-exec:\s*sandbox_apply:/i.test(line) && OPERATION_NOT_PERMITTED.test(line)) {
+    if (/^sandbox-exec:\s*sandbox_apply:/i.test(diagnostic) && OPERATION_NOT_PERMITTED.test(diagnostic)) {
       return { operation: 'sandbox-apply', resource: 'generated worker sandbox profile', line };
     }
 
-    const childFailure = line.match(/^([^:]+):\s+(.+?):\s*Operation not permitted\s*$/i);
+    const childFailure = diagnostic.match(/^([\w./-]+):\s+(.+?):\s*Operation not permitted\s*$/i);
     if (childFailure) {
       return {
         operation: operationForCommand(childFailure[1] ?? ''),
@@ -60,7 +62,39 @@ export function detectSandboxDenial(raw: string): SandboxDenial | null {
   return null;
 }
 
+/** Stdout is provider data, not stderr. Inspect only explicit failed tool envelopes. */
+export function detectRunSandboxDenial(runtime: string, stdout: string, stderr: string): SandboxDenial | null {
+  const stderrDenial = detectSandboxDenial(stderr);
+  if (stderrDenial) return stderrDenial;
+  for (const line of stdout.split(/\r?\n/)) {
+    let event;
+    try { event = JSON.parse(line); } catch { continue; }
+    if (!event || typeof event !== 'object') continue;
+    const diagnostics: string[] = [];
+    if (runtime === 'claude-code' && event.type === 'user' && Array.isArray(event.message?.content)) {
+      for (const result of event.message.content) {
+        if (result?.type !== 'tool_result' || result.is_error !== true) continue;
+        if (typeof result.content === 'string') diagnostics.push(result.content);
+        else if (Array.isArray(result.content)) {
+          for (const part of result.content) {
+            if (part?.type === 'text' && typeof part.text === 'string') diagnostics.push(part.text);
+          }
+        }
+      }
+    }
+    const item = event.item;
+    if (runtime === 'codex' && event.type === 'item.completed' && item?.type === 'command_execution'
+      && (item.status === 'failed' || (typeof item.exit_code === 'number' && item.exit_code !== 0))
+      && typeof item.aggregated_output === 'string') diagnostics.push(item.aggregated_output);
+    for (const diagnostic of diagnostics) {
+      const denial = detectSandboxDenial(diagnostic);
+      if (denial) return denial;
+    }
+  }
+  return null;
+}
+
 export function sandboxDenialOperatorMessage(runtime: string, denial: SandboxDenial): string {
   return `${runtime} worker sandbox blocked ${denial.operation} access to ${denial.resource}. `
-    + 'The worker stopped; review the opt-in sandbox profile before retrying.';
+    + 'Review the opt-in sandbox profile before retrying the blocked operation.';
 }

--- a/src/lib/runtimes/shared/owned-session/sandbox.test.ts
+++ b/src/lib/runtimes/shared/owned-session/sandbox.test.ts
@@ -7,6 +7,7 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import os from 'node:os';
@@ -20,6 +21,7 @@ import {
   SandboxUnavailableError,
   SANDBOX_EXEC_PATH,
   assertNoRegrantOverlap,
+  assertNarrowRuntimeStateRegrants,
 } from './sandbox';
 import { isReadOnlyRuntimeConfig, resolveReadOnlySandboxPlan } from './work-mode';
 
@@ -606,6 +608,101 @@ describe('read-only enforcement — single git probe, fail-closed, correct order
     expect(() => assertNoRegrantOverlap(['/tmp/identity'], ['/tmp/wt'])).not.toThrow();
     // A shared string prefix that is not a path boundary is not an overlap.
     expect(() => assertNoRegrantOverlap(['/tmp/wt-other'], ['/tmp/wt'])).not.toThrow();
+  });
+
+  it('refuses runtime-state grants that contain HOME, data, or session roots', () => {
+    expect(() => assertNarrowRuntimeStateRegrants(
+      ['/Users/op'],
+      ['/Users/op', '/Users/op/.o8', '/Users/op/.o8/owned/session-1'],
+    )).toThrow(SandboxUnavailableError);
+    expect(() => assertNarrowRuntimeStateRegrants(
+      ['/Users/op/.o8'],
+      ['/Users/op', '/Users/op/.o8', '/Users/op/.o8/owned/session-1'],
+    )).toThrow(SandboxUnavailableError);
+    expect(() => assertNarrowRuntimeStateRegrants(
+      ['/Users/op/.o8/owned/session-1'],
+      ['/Users/op', '/Users/op/.o8', '/Users/op/.o8/owned/session-1'],
+    )).toThrow(SandboxUnavailableError);
+    expect(() => assertNarrowRuntimeStateRegrants(
+      ['/Users/op/.o8/owned/session-1/claude-code-worker-config'],
+      ['/Users/op', '/Users/op/.o8', '/Users/op/.o8/owned/session-1'],
+    )).not.toThrow();
+    expect(() => assertNarrowRuntimeStateRegrants(
+      ['relative/runtime-state'],
+      ['/Users/op'],
+    )).toThrow(SandboxUnavailableError);
+  });
+
+  it.skipIf(!isDarwin)('refuses a symlinked runtime-state grant that resolves to the session root', async () => {
+    const root = tmpRoot('o8-sbx-runtime-state-link-');
+    const home = path.join(root, 'home');
+    const worktree = path.join(home, 'repo');
+    const sessionDir = path.join(root, 'data', 'owned', 'session-1');
+    const profileDir = path.join(sessionDir, 'runs');
+    const configLink = path.join(sessionDir, 'claude-code-worker-config');
+    mkdirSync(worktree, { recursive: true });
+    mkdirSync(profileDir, { recursive: true });
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: worktree });
+    symlinkSync(sessionDir, configLink, 'dir');
+
+    await expect(prepareWorkerSandbox({
+      runId: 'symlink-runtime-state',
+      profileDir,
+      cwd: worktree,
+      repoPath: worktree,
+      binary: '/bin/sh',
+      args: [],
+      homeDir: home,
+      enforceReadOnly: true,
+      finalAllowReadWritePaths: [configLink],
+    })).rejects.toBeInstanceOf(SandboxUnavailableError);
+  });
+
+  it.skipIf(!isDarwin)('denies creation of missing policy files beneath a symlinked state root', async () => {
+    const root = tmpRoot('o8-sbx-missing-policy-');
+    const worktree = path.join(root, 'repo');
+    const config = path.join(root, 'session', 'config');
+    const alias = path.join(root, 'state-alias');
+    const profileDir = path.join(root, 'session', 'runs');
+    mkdirSync(worktree);
+    mkdirSync(config, { recursive: true });
+    mkdirSync(profileDir);
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: worktree });
+    symlinkSync(config, alias, 'dir');
+    const protectedFiles = ['settings.json', path.join('hooks', 'guard.js')];
+    const prepared = await prepareWorkerSandbox({
+      runId: 'missing-policy', profileDir, cwd: worktree, repoPath: worktree,
+      binary: '/bin/sh', args: [], enforceReadOnly: true,
+      finalAllowReadWritePaths: [alias],
+      finalImmutableWritePaths: protectedFiles.map((file) => path.join(alias, file)),
+    });
+    for (const file of protectedFiles) {
+      expect(existsSync(path.join(config, file))).toBe(false);
+      const canonical = path.join(realpathSync(config), file);
+      expect(prepared.profileText).toContain(`(literal "${canonical}")`);
+      for (const configRoot of [alias, config]) {
+        const destination = path.join(configRoot, file);
+        expect(() => execFileSync(SANDBOX_EXEC_PATH, [
+          '-f', prepared.profilePath, '/bin/sh', '-c',
+          `mkdir -p ${JSON.stringify(path.dirname(destination))} && printf blocked > ${JSON.stringify(destination)}`,
+        ], { stdio: 'ignore' })).toThrow();
+        expect(existsSync(path.join(config, file))).toBe(false);
+      }
+    }
+    // Ordinary scratch remains writable beneath the same prepared state root.
+    const scratch = path.join(alias, 'scratch.json');
+    execFileSync(SANDBOX_EXEC_PATH, [
+      '-f', prepared.profilePath, '/bin/sh', '-c', `printf allowed > ${JSON.stringify(scratch)}`,
+    ]);
+    expect(readFileSync(scratch, 'utf8')).toBe('allowed');
+
+    const dangling = path.join(root, 'dangling-state');
+    symlinkSync(path.join(root, 'future-state'), dangling, 'dir');
+    await expect(prepareWorkerSandbox({
+      runId: 'dangling-policy', profileDir, cwd: worktree, repoPath: worktree,
+      binary: '/bin/sh', args: [], enforceReadOnly: true,
+      finalAllowReadWritePaths: [dangling],
+    })).rejects.toBeInstanceOf(SandboxUnavailableError);
   });
 
   it.skipIf(!isDarwin)('refuses a read-only launch when the git probe resolves nothing', async () => {

--- a/src/lib/runtimes/shared/owned-session/sandbox.ts
+++ b/src/lib/runtimes/shared/owned-session/sandbox.ts
@@ -28,12 +28,13 @@
  * caller refuses to spawn rather than silently running the worker unsandboxed.
  */
 
-import { realpath, writeFile } from 'node:fs/promises';
+import { lstat, realpath, writeFile } from 'node:fs/promises';
 import { access, constants as fsConstants } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import os from 'node:os';
 import path from 'node:path';
+import { backingProjectConfigPaths } from './project-config';
 
 const execFileAsync = promisify(execFile);
 
@@ -72,12 +73,28 @@ function regexFragment(value: string): string {
   return value.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&').replace(/"/g, '\\"');
 }
 
-/** best-effort realpath; falls back to the input when it doesn't resolve yet. */
+/** Resolve existing ancestors too, so missing policy files retain canonical denials. */
 async function safeRealpath(p: string): Promise<string> {
-  try {
-    return await realpath(p);
-  } catch {
-    return p;
+  let current = path.resolve(p);
+  const missing: string[] = [];
+  for (;;) {
+    try {
+      return path.join(await realpath(current), ...missing);
+    } catch (error) {
+      const parent = path.dirname(current);
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT' || parent === current) {
+        throw new SandboxUnavailableError(`Cannot resolve sandbox policy path '${p}'.`);
+      }
+      // A dangling symlink is not a missing tail: its eventual target could
+      // differ from this lexical path. Refuse it instead of guessing a grant.
+      const existing = await lstat(current).catch((statError: NodeJS.ErrnoException) => {
+        if (statError.code === 'ENOENT') return null;
+        throw new SandboxUnavailableError(`Cannot inspect sandbox policy path '${p}'.`);
+      });
+      if (existing) throw new SandboxUnavailableError(`Unresolved sandbox policy path '${p}'.`);
+      missing.unshift(path.basename(current));
+      current = parent;
+    }
   }
 }
 
@@ -112,6 +129,27 @@ export function assertNoRegrantOverlap(
         throw new SandboxUnavailableError(
           `Sandbox policy conflict: '${allowed}' is re-opened for writes while '${denied}' is `
           + 'write-denied. Refusing to build a profile whose allow and deny sets overlap.',
+        );
+      }
+    }
+  }
+}
+
+/** Refuse a runtime-state allow that resolves to a protected parent root. */
+export function assertNarrowRuntimeStateRegrants(
+  allowedPaths: string[],
+  protectedRoots: string[],
+): void {
+  for (const allowed of allowedPaths) {
+    if (!path.isAbsolute(allowed)) {
+      throw new SandboxUnavailableError(
+        `Sandbox runtime state path '${allowed}' is not absolute. Refusing an ambiguous regrant.`,
+      );
+    }
+    for (const protectedRoot of protectedRoots) {
+      if (pathIsWithin(protectedRoot, allowed)) {
+        throw new SandboxUnavailableError(
+          `Sandbox runtime state path '${allowed}' would re-open protected root '${protectedRoot}'.`,
         );
       }
     }
@@ -501,6 +539,8 @@ export interface PrepareWorkerSandboxInput {
   extraReadWritePaths?: string[];
   /** Extra read-only roots (e.g. node runtime dir, CLI binary dir). */
   extraReadPaths?: string[];
+  /** Read only the linked checkout's exact backing project configuration. */
+  readBackingProjectConfig?: boolean;
   extraDenyPaths?: string[];
   trustedReadWritePaths?: string[];
   finalDenyPaths?: string[];
@@ -600,6 +640,9 @@ export async function prepareWorkerSandbox(input: PrepareWorkerSandboxInput): Pr
     path.join(homeReal, '.cortex-ide'),
     ...configuredDataDirs,
   ]);
+  const projectConfigPaths = input.readBackingProjectConfig
+    ? await backingProjectConfigPaths(gitPaths, worktreeReal, [homeReal, ...dataSecretRoots])
+    : [];
   const workspacePaths = await resolveAll([
     input.cwd,
     worktreeReal,
@@ -638,9 +681,23 @@ export async function prepareWorkerSandbox(input: PrepareWorkerSandboxInput): Pr
   const readOnlyDenyWrite = input.enforceReadOnly
     ? workspacePaths
     : [];
-  const finalImmutableWrite = await resolveAll(input.finalImmutableWritePaths ?? []);
-  const finalAllowRead = await resolveAll(input.finalAllowReadPaths ?? []);
+  const finalImmutableWrite = await resolveAll([
+    ...(input.finalImmutableWritePaths ?? []), ...projectConfigPaths,
+  ]);
+  const finalAllowRead = await resolveAll([
+    ...(input.finalAllowReadPaths ?? []), ...projectConfigPaths,
+  ]);
   const finalAllowExec = await resolveAll(input.finalAllowExecPaths ?? []);
+
+  // Runtime state may live inside the denied o8 data tree, but its grant must
+  // stay narrower than HOME, any data root, and the session metadata root.
+  // resolveAll includes symlink targets, so an apparently narrow symlink cannot
+  // re-open one of those parents after canonicalisation.
+  assertNarrowRuntimeStateRegrants(finalAllowReadWrite, await resolveAll([
+    homeReal,
+    ...dataSecretRoots,
+    path.dirname(input.profileDir),
+  ]));
 
   // Order alone already keeps the read-only denial authoritative. This refuses
   // the launch outright when a caller ALSO tries to re-open something inside

--- a/src/lib/runtimes/shared/owned-session/store-child-exit.test.ts
+++ b/src/lib/runtimes/shared/owned-session/store-child-exit.test.ts
@@ -83,6 +83,118 @@ describe('createOwnedSessionStore child exit recording', () => {
     expect(run.childExit?.stderrTail).toContain('rmcp session-delete 404');
   }, 20_000);
 
+  it('persists provider failure truth when the real child exits zero', async () => {
+    const [{ createLane, getLaneEvents }, { createOwnedSessionStore }] = await Promise.all([
+      import('@/lib/lane/registry'),
+      import('./store'),
+    ]);
+    const lane = createLane({
+      repoPath,
+      branch: 'main',
+      runtime: 'claude-code',
+      label: 'provider error child exit',
+    });
+    const store = createOwnedSessionStore(testAdapter('provider-error'));
+
+    const launched = await store.launch({
+      cwd: repoPath,
+      prompt: 'provider exits zero with an error result',
+      laneId: lane.id,
+    });
+    const session = await waitForRecordedExit(launched.surfaceId);
+    const event = await waitForLaneEvent(lane.id, 'runtime_process_exit', getLaneEvents);
+
+    expect(session.recentRuns[0]).toMatchObject({
+      outcome: 'failed',
+      childExit: { code: 0, classification: 'clean-exit' },
+    });
+    expect(event.payload).toMatchObject({
+      exitCode: 0,
+      classification: 'clean-exit',
+      runtimeOutcome: 'failed',
+      completedTurn: false,
+      providerFailure: { subtype: 'success', message: 'Not logged in' },
+    });
+  }, 20_000);
+
+  it('reconciles a stored successful bridge run through tail and review using provider failure', async () => {
+    const { createOwnedSessionStore } = await import('./store');
+    const { deriveRunOutcome } = await import('./helpers');
+    const adapter = testAdapter('provider-error');
+    const store = createOwnedSessionStore(adapter);
+    const surfaceId = 'test-child-provider-error:bridge-failure';
+    await writeSession(surfaceId, 'bridge-failure');
+    const sessionPath = path.join(process.env.O8_TEST_CHILD_EXIT_ROOT!, 'bridge-failure', 'session.json');
+    const session = JSON.parse(await readFile(sessionPath, 'utf8')) as OwnedSessionRecord;
+    const run = session.recentRuns[0];
+    run.outcome = 'finished';
+    run.detachMode = 'bridge';
+    run.childExit = { code: 0, signal: null, classification: 'clean-exit' };
+    session.updatedAt = new Date().toISOString();
+    session.activeRun = undefined;
+    await writeFile(run.stdoutPath, '{"is_error":true}\n');
+    await writeFile(sessionPath, JSON.stringify(session));
+    const parsed = adapter.parseRunLog('{"is_error":true}', run);
+    expect(deriveRunOutcome(run, { ...parsed, completedTurn: true }, '', [])).toBe('failed');
+    expect(deriveRunOutcome({ ...run, outcome: 'interrupted' }, parsed, '', [])).toBe('interrupted');
+    expect(deriveRunOutcome({ ...run, interruptRequestedAt: new Date().toISOString() }, parsed, '', [])).toBe('interrupted');
+    expect((await store.getRuntimeTail(surfaceId)).groups[0]?.outcome).toBe('failed');
+    expect((await store.getReviewPacket(surfaceId)).lastRun?.outcome).toBe('failed');
+    const persisted = JSON.parse(await readFile(sessionPath, 'utf8')) as OwnedSessionRecord;
+    expect(persisted.recentRuns[0].outcome).toBe('failed');
+  });
+
+  it.each([false, true])('refuses a missing terminal result after child exit (warm transcript cache: %s)', async (warmCache) => {
+    const [{ createLane, getLaneEvents }, { createOwnedSessionStore }, { claudeCodeOwnedAdapter }] = await Promise.all([
+      import('@/lib/lane/registry'), import('./store'), import('@/lib/claude-code/owned'),
+    ]);
+    const lane = createLane({ repoPath, branch: 'main', runtime: 'claude-code' });
+    const stream = [
+      { type: 'assistant', message: { content: [{ type: 'text', text: 'partial work' }] } },
+      { type: 'message_stop' }, { type: 'system', subtype: 'compact_boundary' },
+    ].map((event) => JSON.stringify(event)).join('\n') + '\n';
+    const readyPath = path.join(tempRoot, 'stream-ready');
+    const releasePath = path.join(tempRoot, 'release-child');
+    const script = `
+      const fs = require('node:fs');
+      process.stdout.write(${JSON.stringify(stream)}, () => {
+        fs.writeFileSync(${JSON.stringify(readyPath)}, 'ready');
+        setInterval(() => {
+          if (fs.existsSync(${JSON.stringify(releasePath)})) process.exit(0);
+        }, 10);
+        setTimeout(() => process.exit(3), 8000);
+      });
+    `;
+    const parseRunLog = vi.fn(claudeCodeOwnedAdapter.parseRunLog);
+    const store = createOwnedSessionStore({
+      ...testAdapter('provider-error'),
+      launchArgs: () => ['-e', script],
+      parseRunLog,
+    });
+    const launched = await store.launch({ cwd: repoPath, prompt: 'synthetic missing result', laneId: lane.id });
+    try {
+      await vi.waitFor(async () => expect(await readFile(readyPath, 'utf8')).toBe('ready'), { timeout: 3000 });
+      if (warmCache) {
+        const tail = await store.getRuntimeTail(launched.surfaceId);
+        expect(tail.groups[0]?.entries.some((entry) => entry.text === 'partial work')).toBe(true);
+        const parseCount = parseRunLog.mock.calls.length;
+        await store.getRuntimeTail(launched.surfaceId);
+        expect(parseRunLog).toHaveBeenCalledTimes(parseCount);
+      }
+    } finally {
+      await writeFile(releasePath, 'exit without further output');
+      await waitForRecordedExit(launched.surfaceId);
+    }
+    const session = await waitForRecordedExit(launched.surfaceId);
+    const event = await waitForLaneEvent(lane.id, 'runtime_process_exit', getLaneEvents);
+    expect(session.recentRuns[0]).toMatchObject({ outcome: 'failed', childExit: { code: 0 } });
+    expect(event.payload).toMatchObject({
+      runtimeOutcome: 'failed', completedTurn: false, providerFailure: { subtype: 'missing_result' },
+    });
+    expect(parseRunLog.mock.calls.some(([raw, run]) => raw === stream && run.childExit?.code === 0)).toBe(true);
+    expect((await store.getRuntimeTail(launched.surfaceId)).groups[0]?.outcome).toBe('failed');
+  }, 20_000);
+
   it.skipIf(process.platform !== 'darwin')('persists a readable lane event from a real sandbox-exec denial', async () => {
     const deniedPath = path.join(tempRoot, 'outside-packet.txt');
     await writeFile(deniedPath, 'must stay outside the packet\n', 'utf8');
@@ -166,6 +278,72 @@ describe('createOwnedSessionStore child exit recording', () => {
     await expect(access(path.join(`${process.env.O8_TEST_CHILD_EXIT_ROOT!}-archive`, 'orphan-active', 'session.json'))).resolves.toBeUndefined();
   });
 
+  it.each([false, true])('does not persist quoted source as a denial (failed child: %s)', async (failed) => {
+    const [{ createLane, getLaneEvents }, { createOwnedSessionStore }] = await Promise.all([
+      import('@/lib/lane/registry'), import('./store'),
+    ]);
+    const surfaceId = 'test-child-exit-1:quoted-source';
+    await writeSession(surfaceId, 'quoted-source');
+    const sessionPath = path.join(process.env.O8_TEST_CHILD_EXIT_ROOT!, 'quoted-source', 'session.json');
+    const session = JSON.parse(await readFile(sessionPath, 'utf8')) as OwnedSessionRecord;
+    const lane = createLane({ repoPath, branch: 'main', runtime: 'claude-code' });
+    session.laneId = lane.id;
+    session.createdAt = new Date().toISOString();
+    session.updatedAt = session.createdAt;
+    session.activeRun = undefined;
+    session.recentRuns[0].sandboxed = true;
+    session.recentRuns[0].childExit = {
+      code: failed ? 1 : 0, signal: null, classification: failed ? 'nonzero-exit' : 'clean-exit',
+    };
+    await writeFile(session.recentRuns[0].stdoutPath, JSON.stringify({
+      type: 'user', message: { content: [{ type: 'tool_result', is_error: false,
+        content: '(deny file-read* file-write* ' + 'quoted source '.repeat(1200)
+          + '\ncat: /example/secret: Operation not permitted',
+      }] },
+    }) + '\n');
+    await writeFile(sessionPath, JSON.stringify(session));
+    const store = createOwnedSessionStore(testAdapter('exit-1'));
+    await store.getRuntimeTail(surfaceId);
+    await store.getReviewPacket(surfaceId);
+    const persisted = JSON.parse(await readFile(sessionPath, 'utf8')) as OwnedSessionRecord;
+    expect(persisted.recentRuns[0].sandboxDenial).toBeUndefined();
+    expect(persisted.latestSummary).not.toContain('sandbox blocked');
+    expect(getLaneEvents(lane.id, 50).filter((event) => event.verb === 'sandbox_denied')).toEqual([]);
+  });
+
+  it.each(['stderr', 'failed-tool'] as const)('persists an actual %s denial once through tail and review', async (source) => {
+    const [{ createLane, getLaneEvents }, { createOwnedSessionStore }, { claudeCodeOwnedAdapter }] = await Promise.all([
+      import('@/lib/lane/registry'), import('./store'), import('@/lib/claude-code/owned'),
+    ]);
+    const surfaceId = 'test-child-exit-1:actual-denial';
+    await writeSession(surfaceId, 'actual-denial');
+    const sessionPath = path.join(process.env.O8_TEST_CHILD_EXIT_ROOT!, 'actual-denial', 'session.json');
+    const session = JSON.parse(await readFile(sessionPath, 'utf8')) as OwnedSessionRecord;
+    const lane = createLane({ repoPath, branch: 'main', runtime: 'claude-code' });
+    session.laneId = lane.id;
+    session.createdAt = new Date().toISOString();
+    session.updatedAt = session.createdAt;
+    session.activeRun = undefined;
+    session.recentRuns[0].sandboxed = true;
+    session.recentRuns[0].childExit = { code: 0, signal: null, classification: 'clean-exit' };
+    const diagnostic = 'cat: /example/secret: Operation not permitted';
+    const success = JSON.stringify({ type: 'result', subtype: 'success', is_error: false, result: 'Recovered' });
+    await writeFile(session.recentRuns[0].stderrPath, source === 'stderr' ? diagnostic : '');
+    await writeFile(session.recentRuns[0].stdoutPath, (source === 'failed-tool' ? JSON.stringify({
+      type: 'user', message: { content: [{ type: 'tool_result', is_error: true, content: diagnostic }] },
+    }) + '\n' : '') + success + '\n');
+    await writeFile(sessionPath, JSON.stringify(session));
+    const store = createOwnedSessionStore({ ...testAdapter('exit-1'), runtimeId: 'claude-code',
+      parseRunLog: claudeCodeOwnedAdapter.parseRunLog });
+    await store.getRuntimeTail(surfaceId);
+    await store.getReviewPacket(surfaceId);
+    const persisted = JSON.parse(await readFile(sessionPath, 'utf8')) as OwnedSessionRecord;
+    expect(persisted.recentRuns[0]).toMatchObject({ outcome: 'finished',
+      sandboxDenial: { operation: 'file-read', resource: '/example/secret' } });
+    expect(persisted.latestSummary).not.toContain('worker stopped');
+    expect(getLaneEvents(lane.id, 50).filter((event) => event.verb === 'sandbox_denied')).toHaveLength(1);
+  });
+
   it('keeps an old active owned session when a lane references its surface id', async () => {
     const { createOwnedSessionStore } = await import('./store');
     const store = createOwnedSessionStore(testAdapter('exit-1'));
@@ -177,7 +355,7 @@ describe('createOwnedSessionStore child exit recording', () => {
   });
 });
 
-function testAdapter(kind: 'exit-1' | 'sigkill' | 'sandbox-denial'): OwnedRuntimeAdapter {
+function testAdapter(kind: 'exit-1' | 'sigkill' | 'sandbox-denial' | 'provider-error'): OwnedRuntimeAdapter {
   return {
     runtimeId: `test-child-${kind}`,
     surfaceIdPrefix: `test-child-${kind}:`,
@@ -193,18 +371,27 @@ function testAdapter(kind: 'exit-1' | 'sigkill' | 'sandbox-denial'): OwnedRuntim
     resumeArgs: () => kind === 'sandbox-denial'
       ? [process.env.O8_TEST_SANDBOX_DENIED_PATH ?? '/missing-denial-path']
       : ['-e', childScript(kind)],
-    parseRunLog: (): ParsedRunLog => ({
-      entries: [],
-      outcome: 'running',
-      completedTurn: false,
-    }),
+    parseRunLog: (raw): ParsedRunLog => raw.includes('"is_error":true')
+      ? {
+          entries: [{ id: 'partial', kind: 'message', label: 'assistant', text: 'partial provider response' }],
+          outcome: 'failed',
+          completedTurn: false,
+          providerFailure: { subtype: 'success', message: 'Not logged in' },
+        }
+      : { entries: [], outcome: 'running', completedTurn: false },
   };
 }
 
-function childScript(kind: 'exit-1' | 'sigkill') {
+function childScript(kind: 'exit-1' | 'sigkill' | 'provider-error') {
   const stderrLine = 'rmcp session-delete 404 from fake child\\n';
   if (kind === 'exit-1') {
     return `process.stderr.write(${JSON.stringify(stderrLine)}); process.exit(1);`;
+  }
+  if (kind === 'provider-error') {
+    const result = JSON.stringify({
+      type: 'result', subtype: 'success', is_error: true, result: 'Not logged in',
+    });
+    return `process.stdout.write(${JSON.stringify(`${result}\n`)}); process.exit(0);`;
   }
   return `process.stderr.write(${JSON.stringify(stderrLine)}); process.stderr.write('', () => process.kill(process.pid, 'SIGKILL'));`;
 }

--- a/src/lib/runtimes/shared/owned-session/store-completion-push.test.ts
+++ b/src/lib/runtimes/shared/owned-session/store-completion-push.test.ts
@@ -190,7 +190,7 @@ describe('#1523 — clean child exit pushes completion to the supervisor', () =>
       fetchTranscript: vi.fn(async () => []),
       steerAgent: vi.fn(async () => undefined),
       interruptAgent: vi.fn(async () => undefined),
-      relaunchAgent: vi.fn(async () => null),
+      relaunchAgent: vi.fn(async () => ({ status: 'held' as const, reason: 'test hold' })),
       broadcastAgentUpdate: vi.fn(),
       queueOrchestratorEscalation: vi.fn(),
       onAgentCompletion,
@@ -228,7 +228,7 @@ describe('#1523 — clean child exit pushes completion to the supervisor', () =>
       fetchTranscript: vi.fn(async () => []),
       steerAgent: vi.fn(async () => undefined),
       interruptAgent: vi.fn(async () => undefined),
-      relaunchAgent: vi.fn(async () => null),
+      relaunchAgent: vi.fn(async () => ({ status: 'held' as const, reason: 'test hold' })),
       broadcastAgentUpdate,
       queueOrchestratorEscalation: vi.fn(),
       onAgentCompletion: vi.fn(async () => ({

--- a/src/lib/runtimes/shared/owned-session/types.ts
+++ b/src/lib/runtimes/shared/owned-session/types.ts
@@ -201,6 +201,11 @@ export interface ParsedRunLog {
   entries: OwnedTailEntry[];
   outcome: OwnedRunOutcome;
   completedTurn: boolean;
+  /** Structured terminal failure reported by the provider despite a clean process exit. */
+  providerFailure?: {
+    subtype?: string;
+    message?: string;
+  };
   turnContextUsage?: LaneTurnContextUsage;
 }
 

--- a/src/lib/supervisor/agent-supervisor-types.ts
+++ b/src/lib/supervisor/agent-supervisor-types.ts
@@ -67,7 +67,7 @@ export interface SupervisorCallbacks {
   fetchTranscript(sessionKey: string, limit: number): Promise<TranscriptEntry[]>;
   steerAgent(surfaceId: string, message: string): Promise<void>;
   interruptAgent(surfaceId: string): Promise<void>;
-  relaunchAgent(prompt: string, repoPath: string, taskName: string, retryOfSurfaceId?: string): Promise<string | null>;
+  relaunchAgent(prompt: string, repoPath: string, taskName: string, retryOfSurfaceId?: string): Promise<SupervisorRelaunchResult>;
   broadcastAgentUpdate(update: AgentUpdateEvent): void;
   queueOrchestratorEscalation(repoPath: string, message: string): void;
   onAgentProgress?: (surfaceId: string, lastMessage: string) => void;
@@ -77,6 +77,10 @@ export interface SupervisorCallbacks {
   ) => Promise<AgentCompletionDecision | void> | AgentCompletionDecision | void;
   onAgentRetry?: (oldSurfaceId: string, newSurfaceId: string) => void;
 }
+
+export type SupervisorRelaunchResult =
+  | { status: 'launched'; surfaceId: string }
+  | { status: 'held'; reason: string };
 
 export interface SupervisorFleetStatusSummary {
   repoPath: string;

--- a/src/lib/supervisor/agent-supervisor.ts
+++ b/src/lib/supervisor/agent-supervisor.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { getSqlite } from '@/lib/db';
 import type { WorkerLaunchContext } from '@/lib/orchestrator/types';
+import { retryWatchedAgent } from './retry-watched-agent';
 import type {
   AgentStatusEntry,
   SupervisorCallbacks,
@@ -422,6 +423,10 @@ async function pollWatchedAgent(
   now: number,
 ): Promise<void> {
   watched.lastPolledAt = now;
+  if (watched.completionReported) {
+    scheduleNextAgentPoll(watched, watched.lastStatus, watched.lastRuntimeStatus, now);
+    return;
+  }
   watched.lastRuntimeStatus = runtimeAgent?.status ?? null;
 
   const currentStatus = resolveStatus(runtimeAgent, watched, now);
@@ -644,31 +649,10 @@ async function handleStatusChange(
 
   if (status === 'failed') {
     if (watched.retryCount < MAX_RETRIES) {
-      watched.retryCount += 1;
-      recordWatchedAgentEvent(watched, now);
-      persistWatchedAgent(watched);
-      console.log(`[supervisor] Auto-retrying "${watched.name}" (attempt ${watched.retryCount})`);
-
-      callbacks.broadcastAgentUpdate({
-        surfaceId: watched.surfaceId,
-        name: watched.name,
-        status: 'retrying',
-        detail: `Agent "${watched.name}" failed — auto-retrying (attempt ${watched.retryCount})`,
-      });
-
-      try {
-        const newSurfaceId = await callbacks.relaunchAgent(
-          watched.prompt,
-          watched.repoPath,
-          `${watched.name} (retry ${watched.retryCount})`,
-          // #1292 ROOT — hand the failing session's key so the relaunch reuses
-          // its lane (existingLaneId) instead of auto-wrapping a fresh sibling.
-          watched.surfaceId,
-        );
-        if (newSurfaceId) {
-          // Update lane session binding so the new agent is tracked
-          callbacks.onAgentRetry?.(watched.surfaceId, newSurfaceId);
-
+      await retryWatchedAgent(watched, callbacks, {
+        persist: persistWatchedAgent,
+        scheduleCleanup: () => setTimeout(() => unregisterWatchedAgent(watched.surfaceId), COMPLETION_CLEANUP_MS),
+        replace(newSurfaceId) {
           watchedAgents.delete(watched.surfaceId);
           transcriptSourceCache.delete(watched.surfaceId);
           removePersistedAgent(watched.surfaceId);
@@ -680,10 +664,8 @@ async function handleStatusChange(
             newWatched.steerCount = watched.steerCount;
             persistWatchedAgent(newWatched);
           }
-        }
-      } catch (err) {
-        console.error(`[supervisor] Retry failed for "${watched.name}":`, err);
-      }
+        },
+      });
     } else {
       watched.completionReported = true;
       recordWatchedAgentEvent(watched, now);

--- a/src/lib/supervisor/post-completion-packet.ts
+++ b/src/lib/supervisor/post-completion-packet.ts
@@ -110,3 +110,16 @@ export function transitionPostCompletionLaneToReviewing(
   const lane = setLaneStatus(laneId, 'reviewing', 'system', 'agent_completed');
   return { lane, packetId };
 }
+
+/** Hold failed turns for input; partial work has not passed completion verification. */
+export function transitionFailedPostCompletionLane(
+  laneId: string,
+  hasReviewableWork: boolean,
+): Lane | null {
+  return setLaneStatus(
+    laneId,
+    'awaiting_input',
+    'system',
+    hasReviewableWork ? 'agent_failed_work_present' : 'agent_failed',
+  );
+}

--- a/src/lib/supervisor/process-cwd-budget-real-path.test.ts
+++ b/src/lib/supervisor/process-cwd-budget-real-path.test.ts
@@ -147,7 +147,7 @@ function supervisorCallbacks() {
     async fetchTranscript() { return []; },
     async steerAgent() {},
     async interruptAgent() {},
-    async relaunchAgent() { return null; },
+    async relaunchAgent() { return { status: 'held' as const, reason: 'test hold' }; },
     broadcastAgentUpdate() {},
     queueOrchestratorEscalation() {},
   };

--- a/src/lib/supervisor/relaunch-agent.ts
+++ b/src/lib/supervisor/relaunch-agent.ts
@@ -1,0 +1,94 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync, realpathSync } from 'node:fs';
+
+import { isClaudeCodeModelSource } from '@/lib/claude-code/worker-profile-types';
+import { findLaneBySession, getLane, updateLane } from '@/lib/lane/registry';
+import { isThinkingEffort } from '@/lib/orchestrator/thinking-effort';
+import type { RuntimeLaunchRequest } from '@/lib/runtime/actions';
+import { ownedRoots } from '@/lib/runtimes/shared/owned-session-index';
+import { createOwnedSessionIo } from '@/lib/runtimes/shared/owned-session/session-io';
+import { fetchRuntimeLaunch } from '@/lib/ws-server/next-fetch';
+import type { SupervisorRelaunchResult } from './agent-supervisor-types';
+
+/** Retry from durable launch facts, never the current operator defaults. */
+export async function relaunchSupervisedAgent(
+  prompt: string,
+  repoPath: string,
+  taskName: string,
+  retryOfSurfaceId?: string,
+): Promise<SupervisorRelaunchResult> {
+  const lane = retryOfSurfaceId ? findLaneBySession(retryOfSurfaceId) : null;
+  if (!lane || !retryOfSurfaceId) {
+    return { status: 'held', reason: 'Automatic retry held: the original active lane is unavailable.' };
+  }
+  if (!['running', 'recovering'].includes(lane.status)) {
+    return { status: 'held', reason: 'Automatic retry held: the lane is no longer running or recovering.' };
+  }
+  const hold = (reason: string): SupervisorRelaunchResult => {
+    const note = `Automatic retry held: ${reason}. Use an explicit governed retry.`;
+    const current = getLane(lane.id);
+    if (current?.sessionKey === retryOfSurfaceId && current.status === lane.status
+      && current.runtime === lane.runtime && current.worktreePath === lane.worktreePath) {
+      updateLane(lane.id, {
+        status: 'awaiting_input',
+        outcomeNote: note,
+        lastEventLabel: 'supervisor_retry_held',
+        lastEventAt: new Date().toISOString(),
+      }, 'system', { reason: 'supervisor_retry_held', note });
+    }
+    return { status: 'held', reason: note };
+  };
+  const runtime = lane.runtime;
+  if ((runtime !== 'codex' && runtime !== 'claude-code')
+    || !retryOfSurfaceId.startsWith(`${runtime}-owned:`)) {
+    return hold('the original runtime and session identity disagree');
+  }
+  if (!lane.worktreePath || !existsSync(lane.worktreePath)
+    || realpathSync(lane.worktreePath) === realpathSync(lane.repoPath)
+    || realpathSync(repoPath) !== realpathSync(lane.repoPath)) {
+    return hold('the original isolated worktree is unavailable');
+  }
+  const root = ownedRoots().find((entry) => entry.marker === `${runtime}-owned:`);
+  if (!root) return hold('the original runtime storage is unavailable');
+  const io = createOwnedSessionIo({
+    root: root.root, surfacePrefix: root.marker, invalidateFleetCache: () => {},
+  });
+  const session = await io.findSession(retryOfSurfaceId).catch(() => null);
+  if (!session || session.laneId !== lane.id || session.packetId !== (lane.packetId ?? undefined)
+    || session.cwd !== lane.worktreePath || session.activeRun) {
+    return hold('the original stopped session cannot be verified');
+  }
+  const model = session.model?.trim();
+  if (!model || !isThinkingEffort(session.effort)) {
+    return hold('the saved model or reasoning effort is missing');
+  }
+  const carrier = session.runtimeConfig?.modelSource;
+  if (runtime === 'claude-code' && !isClaudeCodeModelSource(carrier)) {
+    return hold('the saved execution carrier is missing');
+  }
+  // A fresh session would reset its spend counter. Never grant the same packet
+  // another full budget without an explicit remaining-budget decision.
+  if (carrier === 'openrouter') return hold('metered retries need a remaining-budget decision');
+
+  // An operator stop or rebind during the asynchronous read wins over retry.
+  const current = getLane(lane.id);
+  if (!current || current.sessionKey !== retryOfSurfaceId || current.runtime !== runtime
+    || current.status !== lane.status || current.worktreePath !== lane.worktreePath) {
+    return { status: 'held', reason: 'Automatic retry held: the lane changed while reading launch state.' };
+  }
+  const clientMutationId = randomUUID();
+  const launchBody: RuntimeLaunchRequest & { clientMutationId: string } = {
+    runtime, prompt, taskName, model, effort: session.effort,
+    ...(runtime === 'claude-code' && isClaudeCodeModelSource(carrier)
+      ? { claudeCodeModel: model, claudeCodeCarrier: carrier } : {}),
+    workMode: session.runtimeConfig?.workMode === 'read-only' ? 'read-only' : undefined,
+    repoPath: lane.worktreePath, cwd: lane.worktreePath, projectRepoPath: lane.repoPath,
+    branchName: lane.branch, baseBranch: lane.baseBranch,
+    isolate: false, skipSetup: true, existingLaneId: lane.id,
+    packetId: lane.packetId ?? undefined, clientMutationId,
+  };
+  const result = await fetchRuntimeLaunch(launchBody);
+  return result.surfaceId
+    ? { status: 'launched', surfaceId: result.surfaceId }
+    : hold('the launch did not return an accepted session');
+}

--- a/src/lib/supervisor/retry-watched-agent.ts
+++ b/src/lib/supervisor/retry-watched-agent.ts
@@ -1,0 +1,46 @@
+import type { SupervisorCallbacks, SupervisorRelaunchResult, WatchedAgent } from './agent-supervisor-types';
+
+/** Count and announce only accepted launches; a hold ends automatic supervision. */
+export async function retryWatchedAgent(
+  watched: WatchedAgent,
+  callbacks: SupervisorCallbacks,
+  state: {
+    persist(agent: WatchedAgent): void;
+    replace(surfaceId: string): void;
+    scheduleCleanup(): void;
+  },
+): Promise<void> {
+  // Reserve this transition before awaiting launch, including against completion pushes.
+  watched.completionReported = true;
+  watched.lastEventAt = Date.now();
+  state.persist(watched);
+  let result: SupervisorRelaunchResult;
+  try {
+    result = await callbacks.relaunchAgent(
+      watched.prompt, watched.repoPath,
+      `${watched.name} (retry ${watched.retryCount + 1})`, watched.surfaceId,
+    );
+  } catch {
+    // An uncertain launch is not permission to retry again or expose raw provider output.
+    result = { status: 'held', reason: 'Automatic retry held: launch acceptance could not be confirmed. Check the lane before retrying.' };
+  }
+  watched.lastEventAt = Date.now();
+  if (result.status === 'held') {
+    watched.lastStatus = 'failed';
+    state.persist(watched);
+    callbacks.broadcastAgentUpdate({
+      surfaceId: watched.surfaceId, name: watched.name,
+      status: 'awaiting_input', detail: result.reason,
+    });
+    state.scheduleCleanup();
+    return;
+  }
+  watched.retryCount += 1;
+  state.persist(watched);
+  callbacks.broadcastAgentUpdate({
+    surfaceId: watched.surfaceId, name: watched.name, status: 'retrying',
+    detail: `Agent "${watched.name}" failed; retry ${watched.retryCount} was accepted.`,
+  });
+  callbacks.onAgentRetry?.(watched.surfaceId, result.surfaceId);
+  state.replace(result.surfaceId);
+}

--- a/src/lib/ws-server/next-fetch.test.ts
+++ b/src/lib/ws-server/next-fetch.test.ts
@@ -465,8 +465,9 @@ describe('ws-server runtime action transport', () => {
 
     expect(start).toBeGreaterThanOrEqual(0);
     expect(end).toBeGreaterThan(start);
-    expect(section).toContain('const clientMutationId = randomUUID()');
-    expect(section).toContain('clientMutationId }');
-    expect(section).toContain('fetchRuntimeLaunch(launchBody)');
+    expect(section).toContain('relaunchSupervisedAgent(prompt, repoPath, taskName, retryOfSurfaceId)');
+    const retrySource = readFileSync(join(process.cwd(), 'src/lib/supervisor/relaunch-agent.ts'), 'utf8');
+    expect(retrySource).toContain('const clientMutationId = randomUUID()');
+    expect(retrySource).toContain('fetchRuntimeLaunch(launchBody)');
   });
 });

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -302,7 +302,6 @@ import {
   fetchWithRetry,
   fetchNextJson,
   fetchRuntimeAction,
-  fetchRuntimeLaunch,
 } from './lib/ws-server/next-fetch';
 import {
   decideStalePortRecovery,
@@ -9129,45 +9128,8 @@ async function bootstrapWsServer() {
         });
       },
       async relaunchAgent(prompt, repoPath, taskName, retryOfSurfaceId) {
-        // Packet relaunch must ALWAYS isolate. Without isolate:true, shouldIsolate()
-        // falls through to "active worktree count > 0" — when the original lane's
-        // worktree was archived before relaunch, the check returns false and codex
-        // boots at the main repo root, writing agent changes directly into main.
-        // Every packet needs its own worktree, regardless of fleet state.
-        //
-        // #1292 ROOT — reuse the FAILING session's lane instead of auto-wrapping a
-        // fresh sibling. Without existingLaneId the launch creates a brand-new lane
-        // (actions.ts auto-wrap), so each retry doubled the lane count. The
-        // supervisor's onAgentRetry then rebinds that lane to the new session,
-        // matching the existingLaneId "caller attaches the session" convention.
-        // Degrades gracefully: no match (lane already archived/gone) → undefined →
-        // prior behavior.
-        let existingLaneId: string | undefined;
-        let existingWorktree: string | undefined;
-        if (retryOfSurfaceId) {
-          try {
-            const { findLaneBySession } = await import('@/lib/lane/registry');
-            const lane = findLaneBySession(retryOfSurfaceId);
-            existingLaneId = lane?.id ?? undefined;
-            existingWorktree = lane?.worktreePath ?? undefined;
-          } catch { /* best-effort — fall back to a fresh lane */ }
-        }
-        // #1293 — RESUME the retry IN THE LANE'S EXISTING WORKTREE when it still
-        // exists. The old code always isolated a fresh worktree with the changed
-        // "(retry N)" taskName, which orphaned the prior session's committed work:
-        // the lane kept its original worktree_path while the new session ran in a
-        // disconnected `<task>-retry-N` tree (the silent-exit / retry-worktree
-        // disconnect that left the lane stuck `running`/`failed` and never
-        // reviewing). Reusing the worktree keeps the work in one place and the
-        // lane connected, so the next salvage finalizes it to review. Only
-        // isolate a fresh tree when the original is gone (the archived-worktree
-        // case the original comment guarded against booting at the main repo).
-        const clientMutationId = randomUUID();
-        const launchBody = (existingWorktree && existsSync(existingWorktree))
-          ? { runtime: 'codex', prompt, repoPath: existingWorktree, cwd: existingWorktree, taskName, isolate: false, skipSetup: true, existingLaneId, clientMutationId }
-          : { runtime: 'codex', prompt, repoPath, cwd: repoPath, taskName, isolate: true, existingLaneId, clientMutationId };
-        const data = await fetchRuntimeLaunch(launchBody);
-        return data.surfaceId || null;
+        const { relaunchSupervisedAgent } = await import('@/lib/supervisor/relaunch-agent');
+        return relaunchSupervisedAgent(prompt, repoPath, taskName, retryOfSurfaceId);
       },
       broadcastAgentUpdate(update: AgentUpdateEvent) {
         // #529 — Supervisor/agent lifecycle events go on a dedicated channel,
@@ -9531,7 +9493,10 @@ async function bootstrapWsServer() {
             return;
           }
 
-          setLaneStatus(lane.id, 'awaiting_input', 'system', 'agent_failed');
+          const failedProbe = await probeNoChangesProduced(completionCwd, lane.baseBranch)
+            .catch(() => ({ noChangesProduced: true }));
+          const { transitionFailedPostCompletionLane } = await import('@/lib/supervisor/post-completion-packet');
+          transitionFailedPostCompletionLane(lane.id, !failedProbe.noChangesProduced);
           console.log(`[supervisor] Agent ${surfaceId} failed, lane ${lane.id} -> awaiting_input`);
         } catch (error) {
           console.error('[supervisor] Completion callback failed:', error);

--- a/tests/claude-code-worker-skill-isolation-real-path.test.ts
+++ b/tests/claude-code-worker-skill-isolation-real-path.test.ts
@@ -17,6 +17,8 @@ import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 
 const spawnMock = vi.hoisted(() => vi.fn());
 const authStatusMock = vi.hoisted(() => ({ loggedIn: true }));
+const authProbeEnvMock = vi.hoisted(() => vi.fn());
+const keychainLookupMock = vi.hoisted(() => vi.fn());
 const ensureDispatchBackendReadyMock = vi.hoisted(() => vi.fn(async () => ({
   ready: true,
   reason: 'http_200',
@@ -30,11 +32,13 @@ vi.mock('node:child_process', async (importOriginal) => {
     ...actual,
     execFile: ((file: string, args: string[], options: unknown, callback: (...args: unknown[]) => void) => {
       if (file === '/usr/bin/security') {
+        keychainLookupMock();
         const error = Object.assign(new Error('test keychain item unavailable'), { code: 44 });
         callback(error, '', '');
         return {};
       }
       if (args[0] === 'auth' && args[1] === 'status') {
+        authProbeEnvMock((options as { env?: NodeJS.ProcessEnv }).env);
         callback(null, JSON.stringify({ loggedIn: authStatusMock.loggedIn }), '');
         return {};
       }
@@ -58,13 +62,16 @@ describe('Claude Code worker skill isolation real path', () => {
   let tempRoot: string;
   let repoPath: string;
   let fakeHome: string;
+  let dataDir: string;
+  let ownedRoot: string;
   const listeners = new Map<string, (...args: unknown[]) => void>();
 
   beforeAll(() => {
     tempRoot = mkdtempSync(path.join(os.homedir(), '.tmp-o8-claude-skill-isolation-'));
     fakeHome = path.join(tempRoot, 'operator-home');
     repoPath = path.join(fakeHome, 'repo');
-    const dataDir = path.join(tempRoot, 'data');
+    dataDir = path.join(tempRoot, 'data');
+    ownedRoot = path.join(dataDir, 'owned');
     mkdirSync(dataDir, { recursive: true });
     execFileSync('git', ['init', '-q', '-b', 'main', repoPath]);
     execFileSync('git', [
@@ -94,14 +101,23 @@ describe('Claude Code worker skill isolation real path', () => {
       'CORTEX_IDE_DATA_DIR',
       'CORTEX_IDE_OWNED_CLAUDE_CODE_ROOT',
       'O8_CLAUDE_CODE_BIN',
+      'CLAUDE_CONFIG_DIR',
+      'CLAUDE_SECURESTORAGE_CONFIG_DIR',
+      'ANTHROPIC_API_KEY',
+      'CLAUDE_CODE_OAUTH_TOKEN',
+      'O8_MASTER_KEY',
     ]) {
       priorEnv[key] = process.env[key];
+    }
+    for (const key of ['CLAUDE_CONFIG_DIR', 'CLAUDE_SECURESTORAGE_CONFIG_DIR', 'ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN']) {
+      delete process.env[key];
     }
     process.env.HOME = fakeHome;
     process.env.O8_DATA_DIR = dataDir;
     process.env.CORTEX_IDE_DATA_DIR = dataDir;
-    process.env.CORTEX_IDE_OWNED_CLAUDE_CODE_ROOT = path.join(tempRoot, 'owned');
+    process.env.CORTEX_IDE_OWNED_CLAUDE_CODE_ROOT = ownedRoot;
     process.env.O8_CLAUDE_CODE_BIN = process.execPath;
+    process.env.O8_MASTER_KEY = Buffer.alloc(32, 7).toString('base64url');
 
     spawnMock.mockImplementation(() => {
       const child = {
@@ -173,6 +189,13 @@ describe('Claude Code worker skill isolation real path', () => {
       recoveryCount: 0,
       typecheckAutoRetries: 0,
       orchestratorThreadId: null,
+      launchContext: {
+        source: 'agent',
+        presentation: 'split',
+        repoContext: 'registered',
+        ...(process.platform === 'darwin' ? { workMode: 'read-only' as const } : {}),
+        caller: 'claude-code-worker-skill-isolation-real-path',
+      },
     } as OrchestratorPacket;
     const prompt = await buildPacketPrompt(packet, [], 'main', repoPath);
     await addRepo(repoPath);
@@ -216,9 +239,21 @@ describe('Claude Code worker skill isolation real path', () => {
     expect(prompt).not.toContain('Load a large unrelated reference tree.');
     const contextByTurn = [40_651, 41_024, 41_809, 42_331, 43_007];
     const launchCallStart = spawnMock.mock.calls.length;
+    const { saveNativeWorkerToken } = await import('@/lib/claude-code/worker-token');
+    const dedicatedToken = `sk-ant-oat01-${'synthetic'.repeat(12)}`;
+    if (process.platform === 'darwin') await saveNativeWorkerToken(dedicatedToken);
 
     for (const [turnIndex, contextTokens] of contextByTurn.entries()) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+      delete process.env.CLAUDE_SECURESTORAGE_CONFIG_DIR;
+      const selectedStore = path.join(fakeHome, '.claude');
+      mkdirSync(selectedStore, { recursive: true });
+      const sourceCredentialsPath = path.join(selectedStore, '.credentials.json');
+      writeFileSync(sourceCredentialsPath, JSON.stringify({
+        claudeAiOauth: { accessToken: `synthetic-access-${turnIndex}`, refreshToken: `synthetic-refresh-${turnIndex}` },
+      }));
       const inputTokens = 203 + turnIndex;
+      const providerFailed = turnIndex === contextByTurn.length - 1;
       const result = await dispatchLaneCommand({
         verb: 'launch_session',
         laneId: lane.id,
@@ -232,6 +267,9 @@ describe('Claude Code worker skill isolation real path', () => {
       const configDir = options.env.CLAUDE_CONFIG_DIR as string;
       expect(configDir.startsWith(fakeHome)).toBe(false);
       expect(existsSync(configDir)).toBe(true);
+      const scratchDir = path.join(configDir, 'tmp');
+      expect(options.env.CLAUDE_CODE_TMPDIR).toBe(scratchDir);
+      expect(statSync(scratchDir).mode & 0o777).toBe(0o700);
       expect(existsSync(path.join(configDir, 'skills'))).toBe(false);
       expect(args).toContain('--disable-slash-commands');
       expect(spawnMock.mock.results[spawnCallIndex]?.value.stdin.end).toHaveBeenCalledWith(
@@ -239,26 +277,74 @@ describe('Claude Code worker skill isolation real path', () => {
         'utf8',
       );
 
-      // Native carrier: the isolated config dir must be seeded with a copy of
-      // the operator's real credentials, but never their skills directory.
-      const sourceCredentialsPath = path.join(fakeHome, '.claude', '.credentials.json');
+      // Mac workers receive only the inference token, never a refresh-store copy.
       const seededCredentialsPath = path.join(configDir, '.credentials.json');
-      expect(existsSync(seededCredentialsPath)).toBe(true);
-      expect(readFileSync(seededCredentialsPath, 'utf8')).toBe(readFileSync(sourceCredentialsPath, 'utf8'));
-      expect(statSync(seededCredentialsPath).mode & 0o777).toBe(0o600);
+      if (process.platform === 'darwin') {
+        expect(options.env.CLAUDE_SECURESTORAGE_CONFIG_DIR).toBe(configDir);
+        expect(options.env.CLAUDE_CODE_OAUTH_TOKEN).toBe(dedicatedToken);
+        expect(authProbeEnvMock).not.toHaveBeenCalled();
+        expect(keychainLookupMock).not.toHaveBeenCalled();
+        expect(existsSync(seededCredentialsPath)).toBe(false);
+      } else {
+        expect(readFileSync(seededCredentialsPath, 'utf8')).toBe(readFileSync(sourceCredentialsPath, 'utf8'));
+        expect(statSync(seededCredentialsPath).mode & 0o777).toBe(0o600);
+      }
 
       const surfaceId = getLane(lane.id)?.sessionKey;
       if (!surfaceId) throw new Error(`Turn ${turnIndex + 1} did not attach a session.`);
-      const sessionDir = path.join(tempRoot, 'owned', surfaceId.replace('claude-code-owned:', ''));
+      const sessionDir = path.join(ownedRoot, surfaceId.replace('claude-code-owned:', ''));
+      if (process.platform === 'darwin') {
+        // The real macOS policy must re-open only this prepared config subtree
+        // after the relocated data-root denial. Never print credential content.
+        const { SANDBOX_EXEC_PATH } = await import('@/lib/runtimes/shared/owned-session/sandbox');
+        const sandboxIndex = args.indexOf(SANDBOX_EXEC_PATH);
+        expect(sandboxIndex).toBeGreaterThan(-1);
+        const profilePath = args[sandboxIndex + 2]!;
+        const profile = readFileSync(profilePath, 'utf8');
+        expect(profile.lastIndexOf(`(subpath "${configDir}")`))
+          .toBeGreaterThan(profile.indexOf(`(subpath "${dataDir}")`));
+        expect(existsSync(path.join(configDir, 'hooks'))).toBe(false);
+        expect(() => execFileSync(SANDBOX_EXEC_PATH, [
+          '-f', profilePath, process.execPath, '-e',
+          'require("node:fs").openSync(process.argv[1], "r+")', sourceCredentialsPath,
+        ], { stdio: 'ignore' })).toThrow();
+        expect(profile).not.toContain('.oauth_refresh.lock');
+        expect(() => execFileSync(SANDBOX_EXEC_PATH, [
+          '-f', profilePath, '/bin/cat', path.join(dataDir, 'native-worker-token.json'),
+        ], { stdio: 'ignore' })).toThrow();
+        expect(profile).not.toContain('login.keychain-db');
+        const compactedState = path.join(configDir, 'projects', 'repo', `compact-${turnIndex}.json`);
+        execFileSync(SANDBOX_EXEC_PATH, [
+          '-f', profilePath, '/bin/sh', '-c',
+          `mkdir -p ${JSON.stringify(path.dirname(compactedState))} && printf '{}' > ${JSON.stringify(compactedState)}`,
+        ], { stdio: 'ignore' });
+        expect(existsSync(compactedState)).toBe(true);
+
+        expect(() => execFileSync(SANDBOX_EXEC_PATH, [
+          '-f', profilePath, '/bin/cat', path.join(sessionDir, 'session.json'),
+        ], { stdio: 'ignore' })).toThrow();
+        expect(() => execFileSync(SANDBOX_EXEC_PATH, [
+          '-f', profilePath, '/bin/sh', '-c',
+          `printf changed > ${JSON.stringify(path.join(worktreePath, 'sandbox-write.txt'))}`,
+        ], { stdio: 'ignore' })).toThrow();
+      }
       const session = JSON.parse(readFileSync(path.join(sessionDir, 'session.json'), 'utf8')) as {
         recentRuns: Array<{ stdoutPath: string }>;
       };
+      expect(JSON.stringify(session)).not.toContain(dedicatedToken);
       const exitCountBefore = getLaneEvents(lane.id, 200)
         .filter((event) => event.verb === 'runtime_process_exit').length;
-      writeFileSync(session.recentRuns[0]!.stdoutPath, `${JSON.stringify({
+      const streamedMessages = [
+        { type: 'assistant', message: { content: [{ type: 'text', text: 'Inspecting the source.' }] } },
+        { type: 'stream_event', event: { type: 'message_stop' } },
+        { type: 'system', subtype: 'compact_boundary', compact_metadata: { trigger: 'auto', pre_tokens: 58_671 } },
+        { type: 'stream_event', event: { type: 'message_stop' } },
+      ].map((event) => JSON.stringify(event)).join('\n');
+      writeFileSync(session.recentRuns[0]!.stdoutPath, `${streamedMessages}\n${JSON.stringify({
         type: 'result',
         subtype: 'success',
-        result: 'done',
+        ...(providerFailed ? { is_error: true } : {}),
+        result: providerFailed ? 'Not logged in' : 'done',
         session_id: `claude-turn-isolation-${turnIndex + 1}`,
         usage: {
           input_tokens: inputTokens,
@@ -276,6 +362,13 @@ describe('Claude Code worker skill isolation real path', () => {
         inputTokens,
         cacheReadTokens: contextTokens - inputTokens,
         contextTokens,
+        ...(providerFailed ? {
+          exitCode: 0,
+          classification: 'clean-exit',
+          runtimeOutcome: 'failed',
+          completedTurn: false,
+          providerFailure: { subtype: 'success', message: 'Not logged in' },
+        } : {}),
       });
       expect(exitEvent?.payload).not.toHaveProperty('toolName', 'Skill');
       expect(contextTokens).toBeLessThan(50_000);
@@ -289,10 +382,16 @@ describe('Claude Code worker skill isolation real path', () => {
           ? null
           : contextTokens - contextByTurn[turnIndex - 1]!,
       });
+      if (providerFailed) {
+        expect(synced.packets[0]?.status).toBe('failed');
+        expect(synced.packets[0]?.status).not.toBe('awaiting_review');
+        expect(synced.packets[0]?.releaseState).not.toBe('released');
+      }
     }
+    rmSync(path.join(dataDir, 'native-worker-token.json'), { force: true });
   }, 30_000);
 
-  it('fails the persisted dispatch path before spawn when no live credential can be seeded', async () => {
+  it('fails the persisted dispatch path before spawn when no saved credential is available', async () => {
     const noCredsHome = path.join(tempRoot, 'operator-home-no-creds');
     mkdirSync(path.join(noCredsHome, '.claude'), { recursive: true });
     const noCredsRepoPath = path.join(noCredsHome, 'repo');
@@ -398,7 +497,7 @@ describe('Claude Code worker skill isolation real path', () => {
     ]));
   }, 30_000);
 
-  it('rejects a seeded credential when Claude Code reports the isolated config is logged out', async () => {
+  it.skipIf(process.platform === 'darwin')('rejects launch when the native CLI reports the selected store is logged out', async () => {
     const { ensureClaudeCodeWorkerConfigDir } = await import('@/lib/claude-code/codex-subscription-proxy');
     authStatusMock.loggedIn = false;
     try {
@@ -407,11 +506,31 @@ describe('Claude Code worker skill isolation real path', () => {
         'native',
       )).rejects.toMatchObject({
         code: 'worker_not_authenticated',
-        reason: 'Claude Code rejected the seeded credential.',
+        reason: 'The native CLI reports no login in the selected credential store.',
       });
     } finally {
       authStatusMock.loggedIn = true;
     }
+  });
+
+  it.skipIf(process.platform !== 'darwin')('refuses the operator login when a dedicated token is missing', async () => {
+    const { ensureClaudeCodeWorkerConfigDir } = await import('@/lib/claude-code/codex-subscription-proxy');
+    await expect(ensureClaudeCodeWorkerConfigDir(path.join(tempRoot, 'token-unavailable'), 'native'))
+      .rejects.toMatchObject({ code: 'worker_not_authenticated' });
+    expect(keychainLookupMock).not.toHaveBeenCalled();
+  });
+
+  it.skipIf(process.platform !== 'darwin')('removes only an obsolete worker snapshot before reusing its config', async () => {
+    const { ensureClaudeCodeWorkerConfigDir } = await import('@/lib/claude-code/codex-subscription-proxy');
+    const sessionDir = path.join(tempRoot, 'obsolete-snapshot');
+    const configDir = path.join(sessionDir, 'claude-code-worker-config');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(path.join(configDir, '.credentials.json'), 'synthetic-obsolete-snapshot');
+    const sourcePath = path.join(fakeHome, '.claude', '.credentials.json');
+    const before = readFileSync(sourcePath, 'utf8');
+    await expect(ensureClaudeCodeWorkerConfigDir(sessionDir, 'native')).rejects.toMatchObject({ code: 'worker_not_authenticated' });
+    expect(existsSync(path.join(configDir, '.credentials.json'))).toBe(false);
+    expect(readFileSync(sourcePath, 'utf8')).toBe(before);
   });
 
   it('treats empty OAuth token fields as no credential and writes no worker snapshot', async () => {
@@ -429,7 +548,9 @@ describe('Claude Code worker skill isolation real path', () => {
       const { ensureClaudeCodeWorkerConfigDir } = await import('@/lib/claude-code/codex-subscription-proxy');
       await expect(ensureClaudeCodeWorkerConfigDir(sessionDir, 'native')).rejects.toMatchObject({
         code: 'worker_not_authenticated',
-        reason: 'No live Claude OAuth credential was available to seed.',
+        reason: process.platform === 'darwin'
+          ? 'No dedicated worker credential is configured. Run `npm run worker:login` from the application source checkout to connect a dedicated worker token.'
+          : 'No live Claude OAuth credential was available to seed.',
       });
       expect(existsSync(path.join(sessionDir, 'claude-code-worker-config', '.credentials.json'))).toBe(false);
     } finally {

--- a/tests/native-worker-token-setup-real-path.test.ts
+++ b/tests/native-worker-token-setup-real-path.test.ts
@@ -1,0 +1,41 @@
+import { execFile } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+it.skipIf(process.platform !== 'darwin')('captures a setup token through the real PTY entry point without exposing its output', async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), 'o8-token-capture-test-'));
+  const binary = path.join(directory, 'fixture-cli');
+  const token = `sk-ant-oat01-${'synthetic'.repeat(12)}`;
+  writeFileSync(binary, [
+    `#!${process.execPath}`,
+    'if (process.argv.includes("--version")) { console.log("2.1.261"); process.exit(); }',
+    // More redraw data than the old capture ceiling must not abort approval.
+    'process.stdout.write("Browser didn\'t open?".repeat(20000));',
+    `setTimeout(() => console.log(${JSON.stringify(token)}), 100);`,
+  ].join('\n'), { mode: 0o700 });
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    O8_DATA_DIR: directory,
+    CORTEX_IDE_DATA_DIR: directory,
+    O8_MASTER_KEY: Buffer.alloc(32, 7).toString('base64url'),
+    O8_CLAUDE_CODE_BIN: binary,
+  };
+  delete env.O8_WORKER_TOKEN;
+  delete env.O8_WORKER_PACKET_ID;
+  try {
+    const result = await execFileAsync(process.execPath, [
+      '--import', './scripts/register-server-only-stub.mjs', '--import', 'tsx', 'scripts/connect-native-worker.ts',
+    ], { cwd: process.cwd(), env, timeout: 15_000, maxBuffer: 16 * 1024 });
+    expect(result.stdout).toContain('Worker token encrypted and saved.');
+    expect(result.stdout + result.stderr).not.toContain(token);
+    expect(readFileSync(path.join(directory, 'native-worker-token.json'), 'utf8')).not.toContain(token);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}, 20_000);

--- a/tests/read-only-worker-enforcement.test.ts
+++ b/tests/read-only-worker-enforcement.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -327,5 +327,99 @@ describe('an unresolved durable work mode refuses the launch instead of widening
     expect(result.ok).toBe(true);
     expect(launched.length).toBe(before + 1);
     expect(launched[launched.length - 1]!.workMode).toBeUndefined();
+  });
+});
+
+describe('provider-failed turn lifecycle truth', () => {
+  it.each([true, false])('keeps a newer launch running after an old provider failure (same surface: %s)', async (sameSurface) => {
+    const packetId = await persistPacket('stale provider failure lifecycle', sameSurface ? 90_097_008 : 90_097_009, true);
+    const { attachSession, createLane, setLaneStatus } = await import('@/lib/lane/registry');
+    const { recordLaneEvent } = await import('@/lib/lane/events');
+    const { buildDomainLaneSummaries, syncOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+    const lane = createLane({ repoPath, branch: 'main', runtime: 'claude-code', label: 'relaunch', packetId });
+    const previousSurface = `claude-code-owned:${packetId}-previous`;
+    attachSession(lane.id, previousSurface, 'system');
+    setLaneStatus(lane.id, 'running', 'system', 'session_launched');
+    recordLaneEvent(lane.id, 'runtime_process_exit', 'system', {
+      surfaceId: previousSurface, runId: 'previous', exitCode: 0,
+      classification: 'clean-exit', runtimeOutcome: 'failed', completedTurn: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    attachSession(lane.id, sameSurface ? previousSurface : `claude-code-owned:${packetId}-new`, 'system');
+    setLaneStatus(lane.id, 'running', 'system', 'session_launched');
+    expect(buildDomainLaneSummaries().find((entry) => entry.laneId === lane.id)?.status).toBe('running');
+    const synced = await syncOrchestratorControlPlaneState();
+    expect(synced.packets.find((packet) => packet.id === packetId)?.status).toBe('running');
+  });
+
+  it('persists a zero-exit provider failure as failed instead of review or no-changes success', async () => {
+    const packetId = await persistPacket('provider failure lifecycle seam', 90_097_006, true);
+    const { attachSession, createLane, setLaneStatus } = await import('@/lib/lane/registry');
+    const { recordLaneEvent } = await import('@/lib/lane/events');
+    const { syncOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+    const lane = createLane({
+      repoPath,
+      branch: `test/provider-failure-${packetId}`,
+      runtime: 'claude-code',
+      label: 'provider failure lifecycle seam',
+      packetId,
+    });
+    attachSession(lane.id, `claude-code-owned:${packetId}`, 'system');
+    setLaneStatus(lane.id, 'running', 'system', 'session_launched');
+    recordLaneEvent(lane.id, 'runtime_process_exit', 'system', {
+      surfaceId: `claude-code-owned:${packetId}`,
+      exitCode: 0,
+      signal: null,
+      classification: 'clean-exit',
+      runtimeOutcome: 'failed',
+      completedTurn: false,
+      providerFailure: { subtype: 'success', message: 'Not logged in' },
+    });
+
+    const synced = await syncOrchestratorControlPlaneState();
+    const packet = synced.packets.find((candidate) => candidate.id === packetId);
+    expect(packet?.status).toBe('failed');
+    expect(packet?.status).not.toBe('awaiting_review');
+    expect(packet?.releaseState).not.toBe('released');
+    expect(packet?.lastEventLabel).not.toBe('read_only_completed');
+  });
+
+  it('holds failed partial work for input with its diff intact', async () => {
+    const packetId = await persistPacket('failed partial work lifecycle seam', 90_097_007, false);
+    const worktree = mkdtempSync(path.join(dataDir, 'failed-work-'));
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: worktree });
+    execFileSync('git', [
+      '-c', 'user.email=test@o8.test', '-c', 'user.name=o8-test',
+      'commit', '--allow-empty', '-m', 'seed',
+    ], { cwd: worktree });
+    const { createLane, getLane } = await import('@/lib/lane/registry');
+    const { probeNoChangesProduced } = await import('@/lib/lane/no-changes-produced');
+    const { transitionFailedPostCompletionLane } = await import('@/lib/supervisor/post-completion-packet');
+    const lane = createLane({
+      repoPath: worktree,
+      branch: 'main',
+      runtime: 'claude-code',
+      label: 'failed work review settlement',
+      packetId,
+    });
+
+    expect((await probeNoChangesProduced(worktree, 'main')).noChangesProduced).toBe(true);
+    expect(transitionFailedPostCompletionLane(lane.id, false)).toMatchObject({
+      status: 'awaiting_input',
+      lastEventLabel: 'agent_failed',
+    });
+
+    writeFileSync(path.join(worktree, 'partial.ts'), 'export const partial = true;\n');
+    const probe = await probeNoChangesProduced(worktree, 'main');
+    expect(probe.noChangesProduced).toBe(false);
+    expect(transitionFailedPostCompletionLane(lane.id, !probe.noChangesProduced)).toMatchObject({
+      status: 'awaiting_input',
+      lastEventLabel: 'agent_failed_work_present',
+    });
+    expect(getLane(lane.id)?.outcome).not.toBe('no_changes');
+    const { syncOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+    const synced = await syncOrchestratorControlPlaneState();
+    expect(synced.packets.find((candidate) => candidate.id === packetId)?.status).not.toBe('awaiting_review');
+    expect((await probeNoChangesProduced(worktree, 'main')).noChangesProduced).toBe(false);
   });
 });

--- a/tests/sandbox-owned-stop-real-path.test.ts
+++ b/tests/sandbox-owned-stop-real-path.test.ts
@@ -1,0 +1,166 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { NextRequest } from 'next/server';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+
+// Keep retirement outside this test. Auth, route, lifecycle hold, saved-session
+// lookup, process identity, signals, and persisted kill events are all real.
+vi.mock('@/lib/orchestrator/operator-mission-service', () => ({
+  resetPacket: vi.fn(async () => ({ reset: true, worktreePruned: false })),
+}));
+
+const root = mkdtempSync(join(tmpdir(), 'o8-sandbox-stop-'));
+const dataDir = join(root, 'data');
+const repoPath = join(root, 'repo');
+const token = 'sandbox-stop-fixture-operator-token-0123456789';
+mkdirSync(dataDir);
+mkdirSync(repoPath);
+writeFileSync(join(dataDir, 'ws-token'), token);
+process.env.O8_DATA_DIR = dataDir;
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.CORTEX_IDE_OWNED_CLAUDE_CODE_ROOT = join(dataDir, 'owned-claude-code');
+
+const { POST } = await import('@/app/api/orchestrator/stop-packet/route');
+const { createLane, getLaneEvents, setLaneStatus } = await import('@/lib/lane/registry');
+const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+const { readOrchestratorControlPlaneState, writeOrchestratorControlPlaneState } =
+  await import('@/lib/orchestrator/control-plane');
+const { closeDb } = await import('@/lib/db');
+const { isPidAlive, pidCommandLine } = await import('@/lib/runtimes/shared/owned-session/helpers');
+const { prepareWorkerSandbox } = await import('@/lib/runtimes/shared/owned-session/sandbox');
+const { resolveSpawnedProcessGroupId } = await import('@/lib/runtimes/shared/owned-session/run-process-proof');
+
+const children: ChildProcess[] = [];
+afterEach(async () => {
+  for (const child of children.splice(0)) {
+    if (child.pid && isPidAlive(child.pid)) {
+      const done = new Promise<void>((resolve) => child.once('exit', () => resolve()));
+      child.kill('SIGKILL');
+      await done;
+    }
+    expect(child.pid && isPidAlive(child.pid)).toBe(false);
+  }
+});
+afterAll(() => {
+  closeDb();
+  rmSync(root, { recursive: true, force: true });
+});
+
+async function spawnWorker(marker: string) {
+  const prepared = await prepareWorkerSandbox({
+    runId: randomUUID(), profileDir: root, cwd: repoPath, repoPath,
+    binary: process.execPath,
+    args: ['-e', 'setTimeout(() => process.exit(0), 20000); process.stdout.write("ready\\n");'],
+    tmpDir: root,
+  });
+  const child = spawn(prepared.binary, prepared.args, {
+    cwd: repoPath, detached: true, stdio: ['ignore', 'pipe', 'pipe'],
+    // Fixture-only environment; no provider or operator credentials.
+    env: { NODE_ENV: 'test', PATH: '/usr/bin:/bin', O8_OWNED_RUN_MARKER: marker },
+  });
+  children.push(child);
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Sandbox child did not become ready')), 5000);
+    const finish = (error?: Error) => {
+      clearTimeout(timer);
+      if (error) reject(error); else resolve();
+    };
+    child.once('error', finish);
+    child.once('exit', () => finish(new Error('Sandbox child exited before readiness')));
+    child.stdout!.once('data', () => finish());
+  });
+  expect(await pidCommandLine(child.pid!)).not.toContain('sandbox-exec');
+  expect(await resolveSpawnedProcessGroupId(child.pid!)).toBe(child.pid);
+  return child;
+}
+
+function bindWorker(pid: number, marker: string | undefined, processGroupId = pid, commandIdentity = 'sandbox-exec') {
+  const id = randomUUID();
+  const surfaceId = 'claude-code-owned:' + id;
+  const packetId = 'pkt-' + id;
+  const lane = createLane({
+    repoPath, branch: 'inline/stop-' + id, runtime: 'claude-code',
+    packetId, sessionKey: surfaceId,
+  });
+  setLaneStatus(lane.id, 'running', 'system', 'test_running');
+  const sessionDir = join(dataDir, 'owned-claude-code', id);
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(join(sessionDir, 'session.json'), JSON.stringify({
+    surfaceId, repoPath, cwd: repoPath, laneId: lane.id, packetId,
+    activeRun: {
+      id: marker, pid, processGroupId, processMarker: marker,
+      commandIdentity, spawnState: 'spawned', sandboxed: commandIdentity === 'sandbox-exec',
+      outcome: 'running', startedAt: new Date().toISOString(),
+    },
+  }));
+  const packet: OrchestratorPacket = {
+    id: packetId, referenceLabel: 'stop', title: 'sandbox stop', summary: 'stop identity',
+    workspaceTargetPath: repoPath, branchTarget: lane.branch, runtime: 'claude-code',
+    dependencyLabels: [], dependencyPacketIds: [], queueState: 'queued',
+    releaseState: 'pending', status: 'running', blockedReason: null,
+    lastEventAt: null, lastEventLabel: null, archivedAt: null, review: null,
+    orchestratorThreadId: null, operatorStopped: false,
+    lane: {
+      tileId: lane.id, tabId: lane.id, repoPath, worktreePath: null,
+      runtime: 'claude-code', sessionKey: surfaceId, laneId: lane.id,
+      lastHeartbeatAt: null, lastEventAt: null, lastEventLabel: null,
+    },
+  };
+  writeOrchestratorControlPlaneState({
+    ...createEmptyOrchestratorMissionState(),
+    missionId: 'mission-' + id, repoPath, packets: [packet],
+  });
+  return { packetId, laneId: lane.id };
+}
+
+function stop(packetId: string) {
+  return POST(new NextRequest('http://localhost/api/orchestrator/stop-packet', {
+    method: 'POST',
+    headers: { host: 'localhost', authorization: 'Bearer ' + token, 'content-type': 'application/json' },
+    body: JSON.stringify({ packetId }),
+  }));
+}
+
+describe.skipIf(process.platform !== 'darwin')('sandboxed owned stop through the production route', () => {
+  it('stops after wrapper exec and persists confirmed kill and operator hold', async () => {
+    const marker = randomUUID();
+    const child = await spawnWorker(marker);
+    const target = bindWorker(child.pid!, marker);
+    const response = await stop(target.packetId);
+    expect(response.status).toBe(200);
+    expect(isPidAlive(child.pid!)).toBe(false);
+    closeDb();
+    expect(readOrchestratorControlPlaneState().packets[0]).toMatchObject({
+      operatorStopped: true, queueState: 'held', blockedReason: 'operator_stopped',
+    });
+    expect(getLaneEvents(target.laneId, 50).filter((event) => event.verb === 'kill_escalated'))
+      .toEqual([expect.objectContaining({ payload: expect.objectContaining({
+        pid: child.pid, stage: 'SIGINT', confirmed: true,
+      }) })]);
+  });
+
+  it.each(['different', 'prefix', 'missing', 'group', 'legacy'] as const)(
+    'refuses %s identity evidence without signaling a live process',
+    async (kind) => {
+      const marker = randomUUID();
+      const child = await spawnWorker(kind === 'prefix' ? marker + '-other' : marker);
+      const target = bindWorker(
+        child.pid!, kind === 'missing' || kind === 'legacy' ? undefined : kind === 'different' ? randomUUID() : marker,
+        kind === 'group' ? process.pid : child.pid!,
+        kind === 'legacy' ? process.execPath : 'sandbox-exec',
+      );
+      const response = await stop(target.packetId);
+      expect(response.status).toBe(409);
+      expect(isPidAlive(child.pid!)).toBe(true);
+      closeDb();
+      expect(readOrchestratorControlPlaneState().packets[0]).toMatchObject({
+        operatorStopped: true, queueState: 'held', blockedReason: 'kill_unconfirmed',
+      });
+      expect(getLaneEvents(target.laneId, 50).filter((event) => event.verb === 'kill_escalated')).toEqual([]);
+    },
+  );
+});

--- a/tests/stream-terminal-callers-real-path.test.ts
+++ b/tests/stream-terminal-callers-real-path.test.ts
@@ -1,0 +1,185 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClaudeCodeStreamJsonParserEvent } from '@/lib/claude-code/stream-json-parser';
+
+const fixture = vi.hoisted(() => ({ binary: '' }));
+vi.mock('@/lib/runtimes/shared/cli-locate', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/runtimes/shared/cli-locate')>(),
+  resolveClaudeBinary: () => fixture.binary,
+}));
+
+const { askClaudeOneShot } = await import('@/lib/claude-code/one-shot-repl');
+const { askClaudeWarm, prewarmClaudeRepl, resetWarmReplPool } = await import('@/lib/claude-code/warm-repl-pool');
+const { ensureSession, sendMessage, killSession } = await import('@/lib/claude-code/interactive-session');
+const { handleClaudeCodeSend } = await import('@/app/api/claude-code/send/streaming-spawn');
+
+const root = mkdtempSync(path.join(os.tmpdir(), 'o8-stream-callers-'));
+let caseDir = '';
+let ordinal = 0;
+let promptOrdinal = 0;
+const tabs = new Set<string>();
+type Caller = 'one-shot' | 'warm' | 'interactive';
+type Outcome = { ok: true; text: string } | { ok: false; error: unknown };
+
+// Real subprocess, fake protocol peer. It reads only synthetic stdin and files
+// under its case directory. It never invokes a provider or reads account state.
+function writePeer() {
+  fixture.binary = path.join(caseDir, 'stream-peer.cjs');
+  writeFileSync(fixture.binary, `#!${process.execPath}
+const fs = require('node:fs');
+const readline = require('node:readline');
+const path = require('node:path');
+const root = __dirname;
+fs.writeFileSync(path.join(root, 'pid-' + process.pid), String(process.pid));
+setTimeout(() => process.exit(70), 10000);
+const emit = (event) => process.stdout.write(JSON.stringify(event) + '\\n');
+readline.createInterface({ input: process.stdin }).on('line', (line) => {
+  const request = JSON.parse(JSON.parse(line).message.content);
+  emit({ type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'partial' } } });
+  emit({ type: 'stream_event', event: { type: 'message_stop' } });
+  emit({ type: 'system', subtype: 'compact_boundary' });
+  emit({ type: 'message_stop' });
+  fs.writeFileSync(path.join(root, request.id + '-stopped'), 'ready');
+  const gate = setInterval(() => {
+    if (!fs.existsSync(path.join(root, request.id + '-release'))) return;
+    clearInterval(gate);
+    if (request.mode === 'missing') return process.exit(0);
+    const failed = request.mode.startsWith('failure');
+    const result = { type: 'result', subtype: failed ? 'error_during_execution' : 'success',
+      is_error: failed, result: failed ? 'synthetic failure payload' : 'complete-' + request.id,
+      session_id: 'synthetic-session' };
+    if (request.mode.endsWith('trailing')) {
+      process.stdout.write(JSON.stringify(result), () => process.exit(0));
+    } else emit(result);
+  }, 10);
+});
+`);
+  chmodSync(fixture.binary, 0o700);
+}
+
+beforeEach(() => {
+  caseDir = path.join(root, `case-${++ordinal}`);
+  mkdirSync(caseDir);
+  vi.stubEnv('TMPDIR', caseDir);
+  vi.stubEnv('TMP', caseDir);
+  vi.stubEnv('TEMP', caseDir);
+  writePeer();
+});
+
+function alive(pid: number) {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+afterEach(async () => {
+  for (const tab of tabs) killSession(tab);
+  tabs.clear();
+  resetWarmReplPool();
+  vi.unstubAllEnvs();
+  const pids = readdirSync(caseDir).filter((name) => name.startsWith('pid-'))
+    .map((name) => Number(readFileSync(path.join(caseDir, name), 'utf8')));
+  await vi.waitFor(() => expect(pids.filter(alive)).toEqual([]), { timeout: 3_000 });
+});
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+function request(mode: string) {
+  const id = `turn-${++promptOrdinal}`;
+  return {
+    id,
+    prompt: JSON.stringify({ id, mode }),
+    waitForStop: () => vi.waitFor(() => expect(existsSync(path.join(caseDir, `${id}-stopped`))).toBe(true)),
+    release: () => writeFileSync(path.join(caseDir, `${id}-release`), 'go'),
+  };
+}
+
+function sessionFor(tabId = `test-tab-${ordinal}`) {
+  tabs.add(tabId);
+  return ensureSession(tabId, caseDir, 'synthetic-model');
+}
+
+function start(caller: Caller, prompt: string) {
+  const events: ClaudeCodeStreamJsonParserEvent[] = [];
+  const opts = { binary: fixture.binary, model: 'synthetic-model', timeoutMs: 5_000 };
+  const session = caller === 'interactive' ? sessionFor() : null;
+  const work = session
+    ? sendMessage(session, prompt, (event) => events.push(event), { timeoutMs: 5_000 }).then(() => {
+      const done = events.find((event) => event.type === 'done');
+      return done?.type === 'done' ? done.text : '';
+    })
+    : caller === 'warm' ? askClaudeWarm(prompt, opts) : askClaudeOneShot(prompt, opts);
+  let settled = false;
+  const outcome: Promise<Outcome> = work.then(
+    (text) => { settled = true; return { ok: true, text }; },
+    (error: unknown) => { settled = true; return { ok: false, error }; },
+  );
+  return { outcome, events, session, isSettled: () => settled };
+}
+
+describe.skipIf(process.platform === 'win32')('terminal results through real stream callers', () => {
+  for (const caller of ['one-shot', 'warm', 'interactive'] as const) {
+    it.each(['success', 'success-trailing'])(`${caller} waits through message stops and compaction for %s`, async (mode) => {
+      const r = request(mode);
+      if (caller === 'warm') prewarmClaudeRepl(fixture.binary, 'synthetic-model');
+      const turn = start(caller, r.prompt);
+      await r.waitForStop();
+      await delay(100);
+      expect(turn.isSettled()).toBe(false);
+      if (turn.session) expect(turn.session.status).toBe('busy');
+      r.release();
+      expect(await turn.outcome).toEqual({ ok: true, text: `complete-${r.id}` });
+      if (turn.session && mode === 'success') expect(turn.session.status).toBe('ready');
+    });
+
+    it.each(['failure', 'failure-trailing', 'missing'])(`${caller} rejects %s instead of returning partial text`, async (mode) => {
+      const r = request(mode);
+      const turn = start(caller, r.prompt);
+      await r.waitForStop();
+      r.release();
+      expect(await turn.outcome).toMatchObject({ ok: false, error: expect.any(Error) });
+      expect(turn.events.some((event) => event.type === 'done')).toBe(false);
+      if (turn.session && mode === 'failure') expect(turn.session.status).toBe('ready');
+    });
+  }
+
+  it('reuses an interactive session after failure without replaying the previous turn', async () => {
+    const failed = request('failure');
+    const first = start('interactive', failed.prompt);
+    await failed.waitForStop();
+    failed.release();
+    expect(await first.outcome).toMatchObject({ ok: false });
+    const next = request('success');
+    const second = start('interactive', next.prompt);
+    expect(second.session?.proc.pid).toBe(first.session?.proc.pid);
+    await next.waitForStop();
+    expect(second.isSettled()).toBe(false);
+    next.release();
+    expect(await second.outcome).toEqual({ ok: true, text: `complete-${next.id}` });
+    expect(second.events.filter((event) => event.type === 'done')).toHaveLength(1);
+    expect(second.session?.sessionId).toBe('synthetic-session');
+  });
+
+  it.each(['success', 'failure', 'failure-trailing'])('the send route reports %s without a false successful close', async (mode) => {
+    const r = request(mode);
+    const tabId = `route-tab-${ordinal}`;
+    tabs.add(tabId);
+    const response = await handleClaudeCodeSend(new Request('http://localhost/api/claude-code/send', {
+      method: 'POST',
+      body: JSON.stringify({ tabId, cwd: caseDir, message: r.prompt, model: 'synthetic-model' }),
+    }));
+    expect(response.status).toBe(200);
+    const body = response.text();
+    await r.waitForStop();
+    r.release();
+    const events = (await body).split('\n\n').filter(Boolean)
+      .map((line) => JSON.parse(line.slice('data: '.length)) as { type: string; exitCode?: number });
+    if (mode === 'success') {
+      expect(events.filter((event) => event.type === 'done')).toHaveLength(1);
+      expect(events.at(-1)).toMatchObject({ type: 'close', exitCode: 0 });
+    } else {
+      expect(events.some((event) => event.type === 'done' || event.type === 'close')).toBe(false);
+      expect(events.at(-1)).toMatchObject({ type: 'error' });
+    }
+  });
+});

--- a/tests/supervisor-retry-identity-real-path.test.ts
+++ b/tests/supervisor-retry-identity-real-path.test.ts
@@ -1,0 +1,288 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { NextRequest } from 'next/server';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import type { RuntimeLaunchRequest, RuntimeLaunchResult } from '@/lib/runtime/actions';
+import type { OwnedSessionRecord } from '@/lib/runtimes/shared/owned-session/types';
+import type { SupervisorCallbacks } from '@/lib/supervisor/agent-supervisor-types';
+
+const h = vi.hoisted(() => ({
+  launch: vi.fn<(request: RuntimeLaunchRequest) => Promise<RuntimeLaunchResult>>(async (request) => ({
+    ok: true, runtime: request.runtime, surfaceId: `${request.runtime}-owned:retried`,
+    note: 'Provider boundary captured without starting a process.',
+    cwd: request.cwd!, repoPath: request.repoPath!, worktree: null,
+    laneId: request.existingLaneId!, clientMutationId: request.clientMutationId,
+  })),
+}));
+
+vi.mock('@/lib/runtime/actions', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/runtime/actions')>(), launchRuntimeSurface: h.launch,
+}));
+vi.mock('@/lib/realtime/publisher', () => ({ publishRealtimeMutation: vi.fn(async () => {}) }));
+vi.mock('@/lib/command-center/snapshot', () => ({ invalidateCommandCenterSnapshotCaches: vi.fn() }));
+vi.mock('@/lib/mobile/inbox', () => ({ invalidateInboxCache: vi.fn() }));
+// Inventory is supplied by the test; no provider transcript discovery is needed.
+vi.mock('@/lib/claude-code/owned', () => ({
+  getOwnedClaudeCodeTelemetrySources: vi.fn(async () => ({ stdoutPaths: [] })),
+}));
+
+const dataDir = mkdtempSync(path.join(os.tmpdir(), 'o8-retry-identity-'));
+process.env.O8_DATA_DIR = dataDir;
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.CORTEX_IDE_OWNED_CODEX_ROOT = path.join(dataDir, 'owned-codex');
+process.env.CORTEX_IDE_OWNED_CLAUDE_CODE_ROOT = path.join(dataDir, 'owned-claude-code');
+
+const { relaunchSupervisedAgent } = await import('@/lib/supervisor/relaunch-agent');
+const { createLane, getLane, getLaneEvents, listLanes, updateLane } = await import('@/lib/lane/registry');
+const { closeDb, getSqlite } = await import('@/lib/db');
+const route = await import('@/app/api/runtime/launch/route');
+const supervisor = await import('@/lib/supervisor/agent-supervisor');
+let ordinal = 0;
+const launchImplementation = h.launch.getMockImplementation()!;
+
+function fixture(runtime: 'claude-code' | 'codex', config?: Record<string, string>) {
+  const id = ++ordinal;
+  const repo = path.join(dataDir, `repo-${id}`);
+  const worktree = path.join(dataDir, `worktree-${id}`);
+  mkdirSync(repo);
+  mkdirSync(worktree);
+  const surface = `${runtime}-owned:failed-${id}`;
+  const lane = createLane({ repoPath: repo, worktreePath: worktree, runtime, branch: `retry-${id}`, sessionKey: surface });
+  updateLane(lane.id, { status: 'running' });
+  const sessionDir = path.join(dataDir, `owned-${runtime}`, `session-${id}`);
+  mkdirSync(sessionDir, { recursive: true });
+  const session: OwnedSessionRecord = {
+    surfaceId: surface, laneId: lane.id, sessionDir, cwd: worktree, repoPath: worktree,
+    title: 'retry fixture', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+    latestPrompt: 'read only', latestSummary: '', recentRuns: [], effort: 'high',
+    model: runtime === 'codex' || config?.modelSource === 'codex-subscription' ? 'gpt-5.6-sol' : 'claude-opus-5',
+    runtimeConfig: config,
+  };
+  const save = () => writeFileSync(path.join(sessionDir, 'session.json'), JSON.stringify(session));
+  save();
+  return { repo, worktree, surface, lane, session, save };
+}
+
+function serveLaunchRoute() {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+    expect(new URL(String(input)).pathname).toBe('/api/runtime/launch');
+    return route.POST(new NextRequest(String(input), {
+      method: 'POST', headers: init?.headers, body: String(init?.body ?? ''),
+    }));
+  });
+}
+
+afterEach(() => {
+  supervisor.stopSupervisorLoop();
+  for (const watched of supervisor.getWatchedAgents()) supervisor.unregisterWatchedAgent(watched.surfaceId);
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  h.launch.mockReset().mockImplementation(launchImplementation);
+});
+afterAll(() => { closeDb(); rmSync(dataDir, { recursive: true, force: true }); });
+
+describe('supervisor retry identity through persisted state and the launch route', () => {
+  function watch(f: ReturnType<typeof fixture>) {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+    const callbacks = {
+      fetchFleetStatus: vi.fn(async () => [{ sessionKey: f.surface, status: 'failed' }]),
+      fetchTranscript: vi.fn(async () => []),
+      steerAgent: vi.fn(async () => {}),
+      interruptAgent: vi.fn(async () => {}),
+      relaunchAgent: vi.fn(relaunchSupervisedAgent),
+      broadcastAgentUpdate: vi.fn(),
+      queueOrchestratorEscalation: vi.fn(),
+      onAgentCompletion: vi.fn(),
+      onAgentRetry: vi.fn(),
+    } satisfies SupervisorCallbacks;
+    supervisor.registerWatchedAgent(f.surface, f.repo, 'failed worker', 'read only');
+    supervisor.getWatchedAgents(f.repo)[0].nextPollAt = Date.now();
+    supervisor.startSupervisorLoop(callbacks);
+    return callbacks;
+  }
+
+  it.each(['missing-model', 'paused', 'launch-error'] as const)(
+    'settles a %s retry through the live poll callback without counting or claiming an attempt',
+    async (kind) => {
+      const f = fixture('claude-code', { modelSource: 'native' });
+      if (kind === 'missing-model') { f.session.model = undefined; f.save(); }
+      if (kind === 'paused') updateLane(f.lane.id, { status: 'paused' });
+      const transport = serveLaunchRoute();
+      const callbacks = watch(f);
+      if (kind === 'launch-error') callbacks.relaunchAgent.mockRejectedValueOnce(new Error('unconfirmed launch'));
+      await vi.waitFor(() => expect(callbacks.broadcastAgentUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'awaiting_input' }),
+      ));
+      expect(callbacks.relaunchAgent).toHaveBeenCalledTimes(1);
+      expect(callbacks.broadcastAgentUpdate.mock.calls.some(([event]) => event.status === 'retrying')).toBe(false);
+      expect(transport).not.toHaveBeenCalled();
+      expect(callbacks.onAgentCompletion).not.toHaveBeenCalled();
+      expect(callbacks.onAgentRetry).not.toHaveBeenCalled();
+      closeDb();
+      expect(getSqlite().prepare('SELECT retry_count, completion_reported, last_status FROM watched_agents WHERE surface_id = ?')
+        .get(f.surface)).toEqual({ retry_count: 0, completion_reported: 1, last_status: 'failed' });
+      expect(getLane(f.lane.id)?.status).toBe(kind === 'paused' ? 'paused' : kind === 'missing-model' ? 'awaiting_input' : 'running');
+      // A stale later inventory must not reopen a terminal held watcher.
+      callbacks.fetchFleetStatus.mockResolvedValue([{ sessionKey: f.surface, status: 'running' }]);
+      await vi.advanceTimersByTimeAsync(35_000);
+      expect(supervisor.getWatchedAgents(f.repo)[0]).toMatchObject({ retryCount: 0, completionReported: true, lastStatus: 'failed' });
+      expect(callbacks.relaunchAgent).toHaveBeenCalledTimes(1);
+      supervisor.stopSupervisorLoop();
+      // The production startup query excludes this durable, terminal hold.
+      expect(getSqlite().prepare('SELECT surface_id FROM watched_agents WHERE completion_reported = 0')
+        .all()).toEqual([]);
+    },
+  );
+
+  it('counts one accepted retry and reserves the failed transition while acceptance is pending', async () => {
+    const f = fixture('claude-code', { modelSource: 'native', workMode: 'read-only' });
+    let accept!: (result: RuntimeLaunchResult) => void;
+    h.launch.mockImplementationOnce(() => new Promise((resolve) => { accept = resolve; }));
+    serveLaunchRoute();
+    const callbacks = watch(f);
+    await vi.waitFor(() => expect(h.launch).toHaveBeenCalledTimes(1));
+    expect(supervisor.getWatchedAgents(f.repo)[0]).toMatchObject({ retryCount: 0, completionReported: true });
+    expect(callbacks.broadcastAgentUpdate.mock.calls.some(([event]) => event.status === 'retrying')).toBe(false);
+    await supervisor.ingestAgentCompletionSignal(f.surface);
+    expect(callbacks.onAgentCompletion).not.toHaveBeenCalled();
+    accept({ ok: true, runtime: 'claude-code', surfaceId: 'claude-code-owned:accepted-retry',
+      note: 'test acceptance', cwd: f.worktree, repoPath: f.worktree, worktree: null, laneId: f.lane.id });
+    await vi.waitFor(() => expect(callbacks.onAgentRetry).toHaveBeenCalledExactlyOnceWith(f.surface, 'claude-code-owned:accepted-retry'));
+    expect(supervisor.getWatchedAgents(f.repo)).toEqual([expect.objectContaining({
+      surfaceId: 'claude-code-owned:accepted-retry', retryCount: 1, completionReported: false,
+    })]);
+    closeDb();
+    expect(getSqlite().prepare('SELECT retry_count FROM watched_agents WHERE surface_id = ?')
+      .get('claude-code-owned:accepted-retry')).toEqual({ retry_count: 1 });
+    expect(getSqlite().prepare('SELECT surface_id FROM watched_agents WHERE surface_id = ?').get(f.surface)).toBeUndefined();
+    expect(callbacks.broadcastAgentUpdate.mock.calls.filter(([event]) => event.status === 'retrying')).toHaveLength(1);
+  });
+
+  it.each([
+    ['claude-code', 'native'],
+    ['claude-code', 'codex-subscription'],
+    ['codex', undefined],
+  ] as const)('preserves %s / %s after database reopen', async (runtime, carrier) => {
+    const f = fixture(runtime, { workMode: 'read-only', ...(carrier ? { modelSource: carrier } : {}) });
+    const lanesBefore = listLanes().length;
+    closeDb();
+    const transport = serveLaunchRoute();
+    expect(await relaunchSupervisedAgent('read only', f.repo, 'retry', f.surface))
+      .toEqual({ status: 'launched', surfaceId: `${runtime}-owned:retried` });
+    expect(h.launch).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+      runtime, model: f.session.model, effort: 'high', workMode: 'read-only',
+      ...(carrier ? { claudeCodeModel: f.session.model, claudeCodeCarrier: carrier } : {}),
+      repoPath: f.worktree, cwd: f.worktree, projectRepoPath: f.repo,
+      isolate: false, skipSetup: true, existingLaneId: f.lane.id,
+      branchName: f.lane.branch, clientMutationId: expect.any(String),
+    }));
+    expect(listLanes()).toHaveLength(lanesBefore);
+    expect(getLane(f.lane.id)?.sessionKey).toBe(f.surface);
+    const body = JSON.parse(String(transport.mock.calls[0][1]?.body));
+    const replay = await route.POST(new NextRequest('http://localhost/api/runtime/launch', {
+      method: 'POST', body: JSON.stringify(body),
+    }));
+    expect(replay.status).toBe(200);
+    expect(h.launch).toHaveBeenCalledTimes(1);
+    const conflict = await route.POST(new NextRequest('http://localhost/api/runtime/launch', {
+      method: 'POST', body: JSON.stringify({ ...body, claudeCodeCarrier: carrier === 'native' ? 'codex-subscription' : 'native' }),
+    }));
+    expect(conflict.status).toBe(409);
+    expect(h.launch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not silently reset a metered packet budget on retry', async () => {
+    const f = fixture('claude-code', { modelSource: 'openrouter', spendCapCostUsd: '0.5', spendCapInputTokens: '10000' });
+    const transport = serveLaunchRoute();
+    await expect(relaunchSupervisedAgent('read only', f.repo, 'retry', f.surface))
+      .resolves.toEqual({ status: 'held', reason: expect.stringContaining('remaining-budget') });
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it.each(['carrier', 'model', 'effort', 'worktree', 'runtime', 'active-run'] as const)(
+    'holds an unverifiable %s before any launch', async (missing) => {
+      const f = fixture('claude-code', { modelSource: 'native' });
+      if (missing === 'carrier') f.session.runtimeConfig = {};
+      if (missing === 'model') f.session.model = undefined;
+      if (missing === 'effort') f.session.effort = undefined;
+      if (missing === 'worktree') rmSync(f.worktree, { recursive: true });
+      if (missing === 'runtime') {
+        getSqlite().prepare('UPDATE lanes SET runtime = ? WHERE id = ?').run('codex', f.lane.id);
+        expect(getLane(f.lane.id)?.runtime).toBe('codex');
+      }
+      if (missing === 'active-run') f.session.activeRun = { outcome: 'running' } as OwnedSessionRecord['activeRun'];
+      f.save();
+      const transport = serveLaunchRoute();
+      await expect(relaunchSupervisedAgent('read only', f.repo, 'retry', f.surface))
+        .resolves.toEqual({ status: 'held', reason: expect.stringContaining('Automatic retry held') });
+      expect(transport).not.toHaveBeenCalled();
+      expect(h.launch).not.toHaveBeenCalled();
+      expect(getLane(f.lane.id)?.status).toBe('awaiting_input');
+      expect(getLaneEvents(f.lane.id).some((event) => event.payload.reason === 'supervisor_retry_held')).toBe(true);
+    },
+  );
+
+  it('does not restart a paused or archived lane', async () => {
+    const f = fixture('claude-code', { modelSource: 'native' });
+    const transport = serveLaunchRoute();
+    for (const status of ['paused', 'archived'] as const) {
+      updateLane(f.lane.id, { status });
+      await expect(relaunchSupervisedAgent('read only', f.repo, 'retry', f.surface))
+        .resolves.toEqual({ status: 'held', reason: expect.stringContaining('Automatic retry held') });
+      expect(getLane(f.lane.id)?.status).toBe(status);
+    }
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it('honors an operator stop during the saved-session read', async () => {
+    const f = fixture('claude-code', { modelSource: 'native' });
+    const sessionIo = await import('@/lib/runtimes/shared/owned-session/session-io');
+    const original = sessionIo.createOwnedSessionIo;
+    vi.spyOn(sessionIo, 'createOwnedSessionIo').mockImplementation((options) => {
+      const io = original(options);
+      return { ...io, async findSession(surfaceId) {
+        const session = await io.findSession(surfaceId);
+        updateLane(f.lane.id, { status: 'paused' });
+        return session;
+      } };
+    });
+    const transport = serveLaunchRoute();
+    await expect(relaunchSupervisedAgent('read only', f.repo, 'retry', f.surface))
+      .resolves.toEqual({ status: 'held', reason: expect.stringContaining('lane changed') });
+    expect(getLane(f.lane.id)?.status).toBe('paused');
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it('retains an explicit spend cap in the correlated route body', async () => {
+    const body = { runtime: 'claude-code', model: 'test-model', claudeCodeCarrier: 'openrouter',
+      spendCap: { carrier: 'openrouter', costUsd: 0.5, inputTokens: 10000 },
+      prompt: 'test', cwd: dataDir, clientMutationId: 'cap-preservation' };
+    const response = await route.POST(new NextRequest('http://localhost/api/runtime/launch', { method: 'POST', body: JSON.stringify(body) }));
+    expect(response.status).toBe(200);
+    expect(h.launch.mock.calls[0][0].spendCap).toEqual(body.spendCap);
+    const conflict = await route.POST(new NextRequest('http://localhost/api/runtime/launch', {
+      method: 'POST', body: JSON.stringify({ ...body, spendCap: { ...body.spendCap, costUsd: 1 } }),
+    }));
+    expect(conflict.status).toBe(409);
+    expect(h.launch).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed on invalid explicit carrier and safety fields', async () => {
+    for (const invalid of [{ claudeCodeCarrier: 'unknown' }, { workMode: 'unsafe' }, { spendCap: { carrier: 'openrouter', costUsd: -1 } }]) {
+      const response = await route.POST(new NextRequest('http://localhost/api/runtime/launch', {
+        method: 'POST', body: JSON.stringify({ runtime: 'claude-code', prompt: 'test', clientMutationId: 'invalid-retry', ...invalid }),
+      }));
+      expect(response.status).toBe(400);
+    }
+    expect(h.launch).not.toHaveBeenCalled();
+  });
+
+  it('wires the production supervisor callback to the tested retry path', () => {
+    const source = readFileSync(path.join(process.cwd(), 'src/ws-server.ts'), 'utf8');
+    const start = source.indexOf('async relaunchAgent(');
+    const section = source.slice(start, source.indexOf('broadcastAgentUpdate(', start));
+    expect(section).toContain('relaunchSupervisedAgent(prompt, repoPath, taskName, retryOfSurfaceId)');
+    expect(section).not.toContain("runtime: 'codex'");
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1937,6 +1937,13 @@
       ]
     },
     {
+      "path": "tests/native-worker-token-setup-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/o8-serve-governed-loop-real-path.test.ts",
       "reasons": [
         "child-process",
@@ -2336,6 +2343,14 @@
       ]
     },
     {
+      "path": "tests/sandbox-owned-stop-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "process-signal",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/script-shell-neutral.test.ts",
       "reasons": [
         "terminal-tool"
@@ -2455,6 +2470,20 @@
         "git-cli",
         "real-path",
         "worktree-api"
+      ]
+    },
+    {
+      "path": "tests/stream-terminal-callers-real-path.test.ts",
+      "reasons": [
+        "executable-fixture",
+        "process-signal",
+        "real-path"
+      ]
+    },
+    {
+      "path": "tests/supervisor-retry-identity-real-path.test.ts",
+      "reasons": [
+        "real-path"
       ]
     },
     {

--- a/tests/wait-wakes-on-blocked.test.ts
+++ b/tests/wait-wakes-on-blocked.test.ts
@@ -57,15 +57,30 @@ describe('#1467 — wait_for_mission_ready wakes on blocked packets', () => {
       }],
     }));
 
-    const result = await handleWaitForMissionReady(
-      { packetId: 'pkt-rerun', timeoutMs: 1_000, pollIntervalMs: 1_000 },
-      readStatus,
-    );
-    const payload = parsePayload(result as { content?: Array<{ type: string; text?: string }> });
+    vi.useFakeTimers();
+    try {
+      let settled = false;
+      const pending = handleWaitForMissionReady(
+        { packetId: 'pkt-rerun', timeoutMs: 1_000, pollIntervalMs: 1_000 },
+        readStatus,
+      ).then((result) => {
+        settled = true;
+        return result;
+      });
 
-    expect(payload.wakeReason).toBe('timeout');
-    expect(payload.wakeReason).not.toBe('already-terminal');
-    expect(readStatus).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(999);
+      expect(settled).toBe(false);
+      expect(readStatus).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await pending;
+      const payload = parsePayload(result as { content?: Array<{ type: string; text?: string }> });
+      expect(payload.wakeReason).toBe('timeout');
+      expect(payload.wakeReason).not.toBe('already-terminal');
+      expect(readStatus).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('returns immediately when a reviewing lane is already awaiting review', async () => {


### PR DESCRIPTION
## Summary

- Use dedicated native worker credentials without copying the operator refresh store into worker configuration.
- Prepare private worker configuration and compaction scratch before generating the sandbox policy.
- Grant linked workers only the immutable backing-project configuration file needed for startup.
- Preserve launch and stop identity, retry settings, failed outer results, and missing-result evidence across lifecycle caches.
- Stabilize the polling regression with a controlled clock and unchanged exact call-count assertions.

Closes #2095
Closes #2099

## Verification

- TypeScript, touched-file ESLint, changed-line rule check, test classification and diff checks passed.
- Hermetic tests: 4,117 passed, three skipped.
- Focused resource-owning integration: 196 passed, one platform-specific case skipped across 17 files. An initial 90-second aggregate timeout on the five-case cleanup file is retained; that unchanged file passed all five cases under a 300-second bound.
- The config-read regression first failed in read-only and edit modes, then passed using actual sandbox children launched under the production-generated profile. Neighboring reads and config writes remain denied.
- Independent review verified the exact source digest before and after review. No blocking findings were reported; operational limitations below remain explicit.

## Release boundaries

- Source checks are not built-artifact acceptance. A real owned native worker must complete successfully on the built artifact before installer publication.
- Native worker-token setup currently requires a source checkout with `npm run worker:login`; installed-app setup remains #2094.
- Stop existing owned workers through their owners before upgrading. The new stop path deliberately refuses live legacy processes without persisted ownership proof.
- Same-user process-environment exposure remains unresolved in #2098 and is deferred to 0.1.739. This change does not establish a credential-confidentiality boundary.
- The same-head no-work merge-label issue in #2096 is not fixed here.

No visual proof: runtime, sandbox and lifecycle logic changes.
