### PR TITLE
fix: preserve stop state and reduce idle discovery work

### DIFF
--- a/scripts/lib/preship-gate-cleanup.mjs
+++ b/scripts/lib/preship-gate-cleanup.mjs
@@ -1,0 +1,49 @@
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import net from 'node:net';
+import path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+// An attempted load owns persistent work even if its caller throws before it
+// can return a receipt. Only an explicit, complete empty teardown permits removal.
+export function loadTeardownProvesClean(loadScenario) {
+  const teardown = loadScenario?.teardown;
+  const counts = teardown?.residuals?.counts;
+  return teardown?.refused === 0
+    && ['lanes', 'childProcesses', 'worktrees', 'listeners'].every((key) => counts?.[key] === 0)
+    && Object.values(counts).every((count) => count === 0);
+}
+
+function listenerGone(port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host: '127.0.0.1', port });
+    socket.once('connect', () => {
+      socket.destroy();
+      resolve(false);
+    });
+    socket.once('error', () => resolve(true));
+  });
+}
+
+async function killProcessGroup(child) {
+  if (!child?.pid) return;
+  try { process.kill(-child.pid, 'SIGTERM'); } catch {}
+  await sleep(3000);
+  try { process.kill(-child.pid, 'SIGKILL'); } catch {}
+}
+
+export async function cleanupGate({ client, child, dataDir, socketPath, preserveDataDir = false }) {
+  client?.dispose();
+  await killProcessGroup(child);
+  const apiPortPath = dataDir ? path.join(dataDir, 'api-port') : null;
+  const apiPort = apiPortPath && existsSync(apiPortPath) ? Number(readFileSync(apiPortPath, 'utf8')) : null;
+  rmSync(socketPath, { force: true });
+  rmSync(`${socketPath}.token`, { force: true });
+  // Verify shutdown before removing anything that a surviving server may own.
+  if (apiPort && !(await listenerGone(apiPort))) {
+    throw new Error(`child API port still has a listener after cleanup; profile preserved: ${dataDir}`);
+  }
+  if (dataDir && !preserveDataDir) rmSync(dataDir, { recursive: true, force: true });
+  if (dataDir && preserveDataDir) {
+    console.error(`[preship-webview-gate] preserved isolated profile for inspection: ${dataDir}`);
+  }
+}

--- a/scripts/preship-webview-gate.mjs
+++ b/scripts/preship-webview-gate.mjs
@@ -21,6 +21,7 @@ import {
   runLoadScenario,
 } from './lib/footprint-budget-load.mjs';
 import { BOOT_PROBE_JS, classifyBootProbe } from './preship-gate-logic.mjs';
+import { cleanupGate, loadTeardownProvesClean } from './lib/preship-gate-cleanup.mjs';
 
 // Per-phase deadlines (each phase gets its OWN fresh budget — a shared budget
 // let a slow cold boot under machine load starve the later route/health checks
@@ -445,37 +446,6 @@ function resolveAppTarget(mode, target) {
   };
 }
 
-function listenerGone(port) {
-  return new Promise((resolve) => {
-    const socket = net.createConnection({ host: '127.0.0.1', port });
-    socket.once('connect', () => {
-      socket.destroy();
-      resolve(false);
-    });
-    socket.once('error', () => resolve(true));
-  });
-}
-
-async function killProcessGroup(child) {
-  if (!child?.pid) return;
-  try { process.kill(-child.pid, 'SIGTERM'); } catch {}
-  await sleep(3000);
-  try { process.kill(-child.pid, 'SIGKILL'); } catch {}
-}
-
-async function cleanup({ client, child, dataDir, socketPath }) {
-  client?.dispose();
-  await killProcessGroup(child);
-  const apiPortPath = dataDir ? path.join(dataDir, 'api-port') : null;
-  const apiPort = apiPortPath && existsSync(apiPortPath) ? Number(readFileSync(apiPortPath, 'utf8')) : null;
-  if (dataDir) rmSync(dataDir, { recursive: true, force: true });
-  rmSync(socketPath, { force: true });
-  rmSync(`${socketPath}.token`, { force: true });
-  if (apiPort && !(await listenerGone(apiPort))) {
-    throw new Error(`child API port still has a listener after cleanup: ${apiPort}`);
-  }
-}
-
 function bypass(mode, appTar, info) {
   const reason = (process.env.O8_GATE_BYPASS_REASON ?? '').trim();
   if (!reason) {
@@ -536,6 +506,7 @@ async function main() {
   let signalFailed = 'unknown';
   let capturedConsoleErrors = [];
   let footprintReceipt;
+  let preserveDataDir = false;
 
   try {
     child = spawn(machO, [], {
@@ -597,6 +568,7 @@ async function main() {
     });
     let loadScenario = plan;
     if (plan.available) {
+      preserveDataDir = true;
       loadScenario = await runLoadScenario({
         plan,
         driver: createHttpLoadDriver({
@@ -608,6 +580,7 @@ async function main() {
         }),
         sample: ({ laneCount }) => collectFootprintSamples(footprintContext, sampleCount, 'loaded-lanes', laneCount),
       });
+      preserveDataDir = !loadTeardownProvesClean(loadScenario);
     }
 
     signalFailed = 'footprint-budget';
@@ -677,7 +650,7 @@ async function main() {
     console.error(`[preship-webview-gate] child stdout tail:\n${tail(stdout)}`);
     process.exitCode = 1;
   } finally {
-    await cleanup({ client, child, dataDir, socketPath });
+    await cleanupGate({ client, child, dataDir, socketPath, preserveDataDir });
   }
 }
 

--- a/src/app/api/orchestrator/state/route.ts
+++ b/src/app/api/orchestrator/state/route.ts
@@ -12,6 +12,7 @@ import { listApprovals } from '@/lib/approvals/store';
 import { getRuntimeInventorySnapshot } from '@/lib/runtime/inventory';
 import { resolveAgentSummaryStatuses } from '@/lib/orchestrator/operator-status-model';
 import { packetStatusWriteRejection } from '@/lib/orchestrator/packet-patch-policy';
+import { normalizePacketStorageAdmissionEpoch } from '@/lib/orchestrator/packet-storage-admission-normalize';
 import { autoResolveMergedPacketVerificationIncidents } from '@/lib/supervisor/merged-incident-resolution';
 import { listTerminalReviewQueueEvidence } from '@/lib/terminal-status/store';
 import { resolveTerminalStatusEvidence } from '@/lib/terminal-status/resolve';
@@ -194,14 +195,33 @@ function mergeClientMissionUnderLock(
   // Identity matches (or server has no mission yet): accept the body,
   // but pin identity fields to the server's values so a client that
   // synthesized partial state can't overwrite them to empty/different
-  // strings. Packet-level updates flow through as-is.
+  // strings. A whole-client snapshot is not a lifecycle command: it must not
+  // erase a server hold, replay an older hold after reset, or cross a reset's
+  // generation floor. Targeted metadata PATCHes still work on held packets.
+  const serverPackets = new Map(current.packets.map((packet) => [packet.id, packet]));
   const packets: OrchestratorPacket[] = Array.isArray(incoming.packets)
     ? incoming.packets.map((packet) => {
-        const persisted = { ...packet };
+        const serverPacket = serverPackets.get(packet.id);
+        const preserveLifecycle = serverPacket && (
+          serverPacket.operatorStopped === true
+          || packet.operatorStopped === true
+          || normalizePacketStorageAdmissionEpoch(serverPacket.storageAdmissionEpoch)
+            !== normalizePacketStorageAdmissionEpoch(packet.storageAdmissionEpoch)
+        );
+        const persisted = { ...(preserveLifecycle ? serverPacket : packet) };
         delete persisted.statusEvidence;
         return persisted;
       })
     : [];
+  // An old snapshot may not contain the packet at all. Omitting it cannot
+  // delete the durable stop or a packet whose lifecycle has since advanced.
+  const incomingIds = new Set(packets.map((packet) => packet.id));
+  for (const packet of current.packets) {
+    if (!incomingIds.has(packet.id) && (packet.operatorStopped === true
+      || normalizePacketStorageAdmissionEpoch(packet.storageAdmissionEpoch) > 1)) {
+      packets.push(packet);
+    }
+  }
   return {
     ...incoming,
     missionId: current.missionId || incoming.missionId,
@@ -210,6 +230,7 @@ function mergeClientMissionUnderLock(
     repoPath: current.repoPath ?? incoming.repoPath,
     runtime: current.runtime || incoming.runtime,
     constraints: current.constraints ?? incoming.constraints,
+    lifecycleHold: current.lifecycleHold,
     packets,
   };
 }

--- a/src/components/desktop/workspace-terminal/terminal-tab-handlers.ts
+++ b/src/components/desktop/workspace-terminal/terminal-tab-handlers.ts
@@ -5,9 +5,10 @@ import {
   adHocLaneTitle,
 } from '@/lib/orchestrator/display';
 import {
-  persistOrchestratorMissionState,
   readOrchestratorMissionState,
+  updateOrchestratorMissionState,
 } from '@/lib/orchestrator/store';
+import type { OrchestratorStateApiResponse } from '@/lib/orchestrator/types';
 import { ANSI_RE, CLAUDE_CLI_MODELS, CODEX_CLI_MODELS, GEMINI_CLI_MODELS, getOpenCodeModels, CLI_AGENTS, IGNORED_PORTS, LOCALHOST_RE } from '@/components/desktop/workspace-terminal/constants';
 import type {
   LocalhostPreview,
@@ -286,12 +287,17 @@ export function archivePacket(packetId: string | null | undefined): void {
   const missionState = readOrchestratorMissionState();
   const packet = missionState.packets.find((entry) => entry.id === packetId);
   if (!packet || packet.archivedAt) return;
-  void persistOrchestratorMissionState({
-    ...missionState,
-    packets: missionState.packets.map((entry) => (
-      entry.id === packetId ? { ...entry, archivedAt: new Date().toISOString() } : entry
-    )),
-  });
+  // Send only the archive intent. Posting this tab's cached mission can undo a
+  // sibling's stop while its worker is still waiting for kill confirmation.
+  void fetch('/api/orchestrator/state', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ packetId, updates: { archivedAt: new Date().toISOString() } }),
+  }).then(async (response) => {
+    if (!response.ok) return;
+    const payload = await response.json() as Partial<OrchestratorStateApiResponse>;
+    if (payload.mission) updateOrchestratorMissionState(payload.mission);
+  }).catch(() => { /* Keep the current cache when the archive write fails. */ });
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/lib/runtimes/antigravity.ts
+++ b/src/lib/runtimes/antigravity.ts
@@ -8,7 +8,6 @@ import type {
   RuntimeTelemetry,
   RuntimeTranscriptEntry,
 } from './types';
-import { CliNotFoundError, resolveCli } from '@/lib/runtimes/shared/cli-resolver';
 
 const capabilities: RuntimeCapabilities = {
   discover: true,
@@ -20,22 +19,6 @@ const capabilities: RuntimeCapabilities = {
   costTelemetry: false,
   streaming: false,
 };
-
-async function hasAntigravityCli(): Promise<boolean> {
-  try {
-    await resolveCli({
-      runtimeId: 'antigravity',
-      binaryName: 'agy',
-      envOverride: 'O8_ANTIGRAVITY_BIN',
-      aliases: ['antigravity'],
-      extraEnvOverrides: ['ANTIGRAVITY_BIN'],
-    });
-    return true;
-  } catch (error) {
-    if (error instanceof CliNotFoundError) return false;
-    throw error;
-  }
-}
 
 function unavailable(action: string): RuntimeActionResult {
   return {
@@ -49,9 +32,7 @@ export const antigravityRuntime: AgentRuntime = {
   displayName: 'Antigravity',
   capabilities,
 
-  async discoverSessions(options = {}): Promise<RuntimeSession[]> {
-    if (!(options.fresh ?? false)) return [];
-    if (!await hasAntigravityCli()) return [];
+  async discoverSessions(): Promise<RuntimeSession[]> {
     // Parser seam: official docs confirm `agy --print` for one-shot headless use,
     // but do not document a stable session id + streaming JSON contract.
     return [];

--- a/src/lib/runtimes/cursor.ts
+++ b/src/lib/runtimes/cursor.ts
@@ -9,7 +9,6 @@ import type {
   LaunchOptions,
 } from './types';
 import { parseCursorSessionCost } from '@/lib/runtimes/cursor-cost-parser';
-import { CliNotFoundError, resolveCli } from '@/lib/runtimes/shared/cli-resolver';
 import { ownedTailToRuntimeTranscript } from '@/lib/runtimes/shared/owned-transcript';
 import { monitorUsageDispatch, usageSnapshotFromTelemetry } from '@/lib/usage-log';
 import {
@@ -59,21 +58,6 @@ type OwnedAgentLike = {
     cwd?: string;
   };
 };
-
-async function hasCursorCli(): Promise<boolean> {
-  try {
-    await resolveCli({
-      runtimeId: 'cursor',
-      binaryName: 'cursor-agent',
-      envOverride: 'O8_CURSOR_BIN',
-      extraEnvOverrides: ['CURSOR_AGENT_BIN'],
-    });
-    return true;
-  } catch (error) {
-    if (error instanceof CliNotFoundError) return false;
-    throw error;
-  }
-}
 
 function mapStatus(rawStatus: string): RuntimeSession['status'] {
   return rawStatus === 'completed' || rawStatus === 'finished' ? 'completed'
@@ -159,7 +143,7 @@ export const cursorRuntime: AgentRuntime = {
   capabilities,
 
   async discoverSessions(options = {}): Promise<RuntimeSession[]> {
-    if ((options.fresh ?? false) && !await hasCursorCli()) return [];
+    // Fresh means fresh session state, not a repeated installation probe.
     const owned = await getOwnedCursorFleetAdditions({ fresh: options.fresh ?? false }).catch((error) => {
       console.warn('[cursor-runtime] discoverSessions owned fleet failed:', error);
       return null;

--- a/src/lib/runtimes/grok.ts
+++ b/src/lib/runtimes/grok.ts
@@ -9,7 +9,6 @@ import type {
   LaunchOptions,
 } from './types';
 import { parseGrokSessionCost } from '@/lib/runtimes/grok-cost-parser';
-import { CliNotFoundError, resolveCli } from '@/lib/runtimes/shared/cli-resolver';
 import { ownedTailToRuntimeTranscript } from '@/lib/runtimes/shared/owned-transcript';
 import { monitorUsageDispatch, usageSnapshotFromTelemetry } from '@/lib/usage-log';
 import {
@@ -59,21 +58,6 @@ type OwnedAgentLike = {
     cwd?: string;
   };
 };
-
-async function hasGrokCli(): Promise<boolean> {
-  try {
-    await resolveCli({
-      runtimeId: 'grok',
-      binaryName: 'grok',
-      envOverride: 'O8_GROK_BIN',
-      extraEnvOverrides: ['GROK_BUILD_BIN'],
-    });
-    return true;
-  } catch (error) {
-    if (error instanceof CliNotFoundError) return false;
-    throw error;
-  }
-}
 
 function mapStatus(rawStatus: string): RuntimeSession['status'] {
   return rawStatus === 'completed' || rawStatus === 'finished' ? 'completed'
@@ -159,7 +143,7 @@ export const grokRuntime: AgentRuntime = {
   capabilities,
 
   async discoverSessions(options = {}): Promise<RuntimeSession[]> {
-    if ((options.fresh ?? false) && !await hasGrokCli()) return [];
+    // Fresh means fresh session state, not a repeated installation probe.
     const owned = await getOwnedGrokFleetAdditions({ fresh: options.fresh ?? false }).catch((error) => {
       console.warn('[grok-runtime] discoverSessions owned fleet failed:', error);
       return null;

--- a/src/lib/runtimes/magnitude.ts
+++ b/src/lib/runtimes/magnitude.ts
@@ -6,7 +6,6 @@ import type {
   RuntimeTelemetry,
   RuntimeTranscriptEntry,
 } from './types';
-import { CliNotFoundError, resolveCli } from '@/lib/runtimes/shared/cli-resolver';
 
 const capabilities = {
   discover: true,
@@ -18,20 +17,6 @@ const capabilities = {
   costTelemetry: false,
   streaming: false,
 } as const;
-
-async function hasMagnitudeCli(): Promise<boolean> {
-  try {
-    await resolveCli({
-      runtimeId: 'magnitude',
-      binaryName: 'magnitude',
-      envOverride: 'O8_MAGNITUDE_BIN',
-    });
-    return true;
-  } catch (error) {
-    if (error instanceof CliNotFoundError) return false;
-    throw error;
-  }
-}
 
 function unavailable(action: string): RuntimeActionResult {
   return {
@@ -45,9 +30,7 @@ export const magnitudeRuntime: AgentRuntime = {
   displayName: 'Magnitude',
   capabilities,
 
-  async discoverSessions(options = {}): Promise<RuntimeSession[]> {
-    if (!(options.fresh ?? false)) return [];
-    if (!await hasMagnitudeCli()) return [];
+  async discoverSessions(): Promise<RuntimeSession[]> {
     // Live terminal processes are attached through the shared IDE session
     // registry. Upstream session files stay private until a stable transcript
     // or daemon RPC contract is available.

--- a/src/lib/runtimes/pi.ts
+++ b/src/lib/runtimes/pi.ts
@@ -9,7 +9,6 @@ import type {
   RuntimeTranscriptEntry,
 } from './types';
 import { parsePiSessionCost } from '@/lib/runtimes/pi-cost-parser';
-import { resolveCli, CliNotFoundError } from '@/lib/runtimes/shared/cli-resolver';
 import { ownedTailToRuntimeTranscript } from '@/lib/runtimes/shared/owned-transcript';
 import {
   getOwnedPiFleetAdditions,
@@ -33,21 +32,6 @@ const capabilities: RuntimeCapabilities = {
 };
 
 type OwnedAgentLike = Awaited<ReturnType<typeof getOwnedPiFleetAdditions>>['agents'][number];
-
-async function piBinaryPresent(): Promise<boolean> {
-  try {
-    await resolveCli({
-      runtimeId: 'pi',
-      binaryName: 'pi',
-      envOverride: 'O8_PI_BIN',
-      versionArgs: ['--version'],
-    });
-    return true;
-  } catch (error) {
-    if (error instanceof CliNotFoundError) return false;
-    return false;
-  }
-}
 
 function mapAgentToSession(agent: OwnedAgentLike): RuntimeSession {
   const surface = agent.runtimeSurface;
@@ -94,8 +78,9 @@ export const piRuntime: AgentRuntime = {
     },
   },
 
-  async discoverSessions(options = {}): Promise<RuntimeSession[]> {
-    if ((options.fresh ?? false) && !(await piBinaryPresent())) return [];
+  async discoverSessions(): Promise<RuntimeSession[]> {
+    // Discovery reads durable sessions, including history after uninstall.
+    // Resolve the executable only when launching/resuming, not on inventory polls.
     const owned = await getOwnedPiFleetAdditions().catch((error) => {
       console.warn('[pi-runtime] owned-session discovery failed:', error);
       return null;

--- a/src/lib/runtimes/prime-agent.ts
+++ b/src/lib/runtimes/prime-agent.ts
@@ -9,7 +9,6 @@ import type {
   LaunchOptions,
 } from './types';
 import { parsePrimeAgentSessionCost } from '@/lib/runtimes/prime-agent-cost-parser';
-import { CliNotFoundError, resolveCli } from '@/lib/runtimes/shared/cli-resolver';
 import { ownedTailToRuntimeTranscript } from '@/lib/runtimes/shared/owned-transcript';
 import {
   continueOwnedPrimeAgentSession,
@@ -33,20 +32,6 @@ const capabilities: RuntimeCapabilities = {
 };
 
 type OwnedAgentLike = Awaited<ReturnType<typeof getOwnedPrimeAgentFleetAdditions>>['agents'][number];
-
-async function hasPrimeAgentCli(): Promise<boolean> {
-  try {
-    await resolveCli({
-      runtimeId: 'prime-agent',
-      binaryName: 'prime-agent',
-      envOverride: 'O8_PRIME_AGENT_BIN',
-    });
-    return true;
-  } catch (error) {
-    if (error instanceof CliNotFoundError) return false;
-    throw error;
-  }
-}
 
 function mapStatus(rawStatus: string): RuntimeSession['status'] {
   return rawStatus === 'completed' || rawStatus === 'finished' ? 'completed'
@@ -95,8 +80,8 @@ export const primeAgentRuntime: AgentRuntime = {
   displayName: 'Prime Agent',
   capabilities,
 
-  async discoverSessions(options = {}): Promise<RuntimeSession[]> {
-    if ((options.fresh ?? false) && !await hasPrimeAgentCli()) return [];
+  async discoverSessions(): Promise<RuntimeSession[]> {
+    // Saved sessions remain discoverable without probing the launch executable.
     const owned = await getOwnedPrimeAgentFleetAdditions().catch((error) => {
       console.warn('[prime-agent-runtime] discoverSessions owned fleet failed:', error);
       return null;

--- a/tests/preship-cleanup-residuals.test.ts
+++ b/tests/preship-cleanup-residuals.test.ts
@@ -1,0 +1,93 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+// @ts-expect-error plain .mjs gate entry point
+import { cleanupGate, loadTeardownProvesClean } from '../scripts/lib/preship-gate-cleanup.mjs';
+
+const root = mkdtempSync(path.join(os.tmpdir(), 'o8-preship-cleanup-test-'));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+function fixture() {
+  const dataDir = mkdtempSync(path.join(root, 'profile-'));
+  const worktree = path.join(dataDir, 'worktrees', 'packet-fixture');
+  mkdirSync(worktree, { recursive: true });
+  const work = path.join(worktree, 'uncommitted.txt');
+  writeFileSync(work, 'recoverable work');
+  const socketPath = path.join(dataDir, '..', `${path.basename(dataDir)}.sock`);
+  writeFileSync(socketPath, 'fixture socket');
+  writeFileSync(`${socketPath}.token`, 'fixture token');
+  return { dataDir, work, socketPath };
+}
+
+describe('outer pre-ship cleanup preserves failed load evidence', () => {
+  it('requires a complete clean teardown, not merely an available sample', () => {
+    const clean = { teardown: { refused: 0, residuals: { counts: { lanes: 0, childProcesses: 0, worktrees: 0, listeners: 0 } } } };
+    expect(loadTeardownProvesClean(clean)).toBe(true);
+    expect(loadTeardownProvesClean(undefined)).toBe(false);
+    expect(loadTeardownProvesClean({ available: true })).toBe(false);
+    expect(loadTeardownProvesClean({ teardown: { ...clean.teardown, refused: 1 } })).toBe(false);
+    expect(loadTeardownProvesClean({ teardown: {
+      ...clean.teardown, residuals: { counts: { ...clean.teardown.residuals.counts, futureResource: 1 } },
+    } })).toBe(false);
+    for (const key of Object.keys(clean.teardown.residuals.counts)) {
+      expect(loadTeardownProvesClean({ teardown: {
+        ...clean.teardown, residuals: { counts: { ...clean.teardown.residuals.counts, [key]: 1 } },
+      } })).toBe(false);
+      expect(loadTeardownProvesClean({ teardown: {
+        ...clean.teardown, residuals: { counts: { ...clean.teardown.residuals.counts, [key]: undefined } },
+      } })).toBe(false);
+    }
+  });
+
+  it('stops its real child but preserves residual work and removes its socket credentials', async () => {
+    const files = fixture();
+    const child = spawn(process.execPath, ['-e', `
+      const net = require('node:net');
+      const fs = require('node:fs');
+      const server = net.createServer();
+      server.listen(0, '127.0.0.1', () => {
+        fs.writeFileSync(process.argv[1], String(server.address().port));
+      });
+    `, path.join(files.dataDir, 'api-port')], { detached: true, stdio: 'ignore' });
+    try {
+      await vi.waitFor(() => expect(existsSync(path.join(files.dataDir, 'api-port'))).toBe(true));
+      await cleanupGate({ ...files, child, preserveDataDir: true });
+      expect(child.exitCode !== null || child.signalCode !== null).toBe(true);
+      expect(readFileSync(files.work, 'utf8')).toBe('recoverable work');
+      expect(existsSync(files.socketPath)).toBe(false);
+      expect(existsSync(`${files.socketPath}.token`)).toBe(false);
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill('SIGKILL');
+        await once(child, 'exit');
+      }
+    }
+  });
+
+  it('preserves the profile if the API listener has not shut down', async () => {
+    const files = fixture();
+    const server = net.createServer();
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    const address = server.address() as net.AddressInfo;
+    writeFileSync(path.join(files.dataDir, 'api-port'), String(address.port));
+    try {
+      await expect(cleanupGate(files)).rejects.toThrow('profile preserved');
+      expect(readFileSync(files.work, 'utf8')).toBe('recoverable work');
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
+  it('still removes an owned, clean profile on the normal cleanup path', async () => {
+    const files = fixture();
+    await cleanupGate(files);
+    expect(existsSync(files.dataDir)).toBe(false);
+    expect(existsSync(files.socketPath)).toBe(false);
+    expect(existsSync(`${files.socketPath}.token`)).toBe(false);
+  });
+});

--- a/tests/runtime-discovery-no-cli-probe.test.ts
+++ b/tests/runtime-discovery-no-cli-probe.test.ts
@@ -1,0 +1,61 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/runtimes/shared/cli-resolver', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/runtimes/shared/cli-resolver')>();
+  return { ...actual, resolveCli: vi.fn(async () => {
+    throw new actual.CliNotFoundError('fixture-missing-cli', []);
+  }) };
+});
+
+const root = mkdtempSync(path.join(os.tmpdir(), 'o8-discovery-no-probe-'));
+process.env.O8_OWNED_PI_ROOT = path.join(root, 'pi');
+process.env.O8_OWNED_PRIME_AGENT_ROOT = path.join(root, 'prime-agent');
+process.env.O8_OWNED_CURSOR_ROOT = path.join(root, 'cursor');
+process.env.O8_OWNED_GROK_ROOT = path.join(root, 'grok');
+const { resolveCli } = await import('@/lib/runtimes/shared/cli-resolver');
+const { discoverRuntimeSessions } = await import('@/lib/runtime/inventory-discovery');
+const { piRuntime } = await import('@/lib/runtimes/pi');
+const { primeAgentRuntime } = await import('@/lib/runtimes/prime-agent');
+const { cursorRuntime } = await import('@/lib/runtimes/cursor');
+const { grokRuntime } = await import('@/lib/runtimes/grok');
+const { magnitudeRuntime } = await import('@/lib/runtimes/magnitude');
+const { antigravityRuntime } = await import('@/lib/runtimes/antigravity');
+const runtimes = [piRuntime, primeAgentRuntime, cursorRuntime, grokRuntime, magnitudeRuntime, antigravityRuntime];
+
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+describe('runtime inventory does not probe CLI installation to read owned sessions', () => {
+  it('runs repeated fresh discovery through the real aggregator without resolving any CLI', async () => {
+    for (let tick = 0; tick < 3; tick += 1) {
+      const discovered = await discoverRuntimeSessions(runtimes, { fresh: true });
+      expect(discovered).toHaveLength(runtimes.length);
+      for (const entry of discovered) {
+        expect(entry.status).toBe('fulfilled');
+        if (entry.status === 'fulfilled') expect(entry.value.sessions).toEqual([]);
+      }
+    }
+    expect(resolveCli).not.toHaveBeenCalled();
+  });
+
+  it('keeps a persisted session visible when its executable is no longer installed', async () => {
+    const sessionDir = path.join(process.env.O8_OWNED_PI_ROOT!, 'saved-session');
+    mkdirSync(sessionDir, { recursive: true });
+    const metadata = path.join(sessionDir, 'session.json');
+    const saved = JSON.stringify({
+      surfaceId: 'pi-owned:saved-session', sessionDir, cwd: root, repoPath: root,
+      title: 'Saved worker result', createdAt: '2026-09-07T00:00:00.000Z',
+      updatedAt: '2026-09-07T00:00:00.000Z', latestPrompt: 'fixture',
+      latestSummary: 'Finished fixture work', recentRuns: [],
+    });
+    writeFileSync(metadata, saved);
+    const results = await discoverRuntimeSessions([piRuntime], { fresh: true });
+    expect(results[0]).toMatchObject({ status: 'fulfilled', value: { sessions: [
+      { sessionKey: 'pi-owned:saved-session', ownership: 'owned', initialTask: 'Finished fixture work' },
+    ] } });
+    expect(readFileSync(metadata, 'utf8')).toBe(saved);
+    expect(resolveCli).not.toHaveBeenCalled();
+  });
+});

--- a/tests/steer-managed-run-admission-real-path.test.ts
+++ b/tests/steer-managed-run-admission-real-path.test.ts
@@ -20,11 +20,13 @@ process.env.O8_DATA_DIR = dataDir;
 const { closeDb } = await import('@/lib/db');
 const { createLane, getLane, setLaneStatus, updateLane } = await import('@/lib/lane/registry');
 const { recordLaneEvent } = await import('@/lib/lane/events');
-const { writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+const { readOrchestratorControlPlaneState, writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+const { holdPacketLifecycleMutation } = await import('@/lib/orchestrator/packet-lifecycle-guard');
 const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
 const { getOrCreateWsToken } = await import('@/lib/ws-auth');
 const { findManagedRun } = await import('@/lib/runtimes/managed-runs/registry');
 const steerRoute = await import('@/app/api/orchestrator/steer-packet/route');
+const stateRoute = await import('@/app/api/orchestrator/state/route');
 const runsRoute = await import('@/app/api/panel/managed-runs/route');
 
 let sequence = 0;
@@ -53,8 +55,8 @@ function fixture(operatorStopped = false) {
   return { packet, lane, sessionKey };
 }
 
-function request(path: string, body: unknown) {
-  return new NextRequest(`http://localhost${path}`, { method: 'POST', headers: {
+function request(path: string, body: unknown, method = 'POST') {
+  return new NextRequest(`http://localhost${path}`, { method, headers: {
     authorization: `Bearer ${getOrCreateWsToken()}`, 'content-type': 'application/json',
   }, body: JSON.stringify(body) });
 }
@@ -134,6 +136,35 @@ describe('steered-turn managed-run admission through production routes', () => {
     expect((await register(packet)).status).toBe(200);
     updateLane(lane.id, { sessionKey: 'claude-code-owned:unaccepted-successor' });
     expect((await register(packet, 'rebound')).status).toBe(409);
+  });
+
+  it('cannot revive accepted-run admission by replaying a snapshot after Stop', async () => {
+    const { packet } = fixture();
+    expect((await steer(packet.id)).status).toBe(200);
+    expect((await register(packet, 'beforeStop')).status).toBe(200);
+    const cached = readOrchestratorControlPlaneState();
+    const guard = await holdPacketLifecycleMutation({ packetId: packet.id, kind: 'stop' });
+
+    expect((await stateRoute.POST(request('/api/orchestrator/state', { mission: cached }))).status).toBe(200);
+    closeDb();
+    expect(readOrchestratorControlPlaneState().packets[0]).toMatchObject({
+      operatorStopped: true, queueState: 'held', releaseStatePayload: { source: guard?.source },
+    });
+    expect((await register(packet, 'afterStop')).status).toBe(409);
+    expect(findManagedRun(`run${sequence}afterStop`)).toBeNull();
+  });
+
+  it('refuses further managed runs when an accepted turn is archived through the state API', async () => {
+    const { packet } = fixture();
+    expect((await steer(packet.id)).status).toBe(200);
+    expect((await register(packet, 'beforeArchive')).status).toBe(200);
+    const archivedAt = new Date().toISOString();
+    expect((await stateRoute.PATCH(request('/api/orchestrator/state', {
+      packetId: packet.id, updates: { archivedAt },
+    }, 'PATCH'))).status).toBe(200);
+    expect(readOrchestratorControlPlaneState().packets[0]?.archivedAt).toBe(archivedAt);
+    expect((await register(packet, 'afterArchive')).status).toBe(409);
+    expect(findManagedRun(`run${sequence}afterArchive`)).toBeNull();
   });
 
   it.each(['archived', 'released'] as const)('does not steer a %s packet', async (state) => {

--- a/tests/stop-client-state-race.test.ts
+++ b/tests/stop-client-state-race.test.ts
@@ -1,0 +1,251 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { NextRequest } from 'next/server';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+
+const h = vi.hoisted(() => ({
+  killGate: null as Promise<void> | null,
+  killsStarted: 0,
+  resetPacket: vi.fn(async () => ({ reset: true, worktreePruned: false })),
+}));
+vi.mock('@/lib/runtime/inventory', () => ({
+  getRuntimeInventorySnapshot: vi.fn(async () => ({ agents: [], runtimes: [] })),
+}));
+vi.mock('@/lib/lane/reap-sessions', () => ({
+  archiveLaneSessions: vi.fn(),
+  killLaneSessionsConfirmed: vi.fn(async (lanes: Array<{ id: string; sessionKey: string; runtime: string }>) => {
+    h.killsStarted += 1;
+    if (h.killGate) await h.killGate;
+    return lanes.map((lane) => ({
+      laneId: lane.id,
+      sessionKey: lane.sessionKey,
+      runtime: lane.runtime,
+      confirmed: true,
+      alreadyDead: false,
+      stages: [],
+    }));
+  }),
+}));
+vi.mock('@/lib/runtimes/managed-runs/packet-lifecycle', () => ({
+  terminatePacketManagedRuns: vi.fn(async () => ({ targeted: 0, confirmed: 0, failures: [] })),
+}));
+// The race ends at confirmed stop, before asynchronous archive/prune. Actual
+// cleanup and newer-lane preservation are covered by the generation fixtures.
+vi.mock('@/lib/orchestrator/operator-mission-service', () => ({ resetPacket: h.resetPacket }));
+vi.mock('@/lib/orchestrator/operator-mission-service/reset', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/orchestrator/operator-mission-service/reset')>(),
+  resetPacket: h.resetPacket,
+}));
+
+const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-stop-client-race-'));
+const token = 'stop-client-race-operator-0123456789abcdef';
+writeFileSync(join(dataDir, 'ws-token'), token);
+process.env.O8_DATA_DIR = dataDir;
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+const stateRoute = await import('@/app/api/orchestrator/state/route');
+const stopRoute = await import('@/app/api/orchestrator/stop-packet/route');
+// Resolve the mocked lazy service before simultaneous stop imports compete to
+// initialize its re-export graph in the test runner.
+await import('@/lib/orchestrator/operator-mission-service');
+const { closeDb } = await import('@/lib/db');
+const { createLane, deleteLane, listLanes, setLaneStatus } = await import('@/lib/lane/registry');
+const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+const { updateOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+const { archivePacket } = await import('@/components/desktop/workspace-terminal/terminal-tab-handlers');
+const { holdPacketLifecycleMutation } = await import('@/lib/orchestrator/packet-lifecycle-guard');
+const { readOrchestratorControlPlaneState, withLockedState, writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+
+function request(body: unknown, method = 'POST', pathname = '/api/orchestrator/state') {
+  return new NextRequest(`http://localhost${pathname}`, {
+    method,
+    headers: { host: 'localhost', authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function packet(id: string): OrchestratorPacket {
+  return {
+    id, referenceLabel: id, title: id, summary: 'fixture',
+    workspaceTargetPath: null, branchTarget: `packet/${id}`, runtime: 'codex',
+    dependencyLabels: [], dependencyPacketIds: [], queueState: 'draft',
+    releaseState: 'pending', status: 'draft', blockedReason: null, lane: null, review: null,
+  };
+}
+
+function seedMission(withTwoLanes = false) {
+  const lane = createLane({
+    repoPath: dataDir, branch: 'packet/b',
+    runtime: 'codex', packetId: 'b', sessionKey: 'codex-owned:stop-client-race',
+  });
+  setLaneStatus(lane.id, 'running', 'system', 'fixture_running');
+  const worker: OrchestratorPacket = {
+    ...packet('b'), queueState: 'queued', status: 'running',
+    lane: {
+      tileId: 'tile-b', tabId: 'tab-b', laneId: lane.id, sessionKey: lane.sessionKey,
+      runtime: 'codex', repoPath: dataDir, worktreePath: null,
+      lastHeartbeatAt: null, lastEventAt: null, lastEventLabel: null,
+    },
+  };
+  let first = packet('a');
+  if (withTwoLanes) {
+    const firstLane = createLane({ repoPath: dataDir, branch: 'packet/a', runtime: 'codex',
+      packetId: 'a', sessionKey: 'codex-owned:stop-client-race-a' });
+    setLaneStatus(firstLane.id, 'running', 'system', 'fixture_running');
+    first = { ...worker, ...first, queueState: 'queued', status: 'running',
+      lane: { ...worker.lane!, laneId: firstLane.id, sessionKey: firstLane.sessionKey } };
+  }
+  return writeOrchestratorControlPlaneState({
+    ...createEmptyOrchestratorMissionState(), missionId: 'stop-client-race',
+    repoPath: dataDir, packets: [first, worker],
+  });
+}
+
+beforeEach(() => {
+  h.killsStarted = 0;
+  h.killGate = null;
+  h.resetPacket.mockClear();
+  vi.unstubAllGlobals();
+  for (const lane of listLanes()) deleteLane(lane.id);
+});
+afterAll(() => {
+  closeDb();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('cached client mission writes during stop', () => {
+  it('preserves the stop guard when a stale sidebar archives a sibling during kill confirmation', async () => {
+    const cached = seedMission();
+    let releaseKill!: () => void;
+    h.killGate = new Promise<void>((resolve) => { releaseKill = resolve; });
+    const stopping = stopRoute.POST(request({ packetId: 'b' }, 'POST', '/api/orchestrator/stop-packet'));
+    let guardSource: unknown;
+    try {
+      await vi.waitFor(() => expect(h.killsStarted).toBe(1));
+      guardSource = readOrchestratorControlPlaneState().packets[1]?.releaseStatePayload?.source;
+      const response = await stateRoute.POST(request({
+        mission: {
+          ...cached,
+          packets: cached.packets.map((entry) => entry.id === 'a'
+            ? { ...entry, archivedAt: '2026-09-07T00:00:00.000Z' } : entry),
+        },
+      }));
+      expect(response.status).toBe(200);
+    } finally {
+      releaseKill();
+      await stopping;
+    }
+    const stopped = await stopping;
+    const body = await stopped.json();
+    expect(stopped.status, JSON.stringify(body)).toBe(200);
+    expect(body.result).toMatchObject({ ok: true, killConfirmed: true });
+    expect(readOrchestratorControlPlaneState().packets[1]).toMatchObject({
+      queueState: 'held', operatorStopped: true, blockedReason: 'operator_stopped',
+      releaseStatePayload: { source: guardSource },
+    });
+    expect(h.resetPacket).toHaveBeenCalledWith(expect.objectContaining({
+      packetId: 'b', scope: expect.objectContaining({ expectedReleaseSource: guardSource }),
+    }));
+  });
+
+  it('lets both concurrent stops finalize despite a cached reconciliation', async () => {
+    const cached = seedMission(true);
+    let releaseKill!: () => void;
+    h.killGate = new Promise<void>((resolve) => { releaseKill = resolve; });
+    const stopping = ['a', 'b'].map((packetId) => stopRoute.POST(request({ packetId }, 'POST', '/api/orchestrator/stop-packet')));
+    try {
+      await vi.waitFor(() => expect(h.killsStarted).toBe(2), { timeout: 5_000 });
+      expect((await stateRoute.POST(request({ mission: cached }))).status).toBe(200);
+    } finally {
+      releaseKill();
+      await Promise.all(stopping);
+    }
+    for (const response of await Promise.all(stopping)) expect(response.status).toBe(200);
+    expect(readOrchestratorControlPlaneState().packets.every((entry) => entry.operatorStopped && entry.queueState === 'held')).toBe(true);
+    expect(h.resetPacket).toHaveBeenCalledTimes(2);
+  });
+
+  it('cannot drop a stopped packet omitted by a stale client', async () => {
+    const cached = seedMission();
+    const guard = await holdPacketLifecycleMutation({ packetId: 'b', kind: 'stop' });
+    const response = await stateRoute.POST(request({ mission: { ...cached, packets: [cached.packets[0]] } }));
+    expect(response.status).toBe(200);
+    expect(readOrchestratorControlPlaneState().packets.find((entry) => entry.id === 'b')).toMatchObject({
+      operatorStopped: true, queueState: 'held', releaseStatePayload: { source: guard?.source },
+    });
+  });
+
+  it('does not resurrect an older stop after an explicit server-side reset', async () => {
+    seedMission();
+    await holdPacketLifecycleMutation({ packetId: 'b', kind: 'stop' });
+    const stoppedCache = readOrchestratorControlPlaneState();
+    await withLockedState((state) => {
+      state.packets[1] = { ...packet('b'), queueState: 'held', operatorStopped: false, storageAdmissionEpoch: 2 };
+    });
+    const response = await stateRoute.POST(request({ mission: stoppedCache }));
+    expect(response.status).toBe(200);
+    expect(readOrchestratorControlPlaneState().packets[1]).toMatchObject({
+      operatorStopped: undefined, queueState: 'held', storageAdmissionEpoch: 2, lane: null,
+    });
+  });
+
+  it('does not requeue a reset packet from a pre-stop cache with no stop flag', async () => {
+    const cached = seedMission();
+    await withLockedState((state) => {
+      state.packets[1] = { ...packet('b'), queueState: 'held', operatorStopped: false, storageAdmissionEpoch: 2 };
+    });
+    await stateRoute.POST(request({ mission: cached }));
+    expect(readOrchestratorControlPlaneState().packets[1]).toMatchObject({
+      operatorStopped: undefined, queueState: 'held', storageAdmissionEpoch: 2, lane: null,
+    });
+  });
+
+  it('preserves a mission-wide stop hold while still accepting ordinary draft edits', async () => {
+    const cached = seedMission();
+    const lifecycleHold = {
+      source: 'mission-stop-fixture', reason: 'operator_stop' as const,
+      startedAt: new Date().toISOString(), ownerPid: process.pid,
+      leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    };
+    await withLockedState((state) => { state.lifecycleHold = lifecycleHold; });
+    await stateRoute.POST(request({
+      mission: { ...cached, packets: cached.packets.map((entry) => entry.id === 'a'
+        ? { ...entry, title: 'Edited draft', queueState: 'held' } : entry) },
+    }));
+    expect(readOrchestratorControlPlaneState()).toMatchObject({
+      lifecycleHold, packets: [expect.objectContaining({ title: 'Edited draft', queueState: 'held' }), expect.anything()],
+    });
+  });
+
+  it('archives from the real tab handler with a metadata-only PATCH and keeps the sibling stop', async () => {
+    const cached = seedMission();
+    const guard = await holdPacketLifecycleMutation({ packetId: 'b', kind: 'stop' });
+    // The tab sees a stale cache; the API still reads fresh persisted state.
+    updateOrchestratorMissionState(cached);
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => stateRoute.PATCH(request(
+      JSON.parse(String(init.body)), init.method,
+    )));
+    vi.stubGlobal('fetch', fetchMock);
+    archivePacket('a');
+    await vi.waitFor(() => expect(readOrchestratorControlPlaneState().packets[0]?.archivedAt).toEqual(expect.any(String)));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]![1];
+    expect(init.method).toBe('PATCH');
+    expect(JSON.parse(String(init.body))).toEqual({ packetId: 'a', updates: { archivedAt: expect.any(String) } });
+    expect(readOrchestratorControlPlaneState().packets[1]).toMatchObject({
+      operatorStopped: true, releaseStatePayload: { source: guard?.source },
+    });
+  });
+
+  it('accepts held-packet metadata only as a targeted patch and does not undo it on the next snapshot', async () => {
+    seedMission();
+    await holdPacketLifecycleMutation({ packetId: 'b', kind: 'stop' });
+    const cached = readOrchestratorControlPlaneState();
+    const archivedAt = '2026-09-07T00:00:00.000Z';
+    const response = await stateRoute.PATCH(request({ packetId: 'b', updates: { archivedAt } }, 'PATCH'));
+    expect(response.status).toBe(200);
+    await stateRoute.POST(request({ mission: cached }));
+    expect(readOrchestratorControlPlaneState().packets[1]).toMatchObject({ operatorStopped: true, archivedAt });
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2079,6 +2079,14 @@
       ]
     },
     {
+      "path": "tests/preship-cleanup-residuals.test.ts",
+      "reasons": [
+        "child-process",
+        "network-listener",
+        "process-signal"
+      ]
+    },
+    {
       "path": "tests/principal-authz.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
## Summary

Preserve server-owned Stop holds and reset generations when a cached mission snapshot is posted back. The sidebar now sends archive intent through the targeted state PATCH instead of reposting sibling packets. The Stop generation guard is unchanged.

Keep failed load-check profiles when cleanup is uncertain or residual resources remain. Remove the profile only after a complete zero-residual teardown and confirmed API-listener shutdown.

Remove executable-installation probes from owned-session inventory reads and empty placeholder discovery. Saved sessions remain visible without an installed executable. Launch/readiness checks, runtime defaults, polling intervals, and budget thresholds are unchanged.

Refs #1817, #2080, and #2088. This does not close their remaining installed-acceptance work.

## Verification

- The real Stop/state route regression reproduced the generation-finalization failure before the fix. Eight cases cover concurrent stops, stale or omitted packets, reset generations, mission holds, and the actual sidebar archive helper.
- Two additional real-route cases verify that stale snapshots after Stop and archive during an accepted follow-up turn cannot restore managed-run admission. The Stop case reopens SQLite before checking refusal. Runtime delivery is stubbed; these are not live-provider tests.
- The resource-owning gate passed 66 tests in six files, including child/listener shutdown, retained work, registry reset/stop, accepted-turn admission, settlement, and generation guards.
- The full hermetic suite passed 4,141 tests, with three existing skips. TypeScript, touched-file ESLint, changed-line rules, test classification, syntax, and whitespace checks passed.
- The production web/server build passed with private dependencies and an isolated data directory. It still reports warnings from the unchanged lint-loader and middleware-convention paths. The unchanged dependency lockfile retains six audit findings; this PR does not claim a warning-free or dependency-clean build.

## Boundaries

This is source and production web-bundle verification, not native-app acceptance. The updated native Stop/load and quiet-idle checks remain pending. No native app was built, installed, restarted, versioned, or published in this change. No screenshot is attached because the fix concerns lifecycle persistence and background discovery rather than visual layout.
