### PR TITLE
fix: keep preview publication off stable feeds

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -24,11 +24,17 @@ ship; wait for that owner to settle or surface it to Q.
 
 1. Confirm no separately launched legacy ship is already running. The workflow's exclusive lock is the authority once `npm run ship` starts.
 2. Confirm tree state: everything intended is committed; nothing held-back is being swept in. Discard post-build `src-tauri/Cargo.lock` noise (`git checkout -- src-tauri/Cargo.lock`) — a dirty tree fails the bump.
-3. **Bump first — `npm run ship` does NOT bump.** `npm version patch` commits manifests and creates the tag via sync-version.mjs. Then push only `main` and that exact tag:
-   `release_version=$(node -p "require('./package.json').version") && git push origin main "refs/tags/v${release_version}:refs/tags/v${release_version}"`.
+3. **Bump through a PR first.** `npm run ship` does not bump. On a clean release branch, use `npm version patch --no-git-tag-version`, stage only the synchronized manifests, and open a version PR. Protected main requires the seven CI checks, an up-to-date branch, and resolved conversations, including for administrators. After the version PR merges, verify the exact merged main commit and create the version tag there. Push only that exact tag:
+   `release_version=$(node -p "require('./package.json').version") && git push origin "refs/tags/v${release_version}:refs/tags/v${release_version}"`.
    Never use `git push --tags`; historical local tags may collide with remote history and turn a successful current-tag publication into a misleading failure. Skipping the bump makes release.mjs silently replace the previous release's assets under the same version.
 4. `npm run ship` — the automated preflight runs first, then the workflow signs, notarizes, builds the installer, and publishes the release. Deep spec + hazards: repo AGENTS.md "Shipping".
 5. **Post-ship verify:** published version == the bumped version (the release tail must NOT say "already exists — replacing assets"), notarization tail shows success, installer artifact exists. Report the verification tail, not just "shipped".
+
+## Preview boundary
+
+Read `docs/operations/release-channels.md` before preview work. A separately approved preview uses a unique `X.Y.Z-preview.N` version and `O8_RELEASE_CHANNEL=preview npm run ship`. Both repositories receive immutable prereleases, never latest stable; the manifest is `preview.json`. Stable feeds, report receipts, and announcements are skipped. Preview publication does not authorize stable promotion. No in-app preview selector or side-by-side data isolation is implemented by this publishing path.
+
+Publication must not commit or push release-note archives onto protected main. Archive `release-notes/next.md` through a reviewed follow-up PR. Never disable branch protection to perform a version bump or archive.
 
 ## Report format
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
       - run: npm ci --prefer-offline
       - run: npm run protocol:check
       - run: npm run typecheck
+      # These bounded publication fixtures never contact release services or
+      # build an app. Keep the stable/preview boundary on every PR.
+      - name: Release channel policy
+        run: npx vitest run tests/release-channel-real-path.test.ts
 
   # Lint restored to the PR lane 2026-07-18 (#1547): the error debt is burned
   # to zero on main (the old 398 baseline was mostly a stale nested worktree

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,42 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-preview-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
+  validate-preview:
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v') && contains(github.ref_name, '-preview.')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Require an unpublished preview tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node --input-type=module <<'JS'
+          import { readFileSync } from 'node:fs';
+          import { spawnSync } from 'node:child_process';
+          import { resolveReleaseChannel } from './scripts/lib/release-channel.mjs';
+          const { version } = JSON.parse(readFileSync('package.json', 'utf8'));
+          const policy = resolveReleaseChannel(version, { O8_RELEASE_CHANNEL: 'preview' });
+          if (process.env.GITHUB_REF_NAME !== policy.tag) throw new Error('Tag and package version differ.');
+          const result = spawnSync('gh', ['api', `repos/${process.env.GITHUB_REPOSITORY}/releases/tags/${policy.tag}`], { encoding: 'utf8' });
+          if (result.status === 0) throw new Error('A release already exists; use a fresh preview version.');
+          if (!result.stderr.includes('HTTP 404')) throw new Error('Could not verify release absence.');
+          JS
+
   release:
+    # This fallback only stages explicit preview tags. Stable publication stays
+    # in the operator-approved local signed release path.
+    needs: validate-preview
     strategy:
       fail-fast: false
       matrix:
@@ -46,7 +80,14 @@ jobs:
           workspaces: './src-tauri -> target'
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          npm install -g npm@11
+          npm ci
+
+      - name: Validate preview version
+        env:
+          O8_RELEASE_CHANNEL: preview
+        run: node scripts/release.mjs --dry-run
 
       - name: Build and release
         uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
@@ -57,7 +98,7 @@ jobs:
         with:
           tagName: v__VERSION__
           releaseName: 'o8 v__VERSION__'
-          releaseBody: 'See the assets to download and install o8.'
-          releaseDraft: false
-          prerelease: false
+          releaseBody: 'Preview candidate. Not promoted to stable and not safe for side-by-side use with the daily app.'
+          releaseDraft: true
+          prerelease: true
           args: ${{ matrix.args }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,10 +40,11 @@ npm run build               # Next.js production build (webpack, not turbopack)
 npm run tauri:build         # Unsigned native macOS app
 npm run tauri:build:signed  # Signed (updater-ready) build, passes --features dev-mcp-plugin
 
-# Ship (local release — bypasses CI, publishes to GitHub)
-npm version patch            # bump + sync all manifests + tag (runs sync-version.mjs hook)
+# Ship (version PR must pass CI before local signed publication)
+npm version patch --no-git-tag-version # on a clean release branch; commit synced manifests in a PR
+# After the version PR merges, verify merged main and create its exact version tag.
 release_version=$(node -p "require('./package.json').version")
-git push origin main "refs/tags/v${release_version}:refs/tags/v${release_version}"
+git push origin "refs/tags/v${release_version}:refs/tags/v${release_version}"
 npm run ship                 # build signed + upload via scripts/release.mjs
 
 # Lint
@@ -411,9 +412,10 @@ Most are optional. Fresh clones boot with nothing set. Specific features gate on
 
 ## Git Practices
 
-- All work on `main` branch (no feature branches — rapid iteration mode)
+- Use short feature branches and pull requests into protected `main`.
 - `npx tsc --noEmit` before every commit
-- `git push origin main` after each commit
+- Required PR checks, up-to-date branches, and resolved conversations apply to administrators too. Push the feature branch, then merge only after the checks pass and the operator approves. Do not bypass protection for version bumps or generated archives.
+- See `docs/operations/release-channels.md` for stable and preview publication boundaries.
 
 ## Working in public
 
@@ -437,13 +439,14 @@ nvm use                        # reads .nvmrc → Node 22 LTS. REQUIRED for ABI
                                # compiled against the build-machine's NODE_MODULE_VERSION,
                                # and the runtime app requires Node ≥22.
                                # release.mjs hard-fails if node !== 22.x.
-npm version patch              # 0.1.X → 0.1.X+1 — sync-version.mjs hook updates
-                               # package.json + src-tauri/tauri.conf.json +
-                               # src-tauri/Cargo.toml in a single commit, then
-                               # npm creates the v0.1.X+1 tag
+npm version patch --no-git-tag-version
+                               # on a clean release branch; sync all manifests,
+                               # commit them, and open the version PR
+# Wait for required checks, merge the approved PR, and verify exact merged main.
 release_version=$(node -p "require('./package.json').version")
-git push origin main "refs/tags/v${release_version}:refs/tags/v${release_version}"
-                               # send main + only the current release tag
+git tag -a "v${release_version}" -m "Release v${release_version}"
+git push origin "refs/tags/v${release_version}:refs/tags/v${release_version}"
+                               # tag only the verified merged version commit
 npm run ship                    # cargo tauri build with signing key +
                                # dev-mcp-plugin feature, then
                                # scripts/release.mjs creates the GH release
@@ -454,7 +457,9 @@ The user's installed `o8.app` sees the new version via the `UpdateCard` componen
 
 ### Why local instead of CI
 
-GitHub Actions macOS runners failed because of billing, so the normal release runs locally. The CI release workflow (`.github/workflows/release.yml`) still exists as a **manual-only** fallback (`workflow_dispatch`) — the `v*` tag trigger was **removed** so publishing a release tag no longer starts billed macOS runners automatically. Push only the current tag; never use `git push --tags`, because unrelated historical tags can collide with remote history. Run the workflow on-demand from the Actions tab only when the local ship path is unavailable. It uses the same `TAURI_SIGNING_PRIVATE_KEY` secret; `gh release create` in the local script errors cleanly when the release already exists (use `--clobber` to replace assets).
+GitHub Actions macOS runners failed because of billing, so the normal release runs locally. The CI release workflow (`.github/workflows/release.yml`) is a **manual-only**, draft-preview fallback (`workflow_dispatch` on a preview-version tag). Publishing a tag does not start billed macOS runners automatically. Push only the current tag; never use `git push --tags`, because unrelated historical tags can collide with remote history. The fallback uses the same `TAURI_SIGNING_PRIVATE_KEY` secret, but it cannot publish stable. Preview assets cannot be clobbered. The local stable release still requires explicit operator approval; source CI is required before the version PR merges.
+
+For an approved preview, use a unique `X.Y.Z-preview.N` version and `O8_RELEASE_CHANNEL=preview npm run ship`. It publishes `preview.json` on prereleases in both repositories and skips stable feeds and announcements. This does not add app-side preview enrollment or isolate the daily database. See `docs/operations/release-channels.md` before use.
 
 ### Signing
 

--- a/docs/operations/release-channels.md
+++ b/docs/operations/release-channels.md
@@ -1,0 +1,25 @@
+# Stable and preview releases
+
+`main` is the integration branch. Pull requests must be up to date, resolve review conversations, and pass the seven required CI checks from the GitHub Actions app: Type Check, Lint, Hermetic Unit Tests, Security Audit, Governance Smoke, and both Rust Compile Gates. The rules apply to administrators. A second human approval is not required; merge approval remains an operator decision. Force pushes and branch deletion remain blocked.
+
+## Stable
+
+The installed app uses the public mirror's `releases/latest/download/latest.json`. Keep that endpoint unchanged for normal users. `npm run ship` remains the explicitly approved stable publication path and requires a plain `X.Y.Z` version. Version changes go through a PR before tagging the merged commit. Release-note archives also go through a PR; publication never pushes archive commits to main.
+
+## Preview publishing
+
+Preview publishing requires a separate operator decision. It does not run on a schedule or on every push, and it does not create another permanent development branch.
+
+1. Prepare a unique version such as `0.1.741-preview.1`, keeping all manifests synchronized. Review and merge the version PR before tagging the exact commit.
+2. Inspect the publication policy with `O8_RELEASE_CHANNEL=preview node scripts/release.mjs --dry-run`. This does not build or publish.
+3. After approval, use `O8_RELEASE_CHANNEL=preview npm run ship`. Signing, notarization, and the normal preflight still apply.
+4. Verify that both repository releases are prereleases, neither is latest stable, and the tag contains `preview.json` plus signed installers. Preview publication does not upload `latest.json` or `fixed.json`, publish the stable changelog, archive release notes, reconcile report receipts, or post stable announcements.
+5. Verify that the public latest stable release and its updater manifest remain unchanged. Preserve the candidate's test and install receipts.
+
+Preview versions cannot use the clobber override. A repeated or failed candidate needs a fresh version; never replace an existing candidate's bytes. The manual Actions fallback only accepts preview-version tags and stages a draft prerelease. It does not publish a stable release or launch on a nightly timer.
+
+## Boundaries still to implement
+
+This is a publishing boundary, not an installed preview channel. Preview artifacts are reached explicitly by tag. The app does not yet offer a preview selector or a rolling preview feed, and stable and preview installs still share the application identity and user data. Do not install them side by side or use a preview to migrate the daily database as an acceptance shortcut.
+
+Stable promotion requires a separate operator approval and verified installed acceptance. This path does not rename preview versions, retag artifacts, or promote automatically. A stable-number build needs its own exact signed-artifact receipt. App-side channel selection and data isolation must be reviewed separately before promising seamless preview enrollment.

--- a/scripts/lib/release-channel.d.mts
+++ b/scripts/lib/release-channel.d.mts
@@ -1,0 +1,13 @@
+export interface ReleaseChannel {
+  channel: 'stable' | 'preview';
+  preview: boolean;
+  tag: string;
+  manifestName: 'latest.json' | 'preview.json';
+  githubFlags: string[];
+  publishStableEffects: boolean;
+}
+
+export function resolveReleaseChannel(
+  version: string,
+  env?: Record<string, string | undefined>,
+): Readonly<ReleaseChannel>;

--- a/scripts/lib/release-channel.mjs
+++ b/scripts/lib/release-channel.mjs
@@ -1,0 +1,28 @@
+const NUMBER = '(?:0|[1-9][0-9]*)';
+const STABLE_VERSION = new RegExp(`^${NUMBER}\\.${NUMBER}\\.${NUMBER}$`);
+const PREVIEW_VERSION = new RegExp(`^${NUMBER}\\.${NUMBER}\\.${NUMBER}-preview\\.${NUMBER}$`);
+
+/** Fail before build or publication when a channel could reach the wrong feed. */
+export function resolveReleaseChannel(version, env = process.env) {
+  const channel = env.O8_RELEASE_CHANNEL?.trim() || 'stable';
+  if (channel !== 'stable' && channel !== 'preview') {
+    throw new Error('O8_RELEASE_CHANNEL must be stable or preview.');
+  }
+  const preview = channel === 'preview';
+  if (!(preview ? PREVIEW_VERSION : STABLE_VERSION).test(version)) {
+    throw new Error(preview
+      ? 'Preview releases require a unique version such as 0.1.741-preview.1.'
+      : 'Stable releases require a version without a prerelease suffix.');
+  }
+  if (preview && env.O8_RELEASE_CLOBBER === '1') {
+    throw new Error('Preview artifacts are immutable; use a new preview version.');
+  }
+  return Object.freeze({
+    channel,
+    preview,
+    tag: `v${version}`,
+    manifestName: preview ? 'preview.json' : 'latest.json',
+    githubFlags: preview ? ['--prerelease', '--latest=false'] : [],
+    publishStableEffects: !preview,
+  });
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -21,7 +21,7 @@
  *   npm run ship
  */
 
-import { existsSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -32,6 +32,7 @@ import { verifyNativeBundle } from './native-bundle.mjs';
 import { runShipWorkflow } from './lib/ship-broadcast.mjs';
 import { buildReleaseManifest } from './lib/release-manifest.mjs';
 import { buildLatestShip, scrubPublicText } from './lib/public-release.mjs';
+import { resolveReleaseChannel } from './lib/release-channel.mjs';
 
 const REPO = 'hurttlocker/o8';
 const PUBLIC_MIRROR = 'hurttlocker/o8-releases';
@@ -99,7 +100,14 @@ if (process.argv[2] === '--verify-checkout-native-modules') {
 
 const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
 const version = pkg.version;
-const tag = `v${version}`;
+let releaseChannel;
+try {
+  releaseChannel = resolveReleaseChannel(version);
+} catch (error) {
+  console.error(`[release] ${error.message}`);
+  process.exit(1);
+}
+const tag = releaseChannel.tag;
 const dryRun = process.argv.includes('--dry-run');
 const dryRunOutDir = optionValue('--out-dir') || join(tmpdir(), 'o8-public-release-out');
 
@@ -115,6 +123,10 @@ if (nodeMajor !== 22) {
 
 if (dryRun) {
   try {
+    if (releaseChannel.preview) {
+      console.log(JSON.stringify(releaseChannel, null, 2));
+      process.exit(0);
+    }
     publishPublicRelease({
       publishedAt: resolvePublishedAt(),
       dryRun: true,
@@ -125,6 +137,11 @@ if (dryRun) {
     console.error(`[release] dry run failed: ${error?.message ?? error}`);
     process.exit(1);
   }
+}
+
+if (releaseChannel.preview && (process.argv.includes('--announce') || process.argv.includes('--announce-preview'))) {
+  console.error('[release] Stable announcements are disabled for preview releases.');
+  process.exit(1);
 }
 
 if (process.argv[2] === '--ship') {
@@ -244,7 +261,7 @@ const latestNotes = gateReleaseNote ? `o8 ${tag} — ${gateReleaseNote}` : `o8 $
 // Same signed binary works on x86_64 natively and aarch64 under Rosetta, so
 // point both platforms at the same artifact until a native arm64 runner
 // exists. Still signed with the same minisign key the installed app trusts.
-const latestJsonPath = join(BUNDLE, 'macos', 'latest.json');
+const latestJsonPath = join(BUNDLE, 'macos', releaseChannel.manifestName);
 const fixedJsonPath = join(BUNDLE, 'macos', 'fixed.json');
 const { latestJson, uploadArgs } = buildReleaseManifest({
   bundleDir: BUNDLE,
@@ -254,7 +271,7 @@ const { latestJson, uploadArgs } = buildReleaseManifest({
   downloadBase,
   darwinSignature: signature,
   baseUploadAssets: [DMG, APP_TAR, APP_SIG],
-  trailingUploadAssets: [latestJsonPath, fixedJsonPath],
+  trailingUploadAssets: [latestJsonPath, ...(releaseChannel.publishStableEffects ? [fixedJsonPath] : [])],
 });
 writeFileSync(latestJsonPath, JSON.stringify(latestJson, null, 2));
 console.log(`[release] wrote ${latestJsonPath}`);
@@ -271,23 +288,27 @@ console.log(`[release] wrote ${latestJsonPath}`);
 // Mirror the intake channel into the local ledger first — a user's report was
 // recorded on THEIR machine, not ours, so without this every fix we ship for
 // someone else's bug resolves to "unknown id" and never reaches fixed.json.
-try {
-  const { status, fresh } = await syncReports();
-  if (status === 'disabled') {
-    console.log('[release] external intake reconciliation intentionally disabled; continuing with the local ledger');
+let pendingFixes = [];
+if (releaseChannel.publishStableEffects) {
+  try {
+    const { status, fresh } = await syncReports();
+    if (status === 'disabled') {
+      console.log('[release] external intake reconciliation intentionally disabled; continuing with the local ledger');
+    }
+    if (fresh.length > 0) console.log(`[release] imported ${fresh.length} report(s) from the intake channel`);
+  } catch (err) {
+    console.warn(`[release] ⚠ intake-channel sync failed: ${err?.message ?? err}`);
+    console.warn('[release]   only self-filed reports will resolve — fixes for other people\'s bugs will be skipped.');
   }
-  if (fresh.length > 0) console.log(`[release] imported ${fresh.length} report(s) from the intake channel`);
-} catch (err) {
-  console.warn(`[release] ⚠ intake-channel sync failed: ${err?.message ?? err}`);
-  console.warn('[release]   only self-filed reports will resolve — fixes for other people\'s bugs will be skipped.');
-}
-const { entries: pendingFixes, missing: unknownFixes } = resolveNewFixes(releaseRange(tag), version);
-const fixedManifest = buildManifest([...readPublished(), ...pendingFixes], pubDate);
-writeFileSync(fixedJsonPath, JSON.stringify(fixedManifest, null, 2));
-console.log(`[release] wrote ${fixedJsonPath} (${fixedManifest.fixed.length} fixed report${fixedManifest.fixed.length === 1 ? '' : 's'}, ${pendingFixes.length} new this release)`);
-if (unknownFixes.length > 0) {
-  console.warn(`[release] ⚠ ${unknownFixes.length} Fixes-Report trailer(s) name an id with no ledger entry — those reporters will NOT get a receipt:`);
-  for (const { id, commit } of unknownFixes) console.warn(`[release]   ${id} (${commit.sha})`);
+  const { entries, missing: unknownFixes } = resolveNewFixes(releaseRange(tag), version);
+  pendingFixes = entries;
+  const fixedManifest = buildManifest([...readPublished(), ...pendingFixes], pubDate);
+  writeFileSync(fixedJsonPath, JSON.stringify(fixedManifest, null, 2));
+  console.log(`[release] wrote ${fixedJsonPath} (${fixedManifest.fixed.length} fixed report${fixedManifest.fixed.length === 1 ? '' : 's'}, ${pendingFixes.length} new this release)`);
+  if (unknownFixes.length > 0) {
+    console.warn(`[release] ⚠ ${unknownFixes.length} Fixes-Report trailer(s) name an id with no ledger entry — those reporters will NOT get a receipt:`);
+    for (const { id, commit } of unknownFixes) console.warn(`[release]   ${id} (${commit.sha})`);
+  }
 }
 
 try {
@@ -295,7 +316,7 @@ try {
   console.log(`[release] tag ${tag} present on origin`);
 } catch {
   console.error(`[release] tag ${tag} is not on origin.`);
-  console.error(`[release] run: git push origin main refs/tags/${tag}:refs/tags/${tag}`);
+  console.error(`[release] After the version PR merges, push its exact tag: git push origin refs/tags/${tag}:refs/tags/${tag}`);
   process.exit(1);
 }
 
@@ -311,9 +332,10 @@ try {
 // build (the 2026-07-08 #1499 incident). Refuse unless explicitly overridden.
 if (releaseExists && process.env.O8_RELEASE_CLOBBER !== '1') {
   console.error(`[release] REFUSING: ${tag} is already published. Did you forget to bump?`);
-  console.error('[release]   npm version patch');
+  console.error('[release]   Prepare a fresh version PR with npm version patch --no-git-tag-version.');
+  console.error('[release]   Merge after required checks, verify merged main, then create the exact version tag.');
   console.error('[release]   release_version=$(node -p "require(\'./package.json\').version")');
-  console.error('[release]   git push origin main "refs/tags/v${release_version}:refs/tags/v${release_version}"');
+  console.error('[release]   git push origin "refs/tags/v${release_version}:refs/tags/v${release_version}"');
   console.error('[release]   npm run ship');
   console.error('[release] To deliberately replace the existing release assets in place:');
   console.error('[release]   O8_RELEASE_CLOBBER=1 npm run ship');
@@ -326,6 +348,7 @@ if (releaseExists) {
     'release', 'edit', tag,
     '--title', `o8 ${tag}`,
     '--notes', releaseNotes,
+    ...releaseChannel.githubFlags,
     '-R', REPO,
   ], { stdio: 'inherit' });
   execFileSync('gh', [
@@ -339,6 +362,7 @@ if (releaseExists) {
     'release', 'create', tag, ...uploadArgs,
     '--title', `o8 ${tag}`,
     '--notes', releaseNotes,
+    ...releaseChannel.githubFlags,
     '-R', REPO,
   ], { stdio: 'inherit' });
 }
@@ -362,11 +386,15 @@ try {
   } catch {}
 
   if (mirrorExists) {
+    if (releaseChannel.preview) {
+      throw new Error('Preview mirror artifacts already exist; use a new preview version.');
+    }
     console.log(`[release-mirror] ${tag} already exists on ${PUBLIC_MIRROR} — replacing assets`);
     execFileSync('gh', [
       'release', 'edit', tag,
       '--title', `o8 ${tag}`,
       '--notes', mirrorNotes,
+      ...releaseChannel.githubFlags,
       '-R', PUBLIC_MIRROR,
     ], { stdio: 'inherit' });
     execFileSync('gh', [
@@ -380,12 +408,17 @@ try {
       'release', 'create', tag, ...uploadArgs,
       '--title', `o8 ${tag}`,
       '--notes', mirrorNotes,
+      ...releaseChannel.githubFlags,
       '-R', PUBLIC_MIRROR,
     ], { stdio: 'inherit' });
   }
 
   console.log(`[release-mirror] mirrored ${tag} to ${PUBLIC_MIRROR}`);
 
+  if (releaseChannel.preview) {
+    console.log('[release] Preview published for explicit tag downloads; the stable updater and announcements are unchanged.');
+    process.exit(0);
+  }
   // Publish the page feeds from one local mirror checkout and one mirror commit.
   // This runs only after the updater assets are available on the public mirror.
   let publicFeedPublished = false;
@@ -398,12 +431,8 @@ try {
     console.error('[release] re-run manually: node scripts/release.mjs --dry-run');
   }
 
-  if (publicFeedPublished) {
-    try {
-      archiveReleaseNotes();
-    } catch (err) {
-      console.error('[release] release notes archive failed (non-fatal):', err?.message ?? err);
-    }
+  if (publicFeedPublished && existsSync(join(root, 'release-notes', 'next.md'))) {
+    console.log('[release] Archive release-notes/next.md through a follow-up PR; protected main is not modified by publication.');
   }
 
   // Announce the fixes ONLY now — the mirror is what makes v${version} real, and
@@ -429,6 +458,7 @@ try {
 } catch (err) {
   console.error(`[release-mirror] failed to mirror ${tag} to ${PUBLIC_MIRROR}:`, err?.message ?? err);
   console.error(`[release-mirror] private publish above is unaffected — auto-update will not pick up this version until the mirror succeeds`);
+  if (releaseChannel.preview) process.exit(1);
 }
 
 console.log(`[release] the installed o8.app will pick up the update on next launch`);
@@ -552,25 +582,6 @@ function publishPublicRelease({ publishedAt, dryRun: preview = false, outDir = n
   } finally {
     rmSync(stagingDir, { recursive: true, force: true });
   }
-}
-
-function archiveReleaseNotes() {
-  const nextPath = join(root, 'release-notes', 'next.md');
-  if (!existsSync(nextPath)) return;
-  const archivedPath = join(root, 'release-notes', `${version}.md`);
-  if (existsSync(archivedPath)) {
-    throw new Error(`release notes archive already exists: ${archivedPath}`);
-  }
-
-  renameSync(nextPath, archivedPath);
-  execFileSync('git', ['add', '--', nextPath, archivedPath], { cwd: root, stdio: 'inherit' });
-  execFileSync('git', [
-    'commit',
-    '-m', `docs: archive release notes ${version}`,
-    '--', nextPath, archivedPath,
-  ], { cwd: root, stdio: 'inherit' });
-  execFileSync('git', ['push', 'origin', 'HEAD'], { cwd: root, stdio: 'inherit' });
-  console.log(`[release] archived release notes at release-notes/${version}.md`);
 }
 
 async function announceRelease() {

--- a/tests/release-broadcast-real-path.test.ts
+++ b/tests/release-broadcast-real-path.test.ts
@@ -16,6 +16,7 @@ interface Fixture {
   cleanupLog: string;
   stageLog: string;
   envLog: string;
+  channelLog: string;
 }
 
 function makeFixture(options: {
@@ -32,12 +33,14 @@ function makeFixture(options: {
   const cleanupLog = join(root, 'cleanup.log');
   const stageLog = join(root, 'stages.log');
   const envLog = join(root, 'env.json');
+  const channelLog = join(root, 'channels.jsonl');
   const planPath = join(root, 'plan.json');
 
   writeFileSync(stageStub, `
 import { appendFileSync } from 'node:fs';
 const stage = process.argv[2];
 appendFileSync(process.env.O8_STUB_STAGE_LOG, stage + '\\n');
+appendFileSync(process.env.O8_STUB_CHANNEL_LOG, JSON.stringify({ stage, channel: process.env.O8_RELEASE_CHANNEL ?? 'stable' }) + '\\n');
 if (stage === 'preflight' && process.env.O8_STUB_FAIL_PREFLIGHT === '1') process.exit(29);
 if (stage === 'build') {
   appendFileSync(process.env.O8_STUB_ENV_LOG, JSON.stringify({
@@ -90,12 +93,13 @@ if (process.env.O8_STUB_FAIL_BROADCAST === '1') process.exit(23);
     ],
   }));
 
-  return { root, planPath, broadcastPath, broadcastLog, cleanupLog, stageLog, envLog };
+  return { root, planPath, broadcastPath, broadcastLog, cleanupLog, stageLog, envLog, channelLog };
 }
 
-function runRelease(fixture: Fixture, failBroadcast = false) {
+function runRelease(fixture: Fixture, failBroadcast = false, preview = false) {
+  if (preview) writeFileSync(join(fixture.root, 'package.json'), JSON.stringify({ version: '0.1.741-preview.1' }));
   return spawnSync(process.execPath, [releaseScript, '--ship'], {
-    cwd: process.cwd(),
+    cwd: preview ? fixture.root : process.cwd(),
     encoding: 'utf8',
     env: {
       ...process.env,
@@ -107,6 +111,8 @@ function runRelease(fixture: Fixture, failBroadcast = false) {
       O8_STUB_CLEANUP_LOG: fixture.cleanupLog,
       O8_STUB_STAGE_LOG: fixture.stageLog,
       O8_STUB_ENV_LOG: fixture.envLog,
+      O8_STUB_CHANNEL_LOG: fixture.channelLog,
+      O8_RELEASE_CHANNEL: preview ? 'preview' : 'stable',
       O8_STUB_FAIL_BROADCAST: failBroadcast ? '1' : '0',
     },
   });
@@ -143,6 +149,16 @@ afterEach(() => {
 });
 
 describe('release Broadcast milestones through the release entry point', () => {
+  it('preserves preview selection through preflight, build, notarization and publication', () => {
+    const fixture = makeFixture();
+    const result = runRelease(fixture, false, true);
+    expect(result.status, result.stderr).toBe(0);
+    const records = readFileSync(fixture.channelLog, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+    for (const stage of ['preflight', 'build', 'notarize', 'publish']) {
+      expect(records.find(record => record.stage === stage)).toEqual({ stage, channel: 'preview' });
+    }
+  });
+
   it('runs preflight before build and isolates every build worker from operator state', () => {
     const fixture = makeFixture();
     const result = runRelease(fixture);

--- a/tests/release-channel-real-path.test.ts
+++ b/tests/release-channel-real-path.test.ts
@@ -1,0 +1,187 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveReleaseChannel } from '../scripts/lib/release-channel.mjs';
+
+const roots: string[] = [];
+const releaseScript = join(process.cwd(), 'scripts/release.mjs');
+
+function fixture(version = '0.1.741-preview.1') {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'o8-release-channel-')));
+  roots.push(root);
+  const bundle = join(root, 'src-tauri/target/release/bundle');
+  mkdirSync(join(bundle, 'macos'), { recursive: true });
+  mkdirSync(join(bundle, 'dmg'), { recursive: true });
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ version }));
+  writeFileSync(join(bundle, 'dmg', `o8_${version}_x64.dmg`), 'fixture');
+  writeFileSync(join(bundle, 'macos', 'o8.app.tar.gz'), 'fixture');
+  writeFileSync(join(bundle, 'macos', 'o8.app.tar.gz.sig'), 'fixture-signature');
+  const log = join(root, 'effects.jsonl');
+  const prelude = `import { appendFileSync } from 'node:fs';
+const record = (name, args = []) => appendFileSync(process.env.O8_CHANNEL_TEST_LOG, JSON.stringify({name, args}) + '\\n');`;
+  const childProcess = `${prelude}
+export function execFileSync(command, args = []) {
+  record(command, args);
+  if (command === 'gh' && args[0] === 'release' && args[1] === 'view') {
+    if (args.includes('--json')) return '2026-09-07T00:00:00Z';
+    if (process.env.O8_CHANNEL_TEST_EXISTING === '1') return '{}';
+    throw new Error('release not found');
+  }
+  if (command === 'gh' && args[1] === 'create' && args.includes('hurttlocker/o8-releases') && process.env.O8_CHANNEL_TEST_FAIL_MIRROR === '1') throw new Error('mirror unavailable');
+  if (command === 'git' && args[0] === 'describe') return 'v' + process.env.O8_CHANNEL_TEST_VERSION;
+  if (command === 'git' && args[0] === 'ls-remote') return 'a'.repeat(40) + '\\trefs/tags/v' + process.env.O8_CHANNEL_TEST_VERSION;
+  if (command === 'git' && args[0] === 'log') return args.includes('--format=%H%x09%s') ? 'a'.repeat(40) + '\\tfix: improve workspace feedback' : 'fix: improve workspace feedback';
+  return '';
+}
+export const spawn = () => { throw new Error('unexpected spawn'); };
+export const spawnSync = spawn;`;
+  const modules: Record<string, string> = {
+    'node:child_process': childProcess,
+    '/scripts/native-bundle.mjs': 'export function verifyNativeBundle() {}',
+    '/scripts/sync-reports.mjs': `${prelude}\nexport async function syncReports() { record('syncReports'); return { status: 'disabled', fresh: [] }; }`,
+    '/scripts/publish-fixed.mjs': `${prelude}\nexport async function publishFixed() { record('publishFixed'); }`,
+    '/scripts/lib/fixed-reports.mjs': `${prelude}
+export const releaseRange = () => 'HEAD~1..HEAD';
+export function resolveNewFixes() { record('resolveNewFixes'); return { entries: [{ id: 'fixture-report' }], missing: [] }; }
+export function readPublished() { record('readPublished'); return []; }
+export const buildManifest = (fixed) => ({ fixed });`,
+  };
+  // Only platform/provider edges are simulated. The actual release entry point,
+  // channel policy, manifest writer, and publication control flow run unchanged.
+  writeFileSync(join(root, 'loader.mjs'), `const modules = ${JSON.stringify(modules)};
+export async function load(url, context, nextLoad) {
+  const key = Object.keys(modules).find(key => url === key || url.endsWith(key));
+  return key ? { format: 'module', shortCircuit: true, source: modules[key] } : nextLoad(url, context);
+}`);
+  writeFileSync(join(root, 'register.mjs'), `${prelude}
+import { register } from 'node:module';
+register(new URL('./loader.mjs', import.meta.url));
+globalThis.fetch = async () => { record('announceRelease'); return { ok: true }; };`);
+  return { root, bundle, log, version };
+}
+
+function run(f: ReturnType<typeof fixture>, channel: string, args: string[] = [], extraEnv: Record<string, string> = {}) {
+  return spawnSync(process.execPath, ['--import', join(f.root, 'register.mjs'), releaseScript, ...args], {
+    cwd: f.root,
+    encoding: 'utf8',
+    timeout: 15_000,
+    env: {
+      NODE_ENV: 'test',
+      PATH: process.env.PATH,
+      HOME: f.root,
+      O8_DATA_DIR: join(f.root, 'data'),
+      CORTEX_IDE_DATA_DIR: join(f.root, 'data'),
+      O8_RELEASE_CHANNEL: channel,
+      O8_CHANNEL_TEST_VERSION: f.version,
+      O8_CHANNEL_TEST_LOG: f.log,
+      O8_RELEASES_WEBHOOK_URL: 'https://fixture.invalid/webhook',
+      ...extraEnv,
+    },
+  });
+}
+
+function effects(f: ReturnType<typeof fixture>): Array<{ name: string; args: string[] }> {
+  return existsSync(f.log) ? readFileSync(f.log, 'utf8').trim().split('\n').filter(Boolean).map(line => JSON.parse(line)) : [];
+}
+
+afterEach(() => {
+  while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+describe('release channels through the publication entry point', () => {
+  it('publishes two immutable prereleases without reaching any stable surface', () => {
+    const f = fixture();
+    const result = run(f, 'preview');
+    expect(result.status, result.stderr).toBe(0);
+    const calls = effects(f);
+    const creates = calls.filter(c => c.name === 'gh' && c.args[1] === 'create');
+    expect(creates).toHaveLength(2);
+    for (const call of creates) {
+      expect(call.args).toContain('--prerelease');
+      expect(call.args).toContain('--latest=false');
+      expect(call.args).toContain(join(f.bundle, 'macos', 'preview.json'));
+      expect(call.args.some(arg => arg.endsWith('/latest.json') || arg.endsWith('/fixed.json'))).toBe(false);
+    }
+    expect(calls.some(c => ['syncReports', 'resolveNewFixes', 'readPublished', 'publishFixed', 'announceRelease', 'bash'].includes(c.name))).toBe(false);
+    expect(existsSync(join(f.bundle, 'macos', 'latest.json'))).toBe(false);
+    expect(existsSync(join(f.bundle, 'macos', 'fixed.json'))).toBe(false);
+    expect(JSON.parse(readFileSync(join(f.bundle, 'macos', 'preview.json'), 'utf8'))).toMatchObject({ version: f.version });
+    expect(result.stdout).not.toContain('installed o8.app will pick up');
+  });
+
+  it('retains stable publication, receipts and announcements without pushing source archives', () => {
+    const f = fixture('0.1.741');
+    mkdirSync(join(f.root, 'release-notes'));
+    writeFileSync(join(f.root, 'release-notes', 'next.md'), '- Improve workspace feedback.\n');
+    const result = run(f, 'stable');
+    expect(result.status, result.stderr).toBe(0);
+    const calls = effects(f);
+    expect(calls.filter(c => c.name === 'gh' && c.args[1] === 'create')).toHaveLength(2);
+    expect(calls.some(c => c.args.includes('--prerelease'))).toBe(false);
+    for (const name of ['syncReports', 'resolveNewFixes', 'publishFixed', 'announceRelease', 'bash']) {
+      expect(calls.some(c => c.name === name), name).toBe(true);
+    }
+    expect(existsSync(join(f.bundle, 'macos', 'latest.json'))).toBe(true);
+    expect(existsSync(join(f.bundle, 'macos', 'fixed.json'))).toBe(true);
+    expect(existsSync(join(f.root, 'release-notes', 'next.md'))).toBe(true);
+    expect(calls.some(c => c.name === 'git' && ['add', 'commit', 'push'].includes(c.args[0]))).toBe(false);
+  });
+
+  it.each([
+    ['stable', '0.1.741-preview.1', {}],
+    ['preview', '0.1.741', {}],
+    ['nightly', '0.1.741-preview.1', {}],
+    ['preview', '0.1.741-preview.1', { O8_RELEASE_CLOBBER: '1' }],
+  ])('rejects mismatched or unsafe %s publication before side effects', (channel, version, extraEnv) => {
+    const f = fixture(version);
+    const result = run(f, channel, [], extraEnv);
+    expect(result.status).toBe(1);
+    expect(effects(f)).toEqual([]);
+  });
+
+  it('prints a write-free preview plan through dry-run', () => {
+    const f = fixture();
+    const result = run(f, 'preview', ['--dry-run']);
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({ channel: 'preview', publishStableEffects: false, manifestName: 'preview.json' });
+    expect(effects(f)).toEqual([]);
+  });
+
+  it('refuses manual stable announcements for a preview', () => {
+    const f = fixture();
+    expect(run(f, 'preview', ['--announce']).status).toBe(1);
+    expect(effects(f)).toEqual([]);
+  });
+
+  it('refuses to replace an existing candidate', () => {
+    const f = fixture();
+    expect(run(f, 'preview', [], { O8_CHANNEL_TEST_EXISTING: '1' }).status).toBe(1);
+    expect(effects(f).some(c => c.name === 'gh' && ['create', 'edit', 'upload'].includes(c.args[1]))).toBe(false);
+  });
+
+  it('reports mirror failure without claiming a usable preview', () => {
+    const f = fixture();
+    const result = run(f, 'preview', [], { O8_CHANNEL_TEST_FAIL_MIRROR: '1' });
+    expect(result.status).toBe(1);
+    expect(result.stdout).not.toContain('Preview published for explicit');
+    expect(effects(f).some(c => ['publishFixed', 'announceRelease', 'bash'].includes(c.name))).toBe(false);
+  });
+
+  it('keeps ordinary stable versions as the default policy', () => {
+    expect(resolveReleaseChannel('0.1.741', {})).toMatchObject({ channel: 'stable', githubFlags: [], manifestName: 'latest.json' });
+  });
+
+  it('keeps the manual hosted fallback draft-only and preview-only', () => {
+    const workflow = readFileSync(join(process.cwd(), '.github/workflows/release.yml'), 'utf8');
+    expect(workflow).toContain("github.ref_type == 'tag'");
+    expect(workflow).toContain('O8_RELEASE_CHANNEL: preview');
+    expect(workflow).toContain('needs: validate-preview');
+    expect(workflow).toContain('Could not verify release absence.');
+    expect(workflow).toContain('cancel-in-progress: false');
+    expect(workflow).toContain('releaseDraft: true');
+    expect(workflow).toContain('prerelease: true');
+    expect(workflow).not.toContain('schedule:');
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2179,6 +2179,14 @@
       ]
     },
     {
+      "path": "tests/release-channel-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/release-claim-branch-advanced-real-git.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
## Outcome

Add an explicit preview-publishing boundary while keeping the existing installed stable feed unchanged.

- `O8_RELEASE_CHANNEL=preview` requires a unique `X.Y.Z-preview.N` version and refuses clobbering. Both repositories receive prereleases with `--latest=false` and `preview.json`, never stable updater or fixed-report metadata.
- Preview publication skips stable changelog, report reconciliation, fixed receipts, release-note archives, and community announcements. A failed public mirror is reported as failure.
- The hosted fallback validates an unpublished preview tag before starting build jobs and stages draft prereleases only. No timer or push-triggered builds were added.
- Version bumps and note archives now follow protected-main PRs. Publication no longer commits and pushes generated archives onto main.

GitHub main protection was updated separately with operator approval: seven existing Actions checks, strict up-to-date PRs, resolved conversations, and admin enforcement. The human-approval count remains zero so the maintainer can use the gated PR path without an unavailable second reviewer.

## Evidence

- 12 publication entry-point tests, with simulated external platform/service boundaries and persisted manifest/effect receipts.
- 10 ship workflow tests, including preview selection surviving preflight, build, notarization, and publication.
- 7 release-artifact tests.
- 4,126 hermetic tests passed, 3 skipped.
- TypeScript, touched-file lint, classification, workflow YAML parsing, and diff checks passed.
- The publication boundary test now runs in the required Type Check CI job on every PR.

No visual proof: release tooling and repository governance only.

## Residual

No new release, version bump, or preview installation is part of this PR. v0.1.740 remains stable. This provides explicit tag-download previews, not an in-app preview selector or rolling preview feed. Installation identity and data isolation need a separate reviewed change before side-by-side preview use. No other platform work or model-default changes are included.
