### PR TITLE
fix: bound completed dependency download caches

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,7 @@ For maintainers who build, verify, release, recover, or harden o8.
 | [Crash survival](operations/daemon-crash-survival.md) | How worker processes and transcripts recover after app or server failure. |
 | [Project hardening](operations/project-hardening.md) | The multi-repo project contract, retrieval scope, locks, and expected invariants. |
 | [Substrate evaluation gate](operations/substrate-eval-gate.md) | The thresholds and sustainment checks for memory and retrieval quality. |
+| [Dependency cache retention](operations/dependency-cache-retention.md) | Download-cache bounds, active-installer protection, legacy preservation, and maintenance receipts. |
 
 Questions or problems? [Open an issue](https://github.com/hurttlocker/o8/issues) — the bug template asks for the details that make reports actionable.
 

--- a/docs/operations/dependency-cache-retention.md
+++ b/docs/operations/dependency-cache-retention.md
@@ -1,0 +1,81 @@
+# Dependency download cache retention
+
+Tracked in #1817. This policy covers regenerable package-manager downloads, not
+installed dependencies, worktrees, conversation history, release build artifacts,
+or the total operator profile.
+
+## Policy and entry point
+
+`runDependencyInstall` reserves its recipe cache before starting an installer.
+After a successful runner has settled and its private runtime is retired, the
+last reservation for that recipe records its allocated download-cache size.
+Maintenance then removes the least recently used eligible recipes until the
+managed cache is within both limits:
+
+- Download payload allocation: 2 GiB.
+- Completed recipe caches: 12.
+- Unused completed recipes expire after 14 days, even below the size limit.
+
+These are initial retention defaults, not measurements or a whole-profile size
+promise. Active or uncertain caches can exceed the limits and produce a `held`
+receipt. Allocated path sizes are not guaranteed physical bytes reclaimable on a
+copy-on-write filesystem. No periodic timer, idle process probe, or pre-dispatch
+recursive walk is added. Size measurement occurs after an install, and subsequent
+maintenance reads its metadata rather than walking every recipe payload again.
+
+## Safety and recovery
+
+New installs use `package-manager-cache/managed-v1/<manager>/<recipe>/cache` under
+the configured data directory. Previous app versions use a different namespace,
+so their installers cannot race this policy without reservations. Existing
+`package-manager-cache/<manager>/...` caches are preserved. They require a separate
+quiescent migration or cleanup with verified ownership; this policy does not
+silently adopt them or report their bytes as bounded.
+
+Reservations and eviction share the existing cross-process lifecycle lock.
+The managed root is bound to that lock database; another profile with independent
+lock state cannot silently share it through a cache-path override.
+Multiple installers can use one recipe concurrently; the short mutation lock
+does not serialize their package-manager runs. A failed or interrupted runner
+retains its reservation because parent-process death alone does not prove that
+installer children stopped. Do not remove that reservation based on elapsed time.
+Recovery requires establishing that the installer and its children are stopped.
+
+Unknown metadata, changed directory identities, symlinks and incomplete retired
+namespaces are held. The remover checks the recorded directory identity, detaches
+the exact recipe namespace, and uses the existing captured-directory purge. A
+successor install cannot attach to a partially deleted recipe. If retirement is
+interrupted, the detached namespace remains visibly held for recovery; it is not
+reported as freed. Installed dependency views are private copies and remain valid
+when their download cache is evicted.
+
+## Receipts
+
+The install result includes `cacheRetention`. The latest maintenance result is
+also persisted as `package-manager-cache/managed-v1/.o8-retention.json`:
+
+- `scope: managed-v1-only` prevents interpreting the result as whole-profile usage.
+- `status: within-budget | held` reports whether all managed entries were proved.
+- `retainedBytes: null` means a held entry prevented a complete size account.
+- `removed` lists successfully retired recipe identities, not estimated savings.
+- `held` gives the reason for every unproved or interrupted candidate.
+- `legacyPreserved` identifies old manager namespaces outside the policy.
+
+Do not equate `within-budget` with #1817 closure. Its installed-app footprint,
+loaded-worker measurements, real-profile history and deployment evidence remain
+separate acceptance requirements.
+
+## Verification
+
+The resource-owning tests exercise `runDependencyInstall` and persisted files:
+
+```sh
+npx vitest run --config config/vitest/vitest.integration.config.ts \
+  src/lib/workspace/dependency-cache-retention-real-path.test.ts \
+  src/lib/workspace/dependency-install.test.ts
+```
+
+They cover byte/count/age bounds, concurrent cache users, interrupted runners,
+preserved legacy caches and installed views, record corruption, directory
+replacement, manager symlinks and conflicting profile authorities. TypeScript and the hermetic suite remain
+required completion gates.

--- a/src/lib/workspace/dependency-cache-retention-real-path.test.ts
+++ b/src/lib/workspace/dependency-cache-retention-real-path.test.ts
@@ -1,0 +1,195 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { runDependencyInstall, type DependencyInstallInvocation } from './dependency-install';
+import { DEPENDENCY_CACHE_POLICY, pruneDependencyCaches } from './dependency-cache-retention';
+
+const roots: string[] = [];
+function fixture() {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'o8-cache-retention-'));
+  roots.push(root);
+  const cacheRoot = path.join(root, 'caches');
+  mkdirSync(cacheRoot, { mode: 0o700 });
+  const workspace = (name: string, lock = 'lock-v1') => {
+    const dir = path.join(root, name);
+    mkdirSync(dir);
+    writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'fixture', version: '1.0.0', packageManager: 'npm@11.8.0' }));
+    writeFileSync(path.join(dir, 'package-lock.json'), lock);
+    execFileSync('git', ['init', '-q', dir]);
+    execFileSync('git', ['add', '.'], { cwd: dir });
+    execFileSync('git', ['-c', 'user.name=test', '-c', 'user.email=test@invalid', 'commit', '-qm', 'fixture'], { cwd: dir });
+    return dir;
+  };
+  return { root, cacheRoot, workspace };
+}
+
+function writeInstall(invocation: DependencyInstallInvocation): string {
+  const cache = invocation.env.npm_config_cache!;
+  writeFileSync(path.join(cache, 'package.tgz'), Buffer.alloc(8192, 'x'));
+  mkdirSync(path.join(invocation.cwd, 'node_modules'), { recursive: true });
+  writeFileSync(path.join(invocation.cwd, 'node_modules', 'fixture.js'), 'private dependency');
+  return cache;
+}
+
+const keep = { ...DEPENDENCY_CACHE_POLICY };
+const empty = { ...keep, maxBytes: 0, maxEntries: 0 };
+const resolveVersion = async () => '11.8.0';
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('dependency cache retention through the install entry point', { timeout: 30_000 }, () => {
+  it('bounds completed caches by bytes without deleting installed dependencies or legacy caches', async () => {
+    const { cacheRoot, workspace } = fixture();
+    const repo = workspace('repo');
+    const legacy = path.join(cacheRoot, 'npm', 'old-cache');
+    mkdirSync(legacy, { recursive: true });
+    writeFileSync(path.join(legacy, 'keep'), 'legacy');
+    let cache = '';
+    const receipt = await runDependencyInstall(repo, 'npm ci', {
+      cacheRoot, cachePolicy: { ...keep, maxBytes: 0 }, resolveVersion,
+      run: async invocation => { cache = writeInstall(invocation); },
+    });
+    expect(cache).toContain(`${path.sep}managed-v1${path.sep}npm${path.sep}`);
+    expect(existsSync(cache)).toBe(false);
+    expect(readFileSync(path.join(repo, 'node_modules', 'fixture.js'), 'utf8')).toBe('private dependency');
+    expect(readFileSync(path.join(legacy, 'keep'), 'utf8')).toBe('legacy');
+    expect(receipt.cacheRetention).toMatchObject({ status: 'within-budget', retainedBytes: 0, retainedEntries: 0, legacyPreserved: true });
+    expect(receipt.cacheRetention?.removed).toHaveLength(1);
+    expect(JSON.parse(readFileSync(path.join(cacheRoot, 'managed-v1', '.o8-retention.json'), 'utf8'))).toEqual(receipt.cacheRetention);
+  });
+
+  it('evicts the least recently used recipe when the entry count is exceeded', async () => {
+    const { cacheRoot, workspace } = fixture();
+    const caches: string[] = [];
+    const install = async (repo: string) => runDependencyInstall(repo, 'npm ci', {
+      cacheRoot, cachePolicy: { ...keep, maxEntries: 1 }, resolveVersion,
+      run: async invocation => { caches.push(writeInstall(invocation)); },
+    });
+    await install(workspace('first', 'lock-v1'));
+    const second = await install(workspace('second', 'lock-v2'));
+    expect(existsSync(caches[0]!)).toBe(false);
+    expect(existsSync(caches[1]!)).toBe(true);
+    expect(second.cacheRetention).toMatchObject({ status: 'within-budget', retainedEntries: 1 });
+  });
+
+  it('keeps the shared cache until both concurrent installers have finished', async () => {
+    const { cacheRoot, workspace } = fixture();
+    const firstRepo = workspace('first');
+    const secondRepo = workspace('second');
+    let startFirst!: () => void;
+    let startSecond!: () => void;
+    let finishFirst!: () => void;
+    let finishSecond!: () => void;
+    const firstStarted = new Promise<void>(resolve => { startFirst = resolve; });
+    const secondStarted = new Promise<void>(resolve => { startSecond = resolve; });
+    const firstFinish = new Promise<void>(resolve => { finishFirst = resolve; });
+    const secondFinish = new Promise<void>(resolve => { finishSecond = resolve; });
+    let cache = '';
+    const first = runDependencyInstall(firstRepo, 'npm ci', {
+      cacheRoot, cachePolicy: empty, resolveVersion,
+      run: async invocation => { cache = writeInstall(invocation); startFirst(); await firstFinish; },
+    });
+    await firstStarted;
+    const second = runDependencyInstall(secondRepo, 'npm ci', {
+      cacheRoot, cachePolicy: empty, resolveVersion,
+      run: async invocation => { expect(writeInstall(invocation)).toBe(cache); startSecond(); await secondFinish; },
+    });
+    await secondStarted;
+    finishFirst();
+    const partial = await first;
+    expect(partial.cacheRetention?.status).toBe('held');
+    expect(partial.cacheRetention?.retainedBytes).toBeNull();
+    expect(existsSync(cache)).toBe(true);
+    finishSecond();
+    const completed = await second;
+    expect(completed.cacheRetention?.status).toBe('within-budget');
+    expect(existsSync(cache)).toBe(false);
+  });
+
+  it('retains reservations after runner failure instead of guessing installer children are dead', async () => {
+    const { cacheRoot, workspace } = fixture();
+    let cache = '';
+    await expect(runDependencyInstall(workspace('repo'), 'npm ci', {
+      cacheRoot, cachePolicy: empty, resolveVersion,
+      run: async invocation => { cache = writeInstall(invocation); throw new Error('installer interrupted'); },
+    })).rejects.toThrow('installer interrupted');
+    const result = await pruneDependencyCaches(cacheRoot, empty);
+    expect(result.status).toBe('held');
+    expect(result.held).toEqual([expect.objectContaining({ reason: 'active-or-unresolved-installer' })]);
+    expect(existsSync(cache)).toBe(true);
+    expect(readdirSync(path.dirname(cache)).some(name => name.startsWith('.o8-active-'))).toBe(true);
+  });
+
+  it('preserves an inode-replaced recipe and its unrecognized original directory', async () => {
+    const { cacheRoot, workspace } = fixture();
+    let cache = '';
+    await runDependencyInstall(workspace('repo'), 'npm ci', {
+      cacheRoot, resolveVersion, run: async invocation => { cache = writeInstall(invocation); },
+    });
+    const recipe = path.dirname(cache);
+    const record = readFileSync(path.join(recipe, '.o8-cache.json'));
+    renameSync(recipe, `${recipe}-saved`);
+    mkdirSync(recipe, { mode: 0o700 });
+    writeFileSync(path.join(recipe, '.o8-cache.json'), record);
+    writeFileSync(path.join(recipe, 'keep'), 'replacement');
+    const result = await pruneDependencyCaches(cacheRoot, empty);
+    expect(result.status).toBe('held');
+    expect(result.removed).toEqual([]);
+    expect(readFileSync(path.join(recipe, 'keep'), 'utf8')).toBe('replacement');
+    expect(existsSync(`${recipe}-saved`)).toBe(true);
+  });
+
+  it('never follows a manager symlink into another directory', async () => {
+    const { root, cacheRoot } = fixture();
+    const outside = path.join(root, 'outside');
+    mkdirSync(outside);
+    writeFileSync(path.join(outside, 'keep'), 'outside');
+    mkdirSync(path.join(cacheRoot, 'managed-v1'), { recursive: true, mode: 0o700 });
+    symlinkSync(outside, path.join(cacheRoot, 'managed-v1', 'npm'));
+    const result = await pruneDependencyCaches(cacheRoot, empty);
+    expect(result.status).toBe('held');
+    expect(result.held[0]?.reason).toBe('unsafe-manager-namespace');
+    expect(readFileSync(path.join(outside, 'keep'), 'utf8')).toBe('outside');
+  });
+
+  it('expires an unused completed cache while preserving a corrupt record', async () => {
+    const { cacheRoot, workspace } = fixture();
+    let cache = '';
+    await runDependencyInstall(workspace('repo'), 'npm ci', {
+      cacheRoot, resolveVersion, run: async invocation => { cache = writeInstall(invocation); },
+    });
+    const recordPath = path.join(path.dirname(cache), '.o8-cache.json');
+    const record = JSON.parse(readFileSync(recordPath, 'utf8'));
+    writeFileSync(recordPath, 'invalid');
+    expect((await pruneDependencyCaches(cacheRoot, empty)).status).toBe('held');
+    expect(existsSync(cache)).toBe(true);
+    record.lastUsedAt = Date.now() - keep.maxAgeMs - 1000;
+    writeFileSync(recordPath, JSON.stringify(record));
+    const result = await pruneDependencyCaches(cacheRoot);
+    expect(result.status).toBe('within-budget');
+    expect(result.removed).toHaveLength(1);
+    expect(existsSync(cache)).toBe(false);
+  });
+
+  it('refuses another profile with independent lock state before touching shared caches', async () => {
+    const { root, cacheRoot, workspace } = fixture();
+    let cache = '';
+    await runDependencyInstall(workspace('repo'), 'npm ci', {
+      cacheRoot, resolveVersion, run: async invocation => { cache = writeInstall(invocation); },
+    });
+    const previous = process.env.CORTEX_IDE_DB_PATH;
+    process.env.CORTEX_IDE_DB_PATH = path.join(root, 'other-profile.db');
+    try {
+      await expect(pruneDependencyCaches(cacheRoot, empty)).rejects.toThrow('different or unproved lifecycle store');
+      expect(existsSync(cache)).toBe(true);
+    } finally {
+      if (previous === undefined) delete process.env.CORTEX_IDE_DB_PATH;
+      else process.env.CORTEX_IDE_DB_PATH = previous;
+    }
+  });
+});

--- a/src/lib/workspace/dependency-cache-retention.ts
+++ b/src/lib/workspace/dependency-cache-retention.ts
@@ -1,0 +1,282 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { lstat, mkdir, readdir, realpath } from 'node:fs/promises';
+import path from 'node:path';
+
+import { getDataDir } from '@/lib/data-dir-migration';
+import { withPacketLifecycleMutationLock } from '@/lib/orchestrator/lifecycle-mutation-lock';
+import {
+  assertWorktreeMaterializationIdentity,
+  captureWorktreeMaterializationIdentity,
+  type WorktreeMaterializationIdentity,
+} from '@/lib/worktree/materialization-identity';
+import { measureDirectoryStorage } from '@/lib/worktree/storage-telemetry';
+import { purgeExactDirectory } from './exact-directory-purge';
+import { readExactChildFile, renameExactChildDirectory, retireExactChildFile, writeExactChildFile } from './exact-parent-operation';
+import type { DependencyInstallRecipe } from './dependency-install';
+
+export const DEPENDENCY_CACHE_POLICY = {
+  maxBytes: 2 * 1024 ** 3,
+  maxEntries: 12,
+  maxAgeMs: 14 * 24 * 60 * 60_000,
+} as const;
+
+export interface DependencyCachePolicy {
+  maxBytes: number;
+  maxEntries: number;
+  maxAgeMs: number;
+}
+
+export interface DependencyCacheRetentionReceipt {
+  schema: 'o8/dependency-cache-retention/v1';
+  scope: 'managed-v1-only';
+  policy: DependencyCachePolicy;
+  measuredAt: string;
+  status: 'within-budget' | 'held';
+  retainedBytes: number | null;
+  retainedEntries: number;
+  removed: string[];
+  held: Array<{ entry: string; reason: string }>;
+  legacyPreserved: boolean;
+}
+
+interface CacheRecord {
+  schema: 'o8/managed-dependency-cache/v1';
+  key: string;
+  manager: string;
+  identity: WorktreeMaterializationIdentity;
+  lastUsedAt: number;
+  allocatedBytes: number | null;
+}
+
+const MANAGERS = ['npm', 'pnpm', 'yarn', 'bun'];
+const RECORD = '.o8-cache.json';
+const ACTIVE = '.o8-active-';
+
+async function ensurePrivateDirectory(directoryPath: string, parentPath?: string): Promise<void> {
+  try {
+    await mkdir(directoryPath, { recursive: parentPath === undefined, mode: 0o700 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+  }
+  const [entry, canonical, canonicalRoot] = await Promise.all([
+    lstat(directoryPath), realpath(directoryPath), realpath(parentPath ?? directoryPath),
+  ]);
+  if (!entry.isDirectory() || entry.isSymbolicLink()
+    || (process.platform !== 'win32' && (entry.mode & 0o077) !== 0)
+    || (parentPath !== undefined && canonical !== path.join(canonicalRoot, path.basename(directoryPath)))) {
+    throw new Error('Package-manager recipe authority is not an exact private directory.');
+  }
+}
+
+function cacheLock(root: string): string {
+  return `dependency-cache:${createHash('sha256').update(root).digest('hex')}`;
+}
+
+function validPolicy(policy: DependencyCachePolicy): void {
+  for (const value of [policy.maxBytes, policy.maxEntries, policy.maxAgeMs]) {
+    if (!Number.isSafeInteger(value) || value < 0) throw new Error('Invalid dependency-cache retention policy.');
+  }
+}
+
+async function assertCacheStoreBinding(managed: string): Promise<void> {
+  // Lock state must have the same authority for every writer sharing this cache root.
+  const database = await realpath(process.env.CORTEX_IDE_DB_PATH || path.join(getDataDir(), 'cortex-ide.db'));
+  const expected = createHash('sha256').update(database).digest('hex');
+  const identity = await captureWorktreeMaterializationIdentity(managed);
+  const file = path.join(managed, '.o8-cache-store');
+  try {
+    await lstat(file);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    try {
+      await writeExactChildFile(managed, identity, file, expected, 0o600);
+    } catch {
+      // A different profile may have won exclusive creation; read its claim, never overwrite it.
+    }
+  }
+  const stat = await lstat(file);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1 || stat.size !== 64
+    || (await readExactChildFile(managed, identity, file)).contents !== expected) {
+    throw new Error('Dependency cache belongs to a different or unproved lifecycle store.');
+  }
+}
+
+async function removeRecordFile(root: string, identity: WorktreeMaterializationIdentity, name: string): Promise<void> {
+  const file = path.join(root, name);
+  const entry = await lstat(file);
+  if (!entry.isFile() || entry.isSymbolicLink() || entry.nlink !== 1) {
+    throw new Error('Dependency-cache record is not a private regular file.');
+  }
+  await retireExactChildFile(root, identity, file, path.join(root, `.retired-${randomUUID()}`), {
+    device: entry.dev, inode: entry.ino,
+  });
+}
+
+async function saveRecord(root: string, record: CacheRecord): Promise<void> {
+  try {
+    await removeRecordFile(root, record.identity, RECORD);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  await writeExactChildFile(root, record.identity, path.join(root, RECORD), JSON.stringify(record), 0o600);
+}
+
+async function readRecord(root: string, manager: string, key: string): Promise<CacheRecord> {
+  const identity = await captureWorktreeMaterializationIdentity(root);
+  const stat = await lstat(path.join(root, RECORD));
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1 || stat.size > 4096) {
+    throw new Error('Cache retention record is unsafe.');
+  }
+  const record = JSON.parse((await readExactChildFile(root, identity, path.join(root, RECORD))).contents) as CacheRecord;
+  if (record.schema !== 'o8/managed-dependency-cache/v1' || record.key !== key || record.manager !== manager
+    || !Number.isSafeInteger(record.lastUsedAt) || record.lastUsedAt < 0
+    || (record.allocatedBytes !== null && (!Number.isSafeInteger(record.allocatedBytes) || record.allocatedBytes < 0))) {
+    throw new Error('Cache retention record is invalid.');
+  }
+  await assertWorktreeMaterializationIdentity(root, record.identity);
+  return record;
+}
+
+/** New writers use a separate namespace: older apps cannot write unleased caches here. */
+export async function acquireDependencyCache(
+  cacheRoot: string,
+  recipe: DependencyInstallRecipe,
+  policy: DependencyCachePolicy = DEPENDENCY_CACHE_POLICY,
+): Promise<{ root: string; cache: string; release: () => Promise<DependencyCacheRetentionReceipt> }> {
+  validPolicy(policy);
+  if (!MANAGERS.includes(recipe.packageManager) || !/^[0-9a-f]{64}$/.test(recipe.key)
+    || recipe.cacheAuthorityId !== `native-download-cache:${recipe.packageManager}:recipe:${recipe.key}`) {
+    throw new Error('Dependency recipe cache authority is invalid.');
+  }
+  await ensurePrivateDirectory(cacheRoot);
+  const managed = path.join(await realpath(cacheRoot), 'managed-v1');
+  await ensurePrivateDirectory(managed, cacheRoot);
+  const managerRoot = path.join(managed, recipe.packageManager);
+  const root = path.join(managerRoot, recipe.key);
+  const cache = path.join(root, 'cache');
+  const leaseName = `${ACTIVE}${randomUUID()}`;
+  const identity = await withPacketLifecycleMutationLock(cacheLock(managed), async () => {
+    await assertCacheStoreBinding(managed);
+    await ensurePrivateDirectory(managerRoot, managed);
+    await ensurePrivateDirectory(root, managerRoot);
+    await ensurePrivateDirectory(cache, root);
+    const captured = await captureWorktreeMaterializationIdentity(root);
+    // Crashes retain the reservation: parent death or age cannot prove installer children stopped.
+    await writeExactChildFile(root, captured, path.join(root, leaseName), JSON.stringify({ pid: process.pid }), 0o600);
+    return captured;
+  });
+  let released = false;
+  return {
+    root,
+    cache,
+    release: async () => {
+      if (released) throw new Error('Dependency-cache reservation was already released.');
+      released = true;
+      return withPacketLifecycleMutationLock(cacheLock(managed), async () => {
+        await assertWorktreeMaterializationIdentity(root, identity);
+        await removeRecordFile(root, identity, leaseName);
+        if (!(await readdir(root)).some(name => name.startsWith(ACTIVE))) {
+          const storage = await measureDirectoryStorage(cache);
+          await saveRecord(root, {
+            schema: 'o8/managed-dependency-cache/v1', key: recipe.key, manager: recipe.packageManager,
+            identity, lastUsedAt: Date.now(), allocatedBytes: storage.allocatedBytes,
+          });
+        }
+        return pruneLocked(cacheRoot, managed, policy);
+      });
+    },
+  };
+}
+
+/** Event-driven maintenance, never an idle timer or a dispatch preflight walk. */
+export async function pruneDependencyCaches(
+  cacheRoot: string,
+  policy: DependencyCachePolicy = DEPENDENCY_CACHE_POLICY,
+): Promise<DependencyCacheRetentionReceipt> {
+  validPolicy(policy);
+  await ensurePrivateDirectory(cacheRoot);
+  const managed = path.join(await realpath(cacheRoot), 'managed-v1');
+  await ensurePrivateDirectory(managed, cacheRoot);
+  return withPacketLifecycleMutationLock(cacheLock(managed), () => pruneLocked(cacheRoot, managed, policy));
+}
+
+async function pruneLocked(
+  cacheRoot: string,
+  managed: string,
+  policy: DependencyCachePolicy,
+): Promise<DependencyCacheRetentionReceipt> {
+  await assertCacheStoreBinding(managed);
+  const now = Date.now();
+  const receipt: DependencyCacheRetentionReceipt = {
+    schema: 'o8/dependency-cache-retention/v1', scope: 'managed-v1-only', policy: { ...policy }, measuredAt: new Date(now).toISOString(),
+    status: 'within-budget', retainedBytes: 0, retainedEntries: 0, removed: [], held: [],
+    legacyPreserved: (await readdir(cacheRoot)).some(name => MANAGERS.includes(name)),
+  };
+  const candidates: Array<{ root: string; record: CacheRecord }> = [];
+  for (const manager of MANAGERS) {
+    const parent = path.join(managed, manager);
+    try {
+      const entry = await lstat(parent);
+      if (!entry.isDirectory() || entry.isSymbolicLink()) throw new Error('Unsafe manager namespace.');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      receipt.held.push({ entry: manager, reason: 'unsafe-manager-namespace' });
+      continue;
+    }
+    for (const key of await readdir(parent)) {
+      const label = `${manager}/${key}`;
+      if (!/^[0-9a-f]{64}$/.test(key)) {
+        receipt.held.push({ entry: label, reason: 'unrecognized-or-interrupted-retirement' });
+        continue;
+      }
+      receipt.retainedEntries += 1;
+      const root = path.join(parent, key);
+      try {
+        await captureWorktreeMaterializationIdentity(root);
+        if ((await readdir(root)).some(name => name.startsWith(ACTIVE))) {
+          receipt.held.push({ entry: label, reason: 'active-or-unresolved-installer' });
+          continue;
+        }
+        const record = await readRecord(root, manager, key);
+        if (record.allocatedBytes === null) throw new Error('Cache size is unknown.');
+        receipt.retainedBytes! += record.allocatedBytes;
+        candidates.push({ root, record });
+      } catch {
+        receipt.held.push({ entry: label, reason: 'unproved-cache-identity-or-size' });
+      }
+    }
+  }
+  candidates.sort((a, b) => a.record.lastUsedAt - b.record.lastUsedAt || a.root.localeCompare(b.root));
+  for (const { root, record } of candidates) {
+    if (receipt.retainedBytes! <= policy.maxBytes && receipt.retainedEntries <= policy.maxEntries
+      && now - record.lastUsedAt <= policy.maxAgeMs) continue;
+    const label = `${record.manager}/${record.key}`;
+    try {
+      await assertWorktreeMaterializationIdentity(root, record.identity);
+      if ((await readdir(root)).some(name => name.startsWith(ACTIVE))) throw new Error('Cache became active.');
+      const parent = path.dirname(root);
+      const parentIdentity = await captureWorktreeMaterializationIdentity(parent);
+      const retired = path.join(parent, `.o8-pruning-${record.key}-${randomUUID()}`);
+      // Detach before purge so a successor install cannot reuse a partially retired namespace.
+      await renameExactChildDirectory(parent, parentIdentity, root, retired, record.identity);
+      await purgeExactDirectory(retired, record.identity);
+      receipt.removed.push(label);
+      receipt.retainedBytes! -= record.allocatedBytes!;
+      receipt.retainedEntries -= 1;
+    } catch {
+      receipt.held.push({ entry: label, reason: 'retirement-incomplete' });
+    }
+  }
+  if (receipt.held.length > 0) receipt.retainedBytes = null;
+  if (receipt.held.length > 0 || receipt.retainedEntries > policy.maxEntries
+    || (receipt.retainedBytes !== null && receipt.retainedBytes > policy.maxBytes)) receipt.status = 'held';
+  const identity = await captureWorktreeMaterializationIdentity(managed);
+  const receiptName = '.o8-retention.json';
+  try {
+    await removeRecordFile(managed, identity, receiptName);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  await writeExactChildFile(managed, identity, path.join(managed, receiptName), JSON.stringify(receipt), 0o600);
+  return receipt;
+}

--- a/src/lib/workspace/dependency-install.ts
+++ b/src/lib/workspace/dependency-install.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { execFile } from 'node:child_process';
-import { lstat, mkdir, readFile, readdir, realpath, stat } from 'node:fs/promises';
+import { lstat, readFile, readdir, realpath, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
@@ -31,6 +31,7 @@ import {
   resolveReceiptedPackageManagerExecution,
 } from './dependency-manager-executable';
 import { dependencyCacheRoot } from './dependency-cache-root';
+import { acquireDependencyCache, type DependencyCachePolicy, type DependencyCacheRetentionReceipt } from './dependency-cache-retention';
 
 const execFileAsync = promisify(execFile);
 
@@ -67,6 +68,7 @@ export interface DependencyInstallReceipt {
   packageManagerExecutable: string;
   privateViewVerified: boolean;
   completedAt: string;
+  cacheRetention?: DependencyCacheRetentionReceipt;
 }
 
 export { DependencyAuthenticationUnsupportedError } from './dependency-manager-config';
@@ -82,6 +84,7 @@ export interface DependencyInstallOptions {
   run?: (invocation: DependencyInstallInvocation) => Promise<void>;
   resolveVersion?: (manager: SupportedPackageManager) => Promise<string>;
   cacheRoot?: string;
+  cachePolicy?: DependencyCachePolicy;
   now?: () => Date;
   materializationIdentity?: WorktreeMaterializationIdentity;
   /** Recipe derived at the same pinned setup boundary, before execution. */
@@ -474,26 +477,6 @@ export async function deriveDependencyInstallRecipe(
   };
 }
 
-async function ensurePrivateDirectory(directoryPath: string, parentPath?: string): Promise<void> {
-  try {
-    await mkdir(directoryPath, { recursive: parentPath === undefined, mode: 0o700 });
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
-  }
-  const [entry, canonical, canonicalRoot] = await Promise.all([
-    lstat(directoryPath),
-    realpath(directoryPath),
-    realpath(parentPath ?? directoryPath),
-  ]);
-  if (!entry.isDirectory()
-    || entry.isSymbolicLink()
-    || (process.platform !== 'win32' && (entry.mode & 0o077) !== 0)
-    || (parentPath !== undefined
-      && canonical !== path.join(canonicalRoot, path.basename(directoryPath)))) {
-    throw new Error('Package-manager recipe authority is not an exact private directory.');
-  }
-}
-
 interface RecipeCacheAuthority {
   root: string;
   cache: string;
@@ -510,27 +493,6 @@ interface InstallRuntimePaths {
   emptyGlobalConfig: string;
   device: number;
   inode: number;
-}
-
-async function ensureRecipeAuthority(
-  cacheRoot: string,
-  recipe: DependencyInstallRecipe,
-): Promise<RecipeCacheAuthority> {
-  if (!/^[0-9a-f]{64}$/.test(recipe.key)
-    || recipe.cacheAuthorityId !== `native-download-cache:${recipe.packageManager}:recipe:${recipe.key}`) {
-    throw new Error('Dependency recipe cache authority is invalid.');
-  }
-  await ensurePrivateDirectory(cacheRoot);
-  const managerRoot = path.join(cacheRoot, recipe.packageManager);
-  await ensurePrivateDirectory(managerRoot, cacheRoot);
-  const root = path.join(managerRoot, recipe.key);
-  await ensurePrivateDirectory(root, managerRoot);
-  const authority = {
-    root,
-    cache: path.join(root, 'cache'),
-  };
-  await ensurePrivateDirectory(authority.cache, root);
-  return authority;
 }
 
 async function createInstallRuntime(
@@ -741,7 +703,6 @@ export async function runDependencyInstall(
     throw new Error('Prepared dependency recipe does not match the saved install command.');
   }
   const cacheRoot = path.resolve(options.cacheRoot ?? dependencyCacheRoot());
-  const authority = await ensureRecipeAuthority(cacheRoot, recipe);
   const execution = await resolveReceiptedPackageManagerExecution(
     recipe.packageManager,
     recipe.packageManagerVersion,
@@ -749,23 +710,39 @@ export async function runDependencyInstall(
   );
   const materializationIdentity = options.materializationIdentity
     ?? await captureWorktreeMaterializationIdentity(workspacePath);
-  const runtime = await createInstallRuntime(workspacePath, materializationIdentity);
+  const authority = await acquireDependencyCache(cacheRoot, recipe, options.cachePolicy);
+  let runtime: InstallRuntimePaths | undefined;
+  let receipt: DependencyInstallReceipt | undefined;
+  let executionStarted = false;
+  let executionFinished = false;
   try {
+    runtime = await createInstallRuntime(workspacePath, materializationIdentity);
     const invocation = nativeInvocation(
       workspacePath, recipe, authority, runtime, execution.executable,
     );
+    executionStarted = true;
     if (options.run) await options.run(invocation);
     else await defaultRun(invocation, options.materializationIdentity);
+    executionFinished = true;
     await ensurePinnedWorkspaceDirectory(workspacePath, materializationIdentity, 'node_modules');
     await auditPrivateDependencyView(workspacePath);
-    return {
+    receipt = {
       recipe,
       packageManagerExecutable: execution.executable,
       privateViewVerified: true,
       completedAt: (options.now ?? (() => new Date()))().toISOString(),
     };
+    return receipt;
   } finally {
-    await retireInstallRuntime(runtime, options.afterRuntimeTreeCapture);
+    try {
+      if (runtime) await retireInstallRuntime(runtime, options.afterRuntimeTreeCapture);
+    } finally {
+      // A failed/aborted runner may leave installer children alive. Keep its cache reservation.
+      if (!executionStarted || executionFinished) {
+        const retention = await authority.release();
+        if (receipt) receipt.cacheRetention = retention;
+      }
+    }
   }
 }
 

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -683,6 +683,14 @@
       ]
     },
     {
+      "path": "src/lib/workspace/dependency-cache-retention-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path"
+      ]
+    },
+    {
       "path": "src/lib/workspace/dependency-image-device-authority.test.ts",
       "reasons": [
         "apfs-tool",


### PR DESCRIPTION
## Change

Bound the download caches created by `runDependencyInstall`. Completed recipe caches use a 2 GiB allocated-payload limit, a 12-entry limit, and 14-day expiry, evicting the least recently used eligible recipe first. Maintenance runs after installs, not on an idle timer or a dispatch preflight walk.

New writers use a separate managed namespace. Existing caches, installed dependency views, held workspaces, and conversation history are preserved. This contributes the missing package-cache retention mechanism to #1817; it does not close the installed-app footprint issue by itself.

## Safety

- Install reservations and eviction share the existing cross-process lifecycle lock. The managed root is bound to that lock database, including custom cache roots.
- Concurrent users of one recipe retain the cache until the last successful runner finishes. Failed or interrupted runners retain their reservations because parent exit alone cannot prove child processes stopped.
- Eviction requires recorded directory identity and size. Changed identities, symlinks, invalid metadata, and interrupted retirements remain held.
- Eligible namespaces are detached before the existing exact-directory purge. Installed dependency views remain valid after download-cache eviction.
- A persisted receipt distinguishes `within-budget` from `held`, makes unknown sizes explicit, and limits the accounting claim to the new managed namespace. Limits are initial policy defaults, not a whole-profile storage promise.

## Verification

- Hermetic suite: 4,300 passed, four skipped.
- Existing install coverage plus the initial retention suite: 44 passed.
- Final retention, repository-setup and saved-recipe route coverage: 16 passed.
- TypeScript, touched-file ESLint, classification and changed-line rule checks passed.
- Old-code falsification through the install entry point failed as expected: the old implementation did not use the managed namespace or evict the completed cache.
- Self-review tightened the byte-limit test so the entry-count limit cannot make that test pass accidentally. Its independent rerun is recorded in the follow-up verification comment.

No UI changes. No release, daily-app restart, legacy-cache migration or profile cleanup is included.
