### PR TITLE
Name the launch tool in the Multitask and MoA directives (#2153)

### DIFF
--- a/src/lib/orchestrator/composer-wire.test.ts
+++ b/src/lib/orchestrator/composer-wire.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  COMPOSER_MODE_DIRECTIVES,
+  composeComposerWireMessage,
+  isKnownComposerPreambleTitle,
+  resolveOrchestratorTranscriptMessage,
+  stripKnownComposerWirePreamble,
+  type ComposerWireMode,
+} from './composer-wire';
+
+const MODES: ComposerWireMode[] = ['solo', 'multitask', 'moa'];
+
+/** Directives as o8 shipped them before #2153 — still on the wire from old clients. */
+const LEGACY_MULTITASK = '[Mode: Multitask] Decompose this into parallel worker packets and dispatch them into isolated worktrees instead of working serially yourself. Review and merge through the gate as they finish.';
+const LEGACY_MOA = '[Mode: Mixture of Agents] After the proposal round, decompose the work into parallel worker packets and dispatch them into isolated worktrees. Review and merge through the gate as they finish.';
+
+describe('composer mode directives', () => {
+  it('names the launch tool in the dispatching modes (#2153)', () => {
+    for (const mode of ['multitask', 'moa'] as const) {
+      expect(COMPOSER_MODE_DIRECTIVES[mode]).toContain('cortex_launch_agent');
+      expect(COMPOSER_MODE_DIRECTIVES[mode]).toMatch(/call it once per packet/i);
+    }
+  });
+
+  it('keeps Solo a prohibition and never points it at the launch tool', () => {
+    expect(COMPOSER_MODE_DIRECTIVES.solo).toContain('do NOT dispatch worker agents');
+    expect(COMPOSER_MODE_DIRECTIVES.solo).not.toContain('cortex_launch_agent');
+  });
+
+  it('keeps every directive prefixed with its [Mode: …] marker', () => {
+    expect(COMPOSER_MODE_DIRECTIVES.solo.startsWith('[Mode: Solo]')).toBe(true);
+    expect(COMPOSER_MODE_DIRECTIVES.multitask.startsWith('[Mode: Multitask]')).toBe(true);
+    expect(COMPOSER_MODE_DIRECTIVES.moa.startsWith('[Mode: Mixture of Agents]')).toBe(true);
+  });
+});
+
+describe('composeComposerWireMessage', () => {
+  it('round-trips the operator text back out of every mode preamble', () => {
+    const operatorText = 'Build a three-page static site: home, about, contact';
+    for (const mode of MODES) {
+      const { displayMessage, wireMessage } = composeComposerWireMessage(operatorText, mode);
+      expect(displayMessage).toBe(operatorText);
+      expect(wireMessage).toBe(`${COMPOSER_MODE_DIRECTIVES[mode]}\n\n${operatorText}`);
+      expect(stripKnownComposerWirePreamble(wireMessage)).toBe(operatorText);
+      expect(resolveOrchestratorTranscriptMessage({ message: wireMessage })).toBe(operatorText);
+    }
+  });
+
+  it('passes slash commands through unshaped', () => {
+    expect(composeComposerWireMessage('/chat Explain this diff', 'multitask')).toEqual({
+      displayMessage: '/chat Explain this diff',
+      wireMessage: '/chat Explain this diff',
+    });
+  });
+});
+
+describe('stripKnownComposerWirePreamble', () => {
+  it('still strips the pre-#2153 directives sent by older clients', () => {
+    expect(stripKnownComposerWirePreamble(`${LEGACY_MULTITASK}\n\nFan this out`)).toBe('Fan this out');
+    expect(stripKnownComposerWirePreamble(`${LEGACY_MOA}\n\nFan this out`)).toBe('Fan this out');
+  });
+
+  it('leaves operator text that merely resembles a directive alone', () => {
+    const notADirective = 'Multitask this for me please';
+    expect(stripKnownComposerWirePreamble(notADirective)).toBe(notADirective);
+  });
+});
+
+describe('isKnownComposerPreambleTitle', () => {
+  it('recognizes titles derived from any mode directive, bracketed or not', () => {
+    expect(isKnownComposerPreambleTitle('[Mode: Solo] Work directly in this session')).toBe(true);
+    expect(isKnownComposerPreambleTitle('[Mode: Multitask] Decompose this into parallel')).toBe(true);
+    expect(isKnownComposerPreambleTitle('[Mode: Mixture of Agents] After the proposal')).toBe(true);
+    expect(isKnownComposerPreambleTitle('Mode: Multitask Decompose this into parallel')).toBe(true);
+  });
+
+  it('recognizes titles derived from the pre-#2153 directives', () => {
+    expect(isKnownComposerPreambleTitle(LEGACY_MULTITASK.slice(0, 48))).toBe(true);
+    expect(isKnownComposerPreambleTitle(LEGACY_MOA.slice(0, 48))).toBe(true);
+  });
+
+  it('rejects operator-authored titles and non-strings', () => {
+    expect(isKnownComposerPreambleTitle('Fix the multitask dispatch bug')).toBe(false);
+    expect(isKnownComposerPreambleTitle(null)).toBe(false);
+  });
+});

--- a/src/lib/orchestrator/composer-wire.ts
+++ b/src/lib/orchestrator/composer-wire.ts
@@ -1,10 +1,34 @@
 export type ComposerWireMode = 'solo' | 'multitask' | 'moa';
 
+/**
+ * Dispatch is an MCP tool on the `cortex` server, and every orchestrator backend
+ * namespaces it differently in the model's tool list (Claude:
+ * `mcp__cortex__cortex_launch_agent`, Codex: `cortex__cortex_launch_agent` /
+ * `cortex.cortex_launch_agent`). The bare registered name is the one form that
+ * is correct everywhere, it is the suffix of all the namespaced forms, and it is
+ * what `orchestrator.md` already uses in the system prompt — so the directives
+ * name it that way too (#2153).
+ */
+const LAUNCH_TOOL_NAME = 'cortex_launch_agent';
+
+const DISPATCH_IMPERATIVE = `Dispatch means calling the \`${LAUNCH_TOOL_NAME}\` tool — call it once per packet, in parallel, in this turn, BEFORE you write any summary. A turn with no \`${LAUNCH_TOOL_NAME}\` call has dispatched nothing, however good the plan is; never claim work was dispatched without the tool results to show for it. Review and merge through the gate as they finish.`;
+
 export const COMPOSER_MODE_DIRECTIVES: Readonly<Record<ComposerWireMode, string>> = {
   solo: '[Mode: Solo] Work directly in this session yourself — do NOT dispatch worker agents or create missions. Edit, run, and verify with your own tools.',
-  multitask: '[Mode: Multitask] Decompose this into parallel worker packets and dispatch them into isolated worktrees instead of working serially yourself. Review and merge through the gate as they finish.',
-  moa: '[Mode: Mixture of Agents] After the proposal round, decompose the work into parallel worker packets and dispatch them into isolated worktrees. Review and merge through the gate as they finish.',
+  multitask: `[Mode: Multitask] Decompose this into parallel worker packets and dispatch them into isolated worktrees instead of working serially yourself. ${DISPATCH_IMPERATIVE}`,
+  moa: `[Mode: Mixture of Agents] After the proposal round, decompose the work into parallel worker packets and dispatch them into isolated worktrees. ${DISPATCH_IMPERATIVE}`,
 };
+
+/**
+ * Directive strings o8 shipped before #2153. A client running an older build
+ * still sends them, and history written by one still holds them, so the
+ * persistence boundary keeps recognizing them — otherwise the operator's own
+ * words get stored with a stale directive glued to the front.
+ */
+const LEGACY_COMPOSER_MODE_DIRECTIVES: readonly string[] = [
+  '[Mode: Multitask] Decompose this into parallel worker packets and dispatch them into isolated worktrees instead of working serially yourself. Review and merge through the gate as they finish.',
+  '[Mode: Mixture of Agents] After the proposal round, decompose the work into parallel worker packets and dispatch them into isolated worktrees. Review and merge through the gate as they finish.',
+];
 
 export interface ComposerWireMessage {
   /** Operator-authored text used by transcripts, history, and thread titles. */
@@ -31,7 +55,11 @@ export function composeComposerWireMessage(
  * by o8 so the persistence boundary still stores the operator's own words.
  */
 export function stripKnownComposerWirePreamble(message: string): string {
-  for (const directive of Object.values(COMPOSER_MODE_DIRECTIVES)) {
+  const directives = [
+    ...Object.values(COMPOSER_MODE_DIRECTIVES),
+    ...LEGACY_COMPOSER_MODE_DIRECTIVES,
+  ];
+  for (const directive of directives) {
     const prefix = `${directive}\n\n`;
     if (message.startsWith(prefix)) return message.slice(prefix.length);
   }


### PR DESCRIPTION
Closes #2153.

## What changed

`src/lib/orchestrator/composer-wire.ts` — the Multitask and MoA directives now name `cortex_launch_agent` and state the contract as an instruction rather than advice:

> Dispatch means calling the `cortex_launch_agent` tool — call it once per packet, in parallel, in this turn, BEFORE you write any summary. A turn with no `cortex_launch_agent` call has dispatched nothing, however good the plan is; never claim work was dispatched without the tool results to show for it.

Three supporting details:

- **Bare tool name, on purpose.** Each backend namespaces the cortex MCP tool differently in the model's tool list — Claude sees `mcp__cortex__cortex_launch_agent`, Codex sees `cortex__cortex_launch_agent` / `cortex.cortex_launch_agent` (`proposer-lockout.ts:73`, `orchestrator-session.ts:1088`). The bare registered name (`cortex-mcp-server.ts:307`) is the suffix of all of them, it is what `orchestrator.md` already uses throughout the system prompt, and it is the form the operator's successful experiment used.
- **Solo is untouched** and still prohibits dispatch. It never names the launch tool.
- **`stripKnownComposerWirePreamble` also matches the pre-change directive strings.** It keys on exact directive text, so without this an older client's preamble would stop being recognized and the operator's message would be persisted with the directive glued to the front. `isKnownComposerPreambleTitle` keys only on the `[Mode: …]` marker, which is unchanged; both are covered by tests.

## Evidence this works

From the issue comments, same stage / same mode / same launch policy / same model, the only variable being whether the request named the tool:

- **Named:** three packets dispatched 34 seconds after the message, all three ran to review-ready, the merge gate lit up, and the pipeline finished with three clean merges (`{"merged": 3}`).
- **Not named:** zero launch calls across a full day of attempts and many phrasings, including deliberately decisive ones. `proc full/full`, no MCP or tool errors, `sawToolUseAfterText=false` — the model wrote a plan and called nothing.

Everything downstream of the launch call already works. The directive not naming the mechanism was the whole gap.

## Verification

- `npx tsc --noEmit` — clean, no output.
- `npx vitest run src/lib/orchestrator/composer-wire.test.ts src/components/desktop/thoughts/composer-mode.test.ts src/lib/mobile/orchestrator-thread-history.test.ts` — 3 files, 24 tests passed.
- `npx vitest run tests/solo-send-wire-separation.test.ts` — 1 file, 2 tests passed.
- `npx eslint` on both changed files — clean.

New `src/lib/orchestrator/composer-wire.test.ts` covers: the dispatching modes name the tool, Solo still prohibits and does not name it, every mode's preamble round-trips back to the operator's text, the pre-change directives still strip, and title-marker recognition (current, legacy, bracketed and unbracketed, plus negatives).

## Left out of scope

Deliberately not in this PR, per the issue's own ordering — these are larger architectural changes and each deserves its own review:

- Sending the mode to the server as a structured field instead of a text prefix (issue acceptance item 2).
- Moving the mode directive into the system prompt for the turn.
- `tool_choice` forcing / a required-tool turn shape for the first call of a Multitask turn.
- Failing a Multitask turn that ends with zero launch calls — that is #2142.

This PR is the cheapest change with the largest expected effect, which is what the experiment isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dVxFgHWcYwiMja5oBxySH