### PR TITLE
fix: coalesce durable inbox wakes

### DIFF
--- a/src/lib/agents/delivery.test.ts
+++ b/src/lib/agents/delivery.test.ts
@@ -1,11 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildClaudeTerminalUserTurn,
   codexAgentInboxWakeText,
+  deliverAgentMessage,
   submitClaudeTerminalUserTurn,
   submitCodexQueuedUserTurn,
 } from './delivery';
+import { AGENT_NATIVE_WAKE_TTL_MS } from './store';
+import type { AgentMessage, AgentPresence } from './types';
 
 describe('buildClaudeTerminalUserTurn', () => {
   it('builds an idempotent Codex wake without embedding stale peer content', () => {
@@ -82,5 +85,76 @@ describe('buildClaudeTerminalUserTurn', () => {
       cwd: '/workspace/o8',
       codexHome: '/workspace/.codex',
     }]);
+  });
+
+  it('coalesces a Codex inbox wake until the durable cursor advances or the wake expires', async () => {
+    const target: AgentPresence = {
+      agentId: 'codex-session',
+      name: 'Receiver',
+      repo: '/workspace/o8',
+      worktreePath: '/workspace/o8',
+      runtime: 'codex',
+      sessionKey: 'codex:thread',
+      laneId: null,
+      packetId: null,
+      lastSeen: new Date().toISOString(),
+    };
+    const message = (sequence: number): AgentMessage => ({
+      schema: 'o8/agents.message-event/v1',
+      kind: 'message',
+      sequence,
+      id: `message-${sequence}`,
+      from: 'Sender',
+      to: target.name,
+      repo: target.repo,
+      text: `Update ${sequence}`,
+      refs: { laneId: null, packetId: null },
+      delivery: 'poll',
+      deliveryNote: null,
+      timestamp: new Date().toISOString(),
+    });
+    const sendCodex = vi.fn().mockResolvedValue(undefined);
+    let inboxCursor = 0;
+    let now = 1_000;
+    let wake: { sessionKey: string; throughSequence: number; sentAt: number } | null = null;
+    const wakeSeams = {
+      claimCodexInboxWake: ({
+        target: wakeTarget,
+        throughSequence,
+      }: { target: AgentPresence; throughSequence: number }) => {
+        if (wake !== null
+          && wake.sessionKey === wakeTarget.sessionKey
+          && inboxCursor < wake.throughSequence
+          && now - wake.sentAt < AGENT_NATIVE_WAKE_TTL_MS) {
+          wake.throughSequence = Math.max(wake.throughSequence, throughSequence);
+          return false;
+        }
+        wake = {
+          sessionKey: wakeTarget.sessionKey ?? '',
+          throughSequence,
+          sentAt: now,
+        };
+        return true;
+      },
+      releaseCodexInboxWake: () => {
+        wake = null;
+      },
+    };
+    const deliverySeams = {
+      sendClaude: vi.fn().mockResolvedValue(undefined),
+      sendCodex,
+    };
+
+    await deliverAgentMessage(message(1), target, deliverySeams, wakeSeams);
+    await deliverAgentMessage(message(2), target, deliverySeams, wakeSeams);
+    expect(sendCodex).toHaveBeenCalledTimes(1);
+
+    inboxCursor = 2;
+    await deliverAgentMessage(message(3), target, deliverySeams, wakeSeams);
+    expect(sendCodex).toHaveBeenCalledTimes(2);
+
+    now += AGENT_NATIVE_WAKE_TTL_MS;
+    await deliverAgentMessage(message(4), target, deliverySeams, wakeSeams);
+    expect(sendCodex).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/lib/agents/delivery.ts
+++ b/src/lib/agents/delivery.ts
@@ -5,7 +5,7 @@ import os from 'node:os';
 import { promisify } from 'node:util';
 
 import { cliInvocation } from '@/lib/runtimes/shared/cli-spawn';
-import type { AgentMessage, AgentPresence } from './store';
+import type { AgentMessage, AgentPresence } from './types';
 
 const execFileAsync = promisify(execFile);
 
@@ -159,6 +159,14 @@ export interface AgentMessageDeliverySeams {
   sendCodex: (target: AgentPresence, text: string) => Promise<void>;
 }
 
+export interface AgentInboxWakeSeams {
+  claimCodexInboxWake: (input: {
+    target: AgentPresence;
+    throughSequence: number;
+  }) => boolean | Promise<boolean>;
+  releaseCodexInboxWake: (target: AgentPresence) => void | Promise<void>;
+}
+
 export function nativeAgentMessageText(message: AgentMessage): string {
   return [
     `[o8 peer message from ${message.from}]`,
@@ -226,10 +234,22 @@ export const defaultAgentMessageDeliverySeams: AgentMessageDeliverySeams = {
   sendCodex: defaultSendCodex,
 };
 
+export const defaultAgentInboxWakeSeams: AgentInboxWakeSeams = {
+  claimCodexInboxWake: async ({ target, throughSequence }) => {
+    const { claimAgentInboxWake } = await import('./store');
+    return claimAgentInboxWake({ agent: target, throughSequence });
+  },
+  releaseCodexInboxWake: async (target) => {
+    const { releaseAgentInboxWake } = await import('./store');
+    releaseAgentInboxWake(target);
+  },
+};
+
 export async function deliverAgentMessage(
   message: AgentMessage,
   target: AgentPresence,
   seams: AgentMessageDeliverySeams = defaultAgentMessageDeliverySeams,
+  wakeSeams: AgentInboxWakeSeams = defaultAgentInboxWakeSeams,
 ): Promise<{ delivery: AgentMessage['delivery']; note: string }> {
   if (!target.sessionKey) return { delivery: 'poll', note: 'Target polls the durable inbox.' };
   if (target.runtime === 'claude' || target.runtime === 'claude-code') {
@@ -237,8 +257,26 @@ export async function deliverAgentMessage(
     return { delivery: 'native', note: 'Submitted to the exact live Claude terminal session.' };
   }
   if (target.runtime === 'codex') {
-    await seams.sendCodex(target, codexAgentInboxWakeText());
-    return { delivery: 'native', note: 'Accepted by the exact Codex task queue as an inbox wake.' };
+    const claimedWake = await wakeSeams.claimCodexInboxWake({
+      target,
+      throughSequence: message.sequence,
+    });
+    if (!claimedWake) {
+      return {
+        delivery: 'poll',
+        note: 'A Codex inbox wake is already pending; retained in the durable inbox.',
+      };
+    }
+    try {
+      await seams.sendCodex(target, codexAgentInboxWakeText());
+      return {
+        delivery: 'poll',
+        note: 'Codex inbox wake accepted; retained in the durable inbox until the target reads it.',
+      };
+    } catch (error) {
+      await wakeSeams.releaseCodexInboxWake(target);
+      throw error;
+    }
   }
   return { delivery: 'poll', note: 'Target runtime polls the durable inbox.' };
 }

--- a/src/lib/agents/service.ts
+++ b/src/lib/agents/service.ts
@@ -10,6 +10,7 @@ import { getSqlite } from '@/lib/db';
 import { findLaneByPacket, getLane } from '@/lib/lane/registry';
 import type { Lane } from '@/lib/lane/types';
 import {
+  type AgentInboxWakeSeams,
   type AgentMessageDeliverySeams,
   defaultAgentMessageDeliverySeams,
   deliverAgentMessage,
@@ -219,41 +220,14 @@ export async function postAgentMessage(
     refs: messageRefs(body, lane),
   }, sqlite);
   if (!isPresenceLive(target)) return message;
-  const usesCodexInboxWake = target.runtime === 'codex' && target.sessionKey !== null;
-  if (usesCodexInboxWake) {
-    const claimedWake = claimAgentInboxWake({ agent: target, throughSequence: message.sequence }, sqlite);
-    if (!claimedWake) {
-      return updateAgentMessageDelivery(
-        message.id,
-        'poll',
-        'A Codex inbox wake is already pending; retained in the durable inbox.',
-        sqlite,
-      );
-    }
-    try {
-      const result = await deliverAgentMessage(message, target, seams);
-      if (result.delivery !== 'native') {
-        releaseAgentInboxWake(target, sqlite);
-        return updateAgentMessageDelivery(message.id, result.delivery, result.note, sqlite);
-      }
-      return updateAgentMessageDelivery(
-        message.id,
-        'poll',
-        'Codex inbox wake accepted; retained in the durable inbox until the target reads it.',
-        sqlite,
-      );
-    } catch (error) {
-      releaseAgentInboxWake(target, sqlite);
-      return updateAgentMessageDelivery(
-        message.id,
-        'poll',
-        `Live delivery deferred; retained in the durable inbox. ${error instanceof Error ? error.message : String(error)}`,
-        sqlite,
-      );
-    }
-  }
+  const wakeSeams: AgentInboxWakeSeams = {
+    claimCodexInboxWake: ({ target: wakeTarget, throughSequence }) => (
+      claimAgentInboxWake({ agent: wakeTarget, throughSequence }, sqlite)
+    ),
+    releaseCodexInboxWake: (wakeTarget) => releaseAgentInboxWake(wakeTarget, sqlite),
+  };
   try {
-    const result = await deliverAgentMessage(message, target, seams);
+    const result = await deliverAgentMessage(message, target, seams, wakeSeams);
     message = updateAgentMessageDelivery(message.id, result.delivery, result.note, sqlite);
   } catch (error) {
     message = updateAgentMessageDelivery(

--- a/src/lib/agents/store.ts
+++ b/src/lib/agents/store.ts
@@ -13,6 +13,7 @@ export type { AgentMessage, AgentMessageRefs, AgentPresence } from './types';
 
 export const AGENT_MESSAGE_TEXT_MAX_LENGTH = 4_000;
 export const AGENT_PRESENCE_TTL_MS = 6 * 60_000;
+// Re-wake after a bounded delay so a lost queued turn cannot silence a target indefinitely.
 export const AGENT_NATIVE_WAKE_TTL_MS = 15 * 60_000;
 
 export type AgentPresenceWriteResult = AgentPresence & {
@@ -396,6 +397,7 @@ export function claimAgentInboxWake(
     const state = ensureAgentInboxState(input.agent, sqlite);
     const wakeAt = state.native_wake_at ? Date.parse(state.native_wake_at) : Number.NaN;
     const wakeIsFresh = state.native_wake_session_key === input.agent.sessionKey
+      && state.acknowledged_sequence < state.native_wake_through_sequence
       && Number.isFinite(wakeAt)
       && now.getTime() - wakeAt < AGENT_NATIVE_WAKE_TTL_MS;
     if (wakeIsFresh) {


### PR DESCRIPTION
## Summary

- enforce one outstanding durable inbox wake per target session
- release the wake when the acknowledged cursor catches up
- retry after the persisted 15-minute recovery bound

## Verification

- [x] npx tsc --noEmit
- [x] npx eslint on touched files
- [x] npx vitest run src/lib/agents
- [x] npx vitest run tests/agent-message-bus-real-path.test.ts
- [x] npm run rule-check -- --base=origin/main
- [x] npm run test:classification:check

Closes #2100