### PR TITLE
fix: archiving clears the agent rail instead of growing it (#2154)

### DIFF
--- a/src/app/api/lanes/archive-terminal/route.ts
+++ b/src/app/api/lanes/archive-terminal/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requirePanelAuth } from '@/lib/panel/auth';
+import { resolveRequestPrincipalContext } from '@/lib/auth/principal';
+import { archiveTerminalLanes } from '@/lib/lane/archive-terminal';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * #2154 — clear every finished lane in one call.
+ *
+ * Operator-only: a packet-bound worker may archive its OWN lane through
+ * `/api/lanes`, but clearing the rail is an operator gesture over every lane in
+ * the registry. Naturally idempotent — a second call finds nothing terminal
+ * left to archive and reports `archived: 0`, so no idempotency key is required.
+ */
+export async function POST(req: NextRequest) {
+  const denied = requirePanelAuth(req);
+  if (denied) return denied;
+  const principal = resolveRequestPrincipalContext(req);
+  if (principal.role !== 'operator') {
+    return NextResponse.json(
+      { ok: false, error: { code: 'operator_required', message: 'Clearing terminal lanes requires an operator credential.' } },
+      { status: 403 },
+    );
+  }
+
+  try {
+    const result = await archiveTerminalLanes('user');
+    return NextResponse.json({
+      ok: true,
+      archived: result.archived.length,
+      laneIds: result.archived,
+      sessionArchiveFailures: result.sessionArchiveFailures,
+    }, { headers: { 'Cache-Control': 'no-store, max-age=0' } });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Bulk archive failed.';
+    return NextResponse.json({ ok: false, note: message }, { status: 500 });
+  }
+}

--- a/src/app/api/lanes/route.ts
+++ b/src/app/api/lanes/route.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { requirePanelAuth } from '@/lib/panel/auth';
 import { resolveRequestPrincipalContext, workerPacketRefusal } from '@/lib/auth/principal';
 import { getLane, getLaneEvents, listLanes, listActiveLanes } from '@/lib/lane/registry';
-import { summarizeLaneArchive } from '@/lib/lane/archive-summary';
+import { summarizeLaneArchive, wasArchivedByOperator } from '@/lib/lane/archive-summary';
 import { collapseArchivedLanesByTask } from '@/lib/lanes/collapse-archived-by-task';
 import { codename } from '@/lib/agents/codename';
 import { dispatch } from '@/lib/lane/commands';
@@ -75,19 +75,25 @@ export async function GET(req: NextRequest) {
   const launchContexts = resolvePacketLaunchContexts(
     resolvedLanes.flatMap((lane) => lane.packetId ? [lane.packetId] : []),
   );
-  const lanes = await Promise.all(resolvedLanes.map(async (lane) => ({
-    ...lane,
-    ...await resolveLaneTranscriptHealth(lane),
-    launchContext: lane.packetId
-      ? launchContexts.get(lane.packetId)?.launchContext ?? null
-      : null,
-    codename: codename(lane.id),
-    mergeMode: mergePolicy.mode,
-    mergeModeNote: mergePolicy.note,
-    archiveSummary: lane.status === 'archived' || lane.status === 'completed'
-      ? summarizeLaneArchive(lane, getLaneEvents(lane.id, 80))
-      : null,
-  })));
+  const lanes = await Promise.all(resolvedLanes.map(async (lane) => {
+    const retired = lane.status === 'archived' || lane.status === 'completed';
+    const archiveEvents = retired ? getLaneEvents(lane.id, 80) : [];
+    return {
+      ...lane,
+      ...await resolveLaneTranscriptHealth(lane),
+      launchContext: lane.packetId
+        ? launchContexts.get(lane.packetId)?.launchContext ?? null
+        : null,
+      codename: codename(lane.id),
+      mergeMode: mergePolicy.mode,
+      mergeModeNote: mergePolicy.note,
+      archiveSummary: retired ? summarizeLaneArchive(lane, archiveEvents) : null,
+      // #2154 — the rail needs to tell an operator's dismissal apart from the
+      // headless loop's auto-archive: the first clears the row, the second
+      // keeps its 24h outcome chip.
+      archivedByOperator: lane.status === 'archived' && wasArchivedByOperator(archiveEvents),
+    };
+  }));
 
   return NextResponse.json({ lanes }, {
     headers: serverTimingHeaders(startedAt, { 'Cache-Control': 'no-store, max-age=0' }),

--- a/src/app/api/runtime/archive/route.test.ts
+++ b/src/app/api/runtime/archive/route.test.ts
@@ -18,6 +18,7 @@ const stateMocks = vi.hoisted(() => ({
   archiveOwned: vi.fn(),
   getLane: vi.fn(),
   archiveLane: vi.fn(),
+  findLaneBySession: vi.fn(),
 }));
 
 vi.mock('@/lib/codex/owned', () => ({
@@ -55,6 +56,7 @@ vi.mock('@/lib/prime-agent/owned', () => ({
 vi.mock('@/lib/lane/registry', () => ({
   getLane: stateMocks.getLane,
   archiveLane: stateMocks.archiveLane,
+  findLaneBySession: stateMocks.findLaneBySession,
 }));
 vi.mock('@/lib/runtime/inventory', () => ({ invalidateRuntimeInventoryCache: vi.fn() }));
 vi.mock('@/lib/runtime/owned-session-archive', () => ({
@@ -90,6 +92,7 @@ beforeEach(() => {
   stateMocks.pi.mockResolvedValue('active');
   stateMocks.prime.mockResolvedValue('archived');
   stateMocks.getLane.mockReturnValue(null);
+  stateMocks.findLaneBySession.mockReturnValue(null);
   stateMocks.archiveLane.mockReturnValue(null);
   stateMocks.archiveOwned.mockResolvedValue(null);
   __resetIdempotencyStoreForTests();
@@ -173,6 +176,32 @@ describe('POST /api/runtime/archive', () => {
     }));
 
     expect(response.status).toBe(409);
+    expect(stateMocks.archiveLane).not.toHaveBeenCalled();
+  });
+
+  it('retires the lane behind an archived session so the rail row leaves', async () => {
+    const sessionKey = 'codex-owned:lane-failed';
+    const lane = { id: 'lane-failed', sessionKey, status: 'failed' };
+    stateMocks.archiveOwned.mockResolvedValue({ archived: true, note: 'Session archived.' });
+    stateMocks.findLaneBySession.mockReturnValue(lane);
+    stateMocks.archiveLane.mockReturnValue({ ...lane, status: 'archived' });
+
+    const response = await POST(post({ sessionKey, clientMutationId: 'archive-failed-session' }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ ok: true, archived: true, laneId: lane.id });
+    expect(stateMocks.archiveLane).toHaveBeenCalledWith(lane.id, 'user');
+  });
+
+  it('leaves a live lane running when only its session was archived', async () => {
+    const sessionKey = 'codex-owned:lane-reviewing';
+    stateMocks.archiveOwned.mockResolvedValue({ archived: true, note: 'Session archived.' });
+    stateMocks.findLaneBySession.mockReturnValue({ id: 'lane-reviewing', sessionKey, status: 'reviewing' });
+
+    const response = await POST(post({ sessionKey, clientMutationId: 'archive-reviewing-session' }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).not.toMatchObject({ laneId: 'lane-reviewing' });
     expect(stateMocks.archiveLane).not.toHaveBeenCalled();
   });
 

--- a/src/app/api/runtime/archive/route.ts
+++ b/src/app/api/runtime/archive/route.ts
@@ -7,7 +7,8 @@ import { ownedGrokSessionState } from '@/lib/grok/owned';
 import { ownedOpencodeSessionState } from '@/lib/opencode/owned';
 import { ownedPiSessionState } from '@/lib/pi/owned';
 import { ownedPrimeAgentSessionState } from '@/lib/prime-agent/owned';
-import { archiveLane, getLane } from '@/lib/lane/registry';
+import { archiveLane, findLaneBySession, getLane } from '@/lib/lane/registry';
+import { isLaneTerminal } from '@/lib/lane/terminal-states';
 import {
   bindIdempotencyClientMutation,
   deriveIdempotencyKey,
@@ -175,10 +176,19 @@ export async function POST(request: NextRequest) {
         if (!result.archived) {
           throw new RuntimeArchiveRejectedError(409, result.note);
         }
+        // #2154 — archiving the session dir alone left the LANE row at its
+        // terminal status, so the Agents rail re-rendered the row on the next
+        // poll and archiving never shrank the rail. Retire the lane too, but
+        // only once its lifecycle is over: a live lane keeps its row (#2144).
+        const lane = findLaneBySession(ownedSessionKey);
+        const laneRetired = lane && isLaneTerminal(lane.status) && lane.status !== 'archived'
+          ? Boolean(archiveLane(lane.id, 'user'))
+          : false;
         return {
           ok: true,
           archived: true,
           sessionKey: ownedSessionKey,
+          ...(laneRetired && lane ? { laneId: lane.id } : {}),
           clientMutationId,
           note: result.note,
         };

--- a/src/components/desktop/AgentPanelExtraAgentRow.tsx
+++ b/src/components/desktop/AgentPanelExtraAgentRow.tsx
@@ -128,6 +128,16 @@ export function canArchiveExtraAgent(row: ExtraAgentRow): boolean {
     || row.laneStatus === 'archived';
 }
 
+/**
+ * #2154 — rows the Agents header's bulk clear retires. Only lane-terminal
+ * statuses qualify (the server clears exactly this set), so a running,
+ * reviewing or awaiting_* lane is never swept up by a clear. Already-archived
+ * rows aren't on the rail to begin with.
+ */
+export function isClearableExtraAgent(row: ExtraAgentRow): boolean {
+  return row.laneStatus === 'failed' || row.laneStatus === 'completed';
+}
+
 export function ExtraAgentRowView({
   row,
   active,

--- a/src/components/desktop/AgentPanelExtraAgents.test.ts
+++ b/src/components/desktop/AgentPanelExtraAgents.test.ts
@@ -2,9 +2,14 @@ import { describe, expect, it } from 'vitest';
 import type { AgentSummary } from '@/lib/fleet/types';
 import {
   deriveSpawnedAgentRows,
+  isRailLane,
   type LaneSummary,
 } from './AgentPanelExtraAgents';
-import { canArchiveExtraAgent, type ExtraAgentRow } from './AgentPanelExtraAgentRow';
+import {
+  canArchiveExtraAgent,
+  isClearableExtraAgent,
+  type ExtraAgentRow,
+} from './AgentPanelExtraAgentRow';
 
 describe('Agents rail derivation', () => {
   it('keeps worker packets in one flat list across repositories', () => {
@@ -126,6 +131,45 @@ describe('Agents rail derivation', () => {
       agents: [],
       archivedRowKeys: new Set([`lane:${lane.id}`]),
     })).toEqual([]);
+  });
+
+  it('drops an operator-archived lane and keeps the auto-archived outcome chip', () => {
+    const now = Date.parse('2026-09-11T12:00:00.000Z');
+    const archived: LaneSummary = {
+      id: 'lane-archived',
+      label: 'Discarded worker',
+      repoPath: '/repos/project-repo',
+      branch: 'issue/discarded',
+      runtime: 'codex',
+      sessionKey: null,
+      packetId: 'pkt-discarded',
+      status: 'archived',
+      outcome: 'discarded',
+      ownership: 'managed',
+      lastEventAt: '2026-09-11T11:00:00.000Z',
+      lastEventLabel: 'archived',
+    };
+
+    // The operator dismissed it — it belongs in the Archived section now.
+    expect(isRailLane({ ...archived, archivedByOperator: true }, now)).toBe(false);
+    // The headless loop tidied a merged lane — its 24h chip stays on the rail.
+    expect(isRailLane({ ...archived, outcome: 'merged' }, now)).toBe(true);
+    // Live lanes are never filtered, however they were archived before.
+    expect(isRailLane({ ...archived, status: 'running', outcome: null }, now)).toBe(true);
+    // Stale and outcome-less archives stay hidden, as before.
+    expect(isRailLane({ ...archived, lastEventAt: '2026-09-09T11:00:00.000Z' }, now)).toBe(false);
+    expect(isRailLane({ ...archived, outcome: null }, now)).toBe(false);
+  });
+
+  it('clears only lanes whose lifecycle is over', () => {
+    const row = { key: 'lane:1', laneId: 'lane-1', laneStatus: 'failed' } as ExtraAgentRow;
+
+    expect(isClearableExtraAgent(row)).toBe(true);
+    expect(isClearableExtraAgent({ ...row, laneStatus: 'completed' })).toBe(true);
+    expect(isClearableExtraAgent({ ...row, laneStatus: 'running' })).toBe(false);
+    expect(isClearableExtraAgent({ ...row, laneStatus: 'reviewing' })).toBe(false);
+    expect(isClearableExtraAgent({ ...row, laneStatus: 'awaiting_human' })).toBe(false);
+    expect(isClearableExtraAgent({ ...row, laneStatus: null })).toBe(false);
   });
 
   it('offers lane archiving only for sessionless terminal rows', () => {

--- a/src/components/desktop/AgentPanelExtraAgents.tsx
+++ b/src/components/desktop/AgentPanelExtraAgents.tsx
@@ -31,6 +31,7 @@ import { AGENT_STATUS_ACCENT } from '@/components/desktop/AgentStatusDot';
 import {
   ExtraAgentActionMenu,
   ExtraAgentRowView,
+  isClearableExtraAgent,
   type AgentOrigin,
   type ExtraAgentActionMenuState,
   type ExtraAgentRow,
@@ -74,6 +75,8 @@ export interface LaneSummary {
   lastEventAt: string | null;
   lastEventLabel: string | null;
   prNumber?: number | null;
+  /** #2154 — a human archived this lane (vs the headless loop's auto-archive). */
+  archivedByOperator?: boolean;
 }
 
 export interface AgentPanelExtraAgentsProps {
@@ -195,6 +198,29 @@ function buildRows(
   return rows;
 }
 
+/**
+ * Which lanes belong in the Agents section.
+ *
+ * Live lanes always. A terminal lane stays only while it still says something
+ * true about today: outcome-stamped completed/archived lanes keep their chip
+ * for 24h (Q ruling 2026-07-18 — terminal agents live in the CLEAN view, not
+ * behind a click), and legacy archives with no outcome stay hidden.
+ *
+ * #2154 — an archive the OPERATOR performed is a dismissal, not history. That
+ * row leaves the rail at once and the collapsed Archived section keeps it.
+ * Before this, archiving re-rendered the lane as a grey Discarded row forever,
+ * so the rail only ever grew and the sole way to empty it was a hard prune that
+ * deleted the records.
+ */
+export function isRailLane(lane: LaneSummary, now = Date.now()): boolean {
+  if (lane.archivedByOperator) return false;
+  const terminal = lane.status === 'archived' || lane.status === 'completed';
+  if (!terminal) return true;
+  if (!lane.outcome) return false;
+  const at = Date.parse(lane.lastEventAt ?? '');
+  return Number.isFinite(at) && now - at < RECENT_TERMINAL_WINDOW_MS;
+}
+
 function isTerminalRow(row: ExtraAgentRow): boolean {
   return Boolean(row.outcome)
     || row.laneStatus === 'archived'
@@ -234,6 +260,65 @@ export function deriveSpawnedAgentRows({
 
 const COLLAPSED_KEY = 'o8:agent-panel:spawned-agents-collapsed';
 
+/** Tell every lane consumer (this rail, the Archived section) to refetch. */
+function broadcastLaneLifecycle(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event('o8:lifecycle-reconcile'));
+}
+
+/**
+ * #2154 — the bulk clear, on the Agents header. Hover-revealed per the rail's
+ * progressive-disclosure rule (hurttlocker: row actions are never
+ * default-visible); focus reveals it too so it stays keyboard-reachable.
+ */
+function ClearFinishedAgentsButton({
+  count,
+  busy,
+  revealed,
+  onReveal,
+  onHide,
+  onClick,
+}: {
+  count: number;
+  busy: boolean;
+  revealed: boolean;
+  onReveal: () => void;
+  onHide: () => void;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={busy}
+      onFocus={onReveal}
+      onBlur={onHide}
+      onClick={onClick}
+      title={`Archive ${count} finished agent${count === 1 ? '' : 's'} — the lane records are kept`}
+      style={{
+        paddingTop: 2,
+        paddingRight: 6,
+        paddingBottom: 2,
+        paddingLeft: 6,
+        borderWidth: 0,
+        borderRadius: 4,
+        background: 'transparent',
+        fontSize: 10,
+        lineHeight: '14px',
+        fontWeight: 300,
+        letterSpacing: '-0.1px',
+        fontFamily: 'var(--font-sans-system)',
+        color: 'var(--t-text-faint)',
+        cursor: busy ? 'default' : 'pointer',
+        opacity: revealed ? 1 : 0,
+        transition: 'opacity 120ms ease',
+        outline: 'none',
+      }}
+    >
+      Clear
+    </button>
+  );
+}
+
 function AgentPanelExtraAgentsBase({
   activeSessionKey,
   onSelectSession,
@@ -246,6 +331,7 @@ function AgentPanelExtraAgentsBase({
   const [archivedRowKeys, setArchivedRowKeys] = useState<Set<string>>(() => new Set());
   const [hoverCard, setHoverCard] = useState<{ row: ExtraAgentRow; rect: DOMRect } | null>(null);
   const [busy, setBusy] = useState(false);
+  const [headerHovered, setHeaderHovered] = useState(false);
   const [readStateVersion, setReadStateVersion] = useState(0);
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     if (typeof window === 'undefined') return false;
@@ -288,6 +374,7 @@ function AgentPanelExtraAgentsBase({
         row.sessionKey ? { sessionKey: row.sessionKey } : { laneId: row.laneId! },
         clientMutationId,
       );
+      broadcastLaneLifecycle();
     } catch {
       // Roll back the optimistic hide so operator can retry.
       setArchivedRowKeys((prev) => {
@@ -337,18 +424,7 @@ function AgentPanelExtraAgentsBase({
       let laneList: LaneSummary[] = [];
       if (lanesRes.status === 'fulfilled' && lanesRes.value.ok) {
         const json = await lanesRes.value.json() as { lanes?: LaneSummary[] };
-        laneList = (json.lanes ?? []).filter((lane) => {
-          const terminal = lane.status === 'archived' || lane.status === 'completed';
-          if (!terminal) return true;
-          // Recent group (Q ruling 2026-07-18: terminal agents live in the
-          // CLEAN view, not behind a click): outcome-stamped terminal lanes
-          // from the last 24h stay on the rail with their truthful chip.
-          // Legacy archives with no outcome (reset/rerun cleanup noise) stay
-          // hidden — resurrecting history isn't the point, the day's work is.
-          if (!lane.outcome) return false;
-          const at = Date.parse(lane.lastEventAt ?? '');
-          return Number.isFinite(at) && Date.now() - at < RECENT_TERMINAL_WINDOW_MS;
-        });
+        laneList = (json.lanes ?? []).filter((lane) => isRailLane(lane));
         setLanes(laneList);
       }
 
@@ -448,6 +524,34 @@ function AgentPanelExtraAgentsBase({
       };
     }).sort((a, b) => b.rank - a.rank || b.row.lastActivityAt - a.row.lastActivityAt);
   }, [readStateVersion, rows]);
+  // #2154 — the rows a bulk clear would retire. Lane-terminal only, so the
+  // affordance can never reach live work; the count drives the header reveal.
+  const clearableRowKeys = useMemo(
+    () => rankedRows.filter(({ row }) => isClearableExtraAgent(row)).map(({ row }) => row.key),
+    [rankedRows],
+  );
+
+  const handleClearFinished = useCallback(async () => {
+    if (clearableRowKeys.length === 0) return;
+    setArchivedRowKeys((prev) => new Set([...prev, ...clearableRowKeys]));
+    setBusy(true);
+    try {
+      const res = await fetch('/api/lanes/archive-terminal', { method: 'POST' });
+      if (!res.ok) throw new Error(`Clear failed with status ${res.status}`);
+      broadcastLaneLifecycle();
+    } catch (error) {
+      // Roll back the optimistic hide so the operator can retry.
+      setArchivedRowKeys((prev) => {
+        const next = new Set(prev);
+        for (const key of clearableRowKeys) next.delete(key);
+        return next;
+      });
+      console.warn('[spawned-agents] clear finished agents failed:', error);
+    } finally {
+      setBusy(false);
+    }
+  }, [clearableRowKeys]);
+
   const needsYouCount = rankedRows.filter((entry) => entry.rank > 0).length;
   const highestBand = rankedRows.find((entry) => entry.rank > 0)?.band ?? null;
   // Tone ladder mirrors attentionWashStyle — 'human' is warm like rejected,
@@ -504,14 +608,29 @@ function AgentPanelExtraAgentsBase({
         paddingBottom: 8,
       }}
     >
-      <SectionLabel
-        label="Agents"
-        compact
-        count={needsYouCount > 0 ? needsYouCount : undefined}
-        countTone={countTone}
-        collapsed={collapsed}
-        onToggle={toggleCollapsed}
-      />
+      <div
+        onMouseEnter={() => setHeaderHovered(true)}
+        onMouseLeave={() => setHeaderHovered(false)}
+      >
+        <SectionLabel
+          label="Agents"
+          compact
+          count={needsYouCount > 0 ? needsYouCount : undefined}
+          countTone={countTone}
+          collapsed={collapsed}
+          onToggle={toggleCollapsed}
+          action={clearableRowKeys.length > 0 ? (
+            <ClearFinishedAgentsButton
+              count={clearableRowKeys.length}
+              busy={busy}
+              revealed={headerHovered}
+              onReveal={() => setHeaderHovered(true)}
+              onHide={() => setHeaderHovered(false)}
+              onClick={() => { void handleClearFinished(); }}
+            />
+          ) : null}
+        />
+      </div>
       {/* layout="position" springs a row to its new slot when a band change
           re-sorts the list — without it, a working row that flips to needs-you
           teleports (rig finding 2026-07-31). Position-only: rows never resize. */}

--- a/src/components/desktop/repo-focus/tabs/ChatsTab.tsx
+++ b/src/components/desktop/repo-focus/tabs/ChatsTab.tsx
@@ -197,7 +197,7 @@ export function ChatsTab({
   useEffect(() => {
     if (variant !== 'mini') return;
     let cancelled = false;
-    (async () => {
+    const load = async () => {
       try {
         const res = await fetch('/api/lanes?active=false', { cache: 'no-store' });
         if (!res.ok || cancelled) return;
@@ -209,8 +209,16 @@ export function ChatsTab({
       } catch {
         // silent — best-effort
       }
-    })();
-    return () => { cancelled = true; };
+    };
+    void load();
+    // #2154 — a lane archived from the Agents rail must land HERE right away,
+    // not after a reload; otherwise clearing the rail looks like deletion.
+    const onLifecycle = () => { void load(); };
+    window.addEventListener('o8:lifecycle-reconcile', onLifecycle);
+    return () => {
+      cancelled = true;
+      window.removeEventListener('o8:lifecycle-reconcile', onLifecycle);
+    };
   }, [variant]);
 
   const withHistoryBusy = useCallback(async (tabId: string, action: () => Promise<void>) => {

--- a/src/components/desktop/repo-focus/tabs/chats/shared.tsx
+++ b/src/components/desktop/repo-focus/tabs/chats/shared.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { Folder as IconoirFolder } from 'iconoir-react';
 import { ClaudeIcon, CodexIcon, GeminiIcon, OpenCodeIcon } from '@/components/desktop/repo-registry/shared';
 import { ChevronDown, ChevronRight } from '../../../lucide-shims';
@@ -28,6 +28,7 @@ export function SectionLabel({
   countTone,
   collapsed,
   onToggle,
+  action,
 }: {
   label: string;
   compact?: boolean;
@@ -35,6 +36,9 @@ export function SectionLabel({
   countTone?: string;
   collapsed?: boolean;
   onToggle?: () => void;
+  /** Section-level affordance (#2154's Agents "Clear"). Rendered OUTSIDE the
+   *  toggle button — a button inside a button is invalid markup. */
+  action?: ReactNode;
 }) {
   const commonStyle = {
     paddingTop: compact ? 7 : 10,
@@ -71,7 +75,7 @@ export function SectionLabel({
     );
   }
 
-  return (
+  const toggle = (
     <button
       type="button"
       aria-expanded={!collapsed}
@@ -107,6 +111,17 @@ export function SectionLabel({
         </span>
       ) : null}
     </button>
+  );
+
+  if (!action) return toggle;
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', width: '100%' }}>
+      <div style={{ flex: 1, minWidth: 0 }}>{toggle}</div>
+      <div style={{ display: 'flex', alignItems: 'center', paddingRight: 6, flexShrink: 0 }}>
+        {action}
+      </div>
+    </div>
   );
 }
 

--- a/src/lib/lane/archive-summary.test.ts
+++ b/src/lib/lane/archive-summary.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { wasArchivedByOperator } from './archive-summary';
+import type { LaneEvent } from './types';
+
+function event(partial: Partial<LaneEvent>): LaneEvent {
+  return {
+    id: partial.id ?? 'evt',
+    laneId: 'lane-1',
+    verb: partial.verb ?? 'status_change',
+    actor: partial.actor ?? 'system',
+    payload: partial.payload ?? {},
+    timestamp: partial.timestamp ?? '2026-09-11T00:00:00.000Z',
+  };
+}
+
+describe('wasArchivedByOperator', () => {
+  it('reads the actor off the archiving status change', () => {
+    const events = [
+      event({ id: 'a', actor: 'orchestrator', payload: { status: 'failed' } }),
+      event({ id: 'b', actor: 'user', payload: { status: 'archived' } }),
+    ];
+
+    expect(wasArchivedByOperator(events)).toBe(true);
+  });
+
+  it('does not claim the headless loop auto-archive as an operator dismissal', () => {
+    const events = [
+      event({ id: 'a', actor: 'user', payload: { status: 'completed' } }),
+      event({ id: 'b', actor: 'system', payload: { status: 'archived' } }),
+    ];
+
+    expect(wasArchivedByOperator(events)).toBe(false);
+  });
+
+  it('uses the most recent archive transition and ignores unarchived lanes', () => {
+    expect(wasArchivedByOperator([
+      event({ id: 'a', actor: 'user', payload: { status: 'archived' } }),
+      event({ id: 'b', actor: 'system', payload: { status: 'archived' } }),
+    ])).toBe(false);
+    expect(wasArchivedByOperator([
+      event({ id: 'a', actor: 'user', verb: 'update', payload: { label: 'renamed' } }),
+    ])).toBe(false);
+    expect(wasArchivedByOperator([])).toBe(false);
+  });
+});

--- a/src/lib/lane/archive-summary.ts
+++ b/src/lib/lane/archive-summary.ts
@@ -97,3 +97,24 @@ export function summarizeLaneArchive(
     message: 'Archived by the system without merging.',
   };
 }
+
+/**
+ * #2154 — did a HUMAN archive this lane, or did the system tidy it away?
+ *
+ * Both write the same `archived` status, but they mean different things to the
+ * Agents rail: an operator archive is a dismissal ("I'm done looking at this")
+ * and must shrink the rail, while the headless loop's auto-archive of completed
+ * lanes must NOT — those keep their truthful outcome chip for 24h (Q ruling
+ * 2026-07-18). The archiving `status_change` event carries the actor, so the
+ * distinction is already recorded; this reads it back.
+ *
+ * Events arrive oldest-first (see getLaneEvents), so the scan runs backwards and
+ * stops at the most recent archive transition.
+ */
+export function wasArchivedByOperator(events: LaneEvent[]): boolean {
+  const archiveEvent = latestEvent(
+    events,
+    (event) => event.verb === 'status_change' && event.payload.status === 'archived',
+  );
+  return archiveEvent?.actor === 'user';
+}

--- a/src/lib/lane/archive-terminal.test.ts
+++ b/src/lib/lane/archive-terminal.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Lane } from './types';
+
+const mocks = vi.hoisted(() => ({
+  listLanes: vi.fn(),
+  getLane: vi.fn(),
+  archiveLane: vi.fn(),
+  archiveOwnedRuntimeSession: vi.fn(),
+}));
+
+vi.mock('./registry', () => ({
+  listLanes: mocks.listLanes,
+  getLane: mocks.getLane,
+  archiveLane: mocks.archiveLane,
+}));
+vi.mock('@/lib/runtime/owned-session-archive', () => ({
+  archiveOwnedRuntimeSession: mocks.archiveOwnedRuntimeSession,
+}));
+
+import { archiveTerminalLanes, terminalLanesToArchive } from './archive-terminal';
+
+function lane(id: string, status: Lane['status'], sessionKey: string | null = null): Lane {
+  return { id, status, sessionKey, label: id, repoPath: '/repos/project' } as Lane;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.archiveLane.mockImplementation((id: string) => lane(id, 'archived'));
+  mocks.archiveOwnedRuntimeSession.mockResolvedValue({ archived: true, note: 'Archived.' });
+});
+
+describe('terminalLanesToArchive', () => {
+  it('selects only lanes whose lifecycle is already over', () => {
+    const lanes = [
+      lane('failed', 'failed'),
+      lane('completed', 'completed'),
+      lane('running', 'running'),
+      lane('reviewing', 'reviewing'),
+      lane('awaiting', 'awaiting_human'),
+      lane('recovering', 'recovering'),
+      lane('already', 'archived'),
+    ];
+
+    expect(terminalLanesToArchive(lanes).map((entry) => entry.id)).toEqual(['failed', 'completed']);
+  });
+});
+
+describe('archiveTerminalLanes', () => {
+  it('archives every terminal lane in one pass and keeps the records', async () => {
+    const lanes = [lane('failed', 'failed'), lane('completed', 'completed'), lane('live', 'running')];
+    mocks.listLanes.mockReturnValue(lanes);
+    mocks.getLane.mockImplementation((id: string) => lanes.find((entry) => entry.id === id) ?? null);
+
+    const result = await archiveTerminalLanes('user');
+
+    expect(result.archived).toEqual(['failed', 'completed']);
+    expect(mocks.archiveLane).toHaveBeenCalledWith('failed', 'user');
+    expect(mocks.archiveLane).toHaveBeenCalledWith('completed', 'user');
+    expect(mocks.archiveLane).toHaveBeenCalledTimes(2);
+  });
+
+  it('never archives a lane that went live between the listing and the write', async () => {
+    mocks.listLanes.mockReturnValue([lane('relaunched', 'failed')]);
+    // Re-read sees the retry that relaunched it — live work, hands off.
+    mocks.getLane.mockReturnValue(lane('relaunched', 'running'));
+
+    const result = await archiveTerminalLanes('user');
+
+    expect(result.archived).toEqual([]);
+    expect(mocks.archiveLane).not.toHaveBeenCalled();
+  });
+
+  it('retires the owned session before the lane so the rail stops re-adding it', async () => {
+    const failed = lane('with-session', 'failed', 'codex-owned:with-session');
+    mocks.listLanes.mockReturnValue([failed]);
+    mocks.getLane.mockReturnValue(failed);
+
+    const result = await archiveTerminalLanes('user');
+
+    expect(mocks.archiveOwnedRuntimeSession).toHaveBeenCalledWith('codex-owned:with-session');
+    expect(result.archived).toEqual(['with-session']);
+    expect(result.sessionArchiveFailures).toEqual([]);
+  });
+
+  it('still archives the lane when its session dir is already gone', async () => {
+    const failed = lane('stale-session', 'failed', 'codex-owned:stale-session');
+    mocks.listLanes.mockReturnValue([failed]);
+    mocks.getLane.mockReturnValue(failed);
+    mocks.archiveOwnedRuntimeSession.mockResolvedValue({ archived: false, note: 'Session was not found.' });
+
+    const result = await archiveTerminalLanes('user');
+
+    expect(result.archived).toEqual(['stale-session']);
+    expect(result.sessionArchiveFailures).toEqual(['stale-session']);
+  });
+});

--- a/src/lib/lane/archive-terminal.ts
+++ b/src/lib/lane/archive-terminal.ts
@@ -1,0 +1,65 @@
+/**
+ * #2154 — bulk clear for the Agents rail.
+ *
+ * Clearing the rail used to mean either looping one `POST /api/lanes
+ * {verb:'archive'}` per lane, or `POST /api/tasks/{id}/prune` — a hard delete
+ * that takes the lane records (the receipts for what an agent did) with it.
+ * This is the non-destructive bulk path: every lane whose lifecycle is already
+ * over moves to `archived`, the rows stay in the database, and the Archived
+ * section keeps showing them.
+ *
+ * LIVE WORK IS NEVER TOUCHED. Eligibility is `LANE_TERMINAL_STATUSES` only
+ * (`failed` / `completed`) — the set whose only legal successor is `archived`
+ * (see terminal-states.ts). A running / reviewing / awaiting_* lane can never
+ * match, and every lane is re-read from the registry immediately before the
+ * write so one that moved off a terminal status between the listing and the
+ * archive is skipped rather than retired out from under its worker.
+ */
+import { archiveLane, getLane, listLanes } from './registry';
+import { isLaneTerminal } from './terminal-states';
+import { archiveOwnedRuntimeSession } from '@/lib/runtime/owned-session-archive';
+import type { Lane, LaneEventActor } from './types';
+
+export interface TerminalLaneArchiveResult {
+  /** Lane ids moved to `archived` by this call. */
+  archived: string[];
+  /** Lanes whose owned session dir could not be archived; the lane still was. */
+  sessionArchiveFailures: string[];
+}
+
+/** Pure: the lanes a bulk clear may retire. Already-archived lanes are a no-op. */
+export function terminalLanesToArchive(lanes: Lane[]): Lane[] {
+  return lanes.filter((lane) => isLaneTerminal(lane.status) && lane.status !== 'archived');
+}
+
+export async function archiveTerminalLanes(
+  actor: LaneEventActor = 'user',
+): Promise<TerminalLaneArchiveResult> {
+  const result: TerminalLaneArchiveResult = { archived: [], sessionArchiveFailures: [] };
+
+  for (const candidate of terminalLanesToArchive(listLanes())) {
+    // Re-read under the same rule the listing used: anything that left the
+    // terminal set in the meantime is live again and stays untouched.
+    const lane = getLane(candidate.id);
+    if (!lane || !isLaneTerminal(lane.status) || lane.status === 'archived') continue;
+
+    if (lane.sessionKey) {
+      // Same session retirement the per-row Archive performs, so the runtime
+      // inventory stops re-adding a row for a lane that just left the rail.
+      // Best-effort: a session dir that was already cleaned up must not block
+      // the lane archive, or the rail could never be cleared.
+      try {
+        const archivedSession = await archiveOwnedRuntimeSession(lane.sessionKey);
+        if (archivedSession && !archivedSession.archived) {
+          result.sessionArchiveFailures.push(lane.id);
+        }
+      } catch {
+        result.sessionArchiveFailures.push(lane.id);
+      }
+    }
+
+    if (archiveLane(lane.id, actor)) result.archived.push(lane.id);
+  }
+
+  return result;
+}


### PR DESCRIPTION
Closes #2154.

## The bug

Archiving from the Agents rail never removed a row. For a row with a session key, `/api/runtime/archive` archived the runtime session dir and left the **lane** at its terminal status, so the next poll re-rendered it. For a sessionless lane it did archive the lane, but the rail's filter kept outcome-stamped archived lanes for 24h, so it came back as a grey `Discarded` entry. The rail only grew, and the one thing that emptied it — `POST /api/tasks/{id}/prune` — hard-deletes the lane rows and packet.

## What changed

**1. Archiving removes the row (the core fix)**

- `src/app/api/runtime/archive/route.ts` — the session path now also retires the lane behind the session, and only when the lane is already lane-terminal. A `running` / `reviewing` / `awaiting_*` lane keeps its row; that case is #2144.
- `src/lib/lane/archive-summary.ts` — new `wasArchivedByOperator(events)`, read off the actor on the archiving `status_change` event.
- `src/app/api/lanes/route.ts` — exposes `archivedByOperator` per lane (events for retired lanes were already being fetched for `archiveSummary`, so no extra query).
- `src/components/desktop/AgentPanelExtraAgents.tsx` — the rail filter is now the exported, tested `isRailLane`: an operator's archive is a dismissal and leaves the rail immediately, while the headless loop's auto-archive of completed lanes keeps its truthful 24h outcome chip (Q ruling 2026-07-18 would otherwise regress — `archiveCompletedLanes()` runs every sprint tick, so a blanket "hide all archived" would have erased the day's merged work from the rail).
- `src/components/desktop/repo-focus/tabs/ChatsTab.tsx` — the Archived section refetches on `o8:lifecycle-reconcile`, so a cleared lane lands there without a reload instead of looking deleted.

**2. Bulk clear, over HTTP and in the UI**

- `POST /api/lanes/archive-terminal` (operator-only) — archives every lane in `LANE_TERMINAL_STATUSES` in one call. Naturally idempotent, so no idempotency key; a second call reports `archived: 0`.
- `src/lib/lane/archive-terminal.ts` — the helper, with a pure `terminalLanesToArchive` for testing. Archives the owned session dir first where a lane has one, so the runtime inventory does not re-add an agent row for a lane that just left the rail; a session dir that is already gone is recorded in `sessionArchiveFailures` and never blocks the lane archive.
- A hover-revealed `Clear` on the Agents section header drives it (hurttlocker: row actions are never default-visible; focus reveals it too, so it stays keyboard-reachable). `SectionLabel` gained an optional `action` slot rendered outside the toggle button — a button inside a button is invalid markup.

**3. Nothing is deleted.** Every path here writes `status = 'archived'`. Lane rows, lane events and packets are untouched, and the Archived section keeps showing them.

## How live work is guaranteed safe

Two independent guards:

1. **Eligibility is `LANE_TERMINAL_STATUSES` only** (`failed`, `completed`) — the set whose only legal successor is `archived` per `terminal-states.ts`, enforced on write by `isRefusedTerminalTransition`. A `running`, `reviewing`, `merging` or `awaiting_*` lane can never be selected, and the UI's `isClearableExtraAgent` matches that set exactly so the header count cannot promise more than the server clears.
2. **Re-read before write** — each lane is re-fetched from the registry immediately before `archiveLane`, and skipped if it left the terminal set in the meantime (a retry that relaunched it, say). Covered by a test.

The bulk route is also operator-only: a packet-bound worker can archive its own lane through `/api/lanes`, but not clear the operator's rail.

## Left out

- **Dismissing non-terminal lanes that can no longer progress** — that is #2144, explicitly out of scope here.
- **A live UI pass.** The o8 MCP server failed to connect this session (`CONNECTION_CLOSED`), so the rail was not driven in the installed app. The change is covered by unit tests at the derivation, helper and route level, but the hover reveal and the header layout have not been looked at on screen.

## Verification

`npx tsc --noEmit` — clean.
`npx eslint` on all changed files — clean.
`npm run test:classification:check` — manifest matches.

The four touched/new test files, confirmed running under `hermetic-unit` (not silently skipped by the wrong config):

```
 ✓ |hermetic-unit| src/lib/lane/archive-summary.test.ts  (3 tests)
 ✓ |hermetic-unit| src/lib/lane/archive-terminal.test.ts  (5 tests)
 ✓ |hermetic-unit| src/components/desktop/AgentPanelExtraAgents.test.ts  (7 tests)
 ✓ |hermetic-unit| src/app/api/runtime/archive/route.test.ts  (9 tests)

 Test Files  4 passed (4)
      Tests  24 passed (24)
```

Full hermetic suite:

```
 Test Files  705 passed | 3 skipped (708)
      Tests  4538 passed | 4 skipped (4542)
   Duration  148.95s
```

Route gate suites (the new route is denied-by-default under the `/api/lanes` prefix, as intended):

```
 Test Files  2 passed (2)   tests/route-coverage.test.ts tests/middleware-gate.test.ts
      Tests  480 passed (480)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dVxFgHWcYwiMja5oBxySH