### PR TITLE
fix: preserve owned Stop outcomes and prepare 0.1.745

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "o8",
-  "version": "0.1.744",
+  "version": "0.1.745",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "o8",
-      "version": "0.1.744",
+      "version": "0.1.745",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o8",
-  "version": "0.1.744",
+  "version": "0.1.745",
   "description": "o8 — governance layer for autonomous engineering teams. Approvals, audit, organizational memory.",
   "license": "MIT",
   "productName": "o8",

--- a/release-notes/0.1.744.md
+++ b/release-notes/0.1.744.md
@@ -1,0 +1,3 @@
+- Finish writing large CLI replies before exit, including piped JSON output and slow readers.
+- Preserve the selected model and reasoning effort when continuing owned workers, including local-model sessions.
+- Restore branch merge-gate loading and limit the reviewed CLI shutdown exception to the exact approved wrapper.

--- a/release-notes/next.md
+++ b/release-notes/next.md
@@ -1,3 +1,3 @@
-- Finish writing large CLI replies before exit, including piped JSON output and slow readers.
-- Preserve the selected model and reasoning effort when continuing owned workers, including local-model sessions.
-- Restore branch merge-gate loading and limit the reviewed CLI shutdown exception to the exact approved wrapper.
+- Continue owned worker conversations using their saved session and runtime settings.
+- Keep late completion callbacks from settling a newer follow-up turn.
+- Record delivered operator Stops as interruptions while preserving failure reports for unrequested signal exits.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "o8"
-version = "0.1.744"
+version = "0.1.745"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "o8"
-version = "0.1.744"
+version = "0.1.745"
 description = "o8 — governance layer for autonomous engineering teams"
 authors = ["hurttlocker"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "o8",
-  "version": "0.1.744",
+  "version": "0.1.745",
   "identifier": "ai.o8.desktop",
   "build": {
     "frontendDist": "../out/frontend",

--- a/src/lib/runtime/interrupt-escalation.ts
+++ b/src/lib/runtime/interrupt-escalation.ts
@@ -5,6 +5,7 @@ import { isBridgeSessionAlive, signalBridgeTerminalSession } from '@/lib/runtime
 import { lookupOwnedActiveRunFresh } from '@/lib/runtimes/shared/owned-session-index';
 import { isPidAlive, pidCommandLine } from '@/lib/runtimes/shared/owned-session/helpers';
 import { getOwnedSessionLifecycle } from '@/lib/runtimes/shared/owned-session-lifecycle';
+import { withOwnedStopOutcome } from '@/lib/runtimes/shared/owned-session/stop-outcome';
 import {
   probeOwnedRunProcessClaim,
   resolveSpawnedProcessGroupId,
@@ -593,10 +594,10 @@ export async function escalateInterruptOwnedSurface(surfaceId: string): Promise<
     }
   }
 
-  return escalateInterrupt({
+  return withOwnedStopOutcome(surfaceId, activeRun, () => escalateInterrupt({
     pid: activeRun.pid,
     processGroupId: activeRun.processGroupId,
     tmuxSession: activeRun.tmuxSession,
     commandLabel,
-  });
+  }));
 }

--- a/src/lib/runtimes/shared/owned-session-index.ts
+++ b/src/lib/runtimes/shared/owned-session-index.ts
@@ -23,6 +23,7 @@ import { getDataDir } from '@/lib/data-dir-migration';
 import { listOwnedSessionLifecycles } from './owned-session-lifecycle';
 
 export interface OwnedActiveRun {
+  id?: string;
   pid?: number;
   processGroupId?: number;
   tmuxSession?: string;
@@ -121,6 +122,7 @@ async function buildRootIndex(root: string): Promise<RootIndex> {
     if (typeof parsed.surfaceId !== 'string') return;
     index.set(parsed.surfaceId, parsed.activeRun
       ? {
+          id: typeof parsed.activeRun.id === 'string' ? parsed.activeRun.id : undefined,
           pid: typeof parsed.activeRun.pid === 'number' ? parsed.activeRun.pid : undefined,
           processGroupId: typeof parsed.activeRun.processGroupId === 'number'
             ? parsed.activeRun.processGroupId

--- a/src/lib/runtimes/shared/owned-session/fleet.ts
+++ b/src/lib/runtimes/shared/owned-session/fleet.ts
@@ -81,8 +81,13 @@ export function createFleetComputer({
           const filePath = metadataPath(sessionDir);
           if (!(await pathExists(filePath))) return null;
           const session = await io.loadSession(sessionDir);
-          await runController.refreshSession(session);
-          return session;
+          return withSurfaceLock(session.surfaceId, async () => {
+            // Stop, resume or exit recording may have changed the run while
+            // this inventory read waited. Never write that stale snapshot back.
+            const current = await io.loadSession(sessionDir);
+            await runController.refreshSession(current);
+            return current;
+          });
         } catch {
           return null;
         }

--- a/src/lib/runtimes/shared/owned-session/run-controller.ts
+++ b/src/lib/runtimes/shared/owned-session/run-controller.ts
@@ -228,7 +228,7 @@ export function createOwnedRunController({
       const applyExit = (run: OwnedRunRecord): OwnedRunRecord => {
         if (run.id !== runId) return run;
         dirty = true;
-        const nextOutcome = run.outcome === 'interrupted'
+        const nextOutcome = run.outcome === 'interrupted' || run.interruptRequestedAt
           ? 'interrupted'
           : artifacts?.parsed.outcome === 'failed'
             ? 'failed'

--- a/src/lib/runtimes/shared/owned-session/stop-outcome.test.ts
+++ b/src/lib/runtimes/shared/owned-session/stop-outcome.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { chainOnKey } from '@/lib/util/keyed-promise-chain';
+import type { InterruptEscalationResult } from '@/lib/runtime/interrupt-escalation';
+import type { OwnedActiveRun } from '../owned-session-index';
+import type { OwnedSessionIo } from './session-io';
+import type { OwnedSessionRecord } from './types';
+import { registerOwnedStopHandler, withOwnedStopOutcome } from './stop-outcome';
+
+const surfaceId = 'stop-fixture:session';
+const expected: OwnedActiveRun = {
+  id: 'run-1', pid: 42, processGroupId: 42, processMarker: 'marker-1', tmuxSession: undefined,
+};
+const delivered: InterruptEscalationResult = {
+  attempted: true, confirmedDead: true, alreadyDead: false, note: 'Stopped',
+  steps: [{ signal: 'SIGINT', mechanism: 'SIGINT', sent: true, confirmedDead: true, aliveAfter: false }],
+};
+
+describe('owned Stop outcome transaction', () => {
+  let saved: OwnedSessionRecord;
+  let io: OwnedSessionIo;
+  let lock: <T>(key: string, operation: () => Promise<T>) => Promise<T>;
+  const invalidate = vi.fn();
+
+  beforeEach(() => {
+    const run = { ...expected, outcome: 'running' };
+    saved = { surfaceId, activeRun: run, recentRuns: [run, { id: 'prior', outcome: 'finished' }] } as OwnedSessionRecord;
+    io = {
+      findSession: vi.fn(async () => structuredClone(saved)),
+      saveSession: vi.fn(async (value) => { saved = structuredClone(value); }),
+    } as unknown as OwnedSessionIo;
+    const chains = new Map<string, Promise<unknown>>();
+    lock = (key, operation) => chainOnKey(chains, key, operation);
+    invalidate.mockReset();
+    registerOwnedStopHandler('stop-fixture:', io, lock, invalidate);
+  });
+
+  it('records delivered Stop before an exit writer or resume can acquire the store lock', async () => {
+    let release!: () => void;
+    const operation = vi.fn(async () => {
+      await new Promise<void>((resolve) => { release = resolve; });
+      return delivered;
+    });
+    const pending = withOwnedStopOutcome(surfaceId, expected, operation);
+    await vi.waitFor(() => expect(operation).toHaveBeenCalledOnce());
+    let observed: string | undefined;
+    const exitWriter = lock(surfaceId, async () => { observed = saved.recentRuns[0].outcome; });
+    expect(observed).toBeUndefined();
+    release();
+    expect(await pending).toBe(delivered);
+    await exitWriter;
+    expect(observed).toBe('interrupted');
+    expect(saved.activeRun?.interruptRequestedAt).toEqual(expect.any(String));
+    expect(saved.recentRuns[0].interruptRequestedAt).toBe(saved.activeRun?.interruptRequestedAt);
+    expect(saved.recentRuns[1]).toEqual({ id: 'prior', outcome: 'finished' });
+    expect(invalidate).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { id: 'successor' }, { id: undefined }, { pid: 43 }, { processGroupId: 43 },
+    { processMarker: 'successor-marker' }, { tmuxSession: 'successor-bridge' },
+  ])('refuses changed or missing exact-run evidence %j', async (change) => {
+    const operation = vi.fn(async () => delivered);
+    expect(await withOwnedStopOutcome(surfaceId, { ...expected, ...change }, operation))
+      .toMatchObject({ attempted: false, confirmedDead: false });
+    expect(operation).not.toHaveBeenCalled();
+    expect(io.saveSession).not.toHaveBeenCalled();
+  });
+
+  it.each(['absent', 'denied'] as const)('does not relabel an %s signal', async (kind) => {
+    const result = { ...delivered, alreadyDead: kind === 'absent',
+      steps: kind === 'absent' ? [] : [{ ...delivered.steps[0], sent: false, confirmedDead: false }] };
+    expect(await withOwnedStopOutcome(surfaceId, expected, async () => result)).toBe(result);
+    expect(io.saveSession).not.toHaveBeenCalled();
+    expect(saved.recentRuns[0].outcome).toBe('running');
+  });
+
+  it('preserves concurrent tail settlement while labeling only the signaled historical run', async () => {
+    await withOwnedStopOutcome(surfaceId, expected, async () => {
+      saved.activeRun = undefined;
+      saved.recentRuns[0].outcome = 'failed';
+      saved.recentRuns[0].finishedAt = '2026-09-10T00:00:00.000Z';
+      saved.latestSummary = 'Fresh tail';
+      return delivered;
+    });
+    expect(saved.activeRun).toBeUndefined();
+    expect(saved.latestSummary).toBe('Fresh tail');
+    expect(saved.recentRuns[0]).toMatchObject({ outcome: 'interrupted', finishedAt: '2026-09-10T00:00:00.000Z' });
+  });
+});

--- a/src/lib/runtimes/shared/owned-session/stop-outcome.ts
+++ b/src/lib/runtimes/shared/owned-session/stop-outcome.ts
@@ -1,0 +1,59 @@
+import type { InterruptEscalationResult } from '@/lib/runtime/interrupt-escalation';
+import type { OwnedActiveRun } from '../owned-session-index';
+import type { OwnedSessionIo } from './session-io';
+
+type StopOperation = () => Promise<InterruptEscalationResult>;
+type StopHandler = (
+  surfaceId: string, expected: OwnedActiveRun, operation: StopOperation,
+) => Promise<InterruptEscalationResult>;
+
+const handlers = new Map<string, StopHandler>();
+
+/** Use the store's lock so exit recording and resume cannot overtake Stop. */
+export function registerOwnedStopHandler(
+  prefix: string,
+  io: OwnedSessionIo,
+  lock: <T>(surfaceId: string, operation: () => Promise<T>) => Promise<T>,
+  invalidate: () => void,
+): void {
+  handlers.set(prefix, (surfaceId, expected, operation) => lock(surfaceId, async () => {
+    const session = await io.findSession(surfaceId);
+    const run = session?.activeRun;
+    if (!run || !expected.id || run.id !== expected.id
+      || run.pid !== expected.pid || run.tmuxSession !== expected.tmuxSession
+      || run.processMarker !== expected.processMarker
+      || run.processGroupId !== expected.processGroupId) {
+      return {
+        attempted: false, confirmedDead: false, alreadyDead: false, steps: [],
+        note: 'The owned run changed before Stop acquired its session lock; no process was signaled.',
+      };
+    }
+    const requestedAt = new Date().toISOString();
+    const result = await operation();
+    // An absent process or a denied signal is not an intentional interruption.
+    if (!result.steps.some((step) => step.sent)) return result;
+
+    // Tail refresh can settle a dead run while the ladder verifies its children.
+    // Reload that state and label only the exact run whose signal was delivered.
+    const current = await io.findSession(surfaceId);
+    if (!current) throw new Error('Stop signaled the owned run but its outcome record is unavailable.');
+    const stamp = <T extends { id: string; interruptRequestedAt?: string }>(entry: T) => (
+      entry.id === run.id
+        ? { ...entry, outcome: 'interrupted' as const, interruptRequestedAt: entry.interruptRequestedAt ?? requestedAt }
+        : entry
+    );
+    current.recentRuns = current.recentRuns.map(stamp);
+    if (current.activeRun) current.activeRun = stamp(current.activeRun);
+    await io.saveSession(current);
+    invalidate();
+    return result;
+  }));
+}
+
+export function withOwnedStopOutcome(
+  surfaceId: string, expected: OwnedActiveRun, operation: StopOperation,
+): Promise<InterruptEscalationResult> {
+  const handler = [...handlers.entries()].find(([prefix]) => surfaceId.startsWith(prefix))?.[1];
+  // ACP stores have a separate lifecycle and do not use shared run outcomes.
+  return handler ? handler(surfaceId, expected, operation) : operation();
+}

--- a/src/lib/runtimes/shared/owned-session/store.ts
+++ b/src/lib/runtimes/shared/owned-session/store.ts
@@ -35,6 +35,7 @@ import {
   validateWorkspace,
 } from './helpers';
 import { createOwnedSessionIo } from './session-io';
+import { registerOwnedStopHandler } from './stop-outcome';
 import { createOwnedRunController } from './run-controller';
 import { createReviewTailController } from './review-tail';
 import {
@@ -103,6 +104,7 @@ export function createOwnedSessionStore(
     surfacePrefix,
     invalidateFleetCache,
   });
+  registerOwnedStopHandler(surfacePrefix, io, withSurfaceLock, invalidateFleetCache);
   const runController = createOwnedRunController({
     adapter,
     runtimeId,
@@ -628,8 +630,8 @@ export function createOwnedSessionStore(
     launch,
     resume,
     interrupt,
-    getRuntimeTail: reviewTailController.getRuntimeTail,
-    getReviewPacket: reviewTailController.getReviewPacket,
+    getRuntimeTail: (surfaceId, limit) => withSurfaceLock(surfaceId, () => reviewTailController.getRuntimeTail(surfaceId, limit)),
+    getReviewPacket: (surfaceId) => withSurfaceLock(surfaceId, () => reviewTailController.getReviewPacket(surfaceId)),
     getFleetAdditions,
     sessionState: (surfaceId) => readOwnedSessionState(root, surfaceId, surfacePrefix),
     archiveSession: io.archiveSession,

--- a/tests/owned-claude-continuation-real-path.test.ts
+++ b/tests/owned-claude-continuation-real-path.test.ts
@@ -49,6 +49,8 @@ if (args.includes('--version')) {
   }) + '\\n');
   if (prompt === 'hold') {
     setInterval(() => {}, 1000);
+  } else if (prompt === 'external-signal') {
+    process.kill(process.pid, 'SIGINT');
   } else {
     if (!missing) writeFileSync(statePath, JSON.stringify(history));
     console.log(JSON.stringify({ type: 'result', subtype: missing ? 'error_during_execution' : 'success',
@@ -61,6 +63,7 @@ chmodSync(binary, 0o700);
 
 const {
   launchOwnedClaudeCodeSession, archiveOwnedClaudeCodeSession, getOwnedClaudeCodeRuntimeTail,
+  getOwnedClaudeCodeFleetAdditions,
 } = await import('@/lib/claude-code/owned');
 const { claudeCodeRuntime } = await import('@/lib/runtimes/claude-code');
 const { performRuntimeAction } = await import('@/lib/runtime/actions');
@@ -202,15 +205,24 @@ describe.skipIf(process.platform === 'win32')('owned Claude continuation through
         .toMatchObject({ ok: false, note: expect.stringContaining('active run') });
       expect(receipts(repoPath)).toHaveLength(2);
     } finally {
-      expect(await performRuntimeAction({ action: 'stop', surfaceId }))
-        .toMatchObject({ ok: true, status: 'completed', aborted: true });
+      const stop = performRuntimeAction({ action: 'stop', surfaceId });
+      await Promise.all([getOwnedClaudeCodeRuntimeTail(surfaceId), getOwnedClaudeCodeFleetAdditions({ fresh: true })]);
+      expect(await stop).toMatchObject({ ok: true, status: 'completed', aborted: true });
     }
-    // The existing escalation path reports a signaled exit as failed because
-    // it does not stamp the store's interrupt intent. Death is proved below;
-    // this test does not claim that separate status-classification gap is fixed.
-    const stopped = await settled(surfaceId, 2, 'failed');
+    const stopped = await settled(surfaceId, 2, 'interrupted');
+    expect(stopped.recentRuns[0].interruptRequestedAt).toEqual(expect.any(String));
+    expect(stopped.recentRuns[1].outcome).toBe('finished');
     expect(stopped.recentRuns[0].childExit?.signal).toBe('SIGINT');
+    expect((await getOwnedClaudeCodeRuntimeTail(surfaceId))?.surface.lifecycle?.lastOutcome).toBe('interrupted');
     expect(() => process.kill(activePid!, 0)).toThrow();
     expect(receipts(repoPath)).toHaveLength(2);
   }, 20_000);
+
+  it('keeps an unrequested signal exit failed instead of treating all signals as Stop', async () => {
+    const { surfaceId } = await launch('external-signal');
+    expect(await claudeCodeRuntime.resume(surfaceId, 'external-signal')).toMatchObject({ ok: true });
+    const failed = await settled(surfaceId, 2, 'failed');
+    expect(failed.recentRuns[0].childExit?.signal).toBe('SIGINT');
+    expect(failed.recentRuns[0].interruptRequestedAt).toBeUndefined();
+  });
 });

--- a/tests/sandbox-owned-stop-real-path.test.ts
+++ b/tests/sandbox-owned-stop-real-path.test.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { NextRequest } from 'next/server';
@@ -89,13 +89,15 @@ function bindWorker(pid: number, marker: string | undefined, processGroupId = pi
   setLaneStatus(lane.id, 'running', 'system', 'test_running');
   const sessionDir = join(dataDir, 'owned-claude-code', id);
   mkdirSync(sessionDir, { recursive: true });
+  const run = {
+    id: marker, pid, processGroupId, processMarker: marker,
+    commandIdentity, spawnState: 'spawned', sandboxed: commandIdentity === 'sandbox-exec',
+    outcome: 'running', startedAt: new Date().toISOString(),
+    stdoutPath: join(sessionDir, 'run.jsonl'), stderrPath: join(sessionDir, 'run.stderr.log'),
+  };
   writeFileSync(join(sessionDir, 'session.json'), JSON.stringify({
-    surfaceId, repoPath, cwd: repoPath, laneId: lane.id, packetId,
-    activeRun: {
-      id: marker, pid, processGroupId, processMarker: marker,
-      commandIdentity, spawnState: 'spawned', sandboxed: commandIdentity === 'sandbox-exec',
-      outcome: 'running', startedAt: new Date().toISOString(),
-    },
+    surfaceId, sessionDir, repoPath, cwd: repoPath, laneId: lane.id, packetId,
+    activeRun: run, recentRuns: [run],
   }));
   const packet: OrchestratorPacket = {
     id: packetId, referenceLabel: 'stop', title: 'sandbox stop', summary: 'stop identity',
@@ -114,7 +116,7 @@ function bindWorker(pid: number, marker: string | undefined, processGroupId = pi
     ...createEmptyOrchestratorMissionState(),
     missionId: 'mission-' + id, repoPath, packets: [packet],
   });
-  return { packetId, laneId: lane.id };
+  return { packetId, laneId: lane.id, sessionDir };
 }
 
 function stop(packetId: string) {
@@ -133,6 +135,8 @@ describe.skipIf(process.platform !== 'darwin')('sandboxed owned stop through the
     const response = await stop(target.packetId);
     expect(response.status).toBe(200);
     expect(isPidAlive(child.pid!)).toBe(false);
+    expect(JSON.parse(readFileSync(join(target.sessionDir, 'session.json'), 'utf8')).recentRuns[0])
+      .toMatchObject({ outcome: 'interrupted', interruptRequestedAt: expect.any(String) });
     closeDb();
     expect(readOrchestratorControlPlaneState().packets[0]).toMatchObject({
       operatorStopped: true, queueState: 'held', blockedReason: 'operator_stopped',

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -592,6 +592,12 @@
       ]
     },
     {
+      "path": "src/lib/runtimes/shared/owned-session/stop-outcome.test.ts",
+      "reasons": [
+        "process-signal"
+      ]
+    },
+    {
       "path": "src/lib/runtimes/shared/owned-session/store-child-exit.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
## Summary

- Bind the owned Stop signal ladder to its exact run under the session lock. Record an interruption only after a signal was delivered; leave denied signals and unrelated signal exits distinct.
- Serialize fleet and review metadata writers with Stop and continuation so a stale read cannot overwrite the outcome.
- Complete the sandbox Stop fixture's persisted session record and assert its saved outcome through the production route.
- Prepare 0.1.745 with synchronized manifests. Archive the published 0.1.744 notes and describe this release's continuation, completion-race and Stop corrections.

## Verification

- TypeScript, touched-file lint, changed-line rules, classification and diff checks passed.
- 4,245 hermetic tests passed, three existing skips.
- Focused integration checks passed for exact-run Stop locking, denied/stale evidence, normal signal failure, repeated/archived continuation, sandbox wrapper identity, child exit recording, and session launch.
- The public Stop route verifies the process is gone and persists an interrupted outcome. The continuation test polls tail and fleet during Stop.
- Direct review retained marker/group ownership guards and all negative signal cases. No authorization or global runtime defaults changed.

Related #2080 and #2128. Their source fixes are included from #2132 and #2133. Keep both issues open until the installed release completes useful worker continuation, managed-command admission, normal-exit and live-Stop acceptance. #2088 still requires the desktop-absent check. No UI layout change; these are lifecycle and persistence corrections.

The first sandbox test run exposed a partial fixture without run history. Its failure was retained, the fixture now has the production record shape, and the six-test file passes without weakening its ownership assertions.
