### PR TITLE
fix: refuse realtime model ids the realtime endpoint will not accept

### DIFF
--- a/src/app/api/mobile/symon/session/route.test.ts
+++ b/src/app/api/mobile/symon/session/route.test.ts
@@ -21,6 +21,10 @@ const h = vi.hoisted(() => ({
   resolveRealtimeAccess: vi.fn(),
   findRepoByLocalPath: vi.fn(),
   persistSymonScopeGrant: vi.fn(),
+  // Stands in for a bad model CONSTANT (the #2165 failure mode): the phone mint
+  // never takes its model from the request, so the only honest way to drive a
+  // rejected model through the real handler is to make the selector return one.
+  phoneModel: { value: null as string | null },
 }));
 
 vi.mock('@/lib/mcp/o8-webview-client', () => ({
@@ -36,6 +40,16 @@ vi.mock('@/lib/voice/realtime-access', () => ({ resolveRealtimeAccess: h.resolve
 vi.mock('@/lib/auth/principal', () => ({ resolveRequestPrincipal: h.resolveRequestPrincipal }));
 vi.mock('@/lib/mobile/device-registry', () => ({ resolveDeviceByToken: h.resolveDeviceByToken }));
 vi.mock('@/lib/repos/registry', () => ({ findRepoByLocalPath: h.findRepoByLocalPath }));
+vi.mock('@/lib/voice/realtime-session-config', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/lib/voice/realtime-session-config')>();
+  return {
+    ...original,
+    selectPhoneRealtimeModel: (input: Parameters<typeof original.selectPhoneRealtimeModel>[0]) =>
+      h.phoneModel.value
+        ? { model: h.phoneModel.value, variant: 'mini' as const }
+        : original.selectPhoneRealtimeModel(input),
+  };
+});
 vi.mock('@/lib/mobile/symon-agent-registry', async (importOriginal) => {
   const original = await importOriginal<typeof import('@/lib/mobile/symon-agent-registry')>();
   return { ...original, persistSymonScopeGrant: h.persistSymonScopeGrant };
@@ -90,6 +104,7 @@ beforeEach(() => {
   h.resolveRealtimeAccess.mockReset();
   h.findRepoByLocalPath.mockReset();
   h.persistSymonScopeGrant.mockReset();
+  h.phoneModel.value = null;
   delete (globalThis as { __o8BrowserAgentClient?: unknown }).__o8BrowserAgentClient;
   h.resolveRequestPrincipal.mockReturnValue('operator');
   h.resolveChatGPTRealtimeCredential.mockResolvedValue(null);
@@ -595,5 +610,36 @@ describe('POST /api/mobile/symon/session — mint assembly + error table', () =>
     const json = await res.json();
     expect(json.error).toBe('mint_failed');
     expect(json.detail).toContain('bad request');
+  });
+
+  it('400: refuses a model the realtime endpoint will not accept, before OpenAI', async () => {
+    h.phoneModel.value = 'gpt-live-1';
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await POST(req());
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+    expect(json.error).toBe('unsupported_realtime_model');
+    expect(json.detail).toContain('gpt-live-1');
+    expect(json.detail).toContain('gpt-realtime-2.1-mini');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('400: a rejected model never preempts the live desk session or mints a scope', async () => {
+    h.phoneModel.value = 'gpt-realtime-2.1-minii'; // near-miss typo
+    bridgeReady(true);
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await POST(req());
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).detail).toContain('gpt-realtime-2.1-minii');
+    expect(h.evalJs).not.toHaveBeenCalled();
+    expect(h.persistSymonScopeGrant).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/mobile/symon/session/route.ts
+++ b/src/app/api/mobile/symon/session/route.ts
@@ -31,6 +31,7 @@ import {
   REALTIME_BASE_URL,
   CLIENT_SECRETS_URL,
   REALTIME_TOKEN_TTL_SECONDS,
+  assertRealtimeCapableModel,
   buildClientSecretsBody,
 } from '@/lib/voice/realtime-session-config';
 
@@ -386,6 +387,31 @@ export async function POST(request: NextRequest) {
   }
   const workspaceContext = resolvedScope.context;
 
+  const requestedModelVariant = principal === 'operator'
+    ? request.headers.get('x-o8-symon-code-model')
+    : null;
+  const modelSelection = selectPhoneRealtimeModel({
+    workspaceMode: resolvedScope.workspaceMode,
+    experiment: process.env.O8_SYMON_CODE_REALTIME_EXPERIMENT,
+    bucketKey: `${subject.subject}:${subject.deviceId ?? 'operator'}:${resolvedScope.repoId ?? 'life'}`,
+    operatorOverride: requestedModelVariant,
+    experience: workspaceContext.launchKind,
+  });
+  const model = modelSelection.model;
+
+  // Resolved BEFORE the webview bridge and the mint: a model the realtime
+  // endpoint will not accept must not preempt a live desk session or burn a
+  // mint. OpenAI returns a token for such ids and only refuses them at the
+  // WebRTC/WebSocket exchange, where nothing names the model.
+  const modelCheck = assertRealtimeCapableModel(model);
+  if (!modelCheck.ok) {
+    console.warn(`${LOG} unsupported_realtime_model: ${modelCheck.reason}`);
+    return NextResponse.json(
+      { ok: false, error: 'unsupported_realtime_model', detail: modelCheck.reason },
+      { status: 400 },
+    );
+  }
+
   // Subscription voice wins whenever the standard Codex ChatGPT-OAuth session
   // is present. This is the proven #1616 path: the OAuth bearer mints the same
   // short-lived Realtime client secret as BYOK, so the phone keeps the existing
@@ -443,17 +469,6 @@ export async function POST(request: NextRequest) {
   }
 
   const sessionId = `sym-${randomUUID()}`;
-  const requestedModelVariant = principal === 'operator'
-    ? request.headers.get('x-o8-symon-code-model')
-    : null;
-  const modelSelection = selectPhoneRealtimeModel({
-    workspaceMode: resolvedScope.workspaceMode,
-    experiment: process.env.O8_SYMON_CODE_REALTIME_EXPERIMENT,
-    bucketKey: `${subject.subject}:${subject.deviceId ?? 'operator'}:${resolvedScope.repoId ?? 'life'}`,
-    operatorOverride: requestedModelVariant,
-    experience: workspaceContext.launchKind,
-  });
-  const model = modelSelection.model;
   const voice = bridge.voice;
   let phoneBridgeTools = bridge.tools;
   if (workspaceContext.workspaceMode === 'code') {

--- a/src/app/api/voice/realtime/sdp/route.ts
+++ b/src/app/api/voice/realtime/sdp/route.ts
@@ -8,6 +8,7 @@ import {
   CLIENT_SECRETS_URL,
   REALTIME_CALLS_URL,
   REALTIME_TOKEN_TTL_SECONDS,
+  assertRealtimeCapableModel,
   buildClientSecretsBody,
 } from '@/lib/voice/realtime-session-config';
 
@@ -42,6 +43,16 @@ export async function POST(request: NextRequest) {
   }
   const model = typeof body?.model === 'string' ? body.model : REALTIME_MODEL;
   const voice = typeof body?.voice === 'string' ? body.voice : DEFAULT_VOICE;
+
+  // Same gate as the desk mint: a model the realtime endpoint will not accept
+  // fails here, naming itself, instead of as an opaque SDP-exchange failure.
+  const modelCheck = assertRealtimeCapableModel(model);
+  if (!modelCheck.ok) {
+    return NextResponse.json(
+      { ok: false, error: 'unsupported_realtime_model', detail: modelCheck.reason, reason: modelCheck.reason },
+      { status: 400 },
+    );
+  }
 
   const byokKey = await resolveOpenAIKey();
   const access = await resolveRealtimeAccess(Boolean(byokKey));

--- a/src/app/api/voice/realtime/session/route.ts
+++ b/src/app/api/voice/realtime/session/route.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_VOICE,
   CLIENT_SECRETS_URL,
   REALTIME_TOKEN_TTL_SECONDS,
+  assertRealtimeCapableModel,
   buildClientSecretsBody,
 } from '@/lib/voice/realtime-session-config';
 
@@ -39,6 +40,17 @@ export async function POST(request: NextRequest) {
   const body = await request.json().catch(() => ({}));
   const voice = typeof (body as { voice?: unknown })?.voice === 'string' ? (body as { voice: string }).voice : DEFAULT_VOICE;
   const model = typeof (body as { model?: unknown })?.model === 'string' ? (body as { model: string }).model : REALTIME_MODEL;
+
+  // Refuse a non-realtime model id BEFORE spending a mint on it. OpenAI hands
+  // back a token for ids the realtime transport rejects, so the failure would
+  // otherwise surface at the SDP exchange with nothing naming the model.
+  const modelCheck = assertRealtimeCapableModel(model);
+  if (!modelCheck.ok) {
+    return NextResponse.json(
+      { ok: false, error: 'unsupported_realtime_model', detail: modelCheck.reason, reason: modelCheck.reason },
+      { status: 400 },
+    );
+  }
 
   const byokKey = await resolveOpenAIKey();
   const access = await resolveRealtimeAccess(Boolean(byokKey));

--- a/src/components/desktop/dictation/RealtimeVoiceHost.tsx
+++ b/src/components/desktop/dictation/RealtimeVoiceHost.tsx
@@ -175,6 +175,9 @@ export function RealtimeVoiceHost() {
   const respondingRef = useRef(false);
   const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [status, setStatus] = useState<RealtimeStatus>('idle');
+  // Why the session failed (e.g. a model the realtime endpoint refuses). The
+  // pill shows this instead of the generic "Voice unavailable" when we have it.
+  const [statusDetail, setStatusDetail] = useState<string | null>(null);
 
   const clearIdle = useCallback(() => {
     if (idleTimerRef.current) {
@@ -223,7 +226,10 @@ export function RealtimeVoiceHost() {
     console.log(`${LOG} starting realtime voice (voice=${voice})`);
     sessionRef.current = startRealtimeSession({
       voice,
-      onStatus: (s) => setStatus(s),
+      onStatus: (s, detail) => {
+        setStatus(s);
+        setStatusDetail(s === 'error' && detail ? detail : null);
+      },
       onEvent: (e) => {
         const t = typeof e.type === 'string' ? e.type : '';
         // HARD-GATE the idle clock on a responding flag. We must NOT lean on
@@ -498,14 +504,24 @@ export function RealtimeVoiceHost() {
   // Auto-clear the transient error pill after a few seconds.
   useEffect(() => {
     if (status !== 'error') return;
-    const t = setTimeout(() => setStatus('idle'), 3500);
+    const t = setTimeout(() => {
+      setStatus('idle');
+      setStatusDetail(null);
+    }, 3500);
     return () => clearTimeout(t);
   }, [status]);
 
   const connecting = status === 'requesting-mic' || status === 'connecting';
   const visible = connecting || status === 'live' || status === 'error';
   const dotColor = status === 'error' ? '#ef4444' : status === 'live' ? '#34d399' : '#f59e0b';
-  const label = status === 'error' ? 'Voice unavailable' : connecting ? 'Connecting…' : 'Voice live';
+  // Lead with the failure's own first sentence when we have one — a refused
+  // model names itself there; the full reason stays on the hover title.
+  const errorHeadline = statusDetail
+    ? (statusDetail.split('. ')[0] || statusDetail).slice(0, 80)
+    : null;
+  const label = status === 'error'
+    ? (errorHeadline ?? 'Voice unavailable')
+    : connecting ? 'Connecting…' : 'Voice live';
 
   // A fixed, full-width, click-through container handles centering so the pill's
   // own framer transform (y/scale) never fights a translateX centering hack.
@@ -529,7 +545,9 @@ export function RealtimeVoiceHost() {
           <motion.button
             type="button"
             onClick={() => stop()}
-            title="Voice-to-voice is on — double-tap right ⌘ or click to stop"
+            title={status === 'error' && statusDetail
+              ? statusDetail
+              : 'Voice-to-voice is on — double-tap right ⌘ or click to stop'}
             initial={{ opacity: 0, y: -8, scale: 0.96 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: -8, scale: 0.96 }}

--- a/src/lib/voice/realtime-session-config.test.ts
+++ b/src/lib/voice/realtime-session-config.test.ts
@@ -18,6 +18,8 @@ import {
   PHONE_CODE_TOOL_NAMES,
   selectPhoneCodeTools,
   selectPhoneRealtimeModel,
+  REALTIME_CAPABLE_MODELS,
+  assertRealtimeCapableModel,
   buildRealtimeMintSession,
   buildClientSecretsBody,
   buildCodexRealtimeStartParams,
@@ -250,5 +252,43 @@ describe('realtime-session-config — shared assembler', () => {
     expect(selection.missing).toContain('git_status');
     expect(selection.missing).toContain('o8_dispatch');
     expect(selection.missing).toHaveLength(PHONE_CODE_TOOL_NAMES.length - 1);
+  });
+});
+
+describe('assertRealtimeCapableModel — the mint-time model gate (#2165)', () => {
+  it('accepts every allow-listed id', () => {
+    for (const model of REALTIME_CAPABLE_MODELS) {
+      expect(assertRealtimeCapableModel(model)).toEqual({ ok: true });
+    }
+  });
+
+  it('carries both shipping constants, so neither mint can gate itself out', () => {
+    expect(REALTIME_CAPABLE_MODELS).toContain(REALTIME_MODEL);
+    expect(REALTIME_CAPABLE_MODELS).toContain(REALTIME_FLAGSHIP_MODEL);
+  });
+
+  it('rejects a chat-only model id, naming it and the accepted set', () => {
+    const result = assertRealtimeCapableModel('gpt-live-1');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected a rejection');
+    expect(result.reason).toContain('gpt-live-1');
+    expect(result.reason).toContain(REALTIME_MODEL);
+    expect(result.reason).toContain(REALTIME_FLAGSHIP_MODEL);
+    expect(result.allowed).toEqual([...REALTIME_CAPABLE_MODELS]);
+  });
+
+  it('rejects a typo of a real id — near-misses are the failure mode this catches', () => {
+    const typo = `${REALTIME_MODEL}i`;
+    const result = assertRealtimeCapableModel(typo);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected a rejection');
+    expect(result.reason).toContain(typo);
+  });
+
+  it('rejects an empty id without pretending a model was named', () => {
+    const result = assertRealtimeCapableModel('   ');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected a rejection');
+    expect(result.reason).toContain('empty model id');
   });
 });

--- a/src/lib/voice/realtime-session-config.ts
+++ b/src/lib/voice/realtime-session-config.ts
@@ -23,6 +23,46 @@
 // desk mint, the sdp relay, and the Agent-mode mint can never drift apart.
 export const REALTIME_MODEL = 'gpt-realtime-2.1-mini';
 export const REALTIME_FLAGSHIP_MODEL = 'gpt-realtime-2.1';
+
+/**
+ * Model ids the OpenAI realtime endpoint actually accepts.
+ *
+ * `POST /v1/realtime/client_secrets` mints a token for ids the realtime
+ * transport later refuses — the mint returns 200 and the failure only lands at
+ * the WebSocket/SDP exchange as `invalid_model: "not supported in realtime
+ * mode"`, far from the constant that caused it. Every mint route checks the
+ * requested model against this list first so a bad constant or a bad override
+ * fails at the mint with the model named, not as a mute connect failure later.
+ *
+ * Kept next to {@link REALTIME_MODEL} so switching models touches ONE place.
+ */
+export const REALTIME_CAPABLE_MODELS = [
+  REALTIME_FLAGSHIP_MODEL,
+  REALTIME_MODEL,
+  'gpt-realtime-2',
+  'gpt-realtime',
+] as const;
+
+export type RealtimeModelCheck =
+  | { ok: true }
+  | { ok: false; reason: string; allowed: string[] };
+
+/**
+ * Pure guard: is this a realtime-capable model id? The rejection reason names
+ * the offending model AND the accepted set, because that string is what the
+ * desk and the phone show the operator in place of a generic connect failure.
+ */
+export function assertRealtimeCapableModel(model: string): RealtimeModelCheck {
+  const allowed = [...REALTIME_CAPABLE_MODELS];
+  const candidate = typeof model === 'string' ? model.trim() : '';
+  if ((REALTIME_CAPABLE_MODELS as readonly string[]).includes(candidate)) return { ok: true };
+  const named = candidate ? `"${candidate}"` : 'an empty model id';
+  return {
+    ok: false,
+    reason: `${named} is not accepted by the OpenAI realtime endpoint. Realtime-capable models: ${allowed.join(', ')}.`,
+    allowed,
+  };
+}
 export type PhoneCodeModelVariant = 'mini' | 'flagship';
 export type PhoneCodeModelExperiment = PhoneCodeModelVariant | 'ab';
 export type PhoneRealtimeExperience = 'repository-catch-up';

--- a/tests/realtime-model-gate.test.ts
+++ b/tests/realtime-model-gate.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Realtime mint model gate, driven through the REAL desk route handlers (#2165).
+ *
+ * `POST /v1/realtime/client_secrets` mints a token for model ids the realtime
+ * transport later refuses, so a bad constant looks healthy at the mint and only
+ * fails at the SDP exchange with nothing naming the model. Per the reachability
+ * rule these cases invoke the actual route handlers with a constructed Request
+ * — not `assertRealtimeCapableModel` in isolation, which would prove the guard
+ * works while saying nothing about whether either mint calls it.
+ *
+ * Hermetic by construction (no process, socket, or git fixture) — it belongs in
+ * the fast suite, so the filename deliberately avoids the `-real-path` token
+ * that routes a file to the resource-owning runner. The mobile mint's own
+ * route.test.ts follows the same convention.
+ *
+ * The BYOK access path is mocked to its HAPPY state on purpose: the only thing
+ * standing between the request and OpenAI is the model gate, so "fetch was
+ * never called" is evidence about the gate and nothing else. The allow-listed
+ * control case proves the gate can still let a mint through.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { REALTIME_MODEL, REALTIME_CAPABLE_MODELS } from '@/lib/voice/realtime-session-config';
+
+const h = vi.hoisted(() => ({
+  resolveOpenAIKey: vi.fn(),
+  resolveRealtimeAccess: vi.fn(),
+}));
+
+vi.mock('@/lib/cortex/qa/llm/byok-keys', () => ({ resolveOpenAIKey: h.resolveOpenAIKey }));
+vi.mock('@/lib/voice/realtime-access', () => ({ resolveRealtimeAccess: h.resolveRealtimeAccess }));
+
+const session = await import('@/app/api/voice/realtime/session/route');
+const sdp = await import('@/app/api/voice/realtime/sdp/route');
+
+const OFFER_SDP = 'v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\n';
+
+/** Loopback Host — the same in-handler trust the desk webview arrives with. */
+function req(path: string, body: Record<string, unknown>) {
+  return new NextRequest(`http://localhost:3001${path}`, {
+    method: 'POST',
+    headers: { host: 'localhost:3001', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  h.resolveOpenAIKey.mockReset();
+  h.resolveRealtimeAccess.mockReset();
+  h.resolveOpenAIKey.mockResolvedValue('sk-test-key');
+  h.resolveRealtimeAccess.mockResolvedValue({ mode: 'byok', available: true, reason: 'byok' });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('POST /api/voice/realtime/session — model gate', () => {
+  it('400s a non-realtime model, names it, and never reaches OpenAI', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await session.POST(req('/api/voice/realtime/session', { model: 'gpt-live-1' }));
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+    expect(json.error).toBe('unsupported_realtime_model');
+    expect(json.detail).toContain('gpt-live-1');
+    expect(json.detail).toContain(REALTIME_MODEL);
+    // The desk client reads `reason` for the message it shows the operator.
+    expect(json.reason).toBe(json.detail);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('lets every allow-listed model through to the mint', async () => {
+    for (const model of REALTIME_CAPABLE_MODELS) {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ value: 'ek_test_secret', expires_at: 1 }),
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const res = await session.POST(req('/api/voice/realtime/session', { model }));
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).model).toBe(model);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(fetchMock.mock.calls[0][1].body as string).session.model).toBe(model);
+    }
+  });
+});
+
+describe('POST /api/voice/realtime/sdp — model gate', () => {
+  it('400s a non-realtime model before minting or exchanging SDP', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await sdp.POST(req('/api/voice/realtime/sdp', { sdp: OFFER_SDP, model: 'gpt-live-1' }));
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('unsupported_realtime_model');
+    expect(json.detail).toContain('gpt-live-1');
+    expect(json.reason).toBe(json.detail);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('400s a typo of the shipping model id — the near-miss this gate exists for', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const typo = `${REALTIME_MODEL}i`;
+
+    const res = await sdp.POST(req('/api/voice/realtime/sdp', { sdp: OFFER_SDP, model: typo }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).detail).toContain(typo);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('still relays an allow-listed model through mint + SDP exchange', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ value: 'ek_test_secret' }) })
+      .mockResolvedValueOnce({ ok: true, text: async () => 'v=0\r\na=answer\r\n' });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await sdp.POST(req('/api/voice/realtime/sdp', { sdp: OFFER_SDP, model: REALTIME_MODEL }));
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.model).toBe(REALTIME_MODEL);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Mechanic

`POST /v1/realtime/client_secrets` mints a token for model ids the realtime transport will not accept. The mint returns 200, and the failure lands later at the WebSocket or SDP exchange as `invalid_model: "not supported in realtime mode"` — far from the constant that caused it, with nothing naming the model.

## Change

- `REALTIME_CAPABLE_MODELS` and a pure `assertRealtimeCapableModel()` live next to `REALTIME_MODEL` in `src/lib/voice/realtime-session-config.ts`, so switching models still touches one place. The module stays isomorphic.
- Both mints — desk `/api/voice/realtime/session` and phone `/api/mobile/symon/session` — and the `/sdp` relay call the validator before any OpenAI call, returning `400 { ok: false, error: 'unsupported_realtime_model', detail }` where the detail names the model and the accepted set. Success shapes are unchanged.
- On the phone the check runs before the webview bridge, so a refused model no longer preempts a live desk session or persists a scope grant.
- The desk voice pill shows that reason in place of the generic "Voice unavailable", with the full text on the hover title. No restyling.

## Verification

- `npx tsc --noEmit` — exit 0, no output.
- `npm test` — `Test Files 701 passed | 3 skipped (704)`, `Tests 4312 passed | 4 skipped (4316)`.
- `npm run lint` — exit 0, 52 pre-existing warnings, 0 errors, none in the changed files.
- `npm run test:classify` — 704 hermetic / 406 resource-owning, manifest unchanged.

Tests added: validator unit cases (every allow-listed id accepted; a chat-only id, a near-miss typo, and an empty id rejected with the model named) plus real-path cases driving each mint handler with a constructed Request, asserting the 400 and zero fetches to OpenAI, with allow-listed control cases proving a good model still reaches the mint.

Closes #2165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe