### PR TITLE
perf: trim the Symon planner first-turn payload

### DIFF
--- a/src-tauri/src/agent/claude.rs
+++ b/src-tauri/src/agent/claude.rs
@@ -26,15 +26,18 @@
 //! ONE persistent `claude` session per task — not a fresh spawn per turn. The
 //! proc boots once (pre-warmed on the Option keydown via `claude_pool`, so even
 //! turn 1 skips the ~1-2s CLI bootstrap), and each turn sends a single user
-//! frame while the model keeps its context. Turn 1 carries the full system
-//! prompt + tool schema + screenshot; follow-ups carry only the tool result — no
-//! re-boot, no transcript re-prefill. Built-in tools are hard-locked off at
-//! spawn (`--tools ""`), not just discouraged by the planner contract, so a
-//! contract-ignoring turn still has nothing to execute.
+//! frame while the model keeps its context. Turn 1 carries the system prompt +
+//! tool catalog + screenshot (shape and cost: `planner_payload`); follow-ups
+//! carry only the tool result — no re-boot, no transcript re-prefill. What each
+//! first turn cost is logged as one `[symon-planner]` line. Built-in tools are
+//! hard-locked off at spawn (`--tools ""`), not just discouraged by the planner
+//! contract, so a contract-ignoring turn still has nothing to execute.
 
-use super::{tools, ConfirmCorrelation, LoopResult, TaskCtx};
+use super::{ConfirmCorrelation, LoopResult, TaskCtx};
 use serde_json::{json, Value};
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+pub(crate) mod planner_payload;
 
 const MAX_TURNS: usize = 10;
 /// Per-turn ceiling. A real model hang is rare; on timeout the turn errors and
@@ -115,53 +118,6 @@ pub(crate) fn ensure_empty_mcp_config() -> Result<String, String> {
             .map_err(|e| format!("failed to write empty mcp config: {e}"))?;
     }
     Ok(path.to_string_lossy().to_string())
-}
-
-/// Build the first planner prompt: persona + (conversation / edit / SCREEN)
-/// context + the tool schema + the JSON-action contract + the user's request.
-/// When a screenshot rides the turn it is sent as an image block (see
-/// `ClaudeSession::send_turn`) and this prompt teaches the screen + draw
-/// protocol — the selected Claude model sees it directly, with no Gemini middleman.
-fn build_first_prompt(intent: &str, ctx: &TaskCtx) -> String {
-    let mut s = super::system_prompt();
-    if let Some(convo) = super::conversation_context() {
-        s.push_str("\n\n");
-        s.push_str(&convo);
-    }
-    if let Some(edit) = &ctx.edit {
-        s.push_str("\n\n");
-        s.push_str(&super::edit_prompt_section(edit));
-    }
-    if let Some(screen) = &ctx.screen {
-        s.push_str("\n\n");
-        s.push_str(&super::screen_prompt_section(screen));
-        // Planner-path rule: the [POINT]/[DRAW] tags must ride INSIDE the `say`
-        // string of the final {"done": true, "say": "..."} action — never as
-        // loose text outside the JSON, or extract_action won't see them.
-        s.push_str(
-            "\n\n(You CAN see the attached screenshot. When you point or draw, put the \
-             [POINT]/[GUIDE]/[DRAW] tags INSIDE the \"say\" string of your final \
-             {\"done\": true, \"say\": \"...\"} action — never outside the JSON object.)",
-        );
-        // Additive teaching diagrams (#1251): if a drawing session is live, give
-        // the brain back the exact tags it just drew so it re-emits + extends
-        // them instead of starting a fresh figure.
-        if let Some(feedback) = super::last_drawing_feedback() {
-            s.push_str(&feedback);
-        }
-    }
-    // The background brain DOES the work — strip `escalate` so it can't re-hand
-    // the task back to another Claude task (infinite-handoff guard).
-    let tool_specs: Vec<Value> = tools::enabled_tools()
-        .into_iter()
-        .filter(|t| t.get("name").and_then(|n| n.as_str()) != Some("escalate"))
-        .collect();
-    let tools_json =
-        serde_json::to_string_pretty(&tool_specs).unwrap_or_else(|_| "[]".to_string());
-    s.push_str(PLANNER_CONTRACT);
-    s.push_str(&format!("\n\nAVAILABLE TOOLS (JSON Schema):\n{tools_json}"));
-    s.push_str(&format!("\n\nUser request: {intent}"));
-    s
 }
 
 /// Pull the next-action JSON out of Claude's reply — tolerant of stray code
@@ -662,8 +618,16 @@ async fn run_text_planner_loop_inner<S: TextPlannerSession>(
     // Turn 1 carries the full planner prompt; the screenshot rides it once and
     // remains in session context. Each follow-up replaces `next_message`
     // with just the tool-result block built at the loop foot.
-    let mut next_message = build_first_prompt(intent, ctx);
+    let first_turn = planner_payload::build_first_prompt(intent, ctx);
+    let first_turn_bytes = first_turn.prompt.len();
+    let tool_defs = first_turn.tool_defs;
+    // What the first turn cost, measured from here — the session is already
+    // spawned (or pooled), so this is the model's own time to a usable action.
+    let first_turn_started = Instant::now();
+    let mut next_message = first_turn.prompt;
     let mut next_image: Option<String> = ctx.screen.as_ref().map(|s| s.png_base64.clone());
+    // Schema lookups spent on this task (`planner_payload::TOOL_LOOKUP`).
+    let mut lookups = 0usize;
 
     // Anti-fabrication guard state: does the request ask Symon to DO something
     // (an action, not a pure question)? If so and the loop ends `done` with ZERO
@@ -703,7 +667,17 @@ async fn run_text_planner_loop_inner<S: TextPlannerSession>(
             result => result?,
         };
 
-        let Some(action) = extract_action(&raw) else {
+        let parsed = extract_action(&raw);
+        if turn == 0 {
+            // One stable line per planner task — what the first turn carried and
+            // what it bought. Keep the field names: a dashboard may parse them.
+            log::info!(
+                "[symon-planner] seat={provider}/{model} first_turn_bytes={first_turn_bytes} \
+                 tool_defs={tool_defs} first_action_ms={}",
+                first_turn_started.elapsed().as_millis()
+            );
+        }
+        let Some(action) = parsed else {
             // Not parseable as an action — take the reply as the final answer
             // rather than looping blindly.
             result_text = raw.trim().to_string();
@@ -746,6 +720,27 @@ async fn run_text_planner_loop_inner<S: TextPlannerSession>(
             break;
         };
         let tool_args = action.get("args").cloned().unwrap_or(json!({}));
+
+        // A schema lookup, not an action: the first turn carries the tool
+        // catalog compact, so this is how the planner reaches the parameters of
+        // anything whose full schema did not ride along. Answered here, ahead of
+        // the execution seam — it never reaches the ledger or the confirm gate.
+        if tool_name == planner_payload::TOOL_LOOKUP {
+            lookups += 1;
+            let names = planner_payload::requested_lookup_names(&tool_args);
+            log::info!(
+                "[symon-planner] tool_lookup {}/{} {names:?}",
+                lookups,
+                planner_payload::MAX_TOOL_LOOKUPS
+            );
+            next_message = if lookups > planner_payload::MAX_TOOL_LOOKUPS {
+                planner_payload::lookup_budget_spent_message()
+            } else {
+                planner_payload::tool_lookup_message(&names)
+            };
+            next_image = None;
+            continue;
+        }
 
         if let Some(app) = ctx.app.as_ref() {
             super::emit_agent_event(

--- a/src-tauri/src/agent/claude/planner_payload.rs
+++ b/src-tauri/src/agent/claude/planner_payload.rs
@@ -1,0 +1,316 @@
+//! The planner's first-turn payload (#2157).
+//!
+//! Follow-up turns are cheap because the session holds the context, but every
+//! escalation pays turn 1 in full: the persona, the planner contract and the
+//! tool catalog all ride ahead of the task. Two things keep that bill down.
+//!
+//! **A stable prefix.** Persona (no clock) → planner contract → tool catalog,
+//! in that order, with the tools in a deterministic order and every per-task
+//! string — the time, the operator's memory, the conversation, the edit
+//! target, the screen — after it, and the request strictly last. The prefix is
+//! the same bytes on every task, which is the thing a provider prompt cache
+//! can hit on. Anything with a clock or a task id in it breaks that, so it
+//! stays on the far side of the boundary.
+//!
+//! **A compact catalog.** Descriptions choose a tool; parameter schemas call
+//! one. So the catalog carries every tool's name and description on one line
+//! each — the planner can still reach all of them — and prints parameters only
+//! for the few tools real runs call most (`UP_FRONT_FULL_SCHEMA`). For anything
+//! else the planner asks with a `tool_lookup` action and gets the full
+//! description and the exact schema back inside the same session, one turn
+//! later. Long descriptions are cut to whole leading sentences
+//! (`DESCRIPTION_BUDGET`), and the same lookup returns the rest.
+
+use serde_json::{json, Value};
+
+use crate::agent::TaskCtx;
+
+/// The planner-loop verb that trades one turn for a tool's full schema. It is
+/// NOT a dispatchable tool: `run_text_planner_loop_inner` answers it before the
+/// execution seam, so it never reaches the ledger, the confirm gate, or a
+/// handler.
+pub(crate) const TOOL_LOOKUP: &str = "tool_lookup";
+
+/// Lookups per task. A lookup changes nothing, but it spends a turn out of
+/// `MAX_TURNS`, so a planner that keeps reading instead of acting gets told to
+/// act.
+pub(crate) const MAX_TOOL_LOOKUPS: usize = 3;
+
+/// Tools per lookup. Enough to cover a multi-step plan in one ask; not enough
+/// to pull the whole catalog back in through the side door.
+const MAX_LOOKUP_NAMES: usize = 8;
+
+/// Tools whose full JSON Schema rides the first turn. Picked off the task
+/// ledger — these are what real planner runs call most — plus
+/// `symon_execute_plan`, which the planner contract names directly and so must
+/// be callable without a lookup. Frequent tools that take no arguments
+/// (`term_list`) stay compact: `{}` is the whole call. So does the one frequent
+/// tool with a very large schema (`o8_canvas`, ~6 KB), because a lookup on the
+/// runs that need it is cheaper than those bytes on every run that does not.
+pub(crate) const UP_FRONT_FULL_SCHEMA: &[&str] = &[
+    "symon_execute_plan",
+    "o8_ui_set",
+    "o8_ui_open",
+    "o8_status",
+    "mac_reminders_create",
+    "mac_reminders_list",
+    "mac_calendar_list_events",
+];
+
+/// The first turn as sent, with the numbers the `[symon-planner]` log line
+/// reports.
+pub(crate) struct FirstTurn {
+    pub(crate) prompt: String,
+    /// Full JSON-Schema tool definitions carried in the prompt. Every other
+    /// tool is reachable by name from the compact catalog.
+    pub(crate) tool_defs: usize,
+}
+
+fn tool_name(tool: &Value) -> &str {
+    tool.get("name").and_then(Value::as_str).unwrap_or_default()
+}
+
+fn one_line(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Every tool the planner may call, in deterministic order.
+///
+/// `escalate` is stripped: the background brain DOES the work, and handing the
+/// task to another background brain is the infinite-handoff loop. Name order
+/// (rather than source order) is what keeps the prefix byte-stable — the MCP
+/// tools on the tail arrive over HTTP and carry no order of their own.
+pub(crate) fn catalog_tools() -> Vec<Value> {
+    let mut tools: Vec<Value> = crate::agent::tools::enabled_tools()
+        .into_iter()
+        .filter(|tool| tool_name(tool) != "escalate")
+        .collect();
+    tools.sort_by(|left, right| tool_name(left).cmp(tool_name(right)));
+    tools
+}
+
+/// Compact-catalog description budget, in bytes. Sentence-aware: a longer
+/// description keeps whole leading sentences and ends in an ellipsis, and
+/// `tool_lookup` hands back the full text along with the parameters — so the
+/// rest is deferred, not lost.
+const DESCRIPTION_BUDGET: usize = 240;
+
+fn trimmed_description(description: &str) -> String {
+    let text = one_line(description);
+    if text.len() <= DESCRIPTION_BUDGET {
+        return text;
+    }
+    let bytes = text.as_bytes();
+    let mut first_end: Option<usize> = None;
+    let mut last_end: Option<usize> = None;
+    for (at, character) in text.char_indices() {
+        if !matches!(character, '.' | '!' | '?') || bytes.get(at + 1) != Some(&b' ') {
+            continue;
+        }
+        let end = at + 1;
+        first_end.get_or_insert(end);
+        if end <= DESCRIPTION_BUDGET {
+            last_end = Some(end);
+        } else {
+            break;
+        }
+    }
+    let end = last_end.or(first_end).unwrap_or_else(|| {
+        // No sentence to cut on: fall back to the budget, on a char boundary.
+        text.char_indices()
+            .take_while(|(at, _)| *at <= DESCRIPTION_BUDGET)
+            .last()
+            .map(|(at, _)| at)
+            .unwrap_or(text.len())
+    });
+    format!("{} …", &text[..end])
+}
+
+/// `name — what it does`, on one line, parameters omitted.
+fn compact_line(tool: &Value) -> String {
+    let name = tool_name(tool);
+    match tool.get("description").and_then(Value::as_str) {
+        Some(description) if !description.trim().is_empty() => {
+            format!("{name} — {}", trimmed_description(description))
+        }
+        _ => name.to_string(),
+    }
+}
+
+/// An up-front schema without its description — the catalog line right above it
+/// already carries that, and the duplicate is pure weight.
+fn schema_only(tool: &Value) -> Value {
+    let mut object = serde_json::Map::new();
+    object.insert("name".to_string(), json!(tool_name(tool)));
+    if let Some(parameters) = tool.get("parameters") {
+        object.insert("parameters".to_string(), parameters.clone());
+    }
+    Value::Object(object)
+}
+
+/// The tool half of the invariant prefix, and the number of full schemas in it.
+fn catalog_block(tools: &[Value]) -> (String, usize) {
+    let mut block = String::from(
+        "\n\n--- TOOLS ---\n\
+         You can call EVERY tool listed below by name. The list gives each tool's name and a \
+         shortened description; their ARGUMENTS are not printed here, and a description ending \
+         in … has more to it. Before calling a tool whose parameters are not printed further \
+         down, ask for them:\n  \
+         {\"tool\": \"tool_lookup\", \"args\": {\"names\": [\"mac_notes_create\"]}}\n\
+         The system replies with those tools' full description and exact JSON Schema, and you \
+         then call the tool normally. A lookup is not an action — it changes nothing and costs \
+         one turn — so ask whenever you are unsure of an argument name instead of guessing one. \
+         A tool that takes no arguments is called with {} and needs no lookup.\n\n\
+         TOOLS (name — what it does):\n",
+    );
+    for tool in tools {
+        block.push_str(&compact_line(tool));
+        block.push('\n');
+    }
+
+    let full: Vec<&Value> = tools
+        .iter()
+        .filter(|tool| UP_FRONT_FULL_SCHEMA.contains(&tool_name(tool)))
+        .collect();
+    if !full.is_empty() {
+        block.push_str(
+            "\nPARAMETERS for the tools below — call these directly, no lookup needed:\n",
+        );
+        for tool in &full {
+            block.push_str(&serde_json::to_string(&schema_only(tool)).unwrap_or_default());
+            block.push('\n');
+        }
+    }
+    (block, full.len())
+}
+
+/// Persona → planner contract → tool catalog. The same bytes on every task.
+pub(crate) fn invariant_prefix() -> (String, usize) {
+    let tools = catalog_tools();
+    let (catalog, tool_defs) = catalog_block(&tools);
+    let mut prefix = crate::agent::system_prompt_invariant();
+    prefix.push_str(super::PLANNER_CONTRACT);
+    prefix.push_str(&catalog);
+    (prefix, tool_defs)
+}
+
+/// Build the first planner prompt: the invariant prefix, then this task's
+/// context (clock / skill / memory, conversation, edit target, screen), then
+/// the request last. When a screenshot rides the turn it is sent as an image
+/// block (see `ClaudeSession::send_turn`) and this prompt teaches the screen +
+/// draw protocol.
+pub(crate) fn build_first_prompt(intent: &str, ctx: &TaskCtx) -> FirstTurn {
+    let (mut prompt, tool_defs) = invariant_prefix();
+
+    // ---- everything below here is per-task; nothing above it may be ----
+    prompt.push_str("\n\n--- RIGHT NOW ---\n");
+    prompt.push_str(&crate::agent::system_prompt_task_context());
+    if let Some(convo) = crate::agent::conversation_context() {
+        prompt.push_str("\n\n");
+        prompt.push_str(&convo);
+    }
+    if let Some(edit) = &ctx.edit {
+        prompt.push_str("\n\n");
+        prompt.push_str(&crate::agent::edit_prompt_section(edit));
+    }
+    if let Some(screen) = &ctx.screen {
+        prompt.push_str("\n\n");
+        prompt.push_str(&crate::agent::screen_prompt_section(screen));
+        // Planner-path rule: the [POINT]/[DRAW] tags must ride INSIDE the `say`
+        // string of the final {"done": true, "say": "..."} action — never as
+        // loose text outside the JSON, or extract_action won't see them.
+        prompt.push_str(
+            "\n\n(You CAN see the attached screenshot. When you point or draw, put the \
+             [POINT]/[GUIDE]/[DRAW] tags INSIDE the \"say\" string of your final \
+             {\"done\": true, \"say\": \"...\"} action — never outside the JSON object.)",
+        );
+        // Additive teaching diagrams (#1251): if a drawing session is live, give
+        // the brain back the exact tags it just drew so it re-emits + extends
+        // them instead of starting a fresh figure.
+        if let Some(feedback) = crate::agent::last_drawing_feedback() {
+            prompt.push_str(&feedback);
+        }
+    }
+    prompt.push_str(&format!("\n\nUser request: {intent}"));
+    FirstTurn { prompt, tool_defs }
+}
+
+/// Tool names off a `tool_lookup` action. Takes `names: [...]` and tolerates a
+/// single `name: "..."`, because that is the other way a model writes it.
+pub(crate) fn requested_lookup_names(args: &Value) -> Vec<String> {
+    let mut names: Vec<String> = match args.get("names") {
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter_map(|item| item.as_str().map(str::to_string))
+            .collect(),
+        Some(Value::String(single)) => vec![single.clone()],
+        _ => Vec::new(),
+    };
+    if names.is_empty() {
+        if let Some(single) = args
+            .get("name")
+            .or_else(|| args.get("tool"))
+            .and_then(Value::as_str)
+        {
+            names.push(single.to_string());
+        }
+    }
+    names.retain(|name| !name.trim().is_empty());
+    names.truncate(MAX_LOOKUP_NAMES);
+    names
+}
+
+const NEXT_ACTION_TAIL: &str = "\n\nNow respond with your NEXT action as a single JSON object — a \
+                                tool call, or {\"done\": true, \"say\": \"...\"} when the request \
+                                is fully handled.";
+
+/// The `[SYSTEM]` reply to a `tool_lookup`: exact schemas for the names the
+/// planner asked for, and a plain miss for anything not in the catalog.
+pub(crate) fn tool_lookup_message(names: &[String]) -> String {
+    if names.is_empty() {
+        return format!(
+            "[SYSTEM] tool_lookup needs the tool names you want, for example \
+             {{\"tool\": \"tool_lookup\", \"args\": {{\"names\": [\"mac_notes_create\"]}}}}.\
+             {NEXT_ACTION_TAIL}"
+        );
+    }
+    let catalog = catalog_tools();
+    let mut found: Vec<&Value> = Vec::new();
+    let mut missing: Vec<&str> = Vec::new();
+    for name in names {
+        match catalog.iter().find(|tool| tool_name(tool) == name.as_str()) {
+            Some(tool) => found.push(tool),
+            None => missing.push(name.as_str()),
+        }
+    }
+    let mut message = format!(
+        "[SYSTEM] tool_lookup returned the full JSON Schema for {} of {} requested tool(s).",
+        found.len(),
+        names.len()
+    );
+    for tool in found {
+        message.push('\n');
+        message.push_str(&serde_json::to_string(tool).unwrap_or_default());
+    }
+    if !missing.is_empty() {
+        message.push_str(&format!(
+            "\nNot in the catalog (no such tool — use a name exactly as listed): {}",
+            missing.join(", ")
+        ));
+    }
+    message.push_str(NEXT_ACTION_TAIL);
+    message
+}
+
+/// Said once the lookup budget is gone: read enough, now act.
+pub(crate) fn lookup_budget_spent_message() -> String {
+    format!(
+        "[SYSTEM] You have used all {MAX_TOOL_LOOKUPS} tool_lookup turns for this task. Call a \
+         tool now with the schemas you already have, or finish with {{\"done\": true, \"say\": \
+         \"...\"}} if you cannot.{NEXT_ACTION_TAIL}"
+    )
+}
+
+#[cfg(test)]
+#[path = "planner_payload_tests.rs"]
+mod planner_payload_tests;

--- a/src-tauri/src/agent/claude/planner_payload_tests.rs
+++ b/src-tauri/src/agent/claude/planner_payload_tests.rs
@@ -1,0 +1,381 @@
+//! Real-path coverage for the planner's first-turn payload (#2157).
+//!
+//! The payload is only worth what the planner can still do with it, so these
+//! drive the loop a real escalation drives — a spawned planner process, a real
+//! `tool_lookup` round trip, a real second turn — rather than asserting on the
+//! builder alone.
+
+use super::*;
+use crate::agent::{claude, opencode, tools, TaskCtx};
+use serde_json::json;
+use std::sync::Arc;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+/// A throwaway data dir, so nothing in `~/.o8` is read or written while the
+/// prompt builder asks for the operator's skill and memory context.
+struct PayloadFixture {
+    dir: std::path::PathBuf,
+    previous: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    _guard: std::sync::MutexGuard<'static, ()>,
+}
+
+impl PayloadFixture {
+    fn new(name: &str) -> Self {
+        let guard = crate::DATA_DIR_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let dir = std::env::temp_dir().join(format!(
+            "o8-planner-payload-{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let previous = ["O8_DATA_DIR", "CORTEX_IDE_DATA_DIR", "SEAT_CAPTURE"]
+            .into_iter()
+            .map(|key| (key, std::env::var_os(key)))
+            .collect();
+        std::env::set_var("O8_DATA_DIR", &dir);
+        std::env::remove_var("CORTEX_IDE_DATA_DIR");
+        std::env::set_var("SEAT_CAPTURE", dir.join("capture"));
+        Self {
+            dir,
+            previous,
+            _guard: guard,
+        }
+    }
+}
+
+impl Drop for PayloadFixture {
+    fn drop(&mut self) {
+        for (key, value) in &self.previous {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+fn ctx_for(task_id: &str) -> TaskCtx {
+    TaskCtx {
+        task_id: task_id.into(),
+        utterance: "handled by the planner".into(),
+        ledger_session_id: None,
+        machine_session_id: "desktop".into(),
+        app: None,
+        screen: None,
+        spatial: false,
+        crop_png_base64: None,
+        edit: None,
+        cancel: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    }
+}
+
+fn ctx_with_screen(task_id: &str) -> TaskCtx {
+    let mut ctx = ctx_for(task_id);
+    ctx.screen = Some(std::sync::Arc::new(crate::agent::screen::ScreenContext {
+        trace_id: 7,
+        png_base64: "iVBORw0KGgo=".into(),
+        img_w: 1512,
+        img_h: 982,
+        mon_x: 0.0,
+        mon_y: 0.0,
+        mon_w: 1512.0,
+        mon_h: 982.0,
+        ax_catalog: Vec::new(),
+        web_catalog: Vec::new(),
+    }));
+    ctx
+}
+
+/// The whole point of the ordering: the bytes ahead of the task are the same
+/// bytes on every escalation, so a provider prompt cache has something to hit.
+/// Two tasks with different requests AND different per-task context must agree
+/// byte for byte up to the first per-task character.
+#[test]
+fn the_invariant_prefix_is_byte_identical_across_two_tasks() {
+    let _fixture = PayloadFixture::new("prefix");
+    let (prefix, tool_defs) = invariant_prefix();
+    assert!(tool_defs > 0, "some schemas ride the first turn");
+
+    let plain = build_first_prompt(
+        "remind me to call the bank at four",
+        &ctx_for("claude-task-a"),
+    );
+    let with_screen = build_first_prompt(
+        "what is this error on my screen",
+        &ctx_with_screen("claude-task-b"),
+    );
+
+    assert!(plain.prompt.starts_with(&prefix));
+    assert!(with_screen.prompt.starts_with(&prefix));
+    assert_eq!(plain.prompt[..prefix.len()], with_screen.prompt[..prefix.len()]);
+    assert_eq!(plain.tool_defs, with_screen.tool_defs);
+
+    // Nothing per-task may sit inside the prefix — a clock is the one that
+    // would silently break every cache hit.
+    assert!(
+        !prefix.contains("The current local time is"),
+        "the clock belongs after the prefix"
+    );
+    assert!(!prefix.contains("claude-task-a"));
+    assert!(
+        plain.prompt[prefix.len()..].starts_with("\n\n--- RIGHT NOW ---"),
+        "the per-task half starts exactly where the invariant half ends"
+    );
+    assert!(plain.prompt.contains("The current local time is"));
+
+    // ...and the order is the contracted one, with the request strictly last.
+    let at = |needle: &str| plain.prompt.find(needle).expect(needle);
+    assert!(at("--- HOW YOU ACT ---") < at("--- TOOLS ---"));
+    assert!(at("--- TOOLS ---") < at("--- RIGHT NOW ---"));
+    assert!(at("--- RIGHT NOW ---") < at("\n\nUser request: "));
+    assert!(plain
+        .prompt
+        .ends_with("\n\nUser request: remind me to call the bank at four"));
+    // The screen protocol still rides the turn that carries a screenshot.
+    assert!(with_screen.prompt.contains("[POINT]"));
+}
+
+/// Every tool stays reachable: the compact catalog names them all, and the
+/// tools whose full schema did not ride along are one lookup away.
+#[test]
+fn the_compact_catalog_names_every_tool_and_only_the_allow_list_carries_a_schema() {
+    let _fixture = PayloadFixture::new("catalog");
+    let catalog = catalog_tools();
+    let built = build_first_prompt("do the thing", &ctx_for("claude-task-c"));
+
+    assert!(
+        !catalog.is_empty() && catalog.len() > UP_FRONT_FULL_SCHEMA.len(),
+        "the catalog is bigger than the allow list, or this measures nothing"
+    );
+    for tool in &catalog {
+        let name = tool.get("name").and_then(|n| n.as_str()).unwrap();
+        assert!(
+            built.prompt.contains(&format!("\n{name} — ")),
+            "{name} is missing from the compact catalog"
+        );
+    }
+    assert!(
+        !built.prompt.contains("\nescalate — "),
+        "the background brain does the work; re-escalating is the handoff loop"
+    );
+    // The allow list rides as full JSON Schema; nothing else does.
+    for name in UP_FRONT_FULL_SCHEMA {
+        assert!(
+            built.prompt.contains(&format!("\"name\":\"{name}\"")),
+            "{name} should carry its full schema up front"
+        );
+    }
+    assert_eq!(built.tool_defs, UP_FRONT_FULL_SCHEMA.len());
+    assert!(
+        !built.prompt.contains("\"name\":\"mac_notes_create\""),
+        "a tool outside the allow list must not ship its schema"
+    );
+    // Deterministic order — sorted by name, so the prefix cannot shuffle.
+    let names: Vec<&str> = catalog
+        .iter()
+        .map(|t| t.get("name").and_then(|n| n.as_str()).unwrap())
+        .collect();
+    let mut sorted = names.clone();
+    sorted.sort_unstable();
+    assert_eq!(names, sorted);
+}
+
+/// A lookup answers with the exact schema, a miss says so, and the budget
+/// runs out rather than letting the planner read forever.
+#[test]
+fn a_lookup_returns_the_exact_schema_and_names_a_miss() {
+    let _fixture = PayloadFixture::new("lookup");
+    let message = tool_lookup_message(&["mac_notes_create".to_string(), "not_a_tool".to_string()]);
+    assert!(message.contains("\"name\":\"mac_notes_create\""));
+    assert!(message.contains("\"parameters\""));
+    assert!(message.contains("Not in the catalog"));
+    assert!(message.contains("not_a_tool"));
+    assert!(message.contains("your NEXT action"));
+
+    // Both spellings a model reaches for.
+    assert_eq!(
+        requested_lookup_names(&json!({ "names": ["mac_weather"] })),
+        vec!["mac_weather".to_string()]
+    );
+    assert_eq!(
+        requested_lookup_names(&json!({ "name": "mac_weather" })),
+        vec!["mac_weather".to_string()]
+    );
+    assert!(requested_lookup_names(&json!({})).is_empty());
+    assert!(lookup_budget_spent_message().contains("tool_lookup turns"));
+}
+
+/// The real path: `escalate` hands the task to the background brain, and the
+/// loop that brain runs spawns a planner process, sends the first turn, answers
+/// a `tool_lookup` with the full schema, and keeps going to a finished task.
+/// The one seam these two halves meet at is the desktop handle the handoff
+/// needs, which a headless test cannot hold.
+#[cfg(unix)]
+#[tokio::test]
+async fn escalate_hands_off_and_the_planner_loop_serves_a_lookup_and_continues() {
+    let fixture = PayloadFixture::new("realpath");
+    let ctx = ctx_for("claude-task-realpath");
+
+    // Leg 1 — the dispatch really does route to the background brain, stopping
+    // only at the desktop handle `spawn_background_brain_task` needs.
+    let handed_off = tools::dispatch_tool_call(
+        "escalate",
+        json!({ "task": "file this week's notes", "target": "claude_brain" }),
+        &ctx,
+    )
+    .await;
+    assert_eq!(
+        handed_off.unwrap_err(),
+        "This action requires the live o8 desktop app"
+    );
+
+    // Leg 2 — the loop that background task runs, against a real process. The
+    // fixture answers turn 1 with a lookup for a tool whose schema is NOT in
+    // the first turn, then finishes.
+    let planner = fixture.dir.join("opencode-fixture");
+    std::fs::write(
+        &planner,
+        r#"#!/bin/sh
+n=$(cat "$SEAT_COUNT" 2>/dev/null || echo 0)
+n=$((n+1))
+printf '%s' "$n" > "$SEAT_COUNT"
+for arg in "$@"; do last="$arg"; done
+printf '%s' "$last" > "$SEAT_CAPTURE.prompt.$n"
+if [ "$n" = "1" ]; then
+  printf '%s\n' '{"type":"text","sessionID":"ses_fixture","part":{"type":"text","text":"{\"tool\":\"tool_lookup\",\"args\":{\"names\":[\"mac_notes_create\"]}}"}}'
+else
+  printf '%s\n' '{"type":"text","sessionID":"ses_fixture","part":{"type":"text","text":"{\"done\":true,\"say\":\"Filed them.\"}"}}'
+fi
+"#,
+    )
+    .unwrap();
+    std::fs::set_permissions(&planner, std::fs::Permissions::from_mode(0o755)).unwrap();
+    std::env::set_var("SEAT_COUNT", fixture.dir.join("count"));
+
+    let session = opencode::OpencodeSession::new(&planner.to_string_lossy(), None);
+    let result = claude::run_text_planner_loop(
+        session,
+        "opencode",
+        "file this week's notes",
+        &ctx,
+        "opencode",
+    )
+    .await
+    .expect("the planner loop runs to a finished task");
+    std::env::remove_var("SEAT_COUNT");
+    assert_eq!(
+        result.result_text, "Filed them.",
+        "the loop continued past the lookup"
+    );
+
+    // The prompt is the last argument of each spawn — the fixture writes it
+    // out whole, so these are the exact bytes the planner received.
+    let prompt_of = |turn: usize| {
+        std::fs::read_to_string(format!(
+            "{}.prompt.{turn}",
+            fixture.dir.join("capture").display()
+        ))
+        .expect("the fixture recorded the prompt it was sent")
+    };
+
+    // Turn 1 as actually sent: compact catalog, allow-listed schemas only.
+    let first = prompt_of(1);
+    assert!(first.contains("--- TOOLS ---"));
+    assert!(first.contains("\nmac_notes_create — "));
+    assert!(!first.contains("\"name\":\"mac_notes_create\""));
+    for name in UP_FRONT_FULL_SCHEMA {
+        assert!(first.contains(&format!("\"name\":\"{name}\"")));
+    }
+
+    // Turn 2 is the lookup answer — the exact schema the planner asked for.
+    let second = prompt_of(2);
+    assert!(second.contains("tool_lookup returned the full JSON Schema"));
+    assert!(second.contains("\"name\":\"mac_notes_create\""));
+    assert!(second.contains("\"parameters\""));
+}
+
+/// The reduction itself, measured on the payload a scripted escalation sends.
+///
+/// `pre_2157_shape` is the builder this PR replaced, kept verbatim so the
+/// before number is measured from the same live inputs rather than quoted from
+/// a PR, and so the win cannot quietly erode: the acceptance bar from #2157 is
+/// half, and it is asserted here per fixture.
+fn pre_2157_shape(intent: &str, ctx: &TaskCtx) -> String {
+    let mut s = crate::agent::system_prompt();
+    if let Some(convo) = crate::agent::conversation_context() {
+        s.push_str("\n\n");
+        s.push_str(&convo);
+    }
+    if let Some(edit) = &ctx.edit {
+        s.push_str("\n\n");
+        s.push_str(&crate::agent::edit_prompt_section(edit));
+    }
+    if let Some(screen) = &ctx.screen {
+        s.push_str("\n\n");
+        s.push_str(&crate::agent::screen_prompt_section(screen));
+        s.push_str(
+            "\n\n(You CAN see the attached screenshot. When you point or draw, put the \
+             [POINT]/[GUIDE]/[DRAW] tags INSIDE the \"say\" string of your final \
+             {\"done\": true, \"say\": \"...\"} action — never outside the JSON object.)",
+        );
+    }
+    let tool_specs: Vec<serde_json::Value> = crate::agent::tools::enabled_tools()
+        .into_iter()
+        .filter(|t| t.get("name").and_then(|n| n.as_str()) != Some("escalate"))
+        .collect();
+    let tools_json =
+        serde_json::to_string_pretty(&tool_specs).unwrap_or_else(|_| "[]".to_string());
+    s.push_str(super::super::PLANNER_CONTRACT);
+    s.push_str(&format!("\n\nAVAILABLE TOOLS (JSON Schema):\n{tools_json}"));
+    s.push_str(&format!("\n\nUser request: {intent}"));
+    s
+}
+
+#[test]
+fn the_first_turn_payload_is_at_least_half_off() {
+    let _fixture = PayloadFixture::new("measure");
+    let catalog = catalog_tools().len();
+    for (label, ctx, intent) in [
+        (
+            "reminder",
+            ctx_for("claude-task-m1"),
+            "remind me to call the bank at four",
+        ),
+        (
+            "fleet",
+            ctx_for("claude-task-m2"),
+            "what are the agents shipping right now",
+        ),
+        (
+            "screen",
+            ctx_with_screen("claude-task-m3"),
+            "what is this error on my screen",
+        ),
+    ] {
+        let before = pre_2157_shape(intent, &ctx);
+        let after = build_first_prompt(intent, &ctx);
+        println!(
+            "[measure] fixture={label} before_bytes={} before_tool_defs={} \
+             after_bytes={} after_tool_defs={} catalog_tools={}",
+            before.len(),
+            catalog,
+            after.prompt.len(),
+            after.tool_defs,
+            catalog
+        );
+        assert!(
+            after.prompt.len() * 2 < before.len(),
+            "{label}: {} bytes is not at least half off {}",
+            after.prompt.len(),
+            before.len()
+        );
+    }
+}

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -132,17 +132,41 @@ const SYMON_SYSTEM_PROMPT_V1: &str = include_str!(concat!(
     "/../src/lib/prompts/v1/symon-native-system.txt"
 ));
 
-/// Shared system prompt: the agent persona + current-time grounding. Spoken
-/// aloud, so it asks for short, markdown-free replies.
-pub(crate) fn system_prompt() -> String {
-    let when = chrono::Local::now()
-        .format("%A, %B %-d %Y, %-I:%M %p")
-        .to_string();
-    let mut prompt = SYMON_SYSTEM_PROMPT_V1
+/// Opening words of the persona file's closing time sentence. Everything
+/// before it is the same bytes on every task; everything from it on is
+/// per-task — the clock, the active skill, the operator's memory facts. The
+/// planner sends the two halves separately so a provider prompt cache can hit
+/// on the invariant half (#2157); `system_prompt()` still joins them.
+const PERSONA_TIME_SENTENCE: &str = "The current local time is";
+
+fn persona_collapsed() -> String {
+    SYMON_SYSTEM_PROMPT_V1
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ")
-        .replace("{CURRENT_LOCAL_TIME}", &when);
+}
+
+/// The persona alone — no clock, no operator state, so the same bytes on
+/// every task.
+pub(crate) fn system_prompt_invariant() -> String {
+    let collapsed = persona_collapsed();
+    match collapsed.find(PERSONA_TIME_SENTENCE) {
+        Some(at) => collapsed[..at].trim_end().to_string(),
+        None => collapsed,
+    }
+}
+
+/// The per-task half: current-time grounding, the active skill, and the
+/// operator-approved memory facts.
+pub(crate) fn system_prompt_task_context() -> String {
+    let when = chrono::Local::now()
+        .format("%A, %B %-d %Y, %-I:%M %p")
+        .to_string();
+    let collapsed = persona_collapsed();
+    let mut prompt = match collapsed.find(PERSONA_TIME_SENTENCE) {
+        Some(at) => collapsed[at..].replace("{CURRENT_LOCAL_TIME}", &when),
+        None => format!("{PERSONA_TIME_SENTENCE} {when}."),
+    };
     if let Some(skill_prompt) = skills::active_prompt() {
         prompt.push_str("\n\n");
         prompt.push_str(&skill_prompt);
@@ -152,6 +176,16 @@ pub(crate) fn system_prompt() -> String {
         prompt.push_str(&memory_prompt);
     }
     prompt
+}
+
+/// Shared system prompt: the agent persona + current-time grounding. Spoken
+/// aloud, so it asks for short, markdown-free replies.
+pub(crate) fn system_prompt() -> String {
+    format!(
+        "{} {}",
+        system_prompt_invariant(),
+        system_prompt_task_context()
+    )
 }
 
 /// Turn a spoken Control+Fn instruction into text for the captured caret. This


### PR DESCRIPTION
## Mechanic

A planner escalation pays its first turn in full — follow-ups ride the live session, but turn 1 always carried the persona, the planner contract and every enabled tool dumped as pretty JSON (97 definitions), with the request last. Nothing measured it. The per-task strings (the clock, the operator's memory, the conversation, the screen) sat ahead of the invariant ones, so the bytes that never change were never in a position a provider prompt cache could hit.

## Change

**Instrumented first.** One line per planner task, from the shared text-planner loop so all three seats report it:

```
[symon-planner] seat=claude/claude-sonnet-5 first_turn_bytes=32622 tool_defs=7 first_action_ms=2841
```

`first_action_ms` is measured from the first write to the first parsed planner action; the session is already spawned or pooled by then, so it is the model's own time. The field names are stable.

**A stable prefix.** The first turn is now persona → planner contract → tool catalog → this task's context → the request, with the request strictly last. Tools sort by name, so the MCP tools arriving over HTTP cannot shuffle the prefix, and the clock moves out of the persona half: `system_prompt_invariant()` is the persona with no clock in it and `system_prompt_task_context()` is the clock, the active skill and the operator's memory facts. `system_prompt()` joins the two and still returns exactly the bytes it returned before, so the front brains are untouched.

**A compact catalog.** Descriptions choose a tool; parameter schemas call one. So the catalog lists every tool on one line as `name — what it does` and prints parameters only for the tools the task ledger shows real runs calling most. Everything else is one `tool_lookup` action away:

```json
{"tool": "tool_lookup", "args": {"names": ["mac_notes_create"]}}
```

which the loop answers with the full description and exact schema ahead of the execution seam, so a lookup never reaches the ledger or the confirm gate. Three lookups per task, eight names per lookup; past that the planner is told to act. Descriptions longer than 240 bytes are cut to whole leading sentences and end in an ellipsis, and the same lookup returns the rest.

Up front with parameters: `symon_execute_plan` (the planner contract names it directly, so it has to be callable without a lookup), `o8_ui_set`, `o8_ui_open`, `o8_status`, `mac_reminders_create`, `mac_reminders_list`, `mac_calendar_list_events`. Those cover the head of 169 recorded planner tool calls. Two deliberate omissions: frequent tools that take no arguments (`term_list`) need no schema — `{}` is the whole call — and `o8_canvas`, the one frequent tool with a ~6 KB schema, stays compact because a lookup on the runs that need it is cheaper than those bytes on every run that does not.

## Numbers

Three scripted escalations, measured by `the_first_turn_payload_is_at_least_half_off` from the shipped builder. The before column is the pre-#2157 builder kept verbatim in the test and run against the same live inputs, so the comparison is one process, not a quoted figure.

| fixture | before bytes | after bytes | off | tool_defs before → after |
|---|---|---|---|---|
| reminder | 83,721 | 32,622 | 61.0% | 97 → 7 |
| fleet | 83,725 | 32,626 | 61.0% | 97 → 7 |
| screen (screenshot rides the turn) | 86,067 | 34,968 | 59.4% | 97 → 7 |

All 97 tools stay reachable; only 7 carry parameters up front. The issue's bar is half, and the test asserts it per fixture rather than leaving it in this table.

## Verification

```
$ cd src-tauri && cargo test --lib
test result: ok. 386 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 4.62s
```

No TypeScript changed, so `tsc` was not run.

New coverage drives the real entry points:

- `escalate_hands_off_and_the_planner_loop_serves_a_lookup_and_continues` — `dispatch_tool_call("escalate", …)` really does route to the background brain, stopping only at the desktop handle a headless test cannot hold; then the loop that background task runs is driven against a real spawned planner process, which answers turn 1 with a `tool_lookup` for a tool whose schema is not in the first turn and finishes on turn 2. Asserts the first prompt as the process received it (compact catalog present, parameters only for the allow list) and that the lookup reply carried the exact schema.
- `the_invariant_prefix_is_byte_identical_across_two_tasks` — two tasks with different requests and different per-task context agree byte for byte up to the first per-task character, the prefix holds no clock and no task id, and the request is last.
- `the_compact_catalog_names_every_tool_and_only_the_allow_list_carries_a_schema` — every catalog tool has a line, `escalate` does not, order is sorted, and nothing outside the allow list ships a schema.
- `a_lookup_returns_the_exact_schema_and_names_a_miss` — both spellings a model reaches for, a miss named plainly, and the budget message.

## Residual

The byte counts need no live model. What a live escalation does with a shortened description is the thing to watch on the first real run: the catalog header tells the planner to look a tool up rather than guess an argument name, and the loop logs every lookup, so the first `[symon-planner]` lines will say whether that lands.

Out of scope, and unchanged here: wiring the open runtime into the bound phone and text surface, which #2173 left open and which needs its own issue.

Closes #2157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe
