### PR TITLE
fix: complete CLI output and preserve worker resume pins

### DIFF
--- a/cli/src/exit.ts
+++ b/cli/src/exit.ts
@@ -1,0 +1,62 @@
+/** Complete one-shot replies before exiting, without retaining unrelated handles. */
+const FLUSH_TIMEOUT_MS = 10_000;
+
+type FlushResult = 'complete' | 'closed' | 'failed';
+
+function streamFailure(error: unknown): FlushResult {
+  // A consumer such as `head` deliberately closes early. Preserve that normal
+  // pipe behavior without printing a stack trace. Other write failures are not OK.
+  return (error as NodeJS.ErrnoException | null)?.code === 'EPIPE' ? 'closed' : 'failed';
+}
+
+function flushStream(stream: NodeJS.WriteStream, timeoutMs: number): Promise<FlushResult> {
+  if (stream.errored) return Promise.resolve(streamFailure(stream.errored));
+  if (stream.destroyed) return Promise.resolve('closed');
+  if (stream.writableLength === 0) return Promise.resolve('complete');
+
+  return new Promise<FlushResult>((resolve) => {
+    let settled = false;
+    const finish = (result: FlushResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const timer = setTimeout(() => finish('failed'), timeoutMs);
+    // Keep the error handler until the imminent process exit: a write callback
+    // can settle first and its corresponding error event can follow afterward.
+    stream.on('error', (error) => finish(streamFailure(error)));
+    try {
+      // This callback queues behind previous writes, including backpressured
+      // data that has not yet reached the OS pipe.
+      stream.write('', (error) => finish(error ? streamFailure(error) : 'complete'));
+    } catch (error) {
+      finish(streamFailure(error));
+    }
+  });
+}
+
+export async function exitAfterFlush(code: number): Promise<never> {
+  const results = await Promise.all([
+    flushStream(process.stdout, FLUSH_TIMEOUT_MS),
+    flushStream(process.stderr, FLUSH_TIMEOUT_MS),
+  ]);
+  if (!results.includes('failed') || code !== 0) process.exit(code);
+
+  // Do not append another JSON object to a command's existing error response.
+  // A successful command whose output could not drain instead gets a nonzero
+  // exit and, when stderr is available, a small structured diagnostic.
+  if (results[1] === 'complete') {
+    process.stderr.write(`${JSON.stringify({
+      schema: 'o8/cli/error/v1',
+      error: {
+        code: 'output_incomplete',
+        message: 'Command output could not finish writing. The command may have completed; check its state before retrying.',
+        hint: 'Redirect output to a file or use a consumer that reads it promptly.',
+        ambiguous: true,
+      },
+    })}\n`);
+    await flushStream(process.stderr, 250);
+  }
+  process.exit(1);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -98,6 +98,7 @@ import {
 } from './commands/task.js';
 import { runUpdate } from './commands/update.js';
 import { printError, type OutputMode } from './output.js';
+import { exitAfterFlush } from './exit.js';
 import { CliError, EXIT } from './api.js';
 
 function unknownSubcommandError(group: string, sub: string | undefined): CliError {
@@ -501,7 +502,7 @@ async function dispatch(args: ParsedArgs): Promise<number> {
 const parsed = parseArgs(process.argv.slice(2));
 try {
   const code = await dispatch(parsed);
-  process.exit(code);
+  await exitAfterFlush(code);
 } catch (err) {
-  process.exit(printError(err, parsed.mode));
+  await exitAfterFlush(printError(err, parsed.mode));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "o8",
-  "version": "0.1.743",
+  "version": "0.1.744",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "o8",
-      "version": "0.1.743",
+      "version": "0.1.744",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o8",
-  "version": "0.1.743",
+  "version": "0.1.744",
   "description": "o8 — governance layer for autonomous engineering teams. Approvals, audit, organizational memory.",
   "license": "MIT",
   "productName": "o8",

--- a/release-notes/next.md
+++ b/release-notes/next.md
@@ -1,0 +1,3 @@
+- Finish writing large CLI replies before exit, including piped JSON output and slow readers.
+- Preserve the selected model and reasoning effort when continuing owned workers, including local-model sessions.
+- Restore branch merge-gate loading and limit the reviewed CLI shutdown exception to the exact approved wrapper.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "o8"
-version = "0.1.743"
+version = "0.1.744"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "o8"
-version = "0.1.743"
+version = "0.1.744"
 description = "o8 — governance layer for autonomous engineering teams"
 authors = ["hurttlocker"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "o8",
-  "version": "0.1.743",
+  "version": "0.1.744",
   "identifier": "ai.o8.desktop",
   "build": {
     "frontendDist": "../out/frontend",

--- a/src/lib/codex/owned-resume-args.test.ts
+++ b/src/lib/codex/owned-resume-args.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { codexResumeArgs } from './owned';
+import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 
 // `codex exec resume` rejects `-s` (exit 2 before the turn starts) — unlike
 // `codex exec`, it has no sandbox short flag. Live-hit 2026-07-05: every
@@ -12,5 +13,46 @@ describe('codexResumeArgs — codex exec resume argv contract', () => {
     expect(args).not.toContain('--sandbox');
     expect(args.slice(0, 3)).toEqual(['exec', 'resume', 'thread-1']);
     expect(args).toContain('--dangerously-bypass-approvals-and-sandbox');
+  });
+
+  it.each([
+    ['gpt-5.6-sol', 'high', 'high'],
+    ['gpt-5.6-sol', 'ultra', 'ultra'],
+    ['gpt-5.6-terra', 'max', 'xhigh'],
+  ] as const)('pins the saved model %s and effort %s', (model, effort, expectedEffort) => {
+    const args = codexResumeArgs({ threadId: 'thread-1', prompt: 'continue', model, effort });
+    expect(args.slice(0, 3)).toEqual(['exec', 'resume', 'thread-1']);
+    expect(args.slice(args.indexOf('--model'), args.indexOf('--model') + 2)).toEqual(['--model', model]);
+    expect(args.filter((arg) => arg === '--model')).toHaveLength(1);
+    expect(args.filter((arg) => arg.startsWith('model_reasoning_effort=')))
+      .toEqual([`model_reasoning_effort=${expectedEffort}`]);
+    expect(args).toContain('--ignore-user-config');
+    expect(args.at(-1)).toBe('continue');
+  });
+
+  it.each([undefined, 'adaptive'] as Array<ThinkingEffort | undefined>)(
+    'preserves default effort behavior for %s',
+    (effort) => {
+      const args = codexResumeArgs({ threadId: 'thread-1', prompt: 'continue', effort });
+      expect(args).not.toContain('--model');
+      expect(args.some((arg) => arg.startsWith('model_reasoning_effort='))).toBe(false);
+    },
+  );
+
+  it.each(['ollama', 'lmstudio'])('keeps %s provider flags on exec and the model on resume', (provider) => {
+    const args = codexResumeArgs({
+      threadId: 'thread-local', prompt: 'continue', model: `${provider}:qwen-fixture:32b`, effort: 'high',
+    });
+    expect(args.slice(0, 6)).toEqual(['exec', '--oss', '--local-provider', provider, 'resume', 'thread-local']);
+    expect(args.slice(args.indexOf('--model'), args.indexOf('--model') + 2)).toEqual(['--model', 'qwen-fixture:32b']);
+    expect(args.slice(args.indexOf('resume'))).not.toContain('--oss');
+    expect(args.slice(args.indexOf('resume'))).not.toContain('--local-provider');
+    expect(args.at(-1)).toBe('continue');
+  });
+
+  it('does not reinterpret a local model name as another provider prefix', () => {
+    const args = codexResumeArgs({ threadId: 'thread-local', prompt: 'continue', model: 'ollama:ollama:fixture' });
+    expect(args.filter((arg) => arg === '--oss')).toHaveLength(1);
+    expect(args.slice(args.indexOf('--model'), args.indexOf('--model') + 2)).toEqual(['--model', 'ollama:fixture']);
   });
 });

--- a/src/lib/codex/owned.ts
+++ b/src/lib/codex/owned.ts
@@ -4,11 +4,6 @@
  * This file is the Codex-specific adapter on top of the generic
  * owned-session primitive (`@/lib/runtimes/shared/owned-session`).
  *
- * Every public export here preserves the exact same signature and semantics
- * the Codex implementation had before Wave 2b. Callers across the codebase
- * (runtime registry, mobile history, API routes, command-center snapshot)
- * continue to import the same names with no behavioural change.
- *
  * What's Codex-specific and lives here:
  *   - launchArgs / resumeArgs (Codex exec CLI flags, danger-full-access sandbox)
  *   - parseRunLog (Codex JSONL stream: thread.started, turn.started, event_msg,
@@ -44,7 +39,7 @@ import {
   workerMcpServerNameIsValid,
   type ResolvedWorkerMcpServer,
 } from '@/lib/mcp/worker-injection';
-import { codexModelArgs } from './local-model';
+import { codexModelArgs, parseLocalModel } from './local-model';
 import { resolveCodexReasoningEffort } from './reasoning-effort';
 import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import { getDataDir } from '@/lib/data-dir-migration';
@@ -316,22 +311,25 @@ export function codexResumeArgs(ctx: {
   threadId: string;
   prompt: string;
   model?: string;
+  effort?: ThinkingEffort;
   workerMcpServers?: ResolvedWorkerMcpServer[];
   runtimeConfig?: Record<string, string>;
 }): string[] {
+  const local = parseLocalModel(ctx.model);
   return [
     'exec',
+    // Local-provider flags belong to exec, not its resume subcommand.
+    ...(local ? ['--oss', '--local-provider', local.provider] : []),
     'resume',
     ctx.threadId,
     '--json',
-    // NOTE: `codex exec resume` accepts --dangerously-bypass-approvals-and-sandbox
-    // but has NO `-s/--sandbox` flag (unlike `codex exec`) — passing `-s` makes the
-    // CLI exit 2 before the turn starts. Live-hit 2026-07-05: every steer-resume
-    // (#1415) failed silently until dropped — so read-only uses `-c` instead.
+    // Resume has no -s/--sandbox flag; read-only must use -c instead (#1415).
     ...codexSandboxResumeArgs(isReadOnlyRuntimeConfig(ctx.runtimeConfig)),
     ...DISABLE_IMAGE_TOOL,
     ...IGNORE_USER_CONFIG,
     ...codexWorkerMcpOverrideArgs(ctx.workerMcpServers ?? []),
+    ...(local ? ['--model', local.model] : codexModelArgs(ctx.model)),
+    ...codexReasoningEffortArgs(ctx.effort, ctx.model),
     ctx.prompt,
   ];
 }

--- a/src/lib/lane/merge-gate-script.test.ts
+++ b/src/lib/lane/merge-gate-script.test.ts
@@ -30,6 +30,14 @@ describe('branch merge gate script', () => {
     expect(match?.[1]?.startsWith('file://')).toBe(true);
   });
 
+  it('loads the existing server bootstrap before importing the branch gate', () => {
+    const script = branchGateScript('/repo');
+    const bootstrap = `await import(${JSON.stringify(pathToFileURL(path.join('/repo', 'scripts', 'register-server-only-stub.mjs')).href)})`;
+    const gate = `await import(${JSON.stringify(pathToFileURL(path.join('/repo', 'src', 'lib', 'lane', 'merge-gate.ts')).href)})`;
+    expect(script.indexOf(bootstrap)).toBeGreaterThan(-1);
+    expect(script.indexOf(bootstrap)).toBeLessThan(script.indexOf(gate));
+  });
+
   it('actually runs from a directory that is not the repo', () => {
     // The point of the whole exercise: assertions on the generated STRING miss
     // any other syntax error, and this path is fail-closed, so an unrunnable

--- a/src/lib/lane/merge-gate.test.ts
+++ b/src/lib/lane/merge-gate.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -318,4 +318,46 @@ describe('merge gate governance invariants', () => {
       }),
     ]));
   }, 20_000);
+
+  it('allows the exact reviewed CLI flush wrapper through the real Git gate', async () => {
+    const repoPath = initRepo();
+    git(repoPath, ['checkout', '-q', '-b', 'feature/merge-gate-test']);
+    mkdirSync(join(repoPath, 'cli/src'), { recursive: true });
+    const wrapper = readFileSync(join(process.cwd(), 'cli/src/exit.ts'), 'utf8');
+    writeFileSync(join(repoPath, 'cli/src/exit.ts'), wrapper);
+    commitAll(repoPath, 'fix: flush CLI output before termination');
+
+    const result = await runMergeGate(laneFixture(repoPath));
+    expect(result.passed).toBe(true);
+    expect(result.violations.filter((violation) => violation.category === 'security')).toEqual([]);
+  }, 20_000);
+
+  it.each(['modified', 'duplicated', 'other-file', 'dirty-worktree'] as const)(
+    'keeps unreviewed termination blocked: %s',
+    async (kind) => {
+      const repoPath = initRepo();
+      git(repoPath, ['checkout', '-q', '-b', 'feature/merge-gate-test']);
+      mkdirSync(join(repoPath, 'cli/src'), { recursive: true });
+      const wrapper = readFileSync(join(process.cwd(), 'cli/src/exit.ts'), 'utf8');
+      const modified = wrapper.replace('FLUSH_TIMEOUT_MS = 10_000', 'FLUSH_TIMEOUT_MS = 0');
+      const file = kind === 'other-file' ? 'cli/src/other-exit.ts' : 'cli/src/exit.ts';
+      // Keep an approved copy present too, so an allowed file cannot exempt
+      // another file's termination calls.
+      writeFileSync(join(repoPath, 'cli/src/exit.ts'), wrapper);
+      writeFileSync(join(repoPath, file), kind === 'duplicated'
+        ? wrapper + wrapper : kind === 'other-file' ? wrapper : modified);
+      commitAll(repoPath, 'test: unreviewed termination candidate');
+      if (kind === 'dirty-worktree') {
+        // Only the candidate commit can qualify, not a safe unstaged copy.
+        writeFileSync(join(repoPath, file), wrapper);
+      }
+
+      const result = await runMergeGate(laneFixture(repoPath));
+      expect(result.passed).toBe(false);
+      expect(result.violations).toEqual(expect.arrayContaining([
+        expect.objectContaining({ category: 'security', severity: 'block', file }),
+      ]));
+    },
+    20_000,
+  );
 });

--- a/src/lib/lane/merge-gate.ts
+++ b/src/lib/lane/merge-gate.ts
@@ -18,6 +18,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
@@ -58,6 +59,12 @@ const BUDGET_BLOCK_MULTIPLIER = 3;
 // ── Security Patterns (hard-block tier) ──
 // These are a subset of auto-review's patterns, elevated to enforcement.
 // Only patterns that indicate genuine injection risk are hard-blocks.
+
+const PROCESS_EXIT_PATTERN = /\bprocess\.exit\s*\(/;
+const REVIEWED_CLI_EXIT_FILE = 'cli/src/exit.ts';
+// This reviewed wrapper drains output before terminating a one-shot CLI. Pin
+// its entire committed contents when allowing new termination calls.
+const REVIEWED_CLI_EXIT_SHA256 = '538866e90234deda04c1626cf6ecae0d1a930edf3deb798e7f0d30de4d5c9823';
 
 const HARD_BLOCK_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
   // Injection vectors
@@ -130,9 +137,11 @@ const BRANCH_GATE_JSON_MARKER = '__O8_BRANCH_MERGE_GATE_RESULT__';
  */
 export function branchGateScript(cwd: string): string {
   const gateModule = pathToFileURL(path.join(cwd, 'src', 'lib', 'lane', 'merge-gate.ts')).href;
+  const serverOnlyStub = pathToFileURL(path.join(cwd, 'scripts', 'register-server-only-stub.mjs')).href;
   return `
 (async () => {
   console.log = (...args) => process.stderr.write(args.map(String).join(' ') + '\\n');
+  await import(${JSON.stringify(serverOnlyStub)});
   const loaded = await import(${JSON.stringify(gateModule)});
   const api = loaded.runMergeGate ? loaded : (loaded.default ?? loaded['module.exports']);
   const lane = JSON.parse(process.env.${BRANCH_GATE_LANE_ENV} ?? '{}');
@@ -156,10 +165,10 @@ function parseGitDiffFilePath(line: string): string | null {
   return path.startsWith('b/') ? path.slice(2) : path;
 }
 
-function getAddedLines(cwd: string, baseBranch: string): AddedDiffLine[] {
+function getAddedLines(cwd: string, baseBranch: string, headSha: string): AddedDiffLine[] {
   if (!isSafeGitRef(baseBranch)) return [];
   try {
-    const diff = execFileSync('git', ['diff', `${baseBranch}...HEAD`, '--no-color'], {
+    const diff = execFileSync('git', ['diff', `${baseBranch}...${headSha}`, '--no-color'], {
       windowsHide: true,
       cwd,
       timeout: 15_000,
@@ -404,13 +413,30 @@ function isCanonicalWebviewLatchBridge(file: string | null, text: string): boole
   return text.slice(1).replace(/\s+/g, '') === WEBVIEW_LATCH_BRIDGE_CALL;
 }
 
-function checkSecurityPatterns(addedLines: AddedDiffLine[]): MergeViolation[] {
+function hasReviewedCliExit(cwd: string, headSha: string): boolean {
+  try {
+    const contents = execFileSync('git', ['show', `${headSha}:${REVIEWED_CLI_EXIT_FILE}`], {
+      cwd, windowsHide: true, timeout: 5_000, maxBuffer: 64 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return createHash('sha256').update(contents).digest('hex') === REVIEWED_CLI_EXIT_SHA256;
+  } catch {
+    return false;
+  }
+}
+
+function checkSecurityPatterns(cwd: string, headSha: string, addedLines: AddedDiffLine[]): MergeViolation[] {
   const violations: MergeViolation[] = [];
+  const reviewedCliExit = addedLines.some(({ file, text }) => (
+    file === REVIEWED_CLI_EXIT_FILE && PROCESS_EXIT_PATTERN.test(text)
+  )) && hasReviewedCliExit(cwd, headSha);
 
   for (const { pattern, label } of HARD_BLOCK_PATTERNS) {
     for (const { file, text } of addedLines) {
       if (isSecurityScanExemptPath(file)) continue;
       if (isCanonicalWebviewLatchBridge(file, text)) continue;
+      // Only the termination pattern is allowed, never a whole-file exemption.
+      if (pattern.source === PROCESS_EXIT_PATTERN.source && file === REVIEWED_CLI_EXIT_FILE && reviewedCliExit) continue;
 
       if (pattern.test(text)) {
         violations.push({
@@ -614,8 +640,8 @@ export async function runMergeGate(
     };
   }
 
-  const addedLines = getAddedLines(cwd, comparisonRef);
-  const securityViolations = checkSecurityPatterns(addedLines);
+  const addedLines = getAddedLines(cwd, comparisonRef, headSha);
+  const securityViolations = checkSecurityPatterns(cwd, headSha, addedLines);
   const scopePartitionViolations = checkScopePartitionHeuristics(addedLines);
   const budgetViolations = checkDiffBudgets(cwd, comparisonRef, lane.repoPath, orchestratorApproved);
   const importViolations = checkUntrackedImportViolations(cwd, comparisonRef);

--- a/src/lib/runtimes/shared/owned-session/launch-args.ts
+++ b/src/lib/runtimes/shared/owned-session/launch-args.ts
@@ -66,6 +66,7 @@ export async function prepareOwnedLaunchArgs({
     sessionDir: session.sessionDir,
     prompt,
     model: session.model,
+    effort: session.effort,
     workerMcpServers: workerMcp.servers,
     // A resumed read-only packet must stay read-only: the pin lives on the
     // session, so the mode survives even when the resume caller knows nothing.

--- a/src/lib/runtimes/shared/owned-session/types.ts
+++ b/src/lib/runtimes/shared/owned-session/types.ts
@@ -350,6 +350,7 @@ export interface OwnedRuntimeAdapter {
     sessionDir?: string;
     prompt: string;
     model?: string;
+    effort?: ThinkingEffort;
     workerMcpServers?: ResolvedWorkerMcpServer[];
     /** Config pinned when the session was created (carrier, spend cap, work mode). */
     runtimeConfig?: Record<string, string>;

--- a/tests/cli-output-completeness-real-path.test.ts
+++ b/tests/cli-output-completeness-real-path.test.ts
@@ -4,7 +4,7 @@
  *
  * `process.stdout` is asynchronous when it is a pipe — Node writes what the OS
  * pipe accepts (64 KiB on macOS) and buffers the remainder in userspace. The
- * CLI's top-level `process.exit()` used to run before that buffer drained, so a
+ * CLI used to terminate before that buffer drained, so a
  * large payload exited 0 while the consumer saw exactly one pipe buffer of
  * truncated JSON. The same payload redirected to a regular file (a synchronous
  * fd) was complete, which is why this never showed up in file-based checks.

--- a/tests/cli-output-completeness-real-path.test.ts
+++ b/tests/cli-output-completeness-real-path.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Real-path regression: the compiled `o8` binary must deliver COMPLETE output
+ * through a pipe.
+ *
+ * `process.stdout` is asynchronous when it is a pipe — Node writes what the OS
+ * pipe accepts (64 KiB on macOS) and buffers the remainder in userspace. The
+ * CLI's top-level `process.exit()` used to run before that buffer drained, so a
+ * large payload exited 0 while the consumer saw exactly one pipe buffer of
+ * truncated JSON. The same payload redirected to a regular file (a synchronous
+ * fd) was complete, which is why this never showed up in file-based checks.
+ *
+ * Everything here drives the REAL entry point: the bundled `cli/dist/o8.mjs`
+ * spawned as a child process against an ephemeral loopback fixture, with a
+ * disposable data dir. Completeness is judged only after the child's stdio
+ * streams close ('close'), never on 'exit' — 'exit' can fire while stdout is
+ * still being read. Payloads are synthetic.
+ */
+
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+interface CliResult {
+  exitCode: number | null;
+  stdout: Buffer;
+  stderr: Buffer;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+}
+
+/** Multi-byte text that must survive chunked pipe writes intact. */
+const MULTIBYTE = {
+  cjk: '日本語テキスト・タスク',
+  accented: 'café — naïve résumé',
+  astral: '\u{1D11E}\u{1D122}',
+};
+
+const ONE_MIB = 1024 * 1024;
+
+const dataDir = mkdtempSync(join(tmpdir(), 'o8-cli-output-completeness-'));
+const cliEntry = join(process.cwd(), 'cli/dist/o8.mjs');
+let apiServer: Server | null = null;
+let apiPort = 0;
+
+/** Deterministic synthetic task pool whose serialization exceeds 1 MiB. */
+function buildLargeTaskPool(): Record<string, unknown> {
+  const tasks = Array.from({ length: 2_400 }, (_, index) => ({
+    id: `task-${index}`,
+    packetId: null,
+    laneId: null,
+    title: `${MULTIBYTE.cjk} #${index}`,
+    summary: `${MULTIBYTE.accented} ${MULTIBYTE.astral} ${'synthetic-filler-'.repeat(12)}${index}`,
+    group: index % 2 === 0 ? 'done' : 'ready',
+    status: 'synthetic',
+    runtime: 'synthetic-runtime',
+  }));
+  return {
+    schema: 'o8/cli/task-pool/v1',
+    marker: `${MULTIBYTE.cjk}|${MULTIBYTE.accented}|${MULTIBYTE.astral}`,
+    tasks,
+  };
+}
+
+const largeTaskPool = buildLargeTaskPool();
+const largeConflictNote = `${MULTIBYTE.cjk} ${'conflict-detail-'.repeat(80_000)}`;
+
+const children = new Map<ChildProcess, Promise<void>>();
+
+interface CliOptions {
+  pause?: 'stdout' | 'stderr';
+  resumeAfterMs?: number;
+  closeStdoutEarly?: boolean;
+  liveHandle?: boolean;
+}
+
+function runCli(args: string[], options: CliOptions = {}): Promise<CliResult> {
+  return new Promise((resolveRun, reject) => {
+    // Credentials here belong only to the ephemeral fixture, not to the
+    // production control plane or the worker that is running this test.
+    const env = { ...process.env };
+    delete env.O8_WORKER_TOKEN;
+    delete env.O8_WORKER_PACKET_ID;
+    const preload = options.liveHandle ? ['--import', join(dataDir, 'live-handle.mjs')] : [];
+    const child = spawn(process.execPath, [...preload, cliEntry, ...args], {
+      cwd: process.cwd(),
+      env: {
+        ...env,
+        CORTEX_IDE_DATA_DIR: dataDir,
+        O8_DATA_DIR: dataDir,
+        O8_API_PORT: String(apiPort),
+        O8_API_TOKEN: 'synthetic-output-token',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let timedOut = false;
+    const deadline = setTimeout(() => { timedOut = true; child.kill('SIGKILL'); }, 15_000);
+    children.set(child, new Promise<void>((resolve) => child.once('close', resolve)));
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout.push(chunk);
+      if (options.closeStdoutEarly) child.stdout.destroy();
+    });
+    child.stderr.on('data', (chunk: Buffer) => { stderr.push(chunk); });
+    const paused = options.pause ? child[options.pause] : null;
+    paused?.pause();
+    const resumeTimer = paused && options.resumeAfterMs !== undefined
+      ? setTimeout(() => paused.resume(), options.resumeAfterMs) : null;
+    child.on('error', reject);
+    child.on('exit', () => paused?.resume());
+    // 'close' — not 'exit' — is the only point at which stdout is fully read.
+    child.on('close', (exitCode, signal) => {
+      clearTimeout(deadline);
+      if (resumeTimer) clearTimeout(resumeTimer);
+      children.delete(child);
+      resolveRun({ exitCode, signal, timedOut, stdout: Buffer.concat(stdout), stderr: Buffer.concat(stderr) });
+    });
+  });
+}
+
+afterEach(async () => {
+  const pending = [...children];
+  for (const [child] of pending) child.kill('SIGKILL');
+  await Promise.all(pending.map(([, closed]) => closed));
+});
+
+beforeAll(async () => {
+  writeFileSync(join(dataDir, 'live-handle.mjs'), 'setInterval(() => {}, 1000);\n');
+  execFileSync(process.execPath, [join(process.cwd(), 'cli/esbuild.config.mjs')], {
+    cwd: process.cwd(),
+    stdio: 'ignore',
+  });
+
+  apiServer = createServer((request, response) => {
+    if (request.headers.authorization !== 'Bearer synthetic-output-token') {
+      response.writeHead(401);
+      response.end('{}');
+      return;
+    }
+    const requestUrl = new URL(request.url ?? '/', 'http://127.0.0.1');
+    if (requestUrl.pathname !== '/api/tasks') {
+      response.writeHead(404, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify({ error: 'missing fixture route' }));
+      return;
+    }
+    const projectId = requestUrl.searchParams.get('projectId');
+    if (projectId === 'missing') {
+      response.writeHead(404, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify({ error: { code: 'not_found' } }));
+      return;
+    }
+    if (projectId === 'conflict') {
+      response.writeHead(409, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify({ note: largeConflictNote }));
+      return;
+    }
+    response.writeHead(200, { 'Content-Type': 'application/json' });
+    response.end(JSON.stringify(largeTaskPool));
+  });
+  await new Promise<void>((resolveListen) => apiServer!.listen(0, '127.0.0.1', resolveListen));
+  const address = apiServer.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('CLI output-completeness fixture did not bind');
+  }
+  apiPort = address.port;
+}, 60_000);
+
+afterAll(async () => {
+  apiServer?.closeAllConnections();
+  await new Promise<void>((resolveClose, reject) => {
+    if (!apiServer) return resolveClose();
+    apiServer.close((error) => (error ? reject(error) : resolveClose()));
+  });
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('o8 CLI output completeness through a pipe', () => {
+  it('delivers a >1 MiB JSON payload intact, with multi-byte text and one trailing newline', async () => {
+    const result = await runCli(['task', 'list', '--include-done', '--project', 'large']);
+
+    expect(result.exitCode, result.stderr.toString('utf8').slice(0, 2_000)).toBe(0);
+    expect(result.stdout.byteLength).toBeGreaterThan(ONE_MIB);
+
+    const text = result.stdout.toString('utf8');
+    // Byte-exact: what printJson wrote is exactly what the consumer received.
+    expect(text).toBe(`${JSON.stringify(largeTaskPool, null, 2)}\n`);
+    expect(text.endsWith('\n')).toBe(true);
+    expect(text.endsWith('\n\n')).toBe(false);
+
+    const parsed = JSON.parse(text) as typeof largeTaskPool;
+    expect(parsed).toEqual(largeTaskPool);
+    expect((parsed as { marker: string }).marker)
+      .toBe(`${MULTIBYTE.cjk}|${MULTIBYTE.accented}|${MULTIBYTE.astral}`);
+    // No replacement character: no UTF-8 sequence was cut at a chunk boundary.
+    expect(text).not.toContain('�');
+  }, 60_000);
+
+  it('delivers a >1 MiB structured error on stderr and preserves the conflict exit code', async () => {
+    const result = await runCli(['task', 'list', '--project', 'conflict']);
+
+    expect(result.exitCode).toBe(5);
+    expect(result.stdout.byteLength).toBe(0);
+    expect(result.stderr.byteLength).toBeGreaterThan(ONE_MIB);
+
+    const body = JSON.parse(result.stderr.toString('utf8')) as {
+      schema: string;
+      error: { code: string; message: string };
+    };
+    expect(body.schema).toBe('o8/cli/error/v1');
+    expect(body.error.code).toBe('conflict');
+    expect(body.error.message.endsWith(largeConflictNote)).toBe(true);
+  }, 60_000);
+
+  it('preserves small structured errors and their exit codes', async () => {
+    const result = await runCli(['task', 'list', '--project', 'missing']);
+
+    expect(result.exitCode).toBe(4);
+    expect(JSON.parse(result.stderr.toString('utf8'))).toMatchObject({
+      schema: 'o8/cli/error/v1',
+      error: { code: 'not_found' },
+    });
+  }, 60_000);
+
+  // Draining before exit keeps the process alive long enough for a consumer
+  // that walked away to raise EPIPE. `o8 <cmd> | head` must stay a clean,
+  // prompt exit rather than a Node stack trace.
+  it('exits cleanly and promptly when the consumer closes the pipe early', async () => {
+    const startedAt = Date.now();
+    const result = await runCli(['task', 'list', '--project', 'large'], { closeStdoutEarly: true });
+    expect(result.exitCode).toBe(0);
+    expect(result.timedOut).toBe(false);
+    expect(result.stdout.byteLength).toBeGreaterThan(0);
+    expect(result.stdout.byteLength).toBeLessThan(ONE_MIB);
+    expect(result.stderr.byteLength).toBe(0);
+    // Bounded: an early-closing consumer must not hold the CLI for the
+    // stalled-consumer timeout.
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+  }, 60_000);
+
+  it('does not report success when a reader stays blocked past the flush deadline', async () => {
+    const result = await runCli(['task', 'list', '--project', 'large'], { pause: 'stdout' });
+    expect(result.timedOut).toBe(false);
+    expect(result.signal).toBeNull();
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout.byteLength).toBeLessThan(Buffer.byteLength(JSON.stringify(largeTaskPool, null, 2)));
+    expect(JSON.parse(result.stderr.toString('utf8'))).toMatchObject({
+      schema: 'o8/cli/error/v1', error: { code: 'output_incomplete', ambiguous: true },
+    });
+  }, 20_000);
+
+  it('preserves a command failure code when its error output cannot drain', async () => {
+    const result = await runCli(['task', 'list', '--project', 'conflict'], { pause: 'stderr' });
+    expect(result.timedOut).toBe(false);
+    expect(result.signal).toBeNull();
+    expect(result.exitCode).toBe(5);
+  }, 20_000);
+
+  it('delivers the complete payload when a delayed reader resumes', async () => {
+    const result = await runCli(['task', 'list', '--project', 'large'], { pause: 'stdout', resumeAfterMs: 500 });
+    expect(result.exitCode).toBe(0);
+    expect(result.timedOut).toBe(false);
+    expect(result.stdout.toString('utf8')).toBe(`${JSON.stringify(largeTaskPool, null, 2)}\n`);
+  }, 20_000);
+
+  it('exits after complete output even with an unrelated referenced timer', async () => {
+    const startedAt = Date.now();
+    const result = await runCli(['task', 'list', '--project', 'large'], { liveHandle: true });
+    expect(result.exitCode).toBe(0);
+    expect(result.timedOut).toBe(false);
+    expect(result.stdout.toString('utf8')).toBe(`${JSON.stringify(largeTaskPool, null, 2)}\n`);
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+  }, 20_000);
+});

--- a/tests/owned-codex-resume-pinning-real-path.test.ts
+++ b/tests/owned-codex-resume-pinning-real-path.test.ts
@@ -1,0 +1,118 @@
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { getDataDir } from '@/lib/data-dir-migration';
+import type { OwnedSessionRecord } from '@/lib/runtimes/shared/owned-session/types';
+
+// The runtime is a finite, offline executable. Keep readiness and supervisor
+// notifications outside this test; store, argv, spawn, parser and disk are real.
+vi.mock('@/lib/runtimes/shared/dispatch-readiness', () => ({
+  ensureDispatchBackendReady: vi.fn(async () => ({ ready: true })),
+}));
+vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200 })));
+
+const root = mkdtempSync(join(getDataDir(), 'codex-resume-pinning-'));
+const sessionsRoot = join(root, 'sessions');
+const binary = join(root, 'codex-fixture.mjs');
+vi.stubEnv('CORTEX_IDE_OWNED_CODEX_ROOT', sessionsRoot);
+vi.stubEnv('O8_CODEX_BIN', binary);
+vi.stubEnv('O8_CRASH_SURVIVABLE_WORKERS', '1');
+vi.stubEnv('O8_WORKER_SANDBOX', 'off');
+
+writeFileSync(binary, `#!/usr/bin/env node
+import { appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+const args = process.argv.slice(2);
+if (args.includes('--version')) {
+  console.log('codex-fixture 1.0.0');
+} else {
+  const resumeIndex = args.indexOf('resume');
+  const threadId = resumeIndex < 0 ? 'fixture-saved-thread' : args[resumeIndex + 1];
+  const modelIndex = args.indexOf('--model');
+  const receipt = {
+    args, threadId, cwd: process.cwd(),
+    model: modelIndex < 0 ? 'fixture-default-other-model' : args[modelIndex + 1],
+    effort: args.find((arg) => arg.startsWith('model_reasoning_effort=')) ?? 'fixture-default-effort',
+  };
+  appendFileSync(join(process.cwd(), 'argv-receipts.jsonl'), JSON.stringify(receipt) + '\\n');
+  console.log(JSON.stringify({ type: 'thread.started', thread_id: threadId }));
+  console.log(JSON.stringify({ type: 'item.completed', item: {
+    id: 'reply', type: 'agent_message', text: 'Offline fixture completed.',
+  } }));
+  console.log(JSON.stringify({ type: 'turn.completed' }));
+}
+`);
+chmodSync(binary, 0o700);
+
+const {
+  launchOwnedCodexSession,
+  continueOwnedCodexSession,
+  archiveOwnedCodexSession,
+  getOwnedCodexRuntimeTail,
+} = await import('@/lib/codex/owned');
+
+function readSession(surfaceId: string): OwnedSessionRecord {
+  const sessionDir = join(sessionsRoot, surfaceId.slice('codex-owned:'.length));
+  return JSON.parse(readFileSync(join(sessionDir, 'session.json'), 'utf8'));
+}
+
+async function settledSession(surfaceId: string, runCount: number): Promise<OwnedSessionRecord> {
+  await vi.waitFor(async () => {
+    await getOwnedCodexRuntimeTail(surfaceId);
+    const session = readSession(surfaceId);
+    expect(session.activeRun).toBeUndefined();
+    expect(session.threadId).toBe('fixture-saved-thread');
+    expect(session.recentRuns).toHaveLength(runCount);
+    expect(session.recentRuns.every((run) => run.outcome === 'finished' && run.childExit?.code === 0)).toBe(true);
+  }, { timeout: 10_000, interval: 50 });
+  return readSession(surfaceId);
+}
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe.skipIf(process.platform === 'win32')('owned Codex persisted resume pins through a real process', () => {
+  it.each(['warm', 'archived'] as const)('preserves model and effort on %s resume', async (kind) => {
+    const repoPath = join(root, `repo-${kind}`);
+    mkdirSync(repoPath);
+    execFileSync('git', ['init', '-q', repoPath]);
+
+    const launched = await launchOwnedCodexSession({
+      cwd: repoPath, prompt: 'initial fixture turn', model: 'gpt-5.6-sol', effort: 'high',
+    });
+    expect(launched.ok).toBe(true);
+    const original = await settledSession(launched.surfaceId, 1);
+    expect(original).toMatchObject({ model: 'gpt-5.6-sol', effort: 'high' });
+    if (kind === 'archived') {
+      expect((await archiveOwnedCodexSession(launched.surfaceId)).archived).toBe(true);
+    }
+
+    // The caller supplies only the session address and prompt. Pins must be
+    // loaded from disk, including after the archived directory is restored.
+    const resumed = await continueOwnedCodexSession(launched.surfaceId, 'follow-up fixture turn');
+    expect(resumed.ok).toBe(true);
+    const saved = await settledSession(launched.surfaceId, 2);
+    expect(saved).toMatchObject({ model: original.model, effort: original.effort, threadId: original.threadId });
+    expect(saved.runtimeConfig).toEqual(original.runtimeConfig);
+    expect(saved.identity).toEqual(original.identity);
+    expect(new Set(saved.recentRuns.map((run) => run.mode))).toEqual(new Set(['launch', 'resume']));
+
+    const receipts = readFileSync(join(repoPath, 'argv-receipts.jsonl'), 'utf8').trim().split('\n')
+      .map((line) => JSON.parse(line) as { args: string[]; model: string; effort: string; threadId: string; cwd: string });
+    expect(receipts).toHaveLength(2);
+    for (const receipt of receipts) {
+      expect(receipt).toMatchObject({
+        model: 'gpt-5.6-sol', effort: 'model_reasoning_effort=high', threadId: original.threadId, cwd: realpathSync(repoPath),
+      });
+      expect(receipt.args).toContain('--ignore-user-config');
+      expect(receipt.args).toContain('--dangerously-bypass-approvals-and-sandbox');
+    }
+    expect(receipts[1].args.slice(0, 3)).toEqual(['exec', 'resume', original.threadId]);
+    expect(receipts[1].args.at(-1)).toBe('follow-up fixture turn');
+    expect(receipts[1].args).not.toContain('-s');
+  }, 20_000);
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2061,6 +2061,15 @@
       ]
     },
     {
+      "path": "tests/owned-codex-resume-pinning-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "executable-fixture",
+        "git-cli",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/owned-codex-transcript-ingestion-real-path.test.ts",
       "reasons": [
         "real-path"

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1234,6 +1234,15 @@
       ]
     },
     {
+      "path": "tests/cli-output-completeness-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "network-listener",
+        "process-signal",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/cli-packet-target-parsing.test.ts",
       "reasons": [
         "worktree-api"


### PR DESCRIPTION
## Changes

- Drain one-shot CLI replies before termination, preserving error exit codes, bounded slow-reader handling, and normal early pipe closure.
- Scope the merge policy exception to the exact reviewed CLI wrapper and bootstrap server-only modules when running the branch gate.
- Preserve the saved model and reasoning effort on owned Codex continuation, including local-provider argument placement and archived sessions.
- Synchronize release manifests to 0.1.744 and add release notes for the signed Mac update.

## Verification

- Root TypeScript, touched-file ESLint, classification, whitespace, and changed-line rule checks passed.
- Final executable source: 4,245 unit tests passed with three existing skips.
- 39 focused integration checks passed across compiled CLI pipe output, real Git policy, gate subprocess loading, read-only contracts, and persisted owned-session continuation.
- The final committed source merge gate passed with zero blockers. Its three advisory findings are fixture file writes, an in-memory tracking Map, and a hash update call, not production database writes.

The CLI-only TypeScript configuration has 11 pre-existing errors reproduced on unchanged main. This PR does not claim that separate baseline is green. These are backend/CLI changes with no visual diff.

## Release boundary

This PR prepares the Mac release. Signing, notarization, publication, and installed-app acceptance follow the merge. Related #2080 remains open until uncontaminated installed lifecycle acceptance; Claude owned-worker continuation remains separate in #2128. No worker defaults, authentication, permissions, or held packets were changed.
