### PR TITLE
fix: exclude driver delay from startup interaction timing

### DIFF
--- a/docs/operations/interaction-performance-budgets.md
+++ b/docs/operations/interaction-performance-budgets.md
@@ -102,6 +102,21 @@ design-page digest), and the sample count behind every distribution.
 
 ## The measurement order is part of the contract
 
+Startup input uses `page-readiness-plus-trusted-input-paint-v1`: the page stamps
+when its active textarea is visible and editable after hydration, then verifies
+the first trusted keyboard input remains in that same textarea through paint.
+The metric adds readiness time and input-to-paint time. It excludes the test
+driver's idle/protocol wait between those phases, recording that excluded wait
+and the full hydration-to-paint wall time separately in `observation`. Disabled,
+replaced, untrusted or unpainted input cannot produce a pass. The observer stops
+after the first input or its deadline; it does not run during the idle soak.
+
+Older startup observations ended when the driver read the page. They included
+driver delay and are not comparable to this method. The raw receipts remain
+unchanged; baseline deltas report `incomparable` across a method change. New
+observations must be collected before accepting a replacement startup baseline.
+The 2,000 ms startup ceiling is unchanged.
+
 The scenarios run in a fixed order — cold boot, fleet reveal, active-context
 reveal with composer readiness observed concurrently, keystrokes, Design Mode,
 soak, warm relaunch, falsification, then inventory as the final measured step.

--- a/scripts/bench/interactions/budgets.d.mts
+++ b/scripts/bench/interactions/budgets.d.mts
@@ -23,7 +23,9 @@ export interface BudgetResult {
   reason: string | null;
   baselineValue: number | null;
   deltaValue: number | null;
-  deltaStatus: 'improved' | 'regressed' | 'unchanged' | 'missing' | 'no-baseline';
+  deltaStatus: 'improved' | 'regressed' | 'unchanged' | 'missing' | 'no-baseline' | 'incomparable';
+  deltaReason?: string;
+  measurementMethod?: string | null;
 }
 
 export interface BudgetEvaluation {
@@ -69,7 +71,7 @@ export function metricObservations(receipt: InteractionReceiptLike): Array<{
 }>;
 export function evaluateInteractionBudgets(
   receipt: InteractionReceiptLike,
-  baseline?: { metrics?: Record<string, { value?: number | null }>; source?: string } | null,
+  baseline?: { metrics?: Record<string, { value?: number | null; measurementMethod?: string | null }>; source?: string } | null,
   options?: { forceAbsolute?: boolean },
 ): BudgetEvaluation;
 export function checkReceiptValidity(receipt: InteractionReceiptLike): string[];

--- a/scripts/bench/interactions/budgets.mjs
+++ b/scripts/bench/interactions/budgets.mjs
@@ -133,6 +133,7 @@ export function metricObservations(receipt) {
       metric,
       scale: receipt?.fixture?.scale ?? null,
       spec,
+      measurementMethod: scenarios[spec.scenario]?.measurementMethod ?? null,
       ...statisticValue(scenarios[spec.scenario], spec.statistic),
     });
   }
@@ -162,7 +163,12 @@ export function evaluateInteractionBudgets(receipt, baseline = null, { forceAbso
   const results = metricObservations(receipt).map((observation) => {
     const baselineMetric = baselineMetrics[`${observation.metric}@${observation.scale}`]
       ?? baselineMetrics[observation.metric];
-    const delta = classifyDelta(observation.metric, observation.value, baselineMetric?.value);
+    const compatibleMethod = (observation.measurementMethod ?? null) === (baselineMetric?.measurementMethod ?? null);
+    const delta = baselineMetric && !compatibleMethod
+      ? { baselineValue: baselineMetric.value, deltaValue: null, deltaStatus: 'incomparable',
+        deltaReason: 'baseline measurement method differs; collect a matching observation' }
+      : classifyDelta(observation.metric, observation.value, baselineMetric?.value);
+    delta.measurementMethod = observation.measurementMethod ?? null;
     if (!Number.isFinite(observation.value)) {
       return {
         metric: observation.metric,
@@ -206,7 +212,8 @@ export function evaluateInteractionBudgets(receipt, baseline = null, { forceAbso
     buildMode,
     absoluteApplies,
     baselineSource: baseline?.source ?? null,
-    status: failed.length > 0 || regressed.length > 0 ? 'fail' : unavailable.length > 0 ? 'incomplete' : 'pass',
+    status: failed.length > 0 || regressed.length > 0 ? 'fail'
+      : unavailable.length > 0 || results.some(result => result.deltaStatus === 'incomparable') ? 'incomplete' : 'pass',
     failed: failed.map((result) => result.metric),
     regressed: regressed.map((result) => result.metric),
     unavailable: unavailable.map((result) => ({ metric: result.metric, reason: result.reason })),

--- a/scripts/bench/interactions/receipt.mjs
+++ b/scripts/bench/interactions/receipt.mjs
@@ -141,6 +141,7 @@ export function baselineFromReceipt(receipt) {
         value: result.value,
         statistic: result.statistic,
         scale: run.scale,
+        ...(result.measurementMethod ? { measurementMethod: result.measurementMethod } : {}),
       };
     }
   }

--- a/scripts/bench/interactions/startup-readiness.mjs
+++ b/scripts/bench/interactions/startup-readiness.mjs
@@ -1,0 +1,86 @@
+export const STARTUP_MEASUREMENT_METHOD = 'page-readiness-plus-trusted-input-paint-v1';
+
+// Serialized before app code. Keep the readiness clock independent of protocol
+// delivery, but require an actual trusted input to survive through paint.
+export function installStartupReadinessProbe({ timeoutMs = 120_000 } = {}) {
+  const state = { result: null };
+  globalThis.__o8StartupReadiness = state;
+  let candidate = null;
+  let readyAt = null;
+  let key = null;
+  let frame = null;
+  let finished = false;
+  const eligible = element => element instanceof HTMLTextAreaElement
+    && element.matches('textarea[data-o8-active-composer="true"]')
+    && element.isConnected && !element.disabled && !element.readOnly
+    && element.getClientRects().length > 0
+    && (element.checkVisibility?.({ checkOpacity: true, checkVisibilityCSS: true })
+      ?? getComputedStyle(element).visibility !== 'hidden');
+  const refresh = () => {
+    const target = document.querySelector('textarea[data-o8-active-composer="true"]');
+    const hydrated = globalThis.__o8Interactions?.hydratedAtMs;
+    if (!Number.isFinite(hydrated) || !eligible(target)) {
+      candidate = null;
+      readyAt = null;
+    } else if (candidate !== target) {
+      candidate = target;
+      readyAt = performance.now();
+    }
+  };
+  const poll = () => {
+    if (finished) return;
+    refresh();
+    frame = requestAnimationFrame(poll);
+  };
+  const stop = () => {
+    finished = true;
+    if (frame !== null) cancelAnimationFrame(frame);
+    clearTimeout(timer);
+    document.removeEventListener('keydown', onKeydown, true);
+    document.removeEventListener('input', onInput, true);
+  };
+  const onKeydown = event => {
+    if (!event.isTrusted) return;
+    refresh();
+    if (event.target !== candidate || !Number.isFinite(readyAt)) return;
+    key = { target: candidate, readyAt, eventAt: event.timeStamp, value: candidate.value,
+      hydratedAt: globalThis.__o8Interactions?.hydratedAtMs };
+  };
+  const onInput = event => {
+    if (!event.isTrusted || !key || event.target !== key.target) return;
+    const observed = key;
+    stop();
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      const paintedAt = performance.now();
+      if (!eligible(observed.target) || observed.target.value === observed.value
+        || !Number.isFinite(observed.hydratedAt)
+        || observed.readyAt < observed.hydratedAt || observed.eventAt < observed.readyAt) {
+        state.result = { durationMs: null, note: 'trusted startup input did not retain a valid editable target through paint' };
+        return;
+      }
+      const readinessMs = observed.readyAt - observed.hydratedAt;
+      const inputPaintMs = paintedAt - observed.eventAt;
+      state.result = {
+        durationMs: Number((readinessMs + inputPaintMs).toFixed(2)),
+        measurementMethod: 'page-readiness-plus-trusted-input-paint-v1',
+        readinessMs: Number(readinessMs.toFixed(2)),
+        inputPaintMs: Number(inputPaintMs.toFixed(2)),
+        excludedDriverWaitMs: Number((observed.eventAt - observed.readyAt).toFixed(2)),
+        hydrationToPaintWallMs: Number((paintedAt - observed.hydratedAt).toFixed(2)),
+        inputTrusted: true,
+      };
+    }));
+  };
+  const timer = setTimeout(() => {
+    state.result = { durationMs: null, note: 'startup readiness or trusted input was not observed within the bounded window' };
+    stop();
+  }, timeoutMs);
+  document.addEventListener('keydown', onKeydown, true);
+  document.addEventListener('input', onInput, true);
+  frame = requestAnimationFrame(poll);
+}
+
+export function readStartupReadinessSample() {
+  return globalThis.__o8StartupReadiness?.result
+    ?? { durationMs: null, note: 'no startup readiness observation with trusted input paint' };
+}

--- a/scripts/bench/run-interactions.mjs
+++ b/scripts/bench/run-interactions.mjs
@@ -23,6 +23,7 @@ import { measureDesignMode, measureWarmRelaunch } from './interactions/design-an
 import { closeMeasuredBrowser, launchMeasuredBrowser } from './interactions/browser-runtime.mjs';
 import { scenarioResult } from './interactions/statistics.mjs';
 import { runSoak } from './interactions/soak.mjs';
+import { installStartupReadinessProbe, readStartupReadinessSample, STARTUP_MEASUREMENT_METHOD } from './interactions/startup-readiness.mjs';
 import {
   INTERACTION_BUDGETS,
   checkReceiptValidity,
@@ -124,6 +125,7 @@ async function openInstrumentedPage(browser, baseUrl, { injectedDelayMs = 0, boo
     }
   });
   await page.addInitScript(instrumentationInitScript, { injectedDelayMs, selectedRepoId });
+  await page.addInitScript(installStartupReadinessProbe, { timeoutMs: bootTimeoutMs });
   let response;
   try {
     response = await page.goto(`${baseUrl}/dashboard`, { waitUntil: 'domcontentloaded', timeout: bootTimeoutMs });
@@ -155,9 +157,6 @@ function unavailableObservation(label, error) {
     note: `${label} failed: ${error instanceof Error ? error.message : String(error)}`,
   };
 }
-
-// Time from the hydration boundary until a composer will accept input. This is
-// measured in page time, not wall-clock around a protocol round trip.
 
 // The fleet reveal: the operator clicks Projects and the generated repositories
 // paint in the left panel. This is the rendered entry point the scale fixtures
@@ -239,15 +238,9 @@ async function waitForComposer(page, timeoutMs) {
   try {
     await page.locator(COMPOSER_SELECTOR).first().waitFor({ state: 'visible', timeout: timeoutMs });
   } catch {
-    return { durationMs: null, note: `no ${COMPOSER_SELECTOR} became visible within ${timeoutMs}ms` };
+    return { ready: false, note: `no ${COMPOSER_SELECTOR} became visible within ${timeoutMs}ms` };
   }
-  const durationMs = await page.evaluate(() => {
-    const hydratedAtMs = globalThis.__o8Interactions?.hydratedAtMs;
-    return Number.isFinite(hydratedAtMs) ? Number((performance.now() - hydratedAtMs).toFixed(2)) : null;
-  }).catch(() => null);
-  return Number.isFinite(durationMs)
-    ? { durationMs, phases: {} }
-    : { durationMs: null, note: 'hydration boundary was never stamped, so first-interaction time has no origin' };
+  return { ready: true };
 }
 
 async function sampleKeystrokes(page, samples) {
@@ -412,8 +405,10 @@ async function measureScale({ browser, browserPid, scale, runConfig }) {
     const fleetReveal = blocked
       ? { durationMs: null, note: blocked }
       : await measureFleetReveal(page, scale, runConfig.revealTimeoutMs);
-    const composerReady = await composerPending;
+    await composerPending;
     const keystrokes = blocked ? [] : await sampleKeystrokes(page, runConfig.samples);
+    const startupInput = blocked ? { durationMs: null, note: blocked }
+      : await page.evaluate(readStartupReadinessSample);
     // Measure tab switching inside the active restored workspace before the
     // repo-row scenario opens a second repo-bound pane. Reading every pill in
     // the split header can otherwise target an inactive sibling workspace.
@@ -501,7 +496,11 @@ async function measureScale({ browser, browserPid, scale, runConfig }) {
     const scenarios = {
       dashboard_cold_ready_ms: scenarioResult({ samples: coldBoot, phaseNames: PHASE_NAMES, unavailableReason: blocked }),
       warm_relaunch_ready_ms: scenarioResult({ samples: [warmRelaunch], phaseNames: PHASE_NAMES, unavailableReason: blocked }),
-      first_interaction_accepted_ms: scenarioResult({ samples: [composerReady], phaseNames: PHASE_NAMES, unavailableReason: blocked }),
+      first_interaction_accepted_ms: {
+        ...scenarioResult({ samples: [startupInput], phaseNames: PHASE_NAMES, unavailableReason: blocked }),
+        measurementMethod: STARTUP_MEASUREMENT_METHOD,
+        observation: startupInput,
+      },
       fleet_reveal_ms: scenarioResult({ samples: [fleetReveal], phaseNames: PHASE_NAMES, unavailableReason: blocked }),
       active_context_reveal_ms: scenarioResult({ samples: [activeContext], phaseNames: PHASE_NAMES, unavailableReason: blocked }),
       composer_keystroke_to_paint_ms: scenarioResult({ samples: keystrokes, phaseNames: PHASE_NAMES, unavailableReason: blocked }),

--- a/tests/bench-interactions.test.ts
+++ b/tests/bench-interactions.test.ts
@@ -86,6 +86,22 @@ function receipt(overrides: Record<string, unknown> = {}) {
 }
 
 describe('interaction fixtures', () => {
+  it('does not compare startup observations made with different measurement methods', () => {
+    const current = receipt();
+    Object.assign(current.scenarios.first_interaction_accepted_ms, { measurementMethod: 'page-readiness-plus-trusted-input-paint-v1' });
+    const result = evaluateInteractionBudgets(current, { metrics: {
+      'first_interaction_accepted_ms@50': { value: 200 },
+    } });
+    const startup = result.results.find((entry) => entry.metric === 'first_interaction_accepted_ms');
+    expect(startup?.deltaStatus).toBe('incomparable');
+    expect(startup?.deltaValue).toBeNull();
+    expect(startup?.baselineValue).toBe(200);
+    const compatible = evaluateInteractionBudgets(current, { metrics: {
+      'first_interaction_accepted_ms@50': { value: 200, measurementMethod: 'page-readiness-plus-trusted-input-paint-v1' },
+    } });
+    expect(compatible.results.find((entry) => entry.metric === 'first_interaction_accepted_ms')?.deltaStatus).toBe('unchanged');
+  });
+
   it('produces the same plan and digest for the same scale and seed', () => {
     const first = buildFixturePlan(250, 4242);
     const second = buildFixturePlan(250, 4242);

--- a/tests/bench-startup-readiness-real-path.test.ts
+++ b/tests/bench-startup-readiness-real-path.test.ts
@@ -1,0 +1,87 @@
+import { chromium, type Page } from 'playwright-core';
+import { describe, expect, it } from 'vitest';
+import { resolveBrowserPath } from '../scripts/bench/measure-browser-boot.mjs';
+// @ts-expect-error -- serialized browser probes intentionally use plain JavaScript.
+import { installStartupReadinessProbe, readStartupReadinessSample } from '../scripts/bench/interactions/startup-readiness.mjs';
+import { evaluateInteractionBudgets } from '../scripts/bench/interactions/budgets.mjs';
+import { scenarioResult } from '../scripts/bench/interactions/statistics.mjs';
+
+const executablePath = resolveBrowserPath();
+type Sample = { durationMs: number | null; readinessMs?: number; inputPaintMs?: number;
+  excludedDriverWaitMs?: number; hydrationToPaintWallMs?: number; inputTrusted?: boolean; note?: string };
+
+async function fixture(page: Page, readyDelay: number) {
+  await page.setContent('<textarea data-o8-active-composer="true" disabled></textarea>');
+  await page.evaluate((delay) => {
+    (globalThis as typeof globalThis & { __o8Interactions: { hydratedAtMs: number } }).__o8Interactions = { hydratedAtMs: performance.now() };
+    setTimeout(() => { document.querySelector('textarea')!.disabled = false; }, delay);
+  }, readyDelay);
+  await page.evaluate(installStartupReadinessProbe, { timeoutMs: 8000 });
+}
+
+async function typeAndRead(page: Page): Promise<Sample> {
+  await page.locator('textarea').focus();
+  await page.keyboard.press('o');
+  await page.waitForFunction(() => (globalThis as typeof globalThis & {
+    __o8StartupReadiness?: { result: unknown };
+  }).__o8StartupReadiness?.result !== null);
+  return page.evaluate(readStartupReadinessSample);
+}
+
+describe.skipIf(!executablePath)('startup readiness through real trusted browser input', () => {
+  it('excludes delayed driver delivery while retaining readiness and accepted input paint', async () => {
+    const browser = await chromium.launch({ executablePath: executablePath!, headless: true });
+    try {
+      const page = await browser.newPage();
+      await fixture(page, 150);
+      await page.waitForFunction(() => !document.querySelector('textarea')!.disabled);
+      await page.waitForTimeout(650);
+      const sample = await typeAndRead(page);
+      expect(sample.inputTrusted).toBe(true);
+      expect(sample.readinessMs!).toBeGreaterThanOrEqual(140);
+      expect(sample.inputPaintMs!).toBeGreaterThan(0);
+      expect(sample.excludedDriverWaitMs!).toBeGreaterThanOrEqual(550);
+      expect(sample.durationMs!).toBeCloseTo(sample.readinessMs! + sample.inputPaintMs!, 1);
+      expect(sample.hydrationToPaintWallMs! - sample.durationMs!).toBeCloseTo(sample.excludedDriverWaitMs!, 1);
+      expect(await page.locator('textarea').inputValue()).toBe('o');
+    } finally { await browser.close(); }
+  }, 20_000);
+
+  it('still fails the unchanged startup budget when the app delays enabling the composer', async () => {
+    const browser = await chromium.launch({ executablePath: executablePath!, headless: true });
+    try {
+      const page = await browser.newPage();
+      await fixture(page, 2150);
+      await page.waitForFunction(() => !document.querySelector('textarea')!.disabled);
+      await page.waitForTimeout(80);
+      const sample = await typeAndRead(page);
+      expect(sample.durationMs!).toBeGreaterThan(2000);
+      const result = evaluateInteractionBudgets({ target: { buildMode: 'production' }, scenarios: {
+        first_interaction_accepted_ms: scenarioResult({ samples: [{ durationMs: sample.durationMs }] }),
+      } });
+      expect(result.failed).toContain('first_interaction_accepted_ms');
+    } finally { await browser.close(); }
+  }, 20_000);
+
+  it('does not turn synthetic input or a replaced input target into a startup pass', async () => {
+    const browser = await chromium.launch({ executablePath: executablePath!, headless: true });
+    try {
+      const page = await browser.newPage();
+      await fixture(page, 0);
+      await page.evaluate(() => {
+        const input = document.querySelector('textarea')!;
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'x', bubbles: true }));
+        input.value = 'x';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+      expect((await page.evaluate(readStartupReadinessSample) as Sample).durationMs).toBeNull();
+      await page.waitForTimeout(80);
+      await page.evaluate(() => document.querySelector('textarea')!.addEventListener('input', event => {
+        (event.target as HTMLTextAreaElement).remove();
+      }, { once: true }));
+      const sample = await typeAndRead(page);
+      expect(sample.durationMs).toBeNull();
+      expect(sample.note).toContain('through paint');
+    } finally { await browser.close(); }
+  }, 20_000);
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1106,6 +1106,12 @@
       ]
     },
     {
+      "path": "tests/bench-startup-readiness-real-path.test.ts",
+      "reasons": [
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/bench-tmux-scope-real-path.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
## Change

Correct the startup-input clock in #1697's interaction harness. A trace of the same released build observed an editable composer 1,520.4 ms after hydration, but the driver read the page at 2,263.7 ms. The old metric counted that 743.3 ms of driver delay as application startup work.

The new page-side probe records editable readiness, then requires the first trusted keyboard input to remain in the same textarea through paint. The metric adds readiness time and input-to-paint time. The excluded driver wait and full hydration-to-paint wall time remain in the receipt. The 2,000 ms ceiling is unchanged.

The probe rejects missing, disabled, readonly, replaced, synthetic or unpainted input and stops after its first observation or deadline. It adds no product code or idle-soak observer. Baseline rows retain the measurement method; an old/new startup comparison reports `incomparable` instead of inventing an improvement. Other metrics retain their previous comparison behavior.

## Verification

Real-browser tests exercise a deliberately delayed driver, a genuine 2,150 ms application delay that still fails the budget, synthetic events, and replacement of the input before paint. The focused harness suite passed 45 tests. Final TypeScript and full-suite results are recorded below before merge.

The previous release observations remain unchanged. Corrected observations are collected separately, not substituted into the old receipts. The budgets remain provisional pending the separate baseline-policy decision. This PR does not claim whole-app performance acceptance or release publication.
