### PR TITLE
fix: refresh dedicated worker readiness after login

### DIFF
--- a/src/lib/runtimes/shared/auth-detect-claude.test.ts
+++ b/src/lib/runtimes/shared/auth-detect-claude.test.ts
@@ -179,7 +179,7 @@ describe.skipIf(process.platform === 'win32')('Claude Code native sign-in verifi
     }));
     expect(await claudeStatus()).toMatchObject({
       ready: false, authenticated: false, unavailableReason: 'needs_auth',
-      fix: expect.stringContaining('npm run worker:login'),
+      fix: expect.stringContaining('o8 worker login'),
     });
     const response = await createMissionRoute.POST(createMissionRequest(91_762_030));
     expect(response.status).toBe(400);
@@ -198,6 +198,60 @@ describe.skipIf(process.platform === 'win32')('Claude Code native sign-in verifi
     });
     await expect(assertRuntimeDispatchable('claude-code')).resolves.toBeUndefined();
   });
+
+  it('refreshes external token saves and removals through mission creation without expiring the broad cache', async () => {
+    authFixture.dedicatedTokenRequired = true;
+    vi.stubEnv('O8_MASTER_KEY', Buffer.alloc(32, 7).toString('base64url'));
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(Date.now());
+    const tokenPath = path.join(dataRoot, 'native-worker-token.json');
+    const saveExternally = () => execFileSync(process.execPath, [
+      '--conditions=react-server', '--import', 'tsx', '--eval',
+      "const { saveNativeWorkerToken } = require('./src/lib/claude-code/worker-token.ts'); "
+        + "saveNativeWorkerToken('sk-ant-oat01-' + 'synthetic'.repeat(12)).catch(() => process.exit(1));",
+    ], { cwd: process.cwd(), env: process.env, timeout: 15_000, stdio: 'pipe' });
+    try {
+      const cold = await getRuntimeAuthSnapshot();
+      expect(cold.statuses.claude.ready).toBe(false);
+      const missing = await createMissionRoute.POST(createMissionRequest(91_762_040, { carrier: 'native' }));
+      expect(missing.status).toBe(400);
+
+      // A separate login process cannot invalidate this server's in-memory cache.
+      saveExternally();
+      const saved = await createMissionRoute.POST(createMissionRequest(91_762_041, { carrier: 'native' }));
+      expect(saved.status).toBe(201);
+      const savedBody = await saved.json();
+      expect(readOrchestratorControlPlaneState().packets.find(
+        (packet) => packet.id === savedBody.result.packets[0].id,
+      )).toMatchObject({ runtime: 'claude-code', claudeCodeCarrier: 'native' });
+
+      for (const invalidateToken of [
+        () => rmSync(tokenPath),
+        () => writeFileSync(tokenPath, '{"version":1,"ciphertext":"invalid","iv":"invalid"}'),
+      ]) {
+        saveExternally();
+        expect((await getRuntimeAuthSnapshot()).statuses.claude.ready).toBe(true);
+        invalidateToken();
+        const before = readOrchestratorControlPlaneState();
+        const removed = await createMissionRoute.POST(createMissionRequest(91_762_042, { carrier: 'native' }));
+        expect(removed.status).toBe(400);
+        expect(await removed.json()).toMatchObject({
+          ok: false, error: { code: 'dispatch_cli_auth_unavailable' },
+        });
+        expect(readOrchestratorControlPlaneState().packets.map((packet) => packet.id)).toEqual(
+          before.packets.map((packet) => packet.id),
+        );
+        const fresh = await getRuntimeAuthSnapshot();
+        expect(fresh.statuses.claude).toMatchObject({ ready: false, authenticated: false });
+        expect(fresh.suggestedSubscriptionProfile).toEqual(cold.suggestedSubscriptionProfile);
+        expect(fresh.statuses.codex).toBe(cold.statuses.codex);
+        await expect(assertRuntimeDispatchable('claude-code', null, repoPath, {
+          claudeCodeCarrier: 'codex-subscription',
+        })).resolves.toBeUndefined();
+      }
+    } finally {
+      clock.mockRestore();
+    }
+  }, 30_000);
 
   it('refuses stale marker files and empty OAuth fields as sign-in evidence', async () => {
     writeStaleMarkers();

--- a/src/lib/runtimes/shared/auth-detect.ts
+++ b/src/lib/runtimes/shared/auth-detect.ts
@@ -14,6 +14,7 @@ import {
   type RuntimeAuthHouse,
 } from '@/lib/orchestrator/runtime-capabilities';
 import { readClaudeCodeWorkerProfileSync } from '@/lib/claude-code/worker-profile';
+import { requiresNativeWorkerToken } from '@/lib/claude-code/worker-token';
 import type { ClaudeCodeModelSource } from '@/lib/claude-code/worker-profile-types';
 import { claudeCarrierPresentation } from './claude-carrier-presentation';
 import { scanAndLink } from './cli-locate';
@@ -257,8 +258,7 @@ function claudeWorkerCarrier(): ClaudeCodeModelSource {
   }
 }
 
-async function detectClaude(): Promise<RuntimeAuthStatus> {
-  const binaryPath = scanAndLink('claude') ?? undefined;
+async function detectClaude(binaryPath = scanAndLink('claude') ?? undefined): Promise<RuntimeAuthStatus> {
   if (!binaryPath) {
     return nowStatus('claude', 'claude-code', {
       installed: false,
@@ -611,6 +611,15 @@ export function invalidateRuntimeAuthCache(): void {
   opencodeRefresh = null;
 }
 
+async function refreshNativeWorkerReadiness(snapshot: RuntimeAuthSnapshot): Promise<RuntimeAuthSnapshot> {
+  const binaryPath = snapshot.statuses.claude.binaryPath;
+  if (!requiresNativeWorkerToken() || !binaryPath) return snapshot;
+  // The operator login runs in another process and cannot invalidate this cache.
+  // Re-read only its encrypted credential, never the native CLI or other providers.
+  const statuses = { ...snapshot.statuses, claude: await detectClaude(binaryPath) };
+  return { statuses, suggestedSubscriptionProfile: suggestMachineAuthProfile(statuses) };
+}
+
 export async function getRuntimeAuthSnapshot(): Promise<RuntimeAuthSnapshot> {
   while (true) {
     const generation = cacheGeneration;
@@ -620,11 +629,11 @@ export async function getRuntimeAuthSnapshot(): Promise<RuntimeAuthSnapshot> {
       : CACHE_TTL_MS;
     if (cached && Date.now() - cached.cachedAt < cacheTtlMs) {
       const opencode = await refreshOpencodeStatus();
-      if (generation !== cacheGeneration || cache !== cached) continue;
-      const snapshot = {
+      const snapshot = await refreshNativeWorkerReadiness({
         ...cached.snapshot,
         statuses: { ...cached.snapshot.statuses, opencode },
-      };
+      });
+      if (generation !== cacheGeneration || cache !== cached) continue;
       cache = { snapshot, cachedAt: cached.cachedAt };
       return snapshot;
     }
@@ -651,7 +660,7 @@ export async function getRuntimeAuthSnapshot(): Promise<RuntimeAuthSnapshot> {
       refresh = { generation, promise };
       snapshotRefresh = refresh;
     }
-    const snapshot = await refresh.promise;
+    const snapshot = await refreshNativeWorkerReadiness(await refresh.promise);
     if (generation !== cacheGeneration) continue;
     if (snapshotRefresh === refresh) snapshotRefresh = null;
     cache = { snapshot, cachedAt: Date.now() };


### PR DESCRIPTION
## Change

Refresh dedicated native-worker credential evidence at the runtime-readiness boundary. The packaged login helper writes encrypted state in a separate process, so it cannot invalidate the server's earlier missing-token snapshot.

Keep runtime discovery and the broad provider-probe cache intact. On macOS, re-read the dedicated credential before returning readiness, recompute the effective carrier presentation and subscription suggestion, and retain cache-generation guards. No credential values are returned or logged.

## Verification

- Regression reproduced the original immediate post-save 400 response before the source fix.
- Real mission creation now accepts an external encrypted save with the cache clock frozen. Removal and corrupt encrypted state fail closed without persisting another packet. Other runtime evidence remains cached; gateway carrier overrides remain usable.
- Focused native-auth, broad readiness and packaged-login checks pass (64 tests across three files).
- Root TypeScript, touched-file ESLint, rule-check and test-classification checks pass.
- Full hermetic completion passed: 4,123 tests, with 3 existing skips.

References #2094. Keep the issue open until the signed installed build and one successful real-provider worker satisfy the remaining acceptance criteria. No login rotation, model-default changes, isolation changes, or other platform work is included.

No visual proof: backend readiness correction. Reviewed directly under the single-agent policy.
