### PR TITLE
Give session tabs and agent rail rows real semantics and stable handles (#2146)

### DIFF
--- a/src/components/desktop/AgentPanelExtraAgentRow.tsx
+++ b/src/components/desktop/AgentPanelExtraAgentRow.tsx
@@ -198,6 +198,9 @@ export function ExtraAgentRowView({
   return (
     <button
       type="button"
+      // Stable handle for AT/automation (#2146): row.key is `lane:<id>` /
+      // `agent:<sessionKey>`, so it survives a rename of row.name.
+      data-o8-agent-row={row.key}
       disabled={!canInteract}
       onClick={handleClick}
       onContextMenu={(event) => {

--- a/src/components/desktop/AgentPanelExtraAgents.rail-semantics.test.ts
+++ b/src/components/desktop/AgentPanelExtraAgents.rail-semantics.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentPanelExtraAgents, type LaneSummary } from './AgentPanelExtraAgents';
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+function lane(id: string, label: string): LaneSummary {
+  return {
+    id,
+    label,
+    repoPath: '/repos/project-repo',
+    branch: `issue/${id}`,
+    runtime: 'codex',
+    sessionKey: `codex-owned:${id}`,
+    packetId: `pkt-${id}`,
+    status: 'running',
+    ownership: 'managed',
+    lastEventAt: new Date().toISOString(),
+    lastEventLabel: 'agent_progress',
+  };
+}
+
+const LANES = [lane('lane-a', 'Fix the agent rail'), lane('lane-b', 'Rename me later')];
+
+describe('Agents rail row semantics (#2146)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const body = url.includes('/api/lanes') ? { lanes: LANES } : {};
+      return { ok: true, json: async () => body } as unknown as Response;
+    }));
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    await act(async () => {
+      root = createRoot(container);
+      root.render(createElement(AgentPanelExtraAgents, {
+        activeSessionKey: 'codex-owned:lane-b',
+        packets: [],
+      }));
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('groups the rows as a labelled list so AT can announce position', () => {
+    const list = container.querySelector('[role="list"]');
+    expect(list).not.toBeNull();
+    expect(list?.getAttribute('aria-label')).toBe('Agents');
+    expect(list!.querySelectorAll('[role="listitem"]')).toHaveLength(LANES.length);
+  });
+
+  it('carries a stable per-row handle derived from the lane id, not the label', () => {
+    const handles = Array.from(container.querySelectorAll<HTMLElement>('[data-o8-agent-row]'))
+      .map((row) => row.dataset.o8AgentRow);
+    expect(handles).toEqual(expect.arrayContaining(['lane:lane-a', 'lane:lane-b']));
+    expect(handles).toHaveLength(LANES.length);
+    // Every row handle sits inside a listitem — the list is not just a wrapper.
+    for (const row of container.querySelectorAll('[data-o8-agent-row]')) {
+      expect(row.closest('[role="listitem"]')).not.toBeNull();
+    }
+  });
+
+  it('marks the open agent with aria-current', () => {
+    const current = container.querySelector<HTMLElement>('[data-o8-agent-row="lane:lane-b"]');
+    expect(current?.getAttribute('aria-current')).toBe('true');
+    expect(
+      container.querySelector('[data-o8-agent-row="lane:lane-a"]')?.getAttribute('aria-current'),
+    ).toBeNull();
+  });
+});

--- a/src/components/desktop/AgentPanelExtraAgents.tsx
+++ b/src/components/desktop/AgentPanelExtraAgents.tsx
@@ -514,10 +514,15 @@ function AgentPanelExtraAgentsBase({
       />
       {/* layout="position" springs a row to its new slot when a band change
           re-sorts the list — without it, a working row that flips to needs-you
-          teleports (rig finding 2026-07-31). Position-only: rows never resize. */}
-      {!collapsed ? rankedRows.map(({ row, band }) => (
+          teleports (rig finding 2026-07-31). Position-only: rows never resize.
+          The role=list wrapper reproduces the section's own flex column so it
+          is layout-neutral while giving AT grouping + position (#2146). */}
+      {!collapsed ? (
+        <div role="list" aria-label="Agents" style={{ display: 'flex', flexDirection: 'column' }}>
+        {rankedRows.map(({ row, band }) => (
         <motion.div
           key={row.key}
+          role="listitem"
           layout="position"
           transition={{ type: 'spring', stiffness: 400, damping: 30 }}
         >
@@ -540,7 +545,9 @@ function AgentPanelExtraAgentsBase({
           }}
         />
         </motion.div>
-      )) : null}
+        ))}
+        </div>
+      ) : null}
       {actionMenu ? (
         <ExtraAgentActionMenu
           state={actionMenu}

--- a/src/components/desktop/shell/WorkspaceHeaderStrip.test.ts
+++ b/src/components/desktop/shell/WorkspaceHeaderStrip.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WorkspaceHeaderStrip } from './WorkspaceHeaderStrip';
+import type { WorkspaceHeaderStripProps } from './workspace-header-strip-types';
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+// The strip observes its scroller for overflow affordances; jsdom has neither.
+vi.stubGlobal('ResizeObserver', class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+});
+
+function headerTab(index: number, label: string) {
+  return {
+    id: `tab-${index}`,
+    label,
+    kind: 'orchestrator',
+    runtime: null,
+    packetStatus: null,
+  };
+}
+
+function stripProps(overrides: Partial<WorkspaceHeaderStripProps> = {}): WorkspaceHeaderStripProps {
+  return {
+    headerTabs: [
+      headerTab(0, 'Fix the tab strip'),
+      headerTab(1, 'Rename me later'),
+      headerTab(2, 'Third session'),
+    ],
+    headerActiveTabId: 'tab-1',
+    workspaceId: 'ws-1',
+    ...overrides,
+  };
+}
+
+describe('WorkspaceHeaderStrip session tabs (#2146)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    await act(async () => {
+      root = createRoot(container);
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it('exposes the pill strip as a tablist of tabs with aria-selected', async () => {
+    await act(async () => root.render(createElement(WorkspaceHeaderStrip, stripProps())));
+
+    const tablist = container.querySelector('[role="tablist"]');
+    expect(tablist).not.toBeNull();
+    expect(tablist?.getAttribute('aria-orientation')).toBe('horizontal');
+
+    const tabs = Array.from(tablist!.querySelectorAll('[role="tab"]'));
+    expect(tabs).toHaveLength(3);
+    expect(tabs.map((tab) => tab.getAttribute('aria-selected'))).toEqual(['false', 'true', 'false']);
+  });
+
+  it('identifies each tab by session id, not by its user-authored title', async () => {
+    const props = stripProps();
+    await act(async () => root.render(createElement(WorkspaceHeaderStrip, props)));
+
+    const before = Array.from(container.querySelectorAll('[role="tab"]'))
+      .map((tab) => (tab as HTMLElement).dataset.o8WorkspaceTab);
+    expect(before).toEqual(['tab-0', 'tab-1', 'tab-2']);
+
+    // Rename every tab. The stable handles must not move.
+    await act(async () => root.render(createElement(WorkspaceHeaderStrip, {
+      ...props,
+      headerTabs: props.headerTabs!.map((tab) => ({ ...tab, label: `${tab.label} (renamed)` })),
+    })));
+
+    const after = Array.from(container.querySelectorAll('[role="tab"]'))
+      .map((tab) => (tab as HTMLElement).dataset.o8WorkspaceTab);
+    expect(after).toEqual(before);
+    expect(container.querySelector('[data-o8-workspace-tab-close="tab-2"]')).not.toBeNull();
+  });
+
+  it('keeps the close control in the accessibility tree and reachable without a pointer', async () => {
+    await act(async () => root.render(createElement(WorkspaceHeaderStrip, stripProps())));
+
+    // Never hovered: the close control still exists, still carries a label.
+    const close = container.querySelector<HTMLButtonElement>('[data-o8-workspace-tab-close="tab-1"]');
+    expect(close).not.toBeNull();
+    expect(close!.getAttribute('aria-label')).toBe('Close Rename me later');
+    expect(close!.getAttribute('aria-hidden')).toBeNull();
+    // The active tab owns the roving tab stop, so its close button is in the
+    // tab sequence too.
+    expect(close!.tabIndex).toBe(0);
+
+    let closed: string | null = null;
+    const onClose = (event: Event) => {
+      closed = (event as CustomEvent<{ tabId: string }>).detail.tabId;
+    };
+    window.addEventListener('o8:request-close-tab', onClose);
+    await act(async () => {
+      close!.focus();
+    });
+    expect(document.activeElement).toBe(close);
+    await act(async () => {
+      close!.click();
+    });
+    window.removeEventListener('o8:request-close-tab', onClose);
+    expect(closed).toBe('tab-1');
+  });
+
+  it('roves focus with the arrow keys and selects on Enter, not on arrow', async () => {
+    await act(async () => root.render(createElement(WorkspaceHeaderStrip, stripProps())));
+
+    const tabs = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]'));
+    // Roving tabindex: only the active tab is in the Tab sequence.
+    expect(tabs.map((tab) => tab.tabIndex)).toEqual([-1, 0, -1]);
+
+    const selections: string[] = [];
+    const onSelect = (event: Event) => {
+      selections.push((event as CustomEvent<{ tabId: string }>).detail.tabId);
+    };
+    window.addEventListener('o8:request-select-tab', onSelect);
+
+    await act(async () => { tabs[1].focus(); });
+    await act(async () => {
+      tabs[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    });
+    expect(document.activeElement).toBe(tabs[2]);
+    // Manual activation: moving focus must not switch the session.
+    expect(selections).toEqual([]);
+
+    await act(async () => {
+      tabs[2].dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    window.removeEventListener('o8:request-select-tab', onSelect);
+    expect(selections).toEqual(['tab-2']);
+  });
+
+  it('wraps Home/End to the ends of the strip', async () => {
+    await act(async () => root.render(createElement(WorkspaceHeaderStrip, stripProps())));
+    const tabs = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]'));
+
+    await act(async () => { tabs[1].focus(); });
+    await act(async () => {
+      tabs[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    });
+    expect(document.activeElement).toBe(tabs[2]);
+
+    await act(async () => {
+      tabs[2].dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    });
+    expect(document.activeElement).toBe(tabs[0]);
+  });
+});

--- a/src/components/desktop/shell/WorkspaceHeaderStrip.tsx
+++ b/src/components/desktop/shell/WorkspaceHeaderStrip.tsx
@@ -352,6 +352,38 @@ function HeaderPillStrip({
     });
   }, []);
 
+  // Roving tabindex for the tablist (#2146). MANUAL activation: arrows move
+  // focus, Enter/Space selects. Automatic activation would swap the whole
+  // workspace session on every arrow press — APG's stated reason to prefer
+  // manual when revealing a panel is expensive.
+  const [focusedTabId, setFocusedTabId] = useState<string | null>(null);
+  const rovingTabId = tabs.some((tab) => tab.id === focusedTabId)
+    ? focusedTabId
+    : (activeTabId ?? tabs[0]?.id ?? null);
+
+  const focusTabAt = useCallback((index: number) => {
+    const next = tabs[((index % tabs.length) + tabs.length) % tabs.length];
+    if (!next) return;
+    setFocusedTabId(next.id);
+    // Match on the stable data attribute rather than CSS.escape'ing an
+    // arbitrary tab id into a selector.
+    Array.from(scrollRef.current?.querySelectorAll<HTMLElement>('[data-o8-workspace-tab]') ?? [])
+      .find((node) => node.dataset.o8WorkspaceTab === next.id)
+      ?.focus();
+  }, [tabs]);
+
+  const handleStripKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (tabs.length === 0) return;
+    const current = tabs.findIndex((tab) => tab.id === rovingTabId);
+    const from = current < 0 ? 0 : current;
+    if (event.key === 'ArrowRight') focusTabAt(from + 1);
+    else if (event.key === 'ArrowLeft') focusTabAt(from - 1);
+    else if (event.key === 'Home') focusTabAt(0);
+    else if (event.key === 'End') focusTabAt(tabs.length - 1);
+    else return;
+    event.preventDefault();
+  }, [focusTabAt, rovingTabId, tabs]);
+
   const handleSelect = useCallback((tabId: string) => {
     window.dispatchEvent(new CustomEvent('o8:request-select-tab', { detail: { tabId, workspaceId: workspaceId ?? null } }));
   }, [workspaceId]);
@@ -436,6 +468,10 @@ function HeaderPillStrip({
     >
       <div
         ref={scrollRef}
+        role="tablist"
+        aria-label="Open sessions"
+        aria-orientation="horizontal"
+        onKeyDown={handleStripKeyDown}
         style={{
           flex: 1,
           minWidth: 0,
@@ -462,6 +498,9 @@ function HeaderPillStrip({
           <motion.div
             key={tab.id}
             layout
+            // role=presentation keeps the animation wrapper out of the way so
+            // the tablist still owns role=tab children through it (#2146).
+            role="presentation"
             data-pill-active={tab.id === activeTabId ? 'true' : undefined}
             initial={{ opacity: 0, scale: 0.85 }}
             animate={{ opacity: 1, scale: 1 }}
@@ -472,10 +511,12 @@ function HeaderPillStrip({
             <HeaderPill
               tab={tab}
               active={tab.id === activeTabId}
+              tabStop={tab.id === rovingTabId}
               crowded={crowded}
               crowdedLabel={crowdedLabels.get(tab.id) ?? null}
               onSelect={handleSelect}
               onClose={handleClose}
+              onFocusTab={setFocusedTabId}
             />
           </motion.div>
         ))}
@@ -507,10 +548,12 @@ function HeaderPillStrip({
 function HeaderPill({
   tab,
   active,
+  tabStop,
   crowded,
   crowdedLabel,
   onSelect,
   onClose,
+  onFocusTab,
 }: {
   tab: {
     id: string;
@@ -520,17 +563,36 @@ function HeaderPill({
     packetStatus: string | null;
   };
   active: boolean;
+  /** This pill owns the tablist's single Tab stop (roving tabindex). */
+  tabStop: boolean;
   crowded: boolean;
   crowdedLabel: string | null;
   onSelect: (tabId: string) => void;
   onClose: (tabId: string) => void;
+  onFocusTab: (tabId: string) => void;
 }) {
   const [hovered, setHovered] = useState(false);
+  // The close glyph is keyboard-reachable at all times (#2146): it stays in the
+  // accessibility tree with a stable label, and reveals itself on focus exactly
+  // as it does on hover so a keyboard user can see what they are about to hit.
+  const [closeFocused, setCloseFocused] = useState(false);
+  const closeRevealed = hovered || closeFocused;
   const display = crowded ? (crowdedLabel ?? significantWords(tab.label, 1)) : tab.label;
   return (
     <div
       data-no-drag
       data-o8-workspace-tab={tab.id}
+      role="tab"
+      aria-selected={active}
+      tabIndex={tabStop ? 0 : -1}
+      onFocus={() => onFocusTab(tab.id)}
+      onKeyDown={(event) => {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        // Only the pill itself activates — the close button owns its own keys.
+        if (event.target !== event.currentTarget) return;
+        event.preventDefault();
+        onSelect(tab.id);
+      }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       onContextMenu={(event) => {
@@ -569,19 +631,26 @@ function HeaderPill({
       }}
       onClick={() => onSelect(tab.id)}
     >
-      {/* Leading slot morphs runtime-icon ↔ close-X on hover — fixed
-          14px so the pill width never shifts. Click while hovered
+      {/* Leading slot morphs runtime-icon ↔ close-X on hover or focus — fixed
+          14px so the pill width never shifts. Click/Enter while revealed
           (showing X) closes; the rest of the pill selects. */}
       <button
         type="button"
+        data-o8-workspace-tab-close={tab.id}
         onClick={(event) => {
-          if (!hovered) return; // only the X is the close target
+          if (!closeRevealed) return; // only the X is the close target
           event.stopPropagation();
           onClose(tab.id);
         }}
-        aria-label={hovered ? `Close ${tab.label || 'tab'}` : undefined}
-        title={hovered ? 'Close tab (⌘W)' : undefined}
-        tabIndex={hovered ? 0 : -1}
+        onKeyDown={(event) => {
+          // Stop Enter/Space bubbling to the pill, which would also select.
+          if (event.key === 'Enter' || event.key === ' ') event.stopPropagation();
+        }}
+        onFocus={() => setCloseFocused(true)}
+        onBlur={() => setCloseFocused(false)}
+        aria-label={`Close ${tab.label || 'tab'}`}
+        title={closeRevealed ? 'Close tab (⌘W)' : undefined}
+        tabIndex={tabStop ? 0 : -1}
         style={{
           display: 'inline-flex',
           alignItems: 'center',
@@ -590,13 +659,13 @@ function HeaderPill({
           height: 14,
           borderWidth: 0,
           background: 'transparent',
-          color: hovered ? 'var(--t-text)' : 'inherit',
-          cursor: hovered ? 'pointer' : 'inherit',
+          color: closeRevealed ? 'var(--t-text)' : 'inherit',
+          cursor: closeRevealed ? 'pointer' : 'inherit',
           padding: 0,
           flexShrink: 0,
         }}
       >
-        {hovered ? (
+        {closeRevealed ? (
           <svg width={11} height={11} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round">
             <path d="M6 6l12 12M18 6L6 18" />
           </svg>


### PR DESCRIPTION
Closes #2146.

## What changed

### Session tab strip — `src/components/desktop/shell/WorkspaceHeaderStrip.tsx`

The pill strip (`HeaderPillStrip` / `HeaderPill`) was a row of bare `div`s.

- The scroll container is now `role="tablist"` (`aria-label="Open sessions"`, `aria-orientation="horizontal"`).
- Each pill is `role="tab"` with `aria-selected`.
- The `motion.div` animation wrappers are `role="presentation"` so the tablist still owns its tabs through them (the same trick `<ul role="tablist"><li role="presentation">` uses).
- Roving tabindex with `ArrowLeft` / `ArrowRight` / `Home` / `End`, **manual activation** — arrows move focus, `Enter`/`Space` selects.
- `data-o8-workspace-tab-close={tab.id}` joins the `data-o8-workspace-tab={tab.id}` that was already on the pill. Both are derived from the tab id, so neither moves when a session is renamed.

**The close control is no longer hover-gated.** It always renders, always carries `aria-label="Close <title>"`, and is focusable whenever its tab owns the roving tab stop. It reveals its X on focus exactly as it already did on hover, so the resting visual is byte-for-byte what it was — only a keyboard user now sees the glyph they are about to hit.

### Agent rail — `AgentPanelExtraAgents.tsx` / `AgentPanelExtraAgentRow.tsx`

- Rows are wrapped in `role="list"` (`aria-label="Agents"`) with `role="listitem"` on each row wrapper. The wrapper reproduces the section's own `display:flex; flex-direction:column`, so layout is unchanged.
- Each row carries `data-o8-agent-row={row.key}` — `lane:<laneId>` or `agent:<sessionKey>`. Not the displayed name.
- The existing `aria-current` on the open row is untouched and now reads correctly against the list.

## The roles, and why

**Tab strip → `tablist`/`tab`, as the issue asked.** ARIA defines `tab` as "a grouping label providing a mechanism for selecting the tab content that is to be rendered to the user." That is literally what these pills do: single-select, mutually exclusive, and the selected one determines what renders in the same center column. Being closable does not change the role — browser and editor tab strips are closable and still expose `tablist`.

I did **not** add `aria-controls`. The workspace panels are rendered by a separate component tree with no id linkage, and ARIA 1.2 lists `aria-controls` on `tab` as recommended rather than required; screen readers still announce role, position and selected state without it. Wiring `role="tabpanel"` into `WorkspaceTerminalPanels` is a larger change than this issue justifies and would land in files PR #2183 is also touching.

I chose **manual** activation deliberately. APG's stated criterion is that automatic activation is only appropriate when revealing the panel is cheap. Arrowing across this strip under automatic activation would tear down and mount a whole workspace session per keypress. So arrows move focus only; `Enter`/`Space` commits.

**Rail rows → `list`/`listitem`, not `tab` and not `listbox`/`option`.** These rows are not a tab-panel set: they do not swap content inside a shared region, the list re-sorts itself by attention band while you look at it, and a row can be non-interactive (`disabled` when there is nothing to focus) — `tab` would be wrong on all three counts. `listbox`/`option` would be wrong differently: it promises value-selection semantics and a composite widget with its own roving tabindex, which these plain buttons are not, and `option` wants `aria-selected` where the rows already correctly use `aria-current`. `list`/`listitem` delivers exactly the thing the issue is missing — grouping and position ("2 of 5") — without promising interaction the rows do not implement.

## What I left out

- No `aria-controls` / `role="tabpanel"` on the workspace panes (see above).
- The other tab surface, `workspace-terminal/TabBar.tsx`, is untouched. Its close control is already always-rendered and already `tabIndex={0}`, so it does not have the bug in the issue. Giving it tablist semantics is a separate, larger change.
- No visual or layout change anywhere. The only new pixels are the UA focus ring on keyboard focus and the close X appearing on keyboard focus.

## Merge order

This touches `AgentPanelExtraAgents.tsx` and `AgentPanelExtraAgentRow.tsx`, which PR #2183 also touches. My diff in those two files is deliberately tiny — one `<div role="list">` wrapper plus `role="listitem"` in one, one `data-o8-agent-row` attribute in the other (16 lines total). **Land #2183 first**; this should rebase cleanly over it either way. Nothing here touches `src/app/api/lanes/`.

## Verification

- `npx tsc --noEmit` — clean.
- `npx eslint` on all five changed/added files — clean.
- `npm run test:classification:check` — manifest matches.
- `npm test` (full hermetic-unit suite): **705 files passed | 3 skipped (708), 4533 tests passed | 4 skipped (4537)**, 127s.
- Both new test files confirmed to actually execute under `config/vitest/vitest.unit.config.ts` with `--reporter=verbose`:
  - `src/components/desktop/shell/WorkspaceHeaderStrip.test.ts` — 5 passed (tablist/tab/aria-selected; stable handles survive renaming every tab; close control labelled, focusable and firing without any hover; arrow-key roving with no selection side effect, then Enter selects; Home/End).
  - `src/components/desktop/AgentPanelExtraAgents.rail-semantics.test.ts` — 3 passed (labelled list with one listitem per row; row handles derived from lane id; `aria-current` on the open agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dVxFgHWcYwiMja5oBxySH