### PR TITLE
chore: release v0.1.741

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "o8",
-  "version": "0.1.740",
+  "version": "0.1.741",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "o8",
-      "version": "0.1.740",
+      "version": "0.1.741",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o8",
-  "version": "0.1.740",
+  "version": "0.1.741",
   "description": "o8 — governance layer for autonomous engineering teams. Approvals, audit, organizational memory.",
   "license": "MIT",
   "productName": "o8",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "o8"
-version = "0.1.740"
+version = "0.1.741"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "o8"
-version = "0.1.740"
+version = "0.1.741"
 description = "o8 — governance layer for autonomous engineering teams"
 authors = ["hurttlocker"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "o8",
-  "version": "0.1.740",
+  "version": "0.1.741",
   "identifier": "ai.o8.desktop",
   "build": {
     "frontendDist": "../out/frontend",


### PR DESCRIPTION
## Release scope

Prepare the next stable macOS patch with the already-merged idle-probe reductions, stop-state protection, managed-run admission repair, and preview-feed separation.

## Verification

- Synchronize the five version manifests without changing dependencies.
- Carry forward the source checks and isolated native idle acceptance recorded on #2110 and #2112.
- Require protected PR checks before tagging, signing, notarizing, and publishing.
- Verify the published artifact through the installed Mac update path before closing this release.

This version bump does not close the broader footprint or interaction-performance work. Linux and Windows runtime acceptance remain deferred.