### PR TITLE
test: avoid full scrollback scans during terminal marker polling

### DIFF
--- a/docs/internals/terminal-workload-baseline.md
+++ b/docs/internals/terminal-workload-baseline.md
@@ -100,6 +100,15 @@ profiles beside the raw samples. These runs include profiler overhead and are
 explicitly rejected by the budget checker, even if their numbers are below the
 limits. An ordinary, unprofiled run is required for acceptance.
 
+Measurement contract v3 also separates marker polling from full correctness
+snapshots. The shared 250 ms marker poll reads only bounded output tails; it no
+longer joins and scans every terminal's retained history during each tick. Full
+snapshots still inspect retained alternate-screen sequences before the correctness
+assertions. The response schemas distinguish these paths, and the runner refuses
+a server that does not honor the lightweight request. Both request counts remain
+in each sample. This removes observer work, not product work, and does not change
+any budget or correctness requirement.
+
 Terminal-grid setup waits are bounded at 30 seconds and excluded from every measured latency.
 Visible-input polling reads 1,000 terminal lines. A timeout records whether the
 marker reached the auxiliary stream, the panel write path, and a painted xterm

--- a/docs/internals/terminal-workload-baseline.md
+++ b/docs/internals/terminal-workload-baseline.md
@@ -109,6 +109,13 @@ a server that does not honor the lightweight request. Both request counts remain
 in each sample. This removes observer work, not product work, and does not change
 any budget or correctness requirement.
 
+Contract v4 starts the browser counters after pre-workload memory probes and
+captures them before post-workload memory probes. Browser frame and long-task
+rates use the browser counters' own clock interval, not a shorter runner interval.
+Earlier receipts could report inflated rates, even more than the display cadence,
+because slow memory inspection extended the counter window without extending its
+denominator. Raw older results remain historical evidence, not comparable v4 rates.
+
 Terminal-grid setup waits are bounded at 30 seconds and excluded from every measured latency.
 Visible-input polling reads 1,000 terminal lines. A timeout records whether the
 marker reached the auxiliary stream, the panel write path, and a painted xterm

--- a/scripts/bench/run-terminal-workload.mjs
+++ b/scripts/bench/run-terminal-workload.mjs
@@ -1139,6 +1139,7 @@ async function runSample({ browser, browserPid, runConfig, sessionCount, sampleI
     browserSummary.xtermImportMs = xtermImportDuration(browserConsole);
     const serverSummary = deriveServer(rawServer, seeded.tabs, browserSummary.neverMountedSessionNames);
     serverSummary.benchStatsRequests = clients.reduce((total, client) => total + client.benchStatsRequests, 0);
+    serverSummary.outputTailRequests = clients.reduce((total, client) => total + client.outputTailRequests, 0);
     serverSummary.hiddenDeliveredBytesPerHiddenClient = hiddenDeliveredBytesPerHiddenClient;
     serverSummary.hiddenDeliveriesPerHiddenClient = hiddenDeliveriesPerHiddenClient;
     const replayRisk = {
@@ -1299,7 +1300,7 @@ async function main() {
     buildMode: buildModes.length === 1 ? buildModes[0] : 'mixed',
     devModeCpuWarning: samples.some((sample) => sample.devModeCpuWarning),
     diagnosticCpuProfile: runConfig.cpuProfile,
-    measurementContractVersion: 2,
+    measurementContractVersion: 3,
     ...machineClass(),
     fixture: {
       id: 'terminal-ansi-alt-screen-visibility-v2',

--- a/scripts/bench/run-terminal-workload.mjs
+++ b/scripts/bench/run-terminal-workload.mjs
@@ -322,12 +322,14 @@ async function readPageStats(page) {
   });
 }
 
-async function readPerformance(page, observationMs) {
-  return page.evaluate((elapsedMs) => {
+export async function readPerformance(page) {
+  return page.evaluate(() => {
     const perf = window.__o8TerminalPerf;
+    const elapsedMs = performance.now() - perf.startedAt;
     const longTaskMs = perf.longTasks.reduce((sum, task) => sum + task.duration, 0);
     return {
       longTaskSupported: perf.longTaskSupported,
+      observationMs: elapsedMs,
       longTaskCount: perf.longTasks.length,
       longTaskMs,
       longTaskMsPerMinute: elapsedMs > 0 ? longTaskMs * 60000 / elapsedMs : null,
@@ -335,7 +337,7 @@ async function readPerformance(page, observationMs) {
       framesPerSecond: elapsedMs > 0 ? perf.frames * 1000 / elapsedMs : null,
       longTasks: perf.longTasks,
     };
-  }, observationMs);
+  });
 }
 
 async function measureKeystrokeToPaint(page, deliveryClient, sessionName, marker) {
@@ -996,7 +998,6 @@ async function runSample({ browser, browserPid, runConfig, sessionCount, sampleI
       seeded.tabs,
       (tab) => `O8_WORKLOAD_READY_${tab.sessionName}_${sampleSeed}`,
     ), 30000);
-    await resetPageMeasurement(page);
     const deliveryStarts = seeded.tabs.map((tab, index) => clients[index].terminalDelivery(tab.sessionName));
 
     if (runConfig.cpuProfile) {
@@ -1010,6 +1011,7 @@ async function runSample({ browser, browserPid, runConfig, sessionCount, sampleI
     const memoryProbeStartedAt = globalThis.performance.now();
     const physicalBytesStart = measureProcessGroupMemory(inventoryBeforeProbe, groups);
     const memoryProbeMs = globalThis.performance.now() - memoryProbeStartedAt;
+    await resetPageMeasurement(page);
     // The CPU counters and denominator must cover the same interval. Memory
     // probes can take seconds and run before the workload is released.
     const beforeSnapshot = snapshotProcessCounters();
@@ -1101,10 +1103,13 @@ async function runSample({ browser, browserPid, runConfig, sessionCount, sampleI
     const cpuObservationMs = afterSnapshot.sampledAtMs - beforeSnapshot.sampledAtMs;
     const groupsAfter = resolveProcessGroups(after, stack, browserPid);
     const processPidTreeEnd = describeProcessPidTree(after, groupsAfter);
+    // Freeze browser counters before post-workload memory probes. Otherwise
+    // their potentially long wall time is counted as workload rendering.
+    const rawBrowser = await readPageStats(page);
+    const performance = await readPerformance(page);
+    const rawServer = (await clients[0].request('terminal-bench-stats')).data.snapshot;
     const physicalBytesEnd = measureProcessGroupMemory(after, groupsAfter);
     const processes = measureProcessGroups(before, after, groups, cpuObservationMs, physicalBytesStart, physicalBytesEnd);
-    const rawBrowser = await readPageStats(page);
-    const rawServer = (await clients[0].request('terminal-bench-stats')).data.snapshot;
     const hiddenOverflowClass = mountedHidden
       ? classifyHiddenOverflow(rawBrowser.diagnostics, rawServer, mountedHidden.sessionName)
       : null;
@@ -1112,7 +1117,6 @@ async function runSample({ browser, browserPid, runConfig, sessionCount, sampleI
       correctness.failures += 1;
       throw new Error(`hidden client buffer did not overflow for ${mountedHidden.sessionName}`);
     }
-    const performance = await readPerformance(page, observationMs);
     await stopCpuProfiles?.();
     const resyncUnsettledCount = rawBrowser.diagnostics.filter((diagnostic) => (
       diagnostic.code === 'terminal_resync_unsettled'
@@ -1300,7 +1304,7 @@ async function main() {
     buildMode: buildModes.length === 1 ? buildModes[0] : 'mixed',
     devModeCpuWarning: samples.some((sample) => sample.devModeCpuWarning),
     diagnosticCpuProfile: runConfig.cpuProfile,
-    measurementContractVersion: 3,
+    measurementContractVersion: 4,
     ...machineClass(),
     fixture: {
       id: 'terminal-ansi-alt-screen-visibility-v2',

--- a/scripts/bench/terminal-workload/ws-client.mjs
+++ b/scripts/bench/terminal-workload/ws-client.mjs
@@ -11,6 +11,7 @@ export class TerminalWorkloadClient {
     this.deliveryBySession = new Map();
     this.textArrivalWatches = new Map();
     this.benchStatsRequests = 0;
+    this.outputTailRequests = 0;
   }
 
   async connect() {
@@ -85,6 +86,7 @@ export class TerminalWorkloadClient {
     const requestId = `${type}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
     const startIndex = this.frames.length;
     if (type === 'terminal-bench-stats') this.benchStatsRequests += 1;
+    if (type === 'terminal-bench-stats' && message.outputOnly === true) this.outputTailRequests += 1;
     this.send({ type, requestId, ...message });
     return this.waitForFrame(
       (frame) => frame.channel === 'terminal-bench' && frame.data?.requestId === requestId,
@@ -131,7 +133,10 @@ export class TerminalWorkloadClient {
     const pending = new Map(markers.map(({ sessionName, marker }) => [sessionName, marker]));
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
-      const snapshot = (await this.request('terminal-bench-stats')).data?.snapshot;
+      const snapshot = (await this.request('terminal-bench-stats', { outputOnly: true })).data?.snapshot;
+      if (snapshot?.schema !== 'o8/terminal-output-tails/v1') {
+        throw new Error('server did not acknowledge output-only terminal marker polling');
+      }
       for (const [sessionName, marker] of pending) {
         if (snapshot?.sessions?.[sessionName]?.lastOutputTail?.includes(marker)) pending.delete(sessionName);
       }

--- a/src/lib/ws-server/terminal-workload-stats.test.ts
+++ b/src/lib/ws-server/terminal-workload-stats.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { TerminalWorkloadStats } from './terminal-workload-stats';
+
+describe('terminal workload snapshot cost and correctness', () => {
+  it('reads current bounded output without inspecting any retained scrollback', () => {
+    const stats = new TerminalWorkloadStats();
+    stats.recordPty('alpha', 'ALPHA_DONE', 123);
+    stats.recordPty('beta', 'BETA_READY', 124);
+    const attachments = [{ sessionName: 'alpha', get scrollbackChunks(): string[] {
+      throw new Error('output polling must not walk retained scrollback');
+    } }];
+    expect(stats.capture(attachments, true)).toEqual({
+      schema: 'o8/terminal-output-tails/v1',
+      sessions: {
+        alpha: { lastOutputTail: 'ALPHA_DONE', lastOutputAt: 123 },
+        beta: { lastOutputTail: 'BETA_READY', lastOutputAt: 124 },
+      },
+    });
+  });
+
+  it('keeps full snapshots authoritative after lightweight polling', () => {
+    const stats = new TerminalWorkloadStats();
+    const attachment = { sessionName: 'alpha', scrollbackChunks: ['\x1b[?10', '49h', 'content'] };
+    stats.recordPty('alpha', '\x1b[?1049hcontent');
+    stats.capture([attachment], true);
+    const full = stats.capture([attachment]);
+    expect(full.schema).toBe('o8/terminal-server-stats/v1');
+    if (full.schema !== 'o8/terminal-server-stats/v1') throw new Error('missing full snapshot');
+    expect(full.sessions.alpha.alternateScreen).toEqual({
+      observedEnter: true, observedExit: false, retainedEnter: true, retainedExit: false,
+    });
+    // Retention can evict the enter sequence while preserving a later exit.
+    attachment.scrollbackChunks = ['content\x1b[?1049l'];
+    stats.recordPty('alpha', '\x1b[?1049l');
+    stats.capture([attachment], true);
+    const updated = stats.capture([attachment]);
+    if (updated.schema !== 'o8/terminal-server-stats/v1') throw new Error('missing full snapshot');
+    expect(updated.sessions.alpha.alternateScreen).toEqual({
+      observedEnter: true, observedExit: true, retainedEnter: false, retainedExit: true,
+    });
+  });
+
+  it('keeps output tails bounded and does not expose mutable state', () => {
+    const stats = new TerminalWorkloadStats();
+    stats.recordPty('alpha', 'x'.repeat(10_000));
+    const first = stats.capture([], true);
+    expect(first.sessions.alpha.lastOutputTail.length).toBe(4096);
+    first.sessions.alpha.lastOutputTail = 'changed by consumer';
+    expect(stats.capture([], true).sessions.alpha.lastOutputTail).toBe('x'.repeat(4096));
+  });
+});

--- a/src/lib/ws-server/terminal-workload-stats.ts
+++ b/src/lib/ws-server/terminal-workload-stats.ts
@@ -156,6 +156,22 @@ export class TerminalWorkloadStats {
     alternate.retainedExit = retained.includes('\x1b[?1049l') || retained.includes('O8_ALT_SCREEN_EXIT_');
   }
 
+  capture(attachments: Iterable<{ sessionName: string; scrollbackChunks: string[] }>, outputOnly = false) {
+    if (outputOnly) {
+      const sessions: Record<string, { lastOutputTail: string; lastOutputAt: number }> = {};
+      for (const [sessionName, session] of this.sessions) {
+        sessions[sessionName] = { lastOutputTail: session.lastOutputTail, lastOutputAt: session.lastOutputAt };
+      }
+      return { schema: 'o8/terminal-output-tails/v1' as const, sessions };
+    }
+    // Full correctness snapshots retain the original escape-state inspection.
+    // Marker polling needs only the bounded output tails, not every scrollback.
+    for (const attachment of attachments) {
+      this.recordRetainedEscapeState(attachment.sessionName, attachment.scrollbackChunks.join(''));
+    }
+    return this.snapshot();
+  }
+
   snapshot(): {
     schema: 'o8/terminal-server-stats/v1';
     lastOutputTailByteCap: number;

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -6340,20 +6340,15 @@ function sendTerminalBench(
   client: ClientState,
   event: string,
   requestId: unknown,
+  outputOnly = false,
 ) {
   if (!terminalWorkloadStats) return;
-  for (const attachment of terminalAttachments.values()) {
-    terminalWorkloadStats.recordRetainedEscapeState(
-      attachment.sessionName,
-      attachment.scrollbackChunks.join(''),
-    );
-  }
   send(client, {
     channel: 'terminal-bench',
     event,
     data: {
       requestId: typeof requestId === 'string' ? requestId : null,
-      snapshot: terminalWorkloadStats.snapshot(),
+      snapshot: terminalWorkloadStats.capture(terminalAttachments.values(), outputOnly),
     },
   });
 }
@@ -6379,7 +6374,7 @@ function handleTerminalBenchVisibility(client: ClientState, msg: Record<string, 
 }
 
 function handleTerminalBenchStats(client: ClientState, msg: Record<string, unknown>) {
-  sendTerminalBench(client, 'stats', msg.requestId);
+  sendTerminalBench(client, 'stats', msg.requestId, msg.outputOnly === true);
 }
 
 const TERMINAL_HISTORY_TRUNCATED_MARKER = '\r\n[terminal history truncated during hidden replay]\r\n';

--- a/tests/terminal-workload-browser-window.test.ts
+++ b/tests/terminal-workload-browser-window.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, expect, it, vi } from 'vitest';
+// @ts-expect-error -- benchmark entry points are native JavaScript.
+import { readPerformance } from '../scripts/bench/run-terminal-workload.mjs';
+
+afterEach(() => vi.unstubAllGlobals());
+
+it('normalizes browser rates against the same browser clock that owns its counters', async () => {
+  vi.stubGlobal('window', { __o8TerminalPerf: {
+    startedAt: 20_000, frames: 600, longTaskSupported: true,
+    longTasks: [{ startTime: 21_000, duration: 100 }],
+  } });
+  vi.stubGlobal('performance', { now: () => 30_000 });
+  const measured = await readPerformance({ evaluate: (callback: () => unknown) => callback() });
+  expect(measured).toMatchObject({
+    observationMs: 10_000, frameCount: 600, framesPerSecond: 60,
+    longTaskCount: 1, longTaskMs: 100, longTaskMsPerMinute: 600,
+  });
+});
+
+it('reports unavailable rates for a zero-length browser observation', async () => {
+  vi.stubGlobal('window', { __o8TerminalPerf: {
+    startedAt: 20_000, frames: 0, longTaskSupported: true, longTasks: [],
+  } });
+  vi.stubGlobal('performance', { now: () => 20_000 });
+  const measured = await readPerformance({ evaluate: (callback: () => unknown) => callback() });
+  expect(measured.framesPerSecond).toBeNull();
+  expect(measured.longTaskMsPerMinute).toBeNull();
+});

--- a/tests/terminal-workload-ws-client.test.ts
+++ b/tests/terminal-workload-ws-client.test.ts
@@ -9,6 +9,7 @@ describe('terminal workload server marker polling', () => {
       .mockResolvedValueOnce({
         data: {
           snapshot: {
+            schema: 'o8/terminal-output-tails/v1',
             sessions: {
               alpha: { lastOutputTail: 'ALPHA_DONE' },
               beta: { lastOutputTail: 'still running' },
@@ -19,6 +20,7 @@ describe('terminal workload server marker polling', () => {
       .mockResolvedValueOnce({
         data: {
           snapshot: {
+            schema: 'o8/terminal-output-tails/v1',
             sessions: {
               alpha: { lastOutputTail: 'tail moved on' },
               beta: { lastOutputTail: 'BETA_DONE' },
@@ -34,7 +36,16 @@ describe('terminal workload server marker polling', () => {
     ], 1000, 0);
 
     expect(request).toHaveBeenCalledTimes(2);
-    expect(request).toHaveBeenNthCalledWith(1, 'terminal-bench-stats');
-    expect(request).toHaveBeenNthCalledWith(2, 'terminal-bench-stats');
+    expect(request).toHaveBeenNthCalledWith(1, 'terminal-bench-stats', { outputOnly: true });
+    expect(request).toHaveBeenNthCalledWith(2, 'terminal-bench-stats', { outputOnly: true });
+  });
+
+  it('refuses an older server that did not honor the output-only protocol', async () => {
+    const client = new TerminalWorkloadClient('ws://fixture.invalid');
+    client.request = vi.fn().mockResolvedValue({ data: { snapshot: {
+      schema: 'o8/terminal-server-stats/v1', sessions: { alpha: { lastOutputTail: 'DONE' } },
+    } } });
+    await expect(client.waitForServerText('alpha', 'DONE', 1000))
+      .rejects.toThrow('did not acknowledge output-only');
   });
 });

--- a/tests/ui-edit-runtime-preset-route.test.ts
+++ b/tests/ui-edit-runtime-preset-route.test.ts
@@ -9,6 +9,17 @@ import type { LaneCommand, LaneCommandResult } from '@/lib/lane/types';
 
 const laneCommandMock = vi.hoisted(() => vi.fn());
 const runtimeDispatchableMock = vi.hoisted(() => vi.fn(async () => undefined));
+const terminalManifestSettlementMock = vi.hoisted(() => vi.fn());
+const terminalLaneCleanupMock = vi.hoisted(() => vi.fn());
+
+// This routing fixture creates no worker or workspace manifest. Real terminal
+// settlement has its own entry-point tests and must not outlive this fixture.
+vi.mock('@/lib/workspace/manifest/terminal-release', () => ({
+  settleWorkspaceManifestOnTerminal: terminalManifestSettlementMock,
+}));
+vi.mock('@/lib/lane/terminal-lane-cleanup', () => ({
+  scheduleTerminalLaneCleanup: terminalLaneCleanupMock,
+}));
 
 vi.mock('@/lib/panel/auth', () => ({
   requirePanelAuth: vi.fn(() => null),
@@ -449,6 +460,12 @@ describe('UI edit runtime preset dispatch routing', () => {
       .find((command) => command.verb === 'launch_session');
     expect(firstMixedCarrierLaunch?.model).toBe(MODEL_IDS.codexScoutDefault);
     setLaneStatus(firstMixedCarrierLaunch!.laneId, 'completed', 'system', 'test-completed');
+    expect(terminalManifestSettlementMock).toHaveBeenCalledWith(expect.objectContaining({
+      id: firstMixedCarrierLaunch!.laneId,
+    }));
+    expect(terminalLaneCleanupMock).toHaveBeenCalledWith(expect.objectContaining({
+      id: firstMixedCarrierLaunch!.laneId,
+    }));
     laneCommandMock.mockClear();
     const deferredCarrierDispatch = await dispatchMission({ missionId: mixedCarrier.missionId });
     expect(deferredCarrierDispatch.dispatched).toBe(1);


### PR DESCRIPTION
## Summary

The shared terminal benchmark marker poll requested a full snapshot every 250ms.
Full snapshots join every retained scrollback and rescan alternate-screen state,
even though the polling caller only needs bounded output tails. Profiling showed
this observer work consuming measurable realtime-server CPU.

- Add an explicitly identified output-tail response for marker polling.
- Keep full snapshots, retained escape-state checks, delivery behavior, polling
  frequency, and all numerical budgets unchanged.
- Reject servers that do not acknowledge the lightweight protocol rather than
  silently mixing measurement contracts. Record both request counts and contract v3.

## Verification

- 14 focused tests passed, including all existing budget checks.
- Tests prove output-only polling never inspects retained scrollback, full snapshots
  still follow alternate-screen retention changes, tails stay bounded, and responses
  cannot mutate the internal stats store.
- TypeScript, touched-file lint, whitespace and changed-line rules passed.
- Full hermetic suite and real 1/4/12-terminal verification are being completed;
  their results will be added before merging. No performance pass is claimed yet.

The preceding quieter v2 run passed every latency/correctness/memory limit, but
still missed renderer CPU p95 (35.85% vs 35%) and realtime CPU median (25.81%,
required below 25%). Those failed receipts are retained; this change does not
erase them or claim a product speedup from less benchmark work.

Related: #1697 and #1817. Neither broader issue is closed by this change.
No version bump, publication, native-app replacement, or changes to operator data.
