### PR TITLE
fix: bind the text surface to a planner seat by registry id

### DIFF
--- a/src-tauri/src/agent/bound_seat.rs
+++ b/src-tauri/src/agent/bound_seat.rs
@@ -1,0 +1,120 @@
+//! Per-session planner seat handles for the bound text surface (#2176).
+//!
+//! ## Why a handle at all
+//! The bound surface (phone Symon, managed messages) used to name its seat by
+//! an `(engine, model, effort)` triple, so a registry entry whose model comes
+//! from the runtime's own configuration had nothing to be named by. Seat
+//! identity is really the registry entry id; what makes a seat *resumable* is
+//! an opaque handle whose shape belongs to the adapter, not to o8:
+//!
+//! | seat | handle |
+//! |---|---|
+//! | opencode | the `sessionID` its first `run` reports, replayed as `--session <id>` |
+//! | codex | the thread id `exec` reports, replayed as `exec resume <id>` |
+//! | claude | the resident `stream-json` child's session key |
+//!
+//! Only the open seat resumes through this store today. The other two are
+//! already named by an o8-side model id and keep their per-turn spawn — holding
+//! a resident child or a Codex thread across bound turns is a process-lifetime
+//! change this issue does not need, and #2176 requires the default path to stay
+//! byte-identical.
+//!
+//! ## Where the handle lives
+//! Native-side, keyed by the bound surface's own text session id, which every
+//! turn already carries. The handle never crosses the bridge: it is the
+//! adapter's private token, and a phone has no business holding one. A stored
+//! handle is fenced by the engine that produced it, so a seat change mid
+//! conversation starts a new thread instead of replaying someone else's.
+
+use std::sync::Mutex;
+
+/// Conversations tracked at once. The bound surface is a single operator's
+/// phone and message threads, so this is generous; the oldest entry is dropped
+/// rather than letting a long-lived process grow without bound.
+const MAX_TRACKED_SESSIONS: usize = 64;
+
+/// `(text session id, engine id, opaque handle)`, most recently used first.
+static SEATS: Mutex<Vec<(String, &'static str, String)>> = Mutex::new(Vec::new());
+
+fn seats() -> std::sync::MutexGuard<'static, Vec<(String, &'static str, String)>> {
+    SEATS.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// The handle this text session opened on `engine`, or `None` when it has none
+/// — a first turn, or a session whose last turn ran on a different seat.
+pub(crate) fn handle_for(session_id: &str, engine: &str) -> Option<String> {
+    seats()
+        .iter()
+        .find(|(id, seat, _)| id == session_id && *seat == engine)
+        .map(|(_, _, handle)| handle.clone())
+}
+
+/// Remember what the turn ended on so the next turn resumes it. Replaces any
+/// handle already held for this session, including one from another seat.
+pub(crate) fn remember(session_id: &str, engine: &'static str, handle: String) {
+    if handle.trim().is_empty() {
+        return;
+    }
+    let mut seats = seats();
+    seats.retain(|(id, _, _)| id != session_id);
+    seats.insert(0, (session_id.to_string(), engine, handle));
+    seats.truncate(MAX_TRACKED_SESSIONS);
+}
+
+#[cfg(test)]
+pub(crate) fn reset() {
+    seats().clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The store is process-global, so these serialize against each other.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn exclusive() -> std::sync::MutexGuard<'static, ()> {
+        let guard = TEST_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        reset();
+        guard
+    }
+
+    #[test]
+    fn a_handle_is_fenced_by_the_seat_that_produced_it() {
+        let _guard = exclusive();
+        remember("session-a", "opencode", "ses_one".to_string());
+        assert_eq!(handle_for("session-a", "opencode").as_deref(), Some("ses_one"));
+        // Same conversation, different seat: no handle, so the turn opens its
+        // own thread rather than replaying another runtime's id.
+        assert_eq!(handle_for("session-a", "codex"), None);
+        assert_eq!(handle_for("session-b", "opencode"), None);
+
+        // A seat change replaces the entry rather than stacking a second one.
+        remember("session-a", "codex", "thread_two".to_string());
+        assert_eq!(handle_for("session-a", "opencode"), None);
+        assert_eq!(handle_for("session-a", "codex").as_deref(), Some("thread_two"));
+        assert_eq!(seats().len(), 1);
+    }
+
+    #[test]
+    fn the_store_is_bounded_and_drops_the_oldest_conversation() {
+        let _guard = exclusive();
+        for index in 0..(MAX_TRACKED_SESSIONS + 5) {
+            remember(&format!("session-{index}"), "opencode", format!("ses_{index}"));
+        }
+        assert_eq!(seats().len(), MAX_TRACKED_SESSIONS);
+        assert_eq!(handle_for("session-0", "opencode"), None);
+        let newest = MAX_TRACKED_SESSIONS + 4;
+        assert_eq!(
+            handle_for(&format!("session-{newest}"), "opencode").as_deref(),
+            Some(format!("ses_{newest}").as_str())
+        );
+    }
+
+    #[test]
+    fn an_empty_handle_is_never_stored() {
+        let _guard = exclusive();
+        remember("session-empty", "opencode", "   ".to_string());
+        assert_eq!(handle_for("session-empty", "opencode"), None);
+    }
+}

--- a/src-tauri/src/agent/claude.rs
+++ b/src-tauri/src/agent/claude.rs
@@ -580,7 +580,9 @@ pub(crate) async fn run_text_planner_loop<S: TextPlannerSession>(
     ctx: &TaskCtx,
     provider: &'static str,
 ) -> Result<LoopResult, String> {
-    run_text_planner_loop_inner(session, model, intent, ctx, provider, None).await
+    run_text_planner_loop_inner(session, model, intent, ctx, provider, None)
+        .await
+        .map(|(result, _session)| result)
 }
 
 pub(crate) async fn run_text_planner_loop_correlated<S: TextPlannerSession>(
@@ -591,6 +593,23 @@ pub(crate) async fn run_text_planner_loop_correlated<S: TextPlannerSession>(
     provider: &'static str,
     correlation: ConfirmCorrelation,
 ) -> Result<LoopResult, String> {
+    run_text_planner_loop_inner(session, model, intent, ctx, provider, Some(correlation))
+        .await
+        .map(|(result, _session)| result)
+}
+
+/// The correlated loop, handing the session back with the result so the caller
+/// can read the adapter's resume handle off it (#2176). A failed turn keeps
+/// today's shape — the error is returned and the session is dropped, because
+/// there is no thread worth carrying forward from one.
+pub(crate) async fn run_text_planner_loop_correlated_resumable<S: TextPlannerSession>(
+    session: S,
+    model: &str,
+    intent: &str,
+    ctx: &TaskCtx,
+    provider: &'static str,
+    correlation: ConfirmCorrelation,
+) -> Result<(LoopResult, S), String> {
     run_text_planner_loop_inner(session, model, intent, ctx, provider, Some(correlation)).await
 }
 
@@ -601,7 +620,7 @@ async fn run_text_planner_loop_inner<S: TextPlannerSession>(
     ctx: &TaskCtx,
     provider: &'static str,
     correlation: Option<ConfirmCorrelation>,
-) -> Result<LoopResult, String> {
+) -> Result<(LoopResult, S), String> {
     let mut tool_call_log: Vec<Value> = Vec::new();
     let mut brain_sources: Vec<Value> = Vec::new();
     let mut result_text = String::new();
@@ -792,12 +811,15 @@ async fn run_text_planner_loop_inner<S: TextPlannerSession>(
         result_text = "Done.".to_string();
     }
 
-    Ok(LoopResult {
-        result_text,
-        model_used: model.to_string(),
-        tool_calls_json: Value::Array(tool_call_log).to_string(),
-        brain_sources,
-    })
+    Ok((
+        LoopResult {
+            result_text,
+            model_used: model.to_string(),
+            tool_calls_json: Value::Array(tool_call_log).to_string(),
+            brain_sources,
+        },
+        session,
+    ))
 }
 
 pub(crate) fn text_tool_result_message(tool_name: &str, tool_result: &Value) -> String {

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -14,6 +14,7 @@
 //! the loop's `await` from a different thread.
 
 pub mod agent_turn;
+pub mod bound_seat;
 pub mod capabilities;
 pub mod calendar_attention;
 pub mod claude;
@@ -1564,6 +1565,10 @@ pub struct SymonTextPlannerInfo {
     engine: Option<&'static str>,
     model: Option<String>,
     effort: Option<&'static str>,
+    /// The seat named the way Settings → Voice names it — `label · model ·
+    /// effort`, collapsing to `label · runtime-configured` for a seat whose
+    /// model and reasoning both come from the operator's own runtime config.
+    seat: Option<String>,
     tools: Vec<Value>,
     detail: Option<&'static str>,
 }
@@ -1590,10 +1595,15 @@ fn text_task_id(session_id: &str, turn_id: &str) -> Result<String, String> {
     Ok(format!("symon-text:{session_id}:{turn_id}"))
 }
 
-/// Why a resolved seat can still be unusable on the bound text surface.
-pub(crate) const UNBINDABLE_TEXT_PLANNER_MESSAGE: &str =
-    "the selected Symon brain runs its runtime's own configured model, which the text surface cannot pin yet — choose a brain with a model id in Settings → Voice";
-
+/// What the bound text surface (phone Symon, managed messages) can run, and
+/// under what name. The seat's IDENTITY is `engine` — the registry entry id —
+/// and `(engine, model, effort)` is the projection of it that surface already
+/// speaks. A seat whose model comes from the operator's own runtime config has
+/// no o8-side id to project, so it fills the model slot with the registry's
+/// `runtime-configured` marker (#2176) instead of being reported unavailable;
+/// the marker round-trips back through `resolve_bound` and is translated away
+/// before any spawn. What actually resumes such a seat is the per-session
+/// handle in `bound_seat`, which never crosses this bridge.
 pub fn symon_text_planner_info(
     engine: Option<&str>,
     model: Option<&str>,
@@ -1609,28 +1619,12 @@ pub fn symon_text_planner_info(
         },
     };
     match routing {
-        // The text surface resumes a session from a BOUND (engine, model,
-        // effort) triple, so a seat that carries no o8-side model id — an
-        // adapter running whatever model the operator configured for it — is
-        // reported unavailable HERE with the real reason, rather than passed on
-        // as a half-filled triple that reads downstream as "nothing installed".
-        // The voice + escalation paths take that seat happily; only this bound
-        // surface needs the id.
-        planner_route::PlannerRouting::Selected(selection) if selection.model.is_none() => {
-            SymonTextPlannerInfo {
-                available: false,
-                engine: None,
-                model: None,
-                effort: None,
-                tools: Vec::new(),
-                detail: Some(UNBINDABLE_TEXT_PLANNER_MESSAGE),
-            }
-        }
         planner_route::PlannerRouting::Selected(selection) => SymonTextPlannerInfo {
             available: true,
             engine: Some(selection.provider.id),
-            model: selection.model.clone(),
+            model: Some(selection.bound_model().to_string()),
             effort: Some(selection.effort),
+            seat: Some(selection.seat_line()),
             tools: tools::enabled_tools(),
             detail: None,
         },
@@ -1639,6 +1633,7 @@ pub fn symon_text_planner_info(
             engine: None,
             model: None,
             effort: None,
+            seat: None,
             tools: Vec::new(),
             detail: Some(message),
         },
@@ -1647,6 +1642,21 @@ pub fn symon_text_planner_info(
 
 pub async fn run_symon_text_turn(
     app: tauri::AppHandle,
+    session_id: String,
+    turn_id: String,
+    prompt: String,
+    engine: String,
+    model: String,
+    effort: String,
+) -> Result<SymonTextTurnResult, String> {
+    run_symon_text_turn_with(Some(app), session_id, turn_id, prompt, engine, model, effort).await
+}
+
+/// The bound surface's run path. `app` is optional so the real entry can be
+/// driven headless — every app-dependent emit already fails closed on `None`,
+/// the same seam the planner seat tests use for the tool dispatch.
+pub(crate) async fn run_symon_text_turn_with(
+    app: Option<tauri::AppHandle>,
     session_id: String,
     turn_id: String,
     prompt: String,
@@ -1664,12 +1674,15 @@ pub async fn run_symon_text_turn(
         planner_route::PlannerRouting::Unavailable { message } => return Err(message.to_string()),
     };
     let cancel = register_cancel(&task_id);
+    // The conversation key the seat handle is filed under — `session_id` itself
+    // is moved into the confirm correlation below.
+    let bound_session_id = session_id.clone();
     let ctx = TaskCtx {
         task_id: task_id.clone(),
         utterance: prompt.clone(),
         ledger_session_id: Some(session_id.clone()),
         machine_session_id: session_id.clone(),
-        app: Some(app),
+        app,
         screen: None,
         spatial: false,
         crop_png_base64: None,
@@ -1704,14 +1717,26 @@ pub async fn run_symon_text_turn(
             .await
         }
         planner_route::PlannerTransport::OpencodeRun => {
+            // This seat carries no o8-side model id, so what identifies it
+            // across bound turns is the thread it opened (#2176): resume the
+            // one this conversation already holds, and file whatever the turn
+            // ends on for the next one.
+            let resume = bound_seat::handle_for(&bound_session_id, selection.provider.id);
             opencode::run_phone_text_loop(
                 &selection.binary,
                 selection.model.as_deref(),
+                resume.as_deref(),
                 &prompt,
                 &ctx,
                 correlation,
             )
             .await
+            .map(|(result, handle)| {
+                if let Some(handle) = handle {
+                    bound_seat::remember(&bound_session_id, selection.provider.id, handle);
+                }
+                result
+            })
         }
     };
     let interrupted = ctx.is_cancelled();

--- a/src-tauri/src/agent/opencode.rs
+++ b/src-tauri/src/agent/opencode.rs
@@ -52,11 +52,28 @@ pub(crate) struct OpencodeSession {
 
 impl OpencodeSession {
     pub(crate) fn new(binary: &str, model: Option<&str>) -> Self {
+        Self::resuming(binary, model, None)
+    }
+
+    /// Same seat, continuing a thread this machine already opened. `resume` is
+    /// an opaque `sessionID` the bound text surface held for this conversation
+    /// (#2176) — the first turn of a new conversation passes `None`.
+    pub(crate) fn resuming(binary: &str, model: Option<&str>, resume: Option<&str>) -> Self {
         Self {
             binary: binary.to_string(),
             model: model.map(str::to_string),
-            session_id: None,
+            session_id: resume
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .map(str::to_string),
         }
+    }
+
+    /// The thread this session is on, for a caller that has to carry it to the
+    /// next turn. This seat has no o8-side model id, so the handle IS its
+    /// identity across turns.
+    pub(crate) fn resume_handle(&self) -> Option<&str> {
+        self.session_id.as_deref()
     }
 
     /// A screenshot rides the turn as a file attachment, so it has to land on
@@ -203,22 +220,29 @@ pub async fn run_loop(
     .await
 }
 
+/// One bound (phone / managed-messages) turn on the open seat, continuing
+/// `resume` when the conversation already opened a thread. Hands the thread it
+/// ended on back to the caller so the next turn resumes the same one (#2176) —
+/// this seat carries no o8-side model id, so the handle is what binds it.
 pub async fn run_phone_text_loop(
     binary: &str,
     model: Option<&str>,
+    resume: Option<&str>,
     intent: &str,
     ctx: &TaskCtx,
     correlation: ConfirmCorrelation,
-) -> Result<LoopResult, String> {
-    super::claude::run_text_planner_loop_correlated(
-        OpencodeSession::new(binary, model),
+) -> Result<(LoopResult, Option<String>), String> {
+    let (result, session) = super::claude::run_text_planner_loop_correlated_resumable(
+        OpencodeSession::resuming(binary, model, resume),
         model.unwrap_or("opencode"),
         intent,
         ctx,
         "opencode",
         correlation,
     )
-    .await
+    .await?;
+    let handle = session.resume_handle().map(str::to_string);
+    Ok((result, handle))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/agent/planner_route.rs
+++ b/src-tauri/src/agent/planner_route.rs
@@ -55,6 +55,15 @@ pub(crate) const WORKER_CODEX_PLANNER_MODEL: &str = crate::models::CODEX_GPT_5_6
 /// operator's own runtime config rather than from o8.
 pub(crate) const RUNTIME_CONFIGURED_EFFORT: &str = "default";
 
+/// The `model` half of the bound surface's triple for a seat that has no
+/// o8-side model id (#2176). It is a MARKER, never a model: `accepts_model`
+/// refuses it as an operator pin, and `resolve_bound` translates it back to
+/// "no model" before the selection reaches a spawn, so it can never ride a
+/// CLI's `--model` flag. Binding identity for such a seat is the registry id
+/// plus the per-session handle in `bound_seat`; this keeps the triple shape
+/// intact for callers that already speak it.
+pub(crate) const RUNTIME_CONFIGURED_MODEL: &str = "runtime-configured";
+
 /// Voice-pref keys for the Symon brain setting. Written by `voice_prefs_set`
 /// (→ `stt::keys::set_pref`) and read back out of the same JSON file here, so a
 /// settings change applies to the next task with no relaunch.
@@ -146,12 +155,20 @@ pub(crate) struct PlannerAdapter {
 }
 
 impl PlannerAdapter {
+    /// True when this adapter runs whatever model the operator configured for
+    /// it, so o8 holds no model id to bind the text surface with.
+    pub(crate) fn runtime_configured_model(&self) -> bool {
+        self.worker_model.is_none()
+    }
+
     /// Does this adapter accept `model` as an operator pin? Catalog adapters
     /// allow-list their ids (a raw CLI value must never reach the spawn);
     /// open-catalog adapters validate the `provider/model` shape instead.
     pub(crate) fn accepts_model(&self, model: &str) -> bool {
         let model = model.trim();
-        if model.is_empty() {
+        // The bound surface's marker is not a model and must never reach a
+        // spawn — `resolve_bound` is the only place that understands it.
+        if model.is_empty() || model == RUNTIME_CONFIGURED_MODEL {
             return false;
         }
         if !self.pinnable_models.is_empty() {
@@ -279,6 +296,26 @@ impl PlannerSelection {
     /// back to the adapter id when the seat carries no o8-side model.
     pub(crate) fn model_label(&self) -> &str {
         self.model.as_deref().unwrap_or(self.provider.id)
+    }
+
+    /// The `model` the bound (phone / managed-messages) surface carries for
+    /// this seat: the o8-side id when the seat has one, and the
+    /// runtime-configured marker when its model comes from the operator's own
+    /// runtime config. Round-trips back through `resolve_bound`.
+    pub(crate) fn bound_model(&self) -> &str {
+        self.model.as_deref().unwrap_or(RUNTIME_CONFIGURED_MODEL)
+    }
+
+    /// The seat named the way the Settings → Voice status line names it —
+    /// `label · model · effort`. A seat that takes BOTH its model and its
+    /// reasoning from the operator's own runtime config collapses to
+    /// `label · runtime-configured`, because spelling out a model o8 did not
+    /// choose and an effort it did not pass says nothing.
+    pub(crate) fn seat_line(&self) -> String {
+        match &self.model {
+            Some(model) => format!("{} · {model} · {}", self.provider.label, self.effort),
+            None => format!("{} · {RUNTIME_CONFIGURED_MODEL}", self.provider.label),
+        }
     }
 }
 
@@ -579,13 +616,22 @@ where
     let Some(adapter) = adapter_by_id(engine) else {
         return unavailable;
     };
-    if !adapter.accepts_model(model) || !adapter.accepts_effort(effort) {
+    // Bind by seat identity, not by model triple (#2176): a seat whose model
+    // comes from the operator's own runtime config carries the marker in the
+    // model slot, and it is translated back to "no model" here so the spawn is
+    // the same one the voice path makes.
+    let runtime_configured =
+        adapter.runtime_configured_model() && model.trim() == RUNTIME_CONFIGURED_MODEL;
+    if !adapter.accepts_effort(effort) {
+        return unavailable;
+    }
+    if !runtime_configured && !adapter.accepts_model(model) {
         return unavailable;
     }
     let Some(binary) = locate(adapter) else {
         return unavailable;
     };
-    let model = effective_model_for(adapter, model);
+    let model = (!runtime_configured).then(|| effective_model_for(adapter, model));
     PlannerRouting::Selected(PlannerSelection {
         provider: adapter,
         binary,
@@ -594,11 +640,13 @@ where
         // value. The Codex path applies the request verbatim, and an adapter
         // that takes its reasoning from the operator's config reports that.
         effort: match adapter.effort {
-            PlannerEffort::ClaudeBuilderFlag => claude_planner_effort(&model),
+            PlannerEffort::ClaudeBuilderFlag => {
+                model.as_deref().map_or("medium", claude_planner_effort)
+            }
             PlannerEffort::CodexReasoningEffort => static_effort(effort),
             PlannerEffort::RuntimeConfigured => RUNTIME_CONFIGURED_EFFORT,
         },
-        model: Some(model),
+        model,
     })
 }
 
@@ -683,7 +731,7 @@ where
             id: adapter.id,
             label: adapter.label,
             installed: locate(adapter).is_some(),
-            runtime_configured_model: adapter.worker_model.is_none(),
+            runtime_configured_model: adapter.runtime_configured_model(),
         })
         .collect();
     let routing = resolve_with(setting, preferred, &mut locate);

--- a/src-tauri/src/agent/planner_seat_tests.rs
+++ b/src-tauri/src/agent/planner_seat_tests.rs
@@ -161,6 +161,29 @@ impl SeatFixture {
         }
     }
 
+    /// Wait for `expected` fixture spawns and return each one's argv on its
+    /// own. The fixture appends to a single capture file and closes every run
+    /// with `__END__`, so a multi-turn path is read run by run rather than as
+    /// one flattened list.
+    fn captured_runs(&self, expected: usize) -> Vec<Vec<String>> {
+        for _ in 0..200 {
+            let captured = std::fs::read_to_string(&self.capture).unwrap_or_default();
+            if captured.matches("__END__").count() >= expected {
+                return captured
+                    .split("__END__")
+                    .take(expected)
+                    .map(|run| {
+                        run.lines()
+                            .filter_map(|line| line.strip_prefix("argv ").map(str::to_string))
+                            .collect()
+                    })
+                    .collect();
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        panic!("fixture recorded fewer than {expected} runs");
+    }
+
     /// Wait for the spawned fixture to finish writing its argv.
     fn captured_argv(&self) -> Vec<String> {
         for _ in 0..200 {
@@ -403,37 +426,132 @@ fn an_operator_model_pin_reaches_the_open_seat_spawn() {
     assert_eq!(argv[model_at + 1], "openrouter/some-model");
 }
 
-/// The bound text surface (phone / managed messages) resumes from an
-/// `(engine, model, effort)` triple. A seat whose model comes from the runtime's
-/// own config cannot supply one, so the info call says exactly that instead of
-/// handing down a half-filled triple that reads as "nothing installed".
+/// The bound text surface (phone / managed messages) binds a seat by its
+/// registry id, not by a model triple (#2176). This drives the REAL entry
+/// points — `symon_text_planner_info` for what the surface is told, then the
+/// bound run path twice on one conversation — because the registry resolving
+/// an open seat proves nothing if the surface the operator texts cannot take
+/// it.
 #[cfg(unix)]
-#[test]
-fn a_runtime_configured_seat_is_reported_unbindable_to_the_text_surface() {
-    let _fixture = SeatFixture::with_brain_setting(
+#[tokio::test]
+async fn the_open_seat_binds_the_text_surface_and_the_next_turn_resumes_it() {
+    let fixture = SeatFixture::with_brain_setting(
         "codex",
         Some(json!({ "symon_brain_provider": "opencode" })),
     );
-    // The voice path takes this seat.
-    let planner_route::PlannerRouting::Selected(selection) = planner_route::resolve() else {
-        panic!("the opencode fixture binary is installed");
-    };
-    assert_eq!(selection.provider.id, "opencode");
+    bound_seat::reset();
 
-    // The bound surface does not, and says why.
-    let info = symon_text_planner_info(None, None, None);
-    let rendered = serde_json::to_value(&info).unwrap();
-    assert_eq!(rendered["available"], serde_json::Value::Bool(false));
-    assert_eq!(rendered["detail"], UNBINDABLE_TEXT_PLANNER_MESSAGE);
-
-    // A seat that DOES carry a model id is still reported available.
-    std::fs::write(
-        _fixture.dir.join("dictation.json"),
-        json!({ "symon_brain_provider": "codex" }).to_string(),
-    )
-    .unwrap();
+    // What the surface is told: a seat with no o8-side model id is BINDABLE,
+    // and it is named the way Settings → Voice names it.
     let rendered = serde_json::to_value(symon_text_planner_info(None, None, None)).unwrap();
     assert_eq!(rendered["available"], serde_json::Value::Bool(true));
-    assert_eq!(rendered["engine"], "codex");
-    assert_eq!(rendered["model"], planner_route::DEFAULT_CODEX_PLANNER_MODEL);
+    assert_eq!(rendered["engine"], "opencode");
+    assert_eq!(rendered["model"], planner_route::RUNTIME_CONFIGURED_MODEL);
+    assert_eq!(rendered["effort"], planner_route::RUNTIME_CONFIGURED_EFFORT);
+    assert_eq!(rendered["seat"], "opencode · runtime-configured");
+
+    // And the triple it just handed out comes back through the BOUND entry —
+    // the surface re-presents it on every later turn.
+    let bound = serde_json::to_value(symon_text_planner_info(
+        Some("opencode"),
+        Some(planner_route::RUNTIME_CONFIGURED_MODEL),
+        Some(planner_route::RUNTIME_CONFIGURED_EFFORT),
+    ))
+    .unwrap();
+    assert_eq!(bound["available"], serde_json::Value::Bool(true));
+    assert_eq!(bound["engine"], "opencode");
+    assert_eq!(bound["seat"], "opencode · runtime-configured");
+
+    // Two real turns on one conversation, through the run path the Tauri
+    // command calls. `app: None` is the headless seam.
+    let session_id = "symon-text-2176";
+    for turn_id in ["turn-1", "turn-2"] {
+        let result = run_symon_text_turn_with(
+            None,
+            session_id.to_string(),
+            turn_id.to_string(),
+            "what is on my calendar?".to_string(),
+            "opencode".to_string(),
+            planner_route::RUNTIME_CONFIGURED_MODEL.to_string(),
+            planner_route::RUNTIME_CONFIGURED_EFFORT.to_string(),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("{turn_id} must reach the open seat: {error}"));
+        assert_eq!(result.text, "All set.");
+    }
+
+    let runs = fixture.captured_runs(2);
+    assert!(
+        !runs[0].iter().any(|arg| arg == "--session"),
+        "turn 1 opens the thread: {:?}",
+        runs[0]
+    );
+    let resumed_at = runs[1]
+        .iter()
+        .position(|arg| arg == "--session")
+        .unwrap_or_else(|| panic!("turn 2 must resume turn 1's thread: {:?}", runs[1]));
+    assert_eq!(runs[1][resumed_at + 1], "ses_fixture");
+    // The marker is a binding token, never a model — it must not have reached
+    // the CLI.
+    for run in &runs {
+        assert!(
+            !run.iter().any(|arg| arg == "--model"),
+            "the runtime-configured seat is spawned with no o8-chosen model: {run:?}"
+        );
+        assert!(
+            !run.iter().any(|arg| arg == planner_route::RUNTIME_CONFIGURED_MODEL),
+            "the binding marker must never ride the spawn: {run:?}"
+        );
+    }
+    bound_seat::reset();
+}
+
+/// With the Symon brain setting UNSET, the bound surface is told exactly what
+/// it was told before the marker existed — same engine, same model id, same
+/// effort — for both orchestrator backends. The default path never learns a
+/// new shape.
+#[cfg(unix)]
+#[test]
+fn an_unset_brain_setting_projects_the_triple_it_always_did() {
+    for (backend, engine, model, effort) in [
+        ("codex", "codex", planner_route::DEFAULT_CODEX_PLANNER_MODEL, "high"),
+        ("claude", "claude", crate::models::CLAUDE_SONNET_5, "medium"),
+    ] {
+        let _fixture = SeatFixture::new(backend);
+        let rendered = serde_json::to_value(symon_text_planner_info(None, None, None)).unwrap();
+        assert_eq!(rendered["available"], serde_json::Value::Bool(true), "{backend}");
+        assert_eq!(rendered["engine"], engine, "{backend}");
+        assert_eq!(rendered["model"], model, "{backend}");
+        assert_eq!(rendered["effort"], effort, "{backend}");
+
+        // The triple it hands out still round-trips through the bound entry.
+        let bound =
+            serde_json::to_value(symon_text_planner_info(Some(engine), Some(model), Some(effort)))
+                .unwrap();
+        assert_eq!(bound["available"], serde_json::Value::Bool(true), "{backend}");
+        assert_eq!(bound["model"], model, "{backend}");
+
+        // And a seat that HAS a model id refuses the open seat's binding
+        // marker, so a stale binding cannot claim it.
+        let marked = serde_json::to_value(symon_text_planner_info(
+            Some(engine),
+            Some(planner_route::RUNTIME_CONFIGURED_MODEL),
+            Some(planner_route::RUNTIME_CONFIGURED_EFFORT),
+        ))
+        .unwrap();
+        assert_eq!(marked["available"], serde_json::Value::Bool(false), "{backend}");
+    }
+}
+
+/// The seat line the bound surface reports is the one Settings → Voice renders
+/// — `label · model · effort`, collapsed for a runtime-configured seat.
+#[cfg(unix)]
+#[test]
+fn the_bound_surface_names_the_seat_the_way_settings_does() {
+    let _fixture = SeatFixture::new("codex");
+    let rendered = serde_json::to_value(symon_text_planner_info(None, None, None)).unwrap();
+    assert_eq!(
+        rendered["seat"],
+        format!("Codex · {} · high", planner_route::DEFAULT_CODEX_PLANNER_MODEL)
+    );
 }

--- a/src/app/api/mobile/symon/text-session/route.ts
+++ b/src/app/api/mobile/symon/text-session/route.ts
@@ -83,16 +83,15 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // The phone's model picker only lists the two proprietary CLIs. When it
+  // names none of them, ask the native registry for the seat the operator's
+  // Symon brain setting actually resolves — since #2176 the text surface binds
+  // by registry id, so an open runtime seats it the same way. The availability
+  // gate below reports the native side's own reason when there is no seat.
   const requestedPlanner = await resolveRequestedPlanner(context.model);
-  if (!requestedPlanner) {
-    return NextResponse.json(
-      { ok: false, error: 'no_cli', detail: 'No signed-in native Symon planner CLI is available.' },
-      { status: 501 },
-    );
-  }
   let info: SymonTextPlannerInfo;
   try {
-    info = await readSymonTextPlannerInfo(requestedPlanner);
+    info = await readSymonTextPlannerInfo(requestedPlanner ?? undefined);
   } catch (error) {
     return NextResponse.json(
       { ok: false, error: 'desktop_unavailable', detail: error instanceof Error ? error.message : 'Desktop bridge unavailable.' },

--- a/src/app/api/mobile/symon/text-turn/route.ts
+++ b/src/app/api/mobile/symon/text-turn/route.ts
@@ -21,8 +21,12 @@ export async function POST(request: NextRequest) {
   const planner = body?.planner && typeof body.planner === 'object' && !Array.isArray(body.planner)
     ? body.planner as Record<string, unknown>
     : null;
+  // The engine is a native planner registry entry id, so the shape is checked
+  // here and the id itself is verified by the native bound resolve — an unknown
+  // one is refused there rather than pinned to a hardcoded pair (#2176).
   const selection: SymonTextPlannerSelection | null = planner
-    && (planner.engine === 'claude' || planner.engine === 'codex')
+    && typeof planner.engine === 'string'
+    && /^[a-z0-9-]{1,32}$/.test(planner.engine)
     && typeof planner.model === 'string'
     && typeof planner.effort === 'string'
     ? { engine: planner.engine, model: planner.model, effort: planner.effort }

--- a/src/components/desktop/dictation/SymonTextBridgeHost.tsx
+++ b/src/components/desktop/dictation/SymonTextBridgeHost.tsx
@@ -6,9 +6,12 @@ import type { SymonTextPlannerSelection } from '@/lib/mobile/symon-text-eval';
 
 interface SymonTextPlannerInfo {
   available: boolean;
-  engine?: 'claude' | 'codex';
+  /** Native planner registry entry id — the seat's identity. */
+  engine?: string;
   model?: string;
   effort?: string;
+  /** The seat named the way the Settings → Voice status line names it. */
+  seat?: string;
   tools?: Array<Record<string, unknown>>;
   detail?: string;
 }

--- a/src/lib/mobile/symon-text-bridge-client.ts
+++ b/src/lib/mobile/symon-text-bridge-client.ts
@@ -13,9 +13,12 @@ const BRIDGE_TIMEOUT_MS = 5_000;
 
 export interface SymonTextPlannerInfo {
   available?: boolean;
-  engine?: 'claude' | 'codex';
+  engine?: string;
   model?: string;
   effort?: string;
+  /** The seat named the way the Settings → Voice status line names it, e.g.
+   *  `Codex · gpt-5.6-sol · high` or `opencode · runtime-configured`. */
+  seat?: string;
   tools?: Array<Record<string, unknown>>;
   detail?: string;
 }

--- a/src/lib/mobile/symon-text-eval.ts
+++ b/src/lib/mobile/symon-text-eval.ts
@@ -1,5 +1,11 @@
+/** The seat the bound text surface is bound to. `engine` is the native planner
+ *  registry's entry id — the seat's identity — and the model/effort pair is the
+ *  projection of it. A seat whose model comes from the runtime's own config
+ *  reports the registry's `runtime-configured` marker in `model` (#2176); the
+ *  native side translates it back before any spawn, and what actually resumes
+ *  such a seat is a handle kept native-side, never carried here. */
 export interface SymonTextPlannerSelection {
-  engine: 'claude' | 'codex';
+  engine: string;
   model: string;
   effort: string;
 }

--- a/src/lib/mobile/symon-text-session-store.ts
+++ b/src/lib/mobile/symon-text-session-store.ts
@@ -19,7 +19,7 @@ export interface SymonTextSessionRecord extends SymonClientSubject {
   sessionId: string;
   model: string;
   effort: string;
-  engine: 'claude' | 'codex';
+  engine: string;
   workspaceMode: SymonWorkspaceMode;
   repoId: string | null;
   repoPath: string | null;


### PR DESCRIPTION
## Mechanic

The bound text surface (phone Symon, managed messages) named its planner seat by an `(engine, model, effort)` triple. The registry from #2173 added an entry whose model comes from the runtime's own configuration, so that seat had nothing to be named by: the voice and escalation paths took it, and `symon_text_planner_info` reported it unavailable to the text path with the real reason. The open runtime was usable everywhere except the surface the operator texts.

## Change

**Seat identity is the registry entry id.** The model triple stays as its projection. A seat that carries an o8-side model id projects exactly what it always did. A seat that carries none fills the model slot with the registry's `runtime-configured` marker instead of being reported unavailable.

The marker is a binding token, never a model. `accepts_model` refuses it as an operator pin, and `resolve_bound` translates it back to "no model" before the selection reaches a spawn, so it can never ride a CLI's `--model` flag. The test asserts its absence from both turns' argv.

**An opaque per-seat handle is what resumes such a seat.** The shape belongs to the adapter, not to o8:

| seat | handle |
|---|---|
| opencode | the `sessionID` its first `run` reports, replayed as `--session <id>` |
| codex | the thread id `exec` reports, replayed as `exec resume <id>` |
| claude | the resident `stream-json` child's session key |

Only the open seat resumes through it today. It is kept native-side in `bound_seat`, keyed by the conversation's own text session id and fenced by the engine that produced it, so it never crosses the bridge and a mid-conversation seat change opens a new thread rather than replaying another runtime's. The store is bounded at 64 conversations. The other two seats are already named by an o8-side model id, keep their per-turn spawn and report no handle, which is byte-identical to today — carrying a resident child or a thread across bound turns is a process-lifetime change this issue does not need.

**The seat is reported the way Settings → Voice names it** — `label · model · effort`, collapsing to `label · runtime-configured` when both the model and the reasoning come from the operator's own config, because naming a model o8 did not choose and an effort it did not pass says nothing. It rides a new `seat` field on the info payload; no surface was restyled.

**One more block removed.** The phone's session route asked its own curated model picker for a planner and refused the turn when that picker named neither proprietary CLI. It now falls through to the native registry's resolved seat in that case, and reports the native side's own reason when there is genuinely no seat. The engine check on the turn route is now a shape check, with the id itself verified by the native bound resolve.

## Verification

```
$ cd src-tauri && cargo test --lib
test result: ok. 403 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out

$ npx tsc --noEmit
(exit 0)

$ npm test
Test Files  703 passed | 3 skipped (706)
     Tests  4324 passed | 4 skipped (4328)

$ npm run lint
✖ 52 problems (0 errors, 52 warnings)   # unchanged baseline, none in the changed files
```

New coverage drives the bound surface's real entry points rather than the resolver alone:

- `the_open_seat_binds_the_text_surface_and_the_next_turn_resumes_it` reads what the surface is told out of `symon_text_planner_info`, round-trips that triple back through the bound entry, then runs two real turns on one conversation through the run path the Tauri command calls. Turn 1 carries no `--session`; turn 2 resumes turn 1's id. The `a_runtime_configured_seat_is_reported_unbindable_to_the_text_surface` test it replaces is gone. Cutting the resume lookup makes it fail on that assertion, so the instrument can fail.
- `an_unset_brain_setting_projects_the_triple_it_always_did` pins the default path's projection for both orchestrator backends and checks that a seat with a model id refuses the marker.
- `the_bound_surface_names_the_seat_the_way_settings_does` pins the seat line.
- The `bound_seat` tests cover engine fencing, replacement on a seat change, the bounded store, and the empty-handle guard.

## Out of scope

The phone's explicit model picker (`ask-model-routing.ts`) still lists Claude and Codex ids only — adding a selectable open-runtime entry needs a readiness probe for it and a new public model id, which is its own change. The route now reaches the open seat through the registry when the picker names nothing native, which is the path the issue's acceptance walks.

A resumed thread already holds the conversation, but each bound turn still assembles a full first-turn prompt, so the two overlap. That shape predates this change and is worth a follow-on.

Closes #2176

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe
