### PR TITLE
fix: keep completed workers reviewable and prepare 0.1.746

### DIFF
--- a/docs/operations/worker-continuation.md
+++ b/docs/operations/worker-continuation.md
@@ -71,9 +71,9 @@ Nothing converts a Stop into a fresh conversation on its own.
   died by signal."
 - The session record, its saved conversation id and its pins are not erased by the
   interruption itself, which is not a promise the conversation can be picked back up.
-- `o8 packet stop` confirmed-kills the worker, holds the packet (`operatorStopped` /
-  `blocked` / `operator_stopped`), then archives its lanes and prunes the worktree in
-  the background.
+- `o8 packet stop` holds the packet and confirms worker and managed-run death before
+  pausing the lane. The higher-level packet Stop route separately schedules lane
+  archive and worktree pruning after confirmation; CLI Stop does not promise cleanup.
 - While the hold stands, continuation is refused: "Packet cannot be steered while
   operator_stopped." A steer is not authority to undo an operator stop, an archive, or
   a proven release.

--- a/docs/operations/worker-continuation.md
+++ b/docs/operations/worker-continuation.md
@@ -1,0 +1,109 @@
+# Worker continuation runbook
+
+How a dispatched worker's conversation is continued, what survives, and what a refusal
+means. Mechanism-level; runtime names appear only as source paths. Sources:
+`src/lib/claude-code/owned.ts`, `src/lib/runtimes/claude-code.ts`,
+`src/lib/orchestrator/operator-mission-service/{steer,reset,rerun-with-feedback}.ts`,
+`src/lib/runtimes/shared/owned-session/{store,stop-outcome}.ts`, and the real-path
+regression `tests/owned-claude-continuation-real-path.test.ts`.
+
+A dispatched worker is an **owned session**: o8 spawned the process, so it holds a
+durable `session.json` with the provider's saved conversation id plus the model, effort,
+identity and runtime pins. Continuation resumes *that* saved conversation, never a new
+conversation aimed at the same worktree.
+
+## Exact saved-session continuation
+
+- Continuation addresses the saved conversation id from the session record. Never a
+  session name, never a path, never the runtime's most-recent-session fallback.
+  `resumeArgs` validates it against a strict UUID shape and throws before argv exists:
+  "The saved session ID is invalid. No continuation was started."
+- Resume argv carries `--resume <saved-id>` and never `--continue`. The regression
+  asserts turn 1 has no `--resume`, every later turn resumes the same id, and no turn
+  ever passes `--continue`.
+- An archived session is cold-restored and its saved id resumed in a fresh process. The
+  note says so ("no warm context beyond the thread") so cost expectations stay honest;
+  a failed run rolls the restore back.
+- Continuity is observable: three turns driven through the real runtime action, and the worker sees all three prompts in order, warm and after archiving.
+
+## What is preserved
+
+Per-turn callers re-supply none of this; the session record is the pin.
+
+| Preserved | Why it matters |
+|---|---|
+| Model and effort | A continuation cannot silently downgrade the assigned tier. |
+| Session identity | Same owned address; no second session is created. |
+| `runtimeConfig` (carrier, work mode, spend cap) | A read-only packet stays read-only on resume even when the caller knows nothing about work mode. |
+| Isolated config dir + credential env | Same private grant and scratch dir every turn, not a shared temp path. |
+| Working directory | Every turn runs in the packet's own worktree. |
+
+## Busy: an active turn refuses new input
+
+Overlapping input is refused, not queued or raced: an active run with a live pid
+("…still has an active run. Wait for it to settle or interrupt it first."), a run still
+in the `prepared` spawn state (held until marker reconciliation resolves it), an empty
+follow-up message, and any discovered surface, which is not owned and must be continued in
+its original client. None of these spawn a process; the regression proves it by
+asserting the invocation count does not grow.
+
+
+## Missing session or transcript fails explicitly
+
+There is no "start fresh instead" fallback on this path.
+
+- Unknown surface id: "Owned … session was not found."
+- No saved conversation id yet: resume unavailable, stated as such.
+- Saved id the provider no longer has: the turn is attempted and recorded **failed** with
+  the child's non-zero exit. The saved id stays; o8 opens no new conversation to cover it.
+- After a steer, `steer.ts` reads the stderr head of the run *this* steer started and
+  reports "Steer failed to start: …" instead of claiming success.
+
+## Stop is a deliberate interruption, not an automatic restart
+
+Nothing converts a Stop into a fresh conversation on its own.
+
+- Stop labels only the exact run whose signal landed (`stop-outcome.ts` matches run id,
+  pid, process marker and process group under the session lock). A run that changed
+  before Stop took the lock is not signaled at all.
+- An absent process or denied signal is not an intentional interruption, and an
+  **unrequested** signal exit stays `failed`. Stop is never inferred from "the process
+  died by signal."
+- The session record, its saved conversation id and its pins are not erased by the
+  interruption itself, which is not a promise the conversation can be picked back up.
+- `o8 packet stop` confirmed-kills the worker, holds the packet (`operatorStopped` /
+  `blocked` / `operator_stopped`), then archives its lanes and prunes the worktree in
+  the background.
+- While the hold stands, continuation is refused: "Packet cannot be steered while
+  operator_stopped." A steer is not authority to undo an operator stop, an archive, or
+  a proven release.
+- The only paths that clear the hold are the recovery verbs, and both null the packet's
+  lane binding instead of resuming its conversation (`reset.ts`, `rerun-with-feedback.ts`).
+  Reset returns the packet to draft and needs a fresh dispatch; rerun archives the stale
+  lane and launches a new worker. Reset clears the worktree, retry keeps it.
+- Recovery after a Stop is therefore an explicit, potentially destructive lifecycle
+  decision that starts a new worker turn. There is no unhold-and-continue command.
+
+## Operator commands
+
+Verified against `o8 packet --help`, `o8 --help`, and `cli/src`:
+
+- `o8 packet steer --message "<follow-up>"`: continue the warm session (layer-3 escalation).
+  Reports `already in progress (not steered twice)` rather than double-sending.
+- `o8 packet stop` (alias `o8 packet cancel`): interrupt and hold the packet.
+- `o8 packet log --follow`: lane events (`steered_packet`, `steer_failed`). `o8 packet
+  info`: packet metadata, status, bound runtime.
+- `o8 run -- <cmd>`: run a long command in a terminal the operator can watch.
+
+The MCP `steer_packet` tool and the CLI both route through
+`/api/orchestrator/steer-packet`, so lane resolution and the status flip run in the
+process that owns the live session pool.
+
+## Regression coverage
+
+`tests/owned-claude-continuation-real-path.test.ts` covers six behaviors through the real
+runtime action and real subprocesses with the provider offline: warm continuation, archived
+continuation, rejection of discovered/missing/invalid identities, missing-transcript
+failure, busy refusal with a verified Stop, and the unrequested-signal case. Companions:
+`sandbox-owned-stop-real-path.test.ts`, `completion-steer-race-real-path.test.ts`. Keep
+classification current with `node scripts/classify-tests.mjs --check`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "o8",
-  "version": "0.1.745",
+  "version": "0.1.746",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "o8",
-      "version": "0.1.745",
+      "version": "0.1.746",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o8",
-  "version": "0.1.745",
+  "version": "0.1.746",
   "description": "o8 — governance layer for autonomous engineering teams. Approvals, audit, organizational memory.",
   "license": "MIT",
   "productName": "o8",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "o8"
-version = "0.1.745"
+version = "0.1.746"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "o8"
-version = "0.1.745"
+version = "0.1.746"
 description = "o8 — governance layer for autonomous engineering teams"
 authors = ["hurttlocker"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "o8",
-  "version": "0.1.745",
+  "version": "0.1.746",
   "identifier": "ai.o8.desktop",
   "build": {
     "frontendDist": "../out/frontend",

--- a/src/app/api/orchestrator/headless-tick/route.ts
+++ b/src/app/api/orchestrator/headless-tick/route.ts
@@ -9,15 +9,17 @@ export async function POST(request: NextRequest) {
   const denied = requirePanelAuth(request);
   if (denied) return denied;
 
-  const body = await request.json().catch(() => ({})) as { releasePacketIds?: unknown };
-  const releasePacketIds = Array.isArray(body.releasePacketIds)
-    ? body.releasePacketIds
-      .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
-      .map((value) => value.trim())
-    : undefined;
+  const body: unknown = await request.json().catch(() => ({}));
+  if (body && typeof body === 'object' && 'releasePacketIds' in body) {
+    return NextResponse.json({
+      ok: false,
+      error: 'release_requires_merge_evidence',
+      message: 'A scheduler wake cannot release packets. Use the reviewed merge path.',
+    }, { status: 400, headers: { 'Cache-Control': 'no-store, max-age=0' } });
+  }
 
   try {
-    const result = await runHeadlessSprintTick({ releasePacketIds });
+    const result = await runHeadlessSprintTick();
     return NextResponse.json({
       ok: true,
       launched: result.launched,

--- a/src/lib/supervisor/agent-completion.ts
+++ b/src/lib/supervisor/agent-completion.ts
@@ -7,7 +7,7 @@ import { createCompletionTurnGuard, SupersededCompletionError } from './completi
 
 interface CompletionDependencies {
   enqueueAutoReview(laneId: string): Promise<unknown>;
-  triggerHeadlessSprintTick(packetIds?: string[]): Promise<unknown>;
+  triggerHeadlessSprintTick(): Promise<unknown>;
   queueReviewContinuation(lane: Lane): void;
   enqueueVerificationFailureInboxItem(input: {
     repoPath: string;
@@ -335,7 +335,8 @@ export async function handleAgentCompletion(
         void enqueueAutoReview(updated.id).catch((err) => {
           console.warn(`[supervisor] enqueueAutoReview kicked off but errored (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
         });
-        void triggerHeadlessSprintTick(packetId ? [packetId] : undefined).catch((err) => {
+        // Reviewable work is not a release. Only wake dependency scheduling.
+        void triggerHeadlessSprintTick().catch((err) => {
           console.warn(`[supervisor] triggerHeadlessSprintTick errored (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
         });
         queueReviewContinuation({ ...updated, packetId: packetId ?? updated.packetId });

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -468,10 +468,10 @@ async function fetchRuntimeTranscript(sessionKey: string, limit: number) {
   return payload.transcript ?? [];
 }
 
-async function triggerHeadlessSprintTick(releasePacketIds?: string[]) {
+async function triggerHeadlessSprintTick() {
   return fetchNextJson<{ ok: boolean }>('/api/orchestrator/headless-tick', {
     method: 'POST',
-    body: releasePacketIds && releasePacketIds.length > 0 ? { releasePacketIds } : {},
+    body: {},
     // A cold launch can spend up to three minutes in the required base
     // typecheck. The headless loop grants fresh launches a four-minute bound
     // while retaining the 30s wedge deadline for ordinary ticks, so keep this
@@ -841,7 +841,7 @@ async function forceCodexSelfReviewToReview(
   }, 'system');
   if (updated) {
     await enqueueAutoReview(updated.id);
-    await triggerHeadlessSprintTick(updated.packetId ? [updated.packetId] : undefined);
+    await triggerHeadlessSprintTick();
     queueReviewContinuation(updated);
   }
 

--- a/tests/completion-steer-race-real-path.test.ts
+++ b/tests/completion-steer-race-real-path.test.ts
@@ -26,6 +26,7 @@ vi.mock('@/lib/supervisor/completion-verification', () => ({
 }));
 vi.mock('@/lib/orchestrator/context-relay', () => ({ capturePacketCompletionContext: h.capture }));
 vi.mock('@/lib/runtime/transcript', () => ({ readRuntimeTranscript: h.transcript }));
+vi.mock('@/lib/lane/worktree-cleanup', () => ({ pruneRepoWorktrees: vi.fn(async () => []) }));
 
 const dataDir = mkdtempSync(join(tmpdir(), 'o8-completion-steer-race-'));
 process.env.CORTEX_IDE_DATA_DIR = dataDir;
@@ -42,6 +43,9 @@ const { getWatchedAgents, ingestAgentCompletionSignal, registerWatchedAgent,
   startSupervisorLoop, stopSupervisorLoop, unregisterWatchedAgent } = await import('@/lib/supervisor/agent-supervisor');
 const steerRoute = await import('@/app/api/orchestrator/steer-packet/route');
 const runsRoute = await import('@/app/api/panel/managed-runs/route');
+const headlessRoute = await import('@/app/api/orchestrator/headless-tick/route');
+const { readMissionRegistryEntry } = await import('@/lib/orchestrator/mission-registry');
+const { recordMission } = await import('@/lib/db/missions-store');
 
 const dependencies = {
   enqueueAutoReview: vi.fn(async () => {}),
@@ -118,6 +122,7 @@ function delayVerification() {
 beforeEach(() => {
   vi.useFakeTimers();
   vi.clearAllMocks();
+  dependencies.triggerHeadlessSprintTick.mockReset().mockResolvedValue(undefined);
   h.perform.mockReset();
   h.verify.mockReset().mockResolvedValue(verified);
   h.commit.mockReset().mockResolvedValue(false);
@@ -142,6 +147,69 @@ afterEach(() => {
 afterAll(() => { closeDb(); rmSync(dataDir, { recursive: true, force: true }); });
 
 describe('completion and steer overlap through production callbacks and routes', () => {
+  it.each(['current', 'registry'] as const)('keeps fully settled %s work reviewable across repeated continuation', async (location) => {
+    const { packet, lane, sessionKey } = fixture();
+    const missionId = `mission-${packet.id}`;
+    if (location === 'registry') {
+      recordMission({
+        id: missionId, repoPath: lane.repoPath, runtime: 'claude-code',
+        prompt: 'Verify repeated continuation', summary: 'Review without release',
+        constraints: '', packetMeta: [], totalWaves: 1,
+        missionState: readOrchestratorControlPlaneState(),
+      });
+      expect(readMissionRegistryEntry(missionId)?.mission.packets[0]?.id).toBe(packet.id);
+      writeOrchestratorControlPlaneState(createEmptyOrchestratorMissionState());
+    }
+    let tick: Promise<void> = Promise.resolve();
+    // Preserve the bridge's former argument mapping so an accidental release
+    // list reaches the real route rather than disappearing into a no-op stub.
+    dependencies.triggerHeadlessSprintTick.mockImplementation((releasePacketIds?: string[]) => {
+      tick = headlessRoute.POST(request('/api/orchestrator/headless-tick',
+        releasePacketIds ? { releasePacketIds } : {})).then(async (response) => {
+        expect(response.status, await response.clone().text()).toBe(200);
+      });
+      return tick;
+    });
+    for (let turn = 0; turn < 3; turn += 1) {
+      await handleAgentCompletion(sessionKey, 'completed', dependencies);
+      await tick;
+      closeDb();
+      const saved = location === 'current' ? readOrchestratorControlPlaneState()
+        : readMissionRegistryEntry(missionId, { includeArchived: true })?.mission;
+      expect(saved?.packets.find((p) => p.id === packet.id)).toMatchObject({ releaseState: 'pending' });
+      expect(getLane(lane.id)?.status).toBe('reviewing');
+      expect(dependencies.triggerHeadlessSprintTick).toHaveBeenLastCalledWith();
+      expect((await register(packet, `closed${turn}`)).status).toBe(409);
+      // A distinct operator mutation per turn, not an idempotent replay.
+      const response = steerRoute.POST(request('/api/orchestrator/steer-packet', {
+        packetId: packet.id, message: `Review correction ${turn}`, idempotencyKey: `repeat-${packet.id}-${turn}`,
+      }));
+      let settled = false;
+      void response.finally(() => { settled = true; });
+      await vi.waitFor(() => expect(settled).toBe(true), { timeout: 5_000 });
+      expect((await response).status).toBe(200);
+      expect((await register(packet, `active${turn}`)).status).toBe(200);
+      recordLaneEvent(lane.id, 'runtime_process_exit', 'system', { surfaceId: sessionKey, exitCode: 0 });
+    }
+    expect(h.perform).toHaveBeenCalledTimes(3);
+    await persistLanePacketHold(packet.id);
+    setLaneStatus(lane.id, 'paused', 'user', 'operator_stopped');
+    expect((await steer(packet.id)).status).toBe(409);
+    expect((await register(packet, 'stopped')).status).toBe(409);
+    expect(h.perform).toHaveBeenCalledTimes(3);
+  });
+
+  it('rejects raw release IDs at the scheduler route without changing review state', async () => {
+    const { packet, lane } = fixture();
+    const response = await headlessRoute.POST(request('/api/orchestrator/headless-tick', {
+      releasePacketIds: [packet.id],
+    }));
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: 'release_requires_merge_evidence' });
+    expect(readOrchestratorControlPlaneState().packets[0]?.releaseState).toBe('pending');
+    expect(getLane(lane.id)?.status).toBe('reviewing');
+  });
+
   it.each(['pass', 'fail', 'throw'] as const)('discards a delayed %s result while the next turn remains admitted', async (outcome) => {
     const { packet, lane, sessionKey } = fixture();
     const delayed = delayVerification();
@@ -307,5 +375,12 @@ describe('completion and steer overlap through production callbacks and routes',
     expect(callback).toContain("import('@/lib/supervisor/agent-completion')");
     expect(callback).toContain('handleAgentCompletion(surfaceId, outcome, {');
     expect(callback).not.toContain('setLaneStatus(');
+    const bridgeStart = source.indexOf('async function triggerHeadlessSprintTick(');
+    const bridge = source.slice(bridgeStart, source.indexOf('\nasync function ', bridgeStart + 1));
+    expect(bridge).toContain('triggerHeadlessSprintTick()');
+    expect(bridge).not.toContain('releasePacketIds');
+    const stallStart = source.indexOf("lastEventLabel: 'self_review_stall_forced'");
+    const stall = source.slice(stallStart, source.indexOf('resetSelfReviewStallGuard(surfaceId)', stallStart));
+    expect(stall).toContain('await triggerHeadlessSprintTick();');
   });
 });


### PR DESCRIPTION
## Summary

- Keep completed workers reviewable: both completion paths now wake scheduling without asserting a release.
- Reject raw release IDs at the scheduler HTTP endpoint; preserve internal merge release and Stop/archive guards.
- Add persisted current/registry mission regressions for repeated settled continuation and managed-command admission.
- Include the previously local continuation runbook, correcting the distinction between CLI Stop and higher-level cleanup.
- Synchronize manifests for 0.1.746.

## Verification

- 58 focused integration tests passed across completion/steer, managed admission, owned continuation, Stop, PR merge reconciliation, released-review reconstruction and real WebSocket idle coverage.
- 4,248 hermetic unit tests passed; three existing skips.
- TypeScript, touched ESLint, test classification, changed-source rules and whitespace checks passed.
- First-red evidence reproduced premature release before the production fix.

No visual proof: backend lifecycle change. Provider subprocess fixtures are offline; installed acceptance is a separate post-release gate. The forced-stall path is covered by a wiring assertion, not a live forced stall. No historical packet hold is cleared and no internal release receipt migration is included.

Related: #2135, #2080, #2128. These issues stay open until their remaining installed checks pass.
