### PR TITLE
fix: avoid redundant hidden-idle background probes

### DIFF
--- a/src-tauri/src/agent/calendar_attention.rs
+++ b/src-tauri/src/agent/calendar_attention.rs
@@ -26,7 +26,9 @@ fn settings(payload: &Value) -> Option<(bool, i64)> {
 }
 
 async fn poll_once() -> Result<(), String> {
-    let defaults = super::o8_http::get_json("/api/panel/operator-defaults").await?;
+    // This timer only reads settings. The full response also probes worker
+    // authentication, even when Calendar attention is disabled.
+    let defaults = super::o8_http::get_json("/api/panel/operator-defaults?include=values").await?;
     let Some((enabled, lead_minutes)) = settings(&defaults) else {
         return Err("operator defaults response omitted Calendar attention settings".into());
     };
@@ -34,11 +36,9 @@ async fn poll_once() -> Result<(), String> {
         return Ok(());
     }
 
-    let rows = tokio::task::spawn_blocking(|| {
-        super::event_kit::list_events_if_authorized(1, "")
-    })
-    .await
-    .map_err(|error| format!("calendar attention worker failed: {error}"))??;
+    let rows = tokio::task::spawn_blocking(|| super::event_kit::list_events_if_authorized(1, ""))
+        .await
+        .map_err(|error| format!("calendar attention worker failed: {error}"))??;
     let Some(rows) = rows else {
         return Ok(());
     };
@@ -46,9 +46,7 @@ async fn poll_once() -> Result<(), String> {
     let now_ms = chrono::Utc::now().timestamp_millis();
     let lead_ms = lead_minutes * 60_000;
     for row in rows.into_iter().filter(|row| {
-        !row.all_day
-            && row.start_epoch_ms > now_ms
-            && row.start_epoch_ms <= now_ms + lead_ms
+        !row.all_day && row.start_epoch_ms > now_ms && row.start_epoch_ms <= now_ms + lead_ms
     }) {
         let body = json!({
             "eventId": row.id,
@@ -84,8 +82,98 @@ pub fn spawn() {
 
 #[cfg(test)]
 mod tests {
-    use super::settings;
+    use super::{poll_once, settings};
     use serde_json::json;
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpListener;
+    use std::time::{Duration, Instant};
+
+    struct HttpFixture {
+        dir: std::path::PathBuf,
+        previous: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl Drop for HttpFixture {
+        fn drop(&mut self) {
+            for (name, value) in self.previous.drain(..) {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    #[test]
+    fn disabled_calendar_poll_reads_values_only_through_authenticated_http() {
+        let _guard = crate::DATA_DIR_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let fixture = HttpFixture {
+            dir: std::env::temp_dir().join(format!(
+                "o8-calendar-http-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos(),
+            )),
+            previous: ["O8_DATA_DIR", "O8_API_PORT"]
+                .into_iter()
+                .map(|name| (name, std::env::var_os(name)))
+                .collect(),
+        };
+        std::fs::create_dir(&fixture.dir).unwrap();
+        std::fs::write(fixture.dir.join("ws-token"), "calendar-fixture-token").unwrap();
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        std::env::set_var("O8_DATA_DIR", &fixture.dir);
+        std::env::set_var(
+            "O8_API_PORT",
+            listener.local_addr().unwrap().port().to_string(),
+        );
+        let server = std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            let mut stream = loop {
+                match listener.accept() {
+                    Ok((stream, _)) => break stream,
+                    Err(error)
+                        if error.kind() == std::io::ErrorKind::WouldBlock
+                            && Instant::now() < deadline =>
+                    {
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("calendar test accept failed: {error}"),
+                }
+            };
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut request = String::new();
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap() == 0 || line == "\r\n" {
+                    break;
+                }
+                request.push_str(&line);
+                assert!(request.len() <= 8_192);
+            }
+            // A disabled setting must return before accessing native Calendar.
+            let body = r#"{"values":{"broadcastVoice":"off","broadcastVoiceCalendar":true}}"#;
+            write!(stream, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}", body.len(), body).unwrap();
+            request
+        });
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let result = runtime.block_on(poll_once());
+        let request = server.join().unwrap();
+        assert!(result.is_ok(), "calendar poll failed: {result:?}");
+        assert!(request.starts_with("GET /api/panel/operator-defaults?include=values HTTP/1.1\r\n"));
+        assert!(request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer calendar-fixture-token\r\n"));
+    }
 
     #[test]
     fn settings_require_voice_and_calendar_subscription() {

--- a/src/components/desktop/timeline/hooks.test.ts
+++ b/src/components/desktop/timeline/hooks.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTimelineData, useTimelineSessions } from './hooks';
+
+vi.mock('@/lib/panel/fetch-cache', () => ({
+  fetchOnce: (url: string) => fetch(url),
+}));
+
+const ACT_ENV = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+ACT_ENV.IS_REACT_ACT_ENVIRONMENT = true;
+const TIMELINE = '/api/panel/timeline';
+const INBOX = '/api/mobile/inbox?workspaceReview=0';
+
+function setVisibility(value: DocumentVisibilityState) {
+  Object.defineProperty(document, 'visibilityState', { configurable: true, value });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+describe('timeline refresh through mounted hooks', () => {
+  let host: HTMLDivElement;
+  let root: Root | null;
+  let revision: number;
+  let hold: boolean;
+  let pending: Array<() => void>;
+  const fetchMock = vi.fn<(url: string) => Promise<Response>>();
+
+  function Harness() {
+    const timeline = useTimelineData();
+    const sessions = useTimelineSessions();
+    return createElement('output', null, JSON.stringify({ timeline, sessions }));
+  }
+
+  function calls(url: string) {
+    return fetchMock.mock.calls.filter(([calledUrl]) => calledUrl === url).length;
+  }
+
+  async function advance(ms: number) {
+    await act(async () => { await vi.advanceTimersByTimeAsync(ms); });
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setVisibility('visible');
+    sessionStorage.clear();
+    revision = 1;
+    hold = false;
+    pending = [];
+    fetchMock.mockReset();
+    fetchMock.mockImplementation(async (url) => {
+      const response = {
+        ok: true,
+        json: async () => url === TIMELINE
+          ? { segments: [{ kind: 'coding', startMin: 0, durationMin: revision }],
+            windowMinutes: 1440, anchorStartIso: '2026-09-08T00:00:00.000Z' }
+          : { sessions: [{ id: `session-${revision}` }] },
+      } as Response;
+      if (hold) return new Promise<Response>((resolve) => { pending.push(() => resolve(response)); });
+      return response;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    act(() => root?.render(createElement(Harness)));
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    host.remove();
+    sessionStorage.clear();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('keeps the delayed first load and visible five-minute fallback', async () => {
+    await advance(2999);
+    expect(fetchMock).not.toHaveBeenCalled();
+    await advance(1);
+    expect(calls(TIMELINE)).toBe(1);
+    expect(calls(INBOX)).toBe(1);
+    expect(JSON.parse(host.textContent ?? '{}').timeline.loading).toBe(false);
+
+    await advance(296999);
+    expect(calls(TIMELINE)).toBe(1);
+    await advance(1);
+    expect(calls(TIMELINE)).toBe(2);
+    expect(calls(INBOX)).toBe(2);
+  });
+
+  it('defers hidden timers and events, then updates state and storage once on return', async () => {
+    await advance(3000);
+    act(() => {
+      setVisibility('hidden');
+      window.dispatchEvent(new Event('o8:lifecycle-reconcile'));
+      window.dispatchEvent(new Event('o8:inbox'));
+    });
+    await advance(600000);
+    expect(calls(TIMELINE)).toBe(1);
+    expect(calls(INBOX)).toBe(1);
+
+    revision = 2;
+    act(() => setVisibility('visible'));
+    await advance(0);
+    expect(calls(TIMELINE)).toBe(2);
+    expect(calls(INBOX)).toBe(2);
+    const current = JSON.parse(host.textContent ?? '{}');
+    expect(current.timeline.segments[0].durationMin).toBe(2);
+    expect(current.sessions[0].id).toBe('session-2');
+    expect(JSON.parse(sessionStorage.getItem('cortex-timeline') ?? '{}').segments[0].durationMin).toBe(2);
+  });
+
+  it('coalesces visible event bursts and cancels refreshes after unmount', async () => {
+    await advance(3000);
+    hold = true;
+    act(() => window.dispatchEvent(new Event('o8:lifecycle-reconcile')));
+    await advance(0);
+    expect(calls(TIMELINE)).toBe(2);
+    expect(calls(INBOX)).toBe(2);
+    act(() => {
+      window.dispatchEvent(new Event('o8:lifecycle-reconcile'));
+      window.dispatchEvent(new Event('o8:lifecycle-reconcile'));
+      window.dispatchEvent(new Event('o8:inbox'));
+    });
+    await advance(0);
+    expect(calls(TIMELINE)).toBe(2);
+    expect(calls(INBOX)).toBe(2);
+    hold = false;
+    await act(async () => { pending.splice(0).forEach((resolve) => resolve()); });
+    await advance(0);
+    expect(calls(TIMELINE)).toBe(3);
+    expect(calls(INBOX)).toBe(3);
+
+    act(() => root?.unmount());
+    root = null;
+    act(() => {
+      window.dispatchEvent(new Event('o8:lifecycle-reconcile'));
+      window.dispatchEvent(new Event('o8:inbox'));
+      setVisibility('hidden');
+      setVisibility('visible');
+    });
+    await advance(600000);
+    expect(calls(TIMELINE)).toBe(3);
+    expect(calls(INBOX)).toBe(3);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('cancels the delayed initial load on unmount', async () => {
+    act(() => root?.unmount());
+    root = null;
+    await advance(600000);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/components/desktop/timeline/hooks.ts
+++ b/src/components/desktop/timeline/hooks.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { fetchOnce } from '@/lib/panel/fetch-cache';
+import { REALTIME_FALLBACK_REFRESH_MS, startDurableRefresh } from '@/lib/panel/durable-refresh';
 import type { AgentSummary } from '@/lib/fleet/types';
 import type { MobileInboxSnapshot } from '@/lib/mobile/types';
 import type { TimelineSegment } from './types';
@@ -63,14 +64,14 @@ export function useTimelineData() {
 
   useEffect(() => {
     const initialLoad = window.setTimeout(() => { void fetchData(); }, INITIAL_TIMELINE_LOAD_DELAY_MS);
-    const handler = () => { fetchData(); };
-    const wsEvents = ['o8:lifecycle-reconcile'];
-    for (const e of wsEvents) window.addEventListener(e, handler);
-    const fallbackId = setInterval(fetchData, 300_000);
+    const stopRefresh = startDurableRefresh({
+      refresh: fetchData,
+      intervalMs: REALTIME_FALLBACK_REFRESH_MS,
+      events: ['o8:lifecycle-reconcile'],
+    });
     return () => {
       window.clearTimeout(initialLoad);
-      clearInterval(fallbackId);
-      for (const e of wsEvents) window.removeEventListener(e, handler);
+      stopRefresh();
     };
   }, [fetchData]);
 
@@ -93,14 +94,14 @@ export function useTimelineSessions() {
 
   useEffect(() => {
     const initialLoad = window.setTimeout(() => { void fetchSessions(); }, INITIAL_TIMELINE_LOAD_DELAY_MS);
-    const handler = () => { void fetchSessions(); };
-    const wsEvents = ['o8:inbox', 'o8:lifecycle-reconcile'];
-    for (const e of wsEvents) window.addEventListener(e, handler);
-    const fallbackId = setInterval(fetchSessions, 300_000);
+    const stopRefresh = startDurableRefresh({
+      refresh: fetchSessions,
+      intervalMs: REALTIME_FALLBACK_REFRESH_MS,
+      events: ['o8:inbox', 'o8:lifecycle-reconcile'],
+    });
     return () => {
       window.clearTimeout(initialLoad);
-      clearInterval(fallbackId);
-      for (const e of wsEvents) window.removeEventListener(e, handler);
+      stopRefresh();
     };
   }, [fetchSessions]);
 

--- a/src/lib/git/repository-context.test.ts
+++ b/src/lib/git/repository-context.test.ts
@@ -1,0 +1,82 @@
+import { lstat, realpath } from 'node:fs/promises';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:fs/promises', () => ({ lstat: vi.fn(), realpath: vi.fn() }));
+
+import { mayHaveGitRepositoryContext } from './repository-context';
+
+const resolved = path.resolve('fixture-context', 'nested');
+const absent = Object.assign(new Error('absent'), { code: 'ENOENT' });
+const present = {} as Awaited<ReturnType<typeof lstat>>;
+
+beforeEach(() => {
+  vi.stubEnv('GIT_DIR', '');
+  vi.stubEnv('GIT_WORK_TREE', '');
+  vi.mocked(realpath).mockReset().mockResolvedValue(resolved);
+  vi.mocked(lstat).mockReset().mockRejectedValue(absent);
+});
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe('repository context hints', () => {
+  it('proves an ordinary folder has no context without inspecting its contents', async () => {
+    expect(await mayHaveGitRepositoryContext('input')).toBe(false);
+    expect(vi.mocked(lstat).mock.calls.every(([file]) => (
+      ['.git', 'HEAD'].includes(path.basename(String(file)))
+    ))).toBe(true);
+  });
+
+  it('accepts an ancestor marker after resolving the physical folder', async () => {
+    vi.mocked(lstat).mockImplementation(async (file) => {
+      if (file === path.join(path.dirname(resolved), '.git')) return present;
+      throw absent;
+    });
+    expect(await mayHaveGitRepositoryContext('input')).toBe(true);
+    expect(realpath).toHaveBeenCalledWith(path.resolve('input'));
+  });
+
+  it('lets Git validate pointer files, symlinks, and other positive markers', async () => {
+    vi.mocked(lstat).mockResolvedValueOnce(present);
+    expect(await mayHaveGitRepositoryContext('input')).toBe(true);
+  });
+
+  it('retains the bare-repository HEAD hint', async () => {
+    vi.mocked(lstat).mockImplementation(async (file) => {
+      if (file === path.join(resolved, 'HEAD')) return present;
+      throw absent;
+    });
+    expect(await mayHaveGitRepositoryContext('input')).toBe(true);
+  });
+
+  it('rechecks absence so later initialization is not hidden', async () => {
+    expect(await mayHaveGitRepositoryContext('input')).toBe(false);
+    vi.mocked(lstat).mockResolvedValueOnce(present);
+    expect(await mayHaveGitRepositoryContext('input')).toBe(true);
+  });
+
+  it.each(['GIT_DIR', 'GIT_WORK_TREE'])('retains the normal path for %s overrides', async (key) => {
+    vi.stubEnv(key, 'explicit-context');
+    expect(await mayHaveGitRepositoryContext('input')).toBe(true);
+    expect(realpath).not.toHaveBeenCalled();
+    expect(lstat).not.toHaveBeenCalled();
+  });
+
+  it('does not confuse permission or I/O failures with absence', async () => {
+    vi.mocked(lstat).mockRejectedValueOnce(Object.assign(new Error('denied'), { code: 'EACCES' }));
+    expect(await mayHaveGitRepositoryContext('input')).toBe(true);
+  });
+
+  it('keeps discovery when the physical folder cannot be resolved', async () => {
+    vi.mocked(realpath).mockRejectedValueOnce(absent);
+    expect(await mayHaveGitRepositoryContext('input')).toBe(true);
+    expect(lstat).not.toHaveBeenCalled();
+  });
+
+  it('bounds ancestor checks and leaves unusually deep paths to Git', async () => {
+    vi.mocked(realpath).mockResolvedValue(path.resolve(...Array<string>(140).fill('nested')));
+    expect(await mayHaveGitRepositoryContext('input')).toBe(true);
+    expect(lstat).toHaveBeenCalledTimes(256);
+  });
+});

--- a/src/lib/git/repository-context.ts
+++ b/src/lib/git/repository-context.ts
@@ -1,0 +1,41 @@
+import { lstat, realpath } from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * A negative result proves that an existing folder has no discoverable Git
+ * context. Keep ambiguous cases on the normal Git path, including explicit
+ * environment overrides, bare repositories, and unreadable metadata.
+ *
+ * Check only ancestor markers, never workspace contents. Do not cache absence:
+ * a repository initialized after an idle poll must be found by the next poll.
+ */
+export async function mayHaveGitRepositoryContext(folder: string): Promise<boolean> {
+  if (process.env.GIT_DIR || process.env.GIT_WORK_TREE) return true;
+
+  let current: string;
+  try {
+    current = await realpath(path.resolve(folder));
+  } catch {
+    return true;
+  }
+
+  for (let depth = 0; depth < 128; depth += 1) {
+    // A .git marker may be a directory, pointer file, or symlink. A bare
+    // repository has HEAD directly in its root; Git validates positive hints.
+    for (const marker of ['.git', 'HEAD']) {
+      try {
+        await lstat(path.join(current, marker));
+        return true;
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException | null)?.code;
+        if (code !== 'ENOENT' && code !== 'ENOTDIR') return true;
+      }
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return false;
+    current = parent;
+  }
+
+  // An unusually deep path is uncertain, not proof that discovery can be skipped.
+  return true;
+}

--- a/src/lib/worktree/manager.ts
+++ b/src/lib/worktree/manager.ts
@@ -21,6 +21,7 @@
 
 import { access, lstat, realpath, rm, stat } from 'node:fs/promises';
 import path from 'node:path';
+import { mayHaveGitRepositoryContext } from '@/lib/git/repository-context';
 import type {
   CleanupOptions,
   ConflictReport,
@@ -2491,6 +2492,7 @@ export class WorktreeManager {
   }
 
   private async gitWorktreeList(): Promise<Array<{ path: string; branch?: string }>> {
+    if (!await mayHaveGitRepositoryContext(this.repoRoot)) return [];
     try {
       const { stdout } = await execFileAsync('git', ['worktree', 'list', '--porcelain'], {
         windowsHide: true,

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -136,6 +136,7 @@ import {
 import { OrchestratorThreadProjectError } from './lib/mobile/orchestrator-thread-project';
 import { persistOrchestratorThreadUserMessageFromWire } from './lib/ws-server/orchestrator-thread-send';
 import { getLiveReviewChangeSet } from './lib/review/live-changes';
+import { mayHaveGitRepositoryContext } from './lib/git/repository-context';
 import { deriveIdempotencyKey, withIdempotency } from './lib/orchestrator/idempotency-store';
 import { isManualThinkingEffort, type ManualThinkingEffort } from './lib/orchestrator/thinking-effort';
 import { withSessionRules } from './lib/orchestrator/session-rules-prompt';
@@ -8329,6 +8330,7 @@ const REVIEW_POLL_INTERVAL_MS = 10_000;
 const REVIEW_SCAN_CONCURRENCY = 3;
 let reviewRefreshInFlight = false;
 let reviewRefreshRerequest = false;
+let reviewRuntimeRefreshRequested = false;
 
 async function pruneOrphanedCodexWorktreeBranches(repoPath: string): Promise<number> {
   // `git worktree prune` only removes admin entries for deleted git-worktree
@@ -8448,16 +8450,18 @@ async function getReviewWatchTargets() {
   return targets;
 }
 
-function broadcastDiffStats() {
+async function broadcastDiffStats() {
   if (!hasReviewSubscribers()) return;
+  if (!await mayHaveGitRepositoryContext(REPO_ROOT)) return;
 
-  execFile('sh', ['-c', 'git diff --shortstat origin/main..HEAD 2>/dev/null; git diff --shortstat 2>/dev/null'], {
-    windowsHide: true,
-    cwd: REPO_ROOT,
-    encoding: 'utf-8',
-    timeout: 5000,
-  }, (err, stdout) => {
-    if (err || !stdout) return;
+  try {
+    const { stdout } = await execFileAsync('sh', ['-c', 'git diff --shortstat origin/main..HEAD 2>/dev/null; git diff --shortstat 2>/dev/null'], {
+      windowsHide: true,
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+    if (!stdout) return;
     const stat = stdout.trim();
 
     let additions = 0, deletions = 0, files = 0;
@@ -8475,7 +8479,9 @@ function broadcastDiffStats() {
     lastDiffHash = hash;
 
     broadcast({ channel: 'review', event: 'diff-stats', data: { kind: 'diff-stats', additions, deletions, files } });
-  });
+  } catch {
+    // Preserve the last snapshot through transient Git failures.
+  }
 }
 
 // #1484 — incremental review scan. The 10s poll used to run a git change-set
@@ -8546,13 +8552,15 @@ async function reviewTargetStatKey(workspacePath: string): Promise<string> {
 }
 
 async function broadcastReviewFileChanges() {
-  if (!hasReviewSubscribers()) return;
+  if (!hasReviewSubscribers()) return false;
 
   const targets = await getReviewWatchTargets();
   const liveTargetKeys = new Set(targets.map((target) => target.workspacePath));
+  let changed = false;
 
   for (const key of [...reviewTargetHashes.keys()]) {
     if (!liveTargetKeys.has(key)) {
+      changed = true;
       reviewTargetHashes.delete(key);
       // F20 — the stat-gate maps grow with worktree churn unless pruned with
       // their target.
@@ -8588,6 +8596,7 @@ async function broadcastReviewFileChanges() {
         return;
       }
       reviewTargetHashes.set(target.workspacePath, hash);
+      changed = true;
 
       broadcast({
         channel: 'review',
@@ -8622,6 +8631,7 @@ async function broadcastReviewFileChanges() {
       }
     } catch {
       // Ignore transient git failures on disappearing worktrees
+      changed = true;
     }
   };
 
@@ -8634,6 +8644,7 @@ async function broadcastReviewFileChanges() {
     }
   });
   await Promise.all(workers);
+  return changed;
 }
 
 function hasReviewSubscribers() {
@@ -8653,17 +8664,24 @@ async function runCoalescedReviewRefresh() {
   try {
     do {
       reviewRefreshRerequest = false;
-      await broadcastReviewFileChanges();
-      broadcastDiffStats();
-      scheduleRealtimeRuntimeRefresh({ reason: 'review.refresh', fresh: true });
-      scheduleRealtimeMobileInboxRefresh(250, true);
+      const refreshRuntime = reviewRuntimeRefreshRequested;
+      reviewRuntimeRefreshRequested = false;
+      const changed = await broadcastReviewFileChanges();
+      await broadcastDiffStats();
+      // An unchanged review timer is not evidence of a runtime change. Keep
+      // explicit filesystem signals and safety-scan discoveries immediate.
+      if (refreshRuntime || changed) {
+        scheduleRealtimeRuntimeRefresh({ reason: 'review.refresh', fresh: true });
+        scheduleRealtimeMobileInboxRefresh(250, true);
+      }
     } while (reviewRefreshRerequest);
   } finally {
     reviewRefreshInFlight = false;
   }
 }
 
-function scheduleReviewRefresh(delayMs = 500) {
+function scheduleReviewRefresh(delayMs = 500, refreshRuntime = true) {
+  reviewRuntimeRefreshRequested ||= refreshRuntime;
   if (diffDebounceTimer) clearTimeout(diffDebounceTimer);
   diffDebounceTimer = setTimeout(() => {
     diffDebounceTimer = null;
@@ -8772,7 +8790,7 @@ setInterval(() => {
 }, 30_000).unref?.();
 
 reviewPollTimer = setInterval(() => {
-  scheduleReviewRefresh(0);
+  scheduleReviewRefresh(0, false);
 }, REVIEW_POLL_INTERVAL_MS);
 if (reviewPollTimer.unref) reviewPollTimer.unref();
 

--- a/tests/helpers/review-idle-preload.cjs
+++ b/tests/helpers/review-idle-preload.cjs
@@ -1,0 +1,39 @@
+// Test-process instrumentation only. Keep the real WebSocket server, Git,
+// filesystem, and HTTP path; shorten its ten-second timers for a bounded test.
+const cp = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const { promisify } = require('node:util');
+const { syncBuiltinESMExports } = require('node:module');
+
+const root = process.env.O8_REVIEW_TEST_DIR;
+if (!root) throw new Error('Missing isolated review test directory');
+const setIntervalOriginal = global.setInterval;
+global.setInterval = (callback, delay, ...args) => setIntervalOriginal(callback, delay === 10_000 ? 200 : delay, ...args);
+
+const execFileOriginal = cp.execFile;
+cp.execFile = function (file, args, options, callback) {
+  const reviewDiff = file === 'sh' && args?.[1]?.startsWith('git diff --shortstat');
+  if (!reviewDiff) return execFileOriginal.apply(this, arguments);
+  fs.appendFileSync(path.join(root, 'diff-calls.jsonl'), `${JSON.stringify({ cwd: options.cwd })}\n`);
+  return execFileOriginal.call(this, file, args, options, (error, stdout, stderr) => {
+    if (!fs.existsSync(path.join(root, 'hold-diff'))) return callback(error, stdout, stderr);
+    fs.writeFileSync(path.join(root, 'diff-held'), 'ready');
+    const deadline = Date.now() + 5_000;
+    const finish = () => {
+      if (Date.now() < deadline && fs.existsSync(path.join(root, 'hold-diff'))) {
+        setTimeout(finish, 20);
+      } else {
+        callback(error, stdout, stderr);
+      }
+    };
+    finish();
+  });
+};
+cp.execFile[promisify.custom] = (file, args, options) => new Promise((resolve, reject) => {
+  cp.execFile(file, args, options, (error, stdout, stderr) => {
+    if (error) reject(Object.assign(error, { stdout, stderr }));
+    else resolve({ stdout, stderr });
+  });
+});
+syncBuiltinESMExports();

--- a/tests/review-idle-real-path.test.ts
+++ b/tests/review-idle-real-path.test.ts
@@ -1,0 +1,207 @@
+import { execFile, execFileSync, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { WebSocket } from 'ws';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+type Frame = { channel?: string; event?: string; data?: { changedFiles?: { path: string }[] } };
+const root = mkdtempSync(join(tmpdir(), 'o8-review-idle-'));
+const dataDir = join(root, 'data');
+const reviewRoot = join(root, 'review');
+const token = `review-idle-${process.pid}`;
+const requests: { path: string; fresh: boolean }[] = [];
+const frames: Frame[] = [];
+let apiServer: Server;
+let wsProcess: ChildProcess | null = null;
+let socket: WebSocket | null = null;
+let apiPort = 0;
+let wsPort = 0;
+let output = '';
+let holdSnapshot = false;
+let releaseSnapshot: (() => void) | null = null;
+
+async function waitFor(predicate: () => boolean | Promise<boolean>, label: string, timeout = 10_000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for ${label}: ${output.slice(-2_000)}`);
+}
+
+async function freePort(): Promise<number> {
+  const server = createServer();
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Missing listener port');
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return address.port;
+}
+
+function diffCalls() {
+  const file = join(root, 'diff-calls.jsonl');
+  return existsSync(file) ? readFileSync(file, 'utf8').trim().split('\n').filter(Boolean).length : 0;
+}
+
+function freshReads() {
+  return requests.filter((request) => request.path === '/api/command-center/snapshot' && request.fresh).length;
+}
+
+function git(cwd: string, ...args: string[]) {
+  execFileSync('git', ['-c', 'commit.gpgsign=false', '-c', `core.hooksPath=${root}`, ...args], {
+    cwd, encoding: 'utf8', timeout: 5_000,
+  });
+}
+
+async function refresh() {
+  const response = await fetch(`http://127.0.0.1:${wsPort}/internal/realtime`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ kind: 'refresh', targets: ['global'], fresh: true, reason: 'review idle acceptance' }),
+  });
+  expect(response.status).toBe(202);
+}
+
+beforeAll(async () => {
+  mkdirSync(dataDir);
+  mkdirSync(reviewRoot);
+  writeFileSync(join(dataDir, 'ws-token'), token, { mode: 0o600 });
+  apiPort = await freePort();
+  wsPort = await freePort();
+  writeFileSync(join(dataDir, 'api-port'), String(apiPort));
+  writeFileSync(join(dataDir, 'ws-port'), String(wsPort));
+  apiServer = createServer(async (request, response) => {
+    const url = new URL(request.url ?? '/', `http://127.0.0.1:${apiPort}`);
+    requests.push({ path: url.pathname, fresh: url.searchParams.get('fresh') === '1' });
+    response.setHeader('Content-Type', 'application/json');
+    const inbox = {
+      generatedAt: '', mode: 'live', sessions: [], fleetSessions: [], approvals: [], reviewUnits: [], items: [], summary: {},
+    };
+    if (url.pathname === '/api/command-center/snapshot') {
+      if (holdSnapshot) {
+        holdSnapshot = false;
+        await new Promise<void>((resolve) => { releaseSnapshot = resolve; });
+        releaseSnapshot = null;
+      }
+      response.end(JSON.stringify({
+        fleet: { agents: [], meta: { mode: 'live' } }, review: null,
+        browserInventory: { surfaces: [], generatedAt: '' }, attachedBrowser: null,
+      }));
+    } else if (url.pathname === '/api/panel/repos') {
+      response.end(JSON.stringify({ repos: [] }));
+    } else if (url.pathname === '/api/mobile/inbox') {
+      response.end(JSON.stringify(inbox));
+    } else if (url.pathname === '/api/mobile/sync') {
+      response.end(JSON.stringify({ inbox, inboxEtag: 'empty' }));
+    } else if (url.pathname === '/api/worktrees/conflicts') {
+      response.end(JSON.stringify({ files: [], safe: true, mergeOrder: [] }));
+    } else if (url.pathname === '/api/setup/identity') {
+      response.end(JSON.stringify({ configured: false }));
+    } else if (url.pathname === '/api/broadcast/commentary') {
+      response.end(JSON.stringify({ commentary: [], cursor: null, hasMore: false }));
+    } else if (url.pathname === '/api/orchestrator/headless-tick') {
+      response.end(JSON.stringify({ ok: true }));
+    } else {
+      response.statusCode = 404;
+      response.end('{}');
+    }
+  });
+  apiServer.listen(apiPort, '127.0.0.1');
+  await once(apiServer, 'listening');
+  wsProcess = execFile(process.execPath, [
+    '--require=./tests/helpers/review-idle-preload.cjs',
+    '--import=./scripts/register-server-only-stub.mjs', '--import=tsx', 'src/ws-server.ts',
+  ], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env, O8_DATA_DIR: dataDir, CORTEX_IDE_DATA_DIR: dataDir,
+      O8_REVIEW_TEST_DIR: root, CORTEX_IDE_REVIEW_REPO_ROOT: reviewRoot,
+      O8_API_PORT: String(apiPort), O8_WS_PORT: String(wsPort), NEXT_ORIGIN: `http://127.0.0.1:${apiPort}`,
+    },
+  });
+  wsProcess.stdout?.on('data', (chunk) => { output = `${output}${chunk}`.slice(-16_000); });
+  wsProcess.stderr?.on('data', (chunk) => { output = `${output}${chunk}`.slice(-16_000); });
+  await waitFor(async () => {
+    try { return (await fetch(`http://127.0.0.1:${wsPort}/health`)).ok; } catch { return false; }
+  }, 'WebSocket health', 30_000);
+  socket = new WebSocket(`ws://127.0.0.1:${wsPort}/ws?token=${token}`);
+  socket.on('message', (raw) => frames.push(JSON.parse(String(raw)) as Frame));
+  await once(socket, 'open');
+  await waitFor(() => frames.some((frame) => frame.event === 'connected'), 'authenticated connection');
+  socket.send(JSON.stringify({ type: 'realtime-subscribe', subscriptions: [{ stream: 'global' }] }));
+  await waitFor(() => frames.some((frame) => frame.event === 'file-changes'), 'initial review scan');
+  await waitFor(() => freshReads() > 0, 'initial runtime update');
+}, 40_000);
+
+afterAll(async () => {
+  releaseSnapshot?.();
+  socket?.terminate();
+  if (wsProcess && wsProcess.exitCode === null) {
+    const exited = once(wsProcess, 'exit');
+    wsProcess.kill('SIGTERM');
+    await Promise.race([exited, new Promise((resolve) => setTimeout(resolve, 5_000))]);
+    if (wsProcess.exitCode === null) { wsProcess.kill('SIGKILL'); await exited; }
+  }
+  if (apiServer?.listening) {
+    apiServer.closeAllConnections();
+    await new Promise<void>((resolve) => apiServer.close(() => resolve()));
+  }
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('review refresh through the real WebSocket server', () => {
+  it('keeps ordinary-folder timer scans free of diff shells and runtime rediscovery', async () => {
+    // The review root has no Git watcher. Its periodic safety scan still runs.
+    const before = freshReads();
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    expect(diffCalls()).toBe(0);
+    expect(freshReads()).toBe(before);
+  });
+
+  it('discovers a linked repository created later and unstaged edits without a watcher', async () => {
+    const main = join(root, 'main');
+    mkdirSync(main);
+    git(main, 'init', '-q', '-b', 'main');
+    git(main, 'config', 'user.name', 'Fixture');
+    git(main, 'config', 'user.email', 'fixture@example.test');
+    writeFileSync(join(main, 'tracked.txt'), 'base\n');
+    git(main, 'add', 'tracked.txt');
+    git(main, 'commit', '-qm', 'fixture');
+    git(main, 'worktree', 'add', '-qb', 'review-test', reviewRoot);
+    const before = freshReads();
+    writeFileSync(join(reviewRoot, 'tracked.txt'), 'changed\nsecond line\n');
+    await waitFor(() => frames.some((frame) => frame.data?.changedFiles?.some((file) => file.path === 'tracked.txt')),
+      'unstaged linked-worktree edit');
+    await waitFor(() => freshReads() > before, 'change-driven runtime refresh');
+    expect(diffCalls()).toBeGreaterThan(0);
+  });
+
+  it('retains a timer request and an edit arriving during an in-flight review diff', async () => {
+    writeFileSync(join(root, 'hold-diff'), 'hold');
+    await waitFor(() => existsSync(join(root, 'diff-held')), 'held real diff callback');
+    const before = diffCalls();
+    writeFileSync(join(reviewRoot, 'late.txt'), 'late edit\n');
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(diffCalls()).toBe(before);
+    rmSync(join(root, 'hold-diff'));
+    await waitFor(() => frames.some((frame) => frame.data?.changedFiles?.some((file) => file.path === 'late.txt')),
+      'trailing refresh for the in-flight edit');
+    expect(diffCalls()).toBeGreaterThan(before);
+  });
+
+  it('preserves explicit fresh requests and a trailing request while the bridge is busy', async () => {
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    const before = freshReads();
+    holdSnapshot = true;
+    await refresh();
+    await waitFor(() => releaseSnapshot !== null, 'held snapshot request');
+    await refresh();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    releaseSnapshot?.();
+    await waitFor(() => freshReads() >= before + 2, 'second explicit fresh snapshot');
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2311,6 +2311,16 @@
       ]
     },
     {
+      "path": "tests/review-idle-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "network-listener",
+        "process-signal",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/review-stall-reconcile-real-path.test.ts",
       "reasons": [
         "child-process",
@@ -2768,6 +2778,15 @@
       "path": "tests/workspace-parking-mode-real-path.test.ts",
       "reasons": [
         "real-path"
+      ]
+    },
+    {
+      "path": "tests/worktree-conflict-idle-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path",
+        "worktree"
       ]
     },
     {

--- a/tests/worktree-conflict-idle-real-path.test.ts
+++ b/tests/worktree-conflict-idle-real-path.test.ts
@@ -1,0 +1,147 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { NextRequest } from 'next/server';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/worktree/materialization-execution', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/worktree/materialization-execution')>();
+  return {
+    ...actual,
+    materializationAwareExecFile: vi.fn(actual.materializationAwareExecFile),
+  };
+});
+
+import { GET } from '@/app/api/worktrees/conflicts/route';
+import { materializationAwareExecFile } from '@/lib/worktree/materialization-execution';
+import { resolveWorktreeRootLayout } from '@/lib/worktree/root-layout';
+
+const root = mkdtempSync(path.join(os.tmpdir(), 'o8-conflict-idle-'));
+const probe = vi.mocked(materializationAwareExecFile);
+const metadataRoots: string[] = [];
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', [
+    '-c', 'commit.gpgsign=false', '-c', `core.hooksPath=${root}`, ...args,
+  ], { cwd, encoding: 'utf8', timeout: 10_000 }).trim();
+}
+
+function createRepo(repo: string): void {
+  mkdirSync(repo, { recursive: true });
+  git(repo, 'init', '-q', '-b', 'main');
+  git(repo, 'config', 'user.name', 'Fixture');
+  git(repo, 'config', 'user.email', 'fixture@example.test');
+  writeFileSync(path.join(repo, 'shared.txt'), 'base\n');
+  git(repo, 'add', 'shared.txt');
+  git(repo, 'commit', '-qm', 'fixture');
+}
+
+async function report(repo: string) {
+  const request = new NextRequest(`http://localhost/api/worktrees/conflicts?${new URLSearchParams({ repo })}`, {
+    headers: { host: 'localhost' },
+  });
+  const response = await GET(request);
+  return { status: response.status, body: await response.json() };
+}
+
+beforeEach(() => {
+  probe.mockClear();
+});
+
+afterAll(() => {
+  for (const metadataRoot of metadataRoots) rmSync(metadataRoot, { recursive: true, force: true });
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('conflict route without a repository', () => {
+  it('returns an empty report without spawning Git on repeated ordinary-folder polls', async () => {
+    const folder = path.join(root, 'ordinary', 'server');
+    mkdirSync(folder, { recursive: true });
+
+    for (let index = 0; index < 4; index += 1) {
+      const result = await report(folder);
+      expect(result.status).toBe(200);
+      expect(result.body).toMatchObject({ files: [], mergeOrder: [], safe: true });
+    }
+
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it('does not cache a negative result after the folder becomes a repository', async () => {
+    const repo = path.join(root, 'initialized-later');
+    mkdirSync(repo);
+    expect((await report(repo)).status).toBe(200);
+    expect(probe).not.toHaveBeenCalled();
+
+    createRepo(repo);
+    expect((await report(repo)).status).toBe(200);
+    expect(probe.mock.calls.some(([file, args]) => file === 'git' && args[0] === 'worktree')).toBe(true);
+  });
+
+  it('keeps real conflicts visible for nested paths and linked repository markers', async () => {
+    const repo = path.join(root, 'main-repo');
+    const first = path.join(root, 'linked-first');
+    const second = path.join(root, 'linked-second');
+    createRepo(repo);
+    git(repo, 'worktree', 'add', '-qb', 'first', first);
+    git(repo, 'worktree', 'add', '-qb', 'second', second);
+    writeFileSync(path.join(first, 'shared.txt'), 'first edit\n');
+    writeFileSync(path.join(second, 'shared.txt'), 'second edit\n');
+    const nested = path.join(repo, 'nested', 'server');
+    mkdirSync(nested, { recursive: true });
+
+    const nestedResult = await report(nested);
+    expect(nestedResult.status).toBe(200);
+    expect(nestedResult.body.files.some((entry: { file: string }) => entry.file === 'shared.txt')).toBe(true);
+    expect(nestedResult.body.safe).toBe(false);
+
+    const linkedResult = await report(first);
+    expect(linkedResult.status).toBe(200);
+    // The queried workspace itself is excluded by the existing inventory contract.
+    expect(linkedResult.body.mergeOrder).toEqual(expect.arrayContaining([
+      expect.objectContaining({ worktreeId: 'linked-second', fileCount: 1 }),
+    ]));
+  });
+
+  it('still reads child-workspace metadata when the parent folder is not a repository', async () => {
+    const folder = path.join(root, 'metadata-parent');
+    mkdirSync(folder);
+    const base = resolveWorktreeRootLayout(folder).primaryBase;
+    expect(existsSync(base)).toBe(false);
+    metadataRoots.push(base);
+    const child = path.join(base, 'metadata-child');
+    createRepo(child);
+    writeFileSync(path.join(child, 'shared.txt'), 'uncommitted child edit\n');
+    writeFileSync(path.join(base, '.meta.json'), JSON.stringify({
+      version: 1,
+      worktrees: {
+        'metadata-child': {
+          id: 'metadata-child', agentType: 'codex', baseBranch: 'main',
+          createdAt: Date.now(), claudeManaged: false, taskName: 'fixture',
+        },
+      },
+    }));
+
+    const result = await report(folder);
+    expect(result.status).toBe(200);
+    expect(result.body.mergeOrder).toEqual(expect.arrayContaining([
+      expect.objectContaining({ worktreeId: 'metadata-child' }),
+    ]));
+    expect(probe.mock.calls.some(([file, args, options]) => (
+      file === 'git' && args[0] === 'diff' && options?.cwd === child
+    ))).toBe(true);
+    expect(probe.mock.calls.some(([file, args, options]) => (
+      file === 'git' && args[0] === 'worktree' && options?.cwd === folder
+    ))).toBe(false);
+  });
+
+  it('retains authentication refusal before any repository probe', async () => {
+    const request = new NextRequest(`http://example.test/api/worktrees/conflicts?${new URLSearchParams({ repo: root })}`, {
+      headers: { host: 'example.test', 'x-o8-client-addr': '203.0.113.5' },
+    });
+    expect((await GET(request)).status).toBe(401);
+    expect(probe).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Skip Git worktree and review-diff subprocesses only when filesystem evidence proves that the root has no repository context. Keep linked, nested, bare, newly initialized and ambiguous cases on the normal Git path.
- Stop unchanged review timers from forcing runtime discovery. Preserve change-driven and explicit refreshes, including requests that arrive during an in-flight review diff.
- Make native calendar polling read the existing values-only settings response without worker authentication probes.
- Defer hidden timeline timers and events through the existing refresh scheduler, then coalesce a refresh when the window becomes visible.

## Verification

- Full hermetic suite: 4,155 passed; three existing skips.
- Focused mounted-hook and refresh tests: seven passed.
- Real-path integration and authentication tests: 65 passed.
- Native calendar tests: two passed, including the actual authenticated loopback HTTP client.
- TypeScript, touched-file ESLint, changed-line rules and whitespace checks passed.
- Signed local native package: the steady hidden trace recorded zero process-launch API calls across 300,107 ms after startup. Reopening produced exactly one successful timeline response.
- Native quiet measurement: 60 samples across 1,089,810 ms; CPU median 1.98%, maximum 3.09%; physical memory median 1,046 MiB, maximum 1,065 MiB. No observed process churn, repeated headless deadline errors or fatal console errors. Existing regression ceilings passed unchanged.

## Limits

The native checks used an isolated profile with process-observer overhead and other applications running. These are local package results, not an installed-app before/after comparison or a real-worker load test. The peak memory remains approximately 41 MiB above the longer-term 1 GiB target. No release assets, credentials, runtime defaults or production data change in this patch.

Related to #1817 and #1697. Both remain open for their broader footprint and interaction acceptance work.
