### PR TITLE
fix: integrate execution carriers and Mac lifecycle hardening

### DIFF
--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -55,6 +55,10 @@ const RUN_LEADING_FLAGS = new Set([
 
 /** env vars that must NOT leak into the pane (confuse tmux / cwd). */
 const ENV_DENYLIST = new Set(['_', 'PWD', 'OLDPWD', 'SHLVL', 'TMUX', 'TMUX_PANE']);
+const CALLER_ROUTING_ENV = [
+  'O8_API_PORT', 'O8_WS_PORT', 'WS_PORT', 'O8_API_TOKEN', 'O8_WORKER_TOKEN',
+  'O8_WORKER_PACKET_ID', 'O8_SPECTATOR_TOKEN', 'O8_DATA_DIR', 'CORTEX_IDE_DATA_DIR',
+] as const;
 const LEGACY_SERVER_ONLY_STUB_NODE_OPTION = '--import=./scripts/register-server-only-stub.mjs';
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
@@ -72,7 +76,9 @@ export function managedRunEnvironmentLines(
   // Clear the dangerous Node preload first, then restore the caller's value if
   // one exists. The legacy repo-relative preload must become absolute before a
   // managed child changes directory.
-  const lines = ['unset NODE_OPTIONS'];
+  // Absence is meaningful too: an operator must not inherit a previous
+  // worker's credential or a development port from the terminal server.
+  const lines = ['unset NODE_OPTIONS', ...CALLER_ROUTING_ENV.map((key) => `unset ${key}`)];
   for (const [key, rawValue] of Object.entries(env)) {
     if (rawValue == null) continue;
     if (ENV_DENYLIST.has(key)) continue;

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ For contributors who are reading the code, extending o8, or maintaining a cross-
 | [Loopback API security](internals/loopback-api.md) | How socket identity, bearer tokens, origins, and public-route exceptions are enforced. |
 | [Connect contract](internals/connect-contract.md) | The desktop-to-relay wire protocol, ownership rules, and web-surface behavior. |
 | [Runtime adapter contract](internals/runtime-adapter-contract.md) | The supported runtime model and the recipe for adding another agent CLI. |
+| [Execution carriers](internals/execution-carriers.md) | Typed argv and credential wrappers that preserve the underlying runtime identity. |
 | [Local-model coverage](internals/local-model-coverage.md) | Which orchestrators, workers, and support surfaces can use local inference today. |
 | [Task-pool control plane](internals/agent-task-pool-control-plane.md) | How tasks project onto packets, lanes, locks, CLI commands, and MCP tools. |
 | [Fleet state model](internals/fleet-state-model.md) | The canonical status vocabulary for agents, packets, squads, and review. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ For contributors who are reading the code, extending o8, or maintaining a cross-
 | [Loopback API security](internals/loopback-api.md) | How socket identity, bearer tokens, origins, and public-route exceptions are enforced. |
 | [Connect contract](internals/connect-contract.md) | The desktop-to-relay wire protocol, ownership rules, and web-surface behavior. |
 | [Runtime adapter contract](internals/runtime-adapter-contract.md) | The supported runtime model and the recipe for adding another agent CLI. |
+| [Execution carriers](internals/execution-carriers.md) | Typed argv and credential wrappers that preserve the underlying runtime identity. |
 | [Local-model coverage](internals/local-model-coverage.md) | Which orchestrators, workers, and support surfaces can use local inference today. |
 | [Task-pool control plane](internals/agent-task-pool-control-plane.md) | How tasks project onto packets, lanes, locks, CLI commands, and MCP tools. |
 | [Interactive task artifacts](internals/task-artifacts.md) | How an agent hands the operator a sandboxed form whose exact payload returns to the session that asked. |

--- a/docs/internals/execution-carriers.md
+++ b/docs/internals/execution-carriers.md
@@ -1,0 +1,51 @@
+# Execution carriers
+
+An execution carrier is an allowlisted argv and credential wrapper around an existing worker runtime. It is not a runtime adapter. The runtime still owns capabilities, session identity, transcript parsing, cost attribution, review, resume, and cleanup.
+
+The first supported pair is Ori with Codex:
+
+```text
+runtime = codex, execution carrier = ori
+codex exec --json ...
+        becomes
+ori codex exec --json ...
+```
+
+o8 constructs that command as an executable plus an argument array. It does not accept an operator-supplied shell string. Ori's `codex` subcommand comes from the closed carrier catalog, and the existing Codex adapter still produces every argument after it. The concrete Ori contract and installation provenance are documented by [OpenRouter's announcement](https://openrouter.ai/blog/announcements/ori-harness/) and its [official install skill](https://github.com/OpenRouterTeam/skills/blob/main/skills/install-ori-harness/SKILL.md). Do not install the unrelated npm package named `ori`.
+
+On Windows, the selected carrier must resolve to a native `.exe` or `.com` executable. o8 refuses `.cmd` and `.bat` carrier shims because prompt argv would otherwise pass through `cmd.exe`. When `O8_CODEX_BIN` resolves Codex outside the inherited `PATH`, o8 prepends that executable's directory only for the carried child so Ori launches the same underlying CLI that passed preflight.
+
+## Configure the carrier
+
+Set the persisted operator default in `~/.o8/settings.toml`:
+
+```toml
+[models]
+worker_execution_carrier = "ori"
+```
+
+Use an empty string to restore direct runtime launch. The same setting is available through `o8_operator_defaults` as `workerExecutionCarrier`; pass `"ori"` to enable it or `""` to clear it. Mission creation snapshots the resolved value onto every packet, so a later settings change cannot silently reroute a retry or resume.
+
+Ori currently supports only Codex in o8. A mission that resolves any packet to an incompatible runtime is rejected before branch or worktree preparation.
+
+## Identity and authentication precedence
+
+| Concern | Owner when Ori is selected |
+| --- | --- |
+| Runtime and lane identity | Codex |
+| Capability evidence | Codex adapter |
+| Session key and resume protocol | Codex adapter |
+| Transcript and cost parser | Codex adapter |
+| Review and cleanup | Codex adapter |
+| Credential path used to reach the provider | Ori |
+| Launch display | `Codex via Ori` |
+
+Carrier authentication takes precedence for the carried launch, including create-mission and one-step spawn preflight. Preflight runs `ori auth` with all output discarded and records only its boolean result, `authSource: execution-carrier`, binary identities, and resolution sources; it never stores a token, secret, or credential value. Selecting a carrier disables native-runtime auth gating for that launch, but it does not make the underlying CLI optional: both `ori` and `codex` must resolve. A macOS sandboxed worker receives read-only access to Ori's `~/.ori` state; the carrier credential tree is not writable.
+
+A missing Ori binary is a `missing-carrier` failure with `O8_ORI_BIN` guidance. A missing Codex binary is a separate `missing-runtime` failure with `O8_CODEX_BIN` guidance. Neither case falls back to an unwrapped launch.
+
+## Process ownership
+
+The spawned root command is Ori, so the durable run records the resolved Ori executable path as its command identity, even when `sandbox-exec` wraps it. The Ori child inherits the owned-run marker and belongs to the same detached process tree or process group. Interrupt and orphan cleanup validate the exact wrapper path as an argv token, then stop the whole tree. All operator-facing lifecycle and review records continue to attribute that tree to Codex.
+
+This design is the bounded follow-up to [issue #2034](https://github.com/hurttlocker/o8/issues/2034). It does not change the Copilot CLI or Crush runtime adapters landed there.

--- a/docs/internals/execution-carriers.md
+++ b/docs/internals/execution-carriers.md
@@ -1,0 +1,51 @@
+# Execution carriers
+
+An execution carrier is an allowlisted argv and credential wrapper around an existing worker runtime. It is not a runtime adapter. The runtime still owns capabilities, session identity, transcript parsing, cost attribution, review, resume, and cleanup.
+
+The first supported pair is Ori with Codex:
+
+```text
+runtime = codex, execution carrier = ori
+codex exec --json ...
+        becomes
+ori codex exec --json ...
+```
+
+o8 constructs that command as an executable plus an argument array. It does not accept an operator-supplied shell string. Ori's `codex` subcommand comes from the closed carrier catalog, and the existing Codex adapter still produces every argument after it. The concrete Ori contract and installation provenance are documented by [OpenRouter's announcement](https://openrouter.ai/blog/announcements/ori-harness/) and its [official install skill](https://github.com/OpenRouterTeam/skills/blob/main/skills/install-ori-harness/SKILL.md). Do not install the unrelated npm package named `ori`.
+
+On Windows, the selected carrier must resolve to a native `.exe` or `.com` executable. o8 refuses `.cmd` and `.bat` carrier shims because prompt argv would otherwise pass through `cmd.exe`. When `O8_CODEX_BIN` resolves Codex outside the inherited `PATH`, o8 prepends that executable's directory only for the carried child. Carrier mode requires an absolute runtime path with the canonical `codex` executable name (or a supported Windows executable suffix). Renamed wrappers are refused as `runtime-binary-unpinnable` before workspace preparation, because the carrier could otherwise select a different `codex` from PATH. Direct mode continues to support custom executable names.
+
+## Configure the carrier
+
+Set the persisted operator default in `~/.o8/settings.toml`:
+
+```toml
+[models]
+worker_execution_carrier = "ori"
+```
+
+Use an empty string to restore direct runtime launch. The same setting is available through `o8_operator_defaults` as `workerExecutionCarrier`; pass `"ori"` to enable it or `""` to clear it. Mission creation snapshots the resolved value onto every packet, so a later settings change cannot silently reroute a retry or resume.
+
+Ori currently supports only Codex in o8. A mission that resolves any packet to an incompatible runtime is rejected before branch or worktree preparation.
+
+## Identity and authentication precedence
+
+| Concern | Owner when Ori is selected |
+| --- | --- |
+| Runtime and lane identity | Codex |
+| Capability evidence | Codex adapter |
+| Session key and resume protocol | Codex adapter |
+| Transcript and cost parser | Codex adapter |
+| Review and cleanup | Codex adapter |
+| Credential path used to reach the provider | Ori |
+| Launch display | `Codex via Ori` |
+
+Carrier authentication takes precedence for the carried launch, including create-mission and one-step spawn preflight. Preflight runs `ori auth` with all output discarded and records only its boolean result, `authSource: execution-carrier`, binary identities, and resolution sources; it never stores a token, secret, or credential value. Selecting a carrier disables native-runtime auth gating for that launch, but it does not make the underlying CLI optional: both `ori` and `codex` must resolve. A macOS sandboxed worker receives read-only access to Ori's `~/.ori` state; the carrier credential tree is not writable.
+
+A missing Ori binary is a `missing-carrier` failure with `O8_ORI_BIN` guidance. A missing Codex binary is a separate `missing-runtime` failure with `O8_CODEX_BIN` guidance. Neither case falls back to an unwrapped launch.
+
+## Process ownership
+
+The spawned root command is Ori, so the durable run records the resolved Ori executable path as its command identity, even when `sandbox-exec` wraps it. The Ori child inherits the owned-run marker and belongs to the same detached process tree or process group. On macOS and Linux, interrupt and orphan cleanup require the live process marker and recorded process group, including when a wrapper has executed another binary. Unavailable or mismatched proof holds the run without signaling it or claiming an interruption. The Windows command check accepts only the executable position, not a later argument mentioning the path. All operator-facing lifecycle and review records continue to attribute that tree to Codex.
+
+This design is the bounded follow-up to [issue #2034](https://github.com/hurttlocker/o8/issues/2034). It does not change the Copilot CLI or Crush runtime adapters landed there.

--- a/scripts/lib/release-build-cache.mjs
+++ b/scripts/lib/release-build-cache.mjs
@@ -119,6 +119,12 @@ function sha256Text(value) {
   return createHash('sha256').update(value).digest('hex');
 }
 
+function nativeCheckoutIdentity(root) {
+  // Native build scripts retain absolute permission/output paths. Do not
+  // expose the path in receipts or mistake a relocated cache for reusable work.
+  return sha256Text(stableJson({ path: resolve(root), realpath: realpathSync(root) }));
+}
+
 async function sha256File(path) {
   const hash = createHash('sha256');
   for await (const chunk of createReadStream(path)) hash.update(chunk);
@@ -415,6 +421,12 @@ async function verifyCacheEntry(root, identity, manifestPath) {
     || stableJson(manifest.excludes) !== stableJson(expected.excludes)) {
     return { valid: false, reason: 'target_contract_mismatch' };
   }
+  if (identity.phase === 'native') {
+    if (!manifest.nativeCheckoutSha256) return { valid: false, reason: 'native_checkout_unverified' };
+    if (manifest.nativeCheckoutSha256 !== nativeCheckoutIdentity(root)) {
+      return { valid: false, reason: 'native_checkout_mismatch' };
+    }
+  }
   const archivePath = join(dirname(manifestPath), basename(manifest.archive.name));
   if (!existsSync(archivePath)) return { valid: false, reason: 'archive_missing' };
   const size = statSync(archivePath).size;
@@ -681,6 +693,7 @@ export async function captureReleaseBuildCache(root, phase, options = {}) {
       sourceSha256: identity.sourceSha256,
       source: identity.source,
       compatibility: identity.compatibility,
+      ...(phase === 'native' ? { nativeCheckoutSha256: nativeCheckoutIdentity(root) } : {}),
       targets: config.targets,
       excludes: config.excludes,
       buildDurationMs: options.buildDurationMs ?? null,

--- a/src/app/api/orchestrator/create-mission/route.ts
+++ b/src/app/api/orchestrator/create-mission/route.ts
@@ -20,6 +20,10 @@ import {
   resolveRuntimePreset,
 } from '@/lib/orchestrator/runtime-capabilities';
 import { assertRuntimeDispatchable, DispatchPreflightError } from '@/lib/runtimes/shared/auth-detect';
+import {
+  assertExecutionCarrierDispatchable,
+  ExecutionCarrierPreflightError,
+} from '@/lib/runtimes/shared/execution-carrier-preflight';
 import { ControlPlaneLockTimeoutError } from '@/lib/orchestrator/control-plane';
 import { resolveRequestPrincipalContext } from '@/lib/auth/principal';
 import type { PacketDispatcherAttribution } from '@/lib/orchestrator/types';
@@ -262,13 +266,18 @@ export async function POST(request: NextRequest) {
     // stored worker profile: a mission pinned to openrouter / codex-subscription never
     // touches the native CLI login, so a logged-out native CLI must not refuse it.
     const preflightCarrier = { claudeCodeCarrier };
-    await assertRuntimeDispatchable(
-      workerRouting.selectedRuntime, workerRouting.selectedModel, repoPath, preflightCarrier,
-    );
-    for (const issueRouting of issueRoutings) {
+    const preflightRuntime = async (routing: typeof workerRouting) => {
+      if (defaults.workerExecutionCarrier) {
+        await assertExecutionCarrierDispatchable(routing.selectedRuntime, defaults.workerExecutionCarrier);
+        return;
+      }
       await assertRuntimeDispatchable(
-        issueRouting.selectedRuntime, issueRouting.selectedModel, repoPath, preflightCarrier,
+        routing.selectedRuntime, routing.selectedModel, repoPath, preflightCarrier,
       );
+    };
+    await preflightRuntime(workerRouting);
+    for (const issueRouting of issueRoutings) {
+      await preflightRuntime(issueRouting);
     }
   } catch (error) {
     if (error instanceof DispatchPreflightError) {
@@ -278,6 +287,12 @@ export async function POST(request: NextRequest) {
         installed: error.status.installed,
         authenticated: error.status.authenticated,
         unavailableReason: error.status.unavailableReason,
+      });
+    }
+    if (error instanceof ExecutionCarrierPreflightError) {
+      return operatorError(error.failure, error.message, 400, {
+        runtime: workerRouting.selectedRuntime,
+        executionCarrier: defaults.workerExecutionCarrier,
       });
     }
     const message = error instanceof Error ? error.message : 'Runtime readiness check failed.';

--- a/src/app/api/orchestrator/spawn-prompt/route.ts
+++ b/src/app/api/orchestrator/spawn-prompt/route.ts
@@ -15,6 +15,7 @@ import {
   isDispatchableRuntime,
 } from '@/lib/orchestrator/runtime-capabilities';
 import { assertRuntimeDispatchable, DispatchPreflightError } from '@/lib/runtimes/shared/auth-detect';
+import { assertExecutionCarrierDispatchable, ExecutionCarrierPreflightError } from '@/lib/runtimes/shared/execution-carrier-preflight';
 import { findMissionByCreationMutationId } from '@/lib/orchestrator/create-mission-receipt';
 import {
   bindIdempotencyClientMutation,
@@ -100,7 +101,11 @@ export async function POST(request: NextRequest) {
     model: workerRouting.selectedModel,
   });
   try {
-    await assertRuntimeDispatchable(workerRouting.selectedRuntime, workerRouting.selectedModel, repoPath);
+    if (defaults.workerExecutionCarrier) {
+      await assertExecutionCarrierDispatchable(workerRouting.selectedRuntime, defaults.workerExecutionCarrier);
+    } else {
+      await assertRuntimeDispatchable(workerRouting.selectedRuntime, workerRouting.selectedModel, repoPath);
+    }
   } catch (error) {
     if (error instanceof DispatchPreflightError) {
       return operatorError(error.code, `${error.status.detail} ${error.status.fix}`, 400, {
@@ -109,6 +114,12 @@ export async function POST(request: NextRequest) {
         installed: error.status.installed,
         authenticated: error.status.authenticated,
         unavailableReason: error.status.unavailableReason,
+      });
+    }
+    if (error instanceof ExecutionCarrierPreflightError) {
+      return operatorError(error.failure, error.message, 400, {
+        runtime: workerRouting.selectedRuntime,
+        executionCarrier: defaults.workerExecutionCarrier,
       });
     }
     const message = error instanceof Error ? error.message : 'Runtime readiness check failed.';

--- a/src/app/api/panel/operator-defaults/route.ts
+++ b/src/app/api/panel/operator-defaults/route.ts
@@ -29,6 +29,7 @@ import {
 } from '@/lib/operator/broadcast-commentary-defaults';
 import { isDispatchRuntime } from '@/lib/operator/defaults-env';
 import { isWorkerStartMode } from '@/lib/operator/worker-start-mode';
+import { isExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 import { projectAgentRoleRoutes } from '@/lib/operator/role-routing';
 import { listRoleRoutingReceipts } from '@/lib/operator/role-routing-ledger';
 import {
@@ -310,6 +311,13 @@ function normalizeUpdate(body: Record<string, unknown>): Partial<OperatorDefault
       throw new Error('defaultDispatchRuntime must name a dispatchable runtime.');
     }
     update.defaultDispatchRuntime = body.defaultDispatchRuntime;
+  }
+
+  if (body.workerExecutionCarrier !== undefined) {
+    if (body.workerExecutionCarrier !== null && !isExecutionCarrierId(body.workerExecutionCarrier)) {
+      throw new Error('workerExecutionCarrier must be "ori" or null.');
+    }
+    update.workerExecutionCarrier = body.workerExecutionCarrier;
   }
 
   if (body.workerStartMode !== undefined) {

--- a/src/app/api/panel/operator-defaults/route.ts
+++ b/src/app/api/panel/operator-defaults/route.ts
@@ -29,6 +29,7 @@ import {
 } from '@/lib/operator/broadcast-commentary-defaults';
 import { isDispatchRuntime } from '@/lib/operator/defaults-env';
 import { isWorkerStartMode } from '@/lib/operator/worker-start-mode';
+import { isExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 import { projectAgentRoleRoutes } from '@/lib/operator/role-routing';
 import { listRoleRoutingReceipts } from '@/lib/operator/role-routing-ledger';
 import {
@@ -319,6 +320,13 @@ function normalizeUpdate(body: Record<string, unknown>): Partial<OperatorDefault
       throw new Error('defaultDispatchRuntime must name a dispatchable runtime.');
     }
     update.defaultDispatchRuntime = body.defaultDispatchRuntime;
+  }
+
+  if (body.workerExecutionCarrier !== undefined) {
+    if (body.workerExecutionCarrier !== null && !isExecutionCarrierId(body.workerExecutionCarrier)) {
+      throw new Error('workerExecutionCarrier must be "ori" or null.');
+    }
+    update.workerExecutionCarrier = body.workerExecutionCarrier;
   }
 
   if (body.workerStartMode !== undefined) {

--- a/src/components/desktop/settings/OperatorDefaultsTab.tsx
+++ b/src/components/desktop/settings/OperatorDefaultsTab.tsx
@@ -53,6 +53,11 @@ const PARALLEL_CAP_PRESETS: Array<{ key: string; label: string; value: number }>
 ];
 
 const DEFAULT_WORKER_RUNTIME_OPTIONS = DISPATCH_RUNTIME_OPTIONS;
+type ExecutionCarrierSelection = 'direct' | 'ori';
+const EXECUTION_CARRIER_OPTIONS: Array<{ value: ExecutionCarrierSelection; label: string; detail: string }> = [
+  { value: 'direct', label: 'Direct', detail: 'Launch the selected runtime CLI directly.' },
+  { value: 'ori', label: 'Ori', detail: 'Use Ori credentials and routing while Codex keeps session ownership.' },
+];
 
 type CliHouseStatus = NonNullable<OperatorDefaultsResponse['cliAuth']>['statuses']['codex'];
 
@@ -317,6 +322,9 @@ export function OperatorDefaultsTab() {
     }
     return 'Codex is the default worker — pick any available runtime to override';
   })();
+  const carrierCompatibilityReason = values.defaultDispatchRuntime === 'codex'
+    ? null
+    : 'Ori is available when the effective default worker is Codex.';
   const profileHint = cliAuth?.suggestedSubscriptionProfile.profile
     && cliAuth.suggestedSubscriptionProfile.profile !== activeProfile
     ? cliAuth.suggestedSubscriptionProfile
@@ -637,6 +645,24 @@ export function OperatorDefaultsTab() {
               />
             }
             disabled={Boolean(profileOverrideReason) || envLocked('defaultDispatchRuntime') || busyField === 'defaultDispatchRuntime'}
+            divider
+          />
+          <SettingsRow
+            icon={<RocketIcon />}
+            label="Execution carrier"
+            subtitle={carrierCompatibilityReason ?? 'Optional typed argv and credential wrapper. The runtime still owns sessions, transcripts, costs, and review.'}
+            accessory={
+              <PickerMenu<ExecutionCarrierSelection>
+                value={values.workerExecutionCarrier ?? 'direct'}
+                options={carrierCompatibilityReason ? EXECUTION_CARRIER_OPTIONS.slice(0, 1) : EXECUTION_CARRIER_OPTIONS}
+                onChange={(next) => { updateField('workerExecutionCarrier', next === 'direct' ? null : next); }}
+                disabled={busyField === 'workerExecutionCarrier'}
+                minWidth={150}
+                open={openDispatchPicker === 'execution-carrier'}
+                onOpenChange={(open) => setOpenDispatchPicker((current) => resolvePickerGroupOpen(current, 'execution-carrier', open))}
+              />
+            }
+            disabled={busyField === 'workerExecutionCarrier'}
             divider
           />
           <SettingsRow

--- a/src/components/desktop/settings/dispatch-shared.tsx
+++ b/src/components/desktop/settings/dispatch-shared.tsx
@@ -82,6 +82,7 @@ export interface OperatorDefaults {
   opencodeOrchestratorModel: string | null;
   opencodeWorkerModel: string | null;
   defaultDispatchRuntime: DispatchRuntime;
+  workerExecutionCarrier: 'ori' | null;
   workerRuntimes: DispatchRuntime[];
   codexWorkerEffort: ThinkingEffort;
   claudeWorkerEffort: ThinkingEffort;

--- a/src/lib/codex/owned.ts
+++ b/src/lib/codex/owned.ts
@@ -51,10 +51,9 @@ import { getDataDir } from '@/lib/data-dir-migration';
 import { codexSandboxLaunchArgs, codexSandboxResumeArgs } from '@/lib/codex/read-only-args';
 import type { WorkerWorkMode } from '@/lib/orchestrator/types';
 import { isReadOnlyRuntimeConfig, workModeRuntimeConfig } from '@/lib/runtimes/shared/owned-session/work-mode';
-
+import { executionCarrierRuntimeConfig, type ExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 // Re-export the fleet additions shape under its original Codex name.
 export type { OwnedCodexFleetAdditions } from '@/lib/runtimes/shared/owned-session';
-
 // ── Codex-specific types (preserved signatures) ──────────────────────────────
 
 export type OwnedCodexLaunchRequest = {
@@ -67,6 +66,7 @@ export type OwnedCodexLaunchRequest = {
   packetId?: string;
   /** Durable packet work mode; 'read-only' hardens argv and the OS sandbox. */
   workMode?: WorkerWorkMode;
+  executionCarrier?: ExecutionCarrierId;
 };
 
 export type OwnedCodexLaunchResponse = {
@@ -77,7 +77,6 @@ export type OwnedCodexLaunchResponse = {
 };
 
 type OwnedReviewDisposition = 'watching' | 'resolved';
-
 // ── Codex JSONL helpers ──────────────────────────────────────────────────────
 
 function safeObject(value: unknown): Record<string, unknown> | null {
@@ -85,7 +84,6 @@ function safeObject(value: unknown): Record<string, unknown> | null {
     ? value as Record<string, unknown>
     : null;
 }
-
 function parseJsonObject(value: unknown): Record<string, unknown> | null {
   if (typeof value === 'string') {
     try {
@@ -96,7 +94,6 @@ function parseJsonObject(value: unknown): Record<string, unknown> | null {
   }
   return safeObject(value);
 }
-
 function readStringField(source: Record<string, unknown> | null, ...keys: string[]) {
   if (!source) return undefined;
   for (const key of keys) {
@@ -751,7 +748,10 @@ export async function launchOwnedCodexSession(
     ...request,
     // Pinned like the model/carrier pins, so retry/resume/rerun of a read-only
     // packet stays read-only even if the caller omits the mode.
-    runtimeConfig: workModeRuntimeConfig(request.workMode),
+    runtimeConfig: {
+      ...workModeRuntimeConfig(request.workMode),
+      ...executionCarrierRuntimeConfig(request.executionCarrier),
+    },
   });
   return {
     ok: result.ok,

--- a/src/lib/codex/owned.ts
+++ b/src/lib/codex/owned.ts
@@ -46,10 +46,9 @@ import { getDataDir } from '@/lib/data-dir-migration';
 import { codexSandboxLaunchArgs, codexSandboxResumeArgs } from '@/lib/codex/read-only-args';
 import type { WorkerWorkMode } from '@/lib/orchestrator/types';
 import { isReadOnlyRuntimeConfig, workModeRuntimeConfig } from '@/lib/runtimes/shared/owned-session/work-mode';
-
+import { executionCarrierRuntimeConfig, type ExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 // Re-export the fleet additions shape under its original Codex name.
 export type { OwnedCodexFleetAdditions } from '@/lib/runtimes/shared/owned-session';
-
 // ── Codex-specific types (preserved signatures) ──────────────────────────────
 
 export type OwnedCodexLaunchRequest = {
@@ -62,6 +61,7 @@ export type OwnedCodexLaunchRequest = {
   packetId?: string;
   /** Durable packet work mode; 'read-only' hardens argv and the OS sandbox. */
   workMode?: WorkerWorkMode;
+  executionCarrier?: ExecutionCarrierId;
 };
 
 export type OwnedCodexLaunchResponse = {
@@ -72,7 +72,6 @@ export type OwnedCodexLaunchResponse = {
 };
 
 type OwnedReviewDisposition = 'watching' | 'resolved';
-
 // ── Codex JSONL helpers ──────────────────────────────────────────────────────
 
 function safeObject(value: unknown): Record<string, unknown> | null {
@@ -80,7 +79,6 @@ function safeObject(value: unknown): Record<string, unknown> | null {
     ? value as Record<string, unknown>
     : null;
 }
-
 function parseJsonObject(value: unknown): Record<string, unknown> | null {
   if (typeof value === 'string') {
     try {
@@ -91,7 +89,6 @@ function parseJsonObject(value: unknown): Record<string, unknown> | null {
   }
   return safeObject(value);
 }
-
 function readStringField(source: Record<string, unknown> | null, ...keys: string[]) {
   if (!source) return undefined;
   for (const key of keys) {
@@ -749,7 +746,10 @@ export async function launchOwnedCodexSession(
     ...request,
     // Pinned like the model/carrier pins, so retry/resume/rerun of a read-only
     // packet stays read-only even if the caller omits the mode.
-    runtimeConfig: workModeRuntimeConfig(request.workMode),
+    runtimeConfig: {
+      ...workModeRuntimeConfig(request.workMode),
+      ...executionCarrierRuntimeConfig(request.executionCarrier),
+    },
   });
   return {
     ok: result.ok,

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -40,7 +40,7 @@ const DATA_DIR = getDataDir();
 // copy still points at the right file. Renaming the file would require a
 // second migration step with no user-facing benefit.
 const DB_PATH = process.env.CORTEX_IDE_DB_PATH || path.join(DATA_DIR, 'cortex-ide.db');
-export const DB_SCHEMA_VERSION = 60;
+export const DB_SCHEMA_VERSION = 61;
 function migrationMarkerPath(version: number): string {
   return path.join(DATA_DIR, `.db-migrated-v${version}`);
 }

--- a/src/lib/db/latest-schema-migrations.ts
+++ b/src/lib/db/latest-schema-migrations.ts
@@ -24,6 +24,7 @@ import { ensureV57CostLedgerAttributionSchema } from '@/lib/db/v57-cost-ledger-a
 import { ensureV58SpectatorRepoGrantsSchema } from '@/lib/db/v58-spectator-repo-grants-migration';
 import { ensureV59TaskArtifactsSchema } from '@/lib/db/v59-task-artifacts-migration';
 import { ensureV60SymonMcpInjectionSchema } from '@/lib/db/v60-symon-mcp-injection-migration';
+import { ensureV61PrMergeEvidenceSchema } from '@/lib/db/v61-pr-merge-evidence-migration';
 
 /**
  * Keep the current additive migrations behind one boot hook. `db/index.ts` is
@@ -59,4 +60,5 @@ export function ensurePostAutomationSchemas(sqlite: Database.Database): void {
   ensureV58SpectatorRepoGrantsSchema(sqlite);
   ensureV59TaskArtifactsSchema(sqlite);
   ensureV60SymonMcpInjectionSchema(sqlite);
+  ensureV61PrMergeEvidenceSchema(sqlite);
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -360,6 +360,8 @@ export const githubPullRequests = sqliteTable('github_pull_requests', {
   authorLogin: text('author_login'),
   body: text('body'),
   headRefName: text('head_ref_name'),
+  headSha: text('head_sha'),
+  mergeCommit: text('merge_commit'),
   baseRefName: text('base_ref_name'),
   additions: integer('additions').notNull().default(0),
   deletions: integer('deletions').notNull().default(0),

--- a/src/lib/db/v61-pr-merge-evidence-migration.test.ts
+++ b/src/lib/db/v61-pr-merge-evidence-migration.test.ts
@@ -1,0 +1,15 @@
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+import { ensureV61PrMergeEvidenceSchema } from './v61-pr-merge-evidence-migration';
+
+describe('PR merge evidence migration', () => {
+  it('adds nullable commit evidence idempotently without inventing proof for old rows', () => {
+    const sqlite = new Database(':memory:');
+    try {
+      sqlite.exec('CREATE TABLE github_pull_requests (pull_request_id INTEGER PRIMARY KEY); INSERT INTO github_pull_requests VALUES (1)');
+      ensureV61PrMergeEvidenceSchema(sqlite);
+      ensureV61PrMergeEvidenceSchema(sqlite);
+      expect(sqlite.prepare('SELECT * FROM github_pull_requests').get()).toEqual({ pull_request_id: 1, head_sha: null, merge_commit: null });
+    } finally { sqlite.close(); }
+  });
+});

--- a/src/lib/db/v61-pr-merge-evidence-migration.ts
+++ b/src/lib/db/v61-pr-merge-evidence-migration.ts
@@ -1,0 +1,14 @@
+import type Database from 'better-sqlite3';
+
+/** Preserve the immutable commits reported by a merged pull request. */
+export function ensureV61PrMergeEvidenceSchema(sqlite: Database.Database): void {
+  for (const column of ['head_sha', 'merge_commit']) {
+    const columns = sqlite.prepare('PRAGMA table_info(github_pull_requests)').all() as Array<{ name: string }>;
+    if (columns.some((entry) => entry.name === column)) continue;
+    try {
+      sqlite.exec(`ALTER TABLE github_pull_requests ADD COLUMN ${column} TEXT`);
+    } catch (error) {
+      if (!(error instanceof Error && /duplicate column name/i.test(error.message))) throw error;
+    }
+  }
+}

--- a/src/lib/github-broker/store.ts
+++ b/src/lib/github-broker/store.ts
@@ -58,6 +58,8 @@ export interface GitHubPullRequestSnapshot {
   updatedAt: string;
   closedAt: string | null;
   mergedAt: string | null;
+  headSha?: string | null;
+  mergeCommit?: string | null;
 }
 
 export interface GitHubThreadAttentionSnapshot {
@@ -90,6 +92,8 @@ type GitHubPullRequestRow = {
   updatedAt: string | null;
   closedAt: string | null;
   mergedAt: string | null;
+  headSha: string | null;
+  mergeCommit: string | null;
 };
 
 function parseJson<T>(value: string | null | undefined, fallback: T): T {
@@ -122,6 +126,8 @@ function mapPullRequestRow(row: GitHubPullRequestRow): GitHubPullRequestSnapshot
     updatedAt: row.updatedAt ?? row.createdAt ?? '',
     closedAt: row.closedAt,
     mergedAt: row.mergedAt,
+    headSha: row.headSha,
+    mergeCommit: row.mergeCommit,
   };
 }
 
@@ -246,8 +252,8 @@ export function upsertGitHubPullRequest(pull: GitHubPullRequestSnapshot) {
     INSERT INTO github_pull_requests (
       pull_request_id, repo_full_name, number, title, state, author_login, body, head_ref_name,
       base_ref_name, additions, deletions, changed_files, review_decision, status_checks_json,
-      url, created_at, updated_at, closed_at, merged_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      url, created_at, updated_at, closed_at, merged_at, head_sha, merge_commit
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(pull_request_id) DO UPDATE SET
       repo_full_name = excluded.repo_full_name,
       number = excluded.number,
@@ -266,7 +272,9 @@ export function upsertGitHubPullRequest(pull: GitHubPullRequestSnapshot) {
       created_at = excluded.created_at,
       updated_at = excluded.updated_at,
       closed_at = excluded.closed_at,
-      merged_at = excluded.merged_at
+      merged_at = excluded.merged_at,
+      head_sha = excluded.head_sha,
+      merge_commit = excluded.merge_commit
   `).run(
     pull.pullRequestId,
     pull.repoFullName,
@@ -287,6 +295,8 @@ export function upsertGitHubPullRequest(pull: GitHubPullRequestSnapshot) {
     pull.updatedAt,
     pull.closedAt,
     pull.mergedAt,
+    pull.headSha ?? null,
+    pull.mergeCommit ?? null,
   );
 }
 
@@ -399,8 +409,8 @@ export function replaceGitHubPullRequests(repoFullName: string, pulls: GitHubPul
     INSERT INTO github_pull_requests (
       pull_request_id, repo_full_name, number, title, state, author_login, body, head_ref_name,
       base_ref_name, additions, deletions, changed_files, review_decision, status_checks_json,
-      url, created_at, updated_at, closed_at, merged_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      url, created_at, updated_at, closed_at, merged_at, head_sha, merge_commit
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(pull_request_id) DO UPDATE SET
       repo_full_name = excluded.repo_full_name,
       number = excluded.number,
@@ -419,7 +429,9 @@ export function replaceGitHubPullRequests(repoFullName: string, pulls: GitHubPul
       created_at = excluded.created_at,
       updated_at = excluded.updated_at,
       closed_at = excluded.closed_at,
-      merged_at = excluded.merged_at
+      merged_at = excluded.merged_at,
+      head_sha = excluded.head_sha,
+      merge_commit = excluded.merge_commit
   `);
 
   const closeMissing = sqlite.prepare(`
@@ -451,6 +463,8 @@ export function replaceGitHubPullRequests(repoFullName: string, pulls: GitHubPul
         pull.updatedAt,
         pull.closedAt,
         pull.mergedAt,
+        pull.headSha ?? null,
+        pull.mergeCommit ?? null,
       );
     }
   });
@@ -547,7 +561,7 @@ export function listGitHubPullRequests(repoFullName: string): GitHubPullRequestS
            author_login as authorLogin, body, head_ref_name as headRefName, base_ref_name as baseRefName,
            additions, deletions, changed_files as changedFiles, review_decision as reviewDecision,
            status_checks_json as statusChecksJson, url, created_at as createdAt, updated_at as updatedAt,
-           closed_at as closedAt, merged_at as mergedAt
+           closed_at as closedAt, merged_at as mergedAt, head_sha as headSha, merge_commit as mergeCommit
     FROM github_pull_requests
     WHERE repo_full_name = ? AND state = 'open'
     ORDER BY datetime(COALESCE(updated_at, created_at)) DESC
@@ -564,7 +578,7 @@ export function getGitHubPullRequestByNumber(repoFullName: string, prNumber: num
            author_login as authorLogin, body, head_ref_name as headRefName, base_ref_name as baseRefName,
            additions, deletions, changed_files as changedFiles, review_decision as reviewDecision,
            status_checks_json as statusChecksJson, url, created_at as createdAt, updated_at as updatedAt,
-           closed_at as closedAt, merged_at as mergedAt
+           closed_at as closedAt, merged_at as mergedAt, head_sha as headSha, merge_commit as mergeCommit
     FROM github_pull_requests
     WHERE repo_full_name = ? AND number = ?
     LIMIT 1
@@ -579,7 +593,7 @@ export function getGitHubPullRequestByHead(repoFullName: string, headRefName: st
            author_login as authorLogin, body, head_ref_name as headRefName, base_ref_name as baseRefName,
            additions, deletions, changed_files as changedFiles, review_decision as reviewDecision,
            status_checks_json as statusChecksJson, url, created_at as createdAt, updated_at as updatedAt,
-           closed_at as closedAt, merged_at as mergedAt
+           closed_at as closedAt, merged_at as mergedAt, head_sha as headSha, merge_commit as mergeCommit
     FROM github_pull_requests
     WHERE repo_full_name = ? AND head_ref_name = ?
     ORDER BY datetime(COALESCE(updated_at, created_at)) DESC

--- a/src/lib/github-broker/sync.test.ts
+++ b/src/lib/github-broker/sync.test.ts
@@ -28,11 +28,12 @@ const {
 } = await import('@/lib/supervisor/inbox');
 const {
   invalidateGitHubSync,
+  getGitHubPullRequestByNumber,
   updateGitHubThreadAttention,
   upsertGitHubIssue,
   upsertGitHubPullRequest,
 } = await import('./store');
-const { ensureGitHubIssues, ensureGitHubPullRequests } = await import('./sync');
+const { ensureGitHubIssues, ensureGitHubPullRequests, ensureGitHubPullRequest } = await import('./sync');
 
 const NOW = new Date('2026-08-27T16:00:00.000Z');
 
@@ -203,6 +204,15 @@ afterAll(() => {
 });
 
 describe('GitHub outsider attention sync', () => {
+  it('persists immutable merge evidence from a targeted pull response over a legacy mirror row', async () => {
+    upsertGitHubPullRequest(pullRequestSnapshot(77, 'closed', NOW.toISOString()));
+    const headSha = 'a'.repeat(40), mergeCommit = 'b'.repeat(40);
+    installationFetchMock.mockResolvedValue(fetched({ ...pullRequestPayload(77, 'closed', NOW.toISOString()),
+      merged_at: NOW.toISOString(), merge_commit_sha: mergeCommit, head: { ref: 'work', sha: headSha } }));
+    expect((await ensureGitHubPullRequest('example/widgets', 77)).error).toBeNull();
+    expect(getGitHubPullRequestByNumber('example/widgets', 77)).toMatchObject({ headSha, mergeCommit });
+  });
+
   it('keeps the latest human and insider comments across ascending comment pages', async () => {
     installationFetchMock.mockImplementation(async (_repo: string, path: string) => {
       if (path.includes('/comments?') && path.endsWith('page=2')) {

--- a/src/lib/github-broker/sync.ts
+++ b/src/lib/github-broker/sync.ts
@@ -108,9 +108,10 @@ type GitHubPullRequestPayload = {
   updated_at?: string;
   closed_at?: string | null;
   merged_at?: string | null;
+  merge_commit_sha?: string | null;
   user?: { login?: string | null; type?: string | null } | null;
   author_association?: string | null;
-  head?: { ref?: string | null };
+  head?: { ref?: string | null; sha?: string | null };
   base?: { ref?: string | null };
   additions?: number;
   deletions?: number;
@@ -265,6 +266,8 @@ function mapPullRequestSnapshot(
     updatedAt: detail.updated_at ?? item.updated_at ?? item.created_at ?? '',
     closedAt: detail.closed_at ?? item.closed_at ?? null,
     mergedAt: detail.merged_at ?? item.merged_at ?? null,
+    headSha: detail.head?.sha ?? item.head?.sha ?? null,
+    mergeCommit: detail.merge_commit_sha ?? item.merge_commit_sha ?? null,
   };
 }
 

--- a/src/lib/lane/commands-launch.ts
+++ b/src/lib/lane/commands-launch.ts
@@ -222,6 +222,7 @@ export async function launchSession(
       model: command.model,
       claudeCodeModel: command.claudeCodeModel,
       claudeCodeCarrier: command.claudeCodeCarrier,
+      executionCarrier: command.executionCarrier,
       effort: command.effort,
       clientMutationId: command.clientMutationId,
       isolate: !lane.worktreePath,

--- a/src/lib/lane/orchestrator-crash-survival.ts
+++ b/src/lib/lane/orchestrator-crash-survival.ts
@@ -226,6 +226,12 @@ export function listOrchestratorTurnsForThread(threadId: string): OrchestratorTu
     .sort((left, right) => right.startedAt - left.startedAt);
 }
 
+/** Includes settled records: abort acknowledgement does not prove process exit. */
+export function listOrchestratorTurnsForSessions(sessionNames: readonly string[]): OrchestratorTurnRecord[] {
+  const names = new Set(sessionNames);
+  return readAllTurnRecords().filter((record) => names.has(record.sessionName));
+}
+
 export function isPidAlive(pid?: number): boolean {
   if (!pid) return false;
   try {

--- a/src/lib/lane/packet-explainer-ownership.ts
+++ b/src/lib/lane/packet-explainer-ownership.ts
@@ -1,0 +1,102 @@
+import { getSqlite } from '@/lib/db';
+import { listOrchestratorTurnsForSessions } from './orchestrator-crash-survival';
+import { sessionNameForRepo } from './orchestrator-session-core';
+
+export interface ExplainerClaim {
+  id: string;
+  packet_id: string;
+  lane_id: string;
+  repo_path: string;
+  claim_owner: string;
+  payload_json?: string;
+}
+
+/** Use a recognized thread namespace so optional work never borrows a user session. */
+export function explainerThreadId(row: ExplainerClaim): string {
+  return `thoughts-${row.id}-${row.claim_owner}`;
+}
+
+export function ownsCurrentExplainer(row: ExplainerClaim): boolean {
+  return Boolean(getSqlite().prepare(`
+    SELECT 1 FROM explainer_queue current
+    WHERE id = ? AND status = 'in_progress' AND claim_owner = ?
+      AND NOT EXISTS (
+        SELECT 1 FROM explainer_queue newer
+        WHERE newer.packet_id = current.packet_id AND newer.rowid > current.rowid
+      )
+  `).get(row.id, row.claim_owner));
+}
+
+export function isLatestExplainer(id: string): boolean {
+  return Boolean(getSqlite().prepare(`
+    SELECT 1 FROM explainer_queue current WHERE id = ? AND NOT EXISTS (
+      SELECT 1 FROM explainer_queue newer
+      WHERE newer.packet_id = current.packet_id AND newer.rowid > current.rowid
+    )
+  `).get(id));
+}
+
+function mayExist(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // Permission errors and unknown failures are not proof of termination.
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+export function explainerProcessState(row: ExplainerClaim): 'alive' | 'dead' | 'absent' | 'unknown' {
+  const threadId = explainerThreadId(row);
+  const prefixes = ['cortex-codex-orchestrator', 'cortex-orchestrator'];
+  const records = listOrchestratorTurnsForSessions(prefixes.map((prefix) => (
+    sessionNameForRepo(prefix, row.repo_path, threadId)
+  )));
+  // Older versions collapsed non-thoughts IDs into a repo-wide session. Never
+  // kill or assume ownership of that shared session during upgrade recovery.
+  let attemptScoped = false;
+  try {
+    attemptScoped = JSON.parse(row.payload_json ?? '{}').generationId === threadId;
+  } catch { return 'unknown'; }
+  const legacyRecords = records.length || attemptScoped ? [] : listOrchestratorTurnsForSessions(
+    prefixes.map((prefix) => sessionNameForRepo(prefix, row.repo_path)),
+  );
+  const evidence = records.length ? records : legacyRecords;
+  if (evidence.length === 0) return 'absent';
+  if (evidence.some((record) => !record.pid)) return 'unknown';
+  return evidence.some((record) => mayExist(record.pid)
+    || (process.platform !== 'win32' && mayExist(-record.pid))) ? 'alive' : 'dead';
+}
+
+export function hasUnsettledExplainerProcess(row: ExplainerClaim): boolean {
+  const state = explainerProcessState(row);
+  return state === 'alive' || state === 'unknown';
+}
+
+/** Reclaim only after the previous owner AND its provider group have exited. */
+export function recoverExplainerClaims(): void {
+  const rows = getSqlite().prepare(`
+    SELECT id, packet_id, lane_id, repo_path, claim_owner, payload_json, outcome
+    FROM explainer_queue WHERE status = 'in_progress'
+  `).all() as Array<ExplainerClaim & { outcome: string | null }>;
+  for (const row of rows) {
+    const ownerPid = Number(/^explainer-owner-(\d+)-/.exec(row.claim_owner ?? '')?.[1]);
+    if (row.outcome !== 'awaiting_exit' && (!ownerPid || mayExist(ownerPid))) continue;
+    const processState = explainerProcessState(row);
+    if (processState !== 'dead') {
+      const reason = processState === 'alive' ? 'Previous explainer process is still alive; restart held'
+        : 'Previous explainer exit is unconfirmed; restart held';
+      getSqlite().prepare(`
+        UPDATE explainer_queue SET last_error = ?
+        WHERE id = ? AND status = 'in_progress' AND claim_owner = ? AND last_error IS NOT ?
+      `).run(reason, row.id, row.claim_owner, reason);
+      continue;
+    }
+    getSqlite().prepare(`
+      UPDATE explainer_queue
+      SET status = 'pending', last_error = 'Recovered after confirmed provider exit',
+          claimed_at = NULL, claim_owner = NULL, outcome = 'recovered', updated_at = datetime('now')
+      WHERE id = ? AND status = 'in_progress' AND claim_owner = ?
+    `).run(row.id, row.claim_owner);
+  }
+}

--- a/src/lib/lane/packet-explainer-queue.ts
+++ b/src/lib/lane/packet-explainer-queue.ts
@@ -5,6 +5,9 @@ import { resolvePacketExplainerEnabledSync } from '@/lib/operator/defaults';
 import { recordLaneEvent } from './events';
 import { getLane } from './registry';
 import {
+  explainerThreadId, hasUnsettledExplainerProcess, isLatestExplainer, ownsCurrentExplainer, recoverExplainerClaims,
+} from './packet-explainer-ownership';
+import {
   generatePacketExplainer,
   type GenerateExplainerParams,
   type PacketExplainerGenerationResult,
@@ -13,7 +16,7 @@ import {
 const DRAIN_INTERVAL_MS = 5_000;
 const MAX_EXPLAINER_ATTEMPTS = 3;
 
-type StoredExplainerPayload = Omit<GenerateExplainerParams, 'lane' | 'signal'>;
+type StoredExplainerPayload = Omit<GenerateExplainerParams, 'lane' | 'signal' | 'generationId' | 'isCurrent'>;
 
 interface QueuedExplainer {
   id: string;
@@ -48,10 +51,11 @@ function millisecondsSince(value: string): number {
 async function stampPacket(
   packetId: string,
   explainer: NonNullable<import('@/lib/orchestrator/types').OrchestratorPacket['explainer']>,
+  isCurrent: () => boolean,
 ): Promise<void> {
   try {
     const { patchMissionPacket } = await import('@/lib/orchestrator/operator-mission-service/packet-patch');
-    await patchMissionPacket(packetId, { explainer });
+    await patchMissionPacket(packetId, { explainer }, isCurrent);
   } catch (error) {
     console.warn(`[explainer-queue] Failed to stamp packet ${packetId}:`, error);
   }
@@ -60,7 +64,9 @@ async function stampPacket(
 function claimNextExplainer(): QueuedExplainer | null {
   if (hasCorrectnessReviewDemand()) return null;
   return getSqlite().transaction(() => {
-    if (hasCorrectnessReviewDemand()) return null;
+    if (hasCorrectnessReviewDemand() || getSqlite().prepare(
+      "SELECT 1 FROM explainer_queue WHERE status = 'in_progress' LIMIT 1",
+    ).get()) return null;
     const row = getSqlite().prepare(
       `SELECT id, packet_id, lane_id, repo_path, payload_json, attempts,
               contention_count, created_at
@@ -70,16 +76,22 @@ function claimNextExplainer(): QueuedExplainer | null {
     ).get() as Omit<QueuedExplainer, 'claim_owner'> | undefined;
     if (!row) return null;
     const claimOwner = `explainer-owner-${process.pid}-${randomUUID().slice(0, 8)}`;
+    let payloadJson = row.payload_json;
+    try {
+      payloadJson = JSON.stringify({ ...JSON.parse(row.payload_json),
+        generationId: explainerThreadId({ ...row, claim_owner: claimOwner }),
+      });
+    } catch { /* Preserve corrupt payloads for the drain's failure handling. */ }
     const claimed = getSqlite().prepare(
       `UPDATE explainer_queue
        SET status = 'in_progress', claimed_at = datetime('now'), claim_owner = ?,
-           queue_wait_ms = ?, updated_at = datetime('now')
+           queue_wait_ms = ?, payload_json = ?, updated_at = datetime('now')
        WHERE id = ? AND status = 'pending'
          AND NOT EXISTS (
            SELECT 1 FROM review_queue WHERE status IN ('pending', 'in_progress')
          )`,
-    ).run(claimOwner, millisecondsSince(row.created_at), row.id);
-    return claimed.changes === 1 ? { ...row, claim_owner: claimOwner } : null;
+    ).run(claimOwner, millisecondsSince(row.created_at), payloadJson, row.id);
+    return claimed.changes === 1 ? { ...row, payload_json: payloadJson, claim_owner: claimOwner } : null;
   })();
 }
 
@@ -87,6 +99,15 @@ function settleDeferred(
   row: QueuedExplainer,
   result: PacketExplainerGenerationResult,
 ): void {
+  // Backends can acknowledge abort before the detached provider actually exits.
+  // Keep the claim fenced until a later tick confirms the entire group is gone.
+  if (hasUnsettledExplainerProcess(row)) {
+    getSqlite().prepare(`
+      UPDATE explainer_queue SET outcome = 'awaiting_exit', last_error = ?, updated_at = datetime('now')
+      WHERE id = ? AND status = 'in_progress' AND claim_owner = ?
+    `).run(result.reason ?? 'Waiting for interrupted provider exit', row.id, row.claim_owner);
+    return;
+  }
   getSqlite().prepare(
     `UPDATE explainer_queue
      SET status = 'pending', contention_count = contention_count + 1,
@@ -117,6 +138,7 @@ async function settleFailed(
   payload: StoredExplainerPayload,
   result: PacketExplainerGenerationResult,
 ): Promise<void> {
+  if (!ownsCurrentExplainer(row)) return;
   const attempts = row.attempts + 1;
   const terminal = attempts >= MAX_EXPLAINER_ATTEMPTS;
   getSqlite().prepare(
@@ -154,7 +176,7 @@ async function settleFailed(
       changedFileCount: payload.changedFileCount,
       generatedAt: new Date().toISOString(),
       error: (result.reason ?? 'explainer generation failed').slice(0, 300),
-    });
+    }, () => isLatestExplainer(row.id));
   }
 }
 
@@ -191,7 +213,7 @@ export async function enqueuePacketExplainer(
     status: 'generating',
     changedFileCount: params.changedFileCount,
     generatedAt: null,
-  });
+  }, () => isLatestExplainer(id));
   recordLaneEvent(params.lane.id, 'explainer_queued', 'system', {
     packetId: params.packetId,
     explainerId: id,
@@ -208,7 +230,12 @@ export function notifyCorrectnessReviewQueued(): void {
 export async function drainPacketExplainerQueue(
   runner: ExplainerRunner = generatePacketExplainer,
 ): Promise<void> {
-  if (activeExplainer || !resolvePacketExplainerEnabledSync()) return;
+  if (!resolvePacketExplainerEnabledSync()) {
+    activeExplainer?.controller.abort('packet explainer disabled');
+    return;
+  }
+  if (activeExplainer) return;
+  recoverExplainerClaims();
   const row = claimNextExplainer();
   if (!row) return;
   const lane = getLane(row.lane_id);
@@ -242,8 +269,19 @@ export async function drainPacketExplainerQueue(
     queueWaitMs: millisecondsSince(row.created_at),
   });
   try {
-    const result = await runner({ ...payload, lane, signal: controller.signal });
-    if (result.outcome === 'ready') {
+    const result = await runner({ ...payload, lane, signal: controller.signal,
+      generationId: explainerThreadId(row),
+      isCurrent: () => ownsCurrentExplainer(row) && resolvePacketExplainerEnabledSync(),
+    });
+    if (result.outcome !== 'ready' && hasUnsettledExplainerProcess(row)) {
+      settleDeferred(row, result);
+    } else if (!ownsCurrentExplainer(row) && !controller.signal.aborted) {
+      getSqlite().prepare(`
+        UPDATE explainer_queue SET status = 'completed', outcome = 'superseded',
+          completed_at = datetime('now'), claimed_at = NULL, claim_owner = NULL
+        WHERE id = ? AND status = 'in_progress' AND claim_owner = ?
+      `).run(row.id, row.claim_owner);
+    } else if (result.outcome === 'ready' && !controller.signal.aborted) {
       getSqlite().prepare(
         `UPDATE explainer_queue
          SET status = 'completed', backend = ?, turn_duration_ms = ?,
@@ -268,26 +306,22 @@ export async function drainPacketExplainerQueue(
       await settleFailed(row, payload, result);
     }
   } catch (error) {
-    await settleFailed(row, payload, {
+    const result: PacketExplainerGenerationResult = {
       outcome: 'failed',
       backend: null,
       durationMs: 0,
       approximateCost: null,
       reason: error instanceof Error ? error.message : String(error),
-    });
+    };
+    if (hasUnsettledExplainerProcess(row)) settleDeferred(row, result);
+    else await settleFailed(row, payload, result);
   } finally {
-    if (activeExplainer?.row.id === row.id) activeExplainer = null;
+    if (activeExplainer?.row.claim_owner === row.claim_owner) activeExplainer = null;
   }
 }
 
 export function startPacketExplainerQueueDrain(): () => void {
   if (drainTimer) return () => { /* already running */ };
-  getSqlite().prepare(
-    `UPDATE explainer_queue
-     SET status = 'pending', last_error = 'Recovered after process restart',
-         claimed_at = NULL, claim_owner = NULL, updated_at = datetime('now')
-     WHERE status = 'in_progress'`,
-  ).run();
   drainTimer = setInterval(() => {
     void drainPacketExplainerQueue().catch((error) => {
       console.error('[explainer-queue] Drain error:', error);

--- a/src/lib/lane/packet-explainer.test.ts
+++ b/src/lib/lane/packet-explainer.test.ts
@@ -86,7 +86,7 @@ describe('generatePacketExplainer', () => {
   it('keeps the durable report artifact and removes the worktree scratch HTML', async () => {
     const worktree = mkdtempSync(join(os.tmpdir(), 'o8-explainer-worktree-'));
     const packetId = `pkt-cleanup-${Date.now()}`;
-    const scratchPath = join(worktree, `.o8-packet-explainer-${packetId}.html`);
+    let scratchPath = '';
     const html = `<html><body><h1>Packet proof</h1><script type="application/json" id="o8-quiz">${quizJson}</script></body></html>`;
     const lane = createLane({
       repoPath: worktree,
@@ -98,7 +98,9 @@ describe('generatePacketExplainer', () => {
 
     explainerMocks.patchMissionPacket.mockClear();
     explainerMocks.sendTurn.mockReset();
-    explainerMocks.sendTurn.mockImplementationOnce(async () => {
+    explainerMocks.sendTurn.mockImplementationOnce(async (_repo, prompt, _onEvent, options) => {
+      expect(options.threadId).toMatch(/^thoughts-explainer-/);
+      scratchPath = join(worktree, prompt.match(/named exactly `([^`]+)`/)[1]);
       writeFileSync(scratchPath, html, 'utf8');
     });
 
@@ -123,6 +125,34 @@ describe('generatePacketExplainer', () => {
       expect.objectContaining({
         explainer: expect.objectContaining({ status: 'ready', artifactId: reports[0].id }),
       }),
+      expect.any(Function),
     );
+  });
+
+  it('does not publish a superseded generation or reuse another attempt output file', async () => {
+    const worktree = mkdtempSync(join(os.tmpdir(), 'o8-explainer-fence-'));
+    const packetId = `pkt-fence-${Date.now()}`;
+    const lane = createLane({ repoPath: worktree, worktreePath: worktree,
+      branch: 'inline/explainer-fence', runtime: 'codex', packetId });
+    let current = true;
+    const files: string[] = [];
+    explainerMocks.patchMissionPacket.mockClear();
+    explainerMocks.sendTurn.mockReset();
+    explainerMocks.sendTurn.mockImplementation(async (_repo, prompt) => {
+      const output = join(worktree, prompt.match(/named exactly `([^`]+)`/)[1]);
+      files.push(output);
+      writeFileSync(output, '<html>Report</html>');
+      current = false;
+    });
+    const params = { lane, packetId, packetTitle: 'Fence', packetSummary: '',
+      diffSummary: '', changedFileCount: 1, deviationsRaw: null, reviewContext: '',
+      isCurrent: () => current };
+    expect((await generatePacketExplainer(params)).outcome).toBe('deferred');
+    current = true;
+    expect((await generatePacketExplainer(params)).outcome).toBe('deferred');
+    expect(new Set(files).size).toBe(2);
+    expect(files.every(existsSync)).toBe(true);
+    expect(listArtifacts({ packetId })).toHaveLength(0);
+    expect(explainerMocks.patchMissionPacket).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/lane/packet-explainer.ts
+++ b/src/lib/lane/packet-explainer.ts
@@ -15,6 +15,7 @@
  * inside the sandboxed iframe, so the approve-gate logic stays in the app.
  */
 
+import { createHash, randomUUID } from 'node:crypto';
 import { writeFileSync } from 'node:fs';
 import { readFile, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -31,13 +32,13 @@ import { runReviewerTurnWithQuotaFallback } from './review-quota-fallback';
 import type { Lane } from './types';
 
 /**
- * The file the backend agent is told to write in the worktree root. PER-PACKET
- * so two lanes reviewing in the same repo (worktreePath falling back to
- * repoPath) never race on a single fixed path.
+ * The scratch file is unique per attempt, including retries of the same packet.
+ * A detached older writer cannot replace or delete its successor's output.
  */
-function explainerFilename(packetId: string): string {
+function explainerFilename(packetId: string, generationId: string): string {
   const safe = packetId.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 96) || 'packet';
-  return `.o8-packet-explainer-${safe}.html`;
+  const attempt = createHash('sha256').update(generationId).digest('hex').slice(0, 16);
+  return `.o8-packet-explainer-${safe}-${attempt}.html`;
 }
 
 export interface GenerateExplainerParams {
@@ -50,6 +51,9 @@ export interface GenerateExplainerParams {
   deviationsRaw: string | null;
   reviewContext: string;
   signal?: AbortSignal;
+  generationId?: string;
+  /** Evaluated again under the packet lock before publishing a late result. */
+  isCurrent?: () => boolean;
 }
 
 export interface PacketExplainerGenerationResult {
@@ -105,7 +109,7 @@ export function parseExplainerQuiz(html: string): PacketExplainerQuiz | null {
   return questions.length >= 3 ? { questions } : null;
 }
 
-function buildExplainerPrompt(params: GenerateExplainerParams): string {
+function buildExplainerPrompt(params: GenerateExplainerParams, generationId: string): string {
   return [
     `Write a self-contained HTML "packet explainer" for a code change under review, so a human who does NOT read diffs can understand and verify it.`,
     ``,
@@ -119,7 +123,7 @@ function buildExplainerPrompt(params: GenerateExplainerParams): string {
     `Reviewer context (findings so far):`,
     params.reviewContext || '(none yet)',
     ``,
-    `Produce a SINGLE self-contained .html file at the worktree root named exactly \`${explainerFilename(params.packetId)}\`.`,
+    `Produce a SINGLE self-contained .html file at the worktree root named exactly \`${explainerFilename(params.packetId, generationId)}\`.`,
     `Requirements for the file:`,
     `- Inline all CSS; no external assets, no network requests.`,
     `- Sections: what & why (plain language), annotated key hunks (the 2-4 most important changes), data flow touched, deviations from brief, risk notes.`,
@@ -141,20 +145,23 @@ export async function generatePacketExplainer(
   params: GenerateExplainerParams,
 ): Promise<PacketExplainerGenerationResult> {
   const startedAt = Date.now();
+  const generationId = params.generationId ?? `thoughts-explainer-${randomUUID()}`;
+  const isCurrent = () => !params.signal?.aborted && (params.isCurrent?.() ?? true);
   let observedBackend: string | null = null;
   let observedCost: number | null = null;
   const { patchMissionPacket } = await import('@/lib/orchestrator/operator-mission-service/packet-patch');
   const stamp = async (explainer: NonNullable<import('@/lib/orchestrator/types').OrchestratorPacket['explainer']>) => {
     try {
-      await patchMissionPacket(params.packetId, { explainer });
+      await patchMissionPacket(params.packetId, { explainer }, isCurrent);
     } catch (error) {
       console.warn(`[explainer] Failed to stamp explainer status for packet ${params.packetId}:`, error);
     }
   };
 
   try {
-    const threadId = `explainer-${params.lane.id}`;
-    const prompt = buildExplainerPrompt(params);
+    if (!isCurrent()) return { outcome: 'deferred', backend: null, durationMs: 0, approximateCost: null };
+    const threadId = generationId;
+    const prompt = buildExplainerPrompt(params, generationId);
     const turn = await runReviewerTurnWithQuotaFallback({
       laneId: params.lane.id,
       repoPath: params.lane.repoPath,
@@ -170,13 +177,13 @@ export async function generatePacketExplainer(
     });
     observedBackend = turn.backend;
     observedCost = turn.approximateCost;
-    if (params.signal?.aborted) {
+    if (!isCurrent()) {
       return {
         outcome: 'deferred',
         backend: turn.backend,
         durationMs: Date.now() - startedAt,
         approximateCost: turn.approximateCost,
-        reason: 'correctness review took priority',
+        reason: 'explainer was cancelled or superseded',
       };
     }
     if (turn.unavailableReason === 'session_busy') {
@@ -191,8 +198,12 @@ export async function generatePacketExplainer(
     if (!turn.ok) throw new Error(turn.errors.join('; ') || 'reviewer turn failed');
 
     const worktree = params.lane.worktreePath || params.lane.repoPath;
-    const scratchPath = join(worktree, explainerFilename(params.packetId));
+    const scratchPath = join(worktree, explainerFilename(params.packetId, generationId));
     const html = await readFile(scratchPath, 'utf8');
+    if (!isCurrent()) {
+      return { outcome: 'deferred', backend: turn.backend, durationMs: Date.now() - startedAt,
+        approximateCost: turn.approximateCost, reason: 'explainer was superseded while reading output' };
+    }
     if (!html.trim()) {
       throw new Error('explainer file was empty');
     }
@@ -240,7 +251,7 @@ export async function generatePacketExplainer(
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    if (params.signal?.aborted) {
+    if (!isCurrent()) {
       return {
         outcome: 'deferred',
         backend: observedBackend,

--- a/src/lib/lane/types.ts
+++ b/src/lib/lane/types.ts
@@ -18,6 +18,7 @@ import type { MergeCheckResult } from '@/lib/lane/preview-merge';
 import type { ClaudeCodeModelSource } from '@/lib/claude-code/worker-profile-types';
 import type { OrchestratorRuntime, WorkerLaunchContext } from '@/lib/orchestrator/types';
 import type { PacketSpendCap } from '@/lib/orchestrator/metered-spend';
+import type { ExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 import { isWorkerTerminal } from '@/lib/lane/terminal-states';
 
 // ── Lane Status ──
@@ -160,6 +161,7 @@ export type LaneCommand =
       model?: string;
       claudeCodeModel?: string;
       claudeCodeCarrier?: ClaudeCodeModelSource;
+      executionCarrier?: ExecutionCarrierId;
       spendCap?: PacketSpendCap;
       effort?: ThinkingEffort;
       /** Stable for one packet launch attempt so a crash can reconcile the owned session. */
@@ -287,6 +289,7 @@ export type LaneEventVerb =
   | 'explainer_completed'
   | 'explainer_failed'
   | 'runtime_drift'
+  | 'execution_carrier_preflight'
   | 'capacity_snapshot'
   | 'pr_merged_reconciled'
   | 'merged_by_ancestry_reconciled'

--- a/src/lib/lane/worktree-reaper.ts
+++ b/src/lib/lane/worktree-reaper.ts
@@ -244,32 +244,24 @@ async function archiveMergedPullRequestLane(
   repoFullName: string,
   pull: GitHubPullRequestSnapshot,
   match: 'prNumber' | 'headRefName',
-): Promise<void> {
-  console.log(`[worktree-reaper] ${lane.id} PR #${pull.number} merged at ${pull.mergedAt} — archiving`);
+): Promise<boolean> {
   const mergedClean = await stampPrMergedClean(lane, pull);
-  archiveLane(lane.id, 'system');
-  // PR-mode parity (#1386 family): a PR merged on GitHub is this packet's
-  // merge — release it so sequential dependents (wave 2+) launch, exactly as
-  // approve_and_merge would have. The headless tick applies the release to the
-  // current mission and every registry mission.
-  if (lane.packetId) {
-    try {
-      const { queueHeadlessPacketRelease } = await import('@/lib/orchestrator/headless-loop');
-      queueHeadlessPacketRelease([lane.packetId]);
-    } catch (error) {
-      console.warn(`[worktree-reaper] Failed to queue packet release for ${lane.packetId}: ${error instanceof Error ? error.message : String(error)}`);
-    }
-  }
-  appendEvent(lane.id, 'pr_merged_reconciled', 'system', {
-    repoFullName,
-    prNumber: pull.number,
-    mergedAt: pull.mergedAt,
-    match,
-    mergedClean: mergedClean.mergedClean,
-    mergedCleanReason: mergedClean.reason,
-    reviewedHeadSha: mergedClean.reviewedHeadSha ?? null,
-    comparisonRef: mergedClean.comparisonRef ?? null,
+  const { releaseMergedPullRequestPacket } = await import('@/lib/orchestrator/automatic-release');
+  const release = await releaseMergedPullRequestPacket(lane, pull, () => {
+    console.log(`[worktree-reaper] ${lane.id} PR #${pull.number} merged at ${pull.mergedAt} — archiving`);
+    archiveLane(lane.id, 'system');
+    appendEvent(lane.id, 'pr_merged_reconciled', 'system', {
+      repoFullName,
+      prNumber: pull.number,
+      mergedAt: pull.mergedAt,
+      match,
+      mergedClean: mergedClean.mergedClean,
+      mergedCleanReason: mergedClean.reason,
+      reviewedHeadSha: mergedClean.reviewedHeadSha ?? null,
+      comparisonRef: mergedClean.comparisonRef ?? null,
+    });
   });
+  return release !== 'held';
 }
 
 function stampLanePullRequestNumber(lane: Lane, pull: GitHubPullRequestSnapshot): void {
@@ -299,8 +291,8 @@ async function reconcileMergedPullRequest(
   if (prNumber !== null) {
     let pull = getGitHubPullRequestByNumber(repoFullName, prNumber);
     if (pull?.mergedAt) {
-      await archiveMergedPullRequestLane(lane, repoFullName, pull, 'prNumber');
-      return { archived: true, refreshed: false };
+      const archived = await archiveMergedPullRequestLane(lane, repoFullName, pull, 'prNumber');
+      if (archived || (pull.headSha && pull.mergeCommit)) return { archived, refreshed: false };
     }
 
     if (allowTargetedRefresh) {
@@ -308,8 +300,7 @@ async function reconcileMergedPullRequest(
       const refreshed = await ensureGitHubPullRequest(repoFullName, prNumber);
       pull = refreshed.pr;
       if (pull?.mergedAt) {
-        await archiveMergedPullRequestLane(lane, repoFullName, pull, 'prNumber');
-        return { archived: true, refreshed: true };
+        return { archived: await archiveMergedPullRequestLane(lane, repoFullName, pull, 'prNumber'), refreshed: true };
       }
       return { archived: false, refreshed: true };
     }
@@ -321,10 +312,10 @@ async function reconcileMergedPullRequest(
   if (legacyPull) {
     stampLanePullRequestNumber(lane, legacyPull);
     if (legacyPull.mergedAt) {
-      await archiveMergedPullRequestLane(lane, repoFullName, legacyPull, 'headRefName');
-      return { archived: true, refreshed: false };
+      const archived = await archiveMergedPullRequestLane(lane, repoFullName, legacyPull, 'headRefName');
+      if (archived || (legacyPull.headSha && legacyPull.mergeCommit)) return { archived, refreshed: false };
     }
-    return { archived: false, refreshed: false };
+    if (!legacyPull.mergedAt) return { archived: false, refreshed: false };
   }
 
   if (allowTargetedRefresh) {
@@ -334,8 +325,7 @@ async function reconcileMergedPullRequest(
     if (pull) {
       stampLanePullRequestNumber(lane, pull);
       if (pull.mergedAt) {
-        await archiveMergedPullRequestLane(lane, repoFullName, pull, 'headRefName');
-        return { archived: true, refreshed: true };
+        return { archived: await archiveMergedPullRequestLane(lane, repoFullName, pull, 'headRefName'), refreshed: true };
       }
     }
     return { archived: false, refreshed: true };

--- a/src/lib/mcp/operator-handlers/status.ts
+++ b/src/lib/mcp/operator-handlers/status.ts
@@ -294,6 +294,11 @@ export const STATUS_TOOLS: McpTool[] = [
           enum: listDispatchableRuntimes(),
           description: 'Default worker runtime for dispatches.',
         },
+        workerExecutionCarrier: {
+          type: 'string',
+          enum: ['ori', ''],
+          description: 'Allowlisted worker execution carrier. Use "ori" for Ori or an empty string for direct runtime launch.',
+        },
         defaultDispatchModel: {
           type: 'string',
           description: 'Default worker model id. Pass an empty string to restore the selected runtime default.',
@@ -383,6 +388,7 @@ const OPERATOR_DEFAULTS_KEYS = [
   'uiLoopMaxDiffFiles',
   'uiLoopPreviewTimeoutMs',
   'defaultDispatchRuntime',
+  'workerExecutionCarrier',
   'defaultDispatchModel',
   'opencodeOrchestratorModel',
   'opencodeWorkerModel',
@@ -420,7 +426,7 @@ export async function handleOperatorDefaults(args: Record<string, unknown>): Pro
     for (const key of OPERATOR_DEFAULTS_KEYS) {
       if (args[key] !== undefined) update[key] = args[key];
     }
-    const EMPTY_STRING_MEANS_NULL = new Set(['opencodeOrchestratorModel', 'opencodeWorkerModel']);
+    const EMPTY_STRING_MEANS_NULL = new Set(['opencodeOrchestratorModel', 'opencodeWorkerModel', 'workerExecutionCarrier']);
     for (const key of EMPTY_STRING_MEANS_NULL) {
       if (update[key] === '') update[key] = null;
     }

--- a/src/lib/operator/defaults-roundtrip.test.ts
+++ b/src/lib/operator/defaults-roundtrip.test.ts
@@ -10,9 +10,11 @@ process.env.CORTEX_IDE_DATA_DIR = dataDir;
 const {
   getOperatorDefaults,
   getOperatorDefaultsTomlPath,
+  OPERATOR_DEFAULTS_FALLBACK,
   updateOperatorDefaults,
 } = await import('./defaults');
 const { parseOperatorDefaultsToml } = await import('@/lib/settings/toml');
+const { assertRoutingTomlCompatibility } = await import('./routing-compatibility');
 
 /**
  * Evaporation guard: updateOperatorDefaults copies each field from the update
@@ -111,6 +113,38 @@ describe('updateOperatorDefaults round-trip', () => {
     await updateOperatorDefaults({ reviewerBackend: 'codex' });
     const after = await updateOperatorDefaults({ parallelCap: 5 });
     expect(after.values.reviewerBackend).toBe('codex');
+  });
+
+  it('clears the persisted execution carrier back to direct launch', async () => {
+    await updateOperatorDefaults({ defaultDispatchRuntime: 'codex', workerExecutionCarrier: 'ori' });
+    const cleared = await updateOperatorDefaults({ workerExecutionCarrier: null });
+    expect(cleared.values.workerExecutionCarrier).toBeNull();
+    expect(parseOperatorDefaultsToml(readFileSync(getOperatorDefaultsTomlPath(), 'utf8')).workerExecutionCarrier).toBeNull();
+  });
+
+  it('rejects an execution carrier that is incompatible with the effective default runtime', async () => {
+    await updateOperatorDefaults({ defaultDispatchRuntime: 'claude-code' });
+    await expect(updateOperatorDefaults({ workerExecutionCarrier: 'ori' })).rejects.toThrow(/incompatible/);
+  });
+
+  it('honors environment-selected runtime precedence when validating updates and TOML', async () => {
+    const priorRuntime = process.env.O8_DEFAULT_DISPATCH_RUNTIME;
+    const priorProfile = process.env.O8_SUBSCRIPTION_PROFILE;
+    process.env.O8_DEFAULT_DISPATCH_RUNTIME = 'claude-code';
+    process.env.O8_SUBSCRIPTION_PROFILE = 'both';
+    try {
+      await expect(updateOperatorDefaults({ defaultDispatchRuntime: 'codex', workerExecutionCarrier: 'ori' }))
+        .rejects.toThrow(/effective default runtime 'claude-code'/);
+      expect(() => assertRoutingTomlCompatibility(
+        '[models]\ndefault_dispatch_runtime = "codex"\nworker_execution_carrier = "ori"\n',
+        OPERATOR_DEFAULTS_FALLBACK,
+      )).toThrow(/effective default runtime 'claude-code'/);
+    } finally {
+      if (priorRuntime === undefined) delete process.env.O8_DEFAULT_DISPATCH_RUNTIME;
+      else process.env.O8_DEFAULT_DISPATCH_RUNTIME = priorRuntime;
+      if (priorProfile === undefined) delete process.env.O8_SUBSCRIPTION_PROFILE;
+      else process.env.O8_SUBSCRIPTION_PROFILE = priorProfile;
+    }
   });
 
   it('subscriptionProfile persists and flips the effective house defaults', async () => {

--- a/src/lib/operator/defaults-roundtrip.test.ts
+++ b/src/lib/operator/defaults-roundtrip.test.ts
@@ -10,9 +10,11 @@ process.env.CORTEX_IDE_DATA_DIR = dataDir;
 const {
   getOperatorDefaults,
   getOperatorDefaultsTomlPath,
+  OPERATOR_DEFAULTS_FALLBACK,
   updateOperatorDefaults,
 } = await import('./defaults');
 const { parseOperatorDefaultsToml } = await import('@/lib/settings/toml');
+const { assertRoutingTomlCompatibility } = await import('./routing-compatibility');
 
 /**
  * Evaporation guard: updateOperatorDefaults copies each field from the update
@@ -117,6 +119,38 @@ describe('updateOperatorDefaults round-trip', () => {
     await updateOperatorDefaults({ reviewerBackend: 'codex' });
     const after = await updateOperatorDefaults({ parallelCap: 5 });
     expect(after.values.reviewerBackend).toBe('codex');
+  });
+
+  it('clears the persisted execution carrier back to direct launch', async () => {
+    await updateOperatorDefaults({ defaultDispatchRuntime: 'codex', workerExecutionCarrier: 'ori' });
+    const cleared = await updateOperatorDefaults({ workerExecutionCarrier: null });
+    expect(cleared.values.workerExecutionCarrier).toBeNull();
+    expect(parseOperatorDefaultsToml(readFileSync(getOperatorDefaultsTomlPath(), 'utf8')).workerExecutionCarrier).toBeNull();
+  });
+
+  it('rejects an execution carrier that is incompatible with the effective default runtime', async () => {
+    await updateOperatorDefaults({ defaultDispatchRuntime: 'claude-code' });
+    await expect(updateOperatorDefaults({ workerExecutionCarrier: 'ori' })).rejects.toThrow(/incompatible/);
+  });
+
+  it('honors environment-selected runtime precedence when validating updates and TOML', async () => {
+    const priorRuntime = process.env.O8_DEFAULT_DISPATCH_RUNTIME;
+    const priorProfile = process.env.O8_SUBSCRIPTION_PROFILE;
+    process.env.O8_DEFAULT_DISPATCH_RUNTIME = 'claude-code';
+    process.env.O8_SUBSCRIPTION_PROFILE = 'both';
+    try {
+      await expect(updateOperatorDefaults({ defaultDispatchRuntime: 'codex', workerExecutionCarrier: 'ori' }))
+        .rejects.toThrow(/effective default runtime 'claude-code'/);
+      expect(() => assertRoutingTomlCompatibility(
+        '[models]\ndefault_dispatch_runtime = "codex"\nworker_execution_carrier = "ori"\n',
+        OPERATOR_DEFAULTS_FALLBACK,
+      )).toThrow(/effective default runtime 'claude-code'/);
+    } finally {
+      if (priorRuntime === undefined) delete process.env.O8_DEFAULT_DISPATCH_RUNTIME;
+      else process.env.O8_DEFAULT_DISPATCH_RUNTIME = priorRuntime;
+      if (priorProfile === undefined) delete process.env.O8_SUBSCRIPTION_PROFILE;
+      else process.env.O8_SUBSCRIPTION_PROFILE = priorProfile;
+    }
   });
 
   it('subscriptionProfile persists and flips the effective house defaults', async () => {

--- a/src/lib/operator/defaults-roundtrip.test.ts
+++ b/src/lib/operator/defaults-roundtrip.test.ts
@@ -72,7 +72,7 @@ const NON_DEFAULT_UPDATE = {
   crossHouseWorkerFallback: true,
   orchestratorBackend: 'collide',
   reviewerBackend: 'codex',
-  packetExplainerEnabled: false,
+  packetExplainerEnabled: true,
   quizGateEnabled: true,
   buyinDocEnabled: true,
   updateAutoApply: 'idle',
@@ -92,6 +92,12 @@ const NON_DEFAULT_UPDATE = {
 } as const;
 
 describe('updateOperatorDefaults round-trip', () => {
+  it('defaults optional explainers and quiz gates off without disabling explicit opt-in', async () => {
+    expect((await getOperatorDefaults()).values).toMatchObject({
+      packetExplainerEnabled: false,
+      quizGateEnabled: false,
+    });
+  });
   it('migrates the legacy autoApplyUpdates value to updateAutoApply', async () => {
     writeFileSync(join(dataDir, 'operator-defaults.json'), JSON.stringify({
       autoApplyUpdates: 'when-idle',

--- a/src/lib/operator/defaults.ts
+++ b/src/lib/operator/defaults.ts
@@ -2,6 +2,7 @@ import 'server-only';
 import { CODEX_MODEL_IDS, isCodexModelId, isSupportedModelId, MODEL_IDS, SUPPORTED_MODEL_IDS } from '@/lib/models';
 import { isThinkingEffort, type ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+import { isExecutionCarrierId, type ExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 import type { UpdateAutoApply } from '@/lib/app-update/types';
 import { validateCredentialSafeUrl } from '@/lib/settings/credential-safe-url';
 import { applyApfsDependencyImagesUpdate, APFS_DEPENDENCY_IMAGES_FALLBACK, resolveStoredApfsDependencyImages, type ApfsDependencyImagesDefaults } from './apfs-dependency-images-default';
@@ -16,7 +17,7 @@ import {
 import { resolveWorkerEffortDefault } from './worker-effort-default';
 import { isWorkerStartMode, type WorkerStartMode } from './worker-start-mode';
 import { parseStoredJson } from './stored-json';
-import { assertRoutingCompatibility, routingUpdateTouchesCompatibility } from './routing-compatibility';
+import { assertExecutionCarrierRoutingCompatibility, assertRoutingCompatibility, routingUpdateTouchesCompatibility } from './routing-compatibility';
 import {
   coerceStoredTier,
   envTargetingTier,
@@ -24,9 +25,7 @@ import {
   mergeTier,
   type TargetingTier,
 } from './targeting-tier';
-
 export { isSubscriptionProfile };
-
 import { normalizeAcpModelId, isPlausibleAcpModelId } from '@/lib/orchestrator/acp-model-id';
 
 import { isOrchestratorBackendSetting, isReviewerBackendSetting, isCollideAggregator, isPrLinkDestination, sanitizeBranchPrefix, type OrchestratorBackendSetting, type ReviewerBackendSetting, type CollideAggregator, type PrLinkDestination } from './defaults-env';
@@ -107,18 +106,9 @@ export {
   ORCHESTRATOR_MODEL_OPTIONS,
   PARALLEL_CAP_PRESETS,
 } from './default-options';
-/**
- * Operator defaults — the dispatch/supervision knobs exposed in Settings
- * (one field per knob in {@link OperatorDefaults}; the count grows, don't
- * hardcode it in docs).
- * Resolution order (every knob): env var > persisted file > hardcoded fallback.
- * Canonical file: `~/.o8/settings.toml`. The legacy
- * `operator-defaults.json` remains a synchronized last-good fallback so an
- * invalid hand edit never prevents startup.
- * (override root with CORTEX_IDE_DATA_DIR). NOTE: `~/.cortex-ide/` is NOT
- * read — a stale copy of this file there silently does nothing (bit the
- * operator flow 2026-07-07; always verify against getOperatorDefaultsPath()).
- */
+/** Operator defaults exposed in Settings. Resolution: env > persisted file > fallback.
+ * Canonical file: `~/.o8/settings.toml`; the legacy JSON remains a last-good fallback.
+ * Override root with CORTEX_IDE_DATA_DIR. `~/.cortex-ide/` is not read. */
 export type SettingSource = 'env' | 'file' | 'profile' | 'default';
 export type RequireApproval = 'high-risk' | 'surface' | 'always' | 'never';
 
@@ -147,6 +137,7 @@ export interface OperatorDefaults extends StorageReserveDefaults, WorkspaceParki
   /** Model for dispatched opencode workers. Null = the adapter default. */
   opencodeWorkerModel: string | null;
   defaultDispatchRuntime: OrchestratorRuntime;
+  workerExecutionCarrier: ExecutionCarrierId | null;
   workerStartMode: WorkerStartMode;
   workerRuntimes: OrchestratorRuntime[];
   /** Default Codex worker effort. 'adaptive' preserves runtime default behavior. */
@@ -329,9 +320,7 @@ export const OPERATOR_DEFAULTS_FALLBACK: OperatorDefaults = {
   ...REVIEW_CONTINUATION_FALLBACK,
   ...BROADCAST_COMMENTARY_FALLBACK,
   ...APFS_DEPENDENCY_IMAGES_FALLBACK,
-  // Operator-pinned: Opus 4.8 with max thinking is the default orchestrator
-  // brain. Subscription-billed via the REPL migration, so cost is the user's
-  // existing Claude Code MAX plan — not a per-token API charge.
+  // Operator-pinned subscription model; not a per-token API charge.
   thinkingEffort: 'max',
   promptCachingEnabled: true,
   mergeTestReplayEnabled: false,
@@ -340,6 +329,7 @@ export const OPERATOR_DEFAULTS_FALLBACK: OperatorDefaults = {
   opencodeOrchestratorModel: null,
   opencodeWorkerModel: null,
   defaultDispatchRuntime: 'codex',
+  workerExecutionCarrier: null,
   workerStartMode: 'autonomous',
   workerRuntimes: ['codex'],
   codexWorkerEffort: 'adaptive',
@@ -356,11 +346,9 @@ export const OPERATOR_DEFAULTS_FALLBACK: OperatorDefaults = {
   experimentalCanvas: false,
   nativeBrowserView: true,
   classAComposer: 'auto',
-  // ON by default post-#1097. Subscription pool, not Agent SDK pool. See the
-  // docstring above on the field for the rationale.
+  // ON by default post-#1097; subscription pool, not Agent SDK pool.
   inAppOrchestratorEnabled: true,
-  // ON by default — the free, fast (~2.7s warm), subscription-billed Brain for
-  // anyone with a Claude sub. Independent of the orchestrator toggle (2026-06-22).
+  // Subscription-billed Brain, independent of the orchestrator toggle.
   brainUseClaudeCli: true,
   workersUseBrain: 'auto',
   ...WORKSPACE_MANIFEST_POLICY_FALLBACK,
@@ -375,9 +363,7 @@ export const OPERATOR_DEFAULTS_FALLBACK: OperatorDefaults = {
   quizGateEnabled: false,
   // Buy-in doc generation OFF by default — opt-in narrative for external sharing.
   buyinDocEnabled: false,
-  // Targeting Machine tiers. Both default to Codex (the shipping dispatch worker),
-  // differentiated by effort — cheap triage at low, premium action at high. The
-  // operator can point triage at a cheaper runtime/model (gemini, a local model).
+  // Targeting tiers default to Codex and differ by effort.
   targetingTriage: { runtime: 'codex', model: '', effort: 'low' },
   targetingAction: { runtime: 'codex', model: '', effort: 'high' },
   updateAutoApply: 'off',
@@ -410,6 +396,7 @@ interface StoredOperatorDefaults extends Partial<StorageReserveDefaults>, Partia
   opencodeOrchestratorModel?: string | null;
   opencodeWorkerModel?: string | null;
   defaultDispatchRuntime?: OrchestratorRuntime;
+  workerExecutionCarrier?: ExecutionCarrierId | null;
   defaultDispatchRuntimeExplicit?: boolean;
   workerStartMode?: WorkerStartMode;
   workerRuntimes?: OrchestratorRuntime[];
@@ -503,6 +490,9 @@ function resolveFromFile(stored: StoredOperatorDefaults): FileOperatorDefaults {
   if (isDispatchRuntime(stored.defaultDispatchRuntime)) {
     result.defaultDispatchRuntime = stored.defaultDispatchRuntime;
     result.defaultDispatchRuntimeExplicit = stored.defaultDispatchRuntimeExplicit !== false;
+  }
+  if (stored.workerExecutionCarrier === null || isExecutionCarrierId(stored.workerExecutionCarrier)) {
+    result.workerExecutionCarrier = stored.workerExecutionCarrier;
   }
   if (isWorkerStartMode(stored.workerStartMode)) result.workerStartMode = stored.workerStartMode;
   if (Array.isArray(stored.workerRuntimes)) {
@@ -706,6 +696,7 @@ function resolveDefaults(fileValues: FileOperatorDefaults): OperatorDefaultsWith
       fileValues.opencodeOrchestratorModel ?? OPERATOR_DEFAULTS_FALLBACK.opencodeOrchestratorModel,
     opencodeWorkerModel: fileValues.opencodeWorkerModel ?? OPERATOR_DEFAULTS_FALLBACK.opencodeWorkerModel,
     defaultDispatchRuntime,
+    workerExecutionCarrier: fileValues.workerExecutionCarrier !== undefined ? fileValues.workerExecutionCarrier : OPERATOR_DEFAULTS_FALLBACK.workerExecutionCarrier,
     workerStartMode: fileValues.workerStartMode ?? OPERATOR_DEFAULTS_FALLBACK.workerStartMode,
     workerRuntimes: fileValues.workerRuntimes ?? OPERATOR_DEFAULTS_FALLBACK.workerRuntimes,
     codexWorkerEffort:
@@ -777,6 +768,7 @@ function resolveDefaults(fileValues: FileOperatorDefaults): OperatorDefaultsWith
     opencodeOrchestratorModel: fileValues.opencodeOrchestratorModel !== undefined ? 'file' : 'default',
     opencodeWorkerModel: fileValues.opencodeWorkerModel !== undefined ? 'file' : 'default',
     defaultDispatchRuntime: profileDefaults ? 'profile' : envRuntime !== null ? 'env' : fileValues.defaultDispatchRuntimeExplicit ? 'file' : 'default',
+    workerExecutionCarrier: fileValues.workerExecutionCarrier !== undefined ? 'file' : 'default',
     workerStartMode: fileValues.workerStartMode !== undefined ? 'file' : 'default',
     workerRuntimes: fileValues.workerRuntimes !== undefined ? 'file' : 'default',
     codexWorkerEffort:
@@ -932,6 +924,12 @@ async function updateOperatorDefaultsOnce(update: Partial<OperatorDefaults>): Pr
     }
     stored.defaultDispatchRuntime = update.defaultDispatchRuntime;
     stored.defaultDispatchRuntimeExplicit = true;
+  }
+  if (update.workerExecutionCarrier !== undefined) {
+    if (update.workerExecutionCarrier !== null && !isExecutionCarrierId(update.workerExecutionCarrier)) {
+      throw new Error('workerExecutionCarrier must be "ori" or null.');
+    }
+    stored.workerExecutionCarrier = update.workerExecutionCarrier;
   }
   if (update.workerStartMode !== undefined) {
     if (!isWorkerStartMode(update.workerStartMode)) throw new Error('workerStartMode must be one of "autonomous", "huddle", or "adaptive".');
@@ -1118,7 +1116,7 @@ async function updateOperatorDefaultsOnce(update: Partial<OperatorDefaults>): Pr
     ...OPERATOR_DEFAULTS_FALLBACK,
     ...fileValues,
   };
-  if (routingUpdateTouchesCompatibility(update)) assertRoutingCompatibility(canonicalValues);
+  if (routingUpdateTouchesCompatibility(update)) { assertRoutingCompatibility(canonicalValues); assertExecutionCarrierRoutingCompatibility(resolveDefaults(fileValues).values); }
   await persistOperatorDefaults(canonicalValues, stored, existingToml, revision);
 
   return getOperatorDefaults();

--- a/src/lib/operator/defaults.ts
+++ b/src/lib/operator/defaults.ts
@@ -248,7 +248,7 @@ export interface OperatorDefaults extends StorageReserveDefaults, WorkspaceParki
   /** Which backend runs lane auto-reviews. 'follow' rides orchestratorBackend. */
   reviewerBackend: ReviewerBackendSetting;
   /**
-   * HTML packet explainer generation (#1491). **On by default** — when a packet
+   * HTML packet explainer generation (#1491). **Off by default** — when enabled and a packet
    * reaches review, a self-contained explainer + quiz is generated
    * fire-and-forget and stored as a report artifact. Non-blocking; failure
    * degrades the review surface to the raw diff. Env: `O8_EXPLAINER`.
@@ -371,7 +371,7 @@ export const OPERATOR_DEFAULTS_FALLBACK: OperatorDefaults = {
   // 'follow' → reviews ride the orchestrator backend (pre-split behavior).
   reviewerBackend: 'follow',
   // Explainer generation ON (non-blocking); quiz gate OFF (opt-in speed bump).
-  packetExplainerEnabled: true,
+  packetExplainerEnabled: false,
   quizGateEnabled: false,
   // Buy-in doc generation OFF by default — opt-in narrative for external sharing.
   buyinDocEnabled: false,
@@ -1236,7 +1236,7 @@ export function resolveReviewerBackendSync(): ReviewerBackendSetting {
   return getOperatorDefaultsSync().values.reviewerBackend;
 }
 
-/** Whether packet explainer generation is enabled (#1491, default on). */
+/** Whether packet explainer generation is enabled (#1491, default off). */
 export function resolvePacketExplainerEnabledSync(): boolean {
   return getOperatorDefaultsSync().values.packetExplainerEnabled;
 }

--- a/src/lib/operator/routing-compatibility.ts
+++ b/src/lib/operator/routing-compatibility.ts
@@ -1,10 +1,14 @@
 import { validateRuntimeModelSelection } from '@/lib/runtimes/shared/model-compatibility';
+import { assertExecutionCarrierCompatible } from '@/lib/runtimes/shared/execution-carrier';
 import { parseOperatorDefaultsToml } from '@/lib/settings/toml';
 import type { OperatorDefaults } from './defaults';
+import { isSubscriptionProfile, resolveSubscriptionProfileHouseDefaults } from './subscription-profile';
+import { isDispatchRuntime } from './defaults-env';
 
 type RoutingCompatibilityValues = Pick<
   OperatorDefaults,
-  'defaultDispatchRuntime' | 'defaultDispatchModel' | 'targetingTriage' | 'targetingAction'
+  'subscriptionProfile' | 'defaultDispatchRuntime' | 'workerExecutionCarrier'
+    | 'defaultDispatchModel' | 'targetingTriage' | 'targetingAction'
 >;
 
 function assertRuntimeModelCompatibility(
@@ -20,19 +24,43 @@ function assertRuntimeModelCompatibility(
 
 export function assertRoutingCompatibility(values: RoutingCompatibilityValues): void {
   assertRuntimeModelCompatibility(values.defaultDispatchRuntime, values.defaultDispatchModel, 'Default worker');
+  assertExecutionCarrierRoutingCompatibility(values);
   assertRuntimeModelCompatibility(values.targetingTriage.runtime, values.targetingTriage.model, 'Triage');
   assertRuntimeModelCompatibility(values.targetingAction.runtime, values.targetingAction.model, 'Action tier');
+}
+
+export function assertExecutionCarrierRoutingCompatibility(values: RoutingCompatibilityValues): void {
+  const effectiveRuntime = resolveSubscriptionProfileHouseDefaults(values.subscriptionProfile)?.defaultDispatchRuntime
+    ?? values.defaultDispatchRuntime;
+  if (values.workerExecutionCarrier) {
+    try {
+      assertExecutionCarrierCompatible(values.workerExecutionCarrier, effectiveRuntime);
+    } catch {
+      throw new Error(
+        `Execution carrier '${values.workerExecutionCarrier}' is incompatible with the effective default runtime '${effectiveRuntime}'. Select a compatible runtime or use Direct.`,
+      );
+    }
+  }
 }
 
 export function assertRoutingTomlCompatibility(
   raw: string,
   fallback: OperatorDefaults,
 ): void {
-  assertRoutingCompatibility({ ...fallback, ...parseOperatorDefaultsToml(raw) });
+  const values = { ...fallback, ...parseOperatorDefaultsToml(raw) };
+  if (isSubscriptionProfile(process.env.O8_SUBSCRIPTION_PROFILE)) {
+    values.subscriptionProfile = process.env.O8_SUBSCRIPTION_PROFILE;
+  }
+  if (isDispatchRuntime(process.env.O8_DEFAULT_DISPATCH_RUNTIME)) {
+    values.defaultDispatchRuntime = process.env.O8_DEFAULT_DISPATCH_RUNTIME;
+  }
+  assertRoutingCompatibility(values);
 }
 
 export function routingUpdateTouchesCompatibility(update: Partial<OperatorDefaults>): boolean {
-  return update.defaultDispatchRuntime !== undefined
+  return update.subscriptionProfile !== undefined
+    || update.defaultDispatchRuntime !== undefined
+    || update.workerExecutionCarrier !== undefined
     || update.defaultDispatchModel !== undefined
     || update.targetingTriage !== undefined
     || update.targetingAction !== undefined;

--- a/src/lib/operator/shipped-dark-manifest.ts
+++ b/src/lib/operator/shipped-dark-manifest.ts
@@ -87,6 +87,11 @@ export const SHIPPED_DARK_FLAG_MANIFEST: Readonly<
     lifecycle: 'deliberate-default-off',
     rationale: 'Optional merge-gate test replay; kept off because repository test commands can be slow.',
   },
+  packetExplainerEnabled: {
+    landedRelease: '0.1.560',
+    lifecycle: 'deliberate-default-off',
+    rationale: 'Optional AI report and quiz consume a separate model turn; generation requires operator opt-in.',
+  },
   quizGateEnabled: {
     landedRelease: '0.1.681',
     lifecycle: 'deliberate-default-off',

--- a/src/lib/orchestrator/automatic-release.ts
+++ b/src/lib/orchestrator/automatic-release.ts
@@ -1,0 +1,72 @@
+import type { GitHubPullRequestSnapshot } from '@/lib/github-broker/store';
+import { getLane } from '@/lib/lane/registry';
+import type { Lane } from '@/lib/lane/types';
+import { readOrchestratorControlPlaneState, withLockedState } from './control-plane';
+import { findMissionRegistryEntryByPacketId, withMissionRegistryState } from './mission-registry';
+import { markPacketReleased } from './packet-release-truth';
+import type { OrchestratorPacket } from './types';
+import { packetReleaseGeneration, packetReleaseIdentityIsCurrent, verifyCurrentLaneHead } from './release-ownership';
+
+const SHA = /^(?:[a-f0-9]{40}|[a-f0-9]{64})$/i;
+
+export function canApplyAutomaticRelease(packet: OrchestratorPacket, lane: Lane, generation: string, allowReleased = false): boolean {
+  if (['launching', 'running', 'recovering', 'queued'].includes(packet.status)) return false;
+  if (!['reviewing', 'completed', 'archived'].includes(lane.status)) return false;
+  if (lane.packetId !== packet.id) return false;
+  return packetReleaseIdentityIsCurrent(packet, lane.id, generation, allowReleased);
+}
+
+async function matchesMergedPull(lane: Lane, pull: GitHubPullRequestSnapshot): Promise<boolean> {
+  if (!pull.mergedAt || !SHA.test(pull.headSha ?? '') || !SHA.test(pull.mergeCommit ?? '')) return false;
+  if (pull.baseRefName !== lane.baseBranch || pull.headRefName !== lane.branch) return false;
+  return verifyCurrentLaneHead(lane, pull.headSha!);
+}
+
+/** Persist the PR's commit proof before archiving, never enqueue an unproved packet ID. */
+export async function releaseMergedPullRequestPacket(
+  lane: Lane,
+  pull: GitHubPullRequestSnapshot,
+  onReleased?: () => void,
+): Promise<'released' | 'held' | 'unbound'> {
+  const sameLane = (fresh: Lane | null) => fresh && fresh.branch === lane.branch
+    && fresh.worktreePath === lane.worktreePath && fresh.repoPath === lane.repoPath
+    && fresh.baseBranch === lane.baseBranch && fresh.packetId === lane.packetId;
+  const unbound = () => {
+    const fresh = getLane(lane.id);
+    if (!sameLane(fresh) || fresh?.status !== 'reviewing') return 'held' as const;
+    onReleased?.();
+    return 'unbound' as const;
+  };
+  if (!lane.packetId) return unbound();
+  const packetId = lane.packetId;
+  const currentPacket = readOrchestratorControlPlaneState().packets.find((packet) => packet.id === packetId);
+  const entry = !currentPacket ? findMissionRegistryEntryByPacketId(packetId, { includeArchived: true }) : null;
+  const snapshot = currentPacket ?? entry?.mission.packets.find((packet) => packet.id === packetId);
+  if (!snapshot) return unbound();
+  const generation = packetReleaseGeneration(snapshot, lane.id);
+  const apply = async (packet: OrchestratorPacket | undefined): Promise<boolean> => {
+    const freshLane = getLane(lane.id);
+    if (!packet || !freshLane || !sameLane(freshLane) || !canApplyAutomaticRelease(packet, freshLane, generation, true)) return false;
+    if (packet.releaseState === 'released' && (packet.releaseStatePayload?.headSha !== pull.headSha
+      || packet.releaseStatePayload?.mergeCommit !== pull.mergeCommit)) return false;
+    if (!(await matchesMergedPull(freshLane, pull))) return false;
+    const finalLane = getLane(lane.id);
+    if (!finalLane || !sameLane(finalLane) || !canApplyAutomaticRelease(packet, finalLane, generation, true)) return false;
+    markPacketReleased(packet, { source: 'headless_released', evidenceKind: 'pull_request_merged',
+      mergeCommit: pull.mergeCommit, headSha: pull.headSha, releasedAt: pull.mergedAt! });
+    packet.lastEventAt = new Date().toISOString();
+    packet.lastEventLabel = 'pr_merged_reconciled';
+    // Archive in this same critical section. A reset or Stop must not interleave
+    // between checking packet ownership and retiring its lane.
+    onReleased?.();
+    return true;
+  };
+  if (currentPacket) {
+    const { result } = await withLockedState((state) => apply(state.packets.find((packet) => packet.id === packetId)));
+    return result ? 'released' : 'held';
+  }
+  const { result } = await withMissionRegistryState(entry!.id, async (state) => ({
+    state, result: await apply(state.packets.find((packet) => packet.id === packetId)),
+  }));
+  return result ? 'released' : 'held';
+}

--- a/src/lib/orchestrator/branch-merge-probe.ts
+++ b/src/lib/orchestrator/branch-merge-probe.ts
@@ -15,6 +15,7 @@ export interface BranchMergeProbeInput {
 export interface BranchMergeProbeResult {
   merged: boolean;
   mergeCommit: string | null;
+  headSha: string;
   ahead: number;
 }
 
@@ -53,9 +54,8 @@ async function readAheadCount(repoPath: string, baseRef: string, branch: string)
   return ahead;
 }
 
-async function readShortSha(repoPath: string, ref: string): Promise<string | null> {
-  const output = await gitValue(repoPath, ['rev-parse', '--short', ref]);
-  return output || null;
+async function readSha(repoPath: string, ref: string): Promise<string> {
+  return gitValue(repoPath, ['rev-parse', '--verify', '--end-of-options', `${ref}^{commit}`]);
 }
 
 export async function probeBranchMerged(input: BranchMergeProbeInput): Promise<BranchMergeProbeResult> {
@@ -67,11 +67,13 @@ export async function probeBranchMerged(input: BranchMergeProbeInput): Promise<B
   const branch = normalizeRef(input.branch, 'branch');
   const base = normalizeRef(input.base, 'base');
   const baseRef = `origin/${base}`;
-  const ahead = await readAheadCount(repoPath, baseRef, branch);
+  const [headSha, baseSha] = await Promise.all([readSha(repoPath, branch), readSha(repoPath, baseRef)]);
+  const ahead = await readAheadCount(repoPath, baseSha, headSha);
 
   return {
     merged: ahead === 0,
-    mergeCommit: ahead === 0 ? await readShortSha(repoPath, baseRef) : null,
+    mergeCommit: ahead === 0 ? baseSha : null,
+    headSha,
     ahead,
   };
 }

--- a/src/lib/orchestrator/dispatch-packet-launch.ts
+++ b/src/lib/orchestrator/dispatch-packet-launch.ts
@@ -18,6 +18,8 @@ import type { PacketSpendCap } from './metered-spend';
 import { getProjectContext } from '@/lib/projects/context';
 import { resolveDefaultBranch } from '@/lib/repos/registry';
 import { assertRuntimeDispatchable } from '@/lib/runtimes/shared/auth-detect';
+import { assertExecutionCarrierDispatchable, type ExecutionCarrierPreflightEvidence } from '@/lib/runtimes/shared/execution-carrier-preflight';
+import { executionCarrierDefinition } from '@/lib/runtimes/shared/execution-carrier';
 import type {
   OrchestratorPacket,
   OrchestratorRuntime,
@@ -155,6 +157,12 @@ function recordPacketRouting(input: {
   });
 }
 
+function carrierAuditReason(packet: OrchestratorPacket, routing: WorkerRouting, reason: string): string {
+  return packet.executionCarrier
+    ? `${reason} Effective runtime: ${getRuntimeCapability(routing.selectedRuntime).label} via ${executionCarrierDefinition(packet.executionCarrier).label}; auth source: execution-carrier.`
+    : reason;
+}
+
 export async function launchPacketWithStorageAdmission(input: {
   packet: OrchestratorPacket;
   allPackets: OrchestratorPacket[];
@@ -169,15 +177,20 @@ export async function launchPacketWithStorageAdmission(input: {
   });
   const projectContext = await getProjectContext({ repoPath: packet.workspaceTargetPath });
   const baseBranch = await resolveDefaultBranch(packet.workspaceTargetPath!);
+  let carrierPreflight: ExecutionCarrierPreflightEvidence | null = null;
   try {
-    await assertRuntimeDispatchable(
-      workerRouting.selectedRuntime,
-      workerRouting.selectedModel,
-      packet.workspaceTargetPath,
-      // Retry / rerun relaunches a persisted packet, whose pinned carrier can differ
-      // from the stored worker profile the auth snapshot was computed against.
-      { claudeCodeCarrier: packet.claudeCodeCarrier ?? null },
-    );
+    if (packet.executionCarrier) {
+      carrierPreflight = await assertExecutionCarrierDispatchable(workerRouting.selectedRuntime, packet.executionCarrier);
+    } else {
+      await assertRuntimeDispatchable(
+        workerRouting.selectedRuntime,
+        workerRouting.selectedModel,
+        packet.workspaceTargetPath,
+        // Retry / rerun relaunches a persisted packet, whose pinned carrier can differ
+        // from the stored worker profile the auth snapshot was computed against.
+        { claudeCodeCarrier: packet.claudeCodeCarrier ?? null },
+      );
+    }
   } catch (error) {
     recordPacketRouting({
       packet,
@@ -225,7 +238,7 @@ export async function launchPacketWithStorageAdmission(input: {
       receiptKey: `packet-storage-launch:${admissionLease.receipt.reservationId}`,
       contextId: packet.id,
       status: fallback ? 'fallback' : 'selected',
-      reason: workerRouting.reason,
+      reason: carrierAuditReason(packet, workerRouting, workerRouting.reason),
       fallbackReason: fallback ? workerRouting.reason : null,
     });
     return result;
@@ -278,6 +291,18 @@ export async function launchPacketWithStorageAdmission(input: {
         storageAdmissionOwnerGeneration: launchGeneration,
         storageAdmissionReservationId: admissionLease.receipt.reservationId,
       });
+      if (carrierPreflight) {
+        recordLaneEvent(laneResult.laneId, 'execution_carrier_preflight', 'orchestrator', {
+          runtime: carrierPreflight.runtime,
+          runtimeBinary: carrierPreflight.runtimeBinaryName,
+          runtimeBinarySource: carrierPreflight.runtimeCli.source,
+          executionCarrier: carrierPreflight.executionCarrier,
+          carrierBinary: carrierPreflight.carrierBinaryName,
+          carrierBinarySource: carrierPreflight.carrierCli.source,
+          authSource: carrierPreflight.authSource,
+          authenticated: carrierPreflight.authenticated,
+        });
+      }
       launchResult = await dispatchLaneCommand({
         verb: 'launch_session',
         laneId: laneResult.laneId,
@@ -290,6 +315,7 @@ export async function launchPacketWithStorageAdmission(input: {
         model: workerRouting.selectedModel ?? undefined,
         claudeCodeModel: packet.claudeCodeModel ?? undefined,
         claudeCodeCarrier: packet.claudeCodeCarrier ?? undefined,
+        executionCarrier: packet.executionCarrier ?? undefined,
         spendCap,
         effort: workerRouting.selectedEffort ?? undefined,
         clientMutationId: `packet-launch:${packet.id}:${launchGeneration}`,
@@ -345,7 +371,7 @@ export async function launchPacketWithStorageAdmission(input: {
       receiptKey: claimKey,
       contextId: packet.id,
       status: fallback ? 'fallback' : 'selected',
-      reason: outcome.result.workerRouting.reason,
+      reason: carrierAuditReason(packet, outcome.result.workerRouting, outcome.result.workerRouting.reason),
       fallbackReason: fallback ? outcome.result.workerRouting.reason : null,
     });
     return outcome.result;

--- a/src/lib/orchestrator/headless-loop.ts
+++ b/src/lib/orchestrator/headless-loop.ts
@@ -11,9 +11,7 @@ import { buildDagMetadata, hasLaneBinding } from '@/lib/orchestrator/dag';
 import { buildRemainingLaunchBudget, runDispatchTick } from '@/lib/orchestrator/dispatch';
 import { applyHeadlessTickDeadline } from '@/lib/orchestrator/headless-tick-deadline';
 import { hasRegistryPendingHeadlessWork, listActiveMissionRegistryEntries, missionHasPendingHeadlessWork, persistMissionRegistryState, withMissionRegistryState } from '@/lib/orchestrator/mission-registry';
-import { normalizeOrchestratorMissionState } from '@/lib/orchestrator/store';
 import type { OrchestratorMissionState } from '@/lib/orchestrator/types';
-import { markPacketReleased } from '@/lib/orchestrator/packet-release-truth';
 
 const DEFAULT_INTERVAL_MS = 10_000;
 const MIN_INTERVAL_MS = 1_000;
@@ -30,81 +28,10 @@ interface HeadlessSprintTickResult {
 let loopTimer: ReturnType<typeof setInterval> | null = null;
 let tickPromise: Promise<HeadlessSprintTickResult> | null = null;
 let rerunRequested = false;
-const queuedReleasePacketIds = new Set<string>();
 let lastPruneAt = 0;
 let prunePromise: Promise<void> | null = null;
 let lastCompletedMissionId = '';
 let silentIdleTickCount = 0;
-
-function queueReleasedPackets(packetIds?: string[]) {
-  for (const packetId of packetIds ?? []) {
-    const normalized = packetId.trim();
-    if (normalized) {
-      queuedReleasePacketIds.add(normalized);
-    }
-  }
-}
-
-/**
- * Public enqueue for packet releases that happen OUTSIDE approve_and_merge —
- * the PR-mode reconciler archives a lane when its PR merges on GitHub, but the
- * packet's releaseState only ever flipped inside the merge path, so wave 2+ of
- * a sequential mission blocked forever on "waiting to be explicitly released"
- * (live-hit 2026-07-04, the #1389 wave itself; third member of the PR-mode
- * bypass family on #1386). The next tick applies queued releases to the
- * current mission AND every registry mission.
- */
-export function queueHeadlessPacketRelease(packetIds: string[]) {
-  queueReleasedPackets(packetIds);
-}
-
-function drainReleasedPackets() {
-  const packetIds = [...queuedReleasePacketIds];
-  queuedReleasePacketIds.clear();
-  return packetIds;
-}
-
-function markReleasedPackets(
-  state: OrchestratorMissionState,
-  packetIds: string[],
-): OrchestratorMissionState {
-  if (packetIds.length === 0) {
-    return state;
-  }
-
-  const packetIdSet = new Set(packetIds);
-  const releasedAt = new Date().toISOString();
-  let changed = false;
-
-  const packets = state.packets.map((packet) => {
-    if (!packetIdSet.has(packet.id) || packet.releaseState === 'released') {
-      return packet;
-    }
-
-    changed = true;
-    const releasedPacket = { ...packet };
-    markPacketReleased(releasedPacket, {
-      source: 'headless_released',
-      evidenceKind: 'headless_loop',
-      releasedAt,
-    });
-    return {
-      ...releasedPacket,
-      lastEventAt: releasedAt,
-      lastEventLabel: 'headless_released',
-    };
-  });
-
-  if (!changed) {
-    return state;
-  }
-
-  return normalizeOrchestratorMissionState({
-    ...state,
-    packets,
-    updatedAt: releasedAt,
-  });
-}
 
 function countLaunchedPackets(
   beforeDispatch: OrchestratorMissionState,
@@ -165,10 +92,6 @@ function buildIdleTickResult(mission: OrchestratorMissionState): HeadlessSprintT
 }
 
 function maybeShortCircuitIdleTick(): HeadlessSprintTickResult | null {
-  if (queuedReleasePacketIds.size > 0) {
-    return null;
-  }
-
   const mission = readOrchestratorControlPlaneState();
   if (hasPendingHeadlessWork(mission)) {
     silentIdleTickCount = 0;
@@ -233,14 +156,12 @@ async function pruneWorktreesIfDue(state: OrchestratorMissionState) {
 
 async function runRegistryMissionTicks(
   currentMissionId: string | null | undefined,
-  releasedPacketIds: string[],
 ) {
   let launched = 0;
   let maintenanceNeeded = false;
   for (const entry of listActiveMissionRegistryEntries(currentMissionId)) {
     const { result: activity } = await withMissionRegistryState(entry.id, async (fresh) => {
-      const withReleases = markReleasedPackets(fresh, releasedPacketIds);
-      const reconciled = reconcileOrchestratorControlPlaneState(withReleases);
+      const reconciled = reconcileOrchestratorControlPlaneState(fresh);
       const fanned = fanOutComparisonPackets(reconciled);
       const budget = buildRemainingLaunchBudget();
       if (!missionHasPendingHeadlessWork(fanned) || budget.maxLaunches <= 0) {
@@ -263,12 +184,10 @@ async function runRegistryMissionTicks(
 }
 
 async function executeHeadlessSprintTick(): Promise<HeadlessSprintTickResult> {
-  const releasedPacketIds = drainReleasedPackets();
   // #460 — Acquire the control-plane lock so concurrent API operations
   // (reset_packet, etc.) don't race our read-modify-write cycle.
   const { result } = await withLockedState(async (current) => {
-    const withReleases = markReleasedPackets(current, releasedPacketIds);
-    const reconciled = reconcileOrchestratorControlPlaneState(withReleases);
+    const reconciled = reconcileOrchestratorControlPlaneState(current);
     // #1293 — best-of-N fan-out: a seed packet (comparisonModels set, no
     // comparisonGroupId) is consumed by fanOutComparisonPackets — replaced by
     // its N sibling candidates. Persist that consumption BEFORE dispatch so a
@@ -310,7 +229,7 @@ async function executeHeadlessSprintTick(): Promise<HeadlessSprintTickResult> {
       mission,
     } satisfies HeadlessSprintTickResult;
   });
-  const registryActivity = await runRegistryMissionTicks(result.mission.missionId, releasedPacketIds);
+  const registryActivity = await runRegistryMissionTicks(result.mission.missionId);
   const tickResult = {
     ...result,
     launched: result.launched + registryActivity.launched,
@@ -320,8 +239,7 @@ async function executeHeadlessSprintTick(): Promise<HeadlessSprintTickResult> {
   let maintenanceNeeded = tickResult.launched > 0
     || hasWorktreeMaintenanceDemand(tickResult.mission)
     || registryActivity.maintenanceNeeded
-    || archivedCompleted > 0
-    || releasedPacketIds.length > 0;
+    || archivedCompleted > 0;
   if (archivedCompleted > 0) {
     console.log(`[headless] Archived ${archivedCompleted} completed lane${archivedCompleted === 1 ? '' : 's'}`);
   }
@@ -344,9 +262,7 @@ async function executeHeadlessSprintTick(): Promise<HeadlessSprintTickResult> {
   return tickResult;
 }
 
-export async function runHeadlessSprintTick(options: { releasePacketIds?: string[] } = {}) {
-  queueReleasedPackets(options.releasePacketIds);
-
+export async function runHeadlessSprintTick() {
   if (tickPromise) {
     rerunRequested = true;
     return tickPromise;
@@ -373,7 +289,7 @@ export async function runHeadlessSprintTick(options: { releasePacketIds?: string
       rerunRequested = false;
       silentIdleTickCount = 0;
       result = await executeHeadlessSprintTick();
-    } while (rerunRequested || queuedReleasePacketIds.size > 0);
+    } while (rerunRequested);
 
     return result;
   })();

--- a/src/lib/orchestrator/merged-by-ancestry.test.ts
+++ b/src/lib/orchestrator/merged-by-ancestry.test.ts
@@ -290,6 +290,27 @@ describe('merged-by-ancestry reconciliation', () => {
     ))).toEqual([]);
   }, 20_000);
 
+  it.each(['stop', 'new-steer', 'new-attempt'] as const)('rejects old merge evidence after %s wins during the sweep', async (change) => {
+    const { clone, seed } = makeRepo(`o8-merge-generation-${change}`);
+    writeFileSync(join(clone, 'work.txt'), 'merged work');
+    commitAll(clone, 'work');
+    git(clone, ['push', 'origin', 'packet']);
+    git(seed, ['fetch', 'origin', 'packet', '--quiet']);
+    git(seed, ['merge', '--ff-only', 'origin/packet']);
+    git(seed, ['push', 'origin', 'main']);
+    const lane = seedPacket(clone, `pkt-generation-${change}`);
+    h.beforeActivityAssessment = () => {
+      const state = readOrchestratorControlPlaneState();
+      if (change === 'stop') state.packets[0].operatorStopped = true;
+      if (change === 'new-attempt') state.packets[0].attemptCount = (state.packets[0].attemptCount ?? 0) + 1;
+      if (change === 'new-steer') appendEvent(lane.id, 'steered_packet', 'user', { message: 'new work' });
+      writeOrchestratorControlPlaneState(state);
+    };
+    expect((await sweepPacketsMergedByAncestry()).merged).toBe(0);
+    expect(persistedPacket(`pkt-generation-${change}`)?.releaseState).toBe('pending');
+    expect(getLane(lane.id)?.status).toBe('reviewing');
+  });
+
   it('leaves unmerged branch content untouched', async () => {
     const { clone } = makeRepo('o8-merged-unmerged');
     writeFileSync(join(clone, 'packet.txt'), 'packet\n');

--- a/src/lib/orchestrator/merged-by-ancestry.ts
+++ b/src/lib/orchestrator/merged-by-ancestry.ts
@@ -14,6 +14,7 @@ import {
 import { MergedByAncestryBackoff } from '@/lib/orchestrator/merged-by-ancestry-backoff';
 import { packetTerminalState } from '@/lib/orchestrator/packet-state';
 import { markPacketReleased } from '@/lib/orchestrator/packet-release-truth';
+import { packetReleaseGeneration, packetReleaseIdentityIsCurrent, verifyCurrentLaneHead } from './release-ownership';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 import { enqueueInboxItem } from '@/lib/supervisor/inbox';
 import { autoResolveMergedPacketVerificationIncidents } from '@/lib/supervisor/merged-incident-resolution';
@@ -535,20 +536,39 @@ function recordEvidenceDeclined(candidate: Candidate, evidence: MergeEvidence): 
   });
 }
 
-async function releasePacket(candidate: Candidate, evidence: MergeEvidence): Promise<boolean> {
+async function releasePacket(candidate: Candidate, evidence: MergeEvidence, generation: string | null): Promise<boolean> {
   if (!(await evidenceStillHolds(evidence))) {
     recordEvidenceDeclined(candidate, evidence);
     return false;
   }
 
   const releasedAt = new Date().toISOString();
+  const { cancelAutoReviewForLane } = await import('@/lib/lane/auto-review');
+  const archive = () => {
+    if (!candidate.laneId) return;
+    cancelAutoReviewForLane(candidate.laneId, MERGED_BY_ANCESTRY_SOURCE);
+    appendEvent(candidate.laneId, 'merged_by_ancestry_reconciled', 'system', {
+      packetId: candidate.packet?.id ?? candidate.lane?.packetId ?? null,
+      evidenceKind: evidence.kind, branchRef: evidence.branchRef, baseRef: evidence.baseRef,
+      headSha: evidence.headSha, baseSha: evidence.baseSha,
+      mergeBaseSha: evidence.mergeBaseSha ?? null, patchId: evidence.patchId ?? null,
+    });
+    archiveLane(candidate.laneId, 'system', { outcome: 'merged',
+      outcomeNote: `Merged by ${evidence.kind === 'ancestor' ? 'ancestry' : 'patch identity'} into ${evidence.baseRef}.` });
+  };
   if (candidate.packet) {
     const packetId = candidate.packet.id;
-    await withLockedState((state) => {
+    const { result: accepted } = await withLockedState(async (state) => {
       const packet = state.packets.find((item) => item.id === packetId);
-      if (!packet) return;
+      if (!packet || !candidate.laneId || !generation
+        || !packetReleaseIdentityIsCurrent(packet, candidate.laneId, generation)) return false;
       const terminal = packetTerminalState(packet);
-      if (terminal === 'released' || terminal === 'archived') return;
+      if (terminal === 'released' || terminal === 'archived') return false;
+      const lane = getLane(candidate.laneId);
+      if (!lane || !PACKET_LANE_SWEEPABLE_STATUSES.has(lane.status)) return false;
+      if (!(await verifyCurrentLaneHead(lane, evidence.headSha))) return false;
+      if (await revParse(evidence.repoPath, evidence.baseRef) !== evidence.baseSha
+        || !packetReleaseIdentityIsCurrent(packet, lane.id, generation)) return false;
 
       markPacketReleased(packet, {
         source: MERGED_BY_ANCESTRY_SOURCE,
@@ -565,26 +585,15 @@ async function releasePacket(candidate: Candidate, evidence: MergeEvidence): Pro
         packet.lane.lastEventAt = releasedAt;
         packet.lane.lastEventLabel = packet.lastEventLabel;
       }
+      archive();
+      return true;
     });
-  }
-
-  if (candidate.laneId) {
-    const { cancelAutoReviewForLane } = await import('@/lib/lane/auto-review');
-    cancelAutoReviewForLane(candidate.laneId, MERGED_BY_ANCESTRY_SOURCE);
-    appendEvent(candidate.laneId, 'merged_by_ancestry_reconciled', 'system', {
-      packetId: candidate.packet?.id ?? candidate.lane?.packetId ?? null,
-      evidenceKind: evidence.kind,
-      branchRef: evidence.branchRef,
-      baseRef: evidence.baseRef,
-      headSha: evidence.headSha,
-      baseSha: evidence.baseSha,
-      mergeBaseSha: evidence.mergeBaseSha ?? null,
-      patchId: evidence.patchId ?? null,
-    });
-    archiveLane(candidate.laneId, 'system', {
-      outcome: 'merged',
-      outcomeNote: `Merged by ${evidence.kind === 'ancestor' ? 'ancestry' : 'patch identity'} into ${evidence.baseRef}.`,
-    });
+    if (!accepted) return false;
+  } else {
+    const current = candidate.laneId ? getLane(candidate.laneId) : null;
+    if (current && (!LANE_ONLY_SWEEPABLE_STATUSES.has(current.status)
+      || current.sessionKey !== candidate.lane?.sessionKey)) return false;
+    archive();
   }
 
   const incidentPacketId = candidate.packet?.id ?? candidate.lane?.packetId ?? null;
@@ -598,7 +607,7 @@ async function releasePacket(candidate: Candidate, evidence: MergeEvidence): Pro
   return true;
 }
 
-async function finishWithoutChanges(candidate: Candidate, evidence: MergeEvidence): Promise<boolean> {
+async function finishWithoutChanges(candidate: Candidate, evidence: MergeEvidence, generation: string | null): Promise<boolean> {
   if (hasUnsuccessfulTurn(candidate)) return false;
   if (!(await evidenceStillHolds(evidence))) {
     recordEvidenceDeclined(candidate, evidence);
@@ -614,7 +623,9 @@ async function finishWithoutChanges(candidate: Candidate, evidence: MergeEvidenc
     let accepted = false;
     await withLockedState((state) => {
       const packet = state.packets.find((item) => item.id === candidate.packet?.id);
-      if (!packet || hasUnsuccessfulTurn({ ...candidate, packet })) return;
+      if (!packet || !candidate.laneId || !generation
+        || !packetReleaseIdentityIsCurrent(packet, candidate.laneId, generation)
+        || hasUnsuccessfulTurn({ ...candidate, packet })) return;
       accepted = true;
       packet.status = 'archived';
       packet.queueState = 'held';
@@ -695,6 +706,8 @@ export async function sweepPacketsMergedByAncestry(): Promise<MergedByAncestrySw
       continue;
     }
     try {
+      const generation = candidate.packet && candidate.laneId
+        ? packetReleaseGeneration(candidate.packet, candidate.laneId) : null;
       const evidence = await detectMergedByAncestry(candidate);
       detectBackoff.recordSuccess(key);
       if (!evidence) {
@@ -715,8 +728,8 @@ export async function sweepPacketsMergedByAncestry(): Promise<MergedByAncestrySw
         }
       }
       const settled = evidence.kind === 'no-changes'
-        ? await finishWithoutChanges(candidate, evidence)
-        : await releasePacket(candidate, evidence);
+        ? await finishWithoutChanges(candidate, evidence, generation)
+        : await releasePacket(candidate, evidence, generation);
       if (settled) merged += 1;
       else skipped += 1;
     } catch (error) {

--- a/src/lib/orchestrator/normalize/decomposition.ts
+++ b/src/lib/orchestrator/normalize/decomposition.ts
@@ -1,6 +1,7 @@
 import type { OrchestratorPacket, OrchestratorPacketType } from '@/lib/orchestrator/types';
 import { normalizePacketTaskContract } from '@/lib/orchestrator/packet-task-contract';
 import { normalizeWorkerLaunchContext } from '@/lib/orchestrator/worker-launch-context';
+import { isExecutionCarrierId, UnknownExecutionCarrierError } from '@/lib/runtimes/shared/execution-carrier';
 
 /**
  * Narrow an arbitrary value to a known packet type tag. Only `decompose` is
@@ -48,6 +49,12 @@ export function normalizeClaudeCodePacketPins(
       ? carrier
       : null,
   };
+}
+
+export function normalizePacketExecutionCarrier(value: unknown): OrchestratorPacket['executionCarrier'] {
+  if (value === null || value === undefined) return null;
+  if (isExecutionCarrierId(value)) return value;
+  throw new UnknownExecutionCarrierError(value);
 }
 
 /**

--- a/src/lib/orchestrator/operator-mission-service/merge-head-error.ts
+++ b/src/lib/orchestrator/operator-mission-service/merge-head-error.ts
@@ -1,0 +1,17 @@
+export class HeadShaMismatchError extends Error {
+  readonly packetId: string;
+  readonly expectedHeadSha: string;
+  readonly currentHeadSha: string;
+
+  constructor(packetId: string, expectedHeadSha: string, currentHeadSha: string) {
+    super(`Worktree HEAD changed since review for packet ${packetId}: expected ${expectedHeadSha}, current ${currentHeadSha}. Re-review before merging.`);
+    this.name = 'HeadShaMismatchError';
+    this.packetId = packetId;
+    this.expectedHeadSha = expectedHeadSha;
+    this.currentHeadSha = currentHeadSha;
+  }
+}
+
+export function isHeadShaMismatchError(error: unknown): error is HeadShaMismatchError {
+  return error instanceof HeadShaMismatchError;
+}

--- a/src/lib/orchestrator/operator-mission-service/merge.ts
+++ b/src/lib/orchestrator/operator-mission-service/merge.ts
@@ -5,8 +5,12 @@ import type { WorktreeInfo } from '@/lib/worktree/types';
 import type { ApproveAndMergeInput, MergePacketResult, PickComparisonWinnerInput } from './types';
 import { autoResolveMergedPacketVerificationIncidents } from '@/lib/supervisor/merged-incident-resolution';
 import { attachQualitySearchReceipt, ensureComparisonWinnerReview, resolveQualitySearchComparison } from './quality-search-selection';
-import { alreadyReleasedResultForPacket, buildAlreadyReleasedResult } from './release-truth';
+import { alreadyReleasedResultForPacketId } from './release-truth';
+export { isTerminalReleaseLane } from './release-truth';
+import { HeadShaMismatchError } from './merge-head-error';
+export { HeadShaMismatchError, isHeadShaMismatchError } from './merge-head-error';
 import { markPacketReleased } from '@/lib/orchestrator/packet-release-truth';
+import { packetReleaseGeneration, packetReleaseIdentityIsCurrent } from '@/lib/orchestrator/release-ownership';
 import { withPacketMergeWorkspace } from './merge-workspace-guard';
 import { selectMergeSequence } from './merge-order';
 export { selectMergeSequence } from './merge-order';
@@ -26,7 +30,6 @@ const loadDispatch = () => import('@/lib/orchestrator/dispatch');
 const loadWorktreeCleanup = () => import('@/lib/orchestrator/worktree-cleanup');
 const loadWorktreeConflicts = () => import('@/lib/worktree/conflicts');
 const loadWorktreeLaunch = () => import('@/lib/worktree/launch');
-const loadMergeTruth = () => import('./merge-truth');
 const loadPostMergeCleanup = () => import('./post-merge-cleanup');
 const loadReviewCarry = () => import('./review-carry');
 const loadReview = () => import('./review');
@@ -64,66 +67,10 @@ interface OrderedMergeCandidate extends MergeOrderCandidate {
   overlappingWorktreeIds: Set<string>;
 }
 
-export class HeadShaMismatchError extends Error {
-  readonly packetId: string;
-  readonly expectedHeadSha: string;
-  readonly currentHeadSha: string;
-
-  constructor(packetId: string, expectedHeadSha: string, currentHeadSha: string) {
-    super(`Worktree HEAD changed since review for packet ${packetId}: expected ${expectedHeadSha}, current ${currentHeadSha}. Re-review before merging.`);
-    this.name = 'HeadShaMismatchError';
-    this.packetId = packetId;
-    this.expectedHeadSha = expectedHeadSha;
-    this.currentHeadSha = currentHeadSha;
-  }
-}
-
-export function isHeadShaMismatchError(error: unknown): error is HeadShaMismatchError {
-  return error instanceof HeadShaMismatchError;
-}
-
 function isPacketAwaitingMerge(packet: OrchestratorPacket) {
   return packet.status === 'awaiting_review'
     && packet.releaseState !== 'released'
     && packet.review?.approved !== false;
-}
-
-/** Exported for the lane-rebind vitest suite (#1214) — not part of the public API. */
-export async function isTerminalReleaseLane(packetId: string) {
-  const { getLaneEvents, listLanes } = await loadLaneRegistry();
-  return listLanes().some((lane) => {
-    if (lane.packetId !== packetId) return false;
-    if (lane.status === 'completed') return true;
-    if (lane.status !== 'archived') return false;
-    // #1214 — archived alone is NOT release evidence: lanes archive after
-    // worker death too (e.g. silent_exit_no_work), and a dead lane that kept
-    // its packet binding must not short-circuit the recovery lane's merge.
-    // Require the lane to have actually passed through 'completed' (only set
-    // once a merge landed) before claiming the packet was released.
-    return getLaneEvents(lane.id).some((event) =>
-      event.verb === 'status_change' && event.payload.status === 'completed'
-    );
-  });
-}
-
-async function alreadyReleasedResultForPacketId(packetId: string, packets: OrchestratorPacket[]) {
-  const { findLatestLaneByPacket, getLaneEvents } = await loadLaneRegistry();
-  const lane = findLatestLaneByPacket(packetId);
-  const packet = packets.find((candidate) => candidate.id === packetId);
-  const packetResult = await alreadyReleasedResultForPacket(packet, lane);
-  if (packetResult) return packetResult;
-  if (await isTerminalReleaseLane(packetId) && lane?.repoPath) {
-    const laneHeadSha = getLaneEvents(lane.id).slice().reverse()
-      .map((event) => event.payload.laneHeadSha)
-      .find((sha): sha is string => typeof sha === 'string' && sha.trim().length > 0)?.trim();
-    if (laneHeadSha) {
-      const { isAncestorCommit, readGitHead } = await loadMergeTruth();
-      if (await isAncestorCommit(lane.repoPath, laneHeadSha, 'HEAD')) {
-        return buildAlreadyReleasedResult(await readGitHead(lane.repoPath));
-      }
-    }
-  }
-  return null;
 }
 
 async function getWaveMergeOrder(
@@ -331,6 +278,7 @@ async function dispatchPacketMerge(
   if (!workspaceLockHeld) {
     return withPacketMergeWorkspace(lane, () => dispatchPacketMerge(packet, input, actor, true));
   }
+  const releaseGeneration = packetReleaseGeneration(packet, lane.id);
   let carriedReviewedHeadSha: string | undefined;
   const reviewedHead = await checkReviewedHeadIntegrity(lane, lane.worktreePath || lane.repoPath);
   if (!reviewedHead.ok) {
@@ -514,7 +462,7 @@ async function dispatchPacketMerge(
   if (result.ok) {
     await withLockedState((fresh) => {
       const packetState = fresh.packets.find((candidate) => candidate.id === input.packetId);
-      if (!packetState) return;
+      if (!packetState || !packetReleaseIdentityIsCurrent(packetState, lane.id, releaseGeneration)) return;
       markPacketReleased(packetState, {
         source: 'approve_and_merge',
         mergeCommit: result.mergeSha ?? null,

--- a/src/lib/orchestrator/operator-mission-service/mission.ts
+++ b/src/lib/orchestrator/operator-mission-service/mission.ts
@@ -6,7 +6,7 @@ import { buildDagMetadata, buildDependencyGraph } from '@/lib/orchestrator/dag';
 import { applyPacketScopePolicy, buildRemainingLaunchBudget, computePredictedFiles, runDispatchTick } from '@/lib/orchestrator/dispatch';
 import { findLaneByPacket, getLaneEvents, listLanes } from '@/lib/lane/registry';
 import { recoveryInfoFromLaneEvents } from '@/lib/lane/recovery-info';
-import { resolveBranchPrefixSync } from '@/lib/operator/defaults';
+import { getOperatorDefaultsSync, resolveBranchPrefixSync } from '@/lib/operator/defaults';
 import { currentLaneMergePolicy } from '@/lib/lane/dogfood-guard';
 import { listArtifacts, toArtifactRef } from '@/lib/artifacts/store';
 import { normalizeOrchestratorMissionState } from '@/lib/orchestrator/store';
@@ -21,6 +21,7 @@ import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 import { bindWorkerLaunchParent } from '@/lib/orchestrator/worker-launch-context';
 import { assertQualitySearchMissionCompatibility, resolveTaskContractRequired } from '@/lib/orchestrator/task-contract-required';
 import { withMissionHandoffBarrier } from '@/lib/orchestrator/lifecycle-mutation-lock';
+import { assertExecutionCarrierCompatible, isExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 import { releaseAbandonedMissionLifecycleHold } from '@/lib/orchestrator/mission-lifecycle-hold';
 import { getTopRulesForPacket, readRepoScopedRules } from '@/lib/dispatch/rules-store';
 import { prepareMissionBranches, type MissionBranchDecision } from './branch-cleanup';
@@ -141,6 +142,25 @@ export async function createMission(input: CreateMissionInput) {
     requestedEffort: input.requestedEffort,
     source: 'mission-create',
   });
+  const executionCarrier = input.executionCarrier === undefined
+    ? getOperatorDefaultsSync().values.workerExecutionCarrier
+    : input.executionCarrier;
+  if (executionCarrier !== null && !isExecutionCarrierId(executionCarrier)) {
+    throw new Error('executionCarrier must be "ori" or null.');
+  }
+  const packetRoutings = loadedIssues.map((issue) => issue.runtime
+    ? resolveWorkerRouting({
+        workerIntent: input.workerIntent,
+        requestedProvider: input.requestedProvider,
+        requestedRuntime: issue.runtime,
+        requestedModel: resolveRuntimePresetModel(input.runtimePreset, issue.runtime, input.requestedModel, input.claudeCodeCarrier),
+        requestedEffort: input.requestedEffort,
+        source: 'mission-create-packet',
+      })
+    : workerRouting);
+  if (executionCarrier) {
+    for (const routing of packetRoutings) assertExecutionCarrierCompatible(executionCarrier, routing.selectedRuntime);
+  }
   const branchPreparation = await prepareMissionBranches({
     repoPath,
     candidates: loadedIssues.map((issue, index) => ({
@@ -168,16 +188,7 @@ export async function createMission(input: CreateMissionInput) {
     // Per-issue runtime — a mission can mix Codex + Gemini packets (the swarm
     // "split coding/thinking" path). When the issue pins its own runtime, route
     // that packet through it; otherwise inherit the mission-level routing.
-    const packetRouting = issue.runtime
-      ? resolveWorkerRouting({
-          workerIntent: input.workerIntent,
-          requestedProvider: input.requestedProvider,
-          requestedRuntime: issue.runtime,
-          requestedModel: resolveRuntimePresetModel(input.runtimePreset, issue.runtime, input.requestedModel, input.claudeCodeCarrier),
-          requestedEffort: input.requestedEffort,
-          source: 'mission-create-packet',
-        })
-      : workerRouting;
+    const packetRouting = packetRoutings[index]!;
 
     // #453/#inline-branch-hardening — Inline tasks carry their unique issue
     // number in the branch to avoid same-title mission collisions.
@@ -236,6 +247,7 @@ export async function createMission(input: CreateMissionInput) {
       lane: null,
       assignedModel: packetRouting.selectedModel,
       ...(packetRouting.selectedRuntime === 'claude-code' ? { claudeCodeModel: input.claudeCodeModel?.trim() || null, claudeCodeCarrier: input.claudeCodeCarrier ?? null } : {}),
+      ...(executionCarrier ? { executionCarrier } : {}),
       workerIntent: packetRouting.workerIntent,
       workerRouting: packetRouting,
       dispatchRuntimePin: packetRouting.requestedRuntime ?? packetRouting.selectedRuntime,

--- a/src/lib/orchestrator/operator-mission-service/packet-patch.test.ts
+++ b/src/lib/orchestrator/operator-mission-service/packet-patch.test.ts
@@ -42,6 +42,17 @@ function packet(id: string, title: string): OrchestratorPacket {
 }
 
 describe('patchMissionPacket', () => {
+  it('checks generation ownership after acquiring the packet lock and preserves newer output', async () => {
+    const current = { ...packet('pkt-generation', 'Generation'),
+      explainer: { status: 'ready' as const, artifactId: 'newer-artifact' } };
+    writeOrchestratorControlPlaneState({ ...createEmptyOrchestratorMissionState(),
+      missionId: 'mission-generation', packets: [current] });
+    const before = readOrchestratorControlPlaneState().packets[0].explainer;
+    await expect(patchMissionPacket(current.id, {
+      explainer: { status: 'failed', error: 'late failure' },
+    }, () => false)).resolves.toBe(false);
+    expect(readOrchestratorControlPlaneState().packets[0].explainer).toEqual(before);
+  });
   it('preserves a packet added by another process after this process cached mission state', async () => {
     const alpha = packet('pkt-alpha', 'Alpha');
     const beta = packet('pkt-beta', 'Beta');

--- a/src/lib/orchestrator/operator-mission-service/packet-patch.ts
+++ b/src/lib/orchestrator/operator-mission-service/packet-patch.ts
@@ -10,8 +10,13 @@ import type { OrchestratorPacket } from '@/lib/orchestrator/types';
  * Used by the review pipeline to stamp packet-scoped review artifacts
  * (deviations #1490, explainer #1491) that the surfaces read back.
  */
-export async function patchMissionPacket(packetId: string, patch: Partial<OrchestratorPacket>): Promise<boolean> {
+export async function patchMissionPacket(
+  packetId: string,
+  patch: Partial<OrchestratorPacket>,
+  isCurrent: () => boolean = () => true,
+): Promise<boolean> {
   const { result } = await withLockedState((state) => {
+    if (!isCurrent()) return false;
     const index = state.packets.findIndex((candidate) => candidate.id === packetId);
     if (index === -1) return false;
     state.packets[index] = { ...state.packets[index], ...patch };

--- a/src/lib/orchestrator/operator-mission-service/release-truth.ts
+++ b/src/lib/orchestrator/operator-mission-service/release-truth.ts
@@ -1,13 +1,77 @@
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { promisify } from 'node:util';
+import type { Lane } from '@/lib/lane/types';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import { hasCanonicalReleaseEvidence } from '@/lib/orchestrator/packet-release-truth';
 import type { MergePacketResult } from './types';
 
 interface ReleaseLane {
+  id?: string;
   repoPath: string;
   branch?: string | null;
+  baseBranch?: string | null;
+  worktreePath?: string | null;
+  status?: Lane['status'];
 }
 
+const execFileAsync = promisify(execFile);
 const loadControlPlane = () => import('@/lib/orchestrator/control-plane');
 const loadMergeTruth = () => import('./merge-truth');
+const loadLaneRegistry = () => import('@/lib/lane/registry');
+
+async function gitValue(cwd: string, args: string[]): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('git', args, {
+      cwd, windowsHide: true, timeout: 5_000, maxBuffer: 512 * 1024,
+    });
+    return stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+function readCommit(cwd: string, ref: string): Promise<string | null> {
+  return gitValue(cwd, ['rev-parse', '--verify', '--end-of-options', `${ref}^{commit}`]);
+}
+
+/** A release belongs to its target branch, not the checkout's incidental HEAD. */
+async function verifyCurrentRelease(
+  lane: ReleaseLane,
+  mergeSha: string,
+  recordedHead: string | null,
+  acceptsRecordedMerge: boolean,
+): Promise<string | null> {
+  const base = lane.baseBranch?.trim() || 'main';
+  if (base === 'HEAD') return null;
+  const baseRef = base.startsWith('refs/') ? base : `refs/heads/${base}`;
+  const baseSha = await readCommit(lane.repoPath, baseRef)
+    ?? await readCommit(lane.repoPath, `refs/remotes/origin/${base}`);
+  if (!baseSha) return null;
+  const { isAncestorCommit } = await loadMergeTruth();
+  if (!(await isAncestorCommit(lane.repoPath, mergeSha, baseSha))) return null;
+
+  const worktree = lane.worktreePath && existsSync(lane.worktreePath) ? lane.worktreePath : null;
+  const currentHead = worktree
+    ? await readCommit(worktree, 'HEAD')
+    : lane.branch ? await readCommit(lane.repoPath, lane.branch) : null;
+  if (worktree && await gitValue(worktree, ['status', '--porcelain', '--untracked-files=normal']) !== '') return null;
+
+  if (!currentHead) {
+    // A completed merge may have already cleaned up both the branch and worktree.
+    // Only its explicit, HEAD-pinned receipt can survive that missing Git state.
+    return !worktree && acceptsRecordedMerge && recordedHead
+      && (lane.status === 'completed' || lane.status === 'archived')
+      ? baseSha : null;
+  }
+  if (recordedHead && currentHead !== recordedHead) return null;
+  const landed = acceptsRecordedMerge && recordedHead === currentHead
+    || await isAncestorCommit(lane.repoPath, currentHead, baseSha);
+  if (!landed) return null;
+  // Refuse evidence that moved while the Git probes were in flight.
+  const finalHead = await readCommit(worktree || lane.repoPath, worktree ? 'HEAD' : lane.branch!);
+  return finalHead === currentHead ? baseSha : null;
+}
 
 export function buildAlreadyReleasedResult(mergeSha: string): MergePacketResult {
   return {
@@ -23,15 +87,28 @@ function isAlreadyReleasedPacket(packet: OrchestratorPacket | null | undefined) 
   return packet?.releaseState === 'released';
 }
 
-function recordedMergeSha(packet: OrchestratorPacket | null | undefined) {
-  return packet?.releaseStatePayload?.mergeCommit?.trim() || null;
+function claimIdentity(packet: OrchestratorPacket): string {
+  const receipt = packet.releaseStatePayload;
+  return JSON.stringify([
+    receipt?.source ?? null, receipt?.mergeCommit ?? null, receipt?.headSha ?? null,
+    receipt?.evidenceKind ?? null, receipt?.releasedAt ?? null,
+    packet.releaseState, packet.lane?.laneId ?? null, packet.attemptCount ?? 0,
+    packet.storageAdmissionEpoch ?? 0, packet.workspaceTargetPath, packet.branchTarget,
+    Boolean(packet.operatorStopped), packet.archivedAt ?? null,
+  ]);
 }
 
-async function clearStaleReleaseClaim(packetId: string, reason: string) {
+async function claimStillCurrent(packetId: string, expected: OrchestratorPacket | undefined): Promise<boolean> {
+  const { readOrchestratorControlPlaneState } = await loadControlPlane();
+  const current = readOrchestratorControlPlaneState().packets.find((packet) => packet.id === packetId);
+  return expected && current ? claimIdentity(expected) === claimIdentity(current) : !expected && !current;
+}
+
+async function clearStaleReleaseClaim(expected: OrchestratorPacket, reason: string) {
   const { withLockedState } = await loadControlPlane();
   await withLockedState((state) => {
-    const packet = state.packets.find((candidate) => candidate.id === packetId);
-    if (!packet || !isAlreadyReleasedPacket(packet)) return;
+    const packet = state.packets.find((candidate) => candidate.id === expected.id);
+    if (!packet || !isAlreadyReleasedPacket(packet) || claimIdentity(packet) !== claimIdentity(expected)) return;
     packet.releaseState = 'pending';
     if (packet.status === 'released') packet.status = 'awaiting_review';
     packet.releaseStatePayload = { ...(packet.releaseStatePayload ?? {}), source: reason };
@@ -42,37 +119,49 @@ export async function alreadyReleasedResultForPacket(
   packet: OrchestratorPacket | null | undefined,
   lane: ReleaseLane | null | undefined,
 ): Promise<MergePacketResult | null> {
-  if (!isAlreadyReleasedPacket(packet)) return null;
-  const mergeSha = recordedMergeSha(packet);
-  if (mergeSha && lane?.repoPath) {
-    const { isAncestorCommit } = await loadMergeTruth();
-    if (await isAncestorCommit(lane.repoPath, mergeSha, 'HEAD')) {
-      // A no-change reconciliation can record the base as its merge SHA. The
-      // branch must also be on HEAD before that recorded release is trusted.
-      if (lane.branch && !(await isAncestorCommit(lane.repoPath, lane.branch, 'HEAD'))) {
-        console.error('[merge-truth] released packet branch advanced past its recorded merge', {
-          packetId: packet?.id,
-          branch: lane.branch,
-          mergeSha,
-          repoPath: lane.repoPath,
-        });
-        if (packet?.id) await clearStaleReleaseClaim(packet.id, 'stale_release_flag_branch_advanced');
-        return null;
-      }
-      return buildAlreadyReleasedResult(mergeSha);
-    }
-    console.error('[merge-truth] stale released packet flag; merge SHA is not on main ancestry', {
-      packetId: packet?.id,
-      mergeSha,
-      repoPath: lane.repoPath,
-    });
-    await clearStaleReleaseClaim(packet!.id, 'stale_release_flag_ancestry_failed');
-    return null;
+  if (!packet || !isAlreadyReleasedPacket(packet)) return null;
+  // A receipt from another bound lane cannot answer for this packet generation.
+  if (packet.lane?.laneId && packet.lane.laneId !== lane?.id) return null;
+  const payload = packet.releaseStatePayload;
+  const mergeSha = payload?.mergeCommit?.trim();
+  const recordedHead = payload?.headSha?.trim() || null;
+  const acceptsRecordedMerge = hasCanonicalReleaseEvidence(packet)
+    && ['merge_command', 'patch-id', 'pull_request_merged'].includes(payload?.evidenceKind ?? '');
+  if (mergeSha && lane?.repoPath && await verifyCurrentRelease(lane, mergeSha, recordedHead, acceptsRecordedMerge)) {
+    return await claimStillCurrent(packet.id, packet) ? buildAlreadyReleasedResult(mergeSha) : null;
   }
-  console.error('[merge-truth] stale released packet flag; no merge SHA available for ancestry verification', {
-    packetId: packet?.id,
-    repoPath: lane?.repoPath ?? null,
-  });
-  if (packet?.id) await clearStaleReleaseClaim(packet.id, 'stale_release_flag_missing_merge_sha');
+  await clearStaleReleaseClaim(packet, 'stale_release_flag_current_work_unproved');
   return null;
+}
+
+/** Terminal status is only a candidate for Git verification, never release proof. */
+export async function isTerminalReleaseLane(packetId: string): Promise<boolean> {
+  const { findLatestLaneByPacket, getLaneEvents } = await loadLaneRegistry();
+  const lane = findLatestLaneByPacket(packetId);
+  if (!lane) return false;
+  return lane.status === 'completed' || (lane.status === 'archived' && getLaneEvents(lane.id).some(
+    (event) => event.verb === 'status_change' && event.payload.status === 'completed',
+  ));
+}
+
+export async function alreadyReleasedResultForPacketId(packetId: string, packets: OrchestratorPacket[]) {
+  const { findLatestLaneByPacket, getLane, getLaneEvents } = await loadLaneRegistry();
+  const { readOrchestratorControlPlaneState } = await loadControlPlane();
+  // Read-time reconciliation intentionally hides released lane bindings. Use
+  // the durable binding for generation identity, not that UI projection.
+  const packet = readOrchestratorControlPlaneState().packets.find((candidate) => candidate.id === packetId)
+    ?? packets.find((candidate) => candidate.id === packetId);
+  const lane = packet?.lane?.laneId ? getLane(packet.lane.laneId) : findLatestLaneByPacket(packetId);
+  const packetResult = await alreadyReleasedResultForPacket(packet, lane);
+  if (packetResult) return packetResult;
+  // A rejected receipt must not be resurrected by an older lane-completion event.
+  if (packet?.releaseState === 'released' || packet?.operatorStopped || packet?.archivedAt) return null;
+  if (!lane?.repoPath || !['completed', 'archived'].includes(lane.status)) return null;
+  const laneHeadSha = getLaneEvents(lane.id).slice().reverse()
+    .filter((event) => event.verb === 'merge')
+    .map((event) => event.payload.laneHeadSha)
+    .find((sha): sha is string => typeof sha === 'string' && sha.trim().length > 0)?.trim();
+  if (!laneHeadSha) return null;
+  const baseSha = await verifyCurrentRelease(lane, laneHeadSha, laneHeadSha, true);
+  return baseSha && await claimStillCurrent(packetId, packet) ? buildAlreadyReleasedResult(baseSha) : null;
 }

--- a/src/lib/orchestrator/operator-mission-service/types.ts
+++ b/src/lib/orchestrator/operator-mission-service/types.ts
@@ -12,6 +12,7 @@ import type {
 import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import type { ClaudeCodeModelSource } from '@/lib/claude-code/worker-profile-types';
 import type { RuntimePresetId } from '@/lib/orchestrator/runtime-capabilities';
+import type { ExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 
 export interface LoadedIssue {
   number: number;
@@ -44,6 +45,8 @@ export interface CreateMissionInput {
   claudeCodeModel?: string | null;
   /** Explicit per-packet carrier pin for Claude Code workers. */
   claudeCodeCarrier?: ClaudeCodeModelSource | null;
+  /** Optional execution wrapper. Omit to inherit the persisted operator setting. */
+  executionCarrier?: ExecutionCarrierId | null;
   /** Requested worker reasoning effort. Applied at launch only for runtimes with
    *  a reasoning-effort surface (codex/claude-code); a no-op elsewhere. Omit for
    *  today's behavior (runtime default). */

--- a/src/lib/orchestrator/packet-release-truth.ts
+++ b/src/lib/orchestrator/packet-release-truth.ts
@@ -60,7 +60,8 @@ export function hasCanonicalReleaseEvidence(
     return evidenceKind === '' || evidenceKind === 'read_only_no_merge_required';
   }
   if (source === 'headless_released') {
-    return evidenceKind === 'headless_loop';
+    return evidenceKind === 'pull_request_merged' && mergeCommit.length > 0
+      && Boolean(payload?.headSha?.trim());
   }
   if (
     source === 'approve_and_merge'
@@ -115,7 +116,8 @@ export function clearUnprovenReleaseClaim(packet: ReleasablePacket): boolean {
   packet.releaseState = 'pending';
   packet.releaseStatePayload = null;
   if (packet.status === 'released') packet.status = 'awaiting_review';
-  if (packet.queueState === 'held') packet.queueState = 'queued';
+  // Invalid historical receipts need review, not an automatic new worker.
+  packet.queueState = 'held';
   packet.blockedReason = 'Release evidence is missing; review recovery is required.';
   return true;
 }

--- a/src/lib/orchestrator/read-only-completion.test.ts
+++ b/src/lib/orchestrator/read-only-completion.test.ts
@@ -10,6 +10,7 @@ const { createLane, getLane, setLaneStatus } = await import('@/lib/lane/registry
 const {
   readOrchestratorControlPlaneState,
   writeOrchestratorControlPlaneState,
+  withControlPlaneLock,
 } = await import('@/lib/orchestrator/control-plane');
 const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
 const {
@@ -85,6 +86,28 @@ function completionContext(packetId: string): PacketContext {
 }
 
 describe('read-only zero-diff completion', () => {
+  it('does not release or retire a lane when Stop wins the persistence lock', async () => {
+    const lane = seed('pkt-read-only-stop-race', true);
+    let completion!: ReturnType<typeof completeReadOnlyZeroDiffLane>;
+    await withControlPlaneLock(async () => {
+      completion = completeReadOnlyZeroDiffLane(lane, completionContext(lane.packetId!));
+      const state = readOrchestratorControlPlaneState();
+      state.packets[0].operatorStopped = true;
+      writeOrchestratorControlPlaneState(state);
+    });
+    expect((await completion).completed).toBe(false);
+    expect(getLane(lane.id)?.status).toBe('running');
+    expect(readOrchestratorControlPlaneState().packets[0]).toMatchObject({ operatorStopped: true, releaseState: 'pending' });
+  });
+
+  it('refuses a finding receipt from a different session', async () => {
+    const lane = seed('pkt-read-only-other-turn', true);
+    expect(await completeReadOnlyZeroDiffLane(lane, {
+      ...completionContext(lane.packetId!), sessionKey: 'different-session',
+    })).toMatchObject({ completed: false, blocked: true });
+    expect(readOrchestratorControlPlaneState().packets[0].releaseState).toBe('pending');
+  });
+
   it('waits for the final self-review when the runtime completion beats transcript persistence', async () => {
     let captures = 0;
     const context = await captureSettledReadOnlyCompletionContext(async () => {

--- a/src/lib/orchestrator/read-only-completion.ts
+++ b/src/lib/orchestrator/read-only-completion.ts
@@ -1,10 +1,11 @@
-import { updateLane } from '@/lib/lane/registry';
+import { getLane, updateLane } from '@/lib/lane/registry';
 import type { Lane } from '@/lib/lane/types';
 import { readOrchestratorControlPlaneState, withLockedState } from '@/lib/orchestrator/control-plane';
-import { withMissionRegistryState } from '@/lib/orchestrator/mission-registry';
+import { findMissionRegistryEntryByPacketId, withMissionRegistryState } from '@/lib/orchestrator/mission-registry';
 import { resolvePacketLaunchContext } from '@/lib/orchestrator/packet-launch-context';
 import { markPacketReleased } from '@/lib/orchestrator/packet-release-truth';
 import type { OrchestratorPacket, PacketContext } from '@/lib/orchestrator/types';
+import { packetReleaseGeneration, packetReleaseIdentityIsCurrent } from './release-ownership';
 
 export const READ_ONLY_COMPLETED_EVENT_LABEL = 'read_only_completed';
 
@@ -88,72 +89,38 @@ export async function completeReadOnlyZeroDiffLane(
 ): Promise<ReadOnlyCompletionResult> {
   const packetId = lane.packetId?.trim();
   if (!packetId) return { completed: false };
-
-  const resolved = resolvePacketLaunchContext(packetId);
-  if (!isReadOnlyPacketLane(lane) || !resolved) return { completed: false };
-
+  const currentPacket = readOrchestratorControlPlaneState().packets.find((packet) => packet.id === packetId);
+  const entry = !currentPacket ? findMissionRegistryEntryByPacketId(packetId, { includeArchived: true }) : null;
+  const snapshot = currentPacket ?? entry?.mission.packets.find((packet) => packet.id === packetId);
+  if (!snapshot || snapshot.launchContext?.workMode !== 'read-only') return { completed: false };
+  const generation = packetReleaseGeneration(snapshot, lane.id);
   const completedAt = new Date().toISOString();
-  if (!hasCompleteReadOnlyReceipt(context)) {
-    const detail = `Packet ${packetId} ended its read-only run without a complete Outcome, Evidence, Residual, and finding_ready receipt.`;
-    const blockedLane = updateLane(lane.id, {
-      status: 'awaiting_input',
-      outcome: null,
-      outcomeNote: detail,
+  const hasReceipt = hasCompleteReadOnlyReceipt(context) && context?.packetId === packetId
+    && (!lane.sessionKey || context?.sessionKey === lane.sessionKey);
+  const detail = `Packet ${packetId} ended its read-only run without a complete Outcome, Evidence, Residual, and finding_ready receipt.`;
+  const apply = (packet: OrchestratorPacket | undefined): ReadOnlyCompletionResult => {
+    const freshLane = getLane(lane.id);
+    if (!packet || !freshLane || packet.launchContext?.workMode !== 'read-only'
+      || freshLane.sessionKey !== lane.sessionKey || ['paused', 'archived'].includes(freshLane.status)
+      || !packetReleaseIdentityIsCurrent(packet, lane.id, generation)) return { completed: false };
+    const settledLane = updateLane(lane.id, {
+      status: hasReceipt ? 'completed' : 'awaiting_input',
+      outcome: hasReceipt ? 'no_changes' : null,
+      outcomeNote: hasReceipt ? context!.selfReview!.outcome!.trim() : detail,
       lastEventAt: completedAt,
-      lastEventLabel: 'read_only_evidence_missing',
-    }, 'system') ?? lane;
-
-    const current = readOrchestratorControlPlaneState();
-    if (current.packets.some((packet) => packet.id === packetId)) {
-      await withLockedState((state) => {
-        const packet = state.packets.find((candidate) => candidate.id === packetId);
-        if (packet) markPacketEvidenceMissing(packet, completedAt, blockedLane);
-      });
-    }
-
-    if (resolved.missionId) {
-      try {
-        await withMissionRegistryState(resolved.missionId, (state) => {
-          const packet = state.packets.find((candidate) => candidate.id === packetId);
-          if (packet) markPacketEvidenceMissing(packet, completedAt, blockedLane);
-          return { state, result: null };
-        });
-      } catch (error) {
-        console.warn(`[read-only-completion] Failed to block mission ${resolved.missionId}:`, error);
-      }
-    }
-
-    return { completed: false, blocked: true, detail, lane: blockedLane };
+      lastEventLabel: hasReceipt ? READ_ONLY_COMPLETED_EVENT_LABEL : 'read_only_evidence_missing',
+    }, 'system') ?? freshLane;
+    if (hasReceipt) markPacketCompleted(packet, completedAt, settledLane);
+    else markPacketEvidenceMissing(packet, completedAt, settledLane);
+    return hasReceipt ? { completed: true, lane: settledLane }
+      : { completed: false, blocked: true, detail, lane: settledLane };
+  };
+  // Mutate the durable owner only. The headless tick mirrors current missions;
+  // a second unlocked lookup here could apply this old result to a new owner.
+  if (currentPacket) {
+    return (await withLockedState((state) => apply(state.packets.find((packet) => packet.id === packetId)))).result;
   }
-
-  const completedLane = updateLane(lane.id, {
-    status: 'completed',
-    outcome: 'no_changes',
-    outcomeNote: context?.selfReview?.outcome?.trim()
-      || 'Read-only inspection completed without repository changes.',
-    lastEventAt: completedAt,
-    lastEventLabel: READ_ONLY_COMPLETED_EVENT_LABEL,
-  }, 'system') ?? lane;
-
-  const current = readOrchestratorControlPlaneState();
-  if (current.packets.some((packet) => packet.id === packetId)) {
-    await withLockedState((state) => {
-      const packet = state.packets.find((candidate) => candidate.id === packetId);
-      if (packet) markPacketCompleted(packet, completedAt, completedLane);
-    });
-  }
-
-  if (resolved.missionId) {
-    try {
-      await withMissionRegistryState(resolved.missionId, (state) => {
-        const packet = state.packets.find((candidate) => candidate.id === packetId);
-        if (packet) markPacketCompleted(packet, completedAt, completedLane);
-        return { state, result: null };
-      });
-    } catch (error) {
-      console.warn(`[read-only-completion] Failed to update mission ${resolved.missionId}:`, error);
-    }
-  }
-
-  return { completed: true, lane: completedLane };
+  return (await withMissionRegistryState(entry!.id, (state) => ({
+    state, result: apply(state.packets.find((packet) => packet.id === packetId)),
+  }))).result;
 }

--- a/src/lib/orchestrator/release-ownership.ts
+++ b/src/lib/orchestrator/release-ownership.ts
@@ -1,0 +1,41 @@
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { promisify } from 'node:util';
+import { getSqlite } from '@/lib/db';
+import { findLatestLaneByPacket } from '@/lib/lane/registry';
+import type { Lane } from '@/lib/lane/types';
+import type { OrchestratorPacket } from './types';
+
+const execFileAsync = promisify(execFile);
+
+export function packetReleaseGeneration(packet: OrchestratorPacket, laneId: string): string {
+  const turn = getSqlite().prepare(`SELECT id FROM lane_events WHERE lane_id = ?
+    AND verb IN ('steered_packet', 'steer_run_admitted', 'steer_failed', 'launch_requested') ORDER BY rowid DESC LIMIT 1`)
+    .get(laneId) as { id: string } | undefined;
+  return JSON.stringify([packet.id, packet.lane?.laneId ?? laneId, packet.attemptCount ?? 0,
+    packet.storageAdmissionEpoch ?? 0, packet.workspaceTargetPath, packet.branchTarget, turn?.id ?? null]);
+}
+
+export function packetReleaseIdentityIsCurrent(packet: OrchestratorPacket, laneId: string, generation: string, allowReleased = false): boolean {
+  if (packet.operatorStopped || packet.archivedAt || packet.status === 'archived'
+    || (!allowReleased && packet.releaseState === 'released')) return false;
+  const binding = packet.lane?.laneId ?? findLatestLaneByPacket(packet.id)?.id;
+  return binding === laneId && packetReleaseGeneration(packet, laneId) === generation;
+}
+
+async function git(cwd: string, args: string[]): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('git', args, { cwd, windowsHide: true, timeout: 2_000, maxBuffer: 512 * 1024 });
+    return stdout.trim();
+  } catch { return null; }
+}
+
+/** Recheck the actual checkout, including detached HEAD and uncommitted work. */
+export async function verifyCurrentLaneHead(lane: Lane, headSha: string): Promise<boolean> {
+  const worktree = lane.worktreePath && existsSync(lane.worktreePath) ? lane.worktreePath : null;
+  const cwd = worktree || lane.repoPath, ref = worktree ? 'HEAD' : lane.branch;
+  if (!ref || !headSha) return false;
+  if (await git(cwd, ['rev-parse', '--verify', '--end-of-options', `${ref}^{commit}`]) !== headSha) return false;
+  if (worktree && await git(worktree, ['status', '--porcelain', '--untracked-files=normal']) !== '') return false;
+  return await git(cwd, ['rev-parse', '--verify', '--end-of-options', `${ref}^{commit}`]) === headSha;
+}

--- a/src/lib/orchestrator/store.ts
+++ b/src/lib/orchestrator/store.ts
@@ -1,4 +1,4 @@
-import { normalizeClaudeCodePacketPins, normalizeDecompositionMetadata, normalizePacketDispatcher, normalizePacketLaunchContext, normalizePacketTaskContractFields, normalizePacketType } from '@/lib/orchestrator/normalize/decomposition';
+import { normalizeClaudeCodePacketPins, normalizeDecompositionMetadata, normalizePacketDispatcher, normalizePacketExecutionCarrier, normalizePacketLaunchContext, normalizePacketTaskContractFields, normalizePacketType } from '@/lib/orchestrator/normalize/decomposition';
 import { normalizeRuntimeStatusToOrchestratorStatus } from '@/lib/orchestrator/runtime-status';
 import { runtimeTruthHasActiveWriter } from '@/lib/orchestrator/runtime-truth';
 import { normalizePacketRecovery } from '@/lib/lane/recovery-info';
@@ -383,7 +383,7 @@ function normalizePacket(raw: unknown, index: number, existing: Array<Pick<Orche
     comparisonIndex: typeof packet.comparisonIndex === 'number' && Number.isFinite(packet.comparisonIndex) && packet.comparisonIndex >= 0
       ? Math.floor(packet.comparisonIndex)
       : undefined,
-    assignedModel: (typeof packet.assignedModel === 'string' && packet.assignedModel.trim()) || null, ...normalizeClaudeCodePacketPins(packet),
+    assignedModel: (typeof packet.assignedModel === 'string' && packet.assignedModel.trim()) || null, ...normalizeClaudeCodePacketPins(packet), executionCarrier: normalizePacketExecutionCarrier(packet.executionCarrier),
     qualitySearch: normalizeQualitySearchPacketState(packet.qualitySearch),
     tierEscalated: packet.tierEscalated === true ? true : undefined,
     predictedFiles: Array.isArray(packet.predictedFiles)

--- a/src/lib/orchestrator/types.ts
+++ b/src/lib/orchestrator/types.ts
@@ -9,6 +9,7 @@ import type { PacketSpendCap, PacketSpendTelemetry } from '@/lib/orchestrator/me
 import type { PacketContextTelemetry } from '@/lib/orchestrator/packet-context-telemetry';
 import type { AgentSummary } from '@/lib/fleet/types';
 import type { TerminalStatusEvidence } from '@/lib/terminal-status/resolve';
+import type { ExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 
 export type { OrchestratorRuntime } from '@/lib/orchestrator/runtime-capabilities';
 export type OrchestratorExecutionMode = 'fleet' | 'single' | 'fusion';
@@ -381,6 +382,8 @@ export interface OrchestratorPacket {
   claudeCodeModel?: string | null;
   /** Explicit carrier pin for a Claude Code packet. It wins over the global worker profile. */
   claudeCodeCarrier?: ClaudeCodeModelSource | null;
+  /** Optional argv/credential wrapper. The runtime remains the session identity owner. */
+  executionCarrier?: ExecutionCarrierId | null;
   /** Opt-in two-candidate search state. The seed has a null role; fan-out
    * assigns one bounded role to each isolated candidate. */
   qualitySearch?: QualitySearchPacketState;

--- a/src/lib/runtime/actions.ts
+++ b/src/lib/runtime/actions.ts
@@ -5,6 +5,7 @@ import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import type { ClaudeCodeModelSource } from '@/lib/claude-code/worker-profile-types';
 import type { OrchestratorRuntime, WorkerWorkMode } from '@/lib/orchestrator/types';
 import type { PacketSpendCap } from '@/lib/orchestrator/metered-spend';
+import type { ExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 import {
   listDeclarativeRuntimes,
 } from '@/lib/orchestrator/runtime-capabilities';
@@ -75,6 +76,7 @@ export interface RuntimeLaunchRequest {
   model?: string;
   claudeCodeModel?: string;
   claudeCodeCarrier?: ClaudeCodeModelSource;
+  executionCarrier?: ExecutionCarrierId;
   /** Requested reasoning effort — passed to the runtime's launch; per-runtime no-op. */
   effort?: ThinkingEffort;
   clientMutationId?: string;
@@ -365,6 +367,7 @@ export async function launchRuntimeSurface(payload: RuntimeLaunchRequest): Promi
     model: payload.model,
     claudeCodeModel: payload.claudeCodeModel,
     claudeCodeCarrier: payload.claudeCodeCarrier,
+    executionCarrier: payload.executionCarrier,
     effort: payload.effort,
     worktreeFlag: launchWorktree?.claudeWorktreeFlag,
     worktreePath: launchWorktree?.worktree?.path,

--- a/src/lib/runtime/interrupt-escalation.ts
+++ b/src/lib/runtime/interrupt-escalation.ts
@@ -3,7 +3,7 @@ import { promisify } from 'node:util';
 
 import { isBridgeSessionAlive, signalBridgeTerminalSession } from '@/lib/runtime/pty-bridge';
 import { lookupOwnedActiveRunFresh } from '@/lib/runtimes/shared/owned-session-index';
-import { isPidAlive, pidCommandLine } from '@/lib/runtimes/shared/owned-session/helpers';
+import { commandLineMatchesOwnedRun, isPidAlive, pidCommandLine } from '@/lib/runtimes/shared/owned-session/helpers';
 import { getOwnedSessionLifecycle } from '@/lib/runtimes/shared/owned-session-lifecycle';
 import { withOwnedStopOutcome } from '@/lib/runtimes/shared/owned-session/stop-outcome';
 import {
@@ -589,7 +589,7 @@ export async function escalateInterruptOwnedSurface(surfaceId: string): Promise<
     } else {
       const commandLine = await pidCommandLine(activeRun.pid);
       identityMatches = commandLine
-        ? commandLine.includes(expectedCommand)
+        ? commandLineMatchesOwnedRun(commandLine, activeRun.commandIdentity, commandLabel)
         : !isPidAlive(activeRun.pid);
     }
     if (!identityMatches) {

--- a/src/lib/runtime/owned-surface-interrupt.test.ts
+++ b/src/lib/runtime/owned-surface-interrupt.test.ts
@@ -17,7 +17,8 @@ vi.mock('@/lib/runtime/pty-bridge', () => ({
 vi.mock('@/lib/runtimes/shared/owned-session-index', () => ({
   lookupOwnedActiveRunFresh: mocks.lookupRun,
 }));
-vi.mock('@/lib/runtimes/shared/owned-session/helpers', () => ({
+vi.mock('@/lib/runtimes/shared/owned-session/helpers', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/runtimes/shared/owned-session/helpers')>(),
   isPidAlive: mocks.pidAlive,
   pidCommandLine: mocks.pidCommandLine,
 }));

--- a/src/lib/runtimes/codex.ts
+++ b/src/lib/runtimes/codex.ts
@@ -348,6 +348,7 @@ export const codexRuntime: AgentRuntime = {
       effort,
       laneId: opts.laneId,
       packetId: opts.packetId,
+      executionCarrier: opts.executionCarrier,
       // Codex is the DEFAULT worker runtime, so a read-only packet that skipped
       // this thread was read-only in prompt only for almost every dispatch.
       workMode: opts.workMode,

--- a/src/lib/runtimes/codex.ts
+++ b/src/lib/runtimes/codex.ts
@@ -351,6 +351,7 @@ export const codexRuntime: AgentRuntime = {
       effort,
       laneId: opts.laneId,
       packetId: opts.packetId,
+      executionCarrier: opts.executionCarrier,
       // Codex is the DEFAULT worker runtime, so a read-only packet that skipped
       // this thread was read-only in prompt only for almost every dispatch.
       workMode: opts.workMode,

--- a/src/lib/runtimes/shared/execution-carrier-launch.ts
+++ b/src/lib/runtimes/shared/execution-carrier-launch.ts
@@ -1,0 +1,84 @@
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveCli, type CliResolverSpec } from './cli-resolver';
+import {
+  composeExecutionCarrierInvocation,
+  executionCarrierDefinition,
+  executionCarrierFromRuntimeConfig,
+} from './execution-carrier';
+
+type ResolveCli = (spec: CliResolverSpec) => ReturnType<typeof resolveCli>;
+
+export interface ExecutionCarrierInvocation {
+  command: string;
+  args: string[];
+  carried: boolean;
+  runtimeBinDir?: string;
+}
+
+export async function resolveExecutionCarrierInvocation(input: {
+  runtime: OrchestratorRuntime;
+  runtimeConfig: Record<string, string> | undefined;
+  runtimeBinary: string;
+  runtimeArgs: readonly string[];
+  resolve?: ResolveCli;
+}): Promise<ExecutionCarrierInvocation> {
+  const carrier = executionCarrierFromRuntimeConfig(input.runtimeConfig);
+  if (!carrier) {
+    const invocation = composeExecutionCarrierInvocation({
+      carrier: null,
+      runtime: input.runtime,
+      runtimeBinary: input.runtimeBinary,
+      runtimeArgs: input.runtimeArgs,
+    });
+    return { ...invocation, carried: false };
+  }
+
+  const definition = executionCarrierDefinition(carrier);
+  const carrierCli = await (input.resolve ?? resolveCli)({
+    runtimeId: `execution-carrier:${carrier}`,
+    binaryName: definition.binaryName,
+    envOverride: definition.binaryEnvOverride,
+  });
+  if (process.platform === 'win32' && !/\.(?:exe|com)$/i.test(carrierCli.path)) {
+    throw new Error(
+      `Execution carrier '${carrier}' resolved to a script wrapper; Windows carrier launches require a native .exe or .com binary.`,
+    );
+  }
+  const invocation = composeExecutionCarrierInvocation({
+    carrier,
+    runtime: input.runtime,
+    runtimeBinary: input.runtimeBinary,
+    runtimeArgs: input.runtimeArgs,
+    carrierBinary: carrierCli.path,
+  });
+  return {
+    ...invocation,
+    carried: true,
+    ...(path.isAbsolute(input.runtimeBinary) ? { runtimeBinDir: path.dirname(input.runtimeBinary) } : {}),
+  };
+}
+
+export function executionCarrierSpawnPath(
+  basePath: string,
+  launch: ExecutionCarrierInvocation,
+): string {
+  return launch.runtimeBinDir ? `${launch.runtimeBinDir}${path.delimiter}${basePath}` : basePath;
+}
+
+export function executionCarrierSandboxReadPaths(
+  basePaths: readonly string[],
+  launch: ExecutionCarrierInvocation,
+): string[] {
+  return launch.carried
+    ? [...basePaths, path.join(os.homedir(), '.ori'), ...(launch.runtimeBinDir ? [launch.runtimeBinDir] : [])]
+    : [...basePaths];
+}
+
+export function executionCarrierCommandIdentity(
+  launch: ExecutionCarrierInvocation,
+  spawnBinary: string,
+): string {
+  return launch.carried ? launch.command : path.basename(spawnBinary);
+}

--- a/src/lib/runtimes/shared/execution-carrier-launch.ts
+++ b/src/lib/runtimes/shared/execution-carrier-launch.ts
@@ -1,0 +1,96 @@
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveCli, type CliResolverSpec } from './cli-resolver';
+import {
+  composeExecutionCarrierInvocation,
+  executionCarrierDefinition,
+  executionCarrierFromRuntimeConfig,
+} from './execution-carrier';
+
+type ResolveCli = (spec: CliResolverSpec) => ReturnType<typeof resolveCli>;
+
+/** The carrier resolves a fixed executable name, not an arbitrary override path. */
+export function assertExecutionCarrierRuntimeBinary(runtime: OrchestratorRuntime, binary: string): void {
+  const expected = runtime === 'codex' ? 'codex' : null;
+  const name = path.basename(binary);
+  const supportedName = expected && (name === expected || (process.platform === 'win32'
+    && ['.exe', '.com', '.cmd'].some((extension) => name.toLowerCase() === `${expected}${extension}`)));
+  if (!path.isAbsolute(binary) || !supportedName) {
+    throw new Error(`The execution carrier cannot pin runtime binary '${binary}'. Select the intended '${expected ?? runtime}' executable; renamed wrappers are not supported and will not fall back to another PATH entry.`);
+  }
+}
+
+export interface ExecutionCarrierInvocation {
+  command: string;
+  args: string[];
+  carried: boolean;
+  runtimeBinDir?: string;
+}
+
+export async function resolveExecutionCarrierInvocation(input: {
+  runtime: OrchestratorRuntime;
+  runtimeConfig: Record<string, string> | undefined;
+  runtimeBinary: string;
+  runtimeArgs: readonly string[];
+  resolve?: ResolveCli;
+}): Promise<ExecutionCarrierInvocation> {
+  const carrier = executionCarrierFromRuntimeConfig(input.runtimeConfig);
+  if (!carrier) {
+    const invocation = composeExecutionCarrierInvocation({
+      carrier: null,
+      runtime: input.runtime,
+      runtimeBinary: input.runtimeBinary,
+      runtimeArgs: input.runtimeArgs,
+    });
+    return { ...invocation, carried: false };
+  }
+
+  assertExecutionCarrierRuntimeBinary(input.runtime, input.runtimeBinary);
+  const definition = executionCarrierDefinition(carrier);
+  const carrierCli = await (input.resolve ?? resolveCli)({
+    runtimeId: `execution-carrier:${carrier}`,
+    binaryName: definition.binaryName,
+    envOverride: definition.binaryEnvOverride,
+  });
+  if (process.platform === 'win32' && !/\.(?:exe|com)$/i.test(carrierCli.path)) {
+    throw new Error(
+      `Execution carrier '${carrier}' resolved to a script wrapper; Windows carrier launches require a native .exe or .com binary.`,
+    );
+  }
+  const invocation = composeExecutionCarrierInvocation({
+    carrier,
+    runtime: input.runtime,
+    runtimeBinary: input.runtimeBinary,
+    runtimeArgs: input.runtimeArgs,
+    carrierBinary: carrierCli.path,
+  });
+  return {
+    ...invocation,
+    carried: true,
+    ...(path.isAbsolute(input.runtimeBinary) ? { runtimeBinDir: path.dirname(input.runtimeBinary) } : {}),
+  };
+}
+
+export function executionCarrierSpawnPath(
+  basePath: string,
+  launch: ExecutionCarrierInvocation,
+): string {
+  return launch.runtimeBinDir ? `${launch.runtimeBinDir}${path.delimiter}${basePath}` : basePath;
+}
+
+export function executionCarrierSandboxReadPaths(
+  basePaths: readonly string[],
+  launch: ExecutionCarrierInvocation,
+): string[] {
+  return launch.carried
+    ? [...basePaths, path.join(os.homedir(), '.ori'), ...(launch.runtimeBinDir ? [launch.runtimeBinDir] : [])]
+    : [...basePaths];
+}
+
+export function executionCarrierCommandIdentity(
+  launch: ExecutionCarrierInvocation,
+  spawnBinary: string,
+): string {
+  return launch.carried ? launch.command : path.basename(spawnBinary);
+}

--- a/src/lib/runtimes/shared/execution-carrier-preflight.ts
+++ b/src/lib/runtimes/shared/execution-carrier-preflight.ts
@@ -1,0 +1,147 @@
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+import { spawn } from 'node:child_process';
+import { CliNotFoundError, resolveCli, type ResolvedCli } from './cli-resolver';
+import { cliInvocation } from './cli-spawn';
+import {
+  assertExecutionCarrierCompatible,
+  executionCarrierDefinition,
+  type ExecutionCarrierId,
+} from './execution-carrier';
+
+export type ExecutionCarrierPreflightFailure =
+  | 'unsupported-pair'
+  | 'missing-carrier'
+  | 'missing-runtime'
+  | 'unsafe-carrier-binary'
+  | 'carrier-auth-unavailable';
+
+export class ExecutionCarrierPreflightError extends Error {
+  constructor(
+    public readonly failure: ExecutionCarrierPreflightFailure,
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'ExecutionCarrierPreflightError';
+  }
+}
+
+type ResolveCli = typeof resolveCli;
+
+const RUNTIME_CLI: Partial<Record<OrchestratorRuntime, {
+  binaryName: string;
+  envOverride: string;
+}>> = {
+  codex: { binaryName: 'codex', envOverride: 'O8_CODEX_BIN' },
+};
+
+export interface ExecutionCarrierPreflightEvidence {
+  runtime: OrchestratorRuntime;
+  runtimeBinaryName: string;
+  runtimeCli: ResolvedCli;
+  executionCarrier: ExecutionCarrierId;
+  carrierBinaryName: string;
+  carrierCli: ResolvedCli;
+  authSource: 'execution-carrier';
+  authenticated: true;
+}
+
+export async function probeExecutionCarrierAuth(binary: string): Promise<boolean> {
+  const invocation = cliInvocation(binary, ['auth']);
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve(result);
+    };
+    const child = spawn(invocation.command, invocation.args, {
+      windowsHide: true,
+      stdio: 'ignore',
+      env: process.env,
+    });
+    const timeout = setTimeout(() => { child.kill(); finish(false); }, 10_000);
+    child.once('error', () => finish(false));
+    child.once('exit', (code) => finish(code === 0));
+  });
+}
+
+export async function assertExecutionCarrierDispatchable(
+  runtime: OrchestratorRuntime,
+  carrier: ExecutionCarrierId,
+  resolve: ResolveCli = resolveCli,
+  probeAuth: (binary: string) => Promise<boolean> = probeExecutionCarrierAuth,
+): Promise<ExecutionCarrierPreflightEvidence> {
+  try {
+    assertExecutionCarrierCompatible(carrier, runtime);
+  } catch (error) {
+    throw new ExecutionCarrierPreflightError(
+      'unsupported-pair',
+      `Execution carrier '${carrier}' cannot dispatch the '${runtime}' runtime.`,
+      error,
+    );
+  }
+
+  const runtimeSpec = RUNTIME_CLI[runtime];
+  if (!runtimeSpec) {
+    throw new ExecutionCarrierPreflightError(
+      'missing-runtime',
+      `The '${runtime}' runtime does not expose an underlying CLI contract for execution carriers.`,
+    );
+  }
+
+  let carrierCli: ResolvedCli;
+  const definition = executionCarrierDefinition(carrier);
+  try {
+    carrierCli = await resolve({
+      runtimeId: `execution-carrier:${carrier}`,
+      binaryName: definition.binaryName,
+      envOverride: definition.binaryEnvOverride,
+    });
+  } catch (error) {
+    if (!(error instanceof CliNotFoundError)) throw error;
+    throw new ExecutionCarrierPreflightError(
+      'missing-carrier',
+      `Execution carrier '${carrier}' is selected, but '${definition.binaryName}' was not found. Install it or set ${definition.binaryEnvOverride}.`,
+      error,
+    );
+  }
+
+  if (process.platform === 'win32' && !/\.(?:exe|com)$/i.test(carrierCli.path)) {
+    throw new ExecutionCarrierPreflightError(
+      'unsafe-carrier-binary',
+      `Execution carrier '${carrier}' resolved to a script wrapper. On Windows, ${definition.binaryEnvOverride} must name a native .exe or .com binary so worker argv never passes through cmd.exe.`,
+    );
+  }
+
+  if (!await probeAuth(carrierCli.path)) {
+    throw new ExecutionCarrierPreflightError(
+      'carrier-auth-unavailable',
+      `Execution carrier '${carrier}' could not resolve credentials. Run '${definition.binaryName} login'; if '${definition.binaryName} auth' is unknown, upgrade Ori to 0.3.0 or newer.`,
+    );
+  }
+
+  let runtimeCli: ResolvedCli;
+  try {
+    runtimeCli = await resolve({ runtimeId: runtime, ...runtimeSpec });
+  } catch (error) {
+    if (!(error instanceof CliNotFoundError)) throw error;
+    throw new ExecutionCarrierPreflightError(
+      'missing-runtime',
+      `Execution carrier '${carrier}' is available, but the underlying '${runtimeSpec.binaryName}' CLI was not found. Install it or set ${runtimeSpec.envOverride}.`,
+      error,
+    );
+  }
+
+  return {
+    runtime,
+    runtimeBinaryName: runtimeSpec.binaryName,
+    runtimeCli,
+    executionCarrier: carrier,
+    carrierBinaryName: definition.binaryName,
+    carrierCli,
+    authSource: 'execution-carrier',
+    authenticated: true,
+  };
+}

--- a/src/lib/runtimes/shared/execution-carrier-preflight.ts
+++ b/src/lib/runtimes/shared/execution-carrier-preflight.ts
@@ -1,0 +1,159 @@
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+import { spawn } from 'node:child_process';
+import { CliNotFoundError, resolveCli, type ResolvedCli } from './cli-resolver';
+import { cliInvocation } from './cli-spawn';
+import { assertExecutionCarrierRuntimeBinary } from './execution-carrier-launch';
+import {
+  assertExecutionCarrierCompatible,
+  executionCarrierDefinition,
+  type ExecutionCarrierId,
+} from './execution-carrier';
+
+export type ExecutionCarrierPreflightFailure =
+  | 'unsupported-pair'
+  | 'missing-carrier'
+  | 'missing-runtime'
+  | 'unsafe-carrier-binary'
+  | 'runtime-binary-unpinnable'
+  | 'carrier-auth-unavailable';
+
+export class ExecutionCarrierPreflightError extends Error {
+  constructor(
+    public readonly failure: ExecutionCarrierPreflightFailure,
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'ExecutionCarrierPreflightError';
+  }
+}
+
+type ResolveCli = typeof resolveCli;
+
+const RUNTIME_CLI: Partial<Record<OrchestratorRuntime, {
+  binaryName: string;
+  envOverride: string;
+}>> = {
+  codex: { binaryName: 'codex', envOverride: 'O8_CODEX_BIN' },
+};
+
+export interface ExecutionCarrierPreflightEvidence {
+  runtime: OrchestratorRuntime;
+  runtimeBinaryName: string;
+  runtimeCli: ResolvedCli;
+  executionCarrier: ExecutionCarrierId;
+  carrierBinaryName: string;
+  carrierCli: ResolvedCli;
+  authSource: 'execution-carrier';
+  authenticated: true;
+}
+
+export async function probeExecutionCarrierAuth(binary: string): Promise<boolean> {
+  const invocation = cliInvocation(binary, ['auth']);
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve(result);
+    };
+    const child = spawn(invocation.command, invocation.args, {
+      windowsHide: true,
+      stdio: 'ignore',
+      env: process.env,
+    });
+    const timeout = setTimeout(() => { child.kill(); finish(false); }, 10_000);
+    child.once('error', () => finish(false));
+    child.once('exit', (code) => finish(code === 0));
+  });
+}
+
+export async function assertExecutionCarrierDispatchable(
+  runtime: OrchestratorRuntime,
+  carrier: ExecutionCarrierId,
+  resolve: ResolveCli = resolveCli,
+  probeAuth: (binary: string) => Promise<boolean> = probeExecutionCarrierAuth,
+): Promise<ExecutionCarrierPreflightEvidence> {
+  try {
+    assertExecutionCarrierCompatible(carrier, runtime);
+  } catch (error) {
+    throw new ExecutionCarrierPreflightError(
+      'unsupported-pair',
+      `Execution carrier '${carrier}' cannot dispatch the '${runtime}' runtime.`,
+      error,
+    );
+  }
+
+  const runtimeSpec = RUNTIME_CLI[runtime];
+  if (!runtimeSpec) {
+    throw new ExecutionCarrierPreflightError(
+      'missing-runtime',
+      `The '${runtime}' runtime does not expose an underlying CLI contract for execution carriers.`,
+    );
+  }
+
+  let carrierCli: ResolvedCli;
+  const definition = executionCarrierDefinition(carrier);
+  try {
+    carrierCli = await resolve({
+      runtimeId: `execution-carrier:${carrier}`,
+      binaryName: definition.binaryName,
+      envOverride: definition.binaryEnvOverride,
+    });
+  } catch (error) {
+    if (!(error instanceof CliNotFoundError)) throw error;
+    throw new ExecutionCarrierPreflightError(
+      'missing-carrier',
+      `Execution carrier '${carrier}' is selected, but '${definition.binaryName}' was not found. Install it or set ${definition.binaryEnvOverride}.`,
+      error,
+    );
+  }
+
+  if (process.platform === 'win32' && !/\.(?:exe|com)$/i.test(carrierCli.path)) {
+    throw new ExecutionCarrierPreflightError(
+      'unsafe-carrier-binary',
+      `Execution carrier '${carrier}' resolved to a script wrapper. On Windows, ${definition.binaryEnvOverride} must name a native .exe or .com binary so worker argv never passes through cmd.exe.`,
+    );
+  }
+
+  if (!await probeAuth(carrierCli.path)) {
+    throw new ExecutionCarrierPreflightError(
+      'carrier-auth-unavailable',
+      `Execution carrier '${carrier}' could not resolve credentials. Run '${definition.binaryName} login'; if '${definition.binaryName} auth' is unknown, upgrade Ori to 0.3.0 or newer.`,
+    );
+  }
+
+  let runtimeCli: ResolvedCli;
+  try {
+    runtimeCli = await resolve({ runtimeId: runtime, ...runtimeSpec });
+  } catch (error) {
+    if (!(error instanceof CliNotFoundError)) throw error;
+    throw new ExecutionCarrierPreflightError(
+      'missing-runtime',
+      `Execution carrier '${carrier}' is available, but the underlying '${runtimeSpec.binaryName}' CLI was not found. Install it or set ${runtimeSpec.envOverride}.`,
+      error,
+    );
+  }
+
+  try {
+    assertExecutionCarrierRuntimeBinary(runtime, runtimeCli.path);
+  } catch (error) {
+    throw new ExecutionCarrierPreflightError(
+      'runtime-binary-unpinnable',
+      error instanceof Error ? error.message : 'The selected runtime binary cannot be pinned by the execution carrier.',
+      error,
+    );
+  }
+
+  return {
+    runtime,
+    runtimeBinaryName: runtimeSpec.binaryName,
+    runtimeCli,
+    executionCarrier: carrier,
+    carrierBinaryName: definition.binaryName,
+    carrierCli,
+    authSource: 'execution-carrier',
+    authenticated: true,
+  };
+}

--- a/src/lib/runtimes/shared/execution-carrier.test.ts
+++ b/src/lib/runtimes/shared/execution-carrier.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { CliNotFoundError, type CliResolverSpec, type ResolvedCli } from './cli-resolver';
+import {
+  composeExecutionCarrierInvocation,
+  executionCarrierFromRuntimeConfig,
+  executionCarrierRuntimeConfig,
+  UnknownExecutionCarrierError,
+  UnsupportedExecutionCarrierRuntimeError,
+} from './execution-carrier';
+import {
+  executionCarrierCommandIdentity,
+  executionCarrierSandboxReadPaths,
+  executionCarrierSpawnPath,
+  resolveExecutionCarrierInvocation,
+} from './execution-carrier-launch';
+import { assertExecutionCarrierDispatchable, ExecutionCarrierPreflightError } from './execution-carrier-preflight';
+
+function resolved(path: string): ResolvedCli {
+  return { path, source: 'env', detectedAt: 1, envHint: 'test' };
+}
+
+const carrierBinary = process.platform === 'win32' ? 'C:\\tools\\ori.exe' : '/tools/ori';
+
+describe('typed execution carriers', () => {
+  it('composes Ori and Codex as structured argv without a shell string', () => {
+    expect(composeExecutionCarrierInvocation({
+      carrier: 'ori', runtime: 'codex', carrierBinary: '/bin/ori',
+      runtimeBinary: '/bin/codex', runtimeArgs: ['exec', '--json', 'hello; echo unsafe'],
+    })).toEqual({ command: '/bin/ori', args: ['codex', 'exec', '--json', 'hello; echo unsafe'] });
+  });
+
+  it('keeps the no-carrier invocation unchanged', async () => {
+    const resolve = vi.fn();
+    await expect(resolveExecutionCarrierInvocation({
+      runtime: 'codex', runtimeConfig: undefined, runtimeBinary: '/bin/codex',
+      runtimeArgs: ['exec', '--json'], resolve,
+    })).resolves.toEqual({ command: '/bin/codex', args: ['exec', '--json'], carried: false });
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it('exposes an off-PATH underlying runtime to the carrier and keeps Ori state read-only', async () => {
+    const runtimeBinary = process.platform === 'win32' ? 'C:\\private\\codex.exe' : '/private/codex';
+    const launch = await resolveExecutionCarrierInvocation({
+      runtime: 'codex', runtimeConfig: { executionCarrier: 'ori' }, runtimeBinary,
+      runtimeArgs: ['exec', '--json'], resolve: async () => resolved(carrierBinary),
+    });
+    expect(launch).toMatchObject({ command: carrierBinary, args: ['codex', 'exec', '--json'], carried: true });
+    expect(executionCarrierSpawnPath('base-path', launch).split(process.platform === 'win32' ? ';' : ':')[0])
+      .toBe(process.platform === 'win32' ? 'C:\\private' : '/private');
+    expect(executionCarrierSandboxReadPaths(['/mcp'], launch)).toEqual(expect.arrayContaining([
+      '/mcp', expect.stringMatching(/[\\/]\.ori$/), process.platform === 'win32' ? 'C:\\private' : '/private',
+    ]));
+    expect(executionCarrierCommandIdentity(launch, '/usr/bin/sandbox-exec')).toBe(carrierBinary);
+  });
+
+  it('rejects unsupported carrier/runtime pairs', () => {
+    expect(() => composeExecutionCarrierInvocation({
+      carrier: 'ori', runtime: 'claude-code', carrierBinary: '/bin/ori',
+      runtimeBinary: '/bin/claude', runtimeArgs: ['--print'],
+    })).toThrow(UnsupportedExecutionCarrierRuntimeError);
+  });
+
+  it('round-trips the credential-free runtime config pin', () => {
+    expect(executionCarrierRuntimeConfig('ori')).toEqual({ executionCarrier: 'ori' });
+    expect(executionCarrierFromRuntimeConfig({ executionCarrier: 'ori' })).toBe('ori');
+    expect(executionCarrierRuntimeConfig(null)).toEqual({});
+    expect(() => executionCarrierFromRuntimeConfig({ executionCarrier: 'future-carrier' }))
+      .toThrow(UnknownExecutionCarrierError);
+  });
+
+  it('reports a missing carrier separately from a missing underlying runtime', async () => {
+    const missingCarrier = vi.fn(async (spec: CliResolverSpec) => {
+      throw new CliNotFoundError(spec.binaryName, []);
+    });
+    await expect(assertExecutionCarrierDispatchable('codex', 'ori', missingCarrier, async () => true))
+      .rejects.toMatchObject({ failure: 'missing-carrier' } satisfies Partial<ExecutionCarrierPreflightError>);
+
+    const missingRuntime = vi.fn(async (spec: CliResolverSpec) => {
+      if (spec.runtimeId === 'execution-carrier:ori') return resolved(carrierBinary);
+      throw new CliNotFoundError(spec.binaryName, []);
+    });
+    await expect(assertExecutionCarrierDispatchable('codex', 'ori', missingRuntime, async () => true))
+      .rejects.toMatchObject({ failure: 'missing-runtime' } satisfies Partial<ExecutionCarrierPreflightError>);
+  });
+
+  it('fails closed when the carrier cannot resolve credentials', async () => {
+    const resolve = vi.fn(async (spec: CliResolverSpec) => resolved(
+      spec.runtimeId === 'execution-carrier:ori' ? carrierBinary : `/bin/${spec.binaryName}`,
+    ));
+    await expect(assertExecutionCarrierDispatchable('codex', 'ori', resolve, async () => false))
+      .rejects.toMatchObject({ failure: 'carrier-auth-unavailable' } satisfies Partial<ExecutionCarrierPreflightError>);
+  });
+
+  it('reports carrier auth evidence without credentials', async () => {
+    const resolve = vi.fn(async (spec: CliResolverSpec) => resolved(
+      spec.runtimeId === 'execution-carrier:ori' ? carrierBinary : `/bin/${spec.binaryName}`,
+    ));
+    const evidence = await assertExecutionCarrierDispatchable('codex', 'ori', resolve, async () => true);
+    expect(evidence).toMatchObject({ runtime: 'codex', executionCarrier: 'ori', authSource: 'execution-carrier', authenticated: true });
+    expect(JSON.stringify(evidence)).not.toMatch(/token|secret|credential/i);
+  });
+
+  it.skipIf(process.platform !== 'win32')('rejects Windows script carriers before prompt argv can reach cmd.exe', async () => {
+    const resolve = vi.fn(async (spec: CliResolverSpec) => resolved(
+      spec.runtimeId === 'execution-carrier:ori' ? 'C:\\tools\\ori.cmd' : 'C:\\tools\\codex.exe',
+    ));
+    await expect(assertExecutionCarrierDispatchable('codex', 'ori', resolve, async () => true))
+      .rejects.toMatchObject({ failure: 'unsafe-carrier-binary' });
+  });
+});

--- a/src/lib/runtimes/shared/execution-carrier.test.ts
+++ b/src/lib/runtimes/shared/execution-carrier.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { CliNotFoundError, type CliResolverSpec, type ResolvedCli } from './cli-resolver';
+import {
+  composeExecutionCarrierInvocation,
+  executionCarrierFromRuntimeConfig,
+  executionCarrierRuntimeConfig,
+  UnknownExecutionCarrierError,
+  UnsupportedExecutionCarrierRuntimeError,
+} from './execution-carrier';
+import {
+  executionCarrierCommandIdentity,
+  executionCarrierSandboxReadPaths,
+  executionCarrierSpawnPath,
+  resolveExecutionCarrierInvocation,
+} from './execution-carrier-launch';
+import { assertExecutionCarrierDispatchable, ExecutionCarrierPreflightError } from './execution-carrier-preflight';
+
+function resolved(path: string): ResolvedCli {
+  return { path, source: 'env', detectedAt: 1, envHint: 'test' };
+}
+
+const carrierBinary = process.platform === 'win32' ? 'C:\\tools\\ori.exe' : '/tools/ori';
+
+describe('typed execution carriers', () => {
+  it('composes Ori and Codex as structured argv without a shell string', () => {
+    expect(composeExecutionCarrierInvocation({
+      carrier: 'ori', runtime: 'codex', carrierBinary: '/bin/ori',
+      runtimeBinary: '/bin/codex', runtimeArgs: ['exec', '--json', 'hello; echo unsafe'],
+    })).toEqual({ command: '/bin/ori', args: ['codex', 'exec', '--json', 'hello; echo unsafe'] });
+  });
+
+  it('keeps the no-carrier invocation unchanged', async () => {
+    const resolve = vi.fn();
+    await expect(resolveExecutionCarrierInvocation({
+      runtime: 'codex', runtimeConfig: undefined, runtimeBinary: '/bin/codex',
+      runtimeArgs: ['exec', '--json'], resolve,
+    })).resolves.toEqual({ command: '/bin/codex', args: ['exec', '--json'], carried: false });
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it('exposes an off-PATH underlying runtime to the carrier and keeps Ori state read-only', async () => {
+    const runtimeBinary = process.platform === 'win32' ? 'C:\\private\\codex.exe' : '/private/codex';
+    const launch = await resolveExecutionCarrierInvocation({
+      runtime: 'codex', runtimeConfig: { executionCarrier: 'ori' }, runtimeBinary,
+      runtimeArgs: ['exec', '--json'], resolve: async () => resolved(carrierBinary),
+    });
+    expect(launch).toMatchObject({ command: carrierBinary, args: ['codex', 'exec', '--json'], carried: true });
+    expect(executionCarrierSpawnPath('base-path', launch).split(process.platform === 'win32' ? ';' : ':')[0])
+      .toBe(process.platform === 'win32' ? 'C:\\private' : '/private');
+    expect(executionCarrierSandboxReadPaths(['/mcp'], launch)).toEqual(expect.arrayContaining([
+      '/mcp', expect.stringMatching(/[\\/]\.ori$/), process.platform === 'win32' ? 'C:\\private' : '/private',
+    ]));
+    expect(executionCarrierCommandIdentity(launch, '/usr/bin/sandbox-exec')).toBe(carrierBinary);
+  });
+
+  it('refuses renamed or relative runtime overrides before a carrier can select a different PATH executable', async () => {
+    for (const runtimeBinary of ['/private/custom-codex', 'codex']) {
+      const resolve = vi.fn(async () => resolved(carrierBinary));
+      await expect(resolveExecutionCarrierInvocation({
+        runtime: 'codex', runtimeConfig: { executionCarrier: 'ori' }, runtimeBinary,
+        runtimeArgs: ['exec', '--json'], resolve,
+      })).rejects.toThrow('will not fall back');
+      expect(resolve).not.toHaveBeenCalled();
+    }
+  });
+
+  it('reports an unpinnable runtime separately during carrier preflight', async () => {
+    const resolve = vi.fn(async (spec: CliResolverSpec) => resolved(
+      spec.runtimeId === 'execution-carrier:ori' ? carrierBinary : '/private/custom-codex',
+    ));
+    await expect(assertExecutionCarrierDispatchable('codex', 'ori', resolve, async () => true))
+      .rejects.toMatchObject({ failure: 'runtime-binary-unpinnable' });
+  });
+
+  it('rejects unsupported carrier/runtime pairs', () => {
+    expect(() => composeExecutionCarrierInvocation({
+      carrier: 'ori', runtime: 'claude-code', carrierBinary: '/bin/ori',
+      runtimeBinary: '/bin/claude', runtimeArgs: ['--print'],
+    })).toThrow(UnsupportedExecutionCarrierRuntimeError);
+  });
+
+  it('round-trips the credential-free runtime config pin', () => {
+    expect(executionCarrierRuntimeConfig('ori')).toEqual({ executionCarrier: 'ori' });
+    expect(executionCarrierFromRuntimeConfig({ executionCarrier: 'ori' })).toBe('ori');
+    expect(executionCarrierRuntimeConfig(null)).toEqual({});
+    expect(() => executionCarrierFromRuntimeConfig({ executionCarrier: 'future-carrier' }))
+      .toThrow(UnknownExecutionCarrierError);
+  });
+
+  it('reports a missing carrier separately from a missing underlying runtime', async () => {
+    const missingCarrier = vi.fn(async (spec: CliResolverSpec) => {
+      throw new CliNotFoundError(spec.binaryName, []);
+    });
+    await expect(assertExecutionCarrierDispatchable('codex', 'ori', missingCarrier, async () => true))
+      .rejects.toMatchObject({ failure: 'missing-carrier' } satisfies Partial<ExecutionCarrierPreflightError>);
+
+    const missingRuntime = vi.fn(async (spec: CliResolverSpec) => {
+      if (spec.runtimeId === 'execution-carrier:ori') return resolved(carrierBinary);
+      throw new CliNotFoundError(spec.binaryName, []);
+    });
+    await expect(assertExecutionCarrierDispatchable('codex', 'ori', missingRuntime, async () => true))
+      .rejects.toMatchObject({ failure: 'missing-runtime' } satisfies Partial<ExecutionCarrierPreflightError>);
+  });
+
+  it('fails closed when the carrier cannot resolve credentials', async () => {
+    const resolve = vi.fn(async (spec: CliResolverSpec) => resolved(
+      spec.runtimeId === 'execution-carrier:ori' ? carrierBinary : `/bin/${spec.binaryName}`,
+    ));
+    await expect(assertExecutionCarrierDispatchable('codex', 'ori', resolve, async () => false))
+      .rejects.toMatchObject({ failure: 'carrier-auth-unavailable' } satisfies Partial<ExecutionCarrierPreflightError>);
+  });
+
+  it('reports carrier auth evidence without credentials', async () => {
+    const resolve = vi.fn(async (spec: CliResolverSpec) => resolved(
+      spec.runtimeId === 'execution-carrier:ori' ? carrierBinary : `/bin/${spec.binaryName}`,
+    ));
+    const evidence = await assertExecutionCarrierDispatchable('codex', 'ori', resolve, async () => true);
+    expect(evidence).toMatchObject({ runtime: 'codex', executionCarrier: 'ori', authSource: 'execution-carrier', authenticated: true });
+    expect(JSON.stringify(evidence)).not.toMatch(/token|secret|credential/i);
+  });
+
+  it.skipIf(process.platform !== 'win32')('rejects Windows script carriers before prompt argv can reach cmd.exe', async () => {
+    const resolve = vi.fn(async (spec: CliResolverSpec) => resolved(
+      spec.runtimeId === 'execution-carrier:ori' ? 'C:\\tools\\ori.cmd' : 'C:\\tools\\codex.exe',
+    ));
+    await expect(assertExecutionCarrierDispatchable('codex', 'ori', resolve, async () => true))
+      .rejects.toMatchObject({ failure: 'unsafe-carrier-binary' });
+  });
+});

--- a/src/lib/runtimes/shared/execution-carrier.ts
+++ b/src/lib/runtimes/shared/execution-carrier.ts
@@ -1,0 +1,92 @@
+import type { OrchestratorRuntime } from '@/lib/orchestrator/types';
+
+export type ExecutionCarrierId = 'ori';
+
+export interface ExecutionCarrierDefinition {
+  id: ExecutionCarrierId;
+  label: string;
+  binaryName: string;
+  binaryEnvOverride: string;
+  runtimeSubcommands: Readonly<Partial<Record<OrchestratorRuntime, readonly string[]>>>;
+}
+
+const EXECUTION_CARRIERS: Readonly<Record<ExecutionCarrierId, ExecutionCarrierDefinition>> = {
+  ori: {
+    id: 'ori',
+    label: 'Ori',
+    binaryName: 'ori',
+    binaryEnvOverride: 'O8_ORI_BIN',
+    runtimeSubcommands: { codex: ['codex'] },
+  },
+};
+
+export const EXECUTION_CARRIER_RUNTIME_CONFIG_KEY = 'executionCarrier';
+
+export class UnsupportedExecutionCarrierRuntimeError extends Error {
+  constructor(carrier: ExecutionCarrierId, runtime: OrchestratorRuntime) {
+    super(`Execution carrier '${carrier}' does not support runtime '${runtime}'.`);
+    this.name = 'UnsupportedExecutionCarrierRuntimeError';
+  }
+}
+
+export class UnknownExecutionCarrierError extends Error {
+  constructor(value: unknown) {
+    super(`Unknown execution carrier ${JSON.stringify(value)}; refusing to fall back to direct runtime credentials.`);
+    this.name = 'UnknownExecutionCarrierError';
+  }
+}
+
+export function isExecutionCarrierId(value: unknown): value is ExecutionCarrierId {
+  return value === 'ori';
+}
+
+export function executionCarrierDefinition(id: ExecutionCarrierId): ExecutionCarrierDefinition {
+  return EXECUTION_CARRIERS[id];
+}
+
+export function assertExecutionCarrierCompatible(
+  carrier: ExecutionCarrierId,
+  runtime: OrchestratorRuntime,
+): readonly string[] {
+  const subcommand = executionCarrierDefinition(carrier).runtimeSubcommands[runtime];
+  if (!subcommand) throw new UnsupportedExecutionCarrierRuntimeError(carrier, runtime);
+  return subcommand;
+}
+
+export function composeExecutionCarrierInvocation(input: {
+  carrier: ExecutionCarrierId | null | undefined;
+  runtime: OrchestratorRuntime;
+  runtimeBinary: string;
+  runtimeArgs: readonly string[];
+  carrierBinary?: string;
+}): { command: string; args: string[] } {
+  if (!input.carrier) {
+    return { command: input.runtimeBinary, args: [...input.runtimeArgs] };
+  }
+  const subcommand = assertExecutionCarrierCompatible(input.carrier, input.runtime);
+  if (!input.carrierBinary) throw new Error(`Resolved binary is required for execution carrier '${input.carrier}'.`);
+  return { command: input.carrierBinary, args: [...subcommand, ...input.runtimeArgs] };
+}
+
+export function executionCarrierRuntimeConfig(
+  carrier: ExecutionCarrierId | null | undefined,
+): Record<string, string> {
+  return carrier ? { [EXECUTION_CARRIER_RUNTIME_CONFIG_KEY]: carrier } : {};
+}
+
+export function executionCarrierFromRuntimeConfig(
+  runtimeConfig: Record<string, string> | undefined,
+): ExecutionCarrierId | null {
+  const value = runtimeConfig?.[EXECUTION_CARRIER_RUNTIME_CONFIG_KEY];
+  if (value === undefined) return null;
+  if (isExecutionCarrierId(value)) return value;
+  throw new UnknownExecutionCarrierError(value);
+}
+
+export function executionCarrierRuntimeLabel(
+  runtimeLabel: string,
+  runtimeConfig: Record<string, string> | undefined,
+): string {
+  const carrier = executionCarrierFromRuntimeConfig(runtimeConfig);
+  return carrier ? `${runtimeLabel} via ${executionCarrierDefinition(carrier).label}` : runtimeLabel;
+}

--- a/src/lib/runtimes/shared/owned-session/fleet.ts
+++ b/src/lib/runtimes/shared/owned-session/fleet.ts
@@ -5,6 +5,7 @@ import {
 } from './archive';
 import {
   OWNED_STALE_WINDOW_MS,
+  commandLineMatchesOwnedRun,
   isOwnedRunAlive,
   metadataPath,
   nowIso,
@@ -231,7 +232,7 @@ export function createFleetComputer({
           await signalBridgeTerminalSession(activeRun.tmuxSession, 'SIGINT');
         } else {
           const cmd = await pidCommandLine(activeRun.pid);
-          if (cmd && cmd.includes(adapter.binaryName)) {
+          if (commandLineMatchesOwnedRun(cmd, activeRun.commandIdentity, adapter.binaryName)) {
             if (process.platform === 'win32') {
               // A failed kill must NOT return early here: the orphan record and
               // saveSession below are the only trace this session ever existed,

--- a/src/lib/runtimes/shared/owned-session/fleet.ts
+++ b/src/lib/runtimes/shared/owned-session/fleet.ts
@@ -6,13 +6,13 @@ import {
 } from './archive';
 import {
   OWNED_STALE_WINDOW_MS,
+  canSignalOwnedRun,
   isOwnedRunAlive,
   metadataPath,
   nowIso,
   pathExists,
   forceKillTreeWindows,
   isPidAlive,
-  pidCommandLine,
   relativeAge,
   shortHome,
 } from './helpers';
@@ -238,8 +238,7 @@ export function createFleetComputer({
         if (activeRun.tmuxSession) {
           await signalBridgeTerminalSession(activeRun.tmuxSession, 'SIGINT');
         } else {
-          const cmd = await pidCommandLine(activeRun.pid);
-          if (cmd && cmd.includes(adapter.binaryName)) {
+          if (await canSignalOwnedRun(activeRun, adapter.binaryName)) {
             if (process.platform === 'win32') {
               // A failed kill must NOT return early here: the orphan record and
               // saveSession below are the only trace this session ever existed,
@@ -268,8 +267,10 @@ export function createFleetComputer({
                 }
               }
             } else {
-              process.kill(-activeRun.pid, 'SIGINT');
+              process.kill(-(activeRun.processGroupId ?? activeRun.pid), 'SIGINT');
             }
+          } else {
+            return false;
           }
         }
       } catch (error) {

--- a/src/lib/runtimes/shared/owned-session/helpers.test.ts
+++ b/src/lib/runtimes/shared/owned-session/helpers.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
 
 import {
+  commandLineMatchesOwnedRun,
   filterStderrNoise,
   isOwnedRunAlive,
   relativeAge,
@@ -38,6 +39,21 @@ describe('repoSlugFromOrigin', () => {
     expect(repoSlugFromOrigin('https://gitlab.com/team/repo.git')).toBeUndefined();
     expect(repoSlugFromOrigin('')).toBeUndefined();
     expect(repoSlugFromOrigin(undefined)).toBeUndefined();
+  });
+});
+
+describe('commandLineMatchesOwnedRun', () => {
+  it('recognizes a persisted carrier wrapper instead of requiring the runtime binary name', () => {
+    expect(commandLineMatchesOwnedRun('/usr/bin/ori codex exec --json', '/usr/bin/ori', 'codex')).toBe(true);
+    expect(commandLineMatchesOwnedRun('/Users/J Doe/.local/bin/ori codex exec --json', '/Users/J Doe/.local/bin/ori', 'codex')).toBe(true);
+    expect(commandLineMatchesOwnedRun('"/Users/J Doe/.local/bin/ori" codex exec --json', '/Users/J Doe/.local/bin/ori', 'codex')).toBe(true);
+    expect(commandLineMatchesOwnedRun('/Users/J Doe/.local/bin/original codex exec --json', '/Users/J Doe/.local/bin/ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('/bin/sh -c "echo /usr/bin/ori"', '/usr/bin/ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('/usr/bin/ori codex exec --json', undefined, 'codex')).toBe(true);
+    expect(commandLineMatchesOwnedRun('/usr/bin/node unrelated.js', 'ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('/usr/bin/origami codexical', 'ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('git fetch origin', 'ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('/Users/victoria/bin/node task.js', 'ori', 'codex')).toBe(false);
   });
 });
 

--- a/src/lib/runtimes/shared/owned-session/helpers.test.ts
+++ b/src/lib/runtimes/shared/owned-session/helpers.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
 
 import {
+  commandLineMatchesOwnedRun,
   filterStderrNoise,
   isOwnedRunAlive,
   relativeAge,
@@ -38,6 +39,32 @@ describe('repoSlugFromOrigin', () => {
     expect(repoSlugFromOrigin('https://gitlab.com/team/repo.git')).toBeUndefined();
     expect(repoSlugFromOrigin('')).toBeUndefined();
     expect(repoSlugFromOrigin(undefined)).toBeUndefined();
+  });
+});
+
+describe('commandLineMatchesOwnedRun', () => {
+  it('recognizes only the executable position in a Windows CLI invocation', () => {
+    const binary = 'C:\\Program Files\\runtime\\codex.cmd';
+    expect(commandLineMatchesOwnedRun(`C:\\Windows\\system32\\cmd.exe /d /c "${binary}" exec`, binary, 'codex', 'win32')).toBe(true);
+    expect(commandLineMatchesOwnedRun(`cmd.exe /d /c "${binary}" exec`, undefined, 'codex', 'win32')).toBe(true);
+    expect(commandLineMatchesOwnedRun(`cmd.exe /d /c type "${binary}"`, binary, 'codex', 'win32')).toBe(false);
+    expect(commandLineMatchesOwnedRun(`node.exe viewer.js "${binary}"`, binary, 'codex', 'win32')).toBe(false);
+    expect(commandLineMatchesOwnedRun('"C:\\Tools\\ori.exe" codex exec', 'C:\\Tools\\ori.exe', 'codex', 'win32')).toBe(true);
+  });
+  it('recognizes a persisted carrier wrapper instead of requiring the runtime binary name', () => {
+    expect(commandLineMatchesOwnedRun('/usr/bin/ori codex exec --json', '/usr/bin/ori', 'codex')).toBe(true);
+    expect(commandLineMatchesOwnedRun('/Users/J Doe/.local/bin/ori codex exec --json', '/Users/J Doe/.local/bin/ori', 'codex')).toBe(true);
+    expect(commandLineMatchesOwnedRun('"/Users/J Doe/.local/bin/ori" codex exec --json', '/Users/J Doe/.local/bin/ori', 'codex')).toBe(true);
+    expect(commandLineMatchesOwnedRun('/Users/J Doe/.local/bin/original codex exec --json', '/Users/J Doe/.local/bin/ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('/bin/sh -c "echo /usr/bin/ori"', '/usr/bin/ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('/usr/bin/ori codex exec --json', undefined, 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('/bin/cat /usr/bin/ori', '/usr/bin/ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('/usr/bin/node viewer.js /usr/bin/ori', '/usr/bin/ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('/bin/cat "/usr/bin/ori"', '/usr/bin/ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('/usr/bin/node unrelated.js', 'ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('/usr/bin/origami codexical', 'ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('git fetch origin', 'ori', 'codex')).toBe(false);
+    expect(commandLineMatchesOwnedRun('/Users/victoria/bin/node task.js', 'ori', 'codex')).toBe(false);
   });
 });
 

--- a/src/lib/runtimes/shared/owned-session/helpers.ts
+++ b/src/lib/runtimes/shared/owned-session/helpers.ts
@@ -300,6 +300,39 @@ export function isPidAlive(pid?: number) {
   }
 }
 
+export function commandLineMatchesOwnedRun(
+  commandLine: string | null,
+  commandIdentity: string | undefined,
+  fallbackBinaryName: string,
+): boolean {
+  const identity = commandIdentity?.trim() || fallbackBinaryName;
+  if (!commandLine) return false;
+  const normalizedIdentity = identity.toLowerCase();
+  const identityIsPath = identity.includes('/') || identity.includes('\\');
+  if (identityIsPath) {
+    const normalizedCommandLine = commandLine.toLowerCase();
+    const quotedTokens = commandLine.match(/"[^"]*"|'[^']*'/g) ?? [];
+    if (quotedTokens.some((token) => token.slice(1, -1).toLowerCase() === normalizedIdentity)) return true;
+    let offset = normalizedCommandLine.indexOf(normalizedIdentity);
+    while (offset >= 0) {
+      const before = normalizedCommandLine[offset - 1];
+      const after = normalizedCommandLine[offset + normalizedIdentity.length];
+      const prefix = normalizedCommandLine.slice(0, offset);
+      const insideSingleQuotes = (prefix.match(/'/g)?.length ?? 0) % 2 === 1;
+      const insideDoubleQuotes = (prefix.match(/"/g)?.length ?? 0) % 2 === 1;
+      if (!insideSingleQuotes && !insideDoubleQuotes
+        && (!before || /\s/.test(before)) && (!after || /\s/.test(after))) return true;
+      offset = normalizedCommandLine.indexOf(normalizedIdentity, offset + 1);
+    }
+    return false;
+  }
+  const tokens = commandLine.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
+  return tokens.some((rawToken) => {
+    const token = rawToken.replace(/^["']|["']$/g, '').toLowerCase();
+    return path.basename(token) === normalizedIdentity || path.win32.basename(token) === normalizedIdentity;
+  });
+}
+
 export async function isOwnedRunAlive(run?: OwnedRunRecord | null): Promise<boolean> {
   if (!run) return false;
   // A run that already recorded a finish is terminal — never probe it (#1293).

--- a/src/lib/runtimes/shared/owned-session/helpers.ts
+++ b/src/lib/runtimes/shared/owned-session/helpers.ts
@@ -19,6 +19,7 @@ import { truncateText } from '@/lib/util/text';
 import { getDataDir } from '@/lib/data-dir-migration';
 
 import type { OwnedChildExitOutcome, OwnedRunOutcome, OwnedRunRecord, ParsedRunLog } from './types';
+import { probeOwnedRunProcessClaim, resolveSpawnedProcessGroupId } from './run-process-proof';
 
 const execFileAsync = promisify(execFile);
 
@@ -283,6 +284,50 @@ export function isPidAlive(pid?: number) {
     if ((error as NodeJS.ErrnoException)?.code === 'EPERM') return true;
     return false;
   }
+}
+
+export function commandLineMatchesOwnedRun(
+  commandLine: string | null,
+  commandIdentity: string | undefined,
+  fallbackBinaryName: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  const identity = commandIdentity?.trim() || fallbackBinaryName;
+  if (!commandLine) return false;
+  const normalize = (value: string) => platform === 'win32' ? value.toLowerCase() : value;
+  const normalizedIdentity = normalize(identity);
+  const tokens = commandLine.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
+  const unquote = (token: string) => token.replace(/^["']|["']$/g, '');
+  // cliInvocation uses exactly cmd.exe /d /c <CLI> for Windows script shims.
+  // Only that executable position is authority, never a later argv mention.
+  if (platform === 'win32' && path.win32.basename(unquote(tokens[0] ?? '')).toLowerCase() === 'cmd.exe'
+    && tokens[1]?.toLowerCase() === '/d' && tokens[2]?.toLowerCase() === '/c') {
+    return commandLineMatchesOwnedRun(tokens.slice(3).join(' '), commandIdentity, fallbackBinaryName, platform);
+  }
+  const identityIsPath = identity.includes('/') || identity.includes('\\');
+  if (identityIsPath) {
+    const normalizedCommandLine = normalize(commandLine.trimStart());
+    return [normalizedIdentity, `"${normalizedIdentity}"`, `'${normalizedIdentity}'`].some((prefix) => (
+      normalizedCommandLine.startsWith(prefix)
+      && (!normalizedCommandLine[prefix.length] || /\s/.test(normalizedCommandLine[prefix.length]!))
+    ));
+  }
+  const token = normalize(unquote(tokens[0] ?? ''));
+  const basename = platform === 'win32' ? path.win32.basename(token) : path.basename(token);
+  return basename === normalizedIdentity || (platform === 'win32' && !path.win32.extname(identity)
+    && ['.cmd', '.exe', '.com'].some((extension) => basename === `${normalizedIdentity}${extension}`));
+}
+
+/** POSIX run ownership survives wrapper exec; an argv mention does not prove ownership. */
+export async function canSignalOwnedRun(run: OwnedRunRecord, fallbackBinaryName: string): Promise<boolean> {
+  if (process.platform === 'win32') {
+    return commandLineMatchesOwnedRun(await pidCommandLine(run.pid), run.commandIdentity, fallbackBinaryName);
+  }
+  if (!run.processMarker) return false;
+  const claim = await probeOwnedRunProcessClaim({ pid: run.pid, marker: run.processMarker, rootPid: run.pid });
+  if (claim.state !== 'match') return false;
+  const group = await resolveSpawnedProcessGroupId(run.pid);
+  return group !== undefined && group === (run.processGroupId ?? run.pid);
 }
 
 export async function isOwnedRunAlive(run?: OwnedRunRecord | null): Promise<boolean> {

--- a/src/lib/runtimes/shared/owned-session/lifecycle.ts
+++ b/src/lib/runtimes/shared/owned-session/lifecycle.ts
@@ -19,6 +19,7 @@ import type {
   OwnedRuntimeAdapter,
   OwnedSessionRecord,
 } from './types';
+import { executionCarrierRuntimeLabel } from '@/lib/runtimes/shared/execution-carrier';
 
 export interface OwnedLifecycleContext {
   adapter: OwnedRuntimeAdapter;
@@ -100,6 +101,7 @@ export function buildRuntimeSurface(
   running: boolean,
 ): RuntimeSurfaceSummary {
   const { adapter, runtimeId } = context;
+  const runtimeLabel = executionCarrierRuntimeLabel(adapter.squadShortName, session.runtimeConfig);
   const lifecycle = deriveLifecycle(context, session);
   const lastOutcomeLabel = lifecycle.lastOutcome ? ` • last ${lifecycle.lastOutcome}` : '';
 
@@ -112,8 +114,8 @@ export function buildRuntimeSurface(
     cwd: shortHome(session.repoPath),
     branch: session.branch,
     sourceLabel: running
-      ? `IDE-owned ${adapter.squadShortName} registry • active pid ${session.activeRun?.pid ?? 'unknown'}${lastOutcomeLabel}`
-      : `IDE-owned ${adapter.squadShortName} registry • ${lifecycleAvailabilityLabel(lifecycle.availability)}${lastOutcomeLabel}`,
+      ? `IDE-owned ${runtimeLabel} registry • active pid ${session.activeRun?.pid ?? 'unknown'}${lastOutcomeLabel}`
+      : `IDE-owned ${runtimeLabel} registry • ${lifecycleAvailabilityLabel(lifecycle.availability)}${lastOutcomeLabel}`,
     tailSourceLabel: `${shortHome(session.sessionDir)}/${RUNS_DIR}/*.jsonl`,
     capabilities: {
       attach: true,
@@ -158,26 +160,27 @@ export function buildCurrentTask(
   running: boolean,
 ) {
   const { adapter } = context;
+  const runtimeLabel = executionCarrierRuntimeLabel(adapter.squadShortName, session.runtimeConfig);
   const lifecycle = deriveLifecycle(context, session);
   if (running) {
-    return `IDE-launched ${adapter.squadShortName} run active. ${session.latestSummary}`;
+    return `IDE-launched ${runtimeLabel} run active. ${session.latestSummary}`;
   }
   if (lifecycle.availability === 'awaiting-thread') {
-    return `IDE-owned ${adapter.squadShortName} session launched and waiting for its first thread id. ${session.latestSummary}`;
+    return `IDE-owned ${runtimeLabel} session launched and waiting for its first thread id. ${session.latestSummary}`;
   }
   if (reviewDisposition(session) === 'resolved') {
     return `Operator marked this owned result resolved. Keep watching only if new evidence appears. ${session.latestSummary}`;
   }
   if (lifecycle.lastOutcome === 'interrupted') {
-    return `IDE-owned ${adapter.squadShortName} session is ready for resume after an interrupted run. ${session.latestSummary}`;
+    return `IDE-owned ${runtimeLabel} session is ready for resume after an interrupted run. ${session.latestSummary}`;
   }
   if (lifecycle.lastOutcome === 'failed') {
-    return `IDE-owned ${adapter.squadShortName} session is ready for a corrective follow-up after a failed run. ${session.latestSummary}`;
+    return `IDE-owned ${runtimeLabel} session is ready for a corrective follow-up after a failed run. ${session.latestSummary}`;
   }
   if (session.threadId) {
-    return `IDE-owned ${adapter.squadShortName} session ready for the next input via resume. ${session.latestSummary}`;
+    return `IDE-owned ${runtimeLabel} session ready for the next input via resume. ${session.latestSummary}`;
   }
-  return `IDE-owned ${adapter.squadShortName} session is idle. ${session.latestSummary}`;
+  return `IDE-owned ${runtimeLabel} session is idle. ${session.latestSummary}`;
 }
 
 export function formatChildExit(outcome: OwnedChildExitOutcome | undefined) {

--- a/src/lib/runtimes/shared/owned-session/run-controller.ts
+++ b/src/lib/runtimes/shared/owned-session/run-controller.ts
@@ -3,7 +3,6 @@ import { closeSync, openSync } from 'node:fs';
 import { readFile, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
-
 import { getOrCreateLocalWorkerToken } from '@/lib/auth/worker-token';
 import {
   bindPacketWorkerTokenProcess,
@@ -16,10 +15,10 @@ import { spawnBridgeTerminalSession } from '@/lib/runtime/pty-bridge';
 import { ensureDispatchBackendReady } from '@/lib/runtimes/shared/dispatch-readiness';
 import { CliNotFoundError, resolveCli } from '@/lib/runtimes/shared/cli-resolver';
 import { cliInvocation } from '@/lib/runtimes/shared/cli-spawn';
+import { executionCarrierCommandIdentity, executionCarrierSandboxReadPaths, executionCarrierSpawnPath, resolveExecutionCarrierInvocation } from '@/lib/runtimes/shared/execution-carrier-launch';
 import { guardedWorkspaceInvocation } from '@/lib/worktree/materialization-execution';
 import { tmuxSessionName } from '@/lib/terminal/tmux';
 import { pathWithNodeRuntime } from '@/lib/util/node-on-path';
-
 import { crashSurvivableWorkersEnabled } from './crash-survival';
 import { observeChildExit, readAbnormalStderrTail } from './exit-outcome';
 import { prepareOwnedLaunchArgs } from './launch-args';
@@ -535,8 +534,9 @@ export function createOwnedRunController({
       humanLabel,
     });
 
-    let spawnBinary = binary;
-    let spawnArgs = args;
+    const carrierLaunch = await resolveExecutionCarrierInvocation({ runtime: runtimeId as OrchestratorRuntime, runtimeConfig: session.runtimeConfig, runtimeBinary: binary, runtimeArgs: args });
+    let spawnBinary = carrierLaunch.command;
+    let spawnArgs = carrierLaunch.args;
     const sandboxEnvExtra: Record<string, string> = {};
     if (sandboxEnabled) {
       try {
@@ -545,9 +545,9 @@ export function createOwnedRunController({
           profileDir: path.join(session.sessionDir, RUNS_DIR),
           cwd: session.repoPath,
           repoPath: session.repoPath,
-          binary,
-          args,
-          extraReadPaths: workerMcp.sandboxReadPaths,
+          binary: spawnBinary,
+          args: spawnArgs,
+          extraReadPaths: executionCarrierSandboxReadPaths(workerMcp.sandboxReadPaths, carrierLaunch),
           finalAllowReadPaths: workerMcp.configPath ? [workerMcp.configPath] : undefined,
           // Read-only: repo stays readable, kernel refuses every write. Deny
           // paths come from the SAME git probe prepareWorkerSandbox uses to
@@ -627,7 +627,7 @@ export function createOwnedRunController({
       // the spawned process cwd. Keep both values aligned so a worker cannot
       // silently operate in the o8 server's own checkout.
       PWD: session.repoPath,
-      PATH: pathWithNodeRuntime(),
+      PATH: executionCarrierSpawnPath(pathWithNodeRuntime(), carrierLaunch),
       FORCE_COLOR: '0',
       NO_COLOR: '1',
       // Workers must never pop an OS browser: dev servers (CRA, storybook)
@@ -660,7 +660,7 @@ export function createOwnedRunController({
       prompt,
       startedAt: nowIso(),
       pid: 0,
-      commandIdentity: path.basename(spawnBinary),
+      commandIdentity: executionCarrierCommandIdentity(carrierLaunch, spawnBinary),
       processMarker: runId,
       spawnState: 'prepared',
       stdoutPath,
@@ -677,7 +677,7 @@ export function createOwnedRunController({
     await io.saveSession(session);
 
     try {
-      if (!crashSurvivableWorkersEnabled()) {
+      if (!carrierLaunch.carried && !crashSurvivableWorkersEnabled()) {
         try {
           const result = await spawnBridgeTerminalSession({
             sessionName: bridgeSessionName,

--- a/src/lib/runtimes/shared/owned-session/run-controller.ts
+++ b/src/lib/runtimes/shared/owned-session/run-controller.ts
@@ -3,7 +3,6 @@ import { closeSync, openSync } from 'node:fs';
 import { readFile, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
-
 import { getOrCreateLocalWorkerToken } from '@/lib/auth/worker-token';
 import {
   bindPacketWorkerTokenProcess,
@@ -16,10 +15,10 @@ import { spawnBridgeTerminalSession } from '@/lib/runtime/pty-bridge';
 import { ensureDispatchBackendReady } from '@/lib/runtimes/shared/dispatch-readiness';
 import { CliNotFoundError, resolveCli } from '@/lib/runtimes/shared/cli-resolver';
 import { cliInvocation } from '@/lib/runtimes/shared/cli-spawn';
+import { executionCarrierCommandIdentity, executionCarrierSandboxReadPaths, executionCarrierSpawnPath, resolveExecutionCarrierInvocation } from '@/lib/runtimes/shared/execution-carrier-launch';
 import { guardedWorkspaceInvocation } from '@/lib/worktree/materialization-execution';
 import { tmuxSessionName } from '@/lib/terminal/tmux';
 import { pathWithNodeRuntime } from '@/lib/util/node-on-path';
-
 import { crashSurvivableWorkersEnabled } from './crash-survival';
 import { observeChildExit, readAbnormalStderrTail } from './exit-outcome';
 import { prepareOwnedLaunchArgs } from './launch-args';
@@ -541,8 +540,9 @@ export function createOwnedRunController({
       : {};
     const runtimeState = preparedRuntimeStateSandboxPolicy(adapter, session, adapterEnv);
 
-    let spawnBinary = binary;
-    let spawnArgs = args;
+    const carrierLaunch = await resolveExecutionCarrierInvocation({ runtime: runtimeId as OrchestratorRuntime, runtimeConfig: session.runtimeConfig, runtimeBinary: binary, runtimeArgs: args });
+    let spawnBinary = carrierLaunch.command;
+    let spawnArgs = carrierLaunch.args;
     const sandboxEnvExtra: Record<string, string> = {};
     if (sandboxEnabled) {
       try {
@@ -551,9 +551,9 @@ export function createOwnedRunController({
           profileDir: path.join(session.sessionDir, RUNS_DIR),
           cwd: session.repoPath,
           repoPath: session.repoPath,
-          binary,
-          args,
-          extraReadPaths: workerMcp.sandboxReadPaths,
+          binary: spawnBinary,
+          args: spawnArgs,
+          extraReadPaths: executionCarrierSandboxReadPaths(workerMcp.sandboxReadPaths, carrierLaunch),
           readBackingProjectConfig: runtimeId === 'codex',
           finalAllowReadPaths: workerMcp.configPath ? [workerMcp.configPath] : undefined,
           // Read-only: repo stays readable, kernel refuses every write. Deny
@@ -618,7 +618,7 @@ export function createOwnedRunController({
       // the spawned process cwd. Keep both values aligned so a worker cannot
       // silently operate in the o8 server's own checkout.
       PWD: session.repoPath,
-      PATH: pathWithNodeRuntime(),
+      PATH: executionCarrierSpawnPath(pathWithNodeRuntime(), carrierLaunch),
       NODE_ENV: 'development' as const,
       FORCE_COLOR: '0',
       NO_COLOR: '1',
@@ -651,7 +651,7 @@ export function createOwnedRunController({
       prompt,
       startedAt: nowIso(),
       pid: 0,
-      commandIdentity: path.basename(spawnBinary),
+      commandIdentity: executionCarrierCommandIdentity(carrierLaunch, spawnBinary),
       processMarker: runId,
       spawnState: 'prepared',
       stdoutPath,
@@ -668,7 +668,7 @@ export function createOwnedRunController({
     await io.saveSession(session);
 
     try {
-      if (!crashSurvivableWorkersEnabled()) {
+      if (!carrierLaunch.carried && !crashSurvivableWorkersEnabled()) {
         try {
           const result = await spawnBridgeTerminalSession({
             sessionName: bridgeSessionName,

--- a/src/lib/runtimes/shared/owned-session/sandbox.test.ts
+++ b/src/lib/runtimes/shared/owned-session/sandbox.test.ts
@@ -128,6 +128,20 @@ describe('buildSeatbeltProfile — policy shape', () => {
     expect(profile).toContain('(subpath "/Users/op/.codex")');
   });
 
+  it('can grant Ori state read access without making the credential tree writable', () => {
+    const oriProfile = buildSeatbeltProfile({
+      worktreePath: '/tmp/wt',
+      repoPath: '/tmp/repo',
+      homeDir: '/Users/op',
+      tmpDir: '/tmp/T',
+      extraReadPaths: ['/Users/op/.ori'],
+    });
+    const readAllow = oriProfile.indexOf(';; --- read: system + toolchain roots ---');
+    const writeAllow = oriProfile.indexOf(';; --- read+write: packet, Git metadata, TMPDIR, and tool state ---');
+    expect(oriProfile.indexOf('(subpath "/Users/op/.ori")', readAllow)).toBeGreaterThan(readAllow);
+    expect(oriProfile.indexOf('(subpath "/Users/op/.ori")', writeAllow)).toBe(-1);
+  });
+
   it('can deny protected executable paths and keep launch policy immutable', () => {
     expect(profile).toContain('(deny process-exec\n  (literal "/opt/codex/bin/codex")');
     expect(profile).toContain('(regex #"(^|/)codex(?:$|[-.])")');

--- a/src/lib/runtimes/shared/owned-session/sandbox.test.ts
+++ b/src/lib/runtimes/shared/owned-session/sandbox.test.ts
@@ -130,6 +130,20 @@ describe('buildSeatbeltProfile — policy shape', () => {
     expect(profile).toContain('(subpath "/Users/op/.codex")');
   });
 
+  it('can grant Ori state read access without making the credential tree writable', () => {
+    const oriProfile = buildSeatbeltProfile({
+      worktreePath: '/tmp/wt',
+      repoPath: '/tmp/repo',
+      homeDir: '/Users/op',
+      tmpDir: '/tmp/T',
+      extraReadPaths: ['/Users/op/.ori'],
+    });
+    const readAllow = oriProfile.indexOf(';; --- read: system + toolchain roots ---');
+    const writeAllow = oriProfile.indexOf(';; --- read+write: packet, Git metadata, TMPDIR, and tool state ---');
+    expect(oriProfile.indexOf('(subpath "/Users/op/.ori")', readAllow)).toBeGreaterThan(readAllow);
+    expect(oriProfile.indexOf('(subpath "/Users/op/.ori")', writeAllow)).toBe(-1);
+  });
+
   it('can deny protected executable paths and keep launch policy immutable', () => {
     expect(profile).toContain('(deny process-exec\n  (literal "/opt/codex/bin/codex")');
     expect(profile).toContain('(regex #"(^|/)codex(?:$|[-.])")');

--- a/src/lib/runtimes/shared/owned-session/store.ts
+++ b/src/lib/runtimes/shared/owned-session/store.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_AUTO_RETRY_DELAY_MS,
   OWNED_FLEET_TTL_MS,
   compactText,
+  commandLineMatchesOwnedRun,
   ensureDir,
   isPidAlive,
   nowIso,
@@ -345,7 +346,8 @@ export function createOwnedSessionStore(
         await signalBridgeTerminalSession(session.activeRun.tmuxSession, 'SIGINT');
       } else {
         const cmd = await pidCommandLine(session.activeRun.pid);
-        if (cmd && cmd.includes(adapter.binaryName)) {
+        const commandIdentity = session.activeRun.commandIdentity ?? adapter.binaryName;
+        if (commandLineMatchesOwnedRun(cmd, session.activeRun.commandIdentity, adapter.binaryName)) {
           // Windows has no process groups addressed by negative pid and no
           // SIGINT delivery to another tree; the CLI is also a grandchild of
           // the interpreter, so a single-pid kill would leave it running.
@@ -365,7 +367,7 @@ export function createOwnedSessionStore(
           }
         } else {
           console.warn(
-            `[owned-store] Skipping interrupt signal for ${surfaceId}: pid ${session.activeRun.pid} no longer matches an owned ${adapter.binaryName} run (${cmd ?? 'process gone'})`,
+            `[owned-store] Skipping interrupt signal for ${surfaceId}: pid ${session.activeRun.pid} no longer matches owned command ${commandIdentity} (${cmd ?? 'process gone'})`,
           );
         }
       }

--- a/src/lib/runtimes/shared/owned-session/store.ts
+++ b/src/lib/runtimes/shared/owned-session/store.ts
@@ -26,11 +26,11 @@ import {
   DEFAULT_AUTO_RETRY_DELAY_MS,
   OWNED_FLEET_TTL_MS,
   compactText,
+  canSignalOwnedRun,
   ensureDir,
   isPidAlive,
   nowIso,
   forceKillTreeWindows,
-  pidCommandLine,
   resolveRepoContext,
   validateWorkspace,
 } from './helpers';
@@ -346,8 +346,8 @@ export function createOwnedSessionStore(
       if (session.activeRun.tmuxSession) {
         await signalBridgeTerminalSession(session.activeRun.tmuxSession, 'SIGINT');
       } else {
-        const cmd = await pidCommandLine(session.activeRun.pid);
-        if (cmd && cmd.includes(adapter.binaryName)) {
+        const commandIdentity = session.activeRun.commandIdentity ?? adapter.binaryName;
+        if (await canSignalOwnedRun(session.activeRun, adapter.binaryName)) {
           // Windows has no process groups addressed by negative pid and no
           // SIGINT delivery to another tree; the CLI is also a grandchild of
           // the interpreter, so a single-pid kill would leave it running.
@@ -363,12 +363,10 @@ export function createOwnedSessionStore(
               throw new Error(`taskkill could not stop pid ${session.activeRun.pid}`);
             }
           } else {
-            process.kill(-session.activeRun.pid, 'SIGINT');
+            process.kill(-(session.activeRun.processGroupId ?? session.activeRun.pid), 'SIGINT');
           }
         } else {
-          console.warn(
-            `[owned-store] Skipping interrupt signal for ${surfaceId}: pid ${session.activeRun.pid} no longer matches an owned ${adapter.binaryName} run (${cmd ?? 'process gone'})`,
-          );
+          return { interrupted: false, note: `Ownership of the active ${commandIdentity} process could not be verified; no signal was sent and the run remains held.` };
         }
       }
       session.activeRun = {

--- a/src/lib/runtimes/types.ts
+++ b/src/lib/runtimes/types.ts
@@ -5,6 +5,7 @@ import type { ThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import type { ClaudeCodeModelSource } from '@/lib/claude-code/worker-profile-types';
 import type { PacketCostSource, PacketSpendCap } from '@/lib/orchestrator/metered-spend';
 import type { WorkerWorkMode } from '@/lib/orchestrator/types';
+import type { ExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 
 /**
  * Universal Agent Runtime Contract
@@ -272,6 +273,7 @@ export interface LaunchOptions {
   /** Explicit packet-only model/carrier pins for the Claude Code adapter. */
   claudeCodeModel?: string;
   claudeCodeCarrier?: ClaudeCodeModelSource;
+  executionCarrier?: ExecutionCarrierId;
   /** Requested reasoning effort — applied per-runtime (codex today); a no-op elsewhere. */
   effort?: ThinkingEffort;
   worktreeFlag?: string;

--- a/src/lib/settings/toml.ts
+++ b/src/lib/settings/toml.ts
@@ -30,6 +30,7 @@ import { isTargetingTier } from '@/lib/operator/targeting-tier';
 import { isWorkerStartMode } from '@/lib/operator/worker-start-mode';
 import { isThinkingEffort } from '@/lib/orchestrator/thinking-effort';
 import { AUTHENTICATED_ENDPOINT_GUIDANCE, credentialBearingUrlPart } from './credential-safe-url';
+import { isExecutionCarrierId } from '@/lib/runtimes/shared/execution-carrier';
 
 type TomlRecord = Record<string, unknown>;
 
@@ -123,6 +124,16 @@ function acpModelIdField(section: string, key: string): TomlField<string | null>
         ? trimmed
         : invalid(tomlKey, `a model id shaped provider/model, optionally with a /low or /high suffix; received ${JSON.stringify(trimmed)}`);
     },
+  };
+}
+
+function executionCarrierField(section: string, key: string): TomlField<OperatorDefaults['workerExecutionCarrier']> {
+  return {
+    path: [section, key],
+    serialize: (value) => value ?? '',
+    parse: (value, tomlKey) => value === '' || value === null
+      ? null
+      : isExecutionCarrierId(value) ? value : invalid(tomlKey, '"ori" or an empty string'),
   };
 }
 
@@ -244,6 +255,7 @@ export const OPERATOR_DEFAULTS_TOML_MAPPING = {
   opencodeOrchestratorModel: acpModelIdField('models', 'opencode_orchestrator_model'),
   opencodeWorkerModel: acpModelIdField('models', 'opencode_worker_model'),
   defaultDispatchRuntime: enumField('models', 'default_dispatch_runtime', 'a dispatchable runtime name', isDispatchRuntime),
+  workerExecutionCarrier: executionCarrierField('models', 'worker_execution_carrier'),
   workerStartMode: enumField('operator', 'worker_start_mode', 'one of "autonomous", "huddle", or "adaptive"', isWorkerStartMode),
   workerRuntimes: dispatchRuntimeListField('models', 'worker_runtimes'),
   codexWorkerEffort: enumField('models', 'codex_worker_effort', 'a valid thinking effort', isThinkingEffort),

--- a/src/lib/settings/toml.ts
+++ b/src/lib/settings/toml.ts
@@ -298,6 +298,7 @@ const EXPLICIT_OPT_IN_FLAG_KEYS = [
   'broadcastVoice',
   'apfsDependencyImages',
   'mergeTestReplayEnabled',
+  'packetExplainerEnabled',
   'quizGateEnabled',
   'buyinDocEnabled',
   'productTelemetryEnabled',

--- a/src/lib/supervisor/completion-turn.ts
+++ b/src/lib/supervisor/completion-turn.ts
@@ -9,24 +9,27 @@ export class SupersededCompletionError extends Error {
   }
 }
 
-function turnCursor(laneId: string): number {
+function turnCursor(laneId: string, allowRuntimeExit: boolean): number {
   const row = getSqlite().prepare(`
     SELECT rowid FROM lane_events WHERE lane_id = ? AND verb IN (
       'steered_packet', 'steer_run_admitted', 'steer_failed', 'runtime_process_exit'
-    ) ORDER BY rowid DESC LIMIT 1
-  `).get(laneId) as { rowid: number } | undefined;
+    ) AND (? = 0 OR verb != 'runtime_process_exit') ORDER BY rowid DESC LIMIT 1
+  `).get(laneId, allowRuntimeExit ? 1 : 0) as { rowid: number } | undefined;
   return row?.rowid ?? 0;
 }
 
 /** Durable insertion order also distinguishes two turns in one millisecond. */
-export function createCompletionTurnGuard(lane: Lane) {
-  const cursor = turnCursor(lane.id);
+export function createCompletionTurnGuard(lane: Lane, options: { allowRuntimeExit?: boolean } = {}) {
+  // Forced review intentionally interrupts this runtime. Its exit is expected;
+  // new user turns and durable Stop/archive holds still supersede the transition.
+  const allowRuntimeExit = options.allowRuntimeExit === true;
+  const cursor = turnCursor(lane.id, allowRuntimeExit);
   function check(): void {
     const current = getLane(lane.id);
     if (!current || current.sessionKey !== lane.sessionKey || current.packetId !== lane.packetId
       || ['paused', 'merging', 'completed', 'archived'].includes(current.status)
       || (current.packetId && packetSteerHoldReason(current.packetId))
-      || turnCursor(lane.id) !== cursor) {
+      || turnCursor(lane.id, allowRuntimeExit) !== cursor) {
       throw new SupersededCompletionError();
     }
   }

--- a/src/lib/supervisor/force-self-review.ts
+++ b/src/lib/supervisor/force-self-review.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from 'node:crypto';
+import { updateLane } from '@/lib/lane/registry';
+import type { Lane } from '@/lib/lane/types';
+import { fetchRuntimeAction } from '@/lib/ws-server/next-fetch';
+import { recordSelfReviewInterruptFailure } from '@/lib/ws-server/self-review-transition';
+import type { AgentUpdateEvent } from './agent-supervisor-types';
+import { createCompletionTurnGuard, SupersededCompletionError } from './completion-turn';
+import { runCompletionVerification } from './completion-verification';
+import { hasFreshSelfReviewTranscriptActivity, preserveSelfReviewStallWork,
+  resetSelfReviewStallGuard, type SelfReviewStallDecision } from './self-review-stall-guard';
+
+interface ForceReviewDependencies {
+  park(surfaceId: string, lane: Lane, reason: string, captureRef?: string, checkCurrent?: () => void): Promise<void>;
+  unregister(surfaceId: string): void;
+  enqueueAutoReview(laneId: string): Promise<unknown>;
+  triggerHeadlessSprintTick(): Promise<unknown>;
+  queueReviewContinuation(lane: Lane): void;
+  broadcastUpdate(event: AgentUpdateEvent): void;
+  escalate(repoPath: string, message: string): void;
+}
+
+/** The server's forced-review path preserves work, but never creates a merge receipt. */
+export async function forceSelfReviewToReview(
+  surfaceId: string,
+  lane: Lane,
+  decision: Extract<SelfReviewStallDecision, { kind: 'force-review' }>,
+  dependencies: ForceReviewDependencies,
+): Promise<void> {
+  const guard = createCompletionTurnGuard(lane, { allowRuntimeExit: true });
+  const cwd = decision.cwd || lane.worktreePath || lane.repoPath;
+  try {
+    const preservation = await guard.wait(() => preserveSelfReviewStallWork(lane, cwd));
+    if (await guard.wait(() => hasFreshSelfReviewTranscriptActivity(surfaceId))) {
+      resetSelfReviewStallGuard(surfaceId);
+      return;
+    }
+    if (preservation.error || !preservation.hasReviewableDiff) {
+      await dependencies.park(surfaceId, lane, preservation.error
+        ? `Auto-commit failed: ${preservation.error}`
+        : 'No reviewable commit remained after preserving the worktree.', preservation.captureRef, guard.check);
+      return;
+    }
+    const verification = await guard.wait(() => runCompletionVerification(cwd, lane.baseBranch));
+    if (await guard.wait(() => hasFreshSelfReviewTranscriptActivity(surfaceId))) {
+      resetSelfReviewStallGuard(surfaceId);
+      return;
+    }
+    if (!verification.ok) {
+      await dependencies.park(surfaceId, lane,
+        `Preserved work failed ${verification.kind}; operator review is required.`, preservation.captureRef, guard.check);
+      return;
+    }
+    if (lane.packetId) {
+      try {
+        const { capturePacketCompletionContext } = await guard.wait(() => import('@/lib/orchestrator/context-relay'));
+        await guard.wait(() => capturePacketCompletionContext(lane.packetId!, surfaceId));
+      } catch (error) {
+        guard.check();
+        console.error(`[context-relay] Failed to capture self-review context for packet ${lane.packetId}:`, error);
+      }
+    }
+    try {
+      await guard.wait(() => fetchRuntimeAction({ action: 'interrupt', surfaceId, clientMutationId: randomUUID() }));
+    } catch (error) {
+      guard.check();
+      const reason = recordSelfReviewInterruptFailure({ laneId: lane.id, surfaceId, error });
+      resetSelfReviewStallGuard(surfaceId);
+      const detail = `Self-review work was preserved, but interrupt did not confirm a stop: ${reason}`;
+      dependencies.broadcastUpdate({ surfaceId, name: lane.label, status: 'stuck', detail, repoPath: lane.repoPath });
+      dependencies.escalate(lane.repoPath, [
+        `[SUPERVISOR] Agent "${lane.label}" (${surfaceId}) could not be stopped after its work was preserved.`,
+        `Lane: ${lane.id}`, `Reason: ${reason}`, '',
+        'The runtime remains bound and the lane remains active. Confirm the stop before moving this work to review.',
+      ].join('\n'));
+      return;
+    }
+    guard.check();
+    dependencies.unregister(surfaceId);
+    const updated = updateLane(lane.id, { status: 'reviewing', sessionKey: null,
+      lastEventAt: new Date().toISOString(), lastEventLabel: 'self_review_stall_forced' }, 'system');
+    if (!updated) return;
+    const reviewGuard = createCompletionTurnGuard(updated);
+    await reviewGuard.wait(() => dependencies.enqueueAutoReview(updated.id));
+    await reviewGuard.wait(() => dependencies.triggerHeadlessSprintTick());
+    dependencies.queueReviewContinuation(updated);
+    resetSelfReviewStallGuard(surfaceId);
+    dependencies.broadcastUpdate({ surfaceId, name: lane.label, status: 'completed',
+      detail: preservation.committed
+        ? 'Self-review stalled after verification; worktree was committed and moved to review.'
+        : 'Self-review stalled after verification; existing commit was moved to review.', repoPath: lane.repoPath });
+  } catch (error) {
+    if (!(error instanceof SupersededCompletionError)) throw error;
+    resetSelfReviewStallGuard(surfaceId);
+  }
+}

--- a/src/lib/supervisor/heal-bot-auto-release.ts
+++ b/src/lib/supervisor/heal-bot-auto-release.ts
@@ -3,6 +3,7 @@ import { findLaneByPacket, getLane, setLaneStatus } from '@/lib/lane/registry';
 import { probeBranchMerged } from '@/lib/orchestrator/branch-merge-probe';
 import { readOrchestratorControlPlaneState, withLockedState } from '@/lib/orchestrator/control-plane';
 import { markPacketReleased } from '@/lib/orchestrator/packet-release-truth';
+import { packetReleaseGeneration, packetReleaseIdentityIsCurrent, verifyCurrentLaneHead } from '@/lib/orchestrator/release-ownership';
 
 const AUTO_RELEASE_PROBE_RETRY_MS = 60_000;
 const AUTO_RELEASE_MIN_EVENT_AGE_MS = 30_000;
@@ -37,6 +38,7 @@ export async function runAwaitingReviewAutoReleaseSweep(): Promise<void> {
     const branch = worktreePath ? 'HEAD' : lane.branch || 'HEAD';
     const displayBranch = lane.branch || branch;
     const base = lane.baseBranch || 'main';
+    const generation = packetReleaseGeneration(packet, lane.id);
 
     try {
       const probe = await probeBranchMerged({ repoPath: probeRepoPath, branch, base });
@@ -49,14 +51,20 @@ export async function runAwaitingReviewAutoReleaseSweep(): Promise<void> {
       }
 
       const releasedAt = new Date().toISOString();
-      if (lane.status !== 'completed') setLaneStatus(lane.id, 'completed', 'system', 'merged');
-      const { result: released } = await withLockedState((current) => {
+      const { result: released } = await withLockedState(async (current) => {
         const packetState = current.packets.find((candidate) => candidate.id === packet.id);
-        if (!packetState || packetState.releaseState === 'released' || packetState.status !== 'awaiting_review') return false;
+        if (!packetState || packetState.status !== 'awaiting_review'
+          || !packetReleaseIdentityIsCurrent(packetState, lane.id, generation)) return false;
+        if (!(await verifyCurrentLaneHead(lane, probe.headSha))) return false;
+        const finalLane = getLane(lane.id);
+        if (!finalLane || !['reviewing', 'completed'].includes(finalLane.status)
+          || finalLane.branch !== lane.branch || finalLane.worktreePath !== lane.worktreePath
+          || !packetReleaseIdentityIsCurrent(packetState, lane.id, generation)) return false;
 
         markPacketReleased(packetState, {
           source: 'heal_bot_auto_release',
           mergeCommit: probe.mergeCommit,
+          headSha: probe.headSha,
           evidenceKind: 'branch_merged_probe',
           releasedAt,
         });
@@ -67,6 +75,7 @@ export async function runAwaitingReviewAutoReleaseSweep(): Promise<void> {
           packetState.lane.lastEventLabel = 'merged';
         }
         current.updatedAt = releasedAt;
+        if (getLane(lane.id)?.status !== 'completed') setLaneStatus(lane.id, 'completed', 'system', 'merged');
         return true;
       });
 

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -195,13 +195,10 @@ import { isTerminalLaneStatus } from './lib/lane/types';
 import type { Lane } from './lib/lane/types';
 import { getPacketTailBatch, type PacketTailEvent } from './lib/lane/packet-tail';
 import {
-  hasFreshSelfReviewTranscriptActivity,
-  preserveSelfReviewStallWork,
   probeSelfReviewStall,
   resetSelfReviewStallGuard,
   type SelfReviewStallDecision,
 } from './lib/supervisor/self-review-stall-guard';
-import { recordSelfReviewInterruptFailure } from './lib/ws-server/self-review-transition';
 import { invalidateReviewingLaneForWorkerActivity } from './lib/supervisor/review-invalidation';
 import {
   enqueueSupervisorInboxItem,
@@ -758,116 +755,16 @@ async function forceCodexSelfReviewToReview(
   lane: Lane,
   decision: Extract<SelfReviewStallDecision, { kind: 'force-review' }>,
 ): Promise<void> {
-  const cwd = decision.cwd || lane.worktreePath || lane.repoPath;
-  console.warn(`[supervisor] Forcing Codex self-review stall to review lane=${lane.id} session=${surfaceId}: ${decision.reason}`);
-
-  const preservation = await preserveSelfReviewStallWork(lane, cwd);
-  if (await yieldSelfReviewForceToFreshActivity(surfaceId, lane)) return;
-  if (preservation.error) {
-    await parkSelfReviewStallForOrchestrator(
-      surfaceId,
-      lane,
-      `Auto-commit failed: ${preservation.error}`,
-      preservation.captureRef,
-    );
-    return;
-  }
-
-  if (!preservation.hasReviewableDiff) {
-    await parkSelfReviewStallForOrchestrator(
-      surfaceId,
-      lane,
-      'No reviewable commit remained after preserving the worktree.',
-      preservation.captureRef,
-    );
-    return;
-  }
-
-  const { runCompletionVerification } = await import('@/lib/supervisor/completion-verification');
-  const verification = await runCompletionVerification(cwd, lane.baseBranch);
-  if (await yieldSelfReviewForceToFreshActivity(surfaceId, lane)) return;
-  if (!verification.ok) {
-    await parkSelfReviewStallForOrchestrator(
-      surfaceId,
-      lane,
-      `Preserved work failed ${verification.kind}; operator review is required.`,
-      preservation.captureRef,
-    );
-    return;
-  }
-
-  if (lane.packetId) {
-    try {
-      const { capturePacketCompletionContext } = await import('@/lib/orchestrator/context-relay');
-      await capturePacketCompletionContext(lane.packetId, surfaceId);
-    } catch (error) {
-      console.error(`[context-relay] Failed to capture self-review stall context for packet ${lane.packetId}:`, error);
-    }
-  }
-
-  try {
-    await fetchRuntimeAction({
-      action: 'interrupt',
-      surfaceId,
-      clientMutationId: randomUUID(),
-    });
-  } catch (error) {
-    const reason = recordSelfReviewInterruptFailure({ laneId: lane.id, surfaceId, error });
-    resetSelfReviewStallGuard(surfaceId);
-    const detail = `Self-review work was preserved, but the runtime is still active because interrupt failed: ${reason}`;
-    console.warn(`[supervisor] ${detail}`);
-    broadcast({
-      channel: 'supervisor',
-      event: 'agent-update',
-      data: { surfaceId, name: lane.label, status: 'stuck', detail, repoPath: lane.repoPath } satisfies AgentUpdateEvent,
-    });
-    queueOrchestratorEscalation(lane.repoPath, [
-      `[SUPERVISOR] Agent "${lane.label}" (${surfaceId}) could not be stopped after its work was preserved.`,
-      `Lane: ${lane.id}`,
-      `Reason: ${reason}`,
-      '',
-      'The runtime remains bound and the lane remains active. Confirm the stop before moving this work to review.',
-    ].join('\n'));
-    return;
-  }
-
-  unregisterWatchedAgent(surfaceId);
-  const { updateLane } = await import('@/lib/lane/registry');
-  const updated = updateLane(lane.id, {
-    status: 'reviewing',
-    sessionKey: null,
-    lastEventAt: new Date().toISOString(),
-    lastEventLabel: 'self_review_stall_forced',
-  }, 'system');
-  if (updated) {
-    await enqueueAutoReview(updated.id);
-    await triggerHeadlessSprintTick();
-    queueReviewContinuation(updated);
-  }
-
-  resetSelfReviewStallGuard(surfaceId);
-  broadcast({
-    channel: 'supervisor',
-    event: 'agent-update',
-    data: {
-      surfaceId,
-      name: lane.label,
-      status: 'completed',
-      detail: preservation.committed
-        ? 'Self-review stalled after verification; worktree was committed and moved to review.'
-        : 'Self-review stalled after verification; existing commit was moved to review.',
-      repoPath: lane.repoPath,
-    } satisfies AgentUpdateEvent,
+  const { forceSelfReviewToReview } = await import('@/lib/supervisor/force-self-review');
+  await forceSelfReviewToReview(surfaceId, lane, decision, {
+    park: parkSelfReviewStallForOrchestrator,
+    unregister: unregisterWatchedAgent,
+    enqueueAutoReview,
+    triggerHeadlessSprintTick,
+    queueReviewContinuation,
+    broadcastUpdate: (data) => broadcast({ channel: 'supervisor', event: 'agent-update', data }),
+    escalate: queueOrchestratorEscalation,
   });
-}
-
-async function yieldSelfReviewForceToFreshActivity(surfaceId: string, lane: Lane): Promise<boolean> {
-  if (!(await hasFreshSelfReviewTranscriptActivity(surfaceId))) return false;
-  resetSelfReviewStallGuard(surfaceId);
-  console.log(
-    `[supervisor] Self-review force deferred for lane=${lane.id} session=${surfaceId}: transcript activity resumed.`,
-  );
-  return true;
 }
 
 async function parkSelfReviewStallForOrchestrator(
@@ -875,8 +772,10 @@ async function parkSelfReviewStallForOrchestrator(
   lane: Lane,
   reason: string,
   captureRef?: string,
+  checkCurrent?: () => void,
 ): Promise<void> {
   const { appendEvent, setLaneStatus } = await import('@/lib/lane/registry');
+  checkCurrent?.();
   appendEvent(lane.id, 'update', 'system', {
     event: 'self_review_stall_escalated',
     reason,

--- a/tests/approve-and-merge-squash-real-path.test.ts
+++ b/tests/approve-and-merge-squash-real-path.test.ts
@@ -9,6 +9,16 @@ import { NextRequest } from 'next/server';
 
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 
+const lifecycle = vi.hoisted(() => ({ afterMerge: null as (() => void) | null }));
+vi.mock('@/lib/lane/commands', async (original) => {
+  const actual = await original<typeof import('@/lib/lane/commands')>();
+  return { ...actual, dispatch: async (...args: Parameters<typeof actual.dispatch>) => {
+    const result = await actual.dispatch(...args);
+    if (args[0].verb === 'merge' && result.ok) lifecycle.afterMerge?.();
+    return result;
+  } };
+});
+
 const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-governed-squash-'));
 const originalDataDir = process.env.CORTEX_IDE_DATA_DIR;
 const originalO8DataDir = process.env.O8_DATA_DIR;
@@ -38,7 +48,7 @@ const { recordOrchestratorReview } = await import('@/lib/approvals/store');
 const { AGENT_COMMIT_TRAILER } = await import('@/lib/lane/commit-attribution');
 const { createLane } = await import('@/lib/lane/registry');
 const { recordMission } = await import('@/lib/db/missions-store');
-const { writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+const { readOrchestratorControlPlaneState, writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
 const {
   createEmptyOrchestratorMissionState,
   normalizeOrchestratorMissionState,
@@ -210,6 +220,7 @@ beforeAll(async () => {
 });
 
 afterEach(() => {
+  lifecycle.afterMerge = null;
   writeOrchestratorControlPlaneState(createEmptyOrchestratorMissionState());
   __resetIdempotencyStoreForTests();
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
@@ -223,6 +234,20 @@ afterAll(() => {
 });
 
 describe('approve_and_merge governed squash through the route handler', () => {
+  it('does not attach a landed merge to a successor attempt that arrived before release persistence', async () => {
+    const fixture = await createFixture('successor-attempt');
+    lifecycle.afterMerge = () => {
+      const state = readOrchestratorControlPlaneState();
+      state.packets[0].attemptCount = (state.packets[0].attemptCount ?? 0) + 1;
+      state.packets[0].operatorStopped = true;
+      writeOrchestratorControlPlaneState(state);
+    };
+    const response = await mergeRoute.POST(mergeRequest(fixture.packetId));
+    expect(response.status).toBe(200);
+    expect(git(fixture.repo, ['rev-list', '--count', `${fixture.baseSha}..refs/heads/main`])).toBe('1');
+    expect(readOrchestratorControlPlaneState().packets[0]).toMatchObject({ operatorStopped: true, releaseState: 'pending' });
+  }, 60_000);
+
   it('lands one attributed commit with the explicit message', async () => {
     const fixture = await createFixture('explicit-message');
     const commitMessage = 'fix: land the reviewed packet as one commit';

--- a/tests/automatic-release-real-path.test.ts
+++ b/tests/automatic-release-real-path.test.ts
@@ -1,0 +1,187 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import type { OrchestratorMissionState, OrchestratorPacket } from '@/lib/orchestrator/types';
+import type { GitHubPullRequestSnapshot } from '@/lib/github-broker/store';
+
+vi.mock('@/lib/lane/terminal-lane-cleanup', () => ({ scheduleTerminalLaneCleanup: vi.fn() }));
+vi.mock('@/lib/lane/worktree-cleanup', () => ({ pruneRepoWorktrees: vi.fn(async () => []) }));
+vi.mock('@/lib/github-broker/sync', () => ({
+  ensureGitHubPullRequest: vi.fn(async () => ({ pr: null })),
+  ensureGitHubPullRequestByHead: vi.fn(async () => ({ pr: null })),
+}));
+vi.mock('@/lib/runtime/inventory', () => ({ getRuntimeInventorySnapshot: vi.fn(async () => ({ agents: [] })) }));
+vi.mock('@/lib/realtime/publisher', () => ({ publishRealtimeMutation: vi.fn(async () => {}) }));
+vi.mock('@/lib/lane/durable-review-approval', () => ({ hasDurableApprovedReview: vi.fn(async () => true) }));
+
+const dataDir = mkdtempSync(join(tmpdir(), 'o8-automatic-release-'));
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.O8_DATA_DIR = dataDir;
+const roots = [dataDir];
+const { closeDb } = await import('@/lib/db');
+const { createLane, getLane, updateLane } = await import('@/lib/lane/registry');
+const { recordLaneEvent } = await import('@/lib/lane/events');
+const { recordMission } = await import('@/lib/db/missions-store');
+const { upsertGitHubPullRequest } = await import('@/lib/github-broker/store');
+const { runWorktreeReaperTick } = await import('@/lib/lane/worktree-reaper');
+const control = await import('@/lib/orchestrator/control-plane');
+const { readMissionRegistryEntry } = await import('@/lib/orchestrator/mission-registry');
+const { createEmptyOrchestratorMissionState, packetReleaseBlockedBy } = await import('@/lib/orchestrator/store');
+const { releaseMergedPullRequestPacket } = await import('@/lib/orchestrator/automatic-release');
+const { runHeadlessSprintTick } = await import('@/lib/orchestrator/headless-loop');
+const { hasDurableApprovedReview } = await import('@/lib/lane/durable-review-approval');
+const { runAwaitingReviewAutoReleaseSweep } = await import('@/lib/supervisor/heal-bot-auto-release');
+let sequence = 0;
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+
+function commit(cwd: string, content: string): string {
+  writeFileSync(join(cwd, 'app.txt'), `${content}\n`);
+  git(cwd, 'add', 'app.txt');
+  git(cwd, 'commit', '-qm', 'fixture');
+  return git(cwd, 'rev-parse', 'HEAD');
+}
+
+function fixture(location: 'current' | 'registry' = 'current') {
+  const root = mkdtempSync(join(tmpdir(), 'o8-auto-release-git-'));
+  roots.push(root);
+  const repoPath = join(root, 'repo'), worktreePath = join(root, 'worktree');
+  const number = ++sequence, packetId = `pkt-auto-release-${number}`, branch = `inline/${packetId}`;
+  git(root, 'init', '-qb', 'main', repoPath);
+  git(repoPath, 'config', 'user.name', 'o8-test');
+  git(repoPath, 'config', 'user.email', 'test@example.test');
+  git(repoPath, 'remote', 'add', 'origin', `https://github.com/example/release-${number}.git`);
+  commit(repoPath, 'base');
+  git(repoPath, 'worktree', 'add', '-qb', branch, worktreePath);
+  const headSha = commit(worktreePath, 'merged work');
+  git(repoPath, 'merge', '--squash', branch);
+  git(repoPath, 'commit', '-qm', 'merged fixture');
+  const mergeCommit = git(repoPath, 'rev-parse', 'HEAD');
+  const lane = createLane({ repoPath, worktreePath, branch, baseBranch: 'main', runtime: 'codex', packetId });
+  updateLane(lane.id, { status: 'reviewing', prNumber: number }, 'system');
+  const packet: OrchestratorPacket = { id: packetId, referenceLabel: packetId, title: packetId, summary: packetId,
+    runtime: 'codex', workspaceTargetPath: repoPath, branchTarget: branch, dependencyLabels: [], dependencyPacketIds: [],
+    queueState: 'held', releaseState: 'pending', status: 'awaiting_review', attemptCount: 1,
+    lane: { laneId: lane.id, tileId: lane.id, tabId: lane.id, repoPath, worktreePath, runtime: 'codex' },
+  };
+  const dependent = { ...packet, id: `${packetId}-next`, referenceLabel: `${packetId}-next`, title: 'Dependent work', lane: null,
+    status: 'queued' as const, queueState: 'queued' as const, dependencyPacketIds: [packetId] };
+  const mission: OrchestratorMissionState = { ...createEmptyOrchestratorMissionState(),
+    missionId: `mission-${packetId}`, repoPath, packets: [packet, dependent] };
+  const persist = () => {
+    control.writeOrchestratorControlPlaneState(location === 'current' ? mission : createEmptyOrchestratorMissionState());
+    if (location === 'registry') recordMission({ id: mission.missionId!, repoPath, runtime: 'codex',
+      prompt: 'release fixture', summary: 'release fixture', constraints: '', packetMeta: [], totalWaves: 2, missionState: mission });
+  };
+  persist();
+  const read = () => location === 'current' ? control.readOrchestratorControlPlaneState()
+    : readMissionRegistryEntry(mission.missionId!, { includeArchived: true })!.mission;
+  const pull: GitHubPullRequestSnapshot = { pullRequestId: number, repoFullName: `example/release-${number}`,
+    number, title: 'fixture', state: 'closed', author: null, body: '', headRefName: branch, baseRefName: 'main',
+    additions: 1, deletions: 0, changedFiles: 1, reviewDecision: null, statusCheckRollup: [], url: 'https://example.test/pr',
+    createdAt: '2026-09-10T00:00:00Z', updatedAt: '2026-09-10T00:02:00Z', closedAt: '2026-09-10T00:02:00Z',
+    mergedAt: '2026-09-10T00:02:00Z', headSha, mergeCommit };
+  upsertGitHubPullRequest(pull);
+  return { repoPath, worktreePath, lane: getLane(lane.id)!, packet, mission, pull, persist, read };
+}
+
+afterEach(() => vi.restoreAllMocks());
+afterAll(() => { closeDb(); for (const root of roots.reverse()) rmSync(root, { recursive: true, force: true }); });
+
+describe('automatic PR release through the real reaper and durable missions', () => {
+  it.each(['current', 'new-steer'] as const)('pins the approved ancestry auto-release to %s work', async (mode) => {
+    const f = fixture();
+    git(f.repoPath, 'merge', '--no-ff', '-m', 'fixture merge', f.lane.branch);
+    git(f.repoPath, 'update-ref', 'refs/remotes/origin/main', 'HEAD');
+    updateLane(f.lane.id, { lastEventAt: '2026-01-01T00:00:00Z' }, 'system');
+    vi.mocked(hasDurableApprovedReview).mockImplementationOnce(async () => {
+      if (mode === 'new-steer') recordLaneEvent(f.lane.id, 'steered_packet', 'user', { message: 'new work' });
+      return true;
+    });
+    await runAwaitingReviewAutoReleaseSweep();
+    if (mode === 'new-steer') {
+      expect(f.read().packets[0].releaseState).toBe('pending');
+      expect(getLane(f.lane.id)?.status).toBe('reviewing');
+    } else {
+      expect(f.read().packets[0].releaseStatePayload).toMatchObject({
+        source: 'heal_bot_auto_release', headSha: f.pull.headSha, mergeCommit: git(f.repoPath, 'rev-parse', 'HEAD'),
+      });
+    }
+  });
+
+  it.each(['current', 'registry'] as const)('releases proved %s work and unblocks its sequential dependent', async (location) => {
+    const f = fixture(location);
+    expect(packetReleaseBlockedBy(f.mission.packets[1], f.mission.packets)?.id).toBe(f.packet.id);
+    await runWorktreeReaperTick();
+    await runHeadlessSprintTick();
+    const saved = f.read();
+    expect(saved.packets[0]).toMatchObject({ releaseState: 'released', releaseStatePayload: {
+      source: 'headless_released', evidenceKind: 'pull_request_merged', headSha: f.pull.headSha, mergeCommit: f.pull.mergeCommit,
+    } });
+    expect(packetReleaseBlockedBy(saved.packets[1], saved.packets)).toBeNull();
+    expect(saved.packets[1].blockedReason ?? '').not.toContain('explicitly released');
+    expect(getLane(f.lane.id)?.status).toBe('archived');
+  });
+
+  it.each(['current', 'registry'] as const)('preserves a newer unmerged commit in a %s mission', async (location) => {
+    const f = fixture(location);
+    const successor = commit(f.worktreePath, 'unmerged successor');
+    await runWorktreeReaperTick();
+    expect(f.read().packets[0].releaseState).toBe('pending');
+    expect(getLane(f.lane.id)?.status).toBe('reviewing');
+    expect(git(f.worktreePath, 'rev-parse', 'HEAD')).toBe(successor);
+  });
+
+  it.each(['stop', 'archive', 'running', 'missing-proof', 'dirty'] as const)('refuses automatic release for %s', async (reason) => {
+    const f = fixture();
+    if (reason === 'stop') f.packet.operatorStopped = true;
+    if (reason === 'archive') f.packet.archivedAt = new Date().toISOString();
+    if (reason === 'running') f.packet.status = 'running';
+    if (reason === 'missing-proof') upsertGitHubPullRequest({ ...f.pull, headSha: null, mergeCommit: null });
+    if (reason === 'dirty') writeFileSync(join(f.worktreePath, 'app.txt'), 'dirty successor');
+    f.persist();
+    await runWorktreeReaperTick();
+    expect(f.read().packets[0].releaseState).toBe('pending');
+    expect(getLane(f.lane.id)?.status).toBe('reviewing');
+  });
+
+  it('refuses a delayed release after a new steer enters the same lane', async () => {
+    const f = fixture();
+    const lockedWrite = vi.spyOn(control, 'withLockedState');
+    let releasing!: ReturnType<typeof releaseMergedPullRequestPacket>;
+    await control.withControlPlaneLock(async () => {
+      releasing = releaseMergedPullRequestPacket(f.lane, f.pull);
+      await vi.waitFor(() => expect(lockedWrite).toHaveBeenCalled());
+      recordLaneEvent(f.lane.id, 'steered_packet', 'user', { message: 'new work' });
+    });
+    expect(await releasing).toBe('held');
+    expect(f.read().packets[0].releaseState).toBe('pending');
+  });
+
+  it('can finish archiving after release was persisted by an interrupted reaper', async () => {
+    const f = fixture();
+    expect(await releaseMergedPullRequestPacket(f.lane, f.pull)).toBe('released');
+    expect(getLane(f.lane.id)?.status).toBe('reviewing');
+    await runWorktreeReaperTick();
+    expect(getLane(f.lane.id)?.status).toBe('archived');
+    expect(f.read().packets[0].releaseStatePayload?.headSha).toBe(f.pull.headSha);
+  });
+
+  it('does not archive when Stop wins the lock after Git proof was captured', async () => {
+    const f = fixture();
+    const archived = vi.fn();
+    let releasing!: ReturnType<typeof releaseMergedPullRequestPacket>;
+    await control.withControlPlaneLock(async () => {
+      releasing = releaseMergedPullRequestPacket(f.lane, f.pull, archived);
+      f.packet.operatorStopped = true;
+      f.persist();
+    });
+    expect(await releasing).toBe('held');
+    expect(archived).not.toHaveBeenCalled();
+    expect(f.read().packets[0].operatorStopped).toBe(true);
+  });
+});

--- a/tests/cli-stop-parsing.test.ts
+++ b/tests/cli-stop-parsing.test.ts
@@ -114,8 +114,11 @@ describe('CLI stop command parsing', () => {
 
   it('clears stale tmux Node options and anchors an inherited legacy preload', () => {
     const cwd = '/tmp/o8 repo';
+    const clearRouting = ['O8_API_PORT', 'O8_WS_PORT', 'WS_PORT', 'O8_API_TOKEN', 'O8_WORKER_TOKEN',
+      'O8_WORKER_PACKET_ID', 'O8_SPECTATOR_TOKEN', 'O8_DATA_DIR', 'CORTEX_IDE_DATA_DIR'].map((key) => `unset ${key}`);
     expect(managedRunEnvironmentLines({ PATH: '/usr/bin' }, cwd)).toEqual([
       'unset NODE_OPTIONS',
+      ...clearRouting,
       "export PATH='/usr/bin'",
     ]);
 
@@ -125,6 +128,7 @@ describe('CLI stop command parsing', () => {
     const stubUrl = pathToFileURL(`${cwd}/scripts/register-server-only-stub.mjs`).href;
     expect(lines).toEqual([
       'unset NODE_OPTIONS',
+      ...clearRouting,
       `export NODE_OPTIONS='--trace-warnings --import=${stubUrl}'`,
     ]);
   });

--- a/tests/completion-steer-race-real-path.test.ts
+++ b/tests/completion-steer-race-real-path.test.ts
@@ -322,7 +322,7 @@ describe('completion and steer overlap through production callbacks and routes',
       entered.resolve();
       return Promise.resolve({ noChangesProduced: true });
     });
-    h.capture.mockResolvedValue({ selfReview: { passed: true, decision: 'finding_ready',
+    h.capture.mockResolvedValue({ packetId: packet.id, sessionKey, selfReview: { passed: true, decision: 'finding_ready',
       outcome: 'Inspection complete', evidence: ['Observed result'], residual: 'No changes required' } });
     const completion = ingestAgentCompletionSignal(sessionKey);
     await entered.promise;
@@ -379,8 +379,10 @@ describe('completion and steer overlap through production callbacks and routes',
     const bridge = source.slice(bridgeStart, source.indexOf('\nasync function ', bridgeStart + 1));
     expect(bridge).toContain('triggerHeadlessSprintTick()');
     expect(bridge).not.toContain('releasePacketIds');
-    const stallStart = source.indexOf("lastEventLabel: 'self_review_stall_forced'");
-    const stall = source.slice(stallStart, source.indexOf('resetSelfReviewStallGuard(surfaceId)', stallStart));
-    expect(stall).toContain('await triggerHeadlessSprintTick();');
+    const stallStart = source.indexOf('async function forceCodexSelfReviewToReview(');
+    const stall = source.slice(stallStart, source.indexOf('\nasync function ', stallStart + 1));
+    expect(stall).toContain("import('@/lib/supervisor/force-self-review')");
+    expect(stall).toContain('await forceSelfReviewToReview(surfaceId, lane, decision, {');
+    expect(stall).toContain('triggerHeadlessSprintTick,');
   });
 });

--- a/tests/execution-carrier-real-path.test.ts
+++ b/tests/execution-carrier-real-path.test.ts
@@ -3,7 +3,39 @@ import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterAll, describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+const ensureDispatchBackendReadyMock = vi.hoisted(() => vi.fn(async () => ({
+  ready: true,
+  reason: 'test',
+  waitedMs: 0,
+  attempts: 1,
+  lastCheck: {
+    ready: true,
+    reason: 'test',
+    apiBase: 'http://127.0.0.1:1',
+    portSource: 'default' as const,
+    apiPortFilePresent: false,
+  },
+})));
+const measureHostVolumeMock = vi.hoisted(() => vi.fn(async () => ({
+  accountingStatus: 'observed' as const,
+  probePath: '/',
+  availableBytes: 90_000_000_000,
+  freeBytes: 90_000_000_000,
+  totalBytes: 100_000_000_000,
+  error: null,
+})));
+
+vi.mock('@/lib/runtimes/shared/dispatch-readiness', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/runtimes/shared/dispatch-readiness')>(),
+  ensureDispatchBackendReady: ensureDispatchBackendReadyMock,
+}));
+
+vi.mock('@/lib/worktree/storage-telemetry', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/worktree/storage-telemetry')>(),
+  measureHostVolume: measureHostVolumeMock,
+}));
 
 const testRoot = mkdtempSync(path.join(os.tmpdir(), 'o8-execution-carrier-'));
 const dataDir = path.join(testRoot, 'data');
@@ -13,10 +45,17 @@ const carrierPidFile = path.join(testRoot, 'carrier.pid');
 const childPidFile = path.join(testRoot, 'child.pid');
 const carrierArgsFile = path.join(testRoot, 'carrier.args');
 const shellInjectionSentinel = path.join(testRoot, 'argv-was-interpreted');
+const testStorageReserveRatio = 0.000001;
+const testStorageReserveFloorGb = 0.001;
 const priorEnv = new Map<string, string | undefined>();
 const controlledEnv = [
   'CORTEX_IDE_DATA_DIR', 'O8_DATA_DIR', 'CORTEX_IDE_OWNED_CODEX_ROOT',
   'O8_CODEX_BIN', 'O8_ORI_BIN', 'O8_CRASH_SURVIVABLE_WORKERS',
+  'O8_SUBSCRIPTION_PROFILE', 'O8_DEFAULT_DISPATCH_RUNTIME',
+  'O8_WORKER_SANDBOX', 'O8_WORKTREE_ROOT',
+  'O8_APFS_COW_WORKSPACES', 'O8_APFS_DEPENDENCY_IMAGES',
+  'O8_PACKAGED_APP', 'O8_DISPATCH_MODEL',
+  'O8_STORAGE_RESERVE_RATIO', 'O8_STORAGE_RESERVE_FLOOR_GB',
   'O8_SKIP_PRELAUNCH_TYPECHECK', 'O8_TEST_CARRIER_PID_FILE',
   'O8_TEST_CHILD_PID_FILE', 'O8_TEST_CARRIER_ARGS_FILE',
 ] as const;
@@ -119,6 +158,16 @@ wait "$child"
     process.env.O8_CODEX_BIN = fakeCodex;
     process.env.O8_ORI_BIN = fakeOri;
     process.env.O8_CRASH_SURVIVABLE_WORKERS = '1';
+    process.env.O8_SUBSCRIPTION_PROFILE = 'both';
+    process.env.O8_DEFAULT_DISPATCH_RUNTIME = 'codex';
+    process.env.O8_WORKER_SANDBOX = '0';
+    process.env.O8_WORKTREE_ROOT = path.join(testRoot, 'worktrees');
+    process.env.O8_APFS_COW_WORKSPACES = '0';
+    process.env.O8_APFS_DEPENDENCY_IMAGES = '0';
+    process.env.O8_PACKAGED_APP = '0';
+    delete process.env.O8_DISPATCH_MODEL;
+    process.env.O8_STORAGE_RESERVE_RATIO = String(testStorageReserveRatio);
+    process.env.O8_STORAGE_RESERVE_FLOOR_GB = String(testStorageReserveFloorGb);
     process.env.O8_SKIP_PRELAUNCH_TYPECHECK = '1';
     process.env.O8_TEST_CARRIER_PID_FILE = carrierPidFile;
     process.env.O8_TEST_CHILD_PID_FILE = childPidFile;
@@ -128,7 +177,15 @@ wait "$child"
     const { addRepo } = await import('@/lib/repos/registry');
     await addRepo(repoPath);
     const { updateOperatorDefaults } = await import('@/lib/operator/defaults');
-    await updateOperatorDefaults({ defaultDispatchRuntime: 'codex', workerExecutionCarrier: 'ori' });
+    const defaults = await updateOperatorDefaults({ defaultDispatchRuntime: 'codex', workerExecutionCarrier: 'ori' });
+    expect(defaults.values).toMatchObject({
+      storageReserveRatio: testStorageReserveRatio,
+      storageReserveFloorGb: testStorageReserveFloorGb,
+    });
+    expect(defaults.sources).toMatchObject({
+      storageReserveRatio: 'env',
+      storageReserveFloorGb: 'env',
+    });
     const { createMission, dispatchMission } = await import('@/lib/orchestrator/operator-mission-service');
     const mission = await createMission({
       issues: [{ number: 2037, title: 'Prove execution carriers', body: '', url: '' }],
@@ -142,10 +199,19 @@ wait "$child"
     expect(packet.executionCarrier).toBe('ori');
     expect((await dispatchMission({ missionId: mission.missionId })).dispatched).toBe(1);
 
+    const dispatchedPacket = readOrchestratorControlPlaneState().packets
+      .find((candidate) => candidate.id === packetId)!;
+    expect(dispatchedPacket.storageAdmission).toMatchObject({
+      ownerId: packetId,
+      state: 'committed',
+    });
+
     const { findLaneByPacket, getLaneEvents } = await import('@/lib/lane/registry');
     const lane = findLaneByPacket(packet.id)!;
     expect(lane.worktreePath).toBeTruthy();
     expect(lane.worktreePath).not.toBe(repoPath);
+    expect(measureHostVolumeMock).toHaveBeenCalled();
+    expect(ensureDispatchBackendReadyMock).toHaveBeenCalledWith('codex', 'launch');
     const runtime = (await import('@/lib/runtimes')).getRuntime('codex')!;
     await waitUntil(async () => {
       const surface = (await runtime.discoverSessions()).find((candidate) => candidate.sessionKey === lane.sessionKey);
@@ -170,6 +236,7 @@ wait "$child"
     rmSync(childPidFile, { force: true });
     rmSync(carrierArgsFile, { force: true });
     expect((await runtime.resume(lane.sessionKey!, maliciousLookingPrompt)).ok).toBe(true);
+    expect(ensureDispatchBackendReadyMock).toHaveBeenCalledWith('codex', 'resume');
     await waitUntil(() => existsSync(carrierPidFile) && existsSync(childPidFile), 'carried resume processes did not start');
     const carrierPid = Number(readFileSync(carrierPidFile, 'utf8'));
     const childPid = Number(readFileSync(childPidFile, 'utf8'));

--- a/tests/execution-carrier-real-path.test.ts
+++ b/tests/execution-carrier-real-path.test.ts
@@ -85,9 +85,11 @@ async function waitUntil(predicate: () => boolean | Promise<boolean>, message: s
 }
 
 function createRemoteRepo() {
-  const origin = path.join(testRoot, 'origin.git');
-  const seed = path.join(testRoot, 'seed');
-  const repo = path.join(testRoot, 'repo');
+  // Owned-runtime launches are restricted to paths under the home or data
+  // directory, so the fixture repo and worktrees live under the fixture data dir.
+  const origin = path.join(dataDir, 'origin.git');
+  const seed = path.join(dataDir, 'seed');
+  const repo = path.join(dataDir, 'repo');
   execFileSync('git', ['init', '--bare', origin], { stdio: 'pipe' });
   execFileSync('git', ['clone', origin, seed], { stdio: 'pipe' });
   git(seed, 'checkout', '-b', 'main');
@@ -127,6 +129,7 @@ describe.skipIf(process.platform === 'win32')('execution carrier isolated worktr
     const fakeCodex = path.join(runtimeDir, 'codex');
     const fakeOri = path.join(carrierDir, 'ori');
     writeExecutable(fakeCodex, `#!/bin/sh
+case "$1" in --version|-V) printf '%s\n' '0.0.0-test'; exit 0;; esac
 printf '%s\n' '{"type":"thread.started","thread_id":"carrier-thread"}'
 printf '%s\n' '{"type":"item.completed","item":{"id":"proof","type":"agent_message","text":"carrier transcript proof"}}'
 printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":5}}'
@@ -140,6 +143,7 @@ case " $* " in
 esac
 `);
     writeExecutable(fakeOri, `#!/bin/sh
+case "$1" in --version|-V) printf '%s\n' '0.0.0-test'; exit 0;; esac
 if [ "$1" = "auth" ]; then exit 0; fi
 printf '%s\n' "$$" > "$O8_TEST_CARRIER_PID_FILE"
 printf '%s\n' "$@" > "$O8_TEST_CARRIER_ARGS_FILE"
@@ -161,7 +165,7 @@ wait "$child"
     process.env.O8_SUBSCRIPTION_PROFILE = 'both';
     process.env.O8_DEFAULT_DISPATCH_RUNTIME = 'codex';
     process.env.O8_WORKER_SANDBOX = '0';
-    process.env.O8_WORKTREE_ROOT = path.join(testRoot, 'worktrees');
+    process.env.O8_WORKTREE_ROOT = path.join(dataDir, 'worktrees');
     process.env.O8_APFS_COW_WORKSPACES = '0';
     process.env.O8_APFS_DEPENDENCY_IMAGES = '0';
     delete process.env.O8_PACKAGED_APP;
@@ -219,7 +223,7 @@ wait "$child"
     }, 'initial carried Codex run did not reach ready-for-resume');
 
     const surface = (await runtime.discoverSessions()).find((candidate) => candidate.sessionKey === lane.sessionKey);
-    expect(surface).toMatchObject({ runtimeId: 'codex', ownership: 'o8-owned' });
+    expect(surface).toMatchObject({ runtimeId: 'codex', ownership: 'owned' });
     expect(await runtime.readTranscript(lane.sessionKey!)).toEqual(expect.arrayContaining([
       expect.objectContaining({ role: 'assistant', text: 'carrier transcript proof' }),
     ]));

--- a/tests/execution-carrier-real-path.test.ts
+++ b/tests/execution-carrier-real-path.test.ts
@@ -1,0 +1,188 @@
+import { execFileSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const testRoot = mkdtempSync(path.join(os.tmpdir(), 'o8-execution-carrier-'));
+const dataDir = path.join(testRoot, 'data');
+const runtimeDir = path.join(testRoot, 'runtime-bin');
+const carrierDir = path.join(testRoot, 'carrier-bin');
+const carrierPidFile = path.join(testRoot, 'carrier.pid');
+const childPidFile = path.join(testRoot, 'child.pid');
+const carrierArgsFile = path.join(testRoot, 'carrier.args');
+const shellInjectionSentinel = path.join(testRoot, 'argv-was-interpreted');
+const priorEnv = new Map<string, string | undefined>();
+const controlledEnv = [
+  'CORTEX_IDE_DATA_DIR', 'O8_DATA_DIR', 'CORTEX_IDE_OWNED_CODEX_ROOT',
+  'O8_CODEX_BIN', 'O8_ORI_BIN', 'O8_CRASH_SURVIVABLE_WORKERS',
+  'O8_SKIP_PRELAUNCH_TYPECHECK', 'O8_TEST_CARRIER_PID_FILE',
+  'O8_TEST_CHILD_PID_FILE', 'O8_TEST_CARRIER_ARGS_FILE',
+] as const;
+
+for (const key of controlledEnv) priorEnv.set(key, process.env[key]);
+
+function git(cwd: string, ...args: string[]) {
+  return execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+function writeExecutable(file: string, source: string) {
+  writeFileSync(file, source, 'utf8');
+  chmodSync(file, 0o755);
+}
+
+function isPidAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+async function waitUntil(predicate: () => boolean | Promise<boolean>, message: string, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(message);
+}
+
+function createRemoteRepo() {
+  const origin = path.join(testRoot, 'origin.git');
+  const seed = path.join(testRoot, 'seed');
+  const repo = path.join(testRoot, 'repo');
+  execFileSync('git', ['init', '--bare', origin], { stdio: 'pipe' });
+  execFileSync('git', ['clone', origin, seed], { stdio: 'pipe' });
+  git(seed, 'checkout', '-b', 'main');
+  writeFileSync(path.join(seed, 'README.md'), 'execution carrier real-path fixture\n');
+  git(seed, 'add', 'README.md');
+  git(seed, '-c', 'user.email=test@o8.test', '-c', 'user.name=o8-test', 'commit', '-m', 'init');
+  git(seed, 'push', '-u', 'origin', 'main');
+  git(origin, 'symbolic-ref', 'HEAD', 'refs/heads/main');
+  execFileSync('git', ['clone', origin, repo], { stdio: 'pipe' });
+  return repo;
+}
+
+afterAll(async () => {
+  for (const pidFile of [carrierPidFile, childPidFile]) {
+    if (!existsSync(pidFile)) continue;
+    const pid = Number(readFileSync(pidFile, 'utf8'));
+    if (Number.isInteger(pid) && isPidAlive(pid)) {
+      try { process.kill(pid, 'SIGKILL'); } catch {}
+    }
+  }
+  if (process.platform !== 'win32') {
+    await import('@/lib/db').then(({ closeDb }) => closeDb()).catch(() => {});
+  }
+  for (const [key, value] of priorEnv) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+describe.skipIf(process.platform === 'win32')('execution carrier isolated worktree real path', () => {
+  it('routes launch and resume through Ori while Codex retains identity, evidence, and cleanup', async () => {
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(runtimeDir, { recursive: true });
+    mkdirSync(carrierDir, { recursive: true });
+    const fakeCodex = path.join(runtimeDir, 'codex');
+    const fakeOri = path.join(carrierDir, 'ori');
+    writeExecutable(fakeCodex, `#!/bin/sh
+printf '%s\n' '{"type":"thread.started","thread_id":"carrier-thread"}'
+printf '%s\n' '{"type":"item.completed","item":{"id":"proof","type":"agent_message","text":"carrier transcript proof"}}'
+printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":5}}'
+printf '%s\n' 'carrier review proof' > carrier-proof.txt
+case " $* " in
+  *" resume "*)
+    printf '%s\n' "$$" > "$O8_TEST_CHILD_PID_FILE"
+    trap 'exit 0' INT TERM
+    while :; do sleep 1; done
+    ;;
+esac
+`);
+    writeExecutable(fakeOri, `#!/bin/sh
+if [ "$1" = "auth" ]; then exit 0; fi
+printf '%s\n' "$$" > "$O8_TEST_CARRIER_PID_FILE"
+printf '%s\n' "$@" > "$O8_TEST_CARRIER_ARGS_FILE"
+if [ "$1" != "codex" ]; then exit 64; fi
+shift
+codex "$@" &
+child=$!
+printf '%s\n' "$child" > "$O8_TEST_CHILD_PID_FILE"
+trap 'kill -TERM "$child" 2>/dev/null; wait "$child"; exit 0' INT TERM
+wait "$child"
+`);
+
+    process.env.CORTEX_IDE_DATA_DIR = dataDir;
+    process.env.O8_DATA_DIR = dataDir;
+    process.env.CORTEX_IDE_OWNED_CODEX_ROOT = path.join(testRoot, 'owned-codex');
+    process.env.O8_CODEX_BIN = fakeCodex;
+    process.env.O8_ORI_BIN = fakeOri;
+    process.env.O8_CRASH_SURVIVABLE_WORKERS = '1';
+    process.env.O8_SKIP_PRELAUNCH_TYPECHECK = '1';
+    process.env.O8_TEST_CARRIER_PID_FILE = carrierPidFile;
+    process.env.O8_TEST_CHILD_PID_FILE = childPidFile;
+    process.env.O8_TEST_CARRIER_ARGS_FILE = carrierArgsFile;
+
+    const repoPath = createRemoteRepo();
+    const { addRepo } = await import('@/lib/repos/registry');
+    await addRepo(repoPath);
+    const { updateOperatorDefaults } = await import('@/lib/operator/defaults');
+    await updateOperatorDefaults({ defaultDispatchRuntime: 'codex', workerExecutionCarrier: 'ori' });
+    const { createMission, dispatchMission } = await import('@/lib/orchestrator/operator-mission-service');
+    const mission = await createMission({
+      issues: [{ number: 2037, title: 'Prove execution carriers', body: '', url: '' }],
+      repoPath,
+      runtime: 'codex',
+      constraints: '',
+    });
+    const packetId = mission.packets[0]!.id;
+    const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+    const packet = readOrchestratorControlPlaneState().packets.find((candidate) => candidate.id === packetId)!;
+    expect(packet.executionCarrier).toBe('ori');
+    expect((await dispatchMission({ missionId: mission.missionId })).dispatched).toBe(1);
+
+    const { findLaneByPacket, getLaneEvents } = await import('@/lib/lane/registry');
+    const lane = findLaneByPacket(packet.id)!;
+    expect(lane.worktreePath).toBeTruthy();
+    expect(lane.worktreePath).not.toBe(repoPath);
+    const runtime = (await import('@/lib/runtimes')).getRuntime('codex')!;
+    await waitUntil(async () => {
+      const surface = (await runtime.discoverSessions()).find((candidate) => candidate.sessionKey === lane.sessionKey);
+      return surface?.lifecycle?.availability === 'ready-for-resume';
+    }, 'initial carried Codex run did not reach ready-for-resume');
+
+    const surface = (await runtime.discoverSessions()).find((candidate) => candidate.sessionKey === lane.sessionKey);
+    expect(surface).toMatchObject({ runtimeId: 'codex', ownership: 'o8-owned' });
+    expect(await runtime.readTranscript(lane.sessionKey!)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ role: 'assistant', text: 'carrier transcript proof' }),
+    ]));
+    expect(await runtime.getTelemetry?.(lane.sessionKey!)).toMatchObject({ totalTokens: 15, inputTokens: 10, outputTokens: 5 });
+    expect(await runtime.getChangedFiles(lane.sessionKey!)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: 'carrier-proof.txt' }),
+    ]));
+    expect(getLaneEvents(lane.id, 200)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ verb: 'execution_carrier_preflight', payload: expect.objectContaining({ runtime: 'codex', executionCarrier: 'ori' }) }),
+    ]));
+
+    const maliciousLookingPrompt = `resume; touch ${shellInjectionSentinel}`;
+    rmSync(carrierPidFile, { force: true });
+    rmSync(childPidFile, { force: true });
+    rmSync(carrierArgsFile, { force: true });
+    expect((await runtime.resume(lane.sessionKey!, maliciousLookingPrompt)).ok).toBe(true);
+    await waitUntil(() => existsSync(carrierPidFile) && existsSync(childPidFile), 'carried resume processes did not start');
+    const carrierPid = Number(readFileSync(carrierPidFile, 'utf8'));
+    const childPid = Number(readFileSync(childPidFile, 'utf8'));
+    expect(isPidAlive(carrierPid)).toBe(true);
+    expect(isPidAlive(childPid)).toBe(true);
+    expect(readFileSync(carrierArgsFile, 'utf8')).toContain('resume');
+    expect(existsSync(shellInjectionSentinel)).toBe(false);
+
+    const worktreePath = lane.worktreePath!;
+    const { stopPacket } = await import('@/lib/orchestrator/stop-packet');
+    const stopped = await stopPacket(packet.id);
+    expect(stopped).toMatchObject({ ok: true, killConfirmed: true, interruptedSessions: 1 });
+    await waitUntil(() => !isPidAlive(carrierPid) && !isPidAlive(childPid), 'carrier wrapper or runtime child survived stop');
+    await waitUntil(() => !existsSync(worktreePath), 'isolated worktree was not reclaimed after stop');
+  }, 45_000);
+});

--- a/tests/execution-carrier-real-path.test.ts
+++ b/tests/execution-carrier-real-path.test.ts
@@ -164,7 +164,7 @@ wait "$child"
     process.env.O8_WORKTREE_ROOT = path.join(testRoot, 'worktrees');
     process.env.O8_APFS_COW_WORKSPACES = '0';
     process.env.O8_APFS_DEPENDENCY_IMAGES = '0';
-    process.env.O8_PACKAGED_APP = '0';
+    delete process.env.O8_PACKAGED_APP;
     delete process.env.O8_DISPATCH_MODEL;
     process.env.O8_STORAGE_RESERVE_RATIO = String(testStorageReserveRatio);
     process.env.O8_STORAGE_RESERVE_FLOOR_GB = String(testStorageReserveFloorGb);

--- a/tests/execution-carrier-real-path.test.ts
+++ b/tests/execution-carrier-real-path.test.ts
@@ -1,0 +1,272 @@
+import { execFileSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+const ensureDispatchBackendReadyMock = vi.hoisted(() => vi.fn(async () => ({
+  ready: true,
+  reason: 'test',
+  waitedMs: 0,
+  attempts: 1,
+  lastCheck: {
+    ready: true,
+    reason: 'test',
+    apiBase: 'http://127.0.0.1:1',
+    portSource: 'default' as const,
+    apiPortFilePresent: false,
+  },
+})));
+const measureHostVolumeMock = vi.hoisted(() => vi.fn(async () => ({
+  accountingStatus: 'observed' as const,
+  probePath: '/',
+  availableBytes: 90_000_000_000,
+  freeBytes: 90_000_000_000,
+  totalBytes: 100_000_000_000,
+  error: null,
+})));
+
+vi.mock('@/lib/runtimes/shared/dispatch-readiness', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/runtimes/shared/dispatch-readiness')>(),
+  ensureDispatchBackendReady: ensureDispatchBackendReadyMock,
+}));
+
+vi.mock('@/lib/worktree/storage-telemetry', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/worktree/storage-telemetry')>(),
+  measureHostVolume: measureHostVolumeMock,
+}));
+
+const testRoot = mkdtempSync(path.join(os.tmpdir(), 'o8-execution-carrier-'));
+const dataDir = path.join(testRoot, 'data');
+const runtimeDir = path.join(testRoot, 'runtime-bin');
+const carrierDir = path.join(testRoot, 'carrier-bin');
+const carrierPidFile = path.join(testRoot, 'carrier.pid');
+const childPidFile = path.join(testRoot, 'child.pid');
+const carrierArgsFile = path.join(testRoot, 'carrier.args');
+const shellInjectionSentinel = path.join(testRoot, 'argv-was-interpreted');
+const testStorageReserveRatio = 0.000001;
+const testStorageReserveFloorGb = 0.001;
+const priorEnv = new Map<string, string | undefined>();
+const controlledEnv = [
+  'CORTEX_IDE_DATA_DIR', 'O8_DATA_DIR', 'CORTEX_IDE_OWNED_CODEX_ROOT',
+  'O8_CODEX_BIN', 'O8_ORI_BIN', 'O8_CRASH_SURVIVABLE_WORKERS',
+  'O8_SUBSCRIPTION_PROFILE', 'O8_DEFAULT_DISPATCH_RUNTIME',
+  'O8_WORKER_SANDBOX', 'O8_WORKTREE_ROOT',
+  'O8_APFS_COW_WORKSPACES', 'O8_APFS_DEPENDENCY_IMAGES',
+  'O8_PACKAGED_APP', 'O8_DISPATCH_MODEL',
+  'O8_STORAGE_RESERVE_RATIO', 'O8_STORAGE_RESERVE_FLOOR_GB',
+  'O8_SKIP_PRELAUNCH_TYPECHECK', 'O8_TEST_CARRIER_PID_FILE',
+  'O8_TEST_CHILD_PID_FILE', 'O8_TEST_CARRIER_ARGS_FILE',
+] as const;
+
+for (const key of controlledEnv) priorEnv.set(key, process.env[key]);
+
+function git(cwd: string, ...args: string[]) {
+  return execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+function writeExecutable(file: string, source: string) {
+  writeFileSync(file, source, 'utf8');
+  chmodSync(file, 0o755);
+}
+
+function isPidAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+async function waitUntil(predicate: () => boolean | Promise<boolean>, message: string, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(message);
+}
+
+function createRemoteRepo() {
+  // Owned-runtime launches are restricted to paths under the home or data
+  // directory, so the fixture repo and worktrees live under the fixture data dir.
+  const origin = path.join(dataDir, 'origin.git');
+  const seed = path.join(dataDir, 'seed');
+  const repo = path.join(dataDir, 'repo');
+  execFileSync('git', ['init', '--bare', origin], { stdio: 'pipe' });
+  execFileSync('git', ['clone', origin, seed], { stdio: 'pipe' });
+  git(seed, 'checkout', '-b', 'main');
+  writeFileSync(path.join(seed, 'README.md'), 'execution carrier real-path fixture\n');
+  git(seed, 'add', 'README.md');
+  git(seed, '-c', 'user.email=test@o8.test', '-c', 'user.name=o8-test', 'commit', '-m', 'init');
+  git(seed, 'push', '-u', 'origin', 'main');
+  git(origin, 'symbolic-ref', 'HEAD', 'refs/heads/main');
+  execFileSync('git', ['clone', origin, repo], { stdio: 'pipe' });
+  return repo;
+}
+
+afterAll(async () => {
+  for (const pidFile of [carrierPidFile, childPidFile]) {
+    if (!existsSync(pidFile)) continue;
+    const pid = Number(readFileSync(pidFile, 'utf8'));
+    if (Number.isInteger(pid) && isPidAlive(pid)) {
+      try { process.kill(pid, 'SIGKILL'); } catch {}
+    }
+  }
+  if (process.platform !== 'win32') {
+    await import('@/lib/db').then(({ closeDb }) => closeDb()).catch(() => {});
+  }
+  for (const [key, value] of priorEnv) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+describe.skipIf(process.platform === 'win32')('execution carrier isolated worktree real path', () => {
+  it('routes launch and resume through Ori while Codex retains identity, evidence, and cleanup', async () => {
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(runtimeDir, { recursive: true });
+    mkdirSync(carrierDir, { recursive: true });
+    const fakeCodex = path.join(runtimeDir, 'codex');
+    const fakeOri = path.join(carrierDir, 'ori');
+    // Use inspectable processes: the system shell can hide its environment
+    // from the macOS process probe, which must hold Stop rather than guess.
+    writeExecutable(fakeCodex, `#!${process.execPath}
+const { writeFileSync } = require('node:fs');
+const args = process.argv.slice(2);
+if (['--version', '-V'].includes(args[0])) { console.log('0.130.0-test'); process.exit(0); }
+if (args[0] === 'app-server') process.exit(0);
+console.log(JSON.stringify({ type: 'thread.started', thread_id: 'carrier-thread' }));
+console.log(JSON.stringify({ type: 'item.completed', item: { id: 'proof', type: 'agent_message', text: 'carrier transcript proof' } }));
+writeFileSync('carrier-proof.txt', 'carrier review proof');
+if (args.includes('resume')) {
+  process.on('SIGINT', () => process.exit(0));
+  process.on('SIGTERM', () => process.exit(0));
+  setInterval(() => {}, 1000);
+} else {
+  console.log(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 10, output_tokens: 5 } }));
+}
+`);
+    writeExecutable(fakeOri, `#!${process.execPath}
+const { spawn } = require('node:child_process');
+const { writeFileSync } = require('node:fs');
+const args = process.argv.slice(2);
+if (['--version', '-V'].includes(args[0])) { console.log('0.0.0-test'); process.exit(0); }
+if (args[0] === 'auth') process.exit(0);
+if (args.shift() !== 'codex') process.exit(64);
+writeFileSync(process.env.O8_TEST_CARRIER_ARGS_FILE, ['codex', ...args].join('\\n'));
+const child = spawn('codex', args, { stdio: 'inherit' });
+child.on('error', () => process.exit(1));
+child.on('exit', (code) => process.exit(code ?? 0));
+process.on('SIGINT', () => child.kill('SIGTERM'));
+process.on('SIGTERM', () => child.kill('SIGTERM'));
+writeFileSync(process.env.O8_TEST_CHILD_PID_FILE, String(child.pid));
+writeFileSync(process.env.O8_TEST_CARRIER_PID_FILE, String(process.pid));
+`);
+
+    process.env.CORTEX_IDE_DATA_DIR = dataDir;
+    process.env.O8_DATA_DIR = dataDir;
+    process.env.CORTEX_IDE_OWNED_CODEX_ROOT = path.join(testRoot, 'owned-codex');
+    process.env.O8_CODEX_BIN = fakeCodex;
+    process.env.O8_ORI_BIN = fakeOri;
+    process.env.O8_CRASH_SURVIVABLE_WORKERS = '1';
+    process.env.O8_SUBSCRIPTION_PROFILE = 'both';
+    process.env.O8_DEFAULT_DISPATCH_RUNTIME = 'codex';
+    process.env.O8_WORKER_SANDBOX = '0';
+    process.env.O8_WORKTREE_ROOT = path.join(dataDir, 'worktrees');
+    process.env.O8_APFS_COW_WORKSPACES = '0';
+    process.env.O8_APFS_DEPENDENCY_IMAGES = '0';
+    delete process.env.O8_PACKAGED_APP;
+    delete process.env.O8_DISPATCH_MODEL;
+    process.env.O8_STORAGE_RESERVE_RATIO = String(testStorageReserveRatio);
+    process.env.O8_STORAGE_RESERVE_FLOOR_GB = String(testStorageReserveFloorGb);
+    process.env.O8_SKIP_PRELAUNCH_TYPECHECK = '1';
+    process.env.O8_TEST_CARRIER_PID_FILE = carrierPidFile;
+    process.env.O8_TEST_CHILD_PID_FILE = childPidFile;
+    process.env.O8_TEST_CARRIER_ARGS_FILE = carrierArgsFile;
+
+    const repoPath = createRemoteRepo();
+    const { addRepo } = await import('@/lib/repos/registry');
+    await addRepo(repoPath);
+    const { updateOperatorDefaults } = await import('@/lib/operator/defaults');
+    const defaults = await updateOperatorDefaults({ defaultDispatchRuntime: 'codex', workerExecutionCarrier: 'ori' });
+    expect(defaults.values).toMatchObject({
+      storageReserveRatio: testStorageReserveRatio,
+      storageReserveFloorGb: testStorageReserveFloorGb,
+    });
+    expect(defaults.sources).toMatchObject({
+      storageReserveRatio: 'env',
+      storageReserveFloorGb: 'env',
+    });
+    const { createMission, dispatchMission } = await import('@/lib/orchestrator/operator-mission-service');
+    const mission = await createMission({
+      issues: [{ number: 2037, title: 'Prove execution carriers', body: '', url: '' }],
+      repoPath,
+      runtime: 'codex',
+      constraints: '',
+    });
+    const packetId = mission.packets[0]!.id;
+    const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+    const packet = readOrchestratorControlPlaneState().packets.find((candidate) => candidate.id === packetId)!;
+    expect(packet.executionCarrier).toBe('ori');
+    expect((await dispatchMission({ missionId: mission.missionId })).dispatched).toBe(1);
+
+    const dispatchedPacket = readOrchestratorControlPlaneState().packets
+      .find((candidate) => candidate.id === packetId)!;
+    expect(dispatchedPacket.storageAdmission).toMatchObject({
+      ownerId: packetId,
+      state: 'committed',
+    });
+
+    const { findLaneByPacket, getLaneEvents } = await import('@/lib/lane/registry');
+    const lane = findLaneByPacket(packet.id)!;
+    expect(lane.worktreePath).toBeTruthy();
+    expect(lane.worktreePath).not.toBe(repoPath);
+    expect(measureHostVolumeMock).toHaveBeenCalled();
+    expect(ensureDispatchBackendReadyMock).toHaveBeenCalledWith('codex', 'launch');
+    const runtime = (await import('@/lib/runtimes')).getRuntime('codex')!;
+    await waitUntil(async () => {
+      const surface = (await runtime.discoverSessions()).find((candidate) => candidate.sessionKey === lane.sessionKey);
+      return surface?.lifecycle?.availability === 'ready-for-resume';
+    }, 'initial carried Codex run did not reach ready-for-resume');
+
+    const surface = (await runtime.discoverSessions()).find((candidate) => candidate.sessionKey === lane.sessionKey);
+    expect(surface).toMatchObject({ runtimeId: 'codex', ownership: 'owned' });
+    expect(await runtime.readTranscript(lane.sessionKey!)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ role: 'assistant', text: 'carrier transcript proof' }),
+    ]));
+    expect(await runtime.getTelemetry?.(lane.sessionKey!)).toMatchObject({ totalTokens: 15, inputTokens: 10, outputTokens: 5 });
+    expect(await runtime.getChangedFiles(lane.sessionKey!)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: 'carrier-proof.txt' }),
+    ]));
+    expect(getLaneEvents(lane.id, 200)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ verb: 'execution_carrier_preflight', payload: expect.objectContaining({ runtime: 'codex', executionCarrier: 'ori' }) }),
+    ]));
+
+    const maliciousLookingPrompt = `resume; touch ${shellInjectionSentinel}`;
+    rmSync(carrierPidFile, { force: true });
+    rmSync(childPidFile, { force: true });
+    rmSync(carrierArgsFile, { force: true });
+    expect((await runtime.resume(lane.sessionKey!, maliciousLookingPrompt)).ok).toBe(true);
+    expect(ensureDispatchBackendReadyMock).toHaveBeenCalledWith('codex', 'resume');
+    await waitUntil(() => existsSync(carrierPidFile) && existsSync(childPidFile), 'carried resume processes did not start');
+    const carrierPid = Number(readFileSync(carrierPidFile, 'utf8'));
+    const childPid = Number(readFileSync(childPidFile, 'utf8'));
+    expect(isPidAlive(carrierPid)).toBe(true);
+    expect(isPidAlive(childPid)).toBe(true);
+    expect(readFileSync(carrierArgsFile, 'utf8')).toContain('resume');
+    expect(existsSync(shellInjectionSentinel)).toBe(false);
+
+    const worktreePath = lane.worktreePath!;
+    const { stopPacket } = await import('@/lib/orchestrator/stop-packet');
+    const { lookupOwnedActiveRunFresh } = await import('@/lib/runtimes/shared/owned-session-index');
+    const { probeOwnedRunProcessClaim, resolveSpawnedProcessGroupId } = await import('@/lib/runtimes/shared/owned-session/run-process-proof');
+    const activeRun = await lookupOwnedActiveRunFresh(lane.sessionKey!);
+    expect(activeRun).toMatchObject({ pid: carrierPid, processGroupId: carrierPid, processMarker: expect.any(String) });
+    expect(await probeOwnedRunProcessClaim({ pid: carrierPid, marker: activeRun!.processMarker!, rootPid: carrierPid })).toEqual({ state: 'match' });
+    expect(await resolveSpawnedProcessGroupId(carrierPid)).toBe(carrierPid);
+    const stopped = await stopPacket(packet.id);
+    expect(stopped).toMatchObject({ ok: true, killConfirmed: true, interruptedSessions: 1 });
+    await waitUntil(() => !isPidAlive(carrierPid) && !isPidAlive(childPid), 'carrier wrapper or runtime child survived stop');
+    await waitUntil(() => !existsSync(worktreePath), 'isolated worktree was not reclaimed after stop');
+  }, 45_000);
+});

--- a/tests/fixtures/explainer-crash-host.ts
+++ b/tests/fixtures/explainer-crash-host.ts
@@ -1,0 +1,23 @@
+// A real queue owner which can be killed without killing its detached provider.
+import { spawn } from 'node:child_process';
+import { getSqlite } from '../../src/lib/db';
+import { drainPacketExplainerQueue } from '../../src/lib/lane/packet-explainer-queue';
+import { createOrchestratorTurnRecord } from '../../src/lib/lane/orchestrator-crash-survival';
+import { sessionNameForRepo } from '../../src/lib/lane/orchestrator-session-core';
+
+void drainPacketExplainerQueue(async (params) => {
+  const provider = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+    detached: true, stdio: 'ignore',
+  });
+  provider.unref();
+  const record = createOrchestratorTurnRecord({
+    backend: 'codex',
+    sessionName: sessionNameForRepo('cortex-codex-orchestrator', params.lane.repoPath, params.generationId),
+    repoPath: params.lane.repoPath, threadId: params.generationId, pid: provider.pid!,
+  });
+  const row = getSqlite().prepare('SELECT * FROM explainer_queue WHERE status = ?').get('in_progress');
+  process.send?.({ providerPid: provider.pid, record, row });
+  await new Promise(() => {});
+  return { outcome: 'ready', backend: 'codex', durationMs: 0, approximateCost: null };
+});
+setInterval(() => {}, 1000);

--- a/tests/forced-review-real-path.test.ts
+++ b/tests/forced-review-real-path.test.ts
@@ -1,0 +1,127 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+
+const seams = vi.hoisted(() => ({ interrupt: vi.fn(), verify: vi.fn(), fresh: vi.fn(), capture: vi.fn() }));
+vi.mock('@/lib/ws-server/next-fetch', () => ({ fetchRuntimeAction: seams.interrupt }));
+vi.mock('@/lib/supervisor/completion-verification', async (original) => ({
+  ...await original<typeof import('@/lib/supervisor/completion-verification')>(), runCompletionVerification: seams.verify,
+}));
+vi.mock('@/lib/supervisor/self-review-stall-guard', async (original) => ({
+  ...await original<typeof import('@/lib/supervisor/self-review-stall-guard')>(), hasFreshSelfReviewTranscriptActivity: seams.fresh,
+}));
+vi.mock('@/lib/orchestrator/context-relay', () => ({ capturePacketCompletionContext: seams.capture }));
+vi.mock('@/lib/lane/terminal-lane-cleanup', () => ({ scheduleTerminalLaneCleanup: vi.fn() }));
+vi.mock('@/lib/lane/worktree-cleanup', () => ({ pruneRepoWorktrees: vi.fn(async () => []) }));
+vi.mock('@/lib/realtime/publisher', () => ({ publishRealtimeMutation: vi.fn(async () => {}) }));
+
+const dataDir = mkdtempSync(join(tmpdir(), 'o8-forced-review-'));
+process.env.O8_DATA_DIR = dataDir;
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+const roots = [dataDir];
+const { closeDb } = await import('@/lib/db');
+const { createLane, getLane, updateLane, appendEvent } = await import('@/lib/lane/registry');
+const control = await import('@/lib/orchestrator/control-plane');
+const { createEmptyOrchestratorMissionState, packetReleaseBlockedBy } = await import('@/lib/orchestrator/store');
+const { runHeadlessSprintTick } = await import('@/lib/orchestrator/headless-loop');
+const { forceSelfReviewToReview } = await import('@/lib/supervisor/force-self-review');
+let sequence = 0;
+function git(cwd: string, ...args: string[]) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'o8-force-review-git-'));
+  roots.push(root);
+  const id = `force-review-${++sequence}`;
+  git(root, 'init', '-qb', 'main');
+  git(root, 'config', 'user.name', 'o8-test');
+  git(root, 'config', 'user.email', 'test@example.test');
+  writeFileSync(join(root, 'work.txt'), 'base');
+  git(root, 'add', '.'); git(root, 'commit', '-qm', 'fixture');
+  const base = git(root, 'rev-parse', 'HEAD');
+  git(root, 'checkout', '-qb', `inline/${id}`);
+  writeFileSync(join(root, 'work.txt'), 'preserve this work');
+  const lane = createLane({ repoPath: root, worktreePath: root, branch: `inline/${id}`,
+    baseBranch: 'main', runtime: 'codex', packetId: id, sessionKey: `codex-owned:${id}` });
+  updateLane(lane.id, { status: 'running' }, 'system');
+  const packet: OrchestratorPacket = { id, referenceLabel: id, title: 'Source work', summary: 'fixture',
+    workspaceTargetPath: root, branchTarget: lane.branch, runtime: 'codex', status: 'running', queueState: 'held',
+    releaseState: 'pending', dependencyLabels: [], dependencyPacketIds: [], attemptCount: 1,
+    lane: { laneId: lane.id, tileId: lane.id, tabId: lane.id, sessionKey: lane.sessionKey,
+      repoPath: root, worktreePath: root, runtime: 'codex' } };
+  control.writeOrchestratorControlPlaneState({ ...createEmptyOrchestratorMissionState(),
+    missionId: `mission-${id}`, repoPath: root, packets: [packet, { ...packet, id: `${id}-next`,
+      referenceLabel: `${id}-next`, title: 'Dependent work', lane: null, status: 'queued', queueState: 'queued',
+      dependencyPacketIds: [id] }] });
+  const dependencies = { park: vi.fn(async () => {}), unregister: vi.fn(), enqueueAutoReview: vi.fn(async () => {}),
+    triggerHeadlessSprintTick: vi.fn(runHeadlessSprintTick), queueReviewContinuation: vi.fn(), broadcastUpdate: vi.fn(), escalate: vi.fn() };
+  const run = () => forceSelfReviewToReview(lane.sessionKey!, getLane(lane.id)!, { kind: 'force-review',
+    reason: 'fixture stall', idleMs: 100_000, cwd: root,
+    verification: { typecheckPassed: true, lintPassed: true, selfReviewLikely: true } }, dependencies);
+  return { root, base, lane, dependencies, run };
+}
+beforeEach(() => {
+  seams.interrupt.mockReset().mockResolvedValue({ ok: true });
+  seams.verify.mockReset().mockResolvedValue({ ok: true, kind: 'typecheck', output: '' });
+  seams.fresh.mockReset().mockResolvedValue(false);
+  seams.capture.mockReset().mockResolvedValue({});
+});
+afterAll(() => { closeDb(); for (const root of roots.reverse()) rmSync(root, { recursive: true, force: true }); });
+
+describe('forced review through the server production handler', () => {
+  it('preserves real dirty work, moves it to review, and leaves the next job blocked', async () => {
+    const f = fixture();
+    // The handler's own interrupt may emit an exit, but that is not a new turn.
+    seams.interrupt.mockImplementationOnce(async () => { appendEvent(f.lane.id, 'runtime_process_exit', 'system', {}); });
+    await f.run();
+    expect(git(f.root, 'status', '--porcelain')).toBe('');
+    expect(git(f.root, 'rev-parse', 'HEAD')).not.toBe(f.base);
+    expect(git(f.root, 'rev-parse', 'main')).toBe(f.base);
+    expect(getLane(f.lane.id)).toMatchObject({ status: 'reviewing', sessionKey: null });
+    const state = control.readOrchestratorControlPlaneState();
+    expect(state.packets[0]).toMatchObject({ releaseState: 'pending', releaseStatePayload: null });
+    expect(packetReleaseBlockedBy(state.packets[1], state.packets)?.id).toBe(state.packets[0].id);
+    expect(f.dependencies.triggerHeadlessSprintTick).toHaveBeenCalledWith();
+    expect(f.dependencies.enqueueAutoReview).toHaveBeenCalledWith(f.lane.id);
+  });
+
+  it('keeps the runtime bound when interrupt fails and never queues review or release', async () => {
+    const f = fixture();
+    seams.interrupt.mockRejectedValueOnce(new Error('interrupt unavailable'));
+    await f.run();
+    expect(git(f.root, 'status', '--porcelain')).toBe('');
+    expect(getLane(f.lane.id)).toMatchObject({ status: 'running', sessionKey: f.lane.sessionKey });
+    expect(f.dependencies.unregister).not.toHaveBeenCalled();
+    expect(f.dependencies.enqueueAutoReview).not.toHaveBeenCalled();
+    expect(f.dependencies.triggerHeadlessSprintTick).not.toHaveBeenCalled();
+    expect(control.readOrchestratorControlPlaneState().packets[0].releaseState).toBe('pending');
+  });
+
+  it.each(['verify', 'context', 'interrupt'] as const)('yields when a new steer arrives during %s', async (stage) => {
+    const f = fixture();
+    const action = async () => {
+      appendEvent(f.lane.id, 'steered_packet', 'user', { message: 'new work' });
+      return { ok: true, kind: 'typecheck', output: '' };
+    };
+    ({ verify: seams.verify, context: seams.capture, interrupt: seams.interrupt })[stage].mockImplementationOnce(action);
+    await f.run();
+    expect(getLane(f.lane.id)).toMatchObject({ status: 'running', sessionKey: f.lane.sessionKey });
+    expect(f.dependencies.enqueueAutoReview).not.toHaveBeenCalled();
+    expect(f.dependencies.triggerHeadlessSprintTick).not.toHaveBeenCalled();
+  });
+
+  it('preserves a durable Stop that arrives during verification', async () => {
+    const f = fixture();
+    seams.verify.mockImplementationOnce(async () => {
+      await control.withLockedState((state) => { state.packets[0].operatorStopped = true; });
+      return { ok: true, kind: 'typecheck', output: '' };
+    });
+    await f.run();
+    expect(seams.interrupt).not.toHaveBeenCalled();
+    expect(f.dependencies.enqueueAutoReview).not.toHaveBeenCalled();
+    expect(control.readOrchestratorControlPlaneState().packets[0].operatorStopped).toBe(true);
+  });
+});

--- a/tests/headless-idle-maintenance.test.ts
+++ b/tests/headless-idle-maintenance.test.ts
@@ -126,13 +126,14 @@ describe('headless idle worktree maintenance', () => {
     expect(prune).toHaveBeenCalledExactlyOnceWith(repoPath);
   });
 
-  it('runs the terminal cleanup pass after an explicit release', async () => {
+  it('cannot create release evidence from a raw packet ID', async () => {
     const current = mission();
     writeOrchestratorControlPlaneState(current);
 
-    await runHeadlessSprintTick({ releasePacketIds: [current.packets[0].id] });
+    // An old in-process caller can still supply extra JavaScript arguments.
+    await Reflect.apply(runHeadlessSprintTick, null, [{ releasePacketIds: [current.packets[0].id] }]);
 
-    expect(prune).toHaveBeenCalledExactlyOnceWith(repoPath);
-    expect(readOrchestratorControlPlaneState().packets[0]?.releaseState).toBe('released');
+    expect(prune).not.toHaveBeenCalled();
+    expect(readOrchestratorControlPlaneState().packets[0]?.releaseState).toBe('pending');
   });
 });

--- a/tests/managed-run-routing-real-path.test.ts
+++ b/tests/managed-run-routing-real-path.test.ts
@@ -1,0 +1,128 @@
+import { execFileSync, spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { build } from 'esbuild';
+
+const tmux = spawnSync('which', ['tmux'], { encoding: 'utf8' }).stdout?.trim();
+const tsxImport = import.meta.resolve('tsx');
+const cli = new URL('../cli/src/index.ts', import.meta.url).pathname;
+const routingKeys = ['O8_API_PORT', 'O8_WS_PORT', 'WS_PORT', 'O8_API_TOKEN', 'O8_WORKER_TOKEN',
+  'O8_WORKER_PACKET_ID', 'O8_SPECTATOR_TOKEN', 'O8_DATA_DIR', 'CORTEX_IDE_DATA_DIR', 'NODE_OPTIONS'];
+const servers: Server[] = [], roots: string[] = [], sockets: string[] = [], children: ChildProcess[] = [];
+function quote(value: string) { return `'${value.replaceAll("'", "'\\''")}'`; }
+
+afterEach(async () => {
+  for (const child of children.splice(0)) if (child.exitCode === null) child.kill('SIGKILL');
+  for (const socket of sockets.splice(0)) {
+    try { execFileSync(tmux, ['-S', socket, 'kill-server'], { stdio: 'ignore' }); } catch {}
+  }
+  for (const server of servers.splice(0)) {
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+async function endpoint(version: string, token: string) {
+  const requests: string[] = [];
+  const server = createServer(async (request, response) => {
+    for await (const _chunk of request) { /* drain the managed-run registration */ }
+    response.setHeader('content-type', 'application/json');
+    if (request.headers.authorization !== `Bearer ${token}`) {
+      response.writeHead(401).end(JSON.stringify({ error: 'wrong fixture credential' }));
+      return;
+    }
+    requests.push(request.url ?? '');
+    response.end(JSON.stringify(request.url === '/api/panel/status' ? { version } : { ok: true }));
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('missing fixture port');
+  return { port: address.port, requests };
+}
+
+async function run(bundle: string, args: string[], cwd: string, env: NodeJS.ProcessEnv) {
+  const child = spawn(process.execPath, [bundle, ...args], { cwd, env, stdio: ['ignore', 'pipe', 'pipe'] });
+  children.push(child);
+  let output = '';
+  child.stdout!.on('data', (value) => { output += value; });
+  child.stderr!.on('data', (value) => { output += value; });
+  const code = await new Promise<number | null>((resolve, reject) => { child.on('error', reject); child.on('close', resolve); });
+  return { code, output };
+}
+
+describe.skipIf(!tmux || process.platform === 'win32')('managed CLI routing through an existing isolated terminal server', () => {
+  it.each(['persisted', 'explicit-worker'] as const)('uses %s caller context rather than the stale terminal server', async (mode) => {
+    const root = mkdtempSync(join(tmpdir(), 'o8-route-'));
+    roots.push(root);
+    const bundle = join(root, 'o8.mjs');
+    await build({ entryPoints: [cli], outfile: bundle, bundle: true, platform: 'node', format: 'esm', target: 'node22',
+      define: { __O8_CLI_VERSION__: JSON.stringify('test-fixture') },
+      banner: { js: `import { createRequire as __o8_createRequire } from 'node:module';
+import { fileURLToPath as __o8_fileURLToPath } from 'node:url';
+import { dirname as __o8_dirname } from 'node:path';
+const require = __o8_createRequire(import.meta.url); globalThis.require = require;
+const __filename = __o8_fileURLToPath(import.meta.url); const __dirname = __o8_dirname(__filename);` } });
+    const data = join(root, 'data'), staleData = join(root, 'stale'), bin = join(root, 'bin'), socket = join(root, 'sock');
+    for (const dir of [data, staleData, bin]) mkdirSync(dir);
+    const disk = await endpoint('persisted-fixture', 'disk-fixture-token');
+    const explicit = await endpoint('worker-fixture', 'worker-fixture-token');
+    writeFileSync(join(data, 'api-port'), String(disk.port));
+    writeFileSync(join(data, 'ws-token'), 'disk-fixture-token');
+    writeFileSync(join(staleData, 'api-port'), '1');
+    writeFileSync(join(staleData, 'ws-token'), 'stale-fixture-token');
+    // Every CLI tmux invocation uses this private socket. Never change the
+    // operator's global terminal environment to reproduce inherited state.
+    const shim = join(bin, 'tmux');
+    writeFileSync(shim, `#!/bin/sh\nexec ${quote(tmux)} -S ${quote(socket)} "$@"\n`);
+    chmodSync(shim, 0o700);
+    sockets.push(socket);
+    execFileSync(tmux, ['-S', socket, '-f', '/dev/null', 'new-session', '-d', '-s', 'fixture-keepalive', 'sleep 90']);
+    for (const [key, value] of Object.entries({ O8_API_PORT: '1', O8_WS_PORT: '1', WS_PORT: '1',
+      O8_API_TOKEN: 'stale-fixture-token', O8_WORKER_TOKEN: 'stale-worker', O8_WORKER_PACKET_ID: 'stale-packet',
+      O8_SPECTATOR_TOKEN: 'stale-spectator', O8_DATA_DIR: staleData, CORTEX_IDE_DATA_DIR: staleData })) {
+      execFileSync(tmux, ['-S', socket, 'set-environment', '-g', key, value]);
+    }
+    const env: NodeJS.ProcessEnv = { ...process.env, PATH: `${bin}:${process.env.PATH}` };
+    for (const key of routingKeys) delete env[key];
+    env.CORTEX_IDE_DATA_DIR = data;
+    if (mode === 'explicit-worker') Object.assign(env, { O8_API_PORT: String(explicit.port),
+      O8_WORKER_TOKEN: 'worker-fixture-token', O8_WORKER_PACKET_ID: 'caller-packet', O8_WS_PORT: '49999' });
+    const parent = await run(bundle, ['version'], root, env);
+    expect(parent.code, parent.output).toBe(0);
+    expect(parent.output).toContain('"serverReachable": true');
+    const probe = join(root, 'child.mts');
+    const config = new URL('../cli/src/config.ts', import.meta.url).href;
+    const version = new URL('../cli/src/commands/version.ts', import.meta.url).href;
+    writeFileSync(probe, `
+import assert from 'node:assert/strict';
+import { resolveConfig } from ${JSON.stringify(config)};
+import { runVersion } from ${JSON.stringify(version)};
+const config = resolveConfig();
+assert.equal(config.workerPacketId, ${JSON.stringify(mode === 'explicit-worker' ? 'caller-packet' : null)});
+assert.equal(config.source.token, ${JSON.stringify(mode === 'explicit-worker' ? 'worker' : 'data-dir')});
+assert.equal(process.env.O8_SPECTATOR_TOKEN, undefined);
+assert.equal(process.env.O8_DATA_DIR, undefined);
+assert.equal(process.env.CORTEX_IDE_DATA_DIR, ${JSON.stringify(data)});
+await runVersion({ human: false, verbose: false });
+`);
+    const child = await run(bundle, ['run', '--', process.execPath, '--import', tsxImport, probe], root, env);
+    expect(child.code, child.output).toBe(0);
+    expect(child.output).toContain('"serverReachable": true');
+    expect(child.output).toContain(mode === 'persisted' ? 'persisted-fixture' : 'worker-fixture');
+    const target = mode === 'persisted' ? disk : explicit;
+    expect(target.requests.filter((path) => path === '/api/panel/status')).toHaveLength(2);
+    expect(target.requests).toContain('/api/panel/managed-runs');
+    const receiptDir = join(data, 'logs', 'run');
+    const receipt = readdirSync(receiptDir).find((name) => name.endsWith('.exit'));
+    expect(receipt).toBeDefined();
+    expect(readFileSync(join(receiptDir, receipt!), 'utf8')).toBe('0');
+    // The fix is per child; it does not globally repair or erase server state.
+    expect(execFileSync(tmux, ['-S', socket, 'show-environment', '-g', 'O8_API_PORT'], { encoding: 'utf8' }).trim())
+      .toBe('O8_API_PORT=1');
+  }, 30_000);
+});

--- a/tests/operator-defaults-mcp-routing.test.ts
+++ b/tests/operator-defaults-mcp-routing.test.ts
@@ -7,6 +7,17 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import { MODEL_IDS } from '@/lib/models';
 
 const spawnMock = vi.hoisted(() => vi.fn());
+const nativePreflightMock = vi.hoisted(() => vi.fn(async () => undefined));
+const carrierPreflightMock = vi.hoisted(() => vi.fn(async () => ({
+  runtime: 'codex' as const,
+  runtimeBinaryName: 'codex',
+  runtimeCli: { path: '/test/codex', source: 'path' as const, detectedAt: 1 },
+  executionCarrier: 'ori' as const,
+  carrierBinaryName: 'ori',
+  carrierCli: { path: '/test/ori', source: 'path' as const, detectedAt: 1 },
+  authSource: 'execution-carrier' as const,
+  authenticated: true as const,
+})));
 const ensureDispatchBackendReadyMock = vi.hoisted(() => vi.fn(async () => ({
   ready: true,
   reason: 'http_200',
@@ -91,9 +102,14 @@ vi.mock('@/lib/runtimes/shared/auth-detect', async (importOriginal) => {
       },
       suggestedSubscriptionProfile: { profile: null, detail: null },
     })),
-    assertRuntimeDispatchable: vi.fn(async () => undefined),
+    assertRuntimeDispatchable: nativePreflightMock,
   };
 });
+
+vi.mock('@/lib/runtimes/shared/execution-carrier-preflight', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/runtimes/shared/execution-carrier-preflight')>(),
+  assertExecutionCarrierDispatchable: carrierPreflightMock,
+}));
 
 vi.mock('@/lib/usage-log', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/usage-log')>();
@@ -252,6 +268,8 @@ beforeEach(() => {
   vi.resetModules();
 
   spawnMock.mockReset();
+  nativePreflightMock.mockClear();
+  carrierPreflightMock.mockClear();
   spawnMock.mockReturnValue({
     pid: 987_654,
     stdin: { end: vi.fn() },
@@ -310,6 +328,7 @@ describe('MCP operator defaults and dispatch routing', () => {
       broadcastCommentaryMaxPerHour: expect.any(Object),
       brainUseClaudeCli: expect.any(Object),
       defaultDispatchModel: expect.any(Object),
+      workerExecutionCarrier: expect.objectContaining({ enum: ['ori', ''] }),
       meteredPacketCostCapUsd: expect.any(Object),
       meteredPacketInputTokenCap: expect.any(Object),
       uiLoopMaxIterations: expect.any(Object),
@@ -409,6 +428,19 @@ describe('MCP operator defaults and dispatch routing', () => {
     });
     expect(fetchMock).not.toHaveBeenCalled();
     expect((await getOperatorDefaults()).values.codexWorkerEffort).toBe(before);
+  });
+
+  it.skipIf(process.platform === 'win32')('uses execution-carrier auth instead of native auth at the create-mission route', async () => {
+    const { handleOperatorDefaults } = await import('@/lib/mcp/operator-handlers/status');
+    await handleOperatorDefaults({ defaultDispatchRuntime: 'codex', workerExecutionCarrier: 'ori' });
+
+    await expect(createMissionThroughRoute({
+      repoPath: await createRegisteredTempRepo(),
+      issueNumber: 2037,
+      requestedRuntime: 'codex',
+    })).resolves.toMatchObject({ missionId: expect.any(String) });
+    expect(carrierPreflightMock).toHaveBeenCalledWith('codex', 'ori');
+    expect(nativePreflightMock).not.toHaveBeenCalled();
   });
 
   it('carries defaultDispatchModel through mission creation into the Codex spawn argv', async () => {

--- a/tests/operator-defaults-mcp-routing.test.ts
+++ b/tests/operator-defaults-mcp-routing.test.ts
@@ -7,6 +7,17 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import { MODEL_IDS } from '@/lib/models';
 
 const spawnMock = vi.hoisted(() => vi.fn());
+const nativePreflightMock = vi.hoisted(() => vi.fn(async () => undefined));
+const carrierPreflightMock = vi.hoisted(() => vi.fn(async () => ({
+  runtime: 'codex' as const,
+  runtimeBinaryName: 'codex',
+  runtimeCli: { path: '/test/codex', source: 'path' as const, detectedAt: 1 },
+  executionCarrier: 'ori' as const,
+  carrierBinaryName: 'ori',
+  carrierCli: { path: '/test/ori', source: 'path' as const, detectedAt: 1 },
+  authSource: 'execution-carrier' as const,
+  authenticated: true as const,
+})));
 const ensureDispatchBackendReadyMock = vi.hoisted(() => vi.fn(async () => ({
   ready: true,
   reason: 'http_200',
@@ -21,9 +32,8 @@ const ensureCodexSubscriptionProxyReadyMock = vi.hoisted(() => vi.fn(async () =>
 const ensureCodexSubscriptionClaudeConfigDirMock = vi.hoisted(() => vi.fn(async (sessionDir: string) =>
   path.join(sessionDir, 'claude-code-codex-config')));
 
-// The native carrier's config dir seeds real Keychain credentials and verifies
-// them with `claude auth status`, which makes routing assertions depend on the
-// operator's live login. Stub it the same way the codex carrier above is stubbed.
+// Authentication is outside this routing fixture. Stub the current config
+// preparation entry point so it never reads the operator's credential store.
 const ensureClaudeCodeWorkerConfigDirMock = vi.hoisted(() => vi.fn(async (sessionDir: string) =>
   path.join(sessionDir, 'claude-code-worker-config')));
 
@@ -66,6 +76,12 @@ vi.mock('@/lib/claude-code/codex-subscription-proxy', async (importOriginal) => 
   ensureCodexSubscriptionProxyReady: ensureCodexSubscriptionProxyReadyMock,
   ensureCodexSubscriptionClaudeConfigDir: ensureCodexSubscriptionClaudeConfigDirMock,
   ensureClaudeCodeWorkerConfigDir: ensureClaudeCodeWorkerConfigDirMock,
+  prepareClaudeCodeWorkerConfig: vi.fn(async (sessionDir: string, source: string) => ({
+    configDir: source === 'codex-subscription'
+      ? await ensureCodexSubscriptionClaudeConfigDirMock(sessionDir)
+      : await ensureClaudeCodeWorkerConfigDirMock(sessionDir),
+    credentialEnv: {},
+  })),
 }));
 
 vi.mock('@/lib/runtimes/shared/auth-detect', async (importOriginal) => {
@@ -91,9 +107,14 @@ vi.mock('@/lib/runtimes/shared/auth-detect', async (importOriginal) => {
       },
       suggestedSubscriptionProfile: { profile: null, detail: null },
     })),
-    assertRuntimeDispatchable: vi.fn(async () => undefined),
+    assertRuntimeDispatchable: nativePreflightMock,
   };
 });
+
+vi.mock('@/lib/runtimes/shared/execution-carrier-preflight', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/runtimes/shared/execution-carrier-preflight')>(),
+  assertExecutionCarrierDispatchable: carrierPreflightMock,
+}));
 
 vi.mock('@/lib/usage-log', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/usage-log')>();
@@ -252,6 +273,8 @@ beforeEach(() => {
   vi.resetModules();
 
   spawnMock.mockReset();
+  nativePreflightMock.mockClear();
+  carrierPreflightMock.mockClear();
   spawnMock.mockReturnValue({
     pid: 987_654,
     stdin: { end: vi.fn() },
@@ -310,6 +333,7 @@ describe('MCP operator defaults and dispatch routing', () => {
       broadcastCommentaryMaxPerHour: expect.any(Object),
       brainUseClaudeCli: expect.any(Object),
       defaultDispatchModel: expect.any(Object),
+      workerExecutionCarrier: expect.objectContaining({ enum: ['ori', ''] }),
       meteredPacketCostCapUsd: expect.any(Object),
       meteredPacketInputTokenCap: expect.any(Object),
       uiLoopMaxIterations: expect.any(Object),
@@ -409,6 +433,19 @@ describe('MCP operator defaults and dispatch routing', () => {
     });
     expect(fetchMock).not.toHaveBeenCalled();
     expect((await getOperatorDefaults()).values.codexWorkerEffort).toBe(before);
+  });
+
+  it.skipIf(process.platform === 'win32')('uses execution-carrier auth instead of native auth at the create-mission route', async () => {
+    const { handleOperatorDefaults } = await import('@/lib/mcp/operator-handlers/status');
+    await handleOperatorDefaults({ defaultDispatchRuntime: 'codex', workerExecutionCarrier: 'ori' });
+
+    await expect(createMissionThroughRoute({
+      repoPath: await createRegisteredTempRepo(),
+      issueNumber: 2037,
+      requestedRuntime: 'codex',
+    })).resolves.toMatchObject({ missionId: expect.any(String) });
+    expect(carrierPreflightMock).toHaveBeenCalledWith('codex', 'ori');
+    expect(nativePreflightMock).not.toHaveBeenCalled();
   });
 
   it('carries defaultDispatchModel through mission creation into the Codex spawn argv', async () => {

--- a/tests/operator-defaults-runtime-inventory.test.ts
+++ b/tests/operator-defaults-runtime-inventory.test.ts
@@ -34,6 +34,22 @@ afterAll(() => {
 });
 
 describe('operator-defaults dispatchable runtime inventory', () => {
+  it('defaults explainers off and persists both positions of the existing toggle', async () => {
+    const read = async () => (await operatorDefaultsRoute.GET(
+      new Request('http://127.0.0.1/api/panel/operator-defaults'),
+    )).json();
+    expect((await read()).values.packetExplainerEnabled).toBe(false);
+    for (const enabled of [true, false]) {
+      const response = await operatorDefaultsRoute.POST(new Request('http://127.0.0.1/api/panel/operator-defaults', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ packetExplainerEnabled: enabled }),
+      }));
+      expect(response.status).toBe(200);
+      const persisted = await read();
+      expect(persisted.values.packetExplainerEnabled).toBe(enabled);
+      expect(persisted.values.quizGateEnabled).toBe(false);
+    }
+  });
   it('exposes runtime id, label, and structured availability through the existing read route', async () => {
     const response = await operatorDefaultsRoute.GET(new Request('http://127.0.0.1/api/panel/operator-defaults'));
     expect(response.status).toBe(200);

--- a/tests/owned-carrier-signal-real-path.test.ts
+++ b/tests/owned-carrier-signal-real-path.test.ts
@@ -1,0 +1,83 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { OwnedRuntimeAdapter, ParsedRunLog } from '@/lib/runtimes/shared/owned-session/types';
+
+const roots: string[] = [];
+const children: ChildProcess[] = [];
+
+afterEach(async () => {
+  for (const child of children.splice(0)) {
+    if (child.exitCode === null && child.signalCode === null) {
+      const exited = once(child, 'exit');
+      child.kill('SIGKILL');
+      await exited;
+    }
+  }
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+describe.skipIf(process.platform === 'win32')('owned carrier signal authority through the session store', () => {
+  it.each(['unmarked', 'wrong-marker', 'wrong-group', 'exec-replaced'] as const)(
+    '%s uses persisted run ownership instead of an argv mention', async (scenario) => {
+      const root = mkdtempSync(path.join(os.tmpdir(), 'o8-owned-carrier-signal-'));
+      roots.push(root);
+      const sessions = path.join(root, 'sessions');
+      const sessionDir = path.join(sessions, 'fixture');
+      mkdirSync(path.join(sessionDir, 'runs'), { recursive: true });
+      vi.stubEnv('O8_TEST_CARRIER_SIGNAL_ROOT', sessions);
+      const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)', '/tools/ori'], {
+        detached: true, stdio: 'ignore',
+        env: { NODE_ENV: 'test', PATH: process.env.PATH, O8_OWNED_RUN_MARKER: 'carrier-signal-actual' },
+      });
+      children.push(child);
+      await once(child, 'spawn');
+      const pid = child.pid!;
+      const surfaceId = 'carrier-signal-owned:fixture';
+      const now = new Date().toISOString();
+      const run = {
+        id: 'carrier-signal-actual', mode: 'launch', prompt: 'fixture', startedAt: now,
+        pid, processGroupId: scenario === 'wrong-group' ? pid + 1 : pid,
+        processMarker: scenario === 'unmarked' ? undefined
+          : scenario === 'wrong-marker' ? 'carrier-signal-stale' : 'carrier-signal-actual',
+        commandIdentity: '/tools/ori', spawnState: 'started', outcome: 'running',
+        stdoutPath: path.join(sessionDir, 'runs', 'stdout.jsonl'),
+        stderrPath: path.join(sessionDir, 'runs', 'stderr.log'),
+      };
+      writeFileSync(run.stdoutPath, '');
+      writeFileSync(run.stderrPath, '');
+      const metadata = path.join(sessionDir, 'session.json');
+      writeFileSync(metadata, JSON.stringify({
+        surfaceId, sessionDir, runtimeId: 'test-runtime', repoPath: root,
+        createdAt: now, updatedAt: now, activeRun: run, recentRuns: [run],
+      }));
+      const adapter: OwnedRuntimeAdapter = {
+        runtimeId: 'test-runtime', surfaceIdPrefix: 'carrier-signal-owned:',
+        rootEnvVar: 'O8_TEST_CARRIER_SIGNAL_ROOT', rootDefault: sessions,
+        binaryName: 'node', binaryEnvOverride: 'O8_TEST_CARRIER_SIGNAL_BIN',
+        humanLabel: 'Signal fixture', squadShortName: 'Test',
+        launchArgs: () => [], resumeArgs: () => [],
+        parseRunLog: (): ParsedRunLog => ({ entries: [], outcome: 'running', completedTurn: false }),
+      };
+      const { createOwnedSessionStore } = await import('@/lib/runtimes/shared/owned-session/store');
+      const store = createOwnedSessionStore(adapter);
+      const result = await store.interrupt(surfaceId);
+      const persisted = JSON.parse(readFileSync(metadata, 'utf8'));
+      if (scenario === 'exec-replaced') {
+        expect(result.interrupted).toBe(true);
+        expect(persisted.recentRuns[0].interruptRequestedAt).toEqual(expect.any(String));
+        if (child.exitCode === null && child.signalCode === null) await once(child, 'exit');
+        expect(child.signalCode).toBe('SIGINT');
+      } else {
+        expect(result).toMatchObject({ interrupted: false });
+        expect(persisted.activeRun.interruptRequestedAt).toBeUndefined();
+        expect(persisted.activeRun.pid).toBe(pid);
+        expect(() => process.kill(pid, 0)).not.toThrow();
+      }
+    }, 15_000,
+  );
+});

--- a/tests/packet-control-fields-survive-normalize.test.ts
+++ b/tests/packet-control-fields-survive-normalize.test.ts
@@ -16,6 +16,7 @@ import {
   normalizeOrchestratorMissionState,
 } from '@/lib/orchestrator/store';
 import { normalizeOrchestratorMissionStateForPersistence } from '@/lib/orchestrator/persisted-mission';
+import { normalizePacketExecutionCarrier } from '@/lib/orchestrator/normalize/decomposition';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 
 const NOW = new Date('2026-01-01T00:00:00.000Z');
@@ -148,6 +149,7 @@ function fullPacketFixture() {
     assignedModel: 'gpt-5.5',
     claudeCodeModel: 'gateway/model-y',
     claudeCodeCarrier: 'openrouter',
+    executionCarrier: null,
     qualitySearch: {
       version: 1,
       role: 'robustness_complete',
@@ -250,6 +252,10 @@ function stateWithPacket(packet: OrchestratorPacket) {
 }
 
 describe('packet fields survive normalize', () => {
+  it('refuses an unknown persisted execution carrier instead of falling back to direct credentials', () => {
+    expect(() => normalizePacketExecutionCarrier('future-carrier')).toThrow(/refusing to fall back/i);
+  });
+
   it('preserves every packet key across a normalize round-trip', () => {
     vi.useFakeTimers();
     try {

--- a/tests/packet-explainer-restart-real-path.test.ts
+++ b/tests/packet-explainer-restart-real-path.test.ts
@@ -1,0 +1,222 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const backendMocks = vi.hoisted(() => ({ sendTurn: vi.fn() }));
+vi.mock('@/lib/lane/orchestrator-backends/registry', () => {
+  const backend = { id: 'codex', label: 'Fixture',
+    ensureSession: () => ({ status: 'ready' }), sendTurn: backendMocks.sendTurn };
+  return { getActiveReviewerBackend: () => backend, getOrchestratorBackend: () => backend };
+});
+
+const dataDir = mkdtempSync(join(tmpdir(), 'o8-explainer-restart-'));
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.O8_DATA_DIR = dataDir;
+const { getSqlite } = await import('@/lib/db');
+const { createLane } = await import('@/lib/lane/registry');
+const { updateOperatorDefaults } = await import('@/lib/operator/defaults');
+const { enqueuePacketExplainer, drainPacketExplainerQueue, startPacketExplainerQueueDrain } =
+  await import('@/lib/lane/packet-explainer-queue');
+const { createOrchestratorTurnRecord, finishOrchestratorTurn, isPidAlive } =
+  await import('@/lib/lane/orchestrator-crash-survival');
+const { sessionNameForRepo } = await import('@/lib/lane/orchestrator-session-core');
+const { listArtifacts } = await import('@/lib/artifacts/store');
+const { explainerThreadId, ownsCurrentExplainer } = await import('@/lib/lane/packet-explainer-ownership');
+const children: ChildProcess[] = [];
+const providerPids: number[] = [];
+
+beforeAll(async () => { await updateOperatorDefaults({ packetExplainerEnabled: true }); });
+afterAll(() => {
+  for (const child of children) if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+  for (const pid of providerPids) {
+    try { process.kill(-pid, 'SIGKILL'); } catch { /* fixture already gone */ }
+  }
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+async function enqueue(label: string) {
+  const lane = createLane({ label, repoPath: dataDir, worktreePath: dataDir,
+    branch: `inline/${label}`, runtime: 'codex', packetId: `packet-${label}` });
+  const id = await enqueuePacketExplainer({ lane, packetId: lane.packetId!, packetTitle: label,
+    packetSummary: '', diffSummary: '', changedFileCount: 1, deviationsRaw: null, reviewContext: '' });
+  return { lane, id };
+}
+
+function queueRow(id: string | null) {
+  return getSqlite().prepare('SELECT * FROM explainer_queue WHERE id = ?').get(id) as {
+    id: string; packet_id: string; lane_id: string; repo_path: string;
+    claim_owner: string; status: string; outcome: string;
+  };
+}
+
+function completedReport() {
+  backendMocks.sendTurn.mockImplementation(async (repo: string, prompt: string) => {
+    const filename = /named exactly `([^`]+)`/.exec(prompt)![1];
+    writeFileSync(join(repo, filename), '<html>Recovered report</html>');
+  });
+}
+
+describe('explainer process and durable queue restart contract', () => {
+  it('does not reclaim after owner SIGKILL until its detached provider has exited', async () => {
+    const { lane, id } = await enqueue('abrupt-restart');
+    const host = spawn(process.execPath, [
+      '--import', './scripts/register-server-only-stub.mjs', '--import', 'tsx',
+      'tests/fixtures/explainer-crash-host.ts',
+    ], {
+      cwd: resolve('.'), env: { ...process.env, CORTEX_IDE_DATA_DIR: dataDir, O8_DATA_DIR: dataDir },
+      stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+    });
+    children.push(host);
+    let stderr = '';
+    host.stderr?.on('data', (chunk) => { stderr += String(chunk); });
+    const message = await new Promise<{ providerPid: number }>((resolveMessage, reject) => {
+      const timeout = setTimeout(() => reject(new Error(`Fixture did not start: ${stderr}`)), 8_000);
+      host.once('message', (value) => { clearTimeout(timeout); resolveMessage(value as { providerPid: number }); });
+      host.once('exit', (code) => { clearTimeout(timeout); reject(new Error(`Fixture exited ${code}: ${stderr}`)); });
+    });
+    providerPids.push(message.providerPid);
+    const owner = queueRow(id).claim_owner;
+    completedReport();
+    backendMocks.sendTurn.mockClear();
+    await drainPacketExplainerQueue();
+    expect(backendMocks.sendTurn).not.toHaveBeenCalled();
+    expect(queueRow(id).claim_owner).toBe(owner);
+    const closed = once(host, 'exit');
+    host.kill('SIGKILL');
+    await closed;
+    expect(isPidAlive(message.providerPid)).toBe(true);
+    completedReport();
+    backendMocks.sendTurn.mockClear();
+    const stop = startPacketExplainerQueueDrain();
+    await drainPacketExplainerQueue();
+    stop();
+    expect(queueRow(id)).toMatchObject({ status: 'in_progress', claim_owner: owner });
+    expect(backendMocks.sendTurn).not.toHaveBeenCalled();
+
+    process.kill(-message.providerPid, 'SIGTERM');
+    await vi.waitFor(() => expect(isPidAlive(message.providerPid)).toBe(false));
+    await drainPacketExplainerQueue();
+    expect(backendMocks.sendTurn).toHaveBeenCalledOnce();
+    expect(queueRow(id)).toMatchObject({ status: 'completed', outcome: 'ready' });
+    expect(listArtifacts({ packetId: lane.packetId! })).toHaveLength(1);
+  });
+
+  it('keeps an aborted claim until provider exit, even if its ledger already says completed', async () => {
+    const { id } = await enqueue('normal-restart');
+    const provider = spawn(process.execPath, ['-e', `
+      const { spawn } = require('node:child_process');
+      const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });
+      process.send({ childPid: child.pid });
+      setInterval(() => {}, 1000);
+    `], {
+      detached: true, stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+    });
+    children.push(provider);
+    providerPids.push(provider.pid!);
+    const [descendant] = await once(provider, 'message') as [{ childPid: number }];
+    let started!: () => void;
+    const ready = new Promise<void>((resolveReady) => { started = resolveReady; });
+    backendMocks.sendTurn.mockImplementationOnce(async (repo, _prompt, _onEvent, options) => {
+      const record = createOrchestratorTurnRecord({ backend: 'codex', repoPath: repo,
+        sessionName: sessionNameForRepo('cortex-codex-orchestrator', repo, options.threadId),
+        threadId: options.threadId, pid: provider.pid! });
+      started();
+      await new Promise<void>((resolveAbort) => options.signal.addEventListener('abort', () => {
+        finishOrchestratorTurn(record, 'completed');
+        resolveAbort();
+      }, { once: true }));
+    });
+    const stop = startPacketExplainerQueueDrain();
+    await ready;
+    stop();
+    await vi.waitFor(() => expect(queueRow(id).outcome).toBe('awaiting_exit'));
+    const priorCalls = backendMocks.sendTurn.mock.calls.length;
+    await drainPacketExplainerQueue();
+    expect(queueRow(id).status).toBe('in_progress');
+    expect(backendMocks.sendTurn).toHaveBeenCalledTimes(priorCalls);
+    const exited = once(provider, 'exit');
+    provider.kill('SIGTERM');
+    await exited;
+    expect(isPidAlive(descendant.childPid)).toBe(true);
+    await drainPacketExplainerQueue();
+    expect(queueRow(id).status).toBe('in_progress');
+    expect(backendMocks.sendTurn).toHaveBeenCalledTimes(priorCalls);
+    process.kill(-provider.pid!, 'SIGTERM');
+    await vi.waitFor(() => expect(isPidAlive(descendant.childPid)).toBe(false));
+    completedReport();
+    await drainPacketExplainerQueue();
+    expect(queueRow(id)).toMatchObject({ status: 'completed', outcome: 'ready' });
+  });
+
+  it('does not publish a superseded report and gives the successor a distinct session and file', async () => {
+    const { lane, id } = await enqueue('superseded');
+    let successorId: string | null = null;
+    let priorClaim: ReturnType<typeof queueRow> | null = null;
+    backendMocks.sendTurn.mockImplementationOnce(async (repo, prompt) => {
+      priorClaim = queueRow(id);
+      const filename = /named exactly `([^`]+)`/.exec(prompt)![1];
+      writeFileSync(join(repo, filename), '<html>Stale</html>');
+      successorId = await enqueuePacketExplainer({ lane, packetId: lane.packetId!, packetTitle: 'Successor',
+        packetSummary: '', diffSummary: '', changedFileCount: 2, deviationsRaw: null, reviewContext: '' });
+    });
+    await drainPacketExplainerQueue();
+    expect(listArtifacts({ packetId: lane.packetId! })).toHaveLength(0);
+    expect(queueRow(id).outcome).toBe('superseded');
+    expect(ownsCurrentExplainer(priorClaim!)).toBe(false);
+    const staleThread = explainerThreadId(priorClaim!);
+    completedReport();
+    await drainPacketExplainerQueue();
+    expect(queueRow(successorId).status).toBe('completed');
+    expect(backendMocks.sendTurn.mock.lastCall?.[3].threadId).not.toBe(staleThread);
+    expect(listArtifacts({ packetId: lane.packetId! })).toHaveLength(1);
+  });
+
+  it('does not start queued work while the existing setting is off', async () => {
+    const { id } = await enqueue('disabled');
+    await updateOperatorDefaults({ packetExplainerEnabled: false });
+    backendMocks.sendTurn.mockClear();
+    await drainPacketExplainerQueue();
+    expect(backendMocks.sendTurn).not.toHaveBeenCalled();
+    expect(queueRow(id).status).toBe('pending');
+    await updateOperatorDefaults({ packetExplainerEnabled: true });
+    completedReport();
+    await drainPacketExplainerQueue();
+    expect(queueRow(id).status).toBe('completed');
+  });
+
+  it('keeps a failed launch with an unconfirmed PID fenced instead of retrying it', async () => {
+    const { id } = await enqueue('unconfirmed-launch');
+    backendMocks.sendTurn.mockImplementationOnce(async (repo, _prompt, _onEvent, options) => {
+      createOrchestratorTurnRecord({ backend: 'codex', repoPath: repo,
+        sessionName: sessionNameForRepo('cortex-codex-orchestrator', repo, options.threadId),
+        threadId: options.threadId, pid: 0 });
+      throw new Error('provider identity persistence interrupted');
+    });
+    await drainPacketExplainerQueue();
+    expect(queueRow(id)).toMatchObject({ status: 'in_progress', outcome: 'awaiting_exit' });
+    const calls = backendMocks.sendTurn.mock.calls.length;
+    await drainPacketExplainerQueue();
+    expect(backendMocks.sendTurn).toHaveBeenCalledTimes(calls);
+    getSqlite().prepare('DELETE FROM explainer_queue WHERE id = ?').run(id);
+  });
+
+  it('holds an orphan claim without process evidence rather than guessing that it is dead', async () => {
+    const { id } = await enqueue('unknown-exit');
+    const owner = spawn(process.execPath, ['-e', ''], { stdio: 'ignore' });
+    children.push(owner);
+    await once(owner, 'exit');
+    getSqlite().prepare(`UPDATE explainer_queue SET status = 'in_progress', claim_owner = ? WHERE id = ?`)
+      .run(`explainer-owner-${owner.pid}-missing`, id);
+    // Separate repo identity keeps unrelated completed fixture ledgers out of this check.
+    getSqlite().prepare('UPDATE explainer_queue SET repo_path = ? WHERE id = ?').run(join(dataDir, 'unknown'), id);
+    backendMocks.sendTurn.mockClear();
+    const stop = startPacketExplainerQueueDrain();
+    await drainPacketExplainerQueue();
+    stop();
+    expect(queueRow(id).status).toBe('in_progress');
+    expect(backendMocks.sendTurn).not.toHaveBeenCalled();
+  });
+});

--- a/tests/release-build-cache.test.ts
+++ b/tests/release-build-cache.test.ts
@@ -80,6 +80,45 @@ function nativeIdentity(source: string): ReleaseBuildCacheIdentity {
 }
 
 describe('shared release build cache', () => {
+  it('rejects native output from a deleted producer checkout before replacing destination files', async () => {
+    const { root: producer, cacheRoot } = fixture();
+    const { root: destination } = fixture();
+    const target = 'src-tauri/target/release';
+    const permission = 'build/tauri-fixture/out/permissions/default.json';
+    mkdirSync(join(producer, target, 'build/tauri-fixture/out/permissions'), { recursive: true });
+    writeFileSync(join(producer, target, permission), '{}');
+    writeFileSync(join(producer, target, 'build/tauri-fixture/output'), join(producer, target, permission));
+    expect(await captureReleaseBuildCache(producer, 'native', { cacheRoot, identity: nativeIdentity('a') }))
+      .toMatchObject({ status: 'captured' });
+    mkdirSync(join(destination, target), { recursive: true });
+    writeFileSync(join(destination, target, 'keep.bin'), 'destination output');
+    rmSync(producer, { recursive: true, force: true });
+    expect(await restoreReleaseBuildCache(destination, 'native', { cacheRoot, identity: nativeIdentity('b') }))
+      .toMatchObject({ status: 'miss', reason: 'native_checkout_mismatch' });
+    expect(readFileSync(join(destination, target, 'keep.bin'), 'utf8')).toBe('destination output');
+    expect(existsSync(join(destination, target, permission))).toBe(false);
+    expect(readdirSync(cacheRoot).some((name) => name.startsWith('.restore-'))).toBe(false);
+  });
+
+  it('rejects legacy native entries without checkout proof while preserving cross-checkout web reuse', async () => {
+    const { root, cacheRoot } = fixture();
+    const { root: destination } = fixture();
+    mkdirSync(join(root, 'src-tauri/target/release'), { recursive: true });
+    writeFileSync(join(root, 'src-tauri/target/release/artifact.bin'), 'native compiler output');
+    await captureReleaseBuildCache(root, 'native', { cacheRoot, identity: nativeIdentity('a') });
+    const manifestPath = join(cacheRoot, 'entries/native/compatibility-a/entry-a.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    expect(JSON.stringify(manifest)).not.toContain(root);
+    delete manifest.nativeCheckoutSha256;
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+    expect(await restoreReleaseBuildCache(root, 'native', { cacheRoot, identity: nativeIdentity('a') }))
+      .toMatchObject({ status: 'miss', reason: 'native_checkout_unverified' });
+    await captureReleaseBuildCache(root, 'web', { cacheRoot, identity: identity('a') });
+    expect(await restoreReleaseBuildCache(destination, 'web', { cacheRoot, identity: identity('b') }))
+      .toMatchObject({ status: 'hit_compatible', reason: 'verified' });
+    expect(readFileSync(join(destination, '.next/cache/webpack/entry.bin'), 'utf8')).toBe('compiled-source-a');
+  });
+
   it('uses a configured external root only while its mount marker identity matches', async () => {
     const { root } = fixture();
     const volumeRoot = mkdtempSync(join(tmpdir(), 'o8-release-cache-volume-'));

--- a/tests/release-truth-entry-real-path.test.ts
+++ b/tests/release-truth-entry-real-path.test.ts
@@ -1,0 +1,216 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+
+// Cleanup has its own real-path suite. Keep these Git fixtures until assertions finish.
+vi.mock('@/lib/lane/terminal-lane-cleanup', () => ({ scheduleTerminalLaneCleanup: vi.fn() }));
+const dataDir = mkdtempSync(join(tmpdir(), 'o8-release-entry-'));
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.O8_DATA_DIR = dataDir;
+const roots = [dataDir];
+const { closeDb } = await import('@/lib/db');
+const control = await import('@/lib/orchestrator/control-plane');
+const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+const { createLane, getLane, setLaneStatus } = await import('@/lib/lane/registry');
+const { recordLaneEvent } = await import('@/lib/lane/events');
+const { approveAndMergePacket } = await import('@/lib/orchestrator/operator-mission-service/merge');
+const { alreadyReleasedResultForPacket, alreadyReleasedResultForPacketId } = await import('@/lib/orchestrator/operator-mission-service/release-truth');
+let sequence = 0;
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+
+function commit(cwd: string, content: string): string {
+  writeFileSync(join(cwd, 'app.txt'), `${content}\n`);
+  git(cwd, 'add', 'app.txt');
+  git(cwd, 'commit', '-qm', 'fixture');
+  return git(cwd, 'rev-parse', 'HEAD');
+}
+
+function persist(packet: OrchestratorPacket, repoPath: string): OrchestratorPacket {
+  control.writeOrchestratorControlPlaneState({ ...createEmptyOrchestratorMissionState(),
+    missionId: `mission-${packet.id}`, repoPath, packets: [packet] });
+  return control.readOrchestratorControlPlaneState().packets[0];
+}
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'o8-release-git-'));
+  roots.push(root);
+  const repoPath = join(root, 'repo');
+  const worktreePath = join(root, 'worktree');
+  const id = `packet-release-${++sequence}`;
+  const branch = `inline/${id}`;
+  git(root, 'init', '-qb', 'main', repoPath);
+  git(repoPath, 'config', 'user.name', 'o8-test');
+  git(repoPath, 'config', 'user.email', 'test@example.test');
+  const base = commit(repoPath, 'base');
+  git(repoPath, 'worktree', 'add', '-qb', branch, worktreePath);
+  const lane = createLane({ repoPath, worktreePath, branch, baseBranch: 'main', runtime: 'codex', packetId: id });
+  setLaneStatus(lane.id, 'completed', 'system');
+  const packet = persist({ id, title: id, summary: id, referenceLabel: id, runtime: 'codex',
+    workspaceTargetPath: repoPath, branchTarget: branch, dependencyLabels: [], dependencyPacketIds: [],
+    status: 'released', queueState: 'held', releaseState: 'released', attemptCount: 1,
+    releaseStatePayload: { source: 'approve_and_merge', evidenceKind: 'merge_command',
+      mergeCommit: base, headSha: base, releasedAt: '2026-09-10T00:00:00.000Z' },
+    review: { approved: false, summary: 'Review still required', findings: [], recordedAt: '2026-09-10T00:00:00.000Z' },
+    lane: { laneId: lane.id, tileId: lane.id, tabId: lane.id, repoPath, worktreePath, runtime: 'codex' },
+  }, repoPath);
+  return { repoPath, worktreePath, lane: getLane(lane.id)!, packet, base, branch };
+}
+
+afterEach(() => vi.restoreAllMocks());
+afterAll(() => {
+  closeDb();
+  for (const root of roots.reverse()) rmSync(root, { recursive: true, force: true });
+});
+
+describe('release truth through the merge service and persisted packet state', () => {
+  it('does not let a terminal lane event resurrect a stale packet receipt', async () => {
+    const f = fixture();
+    recordLaneEvent(f.lane.id, 'merge', 'system', { laneHeadSha: f.base });
+    commit(f.worktreePath, 'unmerged successor');
+    const result = await approveAndMergePacket({ packetId: f.packet.id });
+    expect(result.merged).toBe(false);
+    expect(result.alreadyReleased).not.toBe(true);
+    expect(control.readOrchestratorControlPlaneState().packets[0].releaseState).toBe('pending');
+    expect(git(f.repoPath, 'rev-parse', 'main')).toBe(f.base);
+  });
+
+  it('checks the target branch even when the repository checkout itself contains the work', async () => {
+    const f = fixture();
+    const head = commit(f.worktreePath, 'not on target');
+    git(f.repoPath, 'checkout', '--detach', head);
+    expect(await approveAndMergePacket({ packetId: f.packet.id })).toMatchObject({ merged: false });
+    expect(git(f.repoPath, 'rev-parse', 'main')).toBe(f.base);
+  });
+
+  it('reads the real worktree HEAD when it has detached from the recorded branch', async () => {
+    const f = fixture();
+    git(f.worktreePath, 'checkout', '--detach');
+    commit(f.worktreePath, 'detached successor');
+    expect(await approveAndMergePacket({ packetId: f.packet.id })).toMatchObject({ merged: false });
+    expect(control.readOrchestratorControlPlaneState().packets[0].releaseState).toBe('pending');
+  });
+
+  it('does not hide uncommitted work behind a previously merged HEAD', async () => {
+    const f = fixture();
+    writeFileSync(join(f.worktreePath, 'app.txt'), 'uncommitted successor\n');
+    expect(await approveAndMergePacket({ packetId: f.packet.id })).toMatchObject({ merged: false });
+    expect(git(f.worktreePath, 'status', '--porcelain')).not.toBe('');
+  });
+
+  it('preserves a genuine clean merge receipt', async () => {
+    const f = fixture();
+    const head = commit(f.worktreePath, 'merged work');
+    git(f.repoPath, 'merge', '--ff-only', f.branch);
+    persist({ ...f.packet, releaseStatePayload: { ...f.packet.releaseStatePayload, mergeCommit: head, headSha: head } }, f.repoPath);
+    expect(await approveAndMergePacket({ packetId: f.packet.id })).toMatchObject({
+      merged: true, alreadyReleased: true, mergeSha: head, ancestryVerified: true,
+    });
+  });
+
+  it('accepts a recorded squash merge of the same HEAD but rejects a later successor', async () => {
+    const f = fixture();
+    const head = commit(f.worktreePath, 'squashed work');
+    git(f.repoPath, 'merge', '--squash', f.branch);
+    git(f.repoPath, 'commit', '-qm', 'squash receipt');
+    const mergeSha = git(f.repoPath, 'rev-parse', 'HEAD');
+    persist({ ...f.packet, releaseStatePayload: { ...f.packet.releaseStatePayload, mergeCommit: mergeSha, headSha: head } }, f.repoPath);
+    expect(await approveAndMergePacket({ packetId: f.packet.id })).toMatchObject({
+      merged: true, alreadyReleased: true, mergeSha,
+    });
+    commit(f.worktreePath, 'unmerged after squash');
+    expect(await approveAndMergePacket({ packetId: f.packet.id })).toMatchObject({ merged: false });
+  });
+
+  it('keeps a genuine release readable after its merged worktree and branch are removed', async () => {
+    const f = fixture();
+    const head = commit(f.worktreePath, 'merged and cleaned');
+    git(f.repoPath, 'merge', '--ff-only', f.branch);
+    persist({ ...f.packet, releaseStatePayload: { ...f.packet.releaseStatePayload, mergeCommit: head, headSha: head } }, f.repoPath);
+    git(f.repoPath, 'worktree', 'remove', f.worktreePath);
+    git(f.repoPath, 'branch', '-d', f.branch);
+    expect(await approveAndMergePacket({ packetId: f.packet.id })).toMatchObject({
+      merged: true, alreadyReleased: true, mergeSha: head,
+    });
+  });
+
+  it('allows a genuine lane-only merge event but not a generic completion event', async () => {
+    const f = fixture();
+    const head = commit(f.worktreePath, 'landed orphan');
+    git(f.repoPath, 'merge', '--ff-only', f.branch);
+    control.writeOrchestratorControlPlaneState(createEmptyOrchestratorMissionState());
+    recordLaneEvent(f.lane.id, 'status_change', 'system', { status: 'completed', laneHeadSha: head });
+    expect(await alreadyReleasedResultForPacketId(f.packet.id, [])).toBeNull();
+    recordLaneEvent(f.lane.id, 'merge', 'system', { laneHeadSha: head });
+    expect(await alreadyReleasedResultForPacketId(f.packet.id, [])).toMatchObject({ merged: true, mergeSha: head });
+  });
+
+  it('does not apply a completed sibling lane to the currently bound recovery lane', async () => {
+    const f = fixture();
+    const head = commit(f.worktreePath, 'new recovery work');
+    const old = createLane({ repoPath: f.repoPath, branch: 'main', baseBranch: 'main',
+      runtime: 'codex', packetId: f.packet.id });
+    setLaneStatus(old.id, 'completed', 'system');
+    recordLaneEvent(old.id, 'merge', 'system', { laneHeadSha: f.base });
+    const packet = persist({ ...f.packet, releaseState: 'pending', releaseStatePayload: null,
+      status: 'awaiting_review' }, f.repoPath);
+    expect(await alreadyReleasedResultForPacketId(packet.id, [packet])).toBeNull();
+    expect(git(f.worktreePath, 'rev-parse', 'HEAD')).toBe(head);
+  });
+
+  it('fails closed when a worktree exists but its HEAD cannot be read', async () => {
+    const f = fixture();
+    // An existing non-repository directory is not evidence of successful cleanup.
+    const invalid = mkdtempSync(join(tmpdir(), 'o8-unreadable-release-'));
+    roots.push(invalid);
+    expect(await alreadyReleasedResultForPacket(f.packet, { ...f.lane, worktreePath: invalid })).toBeNull();
+  });
+
+  it('does not mistake another local branch for the release target', async () => {
+    const f = fixture();
+    git(f.repoPath, 'branch', 'stable', f.base);
+    const head = commit(f.worktreePath, 'only on main');
+    git(f.repoPath, 'merge', '--ff-only', f.branch);
+    const packet = persist({ ...f.packet, releaseStatePayload: { ...f.packet.releaseStatePayload, mergeCommit: head, headSha: head } }, f.repoPath);
+    expect(await alreadyReleasedResultForPacket(packet, { ...f.lane, baseBranch: 'stable' })).toBeNull();
+  });
+
+  it.each(['stop', 'archive'] as const)('keeps the %s boundary while clearing stale release evidence', async (hold) => {
+    const f = fixture();
+    commit(f.worktreePath, 'unmerged');
+    const packet = persist({ ...f.packet, status: hold === 'archive' ? 'archived' : 'blocked',
+      operatorStopped: hold === 'stop', archivedAt: hold === 'archive' ? '2026-09-10T00:01:00.000Z' : null,
+      blockedReason: 'operator hold' }, f.repoPath);
+    expect(await alreadyReleasedResultForPacket(packet, f.lane)).toBeNull();
+    expect(control.readOrchestratorControlPlaneState().packets[0]).toMatchObject({
+      releaseState: 'pending', status: packet.status, queueState: 'held',
+      operatorStopped: packet.operatorStopped, archivedAt: packet.archivedAt,
+    });
+  });
+
+  it('does not overwrite a newer receipt while an older Git check waits for the state lock', async () => {
+    const f = fixture();
+    const head = commit(f.worktreePath, 'successor');
+    const lockedWrite = vi.spyOn(control, 'withLockedState');
+    let checking!: ReturnType<typeof alreadyReleasedResultForPacket>;
+    let fresh!: OrchestratorPacket;
+    await control.withControlPlaneLock(async () => {
+      checking = alreadyReleasedResultForPacket(f.packet, f.lane);
+      await vi.waitFor(() => expect(lockedWrite).toHaveBeenCalled());
+      git(f.repoPath, 'merge', '--ff-only', f.branch);
+      fresh = persist({ ...f.packet, attemptCount: 2, releaseStatePayload: {
+        ...f.packet.releaseStatePayload, mergeCommit: head, headSha: head, releasedAt: '2026-09-10T00:02:00.000Z',
+      } }, f.repoPath);
+    });
+    expect(await checking).toBeNull();
+    expect(control.readOrchestratorControlPlaneState().packets[0]).toMatchObject({
+      releaseState: fresh.releaseState, releaseStatePayload: fresh.releaseStatePayload,
+      attemptCount: fresh.attemptCount, status: fresh.status, queueState: fresh.queueState,
+    });
+  });
+});

--- a/tests/review-state-released-real-path.test.ts
+++ b/tests/review-state-released-real-path.test.ts
@@ -124,8 +124,9 @@ describe('review state for released but unmerged packets through the real route'
     });
     expect(readOrchestratorControlPlaneState().packets[0]).toMatchObject({
       id: packetId,
-      releaseState: 'released',
-      releaseStatePayload: { mergeCommit: null },
+      releaseState: 'pending',
+      releaseStatePayload: null,
+      queueState: 'held',
     });
   });
 });

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1412,6 +1412,16 @@
       ]
     },
     {
+      "path": "tests/execution-carrier-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "executable-fixture",
+        "git-cli",
+        "process-signal",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/feedback-sync-reports.test.ts",
       "reasons": [
         "executable-fixture"

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1039,6 +1039,14 @@
       ]
     },
     {
+      "path": "tests/automatic-release-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/automation-fire-spine-real-path.test.ts",
       "reasons": [
         "real-path"
@@ -1582,6 +1590,14 @@
       ]
     },
     {
+      "path": "tests/forced-review-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/github-broker-supervisor-sync-real-path.test.ts",
       "reasons": [
         "real-path"
@@ -1786,6 +1802,17 @@
       "path": "tests/managed-run-registry-termination.test.ts",
       "reasons": [
         "process-signal"
+      ]
+    },
+    {
+      "path": "tests/managed-run-routing-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "executable-fixture",
+        "network-listener",
+        "process-signal",
+        "real-path",
+        "terminal-tool"
       ]
     },
     {
@@ -2119,6 +2146,14 @@
       ]
     },
     {
+      "path": "tests/packet-explainer-restart-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "process-signal",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/packet-launch-cross-process-real-path.test.ts",
       "reasons": [
         "child-process",
@@ -2290,6 +2325,14 @@
       "reasons": [
         "git-cli",
         "native-build"
+      ]
+    },
+    {
+      "path": "tests/release-truth-entry-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path"
       ]
     },
     {

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1493,6 +1493,16 @@
       ]
     },
     {
+      "path": "tests/execution-carrier-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "executable-fixture",
+        "git-cli",
+        "process-signal",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/feedback-sync-reports.test.ts",
       "reasons": [
         "executable-fixture"
@@ -2096,6 +2106,14 @@
       "reasons": [
         "child-process",
         "git-cli",
+        "real-path"
+      ]
+    },
+    {
+      "path": "tests/owned-carrier-signal-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "process-signal",
         "real-path"
       ]
     },

--- a/tests/worktree-reaper-pr-merge.test.ts
+++ b/tests/worktree-reaper-pr-merge.test.ts
@@ -15,7 +15,6 @@ const targetedHeadRefreshes = new Map<string, {
   closedAt?: string | null;
   mergedAt?: string | null;
 }>();
-const queueHeadlessPacketReleaseMock = vi.hoisted(() => vi.fn());
 
 vi.doMock('@/lib/github-broker/sync', () => ({
   ensureGitHubPullRequest: vi.fn(async (repoFullName: string, prNumber: number) => {
@@ -69,17 +68,6 @@ vi.doMock('@/lib/worktree/live-process-guard', () => ({
   allowWorktreeRemoval: vi.fn(async () => true),
 }));
 
-vi.doMock('@/lib/orchestrator/headless-loop', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/lib/orchestrator/headless-loop')>();
-  return {
-    ...actual,
-    queueHeadlessPacketRelease: (packetIds: string[]) => {
-      queueHeadlessPacketReleaseMock(packetIds);
-      actual.queueHeadlessPacketRelease(packetIds);
-    },
-  };
-});
-
 const { closeDb, getSqlite } = await import('@/lib/db');
 const { createLane, getLane, getLaneEvents } = await import('@/lib/lane/registry');
 const { runWorktreeReaperTick } = await import('@/lib/lane/worktree-reaper');
@@ -97,7 +85,6 @@ afterAll(() => {
 
 afterEach(() => {
   targetedHeadRefreshes.clear();
-  queueHeadlessPacketReleaseMock.mockClear();
 });
 
 function git(cwd: string, args: string[]): string {
@@ -583,7 +570,7 @@ describe('worktree reaper PR merge reconciliation', () => {
   });
 });
 
-  it('queues the packet release when a PR-merged lane is reconciled (sequential wave parity)', { timeout: 20_000 }, async () => {
+  it('does not invent a packet release for a lane absent from durable missions', { timeout: 20_000 }, async () => {
     const repoPath = makeRepo();
     const lane = createLane({
       repoPath,
@@ -604,5 +591,6 @@ describe('worktree reaper PR merge reconciliation', () => {
     await runWorktreeReaperTick();
 
     expect(getLane(lane.id)?.status).toBe('archived');
-    expect(queueHeadlessPacketReleaseMock).toHaveBeenCalledWith(['pkt-pr-merged-release']);
+    const { readOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+    expect(readOrchestratorControlPlaneState().packets.some((packet) => packet.id === lane.packetId)).toBe(false);
   });


### PR DESCRIPTION
## Summary

Integrate the typed execution-carrier contribution from #2073 with the reviewed Mac lifecycle, routing, and build-cache fixes.

- Preserve runtime identity while an optional carrier supplies executable arguments and authentication. Direct launch remains the default.
- Refuse carrier runtime overrides that cannot select the intended executable. Require live process ownership before a POSIX worker can be signaled; recognize only executable positions in Windows command checks.
- Keep packet explainers off by default and give each attempt durable ownership across restart and supersession.
- Require current-work evidence before releasing or archiving a packet. Completion or a historical merged PR is not sufficient.
- Clear stale inherited routing from managed commands, and refuse native build-cache reuse from an unverified or different checkout.

## Contributor credit

The execution-carrier implementation is by @techlowneko in #2073. This integration retains the original contribution commits and their authorship, including the earlier fixture follow-up, rather than copying or squashing away that history. Maintainer changes resolve the current-main conflict, correct runtime pinning and process verification, and update the test fixtures for current lifecycle and credential contracts.

## Verification

- Full hermetic suite: 4,474 passed, 4 skipped.
- TypeScript, touched-file ESLint, test classification, and repository rule checks passed.
- Isolated carrier test exercises real launch, resume, transcript and usage parsing, changed-file evidence, literal prompt arguments, owned-tree Stop, and worktree reclamation.
- Additional real-process tests cover missing markers, wrong markers, wrong process groups, and wrappers that replace their executable.
- Targeted release, cache, routing, explainer-restart, and review tests exercise persisted state and real entry points.

The first combined carrier run failed because the shell fixture hid its process marker on macOS. The revised fixture asserts marker and group proof before Stop; production checks were not relaxed. Routing fixtures now mock the current credential-preparation function and do not rely on an operator login.

## Boundaries

Source integration only. No version bump, installer publication, installed-app replacement, live provider acceptance claim, dependency upgrade, or worktree cleanup. The carrier is opt-in. Packaged acceptance remains separate from these source and fixture checks.

Closes #2037.
Refs #2073, #2139, #2135, #2131, #2130. The Mac acceptance issues remain open pending candidate verification.
