### PR TITLE
fix: preserve worker outcomes and package operator login

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -15,6 +15,7 @@ JSON to stdout is the default; pass `--human` for ANSI-formatted output.
 | `o8 status` | Snapshot: running packets, active lanes, recent merges, pending approvals |
 | `o8 history <thoughts-thread-id> [--limit 200]` | Read one continuous orchestrator transcript with permanent, audited handoff seams |
 | `o8 worker spawn --title "..." [--repo <path>]` | Create and dispatch one governed worker from any local repo without adding it to Projects; the running app opens a dedicated worker pane |
+| `o8 worker login` | Connect a dedicated encrypted native worker token on macOS from an operator terminal; no source checkout is required and raw setup output is suppressed |
 | `o8 mission create --title "..." [--dispatch]` | Create a transient-repo mission; `--dispatch` starts it immediately |
 | `o8 repo list` | List every repository registered in the running app |
 | `o8 repo add <path>` | Register an existing local Git repository from any current directory |

--- a/cli/esbuild.config.mjs
+++ b/cli/esbuild.config.mjs
@@ -45,4 +45,20 @@ await esbuild.build({
 });
 
 execSync(`chmod +x ${outFile}`);
+// Keep the private PTY setup flow in a separate bundle. It can use the server's
+// encrypted storage implementation without adding native modules to every CLI command.
+await esbuild.build({
+  entryPoints: [join(__dirname, '..', 'scripts', 'connect-native-worker.ts')],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  target: 'node22',
+  banner: { js: ESM_BANNER },
+  alias: {
+    '@': join(__dirname, '..', 'src'),
+    'server-only': join(__dirname, '..', 'scripts', 'server-only-stub.js'),
+  },
+  external: ['node-pty'],
+  outfile: join(__dirname, 'dist', 'worker-login.mjs'),
+});
 console.log(`built ${outFile}`);

--- a/cli/src/commands/worker-login.ts
+++ b/cli/src/commands/worker-login.ts
@@ -1,0 +1,47 @@
+import { spawn } from 'node:child_process';
+import { existsSync, realpathSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { CliError, EXIT } from '../api.js';
+import { printJson, type OutputMode } from '../output.js';
+
+/** The companion helper owns the private PTY; raw provider output never reaches this process. */
+export async function runWorkerLogin(mode: OutputMode, rest: string[]): Promise<number> {
+  if (rest.length) throw new CliError('invalid_args', 'Worker login takes no arguments or token values.', EXIT.INVALID_ARGS);
+  if (process.env.O8_WORKER_TOKEN || process.env.O8_WORKER_PACKET_ID || process.env.O8_SPECTATOR_TOKEN) {
+    throw new CliError('operator_required', 'Dedicated worker login requires an operator terminal.', EXIT.UNAUTHORIZED);
+  }
+  if (process.platform !== 'darwin') {
+    throw new CliError('unsupported_platform', 'Dedicated worker login is currently available on macOS.', EXIT.CONFLICT);
+  }
+  const helper = join(dirname(realpathSync(process.argv[1]!)), 'worker-login.mjs');
+  if (!existsSync(helper)) {
+    throw new CliError('worker_login_unavailable', 'This CLI installation is missing its worker login helper.', EXIT.NOT_FOUND,
+      'Update the installed app and use its bundled o8 command.');
+  }
+  const code = await new Promise<number>((resolve) => {
+    const child = spawn(process.execPath, [helper], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, NODE_OPTIONS: '' },
+    });
+    // Only the helper's fixed progress and bounded diagnostic messages are forwarded.
+    child.stdout.on('data', (chunk: Buffer) => process.stderr.write(chunk));
+    child.stderr.on('data', (chunk: Buffer) => process.stderr.write(chunk));
+    const interrupt = () => child.kill('SIGINT');
+    const terminate = () => child.kill('SIGTERM');
+    process.once('SIGINT', interrupt);
+    process.once('SIGTERM', terminate);
+    child.once('error', () => resolve(EXIT.CONFLICT));
+    child.once('close', (exitCode) => {
+      process.off('SIGINT', interrupt);
+      process.off('SIGTERM', terminate);
+      resolve(exitCode === 0 ? EXIT.OK : EXIT.CONFLICT);
+    });
+  });
+  if (code !== EXIT.OK) {
+    throw new CliError('worker_login_incomplete', 'Dedicated worker login stopped without a saved-token receipt.', EXIT.CONFLICT);
+  }
+  if (mode.human) process.stdout.write('Worker token encrypted and saved. Run a worker to verify authentication.\n');
+  else printJson({ schema: 'o8/cli/worker-login/v1', saved: true, authenticationVerified: false });
+  return EXIT.OK;
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -52,6 +52,7 @@ import { runSession } from './commands/session.js';
 import { runRun } from './commands/run.js';
 import { runServe } from './commands/serve.js';
 import { runVersion } from './commands/version.js';
+import { runWorkerLogin } from './commands/worker-login.js';
 import { runPacketInfo } from './commands/packet/info.js';
 import { runPacketHeartbeat } from './commands/packet/heartbeat.js';
 import { runPacketLog } from './commands/packet/log.js';
@@ -257,6 +258,7 @@ commands:
   lease status <resource>   read the holder and FIFO queue for one resource
   lease list           list active named resources
   worker spawn         create + dispatch one governed worker from any Git repo (--title --body [--repo path] [--runtime id] [--caller label] [--read-only])
+  worker login         connect an encrypted native worker token from an operator terminal (macOS; no source checkout needed)
   mission create       create a mission from an inline task (--title --body [--dispatch] [--model m] [--carrier native|openrouter|codex-subscription] [--caller label] [--read-only] [--existingBranchPolicy auto|reset|continue|error] [--compare m1,m2] [--quality-search-contract file])
   mission dispatch     dispatch packets to workers (async; --wait blocks for launch; --watch blocks until review/terminal — the spawner's notification) [--mission <id>]
   mission status       mission + packet state [--mission <id>] [--cost]
@@ -424,6 +426,7 @@ async function dispatch(args: ParsedArgs): Promise<number> {
     case 'mission':
       return runMission(args.mode, secondary, args.rest);
     case 'worker': {
+      if (secondary === 'login') return runWorkerLogin(args.mode, args.rest);
       if (secondary === 'spawn') return runMission(args.mode, 'create', [...args.rest, '--dispatch']);
       throw unknownSubcommandError('worker', secondary);
     }

--- a/scripts/connect-native-worker.ts
+++ b/scripts/connect-native-worker.ts
@@ -12,7 +12,8 @@ import { extractSetupWorkerToken, workerTokenSetupNeedsBrowser } from '../src/li
 // terminal: it prints the credential. This wrapper retains output in memory only.
 async function main(): Promise<void> {
   if (process.platform !== 'darwin') throw new Error('Mac acceptance required.');
-  if (process.env.O8_WORKER_TOKEN || process.env.O8_WORKER_PACKET_ID) throw new Error('Operator context required.');
+  if (process.env.O8_WORKER_TOKEN || process.env.O8_WORKER_PACKET_ID || process.env.O8_SPECTATOR_TOKEN
+    || /(?:^|[/\\])\.cortex-worktrees[/\\]packet-/.test(process.cwd())) throw new Error('Operator context required.');
   const binary = await resolveCli({ runtimeId: 'claude-code', binaryName: 'claude', envOverride: 'O8_CLAUDE_CODE_BIN' });
   const { spawn } = createRequire(import.meta.url)('node-pty') as typeof import('node-pty');
   const configDir = await mkdtemp(path.join(os.tmpdir(), 'o8-worker-login-'));
@@ -27,6 +28,9 @@ async function main(): Promise<void> {
     FORCE_COLOR: '0', NO_COLOR: '1',
   });
   delete env.BROWSER;
+  delete env.O8_MASTER_KEY;
+  delete env.O8_API_TOKEN;
+  delete env.O8_SPECTATOR_TOKEN;
   try {
     await new Promise<void>((resolve, reject) => {
       const child = spawn(binary.path, ['setup-token'], { cwd: configDir, env, cols: 1000, rows: 40 });
@@ -59,6 +63,7 @@ async function main(): Promise<void> {
         }
       });
       child.onExit(({ exitCode }) => {
+        if (settled) return;
         const token = extractSetupWorkerToken(raw, exitCode === 0);
         if (token) saving = saveNativeWorkerToken(token);
         if (saving) void saving.then(() => finish(true), () => finish(false));

--- a/scripts/tauri-export.mjs
+++ b/scripts/tauri-export.mjs
@@ -712,6 +712,7 @@ if (existsSync(DECOMPOSE_PROMPT_SRC)) {
 // sessions do not fail at `#!/usr/bin/env node`.
 const CLI_BUILD = join(root, 'cli', 'esbuild.config.mjs');
 const CLI_OUTPUT = join(root, 'cli', 'dist', 'o8.mjs');
+const CLI_WORKER_LOGIN_OUTPUT = join(root, 'cli', 'dist', 'worker-login.mjs');
 const CLI_BIN_DIR = join(server, 'bin');
 const CLI_BIN_DST = join(CLI_BIN_DIR, 'o8');
 const CLI_BUNDLE_DST = join(CLI_BIN_DIR, 'o8.mjs');
@@ -722,12 +723,13 @@ if (existsSync(CLI_BUILD)) {
     cwd: join(root, 'cli'),
     env: canonicalizeServerOnlyStubEnv(process.env),
   });
-  if (!existsSync(CLI_OUTPUT)) {
+  if (!existsSync(CLI_OUTPUT) || !existsSync(CLI_WORKER_LOGIN_OUTPUT)) {
     console.error(`❌ CLI build did not produce ${CLI_OUTPUT}`);
     process.exit(1);
   }
   mkdirSync(CLI_BIN_DIR, { recursive: true });
   cpSync(CLI_OUTPUT, CLI_BUNDLE_DST);
+  cpSync(CLI_WORKER_LOGIN_OUTPUT, join(CLI_BIN_DIR, 'worker-login.mjs'));
   writeFileSync(CLI_BIN_DST, `#!/bin/sh
 set -eu
 # Resolve the REAL script location through symlinks — o8 is invoked via

--- a/src/lib/claude-code/worker-token.ts
+++ b/src/lib/claude-code/worker-token.ts
@@ -9,7 +9,7 @@ import { decryptValue, encryptValue } from '@/lib/db/master-key';
 import { hasClaudeEnvCredential } from './oauth-credential';
 
 const TOKEN_FILE = 'native-worker-token.json';
-export const WORKER_TOKEN_SETUP_HINT = 'Run `npm run worker:login` from the application source checkout to connect a dedicated worker token.';
+export const WORKER_TOKEN_SETUP_HINT = 'Run `o8 worker login` in an operator terminal to connect a dedicated worker token. No source checkout is needed. Codex workers are unaffected.';
 export const requiresNativeWorkerToken = (): boolean => process.platform === 'darwin';
 
 /** An inference token, never the operator login's refresh credential. */

--- a/src/lib/lane/reconcile.ts
+++ b/src/lib/lane/reconcile.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { promisify } from 'node:util';
 
 import { createApproval } from '@/lib/approvals/store';
+import { laneCreationBaseCommit } from '@/lib/lane/creation-base';
 import { getLaneEvents, listLanes, setLaneStatus } from '@/lib/lane/registry';
 import type { Lane, LaneRuntime, LaneStatus } from '@/lib/lane/types';
 import { getRuntime } from '@/lib/runtimes';
@@ -178,6 +179,13 @@ function latestRecordedMergeHeadSha(lane: Lane): string | null {
 async function laneMergeConfirmed(lane: Lane): Promise<boolean> {
   const laneHeadSha = (await readRefSha(lane.repoPath, lane.branch)) ?? latestRecordedMergeHeadSha(lane);
   if (laneHeadSha) {
+    const events = getLaneEvents(lane.id, 10_000);
+    const creationBase = laneCreationBaseCommit(events);
+    const recordedMerge = events.some((event) => (
+      event.verb === 'merge' && event.payload.laneHeadSha === laneHeadSha
+    ));
+    if (lane.outcome !== 'merged' && !recordedMerge
+      && (!creationBase || creationBase === laneHeadSha)) return false;
     return isAncestorCommit(lane.repoPath, laneHeadSha, lane.baseBranch);
   }
 

--- a/src/lib/orchestrator/merged-by-ancestry.test.ts
+++ b/src/lib/orchestrator/merged-by-ancestry.test.ts
@@ -29,7 +29,7 @@ process.env.CORTEX_IDE_OWNED_CLAUDE_CODE_ROOT = mkdtempSync(
   join(tmpdir(), 'o8-merged-by-ancestry-owned-claude-'),
 );
 
-const { appendEvent, createLane, deleteLane, getLane, setLaneStatus, updateLane } = await import('@/lib/lane/registry');
+const { appendEvent, createLane, deleteLane, getLane, getLaneEvents, setLaneStatus, updateLane } = await import('@/lib/lane/registry');
 const { triggerAutoReview } = await import('@/lib/lane/auto-review');
 const { getSqlite } = await import('@/lib/db');
 const { readOrchestratorControlPlaneState, writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
@@ -183,6 +183,35 @@ afterEach(() => {
 });
 
 describe('merged-by-ancestry reconciliation', () => {
+  it.each([
+    { label: 'failed', laneStatus: 'failed', packetStatus: 'failed', eventLabel: 'agent_failed' },
+    { label: 'stopped', laneStatus: 'paused', packetStatus: 'blocked', eventLabel: 'operator_stopped' },
+    { label: 'stale review', laneStatus: 'reviewing', packetStatus: 'awaiting_review', eventLabel: 'ready_for_review' },
+  ] as const)('preserves $label no-work exit truth across repeated sweeps and base advances', async ({ label, laneStatus, packetStatus, eventLabel }) => {
+    const { clone, seed } = makeRepo('o8-no-work-exit');
+    const packetId = `pkt-no-work-${label}`;
+    const lane = seedPacket(clone, packetId);
+    const exit = { exitCode: 1, classification: 'nonzero-exit', runtimeOutcome: 'failed', completedTurn: false };
+    appendEvent(lane.id, 'runtime_process_exit', 'system', exit);
+    setLaneStatus(lane.id, laneStatus, 'system', eventLabel);
+    const state = readOrchestratorControlPlaneState();
+    state.packets[0]!.status = packetStatus;
+    writeOrchestratorControlPlaneState(state);
+
+    for (const advanceBase of [false, true]) {
+      if (advanceBase) {
+        writeFileSync(join(seed, 'later.txt'), 'unrelated base change\n');
+        commitAll(seed, 'advance base');
+        git(seed, ['push', 'origin', 'main']);
+      }
+      await sweepPacketsMergedByAncestry();
+      expect(persistedPacket(packetId)).toMatchObject({ status: packetStatus, releaseState: 'pending' });
+      expect(getLane(lane.id)).toMatchObject({ status: laneStatus });
+      expect(getLane(lane.id)?.outcome).not.toBe('merged');
+      expect(getLaneEvents(lane.id).find((event) => event.verb === 'runtime_process_exit')?.payload).toEqual(exit);
+    }
+  });
+
   it('releases packet and archives lane when branch head is ancestor of origin/main', async () => {
     const { clone, seed } = makeRepo('o8-merged-ancestor');
     writeFileSync(join(clone, 'packet.txt'), 'packet\n');
@@ -216,6 +245,21 @@ describe('merged-by-ancestry reconciliation', () => {
       last_error: 'Cancelled: merged_by_ancestry_reconcile',
     });
   }, 20_000);
+
+  it('preserves an operator stop that arrives after no-change detection', async () => {
+    const { clone } = makeRepo('o8-no-work-stop-race');
+    const lane = seedPacket(clone, 'pkt-stop-race');
+    h.beforeActivityAssessment = () => {
+      setLaneStatus(lane.id, 'paused', 'user', 'operator_stopped');
+      const state = readOrchestratorControlPlaneState();
+      state.packets[0]!.status = 'blocked';
+      writeOrchestratorControlPlaneState(state);
+    };
+
+    await expect(sweepPacketsMergedByAncestry()).resolves.toMatchObject({ merged: 0 });
+    expect(persistedPacket('pkt-stop-race')).toMatchObject({ status: 'blocked', releaseState: 'pending' });
+    expect(getLane(lane.id)).toMatchObject({ status: 'paused', lastEventLabel: 'operator_stopped' });
+  });
 
   it('releases packet and archives lane when squash-equivalent content is on origin/main', async () => {
     const { clone, seed } = makeRepo('o8-merged-squash');

--- a/src/lib/orchestrator/merged-by-ancestry.ts
+++ b/src/lib/orchestrator/merged-by-ancestry.ts
@@ -116,6 +116,22 @@ function hasDurableLaunchEvidence(candidate: Candidate): boolean {
   ));
 }
 
+function hasUnsuccessfulTurn(candidate: Candidate): boolean {
+  const lane = candidate.laneId ? getLane(candidate.laneId) ?? candidate.lane : candidate.lane;
+  if (candidate.packet?.status === 'failed' || candidate.packet?.status === 'blocked'
+    || lane?.status === 'failed' || lane?.status === 'paused') return true;
+  const exit = candidate.laneId
+    ? getLaneEvents(candidate.laneId, 10_000).slice().reverse()
+      .find((event) => event.verb === 'runtime_process_exit')?.payload
+    : null;
+  return Boolean(exit && (
+    exit.runtimeOutcome === 'failed'
+    || exit.runtimeOutcome === 'interrupted'
+    || exit.completedTurn === false
+    || (typeof exit.exitCode === 'number' && exit.exitCode !== 0)
+  ));
+}
+
 async function git(
   cwd: string,
   args: string[],
@@ -306,6 +322,7 @@ async function detectMergedByAncestry(candidate: Candidate): Promise<MergeEviden
     : null;
   const noChangesEligible = !laneAlreadyMerged
     && durableLaunch
+    && !hasUnsuccessfulTurn(candidate)
     && (
       candidate.packet === null || candidate.packet.status === 'awaiting_review'
     );
@@ -337,7 +354,10 @@ async function detectMergedByAncestry(candidate: Candidate): Promise<MergeEviden
   ]);
   if (!headSha || !baseSha) return null;
 
-  if (noChangesEligible && creationBaseCommit === headSha) {
+  if (!laneAlreadyMerged && creationBaseCommit === headSha) {
+    // An attempted turn does not prove work. Never let an unsuccessful
+    // no-change lane fall through to the reflexive ancestry check below.
+    if (!noChangesEligible) return null;
     return {
       kind: 'no-changes',
       repoPath,
@@ -352,7 +372,7 @@ async function detectMergedByAncestry(candidate: Candidate): Promise<MergeEviden
 
   const publishedBranchExists = branch !== baseBranch
     && await refExists(repoPath, `origin/${branch}`);
-  if (headSha === baseSha && !laneAlreadyMerged) {
+  if (headSha === baseSha && !laneAlreadyMerged && creationBaseCommit === null) {
     if (noChangesEligible
       && creationBaseCommit === null
       && (branch === baseBranch || !publishedBranchExists)) {
@@ -366,10 +386,17 @@ async function detectMergedByAncestry(candidate: Candidate): Promise<MergeEviden
         noChangesReason: 'branch_matches_base',
       };
     }
-    if (!durableLaunch) return null;
+    return null;
   }
 
   if (await isAncestor(repoPath, headSha, baseRef)) {
+    // Legacy lanes without a creation baseline need a recorded merge head;
+    // ancestry alone cannot distinguish untouched work from a real merge.
+    if (!creationBaseCommit && !laneAlreadyMerged && !(
+      candidate.laneId && getLaneEvents(candidate.laneId, 10_000).some((event) => (
+        event.verb === 'merge' && event.payload.laneHeadSha === headSha
+      ))
+    )) return null;
     return {
       kind: 'ancestor',
       repoPath,
@@ -572,6 +599,7 @@ async function releasePacket(candidate: Candidate, evidence: MergeEvidence): Pro
 }
 
 async function finishWithoutChanges(candidate: Candidate, evidence: MergeEvidence): Promise<boolean> {
+  if (hasUnsuccessfulTurn(candidate)) return false;
   if (!(await evidenceStillHolds(evidence))) {
     recordEvidenceDeclined(candidate, evidence);
     return false;
@@ -583,9 +611,11 @@ async function finishWithoutChanges(candidate: Candidate, evidence: MergeEvidenc
   const packetTitle = candidate.packet?.title ?? candidate.lane?.label ?? packetId ?? 'Dispatched packet';
 
   if (candidate.packet) {
+    let accepted = false;
     await withLockedState((state) => {
       const packet = state.packets.find((item) => item.id === candidate.packet?.id);
-      if (!packet) return;
+      if (!packet || hasUnsuccessfulTurn({ ...candidate, packet })) return;
+      accepted = true;
       packet.status = 'archived';
       packet.queueState = 'held';
       packet.blockedReason = null;
@@ -593,6 +623,7 @@ async function finishWithoutChanges(candidate: Candidate, evidence: MergeEvidenc
       packet.lastEventAt = finishedAt;
       packet.lastEventLabel = 'finished_no_changes';
     });
+    if (!accepted) return false;
   }
 
   if (candidate.laneId) {

--- a/tests/merge-truth-ancestry-real-git.test.ts
+++ b/tests/merge-truth-ancestry-real-git.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 
 import { afterAll, describe, expect, it } from 'vitest';
 
-const { appendEvent, createLane, getLane, setLaneStatus } = await import('@/lib/lane/registry');
+const { appendEvent, createLane, getLane, getLaneEvents, setLaneStatus } = await import('@/lib/lane/registry');
 const { reconcileOrphanedWorktrees } = await import('@/lib/lane/reconcile');
 const { listZombieLaneCandidates } = await import('@/lib/lane/reaper');
 const { sweepPacketsMergedByAncestry } = await import('@/lib/orchestrator/merged-by-ancestry');
@@ -90,9 +90,31 @@ afterAll(() => {
 });
 
 describe('merge truth by git ancestry', () => {
+  it('does not complete a failed no-work lane when its worktree is missing', async () => {
+    const repo = makeRepo('o8-no-work-missing-');
+    git(repo, ['checkout', '-b', 'inline/no-work-failed']);
+    const lane = createLane({
+      repoPath: repo,
+      worktreePath: missingWorktree(repo, 'missing-failed'),
+      branch: 'inline/no-work-failed',
+      baseBranch: 'main',
+      runtime: 'codex',
+      packetId: 'pkt-no-work-failed-missing',
+    });
+    const exit = { exitCode: 1, classification: 'nonzero-exit', runtimeOutcome: 'failed', completedTurn: false };
+    appendEvent(lane.id, 'runtime_process_exit', 'system', exit);
+    setLaneStatus(lane.id, 'awaiting_input', 'system', 'agent_failed');
+
+    await reconcileOrphanedWorktrees();
+    expect(getLane(lane.id)?.status).not.toBe('completed');
+    expect(getLane(lane.id)?.outcome).not.toBe('merged');
+    expect(getLaneEvents(lane.id).find((event) => event.verb === 'runtime_process_exit')?.payload).toEqual(exit);
+  });
+
   it('confirms a merged lane head with the lane head as ancestor and base as descendant', async () => {
     const repo = makeRepo('o8-merge-truth-merged-');
     git(repo, ['checkout', '-b', 'inline/merged']);
+    const creationBase = git(repo, ['rev-parse', 'HEAD']);
     writeFileSync(join(repo, 'feature.txt'), 'feature\n');
     const laneHead = commitAll(repo, 'feature');
     git(repo, ['checkout', 'main']);
@@ -107,6 +129,7 @@ describe('merge truth by git ancestry', () => {
       baseBranch: 'main',
       runtime: 'codex',
       packetId: 'pkt-merged',
+      baseCommit: creationBase,
     });
     setLaneStatus(lane.id, 'reviewing', 'system', 'review_ready');
 

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2637,6 +2637,13 @@
       ]
     },
     {
+      "path": "tests/worker-login-cli-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/worker-mcp-injection-codex-real-path.test.ts",
       "reasons": [
         "child-process",

--- a/tests/worker-login-cli-real-path.test.ts
+++ b/tests/worker-login-cli-real-path.test.ts
@@ -1,0 +1,141 @@
+import { execFile } from 'node:child_process';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const roots: string[] = [];
+const sourceRoot = process.cwd();
+
+beforeAll(async () => {
+  await execFileAsync(process.execPath, ['cli/esbuild.config.mjs'], { cwd: sourceRoot, timeout: 30_000 });
+});
+
+afterAll(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+function fixture(providerExitCode = 0) {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'o8-worker-login-cli-'));
+  roots.push(root);
+  const bin = path.join(root, 'server/bin');
+  mkdirSync(bin, { recursive: true });
+  for (const file of ['o8.mjs', 'worker-login.mjs']) {
+    copyFileSync(path.join(sourceRoot, 'cli/dist', file), path.join(bin, file));
+  }
+  symlinkSync(path.join(sourceRoot, 'node_modules'), path.join(root, 'server/node_modules'), 'dir');
+  const native = path.join(root, 'fixture-cli');
+  const record = path.join(root, 'provider-invocation.json');
+  const token = `sk-ant-oat01-${'synthetic'.repeat(12)}`;
+  writeFileSync(native, [
+    `#!${process.execPath}`,
+    'const fs = require("node:fs");',
+    'if (process.argv.includes("--version")) { console.log("2.1.261"); process.exit(); }',
+    `fs.writeFileSync(${JSON.stringify(record)}, JSON.stringify({ args: process.argv.slice(2), cwd: process.cwd(), masterKeyPresent: Boolean(process.env.O8_MASTER_KEY), apiTokenPresent: Boolean(process.env.O8_API_TOKEN) }));`,
+    'process.stdout.write("Browser didn\'t open?".repeat(20000));',
+    `setTimeout(() => { console.log(${JSON.stringify(token)}); process.exitCode = ${providerExitCode}; }, 100);`,
+  ].join('\n'), { mode: 0o700 });
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: root,
+    NODE_OPTIONS: '',
+    O8_DATA_DIR: path.join(root, 'data'),
+    CORTEX_IDE_DATA_DIR: path.join(root, 'data'),
+    O8_MASTER_KEY: Buffer.alloc(32, 7).toString('base64url'),
+    O8_API_TOKEN: 'synthetic-operator-control-token',
+    O8_CLAUDE_CODE_BIN: native,
+  };
+  delete env.O8_WORKER_TOKEN;
+  delete env.O8_WORKER_PACKET_ID;
+  delete env.O8_SPECTATOR_TOKEN;
+  const run = async (args = ['worker', 'login'], extraEnv: Partial<NodeJS.ProcessEnv> = {}) => {
+    try {
+      const result = await execFileAsync(process.execPath, [path.join(bin, 'o8.mjs'), ...args], {
+        cwd: root, env: { ...env, ...extraEnv }, timeout: 15_000, maxBuffer: 32 * 1024,
+      });
+      return { ...result, code: 0 };
+    } catch (error) {
+      const result = error as { stdout: string; stderr: string; code: number };
+      return { stdout: result.stdout, stderr: result.stderr, code: result.code };
+    }
+  };
+  return { root, bin, token, env, record, run };
+}
+
+describe.skipIf(process.platform !== 'darwin')('packaged operator worker login', () => {
+  it('uses only packaged files, saves encrypted state, and supplies the existing worker credential reader', async () => {
+    const f = fixture();
+    expect(existsSync(path.join(f.root, 'scripts'))).toBe(false);
+    const result = await f.run();
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({ schema: 'o8/cli/worker-login/v1', saved: true, authenticationVerified: false });
+    expect(result.stdout + result.stderr).not.toContain(f.token);
+    const saved = readFileSync(path.join(f.env.O8_DATA_DIR!, 'native-worker-token.json'), 'utf8');
+    expect(saved).not.toContain(f.token);
+    expect(JSON.parse(saved)).toMatchObject({ version: 1, ciphertext: expect.any(String), iv: expect.any(String) });
+    const invocation = JSON.parse(readFileSync(f.record, 'utf8'));
+    expect(invocation).toMatchObject({ args: ['setup-token'], masterKeyPresent: false, apiTokenPresent: false });
+    expect(existsSync(invocation.cwd)).toBe(false);
+
+    const { clearMasterKeyCache } = await import('@/lib/db/master-key');
+    try {
+      vi.stubEnv('O8_DATA_DIR', f.env.O8_DATA_DIR!);
+      vi.stubEnv('CORTEX_IDE_DATA_DIR', f.env.CORTEX_IDE_DATA_DIR!);
+      vi.stubEnv('O8_MASTER_KEY', f.env.O8_MASTER_KEY!);
+      for (const key of ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_AUTH_TOKEN']) vi.stubEnv(key, '');
+      clearMasterKeyCache();
+      const { nativeWorkerTokenEnv } = await import('@/lib/claude-code/worker-token');
+      expect(await nativeWorkerTokenEnv()).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: f.token });
+    } finally {
+      vi.unstubAllEnvs();
+      clearMasterKeyCache();
+    }
+  }, 25_000);
+
+  it.each(['O8_WORKER_TOKEN', 'O8_WORKER_PACKET_ID', 'O8_SPECTATOR_TOKEN'])('rejects %s before launching setup', async (key) => {
+    const f = fixture();
+    const result = await f.run(undefined, { [key]: 'synthetic-scoped-principal' });
+    expect(result.code).toBe(3);
+    expect(result.stderr).toContain('operator_required');
+    expect(existsSync(f.record)).toBe(false);
+    expect(existsSync(path.join(f.env.O8_DATA_DIR!, 'native-worker-token.json'))).toBe(false);
+  });
+
+  it('rejects token arguments without echoing their values', async () => {
+    const f = fixture();
+    const result = await f.run(['worker', 'login', '--token', f.token]);
+    expect(result.code).toBe(1);
+    expect(result.stdout + result.stderr).not.toContain(f.token);
+    expect(existsSync(f.record)).toBe(false);
+  });
+
+  it('does not save or disclose token-shaped output from a failed setup', async () => {
+    const f = fixture(1);
+    const result = await f.run();
+    expect(result.code).toBe(5);
+    expect(result.stderr).toContain('worker_login_incomplete');
+    expect(result.stdout + result.stderr).not.toContain(f.token);
+    expect(existsSync(path.join(f.env.O8_DATA_DIR!, 'native-worker-token.json'))).toBe(false);
+    expect(existsSync(JSON.parse(readFileSync(f.record, 'utf8')).cwd)).toBe(false);
+  });
+
+  it('reports a missing installed helper without attempting setup', async () => {
+    const f = fixture();
+    rmSync(path.join(f.bin, 'worker-login.mjs'));
+    const result = await f.run();
+    expect(result.code).toBe(4);
+    expect(result.stderr).toContain('worker_login_unavailable');
+    expect(existsSync(f.record)).toBe(false);
+    expect(existsSync(path.join(f.env.O8_DATA_DIR!, 'native-worker-token.json'))).toBe(false);
+  });
+
+  it('advertises the installed command in help', async () => {
+    const f = fixture();
+    const result = await f.run(['worker', '--help']);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('worker login');
+  });
+});


### PR DESCRIPTION
## Scope

- Preserve failed and stopped no-work outcomes during ancestry reconciliation, including repeated sweeps and stop races.
- Expose dedicated worker token setup through the bundled operator CLI without requiring a source checkout.
- Keep raw provider output private and reuse the existing encrypted token format.

Refs #2096 and #2094. These issues remain open until installed-artifact acceptance; this PR does not claim real provider authentication or privileged isolation.

## Verification

- 4,123 hermetic tests passed; 3 skipped.
- 33 real-Git and persisted-outcome regression tests passed.
- 14 packaged-login and encrypted-state regression tests passed using synthetic credentials.
- Root TypeScript, scoped ESLint, rule check, test classification, and diff whitespace checks passed.
- The additional CLI-project TypeScript check reproduces the same 11 existing errors on unchanged main. No new CLI type errors were introduced.
- Exact source received direct self-review. No independent agent review is claimed.

A signed build and installed checks follow integration. Existing operator authentication and unrelated changes are untouched.