### PR TITLE
fix: continue owned worker conversations with saved session pins

### DIFF
--- a/src/lib/claude-code/owned.ts
+++ b/src/lib/claude-code/owned.ts
@@ -185,12 +185,29 @@ export const claudeCodeOwnedAdapter: OwnedRuntimeAdapter = {
     ...(workerMcpConfigPath ? ['--mcp-config', workerMcpConfigPath] : []),
   ],
   launchStdin: ({ prompt }) => buildClaudeStreamJsonUserPayload(prompt),
-  resumeArgs: () => null,
+  resumeArgs: ({ threadId, model, effort, workerMcpConfigPath, runtimeConfig }) => {
+    // Owned workers must address a saved provider UUID, never a session name,
+    // path, or the provider's most-recent-session fallback.
+    if (!/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(threadId)) {
+      throw new Error('The saved Claude Code session ID is invalid. No continuation was started.');
+    }
+    return [
+      ...buildClaudeStreamJsonArgs(model ?? null, 'bypassPermissions', threadId, effort),
+      ...claudeReadOnlyLockoutArgs(isReadOnlyRuntimeConfig(runtimeConfig)),
+      '--disable-slash-commands',
+      ...(workerMcpConfigPath ? ['--mcp-config', workerMcpConfigPath] : []),
+    ];
+  },
+  resumeStdin: ({ prompt }) => buildClaudeStreamJsonUserPayload(prompt),
   parseRunLog: parseClaudeOwnedRunLog,
   launchGroupLabel: 'Stream-json worker turn',
 };
 
 const claudeCodeOwnedStore = createOwnedSessionStore(claudeCodeOwnedAdapter);
+
+export async function continueOwnedClaudeCodeSession(surfaceId: string, prompt: string) {
+  return claudeCodeOwnedStore.resume(surfaceId, prompt);
+}
 
 export function invalidateOwnedClaudeCodeFleetCache(): void {
   claudeCodeOwnedStore.invalidateFleetCache();

--- a/src/lib/claude-code/read-only-worker-launch.test.ts
+++ b/src/lib/claude-code/read-only-worker-launch.test.ts
@@ -124,6 +124,18 @@ async function spawnedCall(carrier: 'native' | 'codex-subscription') {
 }
 
 describe('owned Claude Code read-only argv', () => {
+  it('preserves the write-tool and MCP restrictions on a resumed read-only session', () => {
+    const args = claudeCodeOwnedAdapter.resumeArgs({
+      threadId: '284368b4-5830-4939-890f-8739f792b608', prompt: 'inspect again',
+      model: 'claude-opus-5', effort: 'high', runtimeConfig: { workMode: 'read-only' },
+    })!;
+    expect(args).toContain('--resume');
+    expect(args).toContain(CLAUDE_STRICT_MCP_CONFIG_FLAG);
+    const denyIndex = args.indexOf('--disallowedTools');
+    expect(denyIndex).toBeGreaterThan(-1);
+    for (const tool of CLAUDE_READ_ONLY_DISALLOWED_TOOLS) expect(args.indexOf(tool)).toBeGreaterThan(denyIndex);
+  });
+
   it('denies the native write tools for a read-only launch', async () => {
     const args = await spawnedArgs('read-only');
     const denyIndex = args.indexOf('--disallowedTools');

--- a/src/lib/orchestrator/operator-mission-service/steer.ts
+++ b/src/lib/orchestrator/operator-mission-service/steer.ts
@@ -95,21 +95,23 @@ function stderrPathForStdout(stdoutPath: string): string {
 }
 
 async function readStartupFailureHead(surfaceId: string, sinceMs: number): Promise<string | null> {
-  if (!surfaceId.startsWith('codex-owned:')) return null;
+  const isClaude = surfaceId.startsWith('claude-code-owned:');
+  if (!isClaude && !surfaceId.startsWith('codex-owned:')) return null;
   await new Promise((resolve) => setTimeout(resolve, STARTUP_FAILURE_PROBE_MS));
-  const sources = await getOwnedCodexTelemetrySources(surfaceId);
+  const claude = isClaude ? await import('@/lib/claude-code/owned') : null;
+  const sources = await (claude?.getOwnedClaudeCodeTelemetrySources ?? getOwnedCodexTelemetrySources)(surfaceId);
   const stdoutPath = sources?.stdoutPaths[sources.stdoutPaths.length - 1];
   if (!stdoutPath) return null;
   const { readFile } = await import('node:fs/promises');
   const stderr = await readFile(stderrPathForStdout(stdoutPath), 'utf8').catch(() => '');
-  const tail = await getOwnedCodexRuntimeTail(surfaceId).catch(() => null);
+  const tail = await (claude?.getOwnedClaudeCodeRuntimeTail ?? getOwnedCodexRuntimeTail)(surfaceId).catch(() => null);
   const lifecycle = tail?.surface.lifecycle;
   // Only a run STARTED BY THIS STEER counts — a previous resume's failure must
   // not flag a fresh, healthy steer (caught by the #1415 regression test).
   const lastRunStartedMs = lifecycle?.lastRunStartedAt ? Date.parse(lifecycle.lastRunStartedAt) : NaN;
   const startedByThisSteer = Number.isFinite(lastRunStartedMs) && lastRunStartedMs >= sinceMs - 1_000;
   if (startedByThisSteer && lifecycle?.lastRunMode === 'resume' && lifecycle.lastOutcome === 'failed') {
-    return (stderr.trim() || lifecycle.summary || 'owned Codex resume exited non-zero')
+    return (stderr.trim() || lifecycle.summary || 'owned worker continuation failed')
       .replace(/\s+/g, ' ')
       .slice(0, 500);
   }

--- a/src/lib/runtime/actions-owned-surface.test.ts
+++ b/src/lib/runtime/actions-owned-surface.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   continueOwnedCodexSession: vi.fn(),
+  continueOwnedClaudeCodeSession: vi.fn(),
   getRuntimeInventorySnapshot: vi.fn(),
   listLanes: vi.fn(),
   recordLaneEvent: vi.fn(),
@@ -31,6 +32,11 @@ vi.mock('@/lib/codex/owned', () => ({
   setOwnedCodexReviewDisposition: vi.fn(),
 }));
 
+vi.mock('@/lib/claude-code/owned', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/claude-code/owned')>(),
+  continueOwnedClaudeCodeSession: mocks.continueOwnedClaudeCodeSession,
+}));
+
 vi.mock('@/lib/runtime/interrupt-escalation', () => ({
   escalateInterrupt: mocks.escalateInterrupt,
   escalateInterruptOwnedSurface: mocks.escalateInterruptOwnedSurface,
@@ -44,6 +50,7 @@ vi.mock('@/lib/runtimes', async (importOriginal) => ({
 describe('performRuntimeAction owned surface resolution', () => {
   beforeEach(() => {
     mocks.continueOwnedCodexSession.mockReset();
+    mocks.continueOwnedClaudeCodeSession.mockReset();
     mocks.getRuntimeInventorySnapshot.mockReset();
     mocks.getRuntimeInventorySnapshot.mockResolvedValue({ agents: [] });
     mocks.listLanes.mockReset();
@@ -104,6 +111,30 @@ describe('performRuntimeAction owned surface resolution', () => {
     expect(result.note).not.toMatch(/IDE-owned|thread id/i);
     expect(mocks.continueOwnedCodexSession).not.toHaveBeenCalled();
     expect(mocks.recordLaneEvent).not.toHaveBeenCalled();
+  });
+
+  it('reaches Claude continuation through the cached inventory and registry capability gates', async () => {
+    const surfaceId = 'claude-code-owned:ready';
+    mocks.getRuntimeInventorySnapshot.mockResolvedValue({ agents: [{
+      id: surfaceId, sessionKey: surfaceId, runtime: 'claude-code',
+      runtimeSurface: { id: surfaceId, ownership: 'owned', capabilities: { sendInput: true } },
+    }] });
+    const { claudeCodeRuntime } = await import('@/lib/runtimes/claude-code');
+    mocks.getRuntime.mockReturnValue(claudeCodeRuntime);
+    mocks.continueOwnedClaudeCodeSession.mockResolvedValue({ ok: true, note: 'queued' });
+    const { performRuntimeAction } = await import('./actions');
+    expect(await performRuntimeAction({ action: 'steer', surfaceId, message: 'follow up' }))
+      .toMatchObject({ ok: true, status: 'queued', sessionKey: surfaceId, runtime: 'claude-code' });
+    expect(mocks.continueOwnedClaudeCodeSession).toHaveBeenCalledExactlyOnceWith(surfaceId, 'follow up');
+  });
+
+  it('returns a structured busy result for Claude without starting a second turn', async () => {
+    const surfaceId = 'claude-code-owned:busy';
+    mocks.continueOwnedClaudeCodeSession.mockRejectedValue(new Error('This owned Claude session still has an active run.'));
+    const { performRuntimeAction } = await import('./actions');
+    expect(await performRuntimeAction({ action: 'steer', surfaceId, message: 'wait' }))
+      .toMatchObject({ ok: false, status: 'unavailable', note: expect.stringContaining('active run') });
+    expect(mocks.continueOwnedClaudeCodeSession).toHaveBeenCalledTimes(1);
   });
 
   it('audits an owned Codex steer only after the runtime accepts it', async () => {

--- a/src/lib/runtime/owned-actions.ts
+++ b/src/lib/runtime/owned-actions.ts
@@ -1,4 +1,5 @@
 import { continueOwnedCodexSession } from '@/lib/codex/owned';
+import { continueOwnedClaudeCodeSession } from '@/lib/claude-code/owned';
 import { escalateInterruptOwnedSurface } from '@/lib/runtime/interrupt-escalation';
 import type { RuntimeActionRequest, RuntimeActionResult } from '@/lib/runtime/actions';
 
@@ -35,11 +36,10 @@ export async function performOwnedActionWithoutInventory(
     if (!message) {
       return actionUnavailable(payload, surfaceId, runtime, `message is required to steer an owned ${runtime} session`);
     }
-    if (runtime !== 'codex') {
-      return actionUnavailable(payload, surfaceId, runtime, 'Claude Code owned sessions do not support resume/steer.');
-    }
     try {
-      const result = await continueOwnedCodexSession(surfaceId, message);
+      const result = await (runtime === 'codex'
+        ? continueOwnedCodexSession(surfaceId, message)
+        : continueOwnedClaudeCodeSession(surfaceId, message));
       return {
         ok: result.ok,
         action: payload.action,
@@ -55,7 +55,7 @@ export async function performOwnedActionWithoutInventory(
         payload,
         surfaceId,
         runtime,
-        error instanceof Error ? error.message : 'Owned Codex session could not be steered.',
+        error instanceof Error ? error.message : `Owned ${runtime} session could not be steered.`,
       );
     }
   }

--- a/src/lib/runtimes/claude-code.ts
+++ b/src/lib/runtimes/claude-code.ts
@@ -34,6 +34,7 @@ import {
   getOwnedClaudeCodeFleetAdditions,
   getOwnedClaudeCodeRuntimeTail,
   launchOwnedClaudeCodeSession,
+  continueOwnedClaudeCodeSession,
 } from '@/lib/claude-code/owned';
 import { resolveDefaultWorkerEffortSync } from '@/lib/operator/defaults';
 import { readClaudeRuntimeCapacity } from '@/lib/usage/cli-scrape';
@@ -61,12 +62,8 @@ const capabilities: RuntimeCapabilities = {
   discover: true,
   readTranscript: true,
   launch: true,
-  // Honesty (#1602): the adapter's resume() is intentionally disabled — owned
-  // Claude workers are one-prompt-per-launch and discovered sessions don't
-  // resume through the stream-json owned path. Declaring false lets the
-  // steer/resume gates fail cleanly ("not supported") instead of passing the
-  // gate and hitting an always-erroring resume().
-  resume: false,
+  // Only owned workers can continue; discovered sessions remain watch-only.
+  resume: true,
   interrupt: true,
   reviewDiffs: true,
   costTelemetry: true,
@@ -794,7 +791,7 @@ export const claudeCodeRuntime: AgentRuntime = {
         status,
         ownership,
         sessionCapabilities: {
-          canSendInput: status !== 'failed',
+          canSendInput: false,
           canInterrupt: status === 'running',
           canReviewDiffs: true,
         },
@@ -894,7 +891,7 @@ export const claudeCodeRuntime: AgentRuntime = {
         status: 'running',
         ownership,
         sessionCapabilities: {
-          canSendInput: true,
+          canSendInput: false,
           canInterrupt: true,
           canReviewDiffs: Boolean(realSessionId),
         },
@@ -928,7 +925,7 @@ export const claudeCodeRuntime: AgentRuntime = {
           status: agent.status === 'running' ? 'running' : agent.status === 'failed' ? 'failed' : 'reviewing',
           ownership: 'owned',
           sessionCapabilities: {
-            canSendInput: false,
+            canSendInput: agent.runtimeSurface?.capabilities?.sendInput ?? false,
             canInterrupt: agent.runtimeSurface?.capabilities?.interrupt ?? false,
             canReviewDiffs: agent.runtimeSurface?.capabilities?.diffContext ?? true,
           },
@@ -1091,14 +1088,16 @@ export const claudeCodeRuntime: AgentRuntime = {
       sideEffect: result.sideEffect,
     };
   },
-  async resume(): Promise<RuntimeActionResult> {
-    // Resume for discovered Claude sessions stays disabled: `claude --continue`
-    // is not the owned interactive stream-json worker path. Owned dispatched
-    // workers are intentionally one prompt per launch.
-    return {
-      ok: false,
-      note: 'Claude Code resume is disabled. Continue the conversation in your own Claude Code client; o8 will pick up the updated transcript via JSONL discovery.',
-    };
+  async resume(sessionKey: string, prompt: string): Promise<RuntimeActionResult> {
+    if (!sessionKey.startsWith('claude-code-owned:')) {
+      return { ok: false, sessionKey, note: 'Only owned Claude Code workers can continue through o8. Continue discovered sessions in their original client.' };
+    }
+    if (!prompt.trim()) return { ok: false, sessionKey, note: 'A follow-up message is required.' };
+    try {
+      return { ...await continueOwnedClaudeCodeSession(sessionKey, prompt.trim()), sessionKey };
+    } catch (error) {
+      return { ok: false, sessionKey, note: error instanceof Error ? error.message : 'Claude Code continuation failed.' };
+    }
   },
 
   async interrupt(sessionKey: string): Promise<RuntimeActionResult> {

--- a/src/lib/runtimes/shared/owned-session/launch-args.ts
+++ b/src/lib/runtimes/shared/owned-session/launch-args.ts
@@ -28,16 +28,13 @@ export async function prepareOwnedLaunchArgs({
   sandboxEnabled: boolean;
   humanLabel: string;
 }): Promise<PreparedOwnedLaunchArgs> {
-  const workerMcp: PreparedOwnedWorkerMcpConfig = mode === 'launch'
-    || adapter.workerMcpInjection === 'config-override'
-    ? await prepareOwnedWorkerMcpConfig({
-        adapter,
-        session,
-        runId,
-        mode,
-        sandboxEnabled,
-      })
-    : { sandboxReadPaths: [], servers: [] };
+  const workerMcp = await prepareOwnedWorkerMcpConfig({
+    adapter,
+    session,
+    runId,
+    mode,
+    sandboxEnabled,
+  });
 
   if (mode === 'launch') {
     return {
@@ -67,6 +64,7 @@ export async function prepareOwnedLaunchArgs({
     prompt,
     model: session.model,
     effort: session.effort,
+    workerMcpConfigPath: workerMcp.configPath,
     workerMcpServers: workerMcp.servers,
     // A resumed read-only packet must stay read-only: the pin lives on the
     // session, so the mode survives even when the resume caller knows nothing.
@@ -77,7 +75,12 @@ export async function prepareOwnedLaunchArgs({
   }
   return {
     args,
-    stdinPayload: null,
+    stdinPayload: adapter.resumeStdin?.({
+      cwd: session.repoPath,
+      prompt,
+      model: session.model,
+      effort: session.effort,
+    }) ?? null,
     workerMcp,
   };
 }

--- a/src/lib/runtimes/shared/owned-session/types.ts
+++ b/src/lib/runtimes/shared/owned-session/types.ts
@@ -340,6 +340,9 @@ export interface OwnedRuntimeAdapter {
   /** Optional stdin payload for runtimes launched as interactive stream processors. */
   launchStdin?(ctx: { cwd: string; prompt: string; model?: string; effort?: ThinkingEffort }): string | null;
 
+  /** Optional input for a fresh process continuing a saved conversation. */
+  resumeStdin?(ctx: { cwd: string; prompt: string; model?: string; effort?: ThinkingEffort }): string | null;
+
   /**
    * Build argv for a resume run. Return null to signal this runtime cannot
    * thread-resume via CLI — the store will raise a friendly "no resume
@@ -351,6 +354,7 @@ export interface OwnedRuntimeAdapter {
     prompt: string;
     model?: string;
     effort?: ThinkingEffort;
+    workerMcpConfigPath?: string;
     workerMcpServers?: ResolvedWorkerMcpServer[];
     /** Config pinned when the session was created (carrier, spend cap, work mode). */
     runtimeConfig?: Record<string, string>;

--- a/tests/completion-steer-race-real-path.test.ts
+++ b/tests/completion-steer-race-real-path.test.ts
@@ -90,10 +90,16 @@ function request(path: string, body: unknown) {
     authorization: `Bearer ${getOrCreateWsToken()}`, 'content-type': 'application/json',
   }, body: JSON.stringify(body) });
 }
-function steer(packetId: string) {
-  return steerRoute.POST(request('/api/orchestrator/steer-packet', {
+async function steer(packetId: string) {
+  const response = steerRoute.POST(request('/api/orchestrator/steer-packet', {
     packetId, message: 'Run the next verification', idempotencyKey: `steer-${packetId}`,
   }));
+  // The route reads the request before scheduling its startup probe. Advance
+  // fake time until it settles, rather than racing a one-shot clock advance.
+  let settled = false;
+  void response.then(() => { settled = true; }, () => { settled = true; });
+  await vi.waitFor(() => expect(settled).toBe(true), { timeout: 5_000 });
+  return response;
 }
 function register(packet: OrchestratorPacket, suffix: string) {
   const id = `race${sequence}${suffix}`;

--- a/tests/owned-claude-continuation-real-path.test.ts
+++ b/tests/owned-claude-continuation-real-path.test.ts
@@ -1,0 +1,216 @@
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { getDataDir } from '@/lib/data-dir-migration';
+import type { OwnedSessionRecord } from '@/lib/runtimes/shared/owned-session/types';
+
+// The provider is offline. Session storage, credential isolation, argv, stdin,
+// subprocess ownership, parsing, runtime actions and archive restoration are real.
+vi.mock('@/lib/runtimes/shared/dispatch-readiness', () => ({
+  ensureDispatchBackendReady: vi.fn(async () => ({ ready: true })),
+}));
+vi.mock('@/lib/runtime/inventory', () => ({
+  getRuntimeInventorySnapshot: vi.fn(async () => ({ agents: [] })),
+}));
+vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200 })));
+
+const root = realpathSync(mkdtempSync(join(getDataDir(), 'claude-continuation-')));
+const sessionsRoot = join(root, 'sessions');
+const binary = join(root, 'claude-fixture.mjs');
+const threadId = '671d7c73-b85f-4489-90ec-05d95af4776a';
+const ownedSurfaceIds = new Set<string>();
+vi.stubEnv('CORTEX_IDE_OWNED_CLAUDE_CODE_ROOT', sessionsRoot);
+vi.stubEnv('O8_CLAUDE_CODE_BIN', binary);
+vi.stubEnv('O8_CRASH_SURVIVABLE_WORKERS', '1');
+vi.stubEnv('O8_WORKER_SANDBOX', 'off');
+vi.stubEnv('ANTHROPIC_API_KEY', '');
+vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', 'synthetic-continuation-fixture');
+
+writeFileSync(binary, `#!/usr/bin/env node
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+const args = process.argv.slice(2);
+if (args.includes('--version')) {
+  console.log('claude-fixture 1.0.0');
+} else {
+  let raw = '';
+  for await (const chunk of process.stdin) raw += chunk;
+  const prompt = JSON.parse(raw).message.content;
+  const resumeIndex = args.indexOf('--resume');
+  const sessionId = resumeIndex < 0 ? '${threadId}' : args[resumeIndex + 1];
+  const statePath = join(process.env.CLAUDE_CONFIG_DIR, sessionId + '.fixture.json');
+  const missing = resumeIndex >= 0 && !existsSync(statePath);
+  const prior = missing || resumeIndex < 0 ? [] : JSON.parse(readFileSync(statePath, 'utf8'));
+  const history = [...prior, prompt];
+  appendFileSync(join(process.cwd(), 'argv-receipts.jsonl'), JSON.stringify({
+    args, prompt, sessionId, history, configDir: process.env.CLAUDE_CONFIG_DIR,
+    cwd: process.cwd(), credential: process.env.CLAUDE_CODE_OAUTH_TOKEN,
+  }) + '\\n');
+  if (prompt === 'hold') {
+    setInterval(() => {}, 1000);
+  } else {
+    if (!missing) writeFileSync(statePath, JSON.stringify(history));
+    console.log(JSON.stringify({ type: 'result', subtype: missing ? 'error_during_execution' : 'success',
+      session_id: sessionId, is_error: missing, result: missing ? 'Saved conversation not found' : JSON.stringify(history) }));
+    if (missing) process.exitCode = 1;
+  }
+}
+`);
+chmodSync(binary, 0o700);
+
+const {
+  launchOwnedClaudeCodeSession, archiveOwnedClaudeCodeSession, getOwnedClaudeCodeRuntimeTail,
+} = await import('@/lib/claude-code/owned');
+const { claudeCodeRuntime } = await import('@/lib/runtimes/claude-code');
+const { performRuntimeAction } = await import('@/lib/runtime/actions');
+
+function sessionPath(surfaceId: string) {
+  return join(sessionsRoot, surfaceId.slice('claude-code-owned:'.length), 'session.json');
+}
+function readSession(surfaceId: string): OwnedSessionRecord {
+  return JSON.parse(readFileSync(sessionPath(surfaceId), 'utf8'));
+}
+function receipts(repoPath: string): Array<{
+  args: string[]; prompt: string; sessionId: string; history: string[];
+  configDir: string; cwd: string; credential: string;
+}> {
+  try {
+    return readFileSync(join(repoPath, 'argv-receipts.jsonl'), 'utf8').trim().split('\n')
+      .map((line) => JSON.parse(line));
+  } catch { return []; }
+}
+async function settled(surfaceId: string, count: number, outcome = 'finished') {
+  await vi.waitFor(async () => {
+    await getOwnedClaudeCodeRuntimeTail(surfaceId);
+    const session = readSession(surfaceId);
+    expect(session.activeRun).toBeUndefined();
+    expect(session.recentRuns).toHaveLength(count);
+    expect(session.recentRuns[0].outcome).toBe(outcome);
+    expect(session.recentRuns[0].childExit).toBeDefined();
+  }, { timeout: 10_000, interval: 50 });
+  return readSession(surfaceId);
+}
+async function launch(label: string) {
+  const repoPath = join(root, label);
+  mkdirSync(repoPath);
+  execFileSync('git', ['init', '-q', repoPath]);
+  const result = await launchOwnedClaudeCodeSession({
+    cwd: repoPath, prompt: 'inspect resume pins', claudeCodeCarrier: 'native',
+    claudeCodeModel: 'claude-opus-5', effort: 'high',
+  });
+  if (result.ok) ownedSurfaceIds.add(result.surfaceId);
+  expect(result, result.note).toMatchObject({ ok: true });
+  await settled(result.surfaceId, 1);
+  return { repoPath, surfaceId: result.surfaceId };
+}
+
+afterAll(async () => {
+  try {
+    // A failed assertion must not leave a fixture process alive or erase its
+    // ownership record before Stop can verify it.
+    for (const surfaceId of ownedSurfaceIds) {
+      await getOwnedClaudeCodeRuntimeTail(surfaceId);
+      if (readSession(surfaceId).activeRun) {
+        expect(await performRuntimeAction({ action: 'stop', surfaceId }))
+          .toMatchObject({ ok: true, status: 'completed' });
+      }
+    }
+    rmSync(root, { recursive: true, force: true });
+  } finally {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  }
+});
+
+describe.skipIf(process.platform === 'win32')('owned Claude continuation through persisted runtime state', () => {
+  it.each(['warm', 'archived'] as const)('continues the exact %s conversation with its pins', async (kind) => {
+    const { repoPath, surfaceId } = await launch(kind);
+    const original = readSession(surfaceId);
+    expect(original.threadId).toBe(threadId);
+    if (kind === 'archived') expect((await archiveOwnedClaudeCodeSession(surfaceId)).archived).toBe(true);
+
+    expect(claudeCodeRuntime.capabilities.resume).toBe(true);
+    expect(await claudeCodeRuntime.resume(surfaceId, 'verify the same session')).toMatchObject({ ok: true, sessionKey: surfaceId });
+    await settled(surfaceId, 2);
+    // Inventory can omit a completed/archived worker. The public action must
+    // still resolve only this owned address, without selecting another session.
+    expect(await performRuntimeAction({ action: 'steer', surfaceId, message: 'one final check' }))
+      .toMatchObject({ ok: true, status: 'queued', sessionKey: surfaceId });
+    const saved = await settled(surfaceId, 3);
+    expect(saved).toMatchObject({ model: original.model, effort: original.effort, threadId });
+    expect(saved.identity).toEqual(original.identity);
+    expect(saved.runtimeConfig).toEqual(original.runtimeConfig);
+    const calls = receipts(repoPath);
+    expect(calls).toHaveLength(3);
+    expect(calls[2].history).toEqual(['inspect resume pins', 'verify the same session', 'one final check']);
+    for (const call of calls) {
+      expect(call.cwd).toBe(realpathSync(repoPath));
+      expect(call.configDir).toBe(calls[0].configDir);
+      expect(call.credential).toBe('synthetic-continuation-fixture');
+      expect(call.args).toContain('--disable-slash-commands');
+      expect(call.args[call.args.indexOf('--model') + 1]).toBe('claude-opus-5');
+      expect(call.args[call.args.indexOf('--effort') + 1]).toBe('high');
+      expect(call.args[call.args.indexOf('--permission-mode') + 1]).toBe('bypassPermissions');
+      expect(call.args).not.toContain('--continue');
+    }
+    expect(calls[0].args).not.toContain('--resume');
+    expect(calls.slice(1).every((call) => call.args[call.args.indexOf('--resume') + 1] === threadId)).toBe(true);
+    const tail = await getOwnedClaudeCodeRuntimeTail(surfaceId);
+    expect(tail?.surface.capabilities.sendInput).toBe(true);
+    expect(tail?.surface.lifecycle?.lastRunMode).toBe('resume');
+  }, 30_000);
+
+  it('rejects discovered, missing and invalid identities without starting a process', async () => {
+    expect(await claudeCodeRuntime.resume(`claude-code:${threadId}`, 'continue'))
+      .toMatchObject({ ok: false, note: expect.stringContaining('Only owned') });
+    expect(await claudeCodeRuntime.resume('claude-code-owned:missing', 'continue'))
+      .toMatchObject({ ok: false, note: expect.stringContaining('not found') });
+    const { repoPath, surfaceId } = await launch('invalid');
+    const original = readSession(surfaceId);
+    writeFileSync(sessionPath(surfaceId), JSON.stringify({ ...original, threadId: undefined, recentRuns: [] }));
+    expect(await claudeCodeRuntime.resume(surfaceId, 'no saved identity'))
+      .toMatchObject({ ok: false, note: expect.stringContaining('thread id') });
+    for (const id of ['--continue', 'last-session', '../another.jsonl']) {
+      writeFileSync(sessionPath(surfaceId), JSON.stringify({ ...original, threadId: id }));
+      expect(await claudeCodeRuntime.resume(surfaceId, 'must not launch'))
+        .toMatchObject({ ok: false, note: expect.stringContaining('invalid') });
+    }
+    expect(receipts(repoPath)).toHaveLength(1);
+  });
+
+  it('reports a missing provider transcript as failed without falling back to a fresh conversation', async () => {
+    const { repoPath, surfaceId } = await launch('missing-transcript');
+    const saved = readSession(surfaceId);
+    const absentId = '8382bafc-08bc-4c13-9d90-cc0701f6d26e';
+    writeFileSync(sessionPath(surfaceId), JSON.stringify({ ...saved, threadId: absentId }));
+    expect(await claudeCodeRuntime.resume(surfaceId, 'no fallback')).toMatchObject({ ok: true });
+    const failed = await settled(surfaceId, 2, 'failed');
+    expect(failed.threadId).toBe(absentId);
+    expect(failed.recentRuns[0].childExit?.code).toBe(1);
+    expect(receipts(repoPath)).toHaveLength(2);
+    expect(receipts(repoPath)[1].args).toContain('--resume');
+  });
+
+  it('refuses overlapping input and verifies that Stop kills the owned process', async () => {
+    const { repoPath, surfaceId } = await launch('active');
+    expect(await claudeCodeRuntime.resume(surfaceId, 'hold')).toMatchObject({ ok: true });
+    await vi.waitFor(() => expect(receipts(repoPath)).toHaveLength(2), { timeout: 10_000 });
+    const activePid = readSession(surfaceId).activeRun?.pid;
+    try {
+      expect(await claudeCodeRuntime.resume(surfaceId, 'must not overlap'))
+        .toMatchObject({ ok: false, note: expect.stringContaining('active run') });
+      expect(receipts(repoPath)).toHaveLength(2);
+    } finally {
+      expect(await performRuntimeAction({ action: 'stop', surfaceId }))
+        .toMatchObject({ ok: true, status: 'completed', aborted: true });
+    }
+    // The existing escalation path reports a signaled exit as failed because
+    // it does not stamp the store's interrupt intent. Death is proved below;
+    // this test does not claim that separate status-classification gap is fixed.
+    const stopped = await settled(surfaceId, 2, 'failed');
+    expect(stopped.recentRuns[0].childExit?.signal).toBe('SIGINT');
+    expect(() => process.kill(activePid!, 0)).toThrow();
+    expect(receipts(repoPath)).toHaveLength(2);
+  }, 20_000);
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2067,6 +2067,16 @@
       ]
     },
     {
+      "path": "tests/owned-claude-continuation-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "executable-fixture",
+        "git-cli",
+        "process-signal",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/owned-codex-resume-pinning-real-path.test.ts",
       "reasons": [
         "child-process",

--- a/tests/worker-mcp-injection-real-path.test.ts
+++ b/tests/worker-mcp-injection-real-path.test.ts
@@ -70,6 +70,8 @@ const controlledEnvKeys = [
   'O8_CRASH_SURVIVABLE_WORKERS',
   'O8_SKIP_PRELAUNCH_TYPECHECK',
   'O8_WORKER_SANDBOX',
+  'ANTHROPIC_API_KEY',
+  'CLAUDE_CODE_OAUTH_TOKEN',
 ] as const;
 
 function packet(packetId: string, branch: string): OrchestratorPacket {
@@ -168,6 +170,8 @@ describe.sequential('worker MCP injection real path', () => {
     process.env.O8_CRASH_SURVIVABLE_WORKERS = '1';
     process.env.O8_SKIP_PRELAUNCH_TYPECHECK = '1';
     delete process.env.O8_WORKER_SANDBOX;
+    process.env.ANTHROPIC_API_KEY = '';
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'synthetic-mcp-fixture';
 
     spawnMock.mockImplementation(() => ({
       pid: 424_242,
@@ -267,7 +271,7 @@ describe.sequential('worker MCP injection real path', () => {
       prompt: firstPrompt,
       actor: 'orchestrator',
     });
-    expect(firstLaunch.ok).toBe(true);
+    expect(firstLaunch.ok, firstLaunch.note).toBe(true);
     const firstArgs = spawnedArgs(firstCall);
     const configFlag = firstArgs.indexOf('--mcp-config');
     expect(configFlag).toBeGreaterThan(-1);
@@ -302,16 +306,21 @@ describe.sequential('worker MCP injection real path', () => {
       'utf8',
     )) as OwnedSessionRecord;
     const { claudeCodeOwnedAdapter } = await import('@/lib/claude-code/owned');
-    const { prepareOwnedWorkerMcpConfig } = await import(
-      '@/lib/runtimes/shared/owned-session/worker-mcp-config'
+    const { prepareOwnedLaunchArgs } = await import(
+      '@/lib/runtimes/shared/owned-session/launch-args'
     );
-    const replacement = await prepareOwnedWorkerMcpConfig({
+    const continued = await prepareOwnedLaunchArgs({
       adapter: claudeCodeOwnedAdapter,
-      session,
+      session: { ...session, threadId: 'f4561e47-70ac-4a72-9406-a340d3ea115e' },
       runId: 'replacement',
-      mode: 'launch',
+      prompt: 'Verify the attached tools again',
+      mode: 'resume',
       sandboxEnabled: false,
+      humanLabel: 'Owned Claude Code',
     });
+    const replacement = continued.workerMcp;
+    expect(continued.args[continued.args.indexOf('--mcp-config') + 1]).toBe(replacement.configPath);
+    expect(JSON.parse(continued.stdinPayload!).message.content).toBe('Verify the attached tools again');
     expect(existsSync(configPath)).toBe(false);
     expect(existsSync(staleConfigPath)).toBe(false);
     expect(replacement.configPath).toBe(path.join(


### PR DESCRIPTION
## Summary

Refs #2128. Keep the issue open until installed-provider acceptance passes.

- Resume owned Claude Code workers using the exact saved provider UUID. Preserve model, effort, carrier, credential isolation, worktree, and session identity.
- Send resumed prompts through stream-json stdin, regenerate packet MCP configuration, and preserve read-only restrictions.
- Wire owned runtime actions and startup-failure reporting. Discovered sessions stay watch-only, active turns reject overlap, and invalid or missing conversations never fall back to a new or latest conversation.
- Update the completion-race fixture to advance fake time until the real steer response settles. Combining the patches exposed its previously unadvanced startup-probe timer; no production check or assertion was removed.

## Verification

- Combined hermetic suite: 4,245 passed, 3 skipped.
- Combined resource-owning suite: 66/66 across seven files, with a per-file watchdog. The original clock-related failures were retained before correction.
- Existing steered-review-settlement suite: 10/10 in a separate bounded run.
- Final TypeScript, touched-file ESLint, rule check, test classification, and diff checks passed.
- The final main-based branch has the exact same Git tree as the locally verified combined candidate. Only the two continuation/test commits are above main; prior release history was preserved separately.

The owned-provider test uses an offline subprocess fixture. It verifies the production store, runtime actions, argv/stdin, archive recovery, overlap refusal, and process death on Stop. It is not an installed-provider acceptance run.

## Boundaries

No release, version bump, app restart, model default, or credential change. No visual change. The existing Stop path can record a signaled process exit as failed rather than interrupted; this patch does not claim to fix that adjacent status-classification issue.
