### PR TITLE
ci: add bounded nightly source verification

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,68 @@
+name: Nightly Verification
+
+# Source health only. Installers, updater manifests, tags, and release services
+# remain on the separately approved publication path.
+on:
+  schedule:
+    - cron: '23 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: nightly-verification-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Nightly Source Health
+    if: github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Skip an unchanged successful nightly
+        id: freshness
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let run = true;
+            if (context.eventName === 'schedule') {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                ...context.repo,
+                workflow_id: 'nightly.yml',
+                branch: context.payload.repository.default_branch,
+                status: 'success',
+                per_page: 1,
+              });
+              run = data.workflow_runs[0]?.head_sha !== context.sha;
+            }
+            core.setOutput('run', String(run));
+            await core.summary.addRaw(run
+              ? `Checking source commit ${context.sha}. No release will be published.`
+              : `Source commit ${context.sha} already passed. Skipping repeated checks.`).write();
+      - uses: actions/checkout@v4
+        if: steps.freshness.outputs.run == 'true'
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        if: steps.freshness.outputs.run == 'true'
+        with:
+          node-version: 22
+          cache: npm
+      - name: Match the lockfile toolchain
+        if: steps.freshness.outputs.run == 'true'
+        run: npm install -g npm@11
+      - name: Install dependencies
+        if: steps.freshness.outputs.run == 'true'
+        run: npm ci --prefer-offline
+      - name: Check protocol, types, and test classification
+        if: steps.freshness.outputs.run == 'true'
+        run: |
+          npm run protocol:check
+          npm run typecheck
+          npm run test:classification:check
+      - name: Run the hermetic unit gate
+        if: steps.freshness.outputs.run == 'true'
+        run: npm run test:unit

--- a/docs/operations/release-channels.md
+++ b/docs/operations/release-channels.md
@@ -2,6 +2,14 @@
 
 `main` is the integration branch. Pull requests must be up to date, resolve review conversations, and pass the seven required CI checks from the GitHub Actions app: Type Check, Lint, Hermetic Unit Tests, Security Audit, Governance Smoke, and both Rust Compile Gates. The rules apply to administrators. A second human approval is not required; merge approval remains an operator decision. Force pushes and branch deletion remain blocked.
 
+## Development and nightly verification
+
+Develop in a short-lived feature or fix branch, preferably in its own worktree. Open a pull request against `main`, retain the required checks, and merge only after approval. There is no permanent `dev` or `nightly` branch to keep synchronized. A development branch does not isolate application data. Source dev servers must use a disposable `CORTEX_IDE_DATA_DIR` and `O8_DATA_DIR` when testing state-changing behavior beside the installed app, with separate API and WebSocket ports.
+
+The `Nightly Verification` workflow checks the default branch once a day at 06:23 UTC. It skips a commit that already passed this workflow; manual dispatch reruns the checks. A single job has a 20-minute ceiling, read-only repository permissions, and runs protocol, TypeScript, classification, and hermetic unit checks. The existing weekly resource-owning integration and security lane remains separate.
+
+This is nightly source verification, not a downloadable nightly app or installed Mac acceptance. It creates no installer, tag, release, updater manifest, or announcement. The schedule becomes active only when its reviewed workflow reaches the default branch. Installable nightlies require the preview identity and data-isolation work described below, followed by an explicit publication-policy decision.
+
 ## Stable
 
 The installed app uses the public mirror's `releases/latest/download/latest.json`. Keep that endpoint unchanged for normal users. `npm run ship` remains the explicitly approved stable publication path and requires a plain `X.Y.Z` version. Version changes go through a PR before tagging the merged commit. Release-note archives also go through a PR; publication never pushes archive commits to main.

--- a/tests/nightly-verification-policy.test.ts
+++ b/tests/nightly-verification-policy.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { runInNewContext } from 'node:vm';
+import { describe, expect, it, vi } from 'vitest';
+import { parse } from 'yaml';
+
+const source = readFileSync(resolve('.github/workflows/nightly.yml'), 'utf8');
+const workflow = parse(source);
+
+async function freshness(eventName: string, previousSha?: string) {
+  const listWorkflowRuns = vi.fn(async () => ({ data: {
+    workflow_runs: previousSha ? [{ head_sha: previousSha }] : [],
+  } }));
+  const setOutput = vi.fn();
+  const summary = { addRaw: vi.fn().mockReturnThis(), write: vi.fn(async () => {}) };
+  const step = workflow.jobs.verify.steps.find((candidate: { id?: string }) => candidate.id === 'freshness');
+  await runInNewContext(`(async () => { ${step.with.script} })()`, {
+    github: { rest: { actions: { listWorkflowRuns } } },
+    context: { eventName, sha: 'current-sha', repo: { owner: 'fixture', repo: 'fixture' },
+      payload: { repository: { default_branch: 'main' } } },
+    core: { setOutput, summary },
+  }, { timeout: 1000 });
+  return { listWorkflowRuns, setOutput };
+}
+
+describe('nightly source-verification policy', () => {
+  it('stays read-only, time-bounded, and on the default branch', () => {
+    expect(workflow.on).toEqual({ schedule: [{ cron: '23 6 * * *' }], workflow_dispatch: null });
+    expect(workflow.permissions).toEqual({ contents: 'read', actions: 'read' });
+    expect(workflow.jobs.verify.if).toBe('github.ref_name == github.event.repository.default_branch');
+    expect(workflow.jobs.verify['timeout-minutes']).toBe(20);
+    expect(workflow.concurrency['cancel-in-progress']).toBe(true);
+    expect(source).not.toContain('secrets.');
+    expect(workflow.jobs.verify.steps.filter((step: { run?: string }) => step.run)
+      .flatMap((step: { run: string }) => step.run.trim().split('\n'))).toEqual([
+      'npm install -g npm@11', 'npm ci --prefer-offline',
+      'npm run protocol:check', 'npm run typecheck', 'npm run test:classification:check',
+      'npm run test:unit',
+    ]);
+    for (const step of workflow.jobs.verify.steps.slice(1)) {
+      expect(step.if).toBe("steps.freshness.outputs.run == 'true'");
+    }
+  });
+
+  it('skips a scheduled commit that already passed this workflow', async () => {
+    const result = await freshness('schedule', 'current-sha');
+    expect(result.setOutput).toHaveBeenCalledWith('run', 'false');
+    expect(result.listWorkflowRuns).toHaveBeenCalledWith(expect.objectContaining({
+      workflow_id: 'nightly.yml', branch: 'main', status: 'success', per_page: 1,
+    }));
+  });
+
+  it.each([undefined, 'older-sha'])('checks new or not-yet-proven source (%s)', async (previousSha) => {
+    expect((await freshness('schedule', previousSha)).setOutput).toHaveBeenCalledWith('run', 'true');
+  });
+
+  it('allows an explicit manual rerun of the same source', async () => {
+    const result = await freshness('workflow_dispatch', 'current-sha');
+    expect(result.setOutput).toHaveBeenCalledWith('run', 'true');
+    expect(result.listWorkflowRuns).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Add a default-branch source check at 06:23 UTC each day. A scheduled run skips a commit that already passed this workflow; manual dispatch can recheck it. The job has read-only repository permissions, a 20-minute ceiling, and runs protocol, type, classification, and hermetic unit checks.

Development remains on short-lived branches with reviewed PRs into protected main. The documentation separates that workflow from stable releases and installable previews.

## Verification and boundaries

- Five tests parse the actual workflow and execute its freshness script, covering unchanged, changed, first-time, and manual runs plus the allowed command and permission boundary.
- Exact branch: all five workflow-policy tests, TypeScript, touched-file lint, and test-classification check passed. PR CI will independently check the merge candidate.
- This does not create installers, tags, releases, updater manifests, or announcements. The schedule remains inactive until merged into the default branch.
- Installable nightlies still require separate application identity, data isolation, and publication approval. Refs #2107.

Stable publication and branch protection are unchanged.
