### PR TITLE
chore: prepare 0.1.747 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "o8",
-  "version": "0.1.746",
+  "version": "0.1.747",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "o8",
-      "version": "0.1.746",
+      "version": "0.1.747",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o8",
-  "version": "0.1.746",
+  "version": "0.1.747",
   "description": "o8 — governance layer for autonomous engineering teams. Approvals, audit, organizational memory.",
   "license": "MIT",
   "productName": "o8",

--- a/release-notes/0.1.746.md
+++ b/release-notes/0.1.746.md
@@ -1,0 +1,3 @@
+- Continue owned worker conversations using their saved session and runtime settings.
+- Keep late completion callbacks from settling a newer follow-up turn.
+- Record delivered operator Stops as interruptions while preserving failure reports for unrequested signal exits.

--- a/release-notes/next.md
+++ b/release-notes/next.md
@@ -1,3 +1,2 @@
-- Continue owned worker conversations using their saved session and runtime settings.
-- Keep late completion callbacks from settling a newer follow-up turn.
-- Record delivered operator Stops as interruptions while preserving failure reports for unrequested signal exits.
+- Verify the current worker process before confirming Stop, even when an earlier turn already finished.
+- Keep Stop unconfirmed while a new worker turn is preparing, and avoid counting an already-idle session as newly interrupted.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "o8"
-version = "0.1.746"
+version = "0.1.747"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "o8"
-version = "0.1.746"
+version = "0.1.747"
 description = "o8 — governance layer for autonomous engineering teams"
 authors = ["hurttlocker"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "o8",
-  "version": "0.1.746",
+  "version": "0.1.747",
   "identifier": "ai.o8.desktop",
   "build": {
     "frontendDist": "../out/frontend",


### PR DESCRIPTION
Synchronizes the package, lockfile and native manifests to 0.1.747. Archives the previous release notes and records the current-worker Stop fix from #2137. No dependency upgrades or additional behavior changes. Local TypeScript check and diff validation passed. Publication remains conditional on signed local candidate acceptance with resumed workers and their managed children; this PR does not close #2128.