### PR TITLE
chore: prepare 0.1.748 Mac and voice release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "o8",
-  "version": "0.1.747",
+  "version": "0.1.748",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "o8",
-      "version": "0.1.747",
+      "version": "0.1.748",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o8",
-  "version": "0.1.747",
+  "version": "0.1.748",
   "description": "o8 — governance layer for autonomous engineering teams. Approvals, audit, organizational memory.",
   "license": "MIT",
   "productName": "o8",

--- a/release-notes/0.1.747.md
+++ b/release-notes/0.1.747.md
@@ -1,0 +1,2 @@
+- Verify the current worker process before confirming Stop, even when an earlier turn already finished.
+- Keep Stop unconfirmed while a new worker turn is preparing, and avoid counting an already-idle session as newly interrupted.

--- a/release-notes/next.md
+++ b/release-notes/next.md
@@ -1,2 +1,8 @@
-- Verify the current worker process before confirming Stop, even when an earlier turn already finished.
-- Keep Stop unconfirmed while a new worker turn is preparing, and avoid counting an already-idle session as newly interrupted.
+- Recover pending review queues when the desktop API restarts, and preserve worker ownership across execution carriers.
+- Reduce terminal decoding allocations and record the accepted Mac interaction baseline for future regression checks.
+- Bound completed dependency-download caches by size, count, and age while preserving active installs, installed dependencies, and legacy caches.
+- Choose Symon's front and background brains in Voice settings through the shared planner registry.
+- Keep the background planner on the worker tier by default, reuse its Codex server, and trim repeated first-turn instructions.
+- Resume the open-runtime text planner on its existing conversation, with session handles fenced to the runtime that created them.
+- Add presentation quiet mode and a review-notification setting with coalesced notices.
+- Scope the Control-key Fn substitute to an attached external keyboard and reject unsupported realtime model selections before connection.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "o8"
-version = "0.1.747"
+version = "0.1.748"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "o8"
-version = "0.1.747"
+version = "0.1.748"
 description = "o8 — governance layer for autonomous engineering teams"
 authors = ["hurttlocker"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "o8",
-  "version": "0.1.747",
+  "version": "0.1.748",
   "identifier": "ai.o8.desktop",
   "build": {
     "frontendDist": "../out/frontend",


### PR DESCRIPTION
## Release

Prepare 0.1.748 from the combined main revision `c74c551d9e3e12bef7e77e7a7638710ba9cd60c5`.

- Synchronize the package, lockfile, native crate and desktop version manifests without dependency changes.
- Record release notes covering the merged Mac lifecycle, review recovery, cache retention and Symon planner work.
- Archive the previously published 0.1.747 notes. No production code changes in this PR.

The combined source includes the Mac acceptance in #2177 and the voice changes through #2179. Issues #1697 and #1817 are closed under their recorded acceptance boundaries; this release does not claim the deferred crop metric or all future performance targets are complete.

## Verification

- `npx tsc --noEmit`: passed.
- `npm test`: 4,324 passed, four skipped, 703 files passed.
- `cargo test --lib --locked --quiet`: 403 passed, two ignored.
- Manifest diff reviewed: version changes only; dependency graph unchanged.
- `git diff --check`: passed.

Merge only after the seven protected checks pass and review conversations are resolved. Publication is separately performed from the exact merged version tag through the normal signed/notarized release workflow, with strict isolated native boot verification. No Linux or Windows VM work is included.

Physical voice hotkey and microphone interaction remain a hands-on check after updating; automated planner-route coverage is not presented as physical-device proof.
