### PR TITLE
chore(ci): keep the PR size advisory to one updated comment, no review threads

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -87,38 +87,34 @@ jobs:
               core.info('Fork pull request detected; wrote the report to the job summary.');
             } else {
               try {
-                await github.rest.issues.createComment({
+                // Update the bot's earlier comment in place so repeated pushes
+                // do not stack duplicate reports on the PR.
+                const marker = '## 🔍 PR Review Bot';
+                const existing = await github.paginate(github.rest.issues.listComments, {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: context.issue.number,
-                  body,
+                  per_page: 100,
                 });
+                const mine = existing.find((c) =>
+                  c.user && c.user.type === 'Bot' && typeof c.body === 'string' && c.body.startsWith(marker));
+                if (mine) {
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: mine.id,
+                    body,
+                  });
+                } else {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    body,
+                  });
+                }
               } catch (error) {
                 if (error.status !== 403) throw error;
                 core.warning(`Could not post the PR review comment: ${error.message}`);
-              }
-            }
-
-            // Also post inline review comments on large files
-            const reviewComments = [];
-            for (const f of stats.largeFiles.slice(0, 3)) {
-              reviewComments.push({
-                path: f.filename,
-                position: 1,
-                body: `⚠️ This file has ${f.changes} lines changed (+${f.additions}/-${f.deletions}). Consider if this can be broken into smaller changes.`,
-              });
-            }
-
-            if (!isFork && reviewComments.length > 0) {
-              try {
-                await github.rest.pulls.createReview({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: context.issue.number,
-                  event: 'COMMENT',
-                  comments: reviewComments,
-                });
-              } catch (e) {
-                core.warning(`Could not post inline comments: ${e.message}`);
               }
             }


### PR DESCRIPTION
## Mechanic
`pr-review.yml` posted a per-file review thread (`pulls.createReview`) for every file over 300 changed lines on every `pull_request` event. Main requires conversation resolution, so every push, including a branch update that only merges main, re-blocked the merge behind the same advisories until they were resolved by hand. #2161 collected eight.

## Change
- Removed the inline review-thread block. The summary comment already carries the "Large files (>300 lines changed)" list.
- The summary comment is now found by its heading and updated in place on later pushes instead of stacking a new comment per push.
- Fork handling, permissions, and the concurrency group are unchanged.

## Verification
- YAML parses (js-yaml load).
- This PR's own bot run exercises the new path: expect one summary comment and zero review threads.

Closes #2167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe