### PR TITLE
fix: verify current owned worker before confirming stop

### DIFF
--- a/src/lib/lane/commands-stop.test.ts
+++ b/src/lib/lane/commands-stop.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createLane, getLaneEvents } from '@/lib/lane/registry';
 import { dispatch } from './commands';
+import { liveWorkerSessionLanes } from './worker-session-state';
 
 const h = vi.hoisted(() => ({
   kill: vi.fn(),
@@ -25,6 +26,16 @@ describe('lane stop command', () => {
     h.persistHold.mockResolvedValue(true);
     h.terminateManagedRuns.mockReset();
     h.terminateManagedRuns.mockResolvedValue({ targeted: 0, confirmed: 0, failures: [] });
+  });
+
+  it('checks a shared owned session only once when multiple lanes refer to it', () => {
+    const lane = createLane({
+      repoPath: process.cwd(), branch: 'test/stop-shared-session', runtime: 'codex',
+      sessionKey: 'codex-owned:shared',
+    });
+    expect(liveWorkerSessionLanes([
+      lane, { ...lane, id: lane.id + '-duplicate' }, { ...lane, sessionKey: null },
+    ])).toEqual([lane]);
   });
 
   it('does not mark paused when the worker survives stop escalation', async () => {
@@ -112,7 +123,7 @@ describe('lane stop command', () => {
     expect(result.lane).toMatchObject({ status: 'paused', lastEventLabel: 'operator_stopped' });
   });
 
-  it('uses a durable worker-exit receipt before settling packet-owned runs', async () => {
+  it('rechecks an owned session despite a durable exit receipt before settling packet-owned runs', async () => {
     const packetId = 'packet-stop-recorded-worker-exit';
     const lane = createLane({
       repoPath: process.cwd(),
@@ -134,10 +145,21 @@ describe('lane stop command', () => {
     });
     h.terminateManagedRuns.mockResolvedValueOnce({ targeted: 1, confirmed: 1, failures: [] });
 
+    h.kill.mockResolvedValueOnce([{
+      laneId: lane.id,
+      sessionKey: 'codex-owned:exited',
+      runtime: 'codex',
+      confirmed: true,
+      alreadyDead: true,
+      stages: [],
+      note: 'The current owned record has no active run.',
+    }]);
+
     const result = await dispatch({ verb: 'stop', laneId: lane.id, actor: 'user' });
 
     expect(result.ok).toBe(true);
-    expect(h.kill).not.toHaveBeenCalled();
+    expect(h.kill).toHaveBeenCalledWith([expect.objectContaining({ id: lane.id })]);
+    expect(h.kill.mock.invocationCallOrder[0]).toBeLessThan(h.terminateManagedRuns.mock.invocationCallOrder[0]);
     expect(h.terminateManagedRuns).toHaveBeenCalledWith(packetId);
     expect(getLaneEvents(lane.id)).toEqual(expect.arrayContaining([
       expect.objectContaining({

--- a/src/lib/lane/worker-session-state.ts
+++ b/src/lib/lane/worker-session-state.ts
@@ -1,5 +1,6 @@
 import { getLaneEvents } from '@/lib/lane/registry';
 import type { Lane, LaneEvent } from '@/lib/lane/types';
+import { ownedRoots } from '@/lib/runtimes/shared/owned-session-index';
 
 function eventMatchesWorkerSession(event: LaneEvent, lane: Lane): boolean {
   if (event.verb !== 'runtime_process_exit') return false;
@@ -31,15 +32,21 @@ export function hasRecordedCleanWorkerExit(lane: Lane): boolean {
 }
 
 /**
- * Return one target per worker session that has no durable exit receipt.
+ * Return one target per worker session that still needs death confirmation.
+ * Owned sessions can resume after a recorded exit. Always send them through
+ * the fresh saved-run lookup and identity-checked kill path, including settled
+ * sessions (already dead) and prepared runs (not yet safe to declare dead).
  * Review turns are tracked separately and never enter this worker kill set.
  */
 export function liveWorkerSessionLanes(lanes: Lane[]): Lane[] {
   const seen = new Set<string>();
   const live: Lane[] = [];
+  const roots = ownedRoots();
   for (const lane of lanes) {
     const sessionKey = lane.sessionKey?.trim();
-    if (!sessionKey || hasRecordedWorkerExit(lane)) continue;
+    if (!sessionKey) continue;
+    const owned = roots.some(({ marker }) => sessionKey.startsWith(marker));
+    if (!owned && hasRecordedWorkerExit(lane)) continue;
     const key = `${lane.runtime}\0${sessionKey}`;
     if (seen.has(key)) continue;
     seen.add(key);

--- a/src/lib/orchestrator/stop-packet.ts
+++ b/src/lib/orchestrator/stop-packet.ts
@@ -158,7 +158,7 @@ async function stopPacketInner(
   }
 
   const kills = await killLaneSessionsConfirmed(liveWorkerSessionLanes(lanes));
-  const reaped = kills.filter((kill) => kill.confirmed || kill.alreadyDead).length;
+  const reaped = kills.filter((kill) => kill.confirmed && !kill.alreadyDead).length;
   const survivors = kills.filter((kill) => !kill.confirmed && !kill.alreadyDead);
 
   if (survivors.length > 0) {

--- a/src/lib/runtime/interrupt-escalation.ts
+++ b/src/lib/runtime/interrupt-escalation.ts
@@ -543,6 +543,17 @@ export async function escalateInterruptOwnedSurface(surfaceId: string): Promise<
   }
 
   if (!activeRun.pid && !activeRun.tmuxSession) {
+    // The index returns {} only for a cleared activeRun. A prepared run has
+    // identity fields but no process yet; its pending spawn is not exit proof.
+    if (Object.keys(activeRun).length > 0) {
+      return {
+        attempted: false,
+        confirmedDead: false,
+        alreadyDead: false,
+        steps: [],
+        note: 'The owned run has no process identity yet; Stop remains held until its process state can be confirmed.',
+      };
+    }
     return {
       attempted: false,
       confirmedDead: true,

--- a/tests/sandbox-owned-stop-real-path.test.ts
+++ b/tests/sandbox-owned-stop-real-path.test.ts
@@ -23,8 +23,11 @@ writeFileSync(join(dataDir, 'ws-token'), token);
 process.env.O8_DATA_DIR = dataDir;
 process.env.CORTEX_IDE_DATA_DIR = dataDir;
 process.env.CORTEX_IDE_OWNED_CLAUDE_CODE_ROOT = join(dataDir, 'owned-claude-code');
+process.env.CORTEX_IDE_OWNED_CODEX_ROOT = join(dataDir, 'owned-codex');
 
 const { POST } = await import('@/app/api/orchestrator/stop-packet/route');
+const laneRoute = await import('@/app/api/lanes/route');
+const { recordLaneEvent } = await import('@/lib/lane/events');
 const { createLane, getLaneEvents, setLaneStatus } = await import('@/lib/lane/registry');
 const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
 const { readOrchestratorControlPlaneState, writeOrchestratorControlPlaneState } =
@@ -78,16 +81,19 @@ async function spawnWorker(marker: string) {
   return child;
 }
 
-function bindWorker(pid: number, marker: string | undefined, processGroupId = pid, commandIdentity = 'sandbox-exec') {
+function bindWorker(
+  pid: number, marker: string | undefined, processGroupId = pid,
+  commandIdentity = 'sandbox-exec', runtime: 'claude-code' | 'codex' = 'claude-code',
+) {
   const id = randomUUID();
-  const surfaceId = 'claude-code-owned:' + id;
+  const surfaceId = runtime + '-owned:' + id;
   const packetId = 'pkt-' + id;
   const lane = createLane({
-    repoPath, branch: 'inline/stop-' + id, runtime: 'claude-code',
+    repoPath, branch: 'inline/stop-' + id, runtime,
     packetId, sessionKey: surfaceId,
   });
   setLaneStatus(lane.id, 'running', 'system', 'test_running');
-  const sessionDir = join(dataDir, 'owned-claude-code', id);
+  const sessionDir = join(dataDir, 'owned-' + runtime, id);
   mkdirSync(sessionDir, { recursive: true });
   const run = {
     id: marker, pid, processGroupId, processMarker: marker,
@@ -101,14 +107,14 @@ function bindWorker(pid: number, marker: string | undefined, processGroupId = pi
   }));
   const packet: OrchestratorPacket = {
     id: packetId, referenceLabel: 'stop', title: 'sandbox stop', summary: 'stop identity',
-    workspaceTargetPath: repoPath, branchTarget: lane.branch, runtime: 'claude-code',
+    workspaceTargetPath: repoPath, branchTarget: lane.branch, runtime,
     dependencyLabels: [], dependencyPacketIds: [], queueState: 'queued',
     releaseState: 'pending', status: 'running', blockedReason: null,
     lastEventAt: null, lastEventLabel: null, archivedAt: null, review: null,
     orchestratorThreadId: null, operatorStopped: false,
     lane: {
       tileId: lane.id, tabId: lane.id, repoPath, worktreePath: null,
-      runtime: 'claude-code', sessionKey: surfaceId, laneId: lane.id,
+      runtime, sessionKey: surfaceId, laneId: lane.id,
       lastHeartbeatAt: null, lastEventAt: null, lastEventLabel: null,
     },
   };
@@ -128,6 +134,77 @@ function stop(packetId: string) {
 }
 
 describe.skipIf(process.platform !== 'darwin')('sandboxed owned stop through the production route', () => {
+  describe.each([
+    ['packet', 'claude-code'], ['lane', 'claude-code'],
+    ['packet', 'codex'], ['lane', 'codex'],
+  ] as const)('%s Stop after a completed %s turn', (entry, runtime) => {
+    async function stopTarget(target: ReturnType<typeof bindWorker>) {
+      if (entry === 'packet') return stop(target.packetId);
+      return laneRoute.POST(new NextRequest('http://localhost/api/lanes', {
+        method: 'POST',
+        headers: { host: 'localhost', authorization: 'Bearer ' + token, 'content-type': 'application/json' },
+        body: JSON.stringify({ verb: 'stop', laneId: target.laneId }),
+      }));
+    }
+
+    function recordPreviousExit(target: ReturnType<typeof bindWorker>) {
+      const saved = JSON.parse(readFileSync(join(target.sessionDir, 'session.json'), 'utf8'));
+      recordLaneEvent(target.laneId, 'runtime_process_exit', 'system', {
+        surfaceId: saved.surfaceId, runId: 'previous-completed-run',
+        classification: 'clean-exit', exitCode: 0, runtimeOutcome: 'finished',
+      });
+    }
+
+    it('kills the current resumed run despite an earlier same-session exit', async () => {
+      const marker = randomUUID();
+      const child = await spawnWorker(marker);
+      const target = bindWorker(child.pid!, marker, child.pid!, 'sandbox-exec', runtime);
+      recordPreviousExit(target);
+      // No admission event is required: saved process truth also covers the
+      // interval before resume admission is recorded and delayed exit events.
+      const response = await stopTarget(target);
+      expect(response.status).toBe(200);
+      expect(isPidAlive(child.pid!)).toBe(false);
+      expect(JSON.parse(readFileSync(join(target.sessionDir, 'session.json'), 'utf8')).recentRuns[0])
+        .toMatchObject({ id: marker, outcome: 'interrupted', interruptRequestedAt: expect.any(String) });
+      expect(getLaneEvents(target.laneId, 50).filter((event) => event.verb === 'kill_escalated'))
+        .toEqual([expect.objectContaining({ payload: expect.objectContaining({ pid: child.pid, confirmed: true }) })]);
+      expect(readOrchestratorControlPlaneState().packets[0].operatorStopped).toBe(true);
+    });
+
+    it('keeps identity-mismatched resumed workers held instead of claiming they exited', async () => {
+      const child = await spawnWorker(randomUUID());
+      const target = bindWorker(child.pid!, randomUUID(), child.pid!, 'sandbox-exec', runtime);
+      recordPreviousExit(target);
+      const response = await stopTarget(target);
+      const body = await response.json();
+      expect(entry === 'packet' ? response.status === 409 : body.ok === false).toBe(true);
+      expect(isPidAlive(child.pid!)).toBe(true);
+      expect(getLaneEvents(target.laneId, 50).filter((event) => event.verb === 'kill_escalated')).toEqual([]);
+      expect(readOrchestratorControlPlaneState().packets[0].operatorStopped).toBe(true);
+    });
+
+    it.each(['prepared', 'missing', 'settled'] as const)('handles a %s saved run without stale exit proof', async (state) => {
+      const target = bindWorker(0, randomUUID(), 0, 'sandbox-exec', runtime);
+      recordPreviousExit(target);
+      const sessionPath = join(target.sessionDir, 'session.json');
+      const saved = JSON.parse(readFileSync(sessionPath, 'utf8'));
+      if (state === 'prepared') saved.activeRun.spawnState = 'prepared';
+      if (state === 'settled') saved.activeRun = null;
+      if (state === 'missing') rmSync(sessionPath);
+      else writeFileSync(sessionPath, JSON.stringify(saved));
+      const response = await stopTarget(target);
+      const body = await response.json();
+      expect(body.ok).toBe(state === 'settled');
+      if (state === 'settled' && entry === 'packet') {
+        expect(body.result).toMatchObject({ interruptedSessions: 0, killConfirmed: true });
+      }
+      if (state !== 'settled' && entry === 'packet') expect(response.status).toBe(409);
+      expect(getLaneEvents(target.laneId, 50).filter((event) => event.verb === 'kill_escalated')).toEqual([]);
+      expect(readOrchestratorControlPlaneState().packets[0].operatorStopped).toBe(true);
+    });
+  });
+
   it('stops after wrapper exec and persists confirmed kill and operator hold', async () => {
     const marker = randomUUID();
     const child = await spawnWorker(marker);


### PR DESCRIPTION
## Summary

The installed continuation acceptance for #2128 exposed a Stop defect: a completed turn's `runtime_process_exit` event caused the shared target filter to omit a currently resumed worker in the same owned session. The command could return success after killing packet-managed commands while the provider process continued running.

- Always recheck owned sessions through the existing fresh saved-run lookup and identity-checked termination path, regardless of historical exit events.
- Keep prepared runs without a process identity unconfirmed instead of reporting them already dead. Keep truly cleared sessions idempotent.
- Do not count already-dead workers as newly interrupted.
- Cover both production Stop routes, both owned runtime records, stale exits, missing records, prepared runs, identity mismatch, settled sessions, and duplicate lane references.

The process identity checks, session lock, packet hold, managed-run termination order, and review/merge gates remain intact. No model, authentication, default-setting, dependency, or UI changes.

## Verification

- Before the fix: both real Stop route reproductions failed because the live provider survived a successful response.
- 4,248 hermetic unit tests passed; 3 skipped.
- 50 final focused Stop, concurrency, session-lock, and continuation tests passed.
- 17 managed-run termination/lifecycle/admission tests passed.
- Earlier adjacent discard, process-tree escalation, and saved Stop-outcome checks also passed (61 tests across six files, overlapping the final focused set).
- TypeScript, touched-file ESLint, changed-line rule check, test classification, and diff whitespace passed.

The Mac real-route tests use isolated persisted state and actual owned child processes. They do not call either provider service. No visual proof is needed for this backend change.

## Acceptance boundary

Part of #2128, not an automatic issue closure. Installed 0.1.746 completed two useful follow-ups per runtime, but exposed the live Stop failure. This patch still needs a new packaged Mac build and installed provider-plus-managed-child Stop acceptance. No release was published by this change. The temporary acceptance merge guard was removed only after all test workers were dead and held; operator settings and both acceptance/public main revisions were preserved.
