### PR TITLE
fix: exclude development artifacts from native releases

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,8 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  // Repository instructions are maintained by the operator, not dev startup.
+  agentRules: false,
   outputFileTracingRoot: __dirname,
   outputFileTracingExcludes: {
     // sharp is Next's image optimizer, pulled in transitively. `images.unoptimized`
@@ -15,6 +17,7 @@ const nextConfig: NextConfig = {
       // Build cache can enter route traces through filesystem reads. Keep it
       // available to the compiler, but never copy it into the runtime bundle.
       './.next/cache/**/*',
+      './.next/dev/**/*',
       '**/node_modules/sharp/**/*',
       '**/node_modules/@img/**/*',
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "o8",
-  "version": "0.1.742",
+  "version": "0.1.743",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "o8",
-      "version": "0.1.742",
+      "version": "0.1.743",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o8",
-  "version": "0.1.742",
+  "version": "0.1.743",
   "description": "o8 — governance layer for autonomous engineering teams. Approvals, audit, organizational memory.",
   "license": "MIT",
   "productName": "o8",

--- a/scripts/lib/tauri-export-safety.mjs
+++ b/scripts/lib/tauri-export-safety.mjs
@@ -13,10 +13,12 @@ export function assertTauriExportInputsSafe(standaloneRoot) {
     );
   }
 
-  const cache = join(standaloneRoot, '.next', 'cache');
   // lstat also catches dangling links. Never silently package or delete a
-  // traced cache: reject before the exporter clears its previous output.
-  if (lstatSync(cache, { throwIfNoEntry: false })) {
-    throw new Error('standalone build contains .next/cache; exclude build cache from tracing and rebuild before packaging');
+  // traced cache or development tree: reject before clearing previous output.
+  for (const directory of ['cache', 'dev']) {
+    const generated = join(standaloneRoot, '.next', directory);
+    if (lstatSync(generated, { throwIfNoEntry: false })) {
+      throw new Error(`standalone build contains .next/${directory}; exclude build-only files from tracing and rebuild before packaging`);
+    }
   }
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "o8"
-version = "0.1.742"
+version = "0.1.743"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "o8"
-version = "0.1.742"
+version = "0.1.743"
 description = "o8 — governance layer for autonomous engineering teams"
 authors = ["hurttlocker"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "o8",
-  "version": "0.1.742",
+  "version": "0.1.743",
   "identifier": "ai.o8.desktop",
   "build": {
     "frontendDist": "../out/frontend",

--- a/tests/packaging-preflight-real-path.test.ts
+++ b/tests/packaging-preflight-real-path.test.ts
@@ -29,8 +29,10 @@ function fixture() {
   return { root, app, server };
 }
 
-function putCache(server: string) {
-  const file = join(server, '.next/cache/webpack/server-production/3.pack');
+function putCache(server: string, kind: 'cache' | 'dev' = 'cache') {
+  const file = join(server, kind === 'dev'
+    ? '.next/dev/cache/turbopack/v16.3.4/00000098.sst'
+    : '.next/cache/webpack/server-production/3.pack');
   mkdirSync(dirname(file), { recursive: true });
   writeFileSync(file, 'compiler-only');
   return file;
@@ -41,11 +43,16 @@ afterEach(() => {
 });
 
 describe('packaging preflight through real filesystem and script entry points', () => {
+  it('keeps development startup from rewriting repository-authored agent instructions', () => {
+    expect(nextConfig.agentRules).toBe(false);
+  });
+
   it('uses the tracing matcher to exclude build cache without excluding runtime assets', () => {
     const patterns = nextConfig.outputFileTracingExcludes!['*'].map(pattern => join(sourceRoot, pattern));
     const excluded = picomatch(patterns, { dot: true, contains: true });
     for (const file of ['.next/cache/.tsbuildinfo', '.next/cache/webpack/server-production/3.pack',
-      '.next/cache/webpack/client-production/index.pack.old']) {
+      '.next/cache/webpack/client-production/index.pack.old',
+      '.next/dev/cache/turbopack/v16.3.4/00000098.sst', '.next/dev/server/app/page.js']) {
       expect(excluded(join(sourceRoot, file)), file).toBe(true);
     }
     for (const file of ['.next/server/app/page.js', '.next/static/chunks/main.js',
@@ -55,20 +62,20 @@ describe('packaging preflight through real filesystem and script entry points', 
     }
   });
 
-  it('rejects a cache directory and a dangling cache link without changing input', () => {
+  it.each(['cache', 'dev'] as const)('rejects a %s directory and a dangling link without changing input', (kind) => {
     const f = fixture();
-    const cacheFile = putCache(f.server);
-    expect(() => assertTauriExportInputsSafe(f.server)).toThrow('contains .next/cache');
+    const cacheFile = putCache(f.server, kind);
+    expect(() => assertTauriExportInputsSafe(f.server)).toThrow(`contains .next/${kind}`);
     expect(readFileSync(cacheFile, 'utf8')).toBe('compiler-only');
     const linked = fixture();
-    symlinkSync(join(linked.root, 'missing-cache'), join(linked.server, '.next/cache'), 'dir');
-    expect(() => assertTauriExportInputsSafe(linked.server)).toThrow('contains .next/cache');
+    symlinkSync(join(linked.root, 'missing-cache'), join(linked.server, '.next', kind), 'dir');
+    expect(() => assertTauriExportInputsSafe(linked.server)).toThrow(`contains .next/${kind}`);
   });
 
-  it('rejects traced cache before the actual exporter clears previous staging', () => {
+  it.each(['cache', 'dev'] as const)('rejects traced %s before the actual exporter clears previous staging', (kind) => {
     const f = fixture();
     const standalone = join(f.root, '.next/standalone');
-    const cacheFile = putCache(standalone);
+    const cacheFile = putCache(standalone, kind);
     const sentinel = join(f.root, 'out/keep.txt');
     mkdirSync(dirname(sentinel), { recursive: true });
     writeFileSync(sentinel, 'previous-output');
@@ -83,7 +90,7 @@ describe('packaging preflight through real filesystem and script entry points', 
       env: { NODE_ENV: 'test', PATH: process.env.PATH, HOME: f.root },
     });
     expect(result.status, result.stderr).toBe(1);
-    expect(result.stderr).toContain('contains .next/cache');
+    expect(result.stderr).toContain(`contains .next/${kind}`);
     expect(readFileSync(sentinel, 'utf8')).toBe('previous-output');
     expect(readFileSync(cacheFile, 'utf8')).toBe('compiler-only');
   });
@@ -110,10 +117,10 @@ describe('packaging preflight through real filesystem and script entry points', 
     expect(existsSync(archive)).toBe(true);
   });
 
-  it.each(['bundle', 'archive', 'cache', 'safe'] as const)(
+  it.each(['bundle', 'archive', 'cache', 'dev', 'safe'] as const)(
     'guards the actual signing entry point for %s input before platform operations', (scenario) => {
       const f = fixture();
-      if (scenario === 'cache') putCache(f.server);
+      if (scenario === 'cache' || scenario === 'dev') putCache(f.server, scenario);
       const log = join(f.root, 'calls.jsonl');
       // Simulate only process/platform edges. The actual signing entry point,
       // size policy, cache guard, stat reads and temp cleanup execute unchanged.
@@ -147,7 +154,7 @@ export function execFileSync(command, args) {
         expect(result.stderr).toContain('PLATFORM_BOUNDARY_REACHED');
         expect(calls.at(-1)?.command).toBe('codesign');
       } else {
-        expect(result.stderr).toContain(scenario === 'cache' ? 'contains .next/cache'
+        expect(result.stderr).toContain(scenario === 'cache' || scenario === 'dev' ? `contains .next/${scenario}`
           : scenario === 'bundle' ? 'appBundleBytes' : 'updaterArchiveBytes');
         expect(calls.every(call => ['cat', 'du', 'tar'].includes(call.command))).toBe(true);
       }


### PR DESCRIPTION
## Summary

- Exclude development-only output from production tracing, including the nested development compiler cache.
- Reject either production cache or development output at the existing export and signing preflights, before prior staging is removed or platform signing begins.
- Disable automatic framework instruction-file generation so development startup preserves repository-authored agent policy and clean-build identity.
- Synchronize release manifests to 0.1.743. The 0.1.742 build was stopped before publication; its existing tag is not rewritten.

## Evidence

The stopped export contained 5,594 development files totaling 3,566,450,772 bytes. The previous exclusion and guard covered `.next/cache` but missed `.next/dev/cache/turbopack`.

Five assertions failed against the previous implementation, including the actual exporter and signing entry points. After the fix, all 25 focused packaging, dependency-patch, and artifact tests passed. The guard also rejects both actual contaminated trees retained from the stopped build. Changed-file lint, rule-check, classification, JavaScript syntax, and whitespace checks passed. TypeScript passed, followed by all 4,237 hermetic unit tests (3 skipped).

## Boundaries

No storage-admission threshold, package-size ceiling, approval rule, or performance budget changes. No publication or installed acceptance is claimed by this PR; the corrected signed release still needs its own package and installed-app verification.
