### PR TITLE
feat: let the Symon front brain read the planner registry seam

### DIFF
--- a/src-tauri/src/agent/claude.rs
+++ b/src-tauri/src/agent/claude.rs
@@ -32,7 +32,7 @@
 //! spawn (`--tools ""`), not just discouraged by the planner contract, so a
 //! contract-ignoring turn still has nothing to execute.
 
-use super::{tools, ConfirmCorrelation, LoopResult, TaskCtx};
+use super::{ConfirmCorrelation, LoopResult, TaskCtx};
 use serde_json::{json, Value};
 use std::time::Duration;
 
@@ -122,7 +122,7 @@ pub(crate) fn ensure_empty_mcp_config() -> Result<String, String> {
 /// When a screenshot rides the turn it is sent as an image block (see
 /// `ClaudeSession::send_turn`) and this prompt teaches the screen + draw
 /// protocol — the selected Claude model sees it directly, with no Gemini middleman.
-fn build_first_prompt(intent: &str, ctx: &TaskCtx) -> String {
+pub(crate) fn build_first_prompt(intent: &str, ctx: &TaskCtx) -> String {
     let mut s = super::system_prompt();
     if let Some(convo) = super::conversation_context() {
         s.push_str("\n\n");
@@ -150,12 +150,10 @@ fn build_first_prompt(intent: &str, ctx: &TaskCtx) -> String {
             s.push_str(&feedback);
         }
     }
-    // The background brain DOES the work — strip `escalate` so it can't re-hand
-    // the task back to another Claude task (infinite-handoff guard).
-    let tool_specs: Vec<Value> = tools::enabled_tools()
-        .into_iter()
-        .filter(|t| t.get("name").and_then(|n| n.as_str()) != Some("escalate"))
-        .collect();
+    // `escalate` is withheld unless this turn's front seat differs from the seat
+    // the handoff would land on (#2164). A background brain task never carries
+    // that flag, so it keeps the infinite-handoff guard it always had.
+    let tool_specs: Vec<Value> = super::front_brain::planner_tool_specs(ctx);
     let tools_json =
         serde_json::to_string_pretty(&tool_specs).unwrap_or_else(|_| "[]".to_string());
     s.push_str(PLANNER_CONTRACT);

--- a/src-tauri/src/agent/claude_pool.rs
+++ b/src-tauri/src/agent/claude_pool.rs
@@ -111,10 +111,12 @@ pub fn acquire(bin: &str, model: &str, mcp_cfg: &str) -> Option<ClaudeSession> {
 /// far more keydowns than it serves.
 /// Called from the Right-Option down edge (`fn_hotkey::begin_agent_dictation`).
 pub fn prewarm_agent() {
-    let super::planner_route::PlannerRouting::Selected(selection) =
-        super::planner_route::resolve()
-    else {
-        return;
+    // #2164: the keydown warms the FRONT seat. Under the default `auto` that is
+    // the same seat the background brain resolves, but an operator who pinned a
+    // front brain must not have the other model booted for them.
+    let routing = super::front_brain::resolve();
+    let Some(selection) = routing.planner_selection() else {
+        return; // the built-in Gemini loop has no process to warm.
     };
     if selection.provider.transport != super::planner_route::PlannerTransport::ClaudeStreamJson {
         return;

--- a/src-tauri/src/agent/codex.rs
+++ b/src-tauri/src/agent/codex.rs
@@ -59,7 +59,7 @@ pub(crate) struct CodexSession {
 }
 
 impl CodexSession {
-    fn new(binary: &str, model: &str, effort: &str) -> Self {
+    pub(crate) fn new(binary: &str, model: &str, effort: &str) -> Self {
         Self {
             binary: binary.to_string(),
             model: model.to_string(),

--- a/src-tauri/src/agent/eval.rs
+++ b/src-tauri/src/agent/eval.rs
@@ -79,6 +79,7 @@ pub async fn run_eval(app: tauri::AppHandle, models: Vec<String>) -> String {
                 crop_png_base64: None,
                 edit: None,
                 cancel: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                escalate_available: false,
             };
             let started = Instant::now();
             let result = if model.contains('/') {

--- a/src-tauri/src/agent/front_brain.rs
+++ b/src-tauri/src/agent/front_brain.rs
@@ -1,0 +1,454 @@
+//! Symon FRONT brain selection — the Right-Option seat (#2164).
+//!
+//! ## What the front brain is
+//! Right-Option drives two lanes. **Agent mode** runs a tool-calling loop over
+//! the native Mac tool catalog; **Ask mode** answers one question with no tools
+//! at all. Both were provider-shaped rather than registry-shaped: Ask always
+//! called Gemini, and Agent mode could only take a planner seat — a machine
+//! with no agent CLI had no front brain at all, and the Gemini loop it used to
+//! run was unreachable.
+//!
+//! This module gives the front seat the same seam the background brain reads
+//! (`planner_route`, #2156) and adds the one entry that registry cannot carry:
+//! the built-in Gemini loop, which needs no binary, only a key or a plan.
+//!
+//! ## The setting
+//! `symon_front_brain` in the voice pref store (`~/.o8/dictation.json`, written
+//! by `voice_prefs_set` exactly like the `symon_brain_*` keys):
+//!
+//! * `auto` (default, and the value of an absent key) — the route the front
+//!   seat already ran: whatever `planner_route::resolve()` seats, which is the
+//!   operator's Symon brain setting. The one thing `auto` adds is a floor: a
+//!   machine with no planner CLI falls to the Gemini loop instead of failing
+//!   the gesture.
+//! * `gemini` — the built-in loop, explicitly.
+//! * a planner adapter id (`claude` / `codex` / `opencode`) — that seat, at the
+//!   WORKER rung unless `symon_brain_tier` says otherwise, honoring
+//!   `symon_brain_model` the same way the background seat does. The front brain
+//!   is the fast lane, so it never inherits a builder default the operator did
+//!   not ask for.
+//!
+//! A chosen adapter whose binary is missing never fails silently: it falls to
+//! Gemini (or, with no Gemini credential, to any other installed seat), says so
+//! in the log, and the settings status line names the pick it could not honor.
+//!
+//! ## Escalation
+//! `escalate` hands the task to `spawn_background_brain_task`, which resolves
+//! through `planner_route` — so when the front seat and the background seat are
+//! the SAME seat there is nothing to escalate to, and the tool is withheld.
+//! That is exactly what the front seat already did on a planner seat (the
+//! planner prompt has always stripped `escalate`), so the default is unchanged;
+//! the rule only opens the handoff back up when the two seats genuinely differ.
+
+use super::planner_route::{self, PlannerRouting, PlannerSelection, PlannerTransport};
+use super::TaskCtx;
+use serde_json::Value;
+use std::time::Duration;
+
+/// Voice-pref key for the front-brain choice.
+pub(crate) const FRONT_BRAIN_PREF: &str = "symon_front_brain";
+
+/// The built-in loop's id — not a planner adapter: it has no binary and speaks
+/// Gemini's own `functionCall` protocol rather than the JSON-action contract.
+pub(crate) const GEMINI_ID: &str = "gemini";
+const GEMINI_LABEL: &str = "Gemini";
+
+/// The model the built-in loop runs when the operator has not configured one.
+/// A flash-tier model: the front seat is the fast lane.
+const GEMINI_FRONT_MODEL: &str = crate::models::GEMINI_3_FLASH_PREVIEW;
+
+/// Ceiling for the single tools-withheld Ask turn on a planner seat. Ask is a
+/// one-shot question, so it never needs the multi-turn planner budget.
+const ASK_TURN_TIMEOUT_SECS: u64 = 90;
+
+/// What the Right-Option gesture runs this turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FrontBrain {
+    /// The built-in Gemini loop (Agent) / Gemini ask (Ask).
+    Gemini { model: String },
+    /// A planner-registry seat speaking the JSON-action protocol.
+    Planner(PlannerSelection),
+}
+
+impl FrontBrain {
+    pub(crate) fn id(&self) -> &str {
+        match self {
+            FrontBrain::Gemini { .. } => GEMINI_ID,
+            FrontBrain::Planner(selection) => selection.provider.id,
+        }
+    }
+
+    pub(crate) fn label(&self) -> &str {
+        match self {
+            FrontBrain::Gemini { .. } => GEMINI_LABEL,
+            FrontBrain::Planner(selection) => selection.provider.label,
+        }
+    }
+
+    /// Model name for logs and the settings status line.
+    pub(crate) fn model_label(&self) -> &str {
+        match self {
+            FrontBrain::Gemini { model } => model,
+            FrontBrain::Planner(selection) => selection.model_label(),
+        }
+    }
+
+    /// Seat identity for the escalate rule. A seat is the adapter AND the rung
+    /// it runs: a worker-tier front brain handing off to a builder-tier
+    /// background brain is a real escalation, so only an identical triple
+    /// counts as "nothing to escalate to".
+    fn seat_key(&self) -> String {
+        match self {
+            FrontBrain::Gemini { model } => format!("gemini|{model}|"),
+            FrontBrain::Planner(selection) => format!(
+                "{}|{}|{}",
+                selection.provider.id,
+                selection.model_label(),
+                selection.effort
+            ),
+        }
+    }
+}
+
+fn background_seat_key(selection: &PlannerSelection) -> String {
+    format!(
+        "{}|{}|{}",
+        selection.provider.id,
+        selection.model_label(),
+        selection.effort
+    )
+}
+
+/// The resolved front seat plus the two facts the surfaces need: which pick we
+/// could not honor, and whether `escalate` is offered this turn.
+#[derive(Debug, Clone)]
+pub(crate) struct FrontRouting {
+    pub brain: FrontBrain,
+    /// The chosen id whose binary was missing, when the route fell through.
+    pub fell_back_from: Option<String>,
+    pub escalate_available: bool,
+}
+
+impl FrontRouting {
+    /// The planner seat to run, or `None` when the built-in loop takes the turn.
+    pub(crate) fn planner_selection(&self) -> Option<&PlannerSelection> {
+        match &self.brain {
+            FrontBrain::Planner(selection) => Some(selection),
+            FrontBrain::Gemini { .. } => None,
+        }
+    }
+
+    pub(crate) fn gemini_model(&self) -> Option<&str> {
+        match &self.brain {
+            FrontBrain::Gemini { model } => Some(model),
+            FrontBrain::Planner(_) => None,
+        }
+    }
+
+    /// One line per task naming the seat the gesture actually took — the
+    /// operator's receipt, and the only place a silent fallback would hide.
+    pub(crate) fn log_seat(&self, lane: &str) {
+        match &self.fell_back_from {
+            Some(missing) => log::warn!(
+                "[symon-front-brain] {lane}: {missing} is not installed — falling back to {} {}",
+                self.brain.id(),
+                self.brain.model_label()
+            ),
+            None => log::info!(
+                "[symon-front-brain] {lane}: {} {} (escalate {})",
+                self.brain.id(),
+                self.brain.model_label(),
+                if self.escalate_available { "on" } else { "withheld" }
+            ),
+        }
+    }
+}
+
+/// The stored choice, or `None` for `auto` (which is also an absent key).
+pub(crate) fn read_choice() -> Option<String> {
+    choice_from(planner_route::read_voice_prefs().as_ref())
+}
+
+fn choice_from(prefs: Option<&Value>) -> Option<String> {
+    prefs?
+        .get(FRONT_BRAIN_PREF)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && *value != "auto")
+        .map(str::to_string)
+}
+
+/// True when the built-in loop can actually run: the operator's own Gemini key
+/// or an active o8 plan.
+fn gemini_available() -> bool {
+    crate::entitlement::resolve_gemini(GEMINI_FRONT_MODEL).is_some()
+}
+
+/// The built-in seat. The legacy `mac_native_action` config stays an escape
+/// hatch for a different Gemini id; anything else (it defaults to a Claude id)
+/// does not belong on this seat and is ignored in favor of the flash default.
+fn gemini_brain() -> FrontBrain {
+    let configured = super::router::load_config().mac_native_action;
+    let model = if configured.contains("gemini") {
+        configured
+    } else {
+        GEMINI_FRONT_MODEL.to_string()
+    };
+    FrontBrain::Gemini { model }
+}
+
+pub(crate) fn resolve() -> FrontRouting {
+    resolve_with(
+        read_choice().as_deref(),
+        planner_route::resolve(),
+        super::router::load_config().voice_escalation.as_str(),
+        gemini_available(),
+        planner_route::locate_planner_binary,
+    )
+}
+
+/// The route itself, with the binary locator injected so a "chosen CLI missing"
+/// case is reachable on a machine that has every CLI installed.
+pub(crate) fn resolve_with<F>(
+    choice: Option<&str>,
+    background: PlannerRouting,
+    escalation: &str,
+    gemini_ready: bool,
+    locate: F,
+) -> FrontRouting
+where
+    F: FnMut(&planner_route::PlannerAdapter) -> Option<String>,
+{
+    let setting = planner_route::read_brain_setting();
+    let background_selection = match &background {
+        PlannerRouting::Selected(selection) => Some(selection.clone()),
+        PlannerRouting::Unavailable { .. } => None,
+    };
+
+    let (brain, fell_back_from) = match choice {
+        // Auto is the route the front seat already ran, with one floor added:
+        // no planner CLI no longer means no front brain.
+        None => match background_selection.clone() {
+            Some(selection) => (FrontBrain::Planner(selection), None),
+            None => (gemini_brain(), None),
+        },
+        Some(GEMINI_ID) => (gemini_brain(), None),
+        Some(id) => match planner_route::seat_front_adapter_with(
+            id,
+            setting.tier,
+            setting.model.as_deref(),
+            locate,
+        ) {
+            Some(selection) => (FrontBrain::Planner(selection), None),
+            // A pick we cannot honor falls to the built-in loop, then to any
+            // other installed seat — never to nothing.
+            None => {
+                let fallback = if gemini_ready {
+                    gemini_brain()
+                } else {
+                    match background_selection.clone() {
+                        Some(selection) => FrontBrain::Planner(selection),
+                        None => gemini_brain(),
+                    }
+                };
+                (fallback, Some(id.to_string()))
+            }
+        },
+    };
+
+    // Nothing to escalate TO when the handoff would land on the same seat, and
+    // nothing to escalate to at all when no background seat resolves.
+    let escalate_available = escalation != "off"
+        && background_selection
+            .as_ref()
+            .is_some_and(|selection| background_seat_key(selection) != brain.seat_key());
+
+    FrontRouting {
+        brain,
+        fell_back_from,
+        escalate_available,
+    }
+}
+
+/// The tool catalog a text-planner first turn presents (#2164).
+///
+/// `escalate` is withheld unless this task's front seat differs from the seat
+/// the handoff would land on. Background brain tasks carry
+/// `escalate_available: false`, which is the infinite-handoff guard the planner
+/// prompt has always enforced by stripping the tool outright.
+pub(crate) fn planner_tool_specs(ctx: &TaskCtx) -> Vec<Value> {
+    super::tools::enabled_tools()
+        .into_iter()
+        .filter(|tool| {
+            ctx.escalate_available
+                || tool.get("name").and_then(|name| name.as_str()) != Some("escalate")
+        })
+        .collect()
+}
+
+// ── Ask mode ────────────────────────────────────────────────────────────────
+
+/// Answer one question on the front seat with NO tools.
+///
+/// The Gemini seat keeps the exact call it always made. A planner seat takes a
+/// single turn carrying the Ask persona and the question — no planner contract,
+/// no tool catalog — on top of the read-only posture each adapter already
+/// spawns with (`--tools ""`, read-only sandbox, `--pure --agent plan`). So
+/// "tools withheld" holds twice over: nothing is offered, and nothing could run.
+pub(crate) async fn ask(question: &str, context: Option<&str>) -> Result<String, String> {
+    let routing = resolve();
+    routing.log_seat("ask");
+    match routing.brain {
+        FrontBrain::Gemini { .. } => crate::ai::gemini_ask::ask(question, context).await,
+        FrontBrain::Planner(selection) => ask_on_seat(&selection, question, context).await,
+    }
+}
+
+pub(crate) fn build_ask_prompt(question: &str, context: Option<&str>) -> String {
+    let mut prompt = crate::ai::gemini_ask::ASK_SYSTEM_PROMPT.to_string();
+    if let Some(extra) = context.map(str::trim).filter(|c| !c.is_empty()) {
+        prompt.push_str("\n\n[On-screen context]\n");
+        prompt.push_str(extra);
+    }
+    prompt.push_str(
+        "\n\nAnswer this question directly in plain spoken prose. You have no tools \
+         on this turn and must not emit JSON, an action object, or a tool call.",
+    );
+    prompt.push_str("\n\n---\n\nQuestion: ");
+    prompt.push_str(question.trim());
+    prompt
+}
+
+/// A planner CLI that ignores the "plain prose" instruction and answers with a
+/// `{"done": true, "say": "..."}` action still has a spoken answer inside it —
+/// take it rather than reading JSON aloud.
+pub(crate) fn plain_answer(reply: &str) -> String {
+    let trimmed = reply.trim().trim_start_matches("```json").trim_matches('`').trim();
+    if let Ok(Value::Object(object)) = serde_json::from_str::<Value>(trimmed) {
+        if let Some(say) = object.get("say").and_then(Value::as_str) {
+            return say.trim().to_string();
+        }
+    }
+    trimmed.to_string()
+}
+
+async fn ask_on_seat(
+    selection: &PlannerSelection,
+    question: &str,
+    context: Option<&str>,
+) -> Result<String, String> {
+    let prompt = build_ask_prompt(question, context);
+    let transport = selection.provider.transport;
+    let provider_id = selection.provider.id;
+    let binary = selection.binary.clone();
+    let model = selection.model.clone();
+    let effort = selection.effort;
+
+    let reply = tokio::time::timeout(
+        Duration::from_secs(ASK_TURN_TIMEOUT_SECS),
+        tokio::task::spawn_blocking(move || ask_turn(transport, &binary, model, effort, &prompt)),
+    )
+    .await
+    .map_err(|_| format!("{provider_id} ask turn timed out"))?
+    .map_err(|error| format!("{provider_id} ask turn join error: {error}"))??;
+
+    let answer = plain_answer(&reply);
+    if answer.is_empty() {
+        return Err(format!("{provider_id} returned no answer"));
+    }
+    Ok(answer)
+}
+
+fn ask_turn(
+    transport: PlannerTransport,
+    binary: &str,
+    model: Option<String>,
+    effort: &str,
+    prompt: &str,
+) -> Result<String, String> {
+    use super::claude::TextPlannerSession;
+    match transport {
+        PlannerTransport::ClaudeStreamJson => {
+            let mcp_cfg = super::claude::ensure_empty_mcp_config()?;
+            let model = model.unwrap_or_else(|| crate::models::CLAUDE_SONNET_5.to_string());
+            let mut session = super::claude_pool::acquire(binary, &model, &mcp_cfg)
+                .ok_or_else(|| "claude session unavailable (spawn failed)".to_string())?;
+            session.send_planner_turn(prompt, None)
+        }
+        PlannerTransport::CodexAppServer => {
+            let model = model.unwrap_or_else(|| crate::models::CODEX_GPT_5_6_TERRA.to_string());
+            let mut session = super::codex::CodexSession::new(binary, &model, effort);
+            session.send_planner_turn(prompt, None)
+        }
+        PlannerTransport::OpencodeRun => {
+            let mut session = super::opencode::OpencodeSession::new(binary, model.as_deref());
+            session.send_planner_turn(prompt, None)
+        }
+    }
+}
+
+// ── settings surface ────────────────────────────────────────────────────────
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrontBrainOptionState {
+    pub id: String,
+    pub label: String,
+    pub installed: bool,
+}
+
+/// What Settings → Voice renders for the Front brain segment: the stored
+/// choice, which seats this machine can actually take, and the seat the next
+/// Right-Option gesture will run.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SymonFrontBrainState {
+    pub choice: String,
+    pub options: Vec<FrontBrainOptionState>,
+    pub resolved_id: Option<String>,
+    pub resolved_label: Option<String>,
+    pub resolved_model: Option<String>,
+    pub fell_back_from: Option<String>,
+    pub escalate_available: bool,
+}
+
+impl Default for SymonFrontBrainState {
+    fn default() -> Self {
+        Self {
+            choice: "auto".to_string(),
+            options: Vec::new(),
+            resolved_id: None,
+            resolved_label: None,
+            resolved_model: None,
+            fell_back_from: None,
+            escalate_available: false,
+        }
+    }
+}
+
+pub(crate) fn state() -> SymonFrontBrainState {
+    let routing = resolve();
+    let mut options = vec![FrontBrainOptionState {
+        id: GEMINI_ID.to_string(),
+        label: GEMINI_LABEL.to_string(),
+        installed: gemini_available(),
+    }];
+    options.extend(
+        planner_route::PLANNER_ADAPTERS
+            .iter()
+            .map(|adapter| FrontBrainOptionState {
+                id: adapter.id.to_string(),
+                label: adapter.label.to_string(),
+                installed: planner_route::locate_planner_binary(adapter).is_some(),
+            }),
+    );
+    SymonFrontBrainState {
+        choice: read_choice().unwrap_or_else(|| "auto".to_string()),
+        options,
+        resolved_id: Some(routing.brain.id().to_string()),
+        resolved_label: Some(routing.brain.label().to_string()),
+        resolved_model: Some(routing.brain.model_label().to_string()),
+        fell_back_from: routing.fell_back_from,
+        escalate_available: routing.escalate_available,
+    }
+}

--- a/src-tauri/src/agent/front_brain_tests.rs
+++ b/src-tauri/src/agent/front_brain_tests.rs
@@ -1,0 +1,518 @@
+//! Real-path coverage for the Symon FRONT brain seam (#2164).
+//!
+//! These drive the entry points the gesture actually takes — the resolve the
+//! agent loop calls, the `ask` the Right-Option Ask lane calls, and the first
+//! prompt the planner loop sends — against the pref file the settings panel
+//! writes, with real fixture processes on the other end. A resolver that is
+//! right proves nothing if the loop never asks it, so every assertion here goes
+//! through the caller rather than the helper.
+
+use super::*;
+use serde_json::json;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+/// The fixture drives the planner registry through its env overrides and a
+/// throwaway data dir, the same way `planner_seat_tests::SeatFixture` does.
+/// This one additionally guarantees NO Gemini credential: no key in the env, no
+/// key in the pref file, and no entitlement token in the data dir — so any test
+/// that lands on the built-in loop is landing there on the route's own logic
+/// and any planner run here is running without a Gemini fallback underneath it.
+#[cfg(unix)]
+struct FrontFixture {
+    dir: std::path::PathBuf,
+    capture: std::path::PathBuf,
+    previous: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    _guard: std::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(unix)]
+impl FrontFixture {
+    fn new(prefs: serde_json::Value) -> Self {
+        Self::with_installed(prefs, &["claude", "codex", "opencode"])
+    }
+
+    /// `installed` names the adapters whose fixture binary exists; every other
+    /// adapter's env override points at a path that is not there, which is how
+    /// a "chosen CLI is missing" case is staged without touching the machine.
+    fn with_installed(prefs: serde_json::Value, installed: &[&str]) -> Self {
+        let guard = crate::DATA_DIR_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let dir = std::env::temp_dir().join(format!(
+            "o8-front-brain-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let capture = dir.join("capture.txt");
+
+        // Holds stdin open the way the resident CLIs do, so a spawned session
+        // stays alive until it is dropped.
+        let resident = "#!/bin/sh\n\
+                        for arg in \"$@\"; do printf 'argv %s\\n' \"$arg\" >> \"$FRONT_CAPTURE\"; done\n\
+                        printf '%s\\n' '__END__' >> \"$FRONT_CAPTURE\"\n\
+                        cat > /dev/null\n";
+        for name in ["claude-fixture", "codex-fixture"] {
+            let path = dir.join(name);
+            std::fs::write(&path, resident).unwrap();
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        // One process PER TURN: records argv and answers on stdout in the real
+        // NDJSON shape. A turn counter walks a scripted script of replies, so a
+        // multi-tool task can actually run to completion against it.
+        let opencode = dir.join("opencode-fixture");
+        std::fs::write(
+            &opencode,
+            "#!/bin/sh\n\
+             for arg in \"$@\"; do printf 'argv %s\\n' \"$arg\" >> \"$FRONT_CAPTURE\"; done\n\
+             printf '%s\\n' '__END__' >> \"$FRONT_CAPTURE\"\n\
+             turn=0\n\
+             if [ -f \"$FRONT_TURNS\" ]; then turn=$(cat \"$FRONT_TURNS\"); fi\n\
+             next=$((turn + 1))\n\
+             printf '%s' \"$next\" > \"$FRONT_TURNS\"\n\
+             action=$(sed -n \"${next}p\" \"$FRONT_SCRIPT\")\n\
+             if [ -z \"$action\" ]; then action='{\\\"done\\\":true,\\\"say\\\":\\\"All set.\\\"}'; fi\n\
+             printf '{\"type\":\"text\",\"sessionID\":\"ses_fixture\",\"part\":{\"type\":\"text\",\"text\":\"%s\"}}\\n' \"$action\"\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&opencode, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        std::fs::write(dir.join("operator-defaults.json"), "{\"orchestratorBackend\":\"codex\"}")
+            .unwrap();
+        std::fs::write(dir.join("dictation.json"), prefs.to_string()).unwrap();
+        // Default script: answer any turn with a plain-prose sentence (the Ask
+        // shape). Tool tests overwrite it.
+        std::fs::write(dir.join("script.txt"), "The dock is on the left.\n").unwrap();
+
+        let keys = [
+            "O8_DATA_DIR",
+            "CORTEX_IDE_DATA_DIR",
+            "O8_CLAUDE_CODE_BIN",
+            "CLAUDE_BIN",
+            "O8_CODEX_BIN",
+            "CODEX_BIN",
+            "O8_OPENCODE_BIN",
+            "OPENCODE_BIN",
+            "GEMINI_API_KEY",
+            "FRONT_CAPTURE",
+            "FRONT_TURNS",
+            "FRONT_SCRIPT",
+        ];
+        let previous = keys
+            .into_iter()
+            .map(|key| (key, std::env::var_os(key)))
+            .collect();
+        std::env::set_var("O8_DATA_DIR", &dir);
+        std::env::remove_var("CORTEX_IDE_DATA_DIR");
+        // No Gemini credential anywhere.
+        std::env::remove_var("GEMINI_API_KEY");
+        let missing = dir.join("not-installed");
+        let bin = |id: &str, file: &str| {
+            if installed.contains(&id) {
+                dir.join(file)
+            } else {
+                missing.clone()
+            }
+        };
+        std::env::set_var("O8_CLAUDE_CODE_BIN", bin("claude", "claude-fixture"));
+        std::env::remove_var("CLAUDE_BIN");
+        std::env::set_var("O8_CODEX_BIN", bin("codex", "codex-fixture"));
+        std::env::remove_var("CODEX_BIN");
+        std::env::set_var("O8_OPENCODE_BIN", bin("opencode", "opencode-fixture"));
+        std::env::remove_var("OPENCODE_BIN");
+        std::env::set_var("FRONT_CAPTURE", &capture);
+        std::env::set_var("FRONT_TURNS", dir.join("turns.txt"));
+        std::env::set_var("FRONT_SCRIPT", dir.join("script.txt"));
+        Self {
+            dir,
+            capture,
+            previous,
+            _guard: guard,
+        }
+    }
+
+    /// One planner action (or prose reply) per line, consumed in order.
+    fn script(&self, lines: &[&str]) {
+        std::fs::write(self.dir.join("script.txt"), format!("{}\n", lines.join("\n"))).unwrap();
+    }
+
+    /// The whole capture, prompt continuation lines included.
+    fn captured_raw(&self) -> String {
+        self.captured_argv();
+        std::fs::read_to_string(&self.capture).unwrap_or_default()
+    }
+
+    fn captured_argv(&self) -> Vec<String> {
+        for _ in 0..200 {
+            let captured = std::fs::read_to_string(&self.capture).unwrap_or_default();
+            if captured.contains("__END__") {
+                return captured
+                    .lines()
+                    .filter_map(|line| line.strip_prefix("argv ").map(str::to_string))
+                    .collect();
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        panic!("fixture never recorded its argv");
+    }
+}
+
+#[cfg(unix)]
+impl Drop for FrontFixture {
+    fn drop(&mut self) {
+        for (key, value) in &self.previous {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// Reports only `installed` as present, whatever this machine actually has.
+fn locator(
+    installed: &'static [&'static str],
+) -> impl FnMut(&planner_route::PlannerAdapter) -> Option<String> {
+    move |adapter| {
+        installed
+            .contains(&adapter.id)
+            .then(|| format!("/fixture/{}", adapter.id))
+    }
+}
+
+#[cfg(unix)]
+fn front_ctx(escalate_available: bool) -> TaskCtx {
+    front_ctx_named("front-brain-test", escalate_available)
+}
+
+/// The loop speaks an opening filler for any task id that is not a background
+/// one. Headless tests take the quiet id; nothing else in the loop reads it.
+#[cfg(unix)]
+fn front_ctx_named(task_id: &str, escalate_available: bool) -> TaskCtx {
+    TaskCtx {
+        task_id: task_id.into(),
+        utterance: "what can you do".into(),
+        ledger_session_id: None,
+        machine_session_id: "desktop".into(),
+        app: None,
+        screen: None,
+        spatial: false,
+        crop_png_base64: None,
+        edit: None,
+        cancel: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        escalate_available,
+    }
+}
+
+/// The default. `auto` must seat exactly what the route seated before this
+/// change — the background registry's own answer, model and effort included —
+/// and it must pick the planner loop, not the built-in one.
+#[cfg(unix)]
+#[test]
+fn auto_seats_exactly_what_the_background_route_seats() {
+    let _fixture = FrontFixture::new(json!({}));
+    let planner_route::PlannerRouting::Selected(background) = planner_route::resolve() else {
+        panic!("the fixture CLIs are installed, so the background route seats one");
+    };
+
+    let routing = front_brain::resolve();
+    let seat = routing
+        .planner_selection()
+        .expect("auto takes the planner loop while a CLI is installed");
+    assert_eq!(seat.provider.id, background.provider.id);
+    assert_eq!(seat.model, background.model);
+    assert_eq!(seat.effort, background.effort);
+    assert!(routing.gemini_model().is_none());
+    assert!(routing.fell_back_from.is_none());
+}
+
+/// The floor `auto` adds: with no agent CLI at all the gesture used to fail
+/// outright. Now it lands on the built-in loop instead.
+#[cfg(unix)]
+#[test]
+fn auto_falls_to_the_built_in_loop_when_no_cli_is_installed() {
+    let _fixture = FrontFixture::new(json!({}));
+    let routing = front_brain::resolve_with(
+        None,
+        planner_route::PlannerRouting::Unavailable { message: "none" },
+        "auto",
+        true,
+        locator(&[]),
+    );
+    assert!(routing.planner_selection().is_none());
+    assert_eq!(routing.gemini_model(), Some(crate::models::GEMINI_3_FLASH_PREVIEW));
+    // Nothing to escalate to: the handoff target is the route that just failed.
+    assert!(!routing.escalate_available);
+}
+
+/// A registry id picks the text-planner loop on that seat — at the WORKER rung
+/// by default, which is the front lane's own discipline rather than the
+/// background seat's default (`codex` seats its builder rung there).
+#[cfg(unix)]
+#[test]
+fn a_registry_id_seats_the_text_planner_loop_at_the_worker_rung() {
+    let _fixture = FrontFixture::new(json!({ "symon_front_brain": "codex" }));
+    let routing = front_brain::resolve();
+    let seat = routing.planner_selection().expect("a registry id takes a planner seat");
+    assert_eq!(seat.provider.id, "codex");
+    assert_eq!(
+        seat.provider.transport,
+        planner_route::PlannerTransport::CodexAppServer
+    );
+    assert_eq!(seat.model.as_deref(), Some(crate::models::CODEX_GPT_5_6_TERRA));
+    assert_eq!(seat.effort, "medium");
+
+    // The background seat's own default is the other rung, and it is unmoved.
+    let planner_route::PlannerRouting::Selected(background) = planner_route::resolve() else {
+        panic!("the background route still seats a CLI");
+    };
+    assert_eq!(background.model.as_deref(), Some(planner_route::DEFAULT_CODEX_PLANNER_MODEL));
+}
+
+/// The operator's existing Symon brain tier and model pin still steer the front
+/// seat when they set one — the front choice picks the adapter, not the rung.
+#[cfg(unix)]
+#[test]
+fn the_brain_tier_and_model_pin_still_reach_the_front_seat() {
+    {
+        let _fixture = FrontFixture::new(json!({
+            "symon_front_brain": "claude",
+            "symon_brain_tier": "builder",
+        }));
+        let routing = front_brain::resolve();
+        let seat = routing.planner_selection().unwrap();
+        assert_eq!(seat.model.as_deref(), Some(planner_route::BUILDER_CLAUDE_PLANNER_MODEL));
+        assert_eq!(seat.effort, "high");
+    }
+    {
+        let _fixture = FrontFixture::new(json!({
+            "symon_front_brain": "opencode",
+            "symon_brain_model": "openrouter/some-model",
+        }));
+        let routing = front_brain::resolve();
+        assert_eq!(
+            routing.planner_selection().unwrap().model.as_deref(),
+            Some("openrouter/some-model")
+        );
+    }
+}
+
+/// A chosen front brain whose binary is missing never fails the gesture: it
+/// falls through, and both the log line and the settings state name the pick it
+/// could not honor. With no Gemini credential in this fixture the fallback is
+/// another installed seat rather than the built-in loop.
+#[cfg(unix)]
+#[test]
+fn a_missing_front_binary_falls_back_and_says_so() {
+    let _fixture = FrontFixture::new(json!({ "symon_front_brain": "opencode" }));
+    let planner_route::PlannerRouting::Selected(background) = planner_route::resolve() else {
+        panic!("the fixture CLIs back the background route");
+    };
+
+    // No Gemini credential in this fixture, so the fallback is another
+    // installed seat rather than the built-in loop — and never nothing.
+    let routing = front_brain::resolve_with(
+        Some("opencode"),
+        planner_route::PlannerRouting::Selected(background.clone()),
+        "auto",
+        false,
+        locator(&["claude", "codex"]),
+    );
+    assert_eq!(routing.fell_back_from.as_deref(), Some("opencode"));
+    assert_eq!(routing.brain.id(), background.provider.id);
+
+    // With a Gemini credential the built-in loop takes it instead.
+    let routing = front_brain::resolve_with(
+        Some("opencode"),
+        planner_route::PlannerRouting::Selected(background),
+        "auto",
+        true,
+        locator(&["claude", "codex"]),
+    );
+    assert_eq!(routing.fell_back_from.as_deref(), Some("opencode"));
+    assert_eq!(routing.brain.id(), "gemini");
+}
+
+/// The settings panel reads one state that names the seat the NEXT gesture
+/// takes, plus every selectable seat — so a pick reads as a pick and a fallback
+/// reads as a fallback rather than silently doing something else.
+#[cfg(unix)]
+#[test]
+fn the_settings_state_names_the_seat_the_next_gesture_takes() {
+    let _fixture = FrontFixture::new(json!({ "symon_front_brain": "codex" }));
+    let state = serde_json::to_value(front_brain::state()).unwrap();
+    assert_eq!(state["choice"], "codex");
+    assert_eq!(state["resolvedId"], "codex");
+    assert_eq!(state["resolvedModel"], crate::models::CODEX_GPT_5_6_TERRA);
+    assert_eq!(state["fellBackFrom"], serde_json::Value::Null);
+
+    // The built-in loop leads the list and is un-credentialed in this fixture;
+    // every planner adapter follows, rendered from the native registry.
+    let options = state["options"].as_array().unwrap();
+    assert_eq!(options[0]["id"], "gemini");
+    assert_eq!(options[0]["installed"], serde_json::Value::Bool(false));
+    let ids: Vec<&str> = options.iter().filter_map(|row| row["id"].as_str()).collect();
+    for adapter in planner_route::PLANNER_ADAPTERS {
+        assert!(ids.contains(&adapter.id), "{} is selectable", adapter.id);
+    }
+
+    // And the same state rides the one command the panel already calls.
+    let brain = serde_json::to_value(planner_route::brain_state()).unwrap();
+    assert_eq!(brain["front"]["resolvedId"], "codex");
+}
+
+/// `escalate` is withheld when the two seats coincide (`auto` always does) and
+/// offered when they genuinely differ — asserted through the REAL first prompt
+/// the planner loop sends, not the flag on its own.
+#[cfg(unix)]
+#[test]
+fn escalate_is_withheld_when_the_front_and_background_seats_coincide() {
+    {
+        let _fixture = FrontFixture::new(json!({}));
+        let routing = front_brain::resolve();
+        assert!(
+            !routing.escalate_available,
+            "auto seats the background brain itself — there is nothing to hand off to"
+        );
+        let prompt =
+            claude::build_first_prompt("tidy my desktop", &front_ctx(routing.escalate_available));
+        assert!(
+            !prompt.contains("\"escalate\""),
+            "the planner catalog must not offer a handoff to its own seat"
+        );
+    }
+    {
+        // A different adapter on the front seat IS a real handoff target.
+        let _fixture = FrontFixture::new(json!({ "symon_front_brain": "claude" }));
+        let routing = front_brain::resolve();
+        assert_eq!(routing.brain.id(), "claude");
+        assert!(
+            routing.escalate_available,
+            "the background brain resolves to codex here, a different seat"
+        );
+        let prompt =
+            claude::build_first_prompt("tidy my desktop", &front_ctx(routing.escalate_available));
+        assert!(
+            prompt.contains("\"escalate\""),
+            "the handoff is offered when it leads somewhere"
+        );
+    }
+    {
+        // The escalation policy still wins outright.
+        let fixture = FrontFixture::new(json!({ "symon_front_brain": "claude" }));
+        std::fs::write(
+            fixture.dir.join("agent_models.json"),
+            json!({ "voice_escalation": "off" }).to_string(),
+        )
+        .unwrap();
+        assert!(!front_brain::resolve().escalate_available);
+    }
+}
+
+/// Background brain tasks keep the infinite-handoff guard: the flag is never
+/// set for them, so the catalog they receive is the one they always received.
+#[cfg(unix)]
+#[test]
+fn a_background_brain_task_never_offers_the_handoff() {
+    let _fixture = FrontFixture::new(json!({ "symon_front_brain": "claude" }));
+    let prompt = claude::build_first_prompt("summarize the week", &front_ctx(false));
+    assert!(!prompt.contains("\"escalate\""));
+}
+
+/// The acceptance case: front brain pinned to a non-Gemini adapter, no Gemini
+/// key and no plan token anywhere, and a TWO-TOOL task runs to completion
+/// through the planner loop — the real loop, a real process per turn, real tool
+/// dispatch. `app: None` is the persisted headless seam, so the two tools are
+/// ones that answer without the desktop handle.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_two_tool_task_completes_on_a_non_gemini_front_brain_with_no_gemini_key() {
+    let fixture = FrontFixture::new(json!({ "symon_front_brain": "opencode" }));
+    assert!(
+        crate::entitlement::resolve_gemini(crate::models::GEMINI_3_FLASH_PREVIEW).is_none(),
+        "the acceptance case runs with no Gemini key and no plan token"
+    );
+    fixture.script(&[
+        r#"{\"tool\":\"symon_capabilities\",\"args\":{}}"#,
+        r#"{\"tool\":\"symon_memory_list\",\"args\":{}}"#,
+        r#"{\"done\":true,\"say\":\"Both checks are done.\"}"#,
+    ]);
+
+    let routing = front_brain::resolve();
+    let seat = routing.planner_selection().expect("the open seat takes the turn").clone();
+    assert_eq!(seat.provider.id, "opencode");
+
+    let ctx = front_ctx_named("claude-task-front-brain", routing.escalate_available);
+    let result = opencode::run_loop(&seat.binary, seat.model.as_deref(), "check yourself", &ctx)
+        .await
+        .expect("the planner loop completes");
+    assert_eq!(result.result_text, "Both checks are done.");
+
+    let calls: Vec<serde_json::Value> = serde_json::from_str(&result.tool_calls_json).unwrap();
+    let names: Vec<&str> = calls
+        .iter()
+        .filter_map(|call| call.get("tool").and_then(|name| name.as_str()))
+        .collect();
+    assert_eq!(names, vec!["symon_capabilities", "symon_memory_list"]);
+    assert!(
+        calls.iter().all(|call| call["ok"] == serde_json::Value::Bool(true)),
+        "both tools ran for real: {calls:?}"
+    );
+}
+
+/// Ask mode on a planner seat: ONE turn, the Ask persona, and no tool catalog
+/// at all — asserted on the argv and the prompt the real process received.
+#[cfg(unix)]
+#[tokio::test]
+async fn ask_mode_answers_on_the_front_seat_with_tools_withheld() {
+    let fixture = FrontFixture::new(json!({ "symon_front_brain": "opencode" }));
+    fixture.script(&["The dock is on the left."]);
+
+    let answer = front_brain::ask("where is my dock", None)
+        .await
+        .expect("the front seat answers");
+    assert_eq!(answer, "The dock is on the left.");
+
+    let sent = fixture.captured_raw();
+    assert!(sent.contains("Question: where is my dock"));
+    assert!(
+        !sent.contains("AVAILABLE TOOLS"),
+        "Ask withholds the tool catalog entirely"
+    );
+    assert!(
+        !sent.contains("HOW YOU ACT"),
+        "Ask sends no planner contract — it is one question, not a loop"
+    );
+    let argv = fixture.captured_argv();
+    // The read-only posture the seat spawns with is still enforced underneath.
+    assert!(argv.windows(2).any(|pair| pair == ["--agent", "plan"]));
+    assert!(argv.iter().any(|arg| arg == "--pure"));
+}
+
+/// A planner seat that answers with an action object anyway is read for its
+/// spoken sentence rather than having JSON spoken aloud.
+#[test]
+fn an_action_shaped_ask_reply_is_read_for_its_spoken_sentence() {
+    assert_eq!(
+        front_brain::plain_answer(r#"{"done": true, "say": "Nine windows are open."}"#),
+        "Nine windows are open."
+    );
+    assert_eq!(front_brain::plain_answer("  Plain prose.  "), "Plain prose.");
+}
+
+/// The Ask prompt carries the same persona the built-in path uses, so the two
+/// seats answer in one voice.
+#[test]
+fn the_ask_prompt_carries_the_shared_persona_and_the_question() {
+    let prompt = front_brain::build_ask_prompt("what is on my screen", Some("Finder is frontmost"));
+    assert!(prompt.starts_with(crate::ai::gemini_ask::ASK_SYSTEM_PROMPT));
+    assert!(prompt.contains("[On-screen context]\nFinder is frontmost"));
+    assert!(prompt.contains("Question: what is on my screen"));
+    assert!(prompt.contains("no tools on this turn") || prompt.contains("no tools"));
+}

--- a/src-tauri/src/agent/gemini.rs
+++ b/src-tauri/src/agent/gemini.rs
@@ -37,7 +37,15 @@ pub async fn run_loop(model: &str, intent: &str, ctx: &TaskCtx) -> Result<LoopRe
     let client = http_client();
 
     let escalation = super::router::load_config().voice_escalation;
-    let tool_specs = tools::enabled_tools_for(&escalation);
+    // #2164: the handoff is also withheld when the background brain would
+    // resolve to this very seat — there would be nothing to escalate to.
+    let tool_specs: Vec<Value> = tools::enabled_tools_for(&escalation)
+        .into_iter()
+        .filter(|tool| {
+            ctx.escalate_available
+                || tool.get("name").and_then(|name| name.as_str()) != Some("escalate")
+        })
+        .collect();
 
     // Gemini folds the system prompt into the first user turn (matches
     // gemini_ask.rs — avoids systemInstruction shape uncertainty). When the

--- a/src-tauri/src/agent/machine_tests.rs
+++ b/src-tauri/src/agent/machine_tests.rs
@@ -51,6 +51,7 @@ async fn active_remote_tool_uses_ssh_at_the_process_spawn_seam() {
         crop_png_base64: None,
         edit: None,
         cancel: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        escalate_available: false,
     };
     let result = dispatch_tool_call_with_spawner(
         "agent_turn",
@@ -101,6 +102,7 @@ async fn remote_prompt_injection_reaches_adapter_only_inside_untrusted_envelope(
         crop_png_base64: None,
         edit: None,
         cancel: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        escalate_available: false,
     };
     let result = dispatch_tool_call_with_spawner("agent_turn_result", json!({}), &ctx, spawner)
         .await

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -23,6 +23,7 @@ pub mod edit_ctx;
 pub mod eval;
 pub mod event_kit;
 mod execution;
+pub mod front_brain;
 pub mod gemini;
 pub mod ledger;
 pub mod machine;
@@ -49,6 +50,10 @@ pub mod worker_pulse;
 #[cfg(test)]
 #[path = "planner_seat_tests.rs"]
 mod planner_seat_tests;
+
+#[cfg(test)]
+#[path = "front_brain_tests.rs"]
+mod front_brain_tests;
 
 pub(crate) use execution::{
     execute_cascaded_tool_call, execute_realtime_tool_call, execute_text_tool_call,
@@ -99,6 +104,11 @@ pub struct TaskCtx {
     /// check it between turns and bail; `run_agent_inner` skips the spoken
     /// result so a cancelled task goes quiet instead of talking over the user.
     pub cancel: Arc<AtomicBool>,
+    /// May this task offer `escalate`? False everywhere except a front voice
+    /// turn whose seat differs from the seat the handoff would land on (#2164)
+    /// — a background brain task keeps the infinite-handoff guard, and the
+    /// phone/realtime surfaces keep the posture they already had.
+    pub escalate_available: bool,
 }
 
 impl TaskCtx {
@@ -1631,6 +1641,7 @@ pub async fn run_symon_text_turn(
         crop_png_base64: None,
         edit: None,
         cancel,
+        escalate_available: false,
     };
     let correlation = ConfirmCorrelation {
         session_id,
@@ -1792,11 +1803,22 @@ async fn run_agent_inner(
     );
     crate::sound::play_sound("Pop");
 
-    // Normal voice turns choose from the same native CLI inventory used at
-    // bootstrap. Resolve before screen/edit capture so a machine with no agent
-    // CLI gets one explicit dock state instead of paying capture latency and
-    // falling through to a provider-specific "spawn failed".
-    let planner_selection = if model_override.is_none() {
+    // The FRONT seat (#2164) reads the same registry the background brain does,
+    // plus the built-in Gemini loop — so the gesture always has a brain even on
+    // a machine with no agent CLI, and a chosen seat whose binary is missing
+    // falls back out loud. Background brain tasks keep the #2155/#2156 route
+    // exactly: the registry, or an explicit "no agent CLI" dock state.
+    // Resolved before screen/edit capture so a dead end costs no capture latency.
+    let front_routing = if model_override.is_none() && !is_background_brain_task {
+        let routing = front_brain::resolve();
+        routing.log_seat("agent");
+        Some(routing)
+    } else {
+        None
+    };
+    let planner_selection = if let Some(routing) = front_routing.as_ref() {
+        routing.planner_selection().cloned()
+    } else if model_override.is_none() {
         match planner_route::resolve() {
             planner_route::PlannerRouting::Selected(selection) => {
                 // One line per task naming the seat — the operator's receipt
@@ -1881,6 +1903,9 @@ async fn run_agent_inner(
         crop_png_base64: spatial_crop,
         edit,
         cancel: cancel.clone(),
+        escalate_available: front_routing
+            .as_ref()
+            .is_some_and(|routing| routing.escalate_available),
     };
 
     // Dropped-file context rides the LLM prompt only — the task store keeps
@@ -1930,6 +1955,11 @@ async fn run_agent_inner(
     let model = planner_selection
         .as_ref()
         .map(|selection| selection.model_label().to_string())
+        .or_else(|| {
+            front_routing
+                .as_ref()
+                .and_then(|routing| routing.gemini_model().map(str::to_string))
+        })
         .unwrap_or_else(|| {
             model_override.unwrap_or_else(|| router::load_config().mac_native_action)
         });
@@ -1976,6 +2006,13 @@ async fn run_agent_inner(
                 .await
             }
         }
+    } else if let Some(gemini_model) = front_routing
+        .as_ref()
+        .and_then(front_brain::FrontRouting::gemini_model)
+    {
+        // The front seat's built-in loop — Gemini's own functionCall protocol,
+        // the one brain that needs a key rather than a binary (#2164).
+        gemini::run_loop(gemini_model, &llm_prompt, &ctx).await
     } else if model.starts_with("claude") {
         claude::run_loop(&model, &llm_prompt, &ctx).await
     } else if model.contains('/') {

--- a/src-tauri/src/agent/openrouter.rs
+++ b/src-tauri/src/agent/openrouter.rs
@@ -29,8 +29,14 @@ pub async fn run_loop(model: &str, intent: &str, ctx: &TaskCtx) -> Result<LoopRe
     // Gemini-format specs {name, description, parameters} wrap cleanly into
     // OpenAI's {type:"function", function:{...}} — `parameters` == the schema.
     let escalation = super::router::load_config().voice_escalation;
+    // #2164: same rule as the other front loops — no handoff when the
+    // background brain would land on this seat.
     let tools_json: Vec<Value> = tools::enabled_tools_for(&escalation)
-        .iter()
+        .into_iter()
+        .filter(|tool| {
+            ctx.escalate_available
+                || tool.get("name").and_then(|name| name.as_str()) != Some("escalate")
+        })
         .map(|spec| json!({ "type": "function", "function": spec }))
         .collect();
 

--- a/src-tauri/src/agent/planner_route.rs
+++ b/src-tauri/src/agent/planner_route.rs
@@ -297,7 +297,7 @@ pub(crate) struct BrainSetting {
     pub model: Option<String>,
 }
 
-fn locate_planner_binary(adapter: &PlannerAdapter) -> Option<String> {
+pub(crate) fn locate_planner_binary(adapter: &PlannerAdapter) -> Option<String> {
     crate::cli_locate::resolve_binary(adapter.binary, adapter.binary_env)
 }
 
@@ -307,6 +307,39 @@ pub(crate) fn resolve() -> PlannerRouting {
 
 pub(crate) fn resolve_bound(engine: &str, model: &str, effort: &str) -> PlannerRouting {
     resolve_bound_with(engine, model, effort, locate_planner_binary)
+}
+
+/// Seat ONE named adapter for the Symon FRONT brain (#2164), or `None` when its
+/// binary is missing — the front seat falls back on its own terms rather than
+/// walking this registry's background fallback order.
+///
+/// The rung differs from `resolve`: with no operator tier the front seat takes
+/// the WORKER rung, because it is the fast lane the operator talks to and it
+/// must never inherit a builder default they did not ask for. The model pin is
+/// the same one the background seat honors, and it still only rides the adapter
+/// it validates for.
+///
+/// The locator is injected: a "this CLI is not installed" case cannot be staged
+/// on a machine that HAS the CLI — a missing env override just falls through to
+/// the PATH scan — so absence is tested through this seam, the way
+/// `only_opencode_installed_routes_the_planner_through_opencode` does.
+pub(crate) fn seat_front_adapter_with<F>(
+    id: &str,
+    tier: Option<PlannerTier>,
+    pin: Option<&str>,
+    mut locate: F,
+) -> Option<PlannerSelection>
+where
+    F: FnMut(&PlannerAdapter) -> Option<String>,
+{
+    let adapter = adapter_by_id(id)?;
+    let binary = locate(adapter)?;
+    Some(selection_for(
+        adapter,
+        binary,
+        Some(tier.unwrap_or(PlannerTier::Worker)),
+        pin,
+    ))
 }
 
 /// The `--effort` flag a Claude planner model is spawned with, or `None` to
@@ -352,7 +385,7 @@ fn read_operator_defaults() -> Option<Value> {
 /// straight off disk rather than through `stt::keys`' mtime cache: the planner
 /// resolves once per task, and a plain read keeps one file as the truth with no
 /// second cached copy to go stale.
-fn read_voice_prefs() -> Option<Value> {
+pub(crate) fn read_voice_prefs() -> Option<Value> {
     let raw = std::fs::read_to_string(super::agent_data_dir().join("dictation.json")).ok()?;
     serde_json::from_str::<Value>(&raw).ok()
 }
@@ -623,10 +656,17 @@ pub struct SymonBrainState {
     /// through to another entry.
     pub fell_back_from: Option<String>,
     pub detail: Option<&'static str>,
+    /// The FRONT seat (#2164) — the Right-Option gesture's own choice, resolved
+    /// through the same registry plus the built-in Gemini loop. Default (empty)
+    /// in the pure-resolution unit tests; `brain_state` fills it for the panel.
+    pub front: super::front_brain::SymonFrontBrainState,
 }
 
 pub fn brain_state() -> SymonBrainState {
-    brain_state_with(&read_brain_setting(), preferred_provider(), locate_planner_binary)
+    let mut state =
+        brain_state_with(&read_brain_setting(), preferred_provider(), locate_planner_binary);
+    state.front = super::front_brain::state();
+    state
 }
 
 fn brain_state_with<F>(
@@ -661,6 +701,7 @@ where
         resolved_effort: None,
         fell_back_from: None,
         detail: None,
+        front: super::front_brain::SymonFrontBrainState::default(),
     };
     match routing {
         PlannerRouting::Selected(selection) => {

--- a/src-tauri/src/agent/planner_seat_tests.rs
+++ b/src-tauri/src/agent/planner_seat_tests.rs
@@ -25,6 +25,7 @@ fn headless_ctx() -> TaskCtx {
         crop_png_base64: None,
         edit: None,
         cancel: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        escalate_available: false,
     }
 }
 

--- a/src-tauri/src/agent/realtime_bridge.rs
+++ b/src-tauri/src/agent/realtime_bridge.rs
@@ -163,6 +163,7 @@ pub async fn symon_transport_invoke_tool(
         crop_png_base64: None,
         edit: None,
         cancel: Arc::new(AtomicBool::new(false)),
+        escalate_available: false,
     };
     tools::dispatch_tool_call(&name, args, &ctx).await
 }
@@ -207,6 +208,7 @@ async fn realtime_invoke_tool_inner(
         crop_png_base64: None,
         edit: None,
         cancel,
+        escalate_available: false,
     };
 
     // Same safety gate as the cascaded loop: ReadOnly passes straight through,

--- a/src-tauri/src/ai/gemini_ask.rs
+++ b/src-tauri/src/ai/gemini_ask.rs
@@ -11,7 +11,9 @@ use serde::Deserialize;
 const DIRECT_MODEL: &str = "gemini-3.1-pro-preview";
 const MAX_OUTPUT_TOKENS: u32 = 2048;
 
-const SYSTEM_PROMPT: &str = "You are o8, a compact macOS assistant for answering questions about the user's current screen, selection, and recent context.\n\
+/// Shared with the front-brain Ask path (#2164) so a planner seat answers
+/// with the same persona and the same "no tools, no actions" posture.
+pub(crate) const ASK_SYSTEM_PROMPT: &str = "You are o8, a compact macOS assistant for answering questions about the user's current screen, selection, and recent context.\n\
 \n\
 Use only the context provided in this request. Do not imply you can see, read, or control anything that was not provided.\n\
 \n\
@@ -62,7 +64,7 @@ pub async fn ask(question: &str, context: Option<&str>) -> Result<String, String
     // Fold the system prompt + optional context + question into a single user
     // turn (avoids systemInstruction API-shape uncertainty; matches aqua's
     // prepend-context approach).
-    let mut prompt = SYSTEM_PROMPT.to_string();
+    let mut prompt = ASK_SYSTEM_PROMPT.to_string();
     if let Some(ctx) = context {
         let ctx = ctx.trim();
         if !ctx.is_empty() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5777,10 +5777,15 @@ fn dictation_history_delete(id: String) {
     dictation_history::delete(&id);
 }
 
-/// Ask Gemini `question` on a dedicated OS thread, emit the answer to the webview
-/// (`o8:ask-answer` / `o8:ask-error`), and SPEAK it through the TTS engine.
-/// Shared by the `ask_question` command (text) and the Right-Option voice path
-/// (`run_finalize`). macOS only. Gemini only — NEVER Anthropic.
+/// Answer `question` on the Symon FRONT brain on a dedicated OS thread, emit the
+/// answer to the webview (`o8:ask-answer` / `o8:ask-error`), and SPEAK it
+/// through the TTS engine. Shared by the `ask_question` command (text) and the
+/// Right-Option voice path (`run_finalize`). macOS only.
+///
+/// #2164: the seat is whatever the front-brain setting resolves — the built-in
+/// Gemini call it always made, or one tools-withheld turn on a planner seat.
+/// The Anthropic billing rule is unchanged: a Claude seat is reached only by
+/// spawning the CLI, never by a direct provider call from o8's backend.
 #[cfg(target_os = "macos")]
 fn spawn_ask_and_speak(app: tauri::AppHandle, question: String) {
     use tauri::Emitter;
@@ -5800,7 +5805,7 @@ fn spawn_ask_and_speak(app: tauri::AppHandle, question: String) {
             }
         };
         log::info!("[ask] question: {} chars", question.len());
-        match rt.block_on(async { ai::gemini_ask::ask(&question, None).await }) {
+        match rt.block_on(async { agent::front_brain::ask(&question, None).await }) {
             Ok(answer) => {
                 log::info!("[ask] answer: {} chars", answer.len());
                 let answer_payload = serde_json::json!({ "question": question, "answer": answer });

--- a/src/components/desktop/settings/VoiceTab.tsx
+++ b/src/components/desktop/settings/VoiceTab.tsx
@@ -267,6 +267,14 @@ export function VoiceTab() {
     void writeBrainPref('symon_brain_provider', next);
   }, [writeBrainPref]);
 
+  // #2164: the FRONT seat — what Right-Option runs, Ask and Agent alike.
+  const handleFrontBrain = useCallback((next: string) => {
+    setBrain((current) => (
+      current ? { ...current, front: { ...current.front, choice: next } } : current
+    ));
+    void writeBrainPref('symon_front_brain', next);
+  }, [writeBrainPref]);
+
   const handleBrainTier = useCallback((next: string) => {
     setBrain((current) => (current ? { ...current, tier: next } : current));
     void writeBrainPref('symon_brain_tier', next);
@@ -328,18 +336,41 @@ export function VoiceTab() {
       brain.resolvedEffort ?? 'default',
     ].join(' · ')
     : null;
+  const front = brain?.front ?? null;
+  const frontBrainOptions = useMemo(
+    () => [
+      { value: 'auto', label: 'Auto' },
+      ...(front?.options ?? []).map((option) => ({ value: option.id, label: option.label })),
+    ],
+    [front],
+  );
+  // Under Auto the front seat IS the background seat, which is also why the
+  // handoff is withheld — saying so beats repeating the same model twice.
+  const frontSeatSameAsBackground = Boolean(
+    front?.resolvedId && front.resolvedId === brain?.resolvedProvider
+      && front.resolvedModel === brain?.resolvedModel,
+  );
+  const frontSeat = front?.resolvedLabel ?? front?.resolvedId ?? null;
+  const frontStatus = !front || !frontSeat
+    ? null
+    : front.fellBackFrom
+      ? `Front brain: ${front.fellBackFrom} not installed — using ${frontSeat}`
+      : frontSeatSameAsBackground
+        ? `Front brain: same as background${front.choice === 'auto' ? ' (auto)' : ''}`
+        : `Front brain: ${frontSeat}${front.resolvedModel && front.resolvedModel !== frontSeat ? ` · ${front.resolvedModel}` : ''}`;
   // Says what the NEXT task will run, so a pick whose CLI is missing reads as a
   // fallback instead of silently doing something else.
-  const brainStatus = !brain
+  const backgroundStatus = !brain
     ? 'Reading the installed agent CLIs…'
     : brain.detail
       ? brain.detail
       : brain.fellBackFrom
         ? `Not installed: ${brain.fellBackFrom} — falling back to ${resolvedSeat}`
-        : `Resolved: ${resolvedSeat}`;
+        : `Background: ${resolvedSeat}`;
+  const brainStatus = frontStatus ? `${frontStatus} · ${backgroundStatus}` : backgroundStatus;
   const brainStatusTone = brain?.detail
     ? '#d94f3a'
-    : brain?.fellBackFrom
+    : brain?.fellBackFrom || front?.fellBackFrom
       ? RAMS_ACCENT
       : 'var(--t-text-faint)';
   const brainModelPlaceholder = brain?.adapters.find(
@@ -610,6 +641,19 @@ export function VoiceTab() {
                       { value: 'auto', label: 'Auto' },
                       { value: 'deep', label: 'Deep' },
                     ]}
+                  />
+                }
+                divider
+              />
+              <SettingsRow
+                icon={<BrainGlyph />}
+                label="Front brain"
+                subtitle="Which brain the Right-Option gesture runs. Ask and Agent both take this seat; Auto follows the background brain below."
+                accessory={
+                  <SettingsSegmented
+                    value={front?.choice ?? 'auto'}
+                    onChange={handleFrontBrain}
+                    options={frontBrainOptions}
                   />
                 }
                 divider

--- a/src/lib/tauri/bridge.ts
+++ b/src/lib/tauri/bridge.ts
@@ -517,6 +517,26 @@ export interface SymonBrainAdapterState {
 /** The Symon brain seat (#2156): the stored setting, which planner adapters are
  * installed, and the seat the registry resolves right now. `fellBackFrom` names
  * the chosen provider when its CLI is missing and another entry took the seat. */
+/** One selectable front-brain seat (#2164) — the built-in Gemini loop plus
+ *  every planner adapter, rendered from the native registry. */
+export interface SymonFrontBrainOption {
+  id: string;
+  label: string;
+  installed: boolean;
+}
+
+/** The seat the Right-Option gesture takes: the stored choice, what this
+ *  machine can run, and what the NEXT gesture will actually use. */
+export interface SymonFrontBrainState {
+  choice: string;
+  options: SymonFrontBrainOption[];
+  resolvedId: string | null;
+  resolvedLabel: string | null;
+  resolvedModel: string | null;
+  fellBackFrom: string | null;
+  escalateAvailable: boolean;
+}
+
 export interface SymonBrainState {
   provider: string;
   tier: string;
@@ -528,6 +548,7 @@ export interface SymonBrainState {
   resolvedEffort: string | null;
   fellBackFrom: string | null;
   detail: string | null;
+  front: SymonFrontBrainState;
 }
 
 export async function symonBrainState(): Promise<SymonBrainState | null> {


### PR DESCRIPTION
## Mechanic

The Right-Option seat was the last provider-shaped brain in Symon. **Ask mode** always called Gemini (`ai/gemini_ask.rs`, one request, no tools). **Agent mode** could only take a planner seat: `run_agent_inner` resolved through `planner_route` and, with no agent CLI installed, failed the gesture outright — so a machine with neither CLI had no front brain at all, and the built-in Gemini tool-calling loop it used to run had become unreachable from every call site.

## Change

**A front-brain route (`agent/front_brain.rs`).** The front seat now reads the same registry the background brain reads (#2156), plus the one entry that registry cannot carry: the built-in Gemini loop, which needs a key rather than a binary. The choice is `symon_front_brain` in the voice pref store (`~/.o8/dictation.json`, written by `voice_prefs_set` exactly like the `symon_brain_*` keys):

| value | Agent mode | Ask mode |
|---|---|---|
| `auto` (default, and an absent key) | whatever `planner_route::resolve()` seats — today's route, model and effort included | the built-in Gemini call, unchanged |
| `gemini` | the built-in `functionCall` loop | the built-in Gemini call |
| `claude` / `codex` / `opencode` | the JSON-action planner loop on that seat | one tools-withheld turn on that seat |

`auto` is the route the seat already ran, with one floor added: no planner CLI now lands on the built-in loop instead of failing the gesture. A chosen adapter takes the **worker** rung unless `symon_brain_tier` says otherwise — the front seat is the fast lane and must not inherit a builder default nobody asked for — and honors `symon_brain_model` the same way the background seat does, pin validation included.

**Ask on a planner seat.** One turn carrying the shared Ask persona and the question: no planner contract, no tool catalog, on top of the read-only posture each adapter already spawns with (`--tools ""`, read-only sandbox, `--pure --agent plan`). So tools are withheld twice over — nothing is offered, and nothing could run. A seat that answers with an action object anyway is read for its spoken sentence rather than having JSON read aloud.

**The escalate rule.** `escalate` hands off to `spawn_background_brain_task`, which resolves through the same registry, so when the front seat and the background seat are the same seat there is nothing to escalate to and the tool is withheld. A planner front seat already behaved that way (the planner catalog has always stripped `escalate`), so the default is unchanged; the rule only opens the handoff back up when the two seats genuinely differ, and a background task never carries the flag, keeping its infinite-handoff guard. Seat identity is the adapter, model and effort together, so a worker-tier front seat handing to a builder-tier background seat still counts as a real escalation. `voice_escalation: off` still wins outright.

This lands on top of #2174's invariant prefix: `escalate` stays out of `catalog_tools()`, and `escalate_block` appends it with its full schema **after** the cached prefix, so the byte-stable prefix that pass bought is untouched and taking the handoff still costs no lookup turn.

**A missing binary never fails the gesture silently.** A chosen seat whose CLI is absent falls to the built-in loop, or to another installed seat when no Gemini credential resolves, logs `[symon-front-brain] … is not installed — falling back to …`, and the settings status line names the pick it could not honor.

**Settings → Voice.** The existing Symon brain control grows a **Front brain** segment rendered from the native registry, and the status line folds both halves: `Front brain: same as background (auto) · Background: Codex · gpt-5.6-sol · high`, or `Front brain: opencode not installed — using Codex · …`. Under Auto the line says "same as background" rather than printing one model twice, which is also the reason the handoff is withheld. The Right-Option keydown pre-warm follows the front seat too, so an operator who pinned one does not get the other model booted for them.

## Verification

```
$ cd src-tauri && cargo test --lib
test result: ok. 398 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 4.72s

$ npx tsc --noEmit
(exit 0)

$ npm run lint
✖ 52 problems (0 errors, 52 warnings)   # all pre-existing, none in the changed files
```

Twelve new cases drive the entry points the gesture takes, against the pref file the panel writes, with real fixture processes on the other end:

- `auto_seats_exactly_what_the_background_route_seats` — the default is the background route's own answer, provider, model and effort.
- `a_registry_id_seats_the_text_planner_loop_at_the_worker_rung` — a pick takes the worker rung while the background seat keeps its own default, on the other rung.
- `the_brain_tier_and_model_pin_still_reach_the_front_seat`.
- `a_two_tool_task_completes_on_a_non_gemini_front_brain_with_no_gemini_key` — the acceptance case. Front brain pinned to a non-Gemini adapter, `resolve_gemini` asserted `None`, and a two-tool task runs the real loop against a real process per turn: both tools dispatch for real and the loop says done.
- `ask_mode_answers_on_the_front_seat_with_tools_withheld` — through `front_brain::ask`, asserting on what the process actually received: the question is there, `AVAILABLE TOOLS` and the planner contract are not, and the read-only argv still is.
- `escalate_is_withheld_when_the_front_and_background_seats_coincide` — asserted on the real assembled first prompt, both directions, plus the policy override.
- `a_background_brain_task_never_offers_the_handoff`.
- `auto_falls_to_the_built_in_loop_when_no_cli_is_installed` and `a_missing_front_binary_falls_back_and_says_so` go through the injected-locator seam, the way `only_opencode_installed_routes_the_planner_through_opencode` does: a missing env override falls through to the PATH scan, so "this CLI is absent" cannot be staged on a machine that has it.
- `the_settings_state_names_the_seat_the_next_gesture_takes` — the state the panel reads, through the command it already calls.
- Plus the Ask prompt and action-shaped-reply cases.

## Manual check owed

The Right-Option gesture itself is a global hotkey on a signed build, so it is not reachable from a test. On the real box, worth walking: Settings → Voice shows the Front brain segment and a correct folded status line; Right-Option Agent on `auto` behaves exactly as before; switching the front brain to another adapter moves the seat on the next gesture with no relaunch; Right-Option Ask on that adapter speaks a plain answer; and a pick whose CLI is missing speaks a fallback rather than going quiet.

Closes #2164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe
