### PR TITLE
test: record accepted Mac interaction baseline

### DIFF
--- a/docs/operations/interaction-performance-budgets.md
+++ b/docs/operations/interaction-performance-budgets.md
@@ -72,9 +72,9 @@ npm run bench:interactions:full -- \
 ```
 
 Each release run writes `tests/bench/results/interactions-baseline-release-<appVersion>.json`,
-so the two coexist and can be diffed. The budgets below stay `provisional`
-(`INTERACTION_BUDGETS.status === 'provisional'`, `lockedBy === null`) until both
-exist and the operator locks them.
+so the two coexist and can be diffed. Exported observations remain `observed`;
+writing an observation does not grant acceptance. The September 11 v1 decision
+below locks the unchanged budget manifest after observing two shipped builds.
 
 Release observations require all three independent provenance links: the
 notarized `.app`, the SHA-256 of its release archive, and a full 40-hex release
@@ -155,16 +155,18 @@ spinner; 3s+ named stages). A surface over its tier either gets faster or grows
 the feedback its tier demands. The terminal-derived ceilings come from
 `scripts/bench/terminal-workload/budgets.mjs`, which the operator already locked.
 
-**These budgets are PROVISIONAL** until two release baselines exist and the
-operator locks them. See the release lane above.
+**These budgets are locked for v1** by `operator-acceptance-2026-09-11`.
+Every numeric ceiling and comparison band is unchanged from the provisional
+manifest. The crop capability remains an explicit unavailable under #2175.
 
 ### Absolute plus delta
 
 Every metric is reported three ways, and a run fails on either gate:
 
 - **Absolute** — value against the budget above.
-- **Accepted baseline delta** — value against the accepted baseline, with a
-  per-metric noise band measured from repeated runs of the same build.
+- **Accepted baseline delta** — value against the accepted baseline, with the
+  unchanged per-metric comparison band. The v1 bands are conservative policy
+  values, not empirically calibrated noise estimates from repeated launches.
 - **Release delta** — the scorecard compares the metric against the previous
   release's scorecard.
 
@@ -226,3 +228,51 @@ screenshot crop is unimplemented, a clean run reports `incomplete` by design.
 ## Measured baseline
 
 <!-- MEASURED-BASELINE -->
+
+### Accepted v1 reference, September 11, 2026
+
+The operator accepted the 0.1.747 reference after the corrected instrument
+measured the exact signed, notarized 0.1.746 and 0.1.747 release artifacts.
+The public, path-sanitized reference is
+[`macos-x64-0.1.747.json`](../../scripts/bench/interactions/baselines/macos-x64-0.1.747.json).
+It contains all 45 available metric observations, exact artifact and instrument
+identities, host class, sample bounds, raw receipt digests, and the decision.
+
+| Released artifact | Startup at 50 / 250 / 1,000 rows | Absolute metric rows |
+| --- | --- | --- |
+| 0.1.746 | 1,027 / 1,253.2 / 929.7 ms | 45 passed, zero failed |
+| 0.1.747 | 1,055.1 / 997.5 / 1,083 ms | 45 passed, zero failed |
+
+These runs used packaged services and a browser, not native-window launch timing.
+Each scale has seven input/tab samples, a 12-second quick soak and one startup
+observation; that startup value is not a population percentile. Earlier full
+observations with 15 samples and 60-second soaks are retained separately. Old
+startup clocks are not comparable with the corrected method.
+
+Acceptance does not rewrite the raw checks. The 0.1.747 raw comparison still
+fails because 1,083 ms is 153.3 ms above the earlier 929.7 ms, exceeding the
+unchanged 150 ms band. The operator accepted that single reference-selection
+exception while retaining the 2,000 ms absolute ceiling. Future regressions
+still fail at the original band. All six scale runs passed artifact identity,
+deliberate-delay falsification and cleanup, with zero browser survivors.
+
+Screenshot crop remains null at all three scales. #2175 owns the missing capture
+measurement; its existing 500 ms ceiling is not removed or increased. The runner
+continues to report unavailable/incomplete for that path. Terminal composition is
+historical for these released artifacts. The separate terminal-workload lane has
+its own measured acceptance and is not silently relabeled as current-release proof.
+
+For a comparable local run, select the accepted reference explicitly:
+
+```sh
+npm run bench:interactions:full -- \
+  --target=release:/path/to/o8.app \
+  --archive-sha256=<64-hex> --release-git-sha=<40-hex> \
+  --baseline=scripts/bench/interactions/baselines/macos-x64-0.1.747.json
+```
+
+Compare matching measurement methods, fixture scales and host class; preserve
+sample/soak differences and host contention in the report. This machine-specific
+reference is not silently selected for other hardware by the default command.
+The acceptance closes #1697's v1 measurement and budget deliverable, not every
+future optimization, every runtime, or an eight-hour endurance test.

--- a/scripts/bench/interactions/baselines/macos-x64-0.1.747.json
+++ b/scripts/bench/interactions/baselines/macos-x64-0.1.747.json
@@ -1,0 +1,331 @@
+{
+  "schema": "o8/interaction-baseline/v1",
+  "status": "accepted",
+  "source": "operator-acceptance-2026-09-11",
+  "observedAt": "2026-09-11T02:18:21.612Z",
+  "acceptance": {
+    "decision": "Accept the v1 reference with documented exceptions; do not relabel the raw run.",
+    "acceptedAt": "2026-09-11",
+    "originalRunStatus": "fail",
+    "numericLimitsChanged": false,
+    "comparisonException": {
+      "metric": "first_interaction_accepted_ms",
+      "scale": 1000,
+      "value": 1083,
+      "previousValue": 929.7,
+      "deltaMs": 153.3,
+      "noiseBandMs": 150,
+      "rawDeltaStatus": "regressed",
+      "scope": "This reference selection only; future comparisons keep the 150 ms band."
+    },
+    "unavailable": {
+      "metric": "design_screenshot_crop_ms",
+      "scales": [
+        50,
+        250,
+        1000
+      ],
+      "followUp": 2175,
+      "numericValue": null
+    },
+    "bounds": "Packaged services and a browser, not native launch timing. Seven input/tab samples and a 12-second quick soak per scale. One startup observation per scale, not a population percentile. Terminal composition is historical for this release.",
+    "rawReceiptSha256": "4a6cede2f4dbbe58f3671ed8aa451d3d6928c794d4d10a93d6fb16910510942d",
+    "comparisonReceiptSha256": "3ccebc007d698b2ad13df0032ab8c241203f9fd3e22776e967d3704c6b5e035d",
+    "comparisonRelease": {
+      "appVersion": "0.1.746",
+      "releaseGitSha": "112d754b924198ece10f8d60ef0107a0d08f6117",
+      "archiveSha256": "53fb5d590eec885e70614af0f22565be058ef979495fc642c3aabd695549b828"
+    }
+  },
+  "observedFrom": {
+    "benchmarkGitSha": "bcd617e3a947aa4be6618384426c5d0dc659bd58",
+    "measuredTarget": {
+      "appVersion": "0.1.747",
+      "buildGitSha": "8bde3690dbda87ab78ff5d37eed2fc2229339919",
+      "buildMode": "packaged",
+      "platform": "darwin",
+      "unavailableReason": null,
+      "serverReportedBuildGitSha": "8bde3690dbda87ab78ff5d37eed2fc2229339919",
+      "buildGitShaSource": "explicit-release-provenance",
+      "reportedBuildMode": "packaged",
+      "artifactTargetDigestSha256": "0916cb70445454bf4970f45fac57089f31d32cf8ff8e37c080dba027f6adf77e",
+      "runtimeIdentityNote": null
+    },
+    "packagedArtifact": {
+      "bundleVersion": "0.1.747",
+      "bundleBuildVersion": "0.1.747",
+      "bundleIdentifier": "ai.o8.desktop",
+      "executableName": "o8",
+      "executableSha256": "80762d03102ccefe0ef971d85ec190c21811f78324ba27436f5627f56697a1b4",
+      "serverEntrySha256": "2fbf7a6236c260fff3ed2b4660eae2f7dfc1f76a07cf0624e9395520b83ee859",
+      "buildId": "K6qVFJv2llhq1Yg11W64Z",
+      "archiveSha256": "d07ab5c48b01707f7b52017cba3040534448be4e030314ffcdfc94171e2e0ee4",
+      "releaseGitSha": "8bde3690dbda87ab78ff5d37eed2fc2229339919",
+      "targetDigestSha256": "0916cb70445454bf4970f45fac57089f31d32cf8ff8e37c080dba027f6adf77e",
+      "signing": {
+        "strictCodesign": true,
+        "gatekeeperAccepted": true,
+        "gatekeeperNotarized": true,
+        "gatekeeperSource": "Notarized Developer ID"
+      },
+      "complete": true,
+      "identityProblems": [],
+      "unavailableReason": null
+    },
+    "fixtureDigests": [
+      {
+        "scale": 50,
+        "digest": "ae2e27323fe3f8c6"
+      },
+      {
+        "scale": 250,
+        "digest": "00a546672d0a5e7d"
+      },
+      {
+        "scale": 1000,
+        "digest": "389e9d0867190618"
+      }
+    ],
+    "host": {
+      "platform": "darwin",
+      "arch": "x64",
+      "cpuCount": 16,
+      "cpuModel": "Intel(R) Core(TM) i7-10700K CPU @ 3.80GHz",
+      "totalMemoryBytes": 68719476736,
+      "nodeVersion": "v22.23.2",
+      "osRelease": "25.6.0"
+    },
+    "samples": 7,
+    "runStatus": "fail"
+  },
+  "metrics": {
+    "dashboard_cold_ready_ms@50": {
+      "value": 644.7,
+      "statistic": "p95",
+      "scale": 50
+    },
+    "warm_relaunch_ready_ms@50": {
+      "value": 384.2,
+      "statistic": "p95",
+      "scale": 50
+    },
+    "first_interaction_accepted_ms@50": {
+      "value": 1055.1,
+      "statistic": "p95",
+      "scale": 50,
+      "measurementMethod": "page-readiness-plus-trusted-input-paint-v1"
+    },
+    "fleet_reveal_ms@50": {
+      "value": 90.1,
+      "statistic": "p95",
+      "scale": 50
+    },
+    "active_context_reveal_ms@50": {
+      "value": 97.8,
+      "statistic": "p95",
+      "scale": 50
+    },
+    "composer_keystroke_to_paint_ms@50": {
+      "value": 41.5,
+      "statistic": "p50",
+      "scale": 50
+    },
+    "composer_keystroke_to_paint_p95_ms@50": {
+      "value": 73.2,
+      "statistic": "p95",
+      "scale": 50
+    },
+    "design_arm_ms@50": {
+      "value": 59.6,
+      "statistic": "p95",
+      "scale": 50
+    },
+    "design_hover_ms@50": {
+      "value": 58.2,
+      "statistic": "p95",
+      "scale": 50
+    },
+    "design_select_ms@50": {
+      "value": 44.7,
+      "statistic": "p95",
+      "scale": 50
+    },
+    "design_prompt_ready_ms@50": {
+      "value": 80,
+      "statistic": "p95",
+      "scale": 50
+    },
+    "tab_switch_ms@50": {
+      "value": 49,
+      "statistic": "p95",
+      "scale": 50
+    },
+    "repo_inventory_ms@50": {
+      "value": 6.1,
+      "statistic": "p50",
+      "scale": 50
+    },
+    "repo_inventory_p95_ms@50": {
+      "value": 10.2,
+      "statistic": "p95",
+      "scale": 50
+    },
+    "soak_long_task_ms_per_minute@50": {
+      "value": 0,
+      "statistic": "p95",
+      "scale": 50
+    },
+    "dashboard_cold_ready_ms@250": {
+      "value": 750.8,
+      "statistic": "p95",
+      "scale": 250
+    },
+    "warm_relaunch_ready_ms@250": {
+      "value": 376.4,
+      "statistic": "p95",
+      "scale": 250
+    },
+    "first_interaction_accepted_ms@250": {
+      "value": 997.5,
+      "statistic": "p95",
+      "scale": 250,
+      "measurementMethod": "page-readiness-plus-trusted-input-paint-v1"
+    },
+    "fleet_reveal_ms@250": {
+      "value": 95.2,
+      "statistic": "p95",
+      "scale": 250
+    },
+    "active_context_reveal_ms@250": {
+      "value": 127.3,
+      "statistic": "p95",
+      "scale": 250
+    },
+    "composer_keystroke_to_paint_ms@250": {
+      "value": 42.9,
+      "statistic": "p50",
+      "scale": 250
+    },
+    "composer_keystroke_to_paint_p95_ms@250": {
+      "value": 52.4,
+      "statistic": "p95",
+      "scale": 250
+    },
+    "design_arm_ms@250": {
+      "value": 63.9,
+      "statistic": "p95",
+      "scale": 250
+    },
+    "design_hover_ms@250": {
+      "value": 62.7,
+      "statistic": "p95",
+      "scale": 250
+    },
+    "design_select_ms@250": {
+      "value": 47.7,
+      "statistic": "p95",
+      "scale": 250
+    },
+    "design_prompt_ready_ms@250": {
+      "value": 80.9,
+      "statistic": "p95",
+      "scale": 250
+    },
+    "tab_switch_ms@250": {
+      "value": 54,
+      "statistic": "p95",
+      "scale": 250
+    },
+    "repo_inventory_ms@250": {
+      "value": 9.9,
+      "statistic": "p50",
+      "scale": 250
+    },
+    "repo_inventory_p95_ms@250": {
+      "value": 10.1,
+      "statistic": "p95",
+      "scale": 250
+    },
+    "soak_long_task_ms_per_minute@250": {
+      "value": 0,
+      "statistic": "p95",
+      "scale": 250
+    },
+    "dashboard_cold_ready_ms@1000": {
+      "value": 710.3,
+      "statistic": "p95",
+      "scale": 1000
+    },
+    "warm_relaunch_ready_ms@1000": {
+      "value": 458.5,
+      "statistic": "p95",
+      "scale": 1000
+    },
+    "first_interaction_accepted_ms@1000": {
+      "value": 1083,
+      "statistic": "p95",
+      "scale": 1000,
+      "measurementMethod": "page-readiness-plus-trusted-input-paint-v1"
+    },
+    "fleet_reveal_ms@1000": {
+      "value": 218,
+      "statistic": "p95",
+      "scale": 1000
+    },
+    "active_context_reveal_ms@1000": {
+      "value": 172.2,
+      "statistic": "p95",
+      "scale": 1000
+    },
+    "composer_keystroke_to_paint_ms@1000": {
+      "value": 43.5,
+      "statistic": "p50",
+      "scale": 1000
+    },
+    "composer_keystroke_to_paint_p95_ms@1000": {
+      "value": 48.8,
+      "statistic": "p95",
+      "scale": 1000
+    },
+    "design_arm_ms@1000": {
+      "value": 65.2,
+      "statistic": "p95",
+      "scale": 1000
+    },
+    "design_hover_ms@1000": {
+      "value": 58.6,
+      "statistic": "p95",
+      "scale": 1000
+    },
+    "design_select_ms@1000": {
+      "value": 46.8,
+      "statistic": "p95",
+      "scale": 1000
+    },
+    "design_prompt_ready_ms@1000": {
+      "value": 81,
+      "statistic": "p95",
+      "scale": 1000
+    },
+    "tab_switch_ms@1000": {
+      "value": 49.6,
+      "statistic": "p95",
+      "scale": 1000
+    },
+    "repo_inventory_ms@1000": {
+      "value": 23.4,
+      "statistic": "p50",
+      "scale": 1000
+    },
+    "repo_inventory_p95_ms@1000": {
+      "value": 28.5,
+      "statistic": "p95",
+      "scale": 1000
+    },
+    "soak_long_task_ms_per_minute@1000": {
+      "value": 0,
+      "statistic": "p95",
+      "scale": 1000
+    }
+  }
+}

--- a/scripts/bench/interactions/budgets.mjs
+++ b/scripts/bench/interactions/budgets.mjs
@@ -1,12 +1,13 @@
 import { packagedTargetIdentityProblems } from './targets.mjs';
 
-// Absolute interaction budgets. These are PROVISIONAL: the issue requires a
-// baseline across two shipped release builds before the operator locks them.
+// Absolute interaction budgets locked after two shipped-build observations.
+// The operator acceptance and its explicit exceptions are documented alongside
+// the saved reference; neither raw failures nor numeric limits are rewritten.
 // Each entry records its interaction-tier or already-locked terminal basis.
-// They are acceptance hypotheses, not values tuned from this packet's runs.
+// Values are unchanged from the provisional manifest.
 export const INTERACTION_BUDGETS = Object.freeze({
-  status: 'provisional',
-  lockedBy: null,
+  status: 'locked-v1',
+  lockedBy: 'operator-acceptance-2026-09-11',
   // Each budget cites its basis. Direct-manipulation ceilings come from the
   // repo's own interaction spec (docs/design/STYLEGUIDE.md, "Feedback timing
   // tiers"): 0-100ms means the result IS the feedback, 100ms-1s needs a busy

--- a/tests/bench-interactions.test.ts
+++ b/tests/bench-interactions.test.ts
@@ -262,6 +262,36 @@ describe('interaction sample statistics', () => {
 });
 
 describe('interaction budgets', () => {
+  it('records the accepted reference without erasing its raw failure or weakening future gates', () => {
+    const accepted = JSON.parse(fs.readFileSync(path.resolve(
+      'scripts/bench/interactions/baselines/macos-x64-0.1.747.json',
+    ), 'utf8'));
+    expect(INTERACTION_BUDGETS.status).toBe('locked-v1');
+    expect(INTERACTION_BUDGETS.lockedBy).toBe('operator-acceptance-2026-09-11');
+    expect(accepted.status).toBe('accepted');
+    expect(accepted.observedFrom.runStatus).toBe('fail');
+    expect(Object.keys(accepted.metrics)).toHaveLength(45);
+    expect(accepted.acceptance.unavailable).toMatchObject({
+      metric: 'design_screenshot_crop_ms', numericValue: null, followUp: 2175,
+    });
+    expect(JSON.stringify(accepted)).not.toContain('/Users/');
+    const method = 'page-readiness-plus-trusted-input-paint-v1';
+    const startup = accepted.metrics['first_interaction_accepted_ms@1000'];
+    expect(startup).toMatchObject({ value: 1083, measurementMethod: method });
+    expect(INTERACTION_BUDGETS.metrics.first_interaction_accepted_ms.max).toBe(2000);
+    expect(INTERACTION_BUDGETS.noiseBandMs.first_interaction_accepted_ms).toBe(150);
+    const candidate = receipt({ fixture: { scale: 1000 }, scenarios: {
+      ...receipt().scenarios,
+      first_interaction_accepted_ms: { ...scenario([1236.3]), measurementMethod: method },
+    } });
+    const evaluation = evaluateInteractionBudgets(candidate, accepted);
+    expect(evaluation.results.find(row => row.metric === 'first_interaction_accepted_ms')).toMatchObject({
+      status: 'pass', baselineValue: 1083, deltaValue: 153.3, deltaStatus: 'regressed',
+    });
+    expect(evaluation.status).toBe('fail');
+    expect(evaluation.unavailable.map(row => row.metric)).toContain('design_screenshot_crop_ms');
+  });
+
   it('passes every measured budget on a healthy production run', () => {
     const evaluation = evaluateInteractionBudgets(receipt());
     expect(evaluation.failed).toEqual([]);


### PR DESCRIPTION
## Outcome

Record the operator-approved v1 interaction reference after measuring the exact 0.1.746 and 0.1.747 released artifacts. The manifest is now locked; every numeric ceiling, comparison band, and evaluator branch is unchanged.

The saved reference contains the 45 measured metrics and their provenance. Acceptance remains separate from the raw result: the newer release's 1,083 ms startup at 1,000 rows is accepted as the initial reference while its +153.3 ms comparison failure against the unchanged 150 ms band remains recorded. No automatic acceptance exception was added to the runner.

Screenshot-crop timing stays null and unavailable, tracked in #2175. The existing terminal acceptance remains separate from these release observations. This patch records the approved scope for #1697; it does not claim a native launch benchmark or an eight-hour soak.

## Verification

- Focused harness and real-browser tests: 46 passed.
- Full hermetic suite: 4,324 passed, four skipped.
- TypeScript, touched-file lint, test classification and diff checks passed.
- Changed-line rule check passed with zero application files in scope.
- All 45 saved metric records match the original observation. All numeric budgets, bands and evaluator code match the pre-acceptance manifest.
- The added check confirms that a future +153.3 ms change still fails, and unavailable crop timing still cannot pass.

Required CI receipts will be checked before merge. No version bump, app publication or permanent daily-app replacement is included.
