### PR TITLE
fix: admit managed runs for accepted steered turns

### DIFF
--- a/src/lib/lane/packet-stop-hold.ts
+++ b/src/lib/lane/packet-stop-hold.ts
@@ -7,6 +7,9 @@ import {
   withMissionRegistryState,
 } from '@/lib/orchestrator/mission-registry';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import { hasCanonicalReleaseEvidence } from '@/lib/orchestrator/packet-release-truth';
+import { getSqlite } from '@/lib/db';
+import { findLaneByPacket } from './registry';
 
 export interface PacketManagedRunAdmission {
   allowed: boolean;
@@ -33,7 +36,17 @@ function applyOperatorHold(packet: OrchestratorPacket) {
 
 function managedRunAdmissionForPacket(packet: OrchestratorPacket | null): PacketManagedRunAdmission {
   if (!packet) return { allowed: false, reason: 'packet_not_found', status: null };
-  if (packet.operatorStopped || packet.queueState === 'held') {
+  if (packet.operatorStopped) {
+    return { allowed: false, reason: 'packet_held', status: packet.status };
+  }
+  const steeredRun = acceptedSteerRunState(packet.id);
+  if (!packetSteerHoldReason(packet.id) && steeredRun === 'active') {
+    return { allowed: true, reason: 'active', status: 'running' };
+  }
+  if (steeredRun === 'closed') {
+    return { allowed: false, reason: 'packet_terminal', status: packet.status };
+  }
+  if (packet.queueState === 'held') {
     return { allowed: false, reason: 'packet_held', status: packet.status };
   }
   if (packet.releaseState === 'released' || MANAGED_RUN_TERMINAL_PACKET_STATUSES.has(packet.status)) {
@@ -43,18 +56,67 @@ function managedRunAdmissionForPacket(packet: OrchestratorPacket | null): Packet
 }
 
 /** Read the durable packet state before admitting a packet-bound managed run. */
-export function inspectPacketManagedRunAdmission(packetId: string): PacketManagedRunAdmission {
+function readManagedRunPacket(packetId: string): OrchestratorPacket | null {
   const normalizedPacketId = packetId.trim();
-  if (!normalizedPacketId) {
-    return { allowed: false, reason: 'packet_not_found', status: null };
-  }
+  if (!normalizedPacketId) return null;
   const currentPacket = readOrchestratorControlPlaneState().packets
     .find((candidate) => candidate.id === normalizedPacketId) ?? null;
-  if (currentPacket) return managedRunAdmissionForPacket(currentPacket);
+  if (currentPacket) return currentPacket;
 
   const registryPacket = findMissionRegistryEntryByPacketId(normalizedPacketId, { includeArchived: true })
     ?.mission.packets.find((candidate) => candidate.id === normalizedPacketId) ?? null;
-  return managedRunAdmissionForPacket(registryPacket);
+  return registryPacket;
+}
+
+/** A steer is not authority to undo an operator stop, archive, or proven release. */
+export function packetSteerHoldReason(packetId: string): string | null {
+  const packet = readManagedRunPacket(packetId);
+  if (packet?.operatorStopped) return 'operator_stopped';
+  if (packet?.archivedAt || packet?.status === 'archived') return 'archived';
+  if (packet?.releaseState === 'released' && hasCanonicalReleaseEvidence(packet)) return 'released';
+  return null;
+}
+
+function acceptedSteerRunState(packetId: string): 'absent' | 'active' | 'closed' {
+  const lane = findLaneByPacket(packetId);
+  if (!lane?.sessionKey) return 'absent';
+  const grant = getSqlite().prepare(`
+    SELECT id, payload_json FROM lane_events
+    WHERE lane_id = ? AND verb = 'steer_run_admitted'
+    ORDER BY timestamp DESC, rowid DESC LIMIT 1
+  `).get(lane.id) as { id: string; payload_json: string } | undefined;
+  if (!grant) return 'absent';
+  let payload: Record<string, unknown>;
+  try { payload = JSON.parse(grant.payload_json) as Record<string, unknown>; }
+  catch { return 'closed'; }
+  if (!payload || typeof payload !== 'object') return 'closed';
+  if (payload.packetId !== packetId || payload.sessionKey !== lane.sessionKey) return 'absent';
+  if (lane.status !== 'running') return 'closed';
+  // Query only lifecycle evidence, not the last N transcript/tool events. A
+  // long turn must not lose admission merely because it produced more output.
+  const event = getSqlite().prepare(`
+    SELECT id FROM lane_events
+    WHERE lane_id = ? AND verb IN (
+      'steer_run_admitted', 'steered_packet', 'steer_failed',
+      'runtime_process_exit', 'status_change'
+    ) ORDER BY timestamp DESC, rowid DESC LIMIT 1
+  `).get(lane.id) as { id: string } | undefined;
+  if (event?.id !== grant.id || typeof payload.steerEventId !== 'string') return 'closed';
+  const intent = getSqlite().prepare(`
+    SELECT rowid FROM lane_events WHERE id = ? AND lane_id = ? AND verb = 'steered_packet'
+  `).get(payload.steerEventId, lane.id) as { rowid: number } | undefined;
+  if (!intent) return 'closed';
+  // An immediate exit can precede the accepted-steer response. Insertion order
+  // keeps equal-millisecond events distinct, including across a database reopen.
+  const exited = getSqlite().prepare(`
+    SELECT 1 FROM lane_events WHERE lane_id = ? AND verb = 'runtime_process_exit'
+    AND rowid > ? LIMIT 1
+  `).get(lane.id, intent.rowid);
+  return exited ? 'closed' : 'active';
+}
+
+export function inspectPacketManagedRunAdmission(packetId: string): PacketManagedRunAdmission {
+  return managedRunAdmissionForPacket(readManagedRunPacket(packetId));
 }
 
 /** Persist the lane stop guard in whichever durable mission store owns it. */

--- a/src/lib/lane/types.ts
+++ b/src/lib/lane/types.ts
@@ -459,6 +459,8 @@ export type LaneEventVerb =
   | 'rules_applied'
   // Packet steer injected into an existing warm session. Payload: { packetId, source, message }
   | 'steered_packet'
+  // Accepted steered turn may register managed runs until its next lifecycle boundary.
+  | 'steer_run_admitted'
   // Design Mode follow-up reused the packet's warm lane. Payload: { packetId, elementSummary }
   | 'ui_loop_steered'
   // Design Mode steer did not settle before its writer deadline. Payload: { packetId, laneId, waitedMs }

--- a/src/lib/orchestrator/operator-mission-service/steer.ts
+++ b/src/lib/orchestrator/operator-mission-service/steer.ts
@@ -17,6 +17,7 @@
 import { findLaneByPacket, setLaneStatus } from '@/lib/lane/registry';
 import type { Lane } from '@/lib/lane/types';
 import { recordLaneEvent } from '@/lib/lane/events';
+import { packetSteerHoldReason } from '@/lib/lane/packet-stop-hold';
 import { rebindLaneSessionIfChanged } from '@/lib/lane/session-rebind';
 import {
   findMissionRegistryEntryByPacketId,
@@ -182,12 +183,16 @@ export async function steerPacket({
   }
 
   const steerSource = normalizeSource(source);
+  const holdReason = packetSteerHoldReason(packetId);
+  if (holdReason) {
+    throw new SteerPacketUnavailableError(`Packet cannot be steered while ${holdReason}.`);
+  }
   const steerStartedMs = Date.now();
   // From the first durable event onward, a thrown call can no longer prove
   // that no visible or provider-side effect landed. All failures below this
   // boundary are typed so routes can finalize a receipt before responding.
   try {
-    recordLaneEvent(lane.id, 'steered_packet', 'orchestrator', {
+    const steerEvent = recordLaneEvent(lane.id, 'steered_packet', 'orchestrator', {
       packetId,
       source: steerSource,
       message,
@@ -211,7 +216,9 @@ export async function steerPacket({
       // process spawn. A lane that went terminal mid-steer must not get a
       // fresh runtime editing its worktree.
       const freshLane = canTryOwnedResumeFallback ? findLaneByPacket(packetId) : null;
-      const laneStillLive = freshLane?.id === lane.id && freshLane.sessionKey === lane.sessionKey;
+      const laneStillLive = freshLane?.id === lane.id
+        && freshLane.sessionKey === lane.sessionKey
+        && !packetSteerHoldReason(packetId);
       const resumed = canTryOwnedResumeFallback && laneStillLive
         ? await resumeExitedOwnedCodexSession(lane.sessionKey, message)
         : canTryOwnedResumeFallback
@@ -256,10 +263,24 @@ export async function steerPacket({
     // unavailable steer must leave the alignment prompt armed for recovery.
     await markAlignmentResolved(packetId);
 
+    const acceptedHoldReason = packetSteerHoldReason(packetId);
+    if (acceptedHoldReason) {
+      throw new SteerPacketUnavailableError(
+        `Packet became ${acceptedHoldReason} while the steer was in flight.`, 'terminal',
+      );
+    }
+    const acceptedSessionKey = result.ok && result.sessionKey ? result.sessionKey : lane.sessionKey;
+    const acceptedLane = findLaneByPacket(packetId);
+    if (acceptedLane?.id !== lane.id || acceptedLane.sessionKey !== acceptedSessionKey) {
+      throw new SteerPacketUnavailableError('Packet session changed while the steer was in flight.', 'terminal');
+    }
     const updated = setLaneStatus(lane.id, 'running', 'orchestrator', 'steered_packet');
     if (!updated || updated.status !== 'running') {
       throw new SteerPacketUnavailableError(NO_STEERABLE_SESSION, 'terminal');
     }
+    recordLaneEvent(lane.id, 'steer_run_admitted', 'orchestrator', {
+      packetId, sessionKey: updated.sessionKey, clientMutationId, steerEventId: steerEvent.id,
+    });
 
     return { packetId, laneId: lane.id, note: steeredNote };
   } catch (error) {

--- a/tests/steer-managed-run-admission-real-path.test.ts
+++ b/tests/steer-managed-run-admission-real-path.test.ts
@@ -1,0 +1,176 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { NextRequest } from 'next/server';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+
+const perform = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/runtime/actions', () => ({ performRuntimeAction: perform }));
+vi.mock('@/lib/runtime/inventory', () => ({
+  getRuntimeInventorySnapshot: vi.fn(async () => ({ agents: [] })),
+}));
+vi.mock('@/lib/realtime/publisher', () => ({ publishRealtimeMutation: vi.fn(async () => {}) }));
+vi.mock('@/lib/command-center/snapshot', () => ({ invalidateCommandCenterSnapshotCaches: vi.fn() }));
+vi.mock('@/lib/mobile/inbox', () => ({ invalidateInboxCache: vi.fn() }));
+
+const dataDir = mkdtempSync(join(tmpdir(), 'o8-steer-run-admission-'));
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.O8_DATA_DIR = dataDir;
+const { closeDb } = await import('@/lib/db');
+const { createLane, getLane, setLaneStatus, updateLane } = await import('@/lib/lane/registry');
+const { recordLaneEvent } = await import('@/lib/lane/events');
+const { writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+const { getOrCreateWsToken } = await import('@/lib/ws-auth');
+const { findManagedRun } = await import('@/lib/runtimes/managed-runs/registry');
+const steerRoute = await import('@/app/api/orchestrator/steer-packet/route');
+const runsRoute = await import('@/app/api/panel/managed-runs/route');
+
+let sequence = 0;
+function fixture(operatorStopped = false) {
+  const id = `pkt-steer-runs-${++sequence}`;
+  const repoPath = join(dataDir, id);
+  const sessionKey = `claude-code-owned:${id}`;
+  const lane = createLane({
+    repoPath, worktreePath: repoPath, branch: `inline/${id}`, runtime: 'claude-code',
+    packetId: id, sessionKey,
+  });
+  setLaneStatus(lane.id, 'reviewing', 'system', 'review_requested');
+  const packet: OrchestratorPacket = {
+    id, referenceLabel: id, title: id, summary: id, runtime: 'claude-code',
+    workspaceTargetPath: repoPath, branchTarget: `inline/${id}`,
+    dependencyLabels: [], dependencyPacketIds: [], queueState: 'held',
+    releaseState: 'pending', status: 'awaiting_review', operatorStopped,
+    blockedReason: operatorStopped ? 'operator_stopped' : null,
+    lastEventAt: null, lastEventLabel: null, archivedAt: null, review: null,
+    lane: { tileId: lane.id, tabId: lane.id, laneId: lane.id, repoPath,
+      worktreePath: repoPath, runtime: 'claude-code', sessionKey },
+  };
+  writeOrchestratorControlPlaneState({ ...createEmptyOrchestratorMissionState(),
+    missionId: `mission-${id}`, repoPath, packets: [packet] });
+  perform.mockResolvedValue({ ok: true, status: 'accepted', sessionKey, note: 'accepted' });
+  return { packet, lane, sessionKey };
+}
+
+function request(path: string, body: unknown) {
+  return new NextRequest(`http://localhost${path}`, { method: 'POST', headers: {
+    authorization: `Bearer ${getOrCreateWsToken()}`, 'content-type': 'application/json',
+  }, body: JSON.stringify(body) });
+}
+function steer(packetId: string) {
+  return steerRoute.POST(request('/api/orchestrator/steer-packet', {
+    packetId, message: 'Run the remaining verification', idempotencyKey: `steer-${packetId}`,
+  }));
+}
+function register(packet: OrchestratorPacket, suffix = 'first') {
+  const id = `run${sequence}${suffix}`;
+  return runsRoute.POST(request('/api/panel/managed-runs', {
+    id, session: `cortex-run-${id}`, command: 'node --version',
+    cwd: packet.workspaceTargetPath, packetId: packet.id, laneId: packet.lane?.laneId,
+  }));
+}
+
+beforeEach(() => perform.mockReset());
+afterAll(() => { closeDb(); rmSync(dataDir, { recursive: true, force: true }); });
+
+describe('steered-turn managed-run admission through production routes', () => {
+  it.each(['awaiting_review', 'released'] as const)('admits an accepted %s turn across reopen, then refuses its exit', async (priorStatus) => {
+    const { packet, lane, sessionKey } = fixture();
+    if (priorStatus === 'released') {
+      // Legacy completion stamped release without canonical merge evidence.
+      packet.status = 'released';
+      packet.releaseState = 'released';
+      writeOrchestratorControlPlaneState({ ...createEmptyOrchestratorMissionState(),
+        missionId: `mission-${packet.id}`, repoPath: packet.workspaceTargetPath, packets: [packet] });
+    }
+    expect((await register(packet, 'before')).status).toBe(409);
+    const response = await steer(packet.id);
+    expect(response.status, await response.clone().text()).toBe(200);
+    expect(getLane(lane.id)?.status).toBe('running');
+    closeDb();
+    const admitted = await register(packet);
+    expect(admitted.status, await admitted.clone().text()).toBe(200);
+    expect(findManagedRun(`run${sequence}first`)?.packetId).toBe(packet.id);
+    // The normal reconciler may already have projected the active turn.
+    writeOrchestratorControlPlaneState({ ...createEmptyOrchestratorMissionState(),
+      missionId: `mission-${packet.id}`, repoPath: packet.workspaceTargetPath,
+      packets: [{ ...packet, status: 'running', queueState: 'queued' }] });
+    recordLaneEvent(lane.id, 'runtime_process_exit', 'system', {
+      surfaceId: sessionKey, exitCode: 0, classification: 'clean-exit',
+    });
+    expect((await register(packet, 'late')).status).toBe(409);
+    expect(findManagedRun(`run${sequence}late`)).toBeNull();
+  });
+
+  it('does not grant admission when the runtime refuses the steer', async () => {
+    const { packet } = fixture();
+    perform.mockResolvedValue({ ok: false, status: 'unavailable', note: 'no warm session' });
+    expect((await steer(packet.id)).status).toBe(409);
+    expect((await register(packet)).status).toBe(409);
+  });
+
+  it('does not resume or admit an operator-stopped packet', async () => {
+    const { packet } = fixture(true);
+    expect((await steer(packet.id)).status).toBe(409);
+    expect(perform).not.toHaveBeenCalled();
+    expect((await register(packet)).status).toBe(409);
+  });
+
+  it('keeps a concurrent operator hold authoritative after runtime acceptance', async () => {
+    const { packet } = fixture();
+    perform.mockImplementation(async () => {
+      const { persistLanePacketHold } = await import('@/lib/lane/packet-stop-hold');
+      await persistLanePacketHold(packet.id);
+      return { ok: true, status: 'accepted', note: 'accepted' };
+    });
+    expect((await steer(packet.id)).status).toBe(409);
+    expect((await register(packet)).status).toBe(409);
+  });
+
+  it('does not carry admission into a rebound session', async () => {
+    const { packet, lane } = fixture();
+    expect((await steer(packet.id)).status).toBe(200);
+    expect((await register(packet)).status).toBe(200);
+    updateLane(lane.id, { sessionKey: 'claude-code-owned:unaccepted-successor' });
+    expect((await register(packet, 'rebound')).status).toBe(409);
+  });
+
+  it.each(['archived', 'released'] as const)('does not steer a %s packet', async (state) => {
+    const { packet } = fixture();
+    if (state === 'archived') {
+      packet.status = 'archived';
+      packet.archivedAt = new Date().toISOString();
+    } else {
+      const { markPacketReleased } = await import('@/lib/orchestrator/packet-release-truth');
+      markPacketReleased(packet, { source: 'read_only_completed' });
+    }
+    writeOrchestratorControlPlaneState({ ...createEmptyOrchestratorMissionState(),
+      missionId: `mission-${packet.id}`, repoPath: packet.workspaceTargetPath, packets: [packet] });
+    expect((await steer(packet.id)).status).toBe(409);
+    expect(perform).not.toHaveBeenCalled();
+    expect((await register(packet)).status).toBe(409);
+  });
+
+  it('does not grant an unrelated session rebound during runtime acceptance', async () => {
+    const { packet, lane, sessionKey } = fixture();
+    perform.mockImplementation(async () => {
+      updateLane(lane.id, { sessionKey: 'claude-code-owned:unaccepted-successor' });
+      return { ok: true, status: 'accepted', sessionKey, note: 'accepted original turn' };
+    });
+    expect((await steer(packet.id)).status).toBe(409);
+    expect((await register(packet)).status).toBe(409);
+  });
+
+  it('does not admit a turn that exits before the steer response', async () => {
+    const { packet, lane, sessionKey } = fixture();
+    perform.mockImplementation(async () => {
+      recordLaneEvent(lane.id, 'runtime_process_exit', 'system', {
+        surfaceId: sessionKey, exitCode: 0, classification: 'clean-exit',
+      });
+      return { ok: true, status: 'accepted', sessionKey, note: 'finished immediately' };
+    });
+    expect((await steer(packet.id)).status).toBe(200);
+    expect((await register(packet)).status).toBe(409);
+  });
+});

--- a/tests/steered-review-settlement-real-path.test.ts
+++ b/tests/steered-review-settlement-real-path.test.ts
@@ -84,6 +84,12 @@ vi.mock('@/lib/lane/review-quota-fallback', async () => {
 vi.mock('@/lib/realtime/publisher', () => ({ publishRealtimeMutation: vi.fn(async () => {}) }));
 vi.mock('@/lib/command-center/snapshot', () => ({ invalidateCommandCenterSnapshotCaches: vi.fn() }));
 vi.mock('@/lib/mobile/inbox', () => ({ invalidateInboxCache: vi.fn() }));
+// These fixtures own Git and review state, not installed runtime discovery.
+// A host inventory probe can outlive the held-turn assertion and contaminate
+// the next test's serialized review slot.
+vi.mock('@/lib/runtime/inventory', () => ({
+  getRuntimeInventorySnapshot: vi.fn(async () => ({ agents: [], runtimes: [] })),
+}));
 
 const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-steer-settlement-data-'));
 writeFileSync(join(dataDir, 'ws-token'), 'steer-settlement-ws-token-0123456789\n', 'utf8');

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2420,6 +2420,12 @@
       ]
     },
     {
+      "path": "tests/steer-managed-run-admission-real-path.test.ts",
+      "reasons": [
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/steer-packet-owned-resume.test.ts",
       "reasons": [
         "child-process"


### PR DESCRIPTION
## Summary

Accepted steered turns can register packet-bound managed runs without clearing an operator stop or inventing release evidence. The admission is persisted against the accepted session and original steer event, and closes at a lifecycle boundary or runtime exit. Archive, proven release, failed acceptance, and session-rebind guards remain in force.

The review-settlement fixture now isolates installed-runtime discovery. Its assertions and deadlines are unchanged. This removes a host inventory probe that could outlive the held-turn assertion and contaminate the next serialized review case.

Refs #2080 and #2088. These issues remain open for integrated and installed acceptance.

## Verification

- Real production steer and managed-run routes with persisted SQLite state: ten admission cases, including database reopen, legacy release flags, concurrent hold, session rebound, and exit before the steer response.
- Review-settlement baseline reproduced five failures in ten tests. Two bounded fix-only reruns passed ten of ten.
- The prepared combined source passed 4,131 hermetic tests with three existing skips, TypeScript, touched-file lint, classification, and changed-line rules. That count includes five tests in the separate nightly-verification PR.
- Exact branch: 28/28 bounded integration tests across the admission, settlement, owned-resume, and idempotency fixtures; 2/2 managed-run guard tests; TypeScript, touched-file lint, classification, changed-line rules, and whitespace checks passed. PR CI will independently check the merge candidate.

No installed app was replaced. Source tests do not prove the real provider's first managed-run command timing before an accepted steer response; that remains part of installed acceptance. The original multi-hour orphan report was not reproduced, so this PR does not claim to have proven its absence.
