### PR TITLE
fix(orchestrator): fail a false-dispatch turn instead of reporting done

### DIFF
--- a/src/components/desktop/thoughts/use-orchestrator-stream/socket.test.ts
+++ b/src/components/desktop/thoughts/use-orchestrator-stream/socket.test.ts
@@ -209,6 +209,44 @@ describe('orchestrator socket — first-turn streaming race', () => {
     expect(h.messagesRef.current[h.messagesRef.current.length - 1]?.toolCalls?.[0]?.name).toBe('Bash');
   });
 
+  // #2142 — the server retried the turn and threw the previous attempt away.
+  // Its narration is already in the live bubble (settle only ever gated the
+  // terminal events), so the client must clear it or the retry's reply appends
+  // to it and the operator reads two turns glued into one.
+  it('a retry boundary clears the discarded attempt out of the live bubble', () => {
+    const current: CurrentAssistantStreamState = {
+      id: 'assistant-1',
+      chunks: ['I dispatched three agents. ', 'Send me a message when you want me to review.'],
+      thinkingChunks: ['planning'],
+      epoch: 0,
+    };
+    const assistant: MobileTranscriptEntry = {
+      id: 'assistant-1',
+      role: 'assistant',
+      text: 'I dispatched three agents. Send me a message when you want me to review.',
+    };
+    const h = makeHarness({ status: 'busy', current, messages: [userMsg, assistant] });
+
+    h.fire({
+      channel: 'orchestrator',
+      event: 'retry',
+      data: { assistantMessageId: 'assistant-1', attempt: 2, reason: 'false-dispatch', notice: 'Discarding it and retrying the turn once.' },
+    });
+
+    expect(h.currentAssistantRef.current?.chunks).toEqual([]);
+    expect(h.currentAssistantRef.current?.thinkingChunks).toEqual([]);
+    const cleared = h.setMessages.mock.calls.reduce<MobileTranscriptEntry[]>(
+      (state, [updater]) => (typeof updater === 'function' ? updater(state) : updater),
+      [userMsg, assistant],
+    );
+    expect(cleared.find((m) => m.id === 'assistant-1')?.text).toBe('');
+
+    // The retry's tokens land in a bubble holding ONLY the retry.
+    h.fire({ channel: 'orchestrator', event: 'output', data: { text: 'Launched lane-a, lane-b, lane-c.', assistantMessageId: 'assistant-1' } });
+    expect(h.currentAssistantRef.current?.chunks).toEqual(['Launched lane-a, lane-b, lane-c.']);
+    expect(h.currentAssistantRef.current?.chunks.join('')).not.toContain('I dispatched three agents');
+  });
+
   it('a LIVE (non-snapshot) "ready" still finalizes the streamed turn', () => {
     const current: CurrentAssistantStreamState = { id: 'a1', chunks: ['x'], thinkingChunks: [], epoch: 0 };
     const h = makeHarness({ status: 'busy', current });

--- a/src/components/desktop/thoughts/use-orchestrator-stream/socket.ts
+++ b/src/components/desktop/thoughts/use-orchestrator-stream/socket.ts
@@ -335,6 +335,40 @@ export function createOrchestratorMessageHandler(
         break;
       }
 
+      // #2142 — the server retried this turn and threw the previous attempt
+      // away. Its narration is already rendered in the live bubble (settle only
+      // ever gated the terminal events, so every token streamed before the
+      // false dispatch could be detected). Clear it here, or the retry's reply
+      // appends to it and the operator reads two turns as one.
+      case 'retry': {
+        const current = options.currentAssistantRef.current;
+        if (current) {
+          current.chunks = [];
+          current.thinkingChunks = [];
+          current.thinkingStartedAt = null;
+          current.thinkingDurationMs = null;
+          setTranscriptMessages((prev) => {
+            const index = prev.findIndex((message) => message.id === current.id);
+            if (index < 0) return prev;
+            const next = [...prev];
+            next[index] = { ...next[index], text: '', thinking: undefined, thinkingActive: false };
+            return next;
+          });
+        }
+        const notice = typeof msg.data?.notice === 'string' ? msg.data.notice : '';
+        if (notice && typeof window !== 'undefined') {
+          window.dispatchEvent(new CustomEvent('cortex:orchestrator-notice', {
+            detail: {
+              kind: 'orchestrator-turn-retry',
+              noticeId: `orch-retry-${current?.id ?? 'turn'}-${msg.data?.attempt ?? 2}`,
+              message: notice,
+              repoPath: typeof msg.data?.repoPath === 'string' ? msg.data.repoPath : undefined,
+            },
+          }));
+        }
+        break;
+      }
+
       case 'output': {
         const text = typeof msg.data?.text === 'string' ? msg.data.text : '';
         const isThinkingMarker = msg.data?.thinking === true;

--- a/src/lib/lane/orchestrator-false-dispatch.test.ts
+++ b/src/lib/lane/orchestrator-false-dispatch.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { OrchestratorEvent } from './orchestrator-stream-events';
+import {
+  claimsDispatch,
+  isFalseDispatchTurn,
+  runTurnWithFalseDispatchRetry,
+  FALSE_DISPATCH_CORRECTION,
+  FALSE_DISPATCH_ERROR,
+  FALSE_DISPATCH_RETRY_REASON,
+  type FalseDispatchAttemptResult,
+} from './orchestrator-false-dispatch';
+
+const done = (id: string): Extract<OrchestratorEvent, { type: 'done' }> => (
+  { type: 'done', sessionId: id, cost: null }
+);
+
+describe('claimsDispatch', () => {
+  // Verbatim from the traces on #2142 — these are the turns that must fail.
+  it.each([
+    'All three are queued in the same wave and the dispatcher is launching them in the background.',
+    'Mission: mission-5ff02201-a37. I dispatched three packets; file ownership is disjoint.',
+    "I've kicked off the three workers — send me a message when you want me to review.",
+    'Agents launched. P1 lands styles.css first.',
+    'I fired off agent X against the demo repo.',
+  ])('flags a dispatch claim: %s', (text) => {
+    expect(claimsDispatch(text)).toBe(true);
+  });
+
+  it('does NOT flag the documented false positive (negated claim)', () => {
+    // Reported on the issue: the bare-keyword pattern flagged a turn whose text
+    // said the OPPOSITE of a dispatch. Under this change that would fail a
+    // healthy turn AND feed the model a correction telling it to launch agents
+    // it deliberately did not launch.
+    const text = 'Nothing dispatched. The three demo-site packets from the previous turn '
+      + 'are still out there untouched by this turn.';
+    expect(claimsDispatch(text)).toBe(false);
+  });
+
+  it.each([
+    'I could not dispatch the packets — the volume is under the storage reserve.',
+    'I have not launched anything yet; tell me which packets you want.',
+    'I will not dispatch until you confirm the file ownership.',
+    'Before dispatching agents I want to confirm the branch.',
+    'Should I dispatch these three packets?',
+    'The retry timer fired and the watchdog reaped the proc.',
+    "I'll keep polling the mission status until the workers report.",
+  ])('does not flag: %s', (text) => {
+    expect(claimsDispatch(text)).toBe(false);
+  });
+
+  it('a negation elsewhere does not mask a real claim', () => {
+    const text = 'I did not touch styles.css.\nI dispatched three agents against the demo repo.';
+    expect(claimsDispatch(text)).toBe(true);
+  });
+});
+
+describe('isFalseDispatchTurn', () => {
+  const claim = 'I dispatched three agents.';
+
+  it('flags a completed, error-free, zero-launch turn that claims a dispatch', () => {
+    expect(isFalseDispatchTurn({
+      completedResult: true, error: null, launchAgentCallCount: 0, assistantText: claim,
+    })).toBe(true);
+  });
+
+  it('leaves a turn with at least one launch call completely alone', () => {
+    expect(isFalseDispatchTurn({
+      completedResult: true, error: null, launchAgentCallCount: 1, assistantText: claim,
+    })).toBe(false);
+  });
+
+  it('excludes every settle that did not come from a stream result', () => {
+    // Watchdog timeout, user abort, stdin-write failure, plan-mode LOCKOUT,
+    // crash-tail end, proc close — all settle with completedResult:false.
+    expect(isFalseDispatchTurn({
+      completedResult: false, error: null, launchAgentCallCount: 0, assistantText: claim,
+    })).toBe(false);
+  });
+
+  it('excludes a turn that already failed', () => {
+    expect(isFalseDispatchTurn({
+      completedResult: true, error: new Error('boom'), launchAgentCallCount: 0, assistantText: claim,
+    })).toBe(false);
+  });
+});
+
+/**
+ * The defect that killed the previous attempt at this fix: the retry streamed
+ * attempt 2's narration into attempt 1's chat bubble, because only the terminal
+ * events were ever gated. These assertions are on TEXT events and their content
+ * — a suite that only counted `done`/`error` passed while the bug was present.
+ */
+describe('runTurnWithFalseDispatchRetry', () => {
+  function recorder() {
+    const events: OrchestratorEvent[] = [];
+    return { events, onEvent: (e: OrchestratorEvent) => { events.push(e); } };
+  }
+
+  const texts = (events: OrchestratorEvent[]) => events
+    .filter((e): e is Extract<OrchestratorEvent, { type: 'text' }> => e.type === 'text')
+    .map((e) => e.text);
+
+  it('a healthy turn runs once and emits nothing extra', async () => {
+    const { events, onEvent } = recorder();
+    const runAttempt = vi.fn(async (): Promise<FalseDispatchAttemptResult> => {
+      onEvent({ type: 'text', text: 'Launched three agents.' });
+      onEvent(done('s1'));
+      return { falseDispatch: false, withheldDone: null };
+    });
+
+    await runTurnWithFalseDispatchRetry({ message: 'fan out', onEvent, runAttempt });
+
+    expect(runAttempt).toHaveBeenCalledTimes(1);
+    expect(runAttempt).toHaveBeenCalledWith('fan out', 1);
+    expect(events.map((e) => e.type)).toEqual(['text', 'done']);
+    expect(events.some((e) => e.type === 'turn_retry')).toBe(false);
+  });
+
+  it('fences the discarded attempt: every text event before the retry belongs to attempt 1, every one after to attempt 2', async () => {
+    const { events, onEvent } = recorder();
+    const runAttempt = vi.fn(async (message: string, attempt: 1 | 2): Promise<FalseDispatchAttemptResult> => {
+      if (attempt === 1) {
+        onEvent({ type: 'text', text: 'I dispatched three agents. ' });
+        onEvent({ type: 'text', text: 'Send me a message when you want me to review.' });
+        return { falseDispatch: true, withheldDone: done('s1') };
+      }
+      expect(message).toBe(FALSE_DISPATCH_CORRECTION);
+      onEvent({ type: 'tool_use', name: 'cortex_launch_agent', input: {} });
+      onEvent({ type: 'text', text: 'Launched lane-a, lane-b, lane-c.' });
+      onEvent(done('s1'));
+      return { falseDispatch: false, withheldDone: null };
+    });
+
+    await runTurnWithFalseDispatchRetry({ message: 'fan out', onEvent, runAttempt });
+
+    const boundary = events.findIndex((e) => e.type === 'turn_retry');
+    expect(boundary).toBeGreaterThan(-1);
+    expect(events.filter((e) => e.type === 'turn_retry')).toHaveLength(1);
+
+    // The discarded attempt's narration is entirely on the far side of the
+    // boundary — a consumer that resets on `turn_retry` never shows it next to
+    // the retry's reply.
+    expect(texts(events.slice(0, boundary))).toEqual([
+      'I dispatched three agents. ',
+      'Send me a message when you want me to review.',
+    ]);
+    expect(texts(events.slice(boundary + 1))).toEqual(['Launched lane-a, lane-b, lane-c.']);
+
+    // Attempt 1's withheld `done` is dropped, not replayed — a discarded
+    // attempt must not report success.
+    expect(events.filter((e) => e.type === 'done')).toHaveLength(1);
+    expect(events.some((e) => e.type === 'error')).toBe(false);
+  });
+
+  it('a false dispatch never emits `done` for the discarded attempt', async () => {
+    const { events, onEvent } = recorder();
+    await runTurnWithFalseDispatchRetry({
+      message: 'fan out',
+      onEvent,
+      runAttempt: async (_m, attempt) => (attempt === 1
+        ? { falseDispatch: true, withheldDone: done('s1') }
+        : { falseDispatch: false, withheldDone: null }),
+    });
+    // Attempt 2 in this stub emits no events of its own, so a `done` here could
+    // only have come from the discarded attempt.
+    expect(events.filter((e) => e.type === 'done')).toHaveLength(0);
+  });
+
+  it('carries the retry reason and a human-readable notice on the boundary', async () => {
+    const { events, onEvent } = recorder();
+    await runTurnWithFalseDispatchRetry({
+      message: 'fan out',
+      onEvent,
+      runAttempt: async (_m, attempt) => (attempt === 1
+        ? { falseDispatch: true, withheldDone: done('s1') }
+        : { falseDispatch: false, withheldDone: null }),
+    });
+    const boundary = events.find((e) => e.type === 'turn_retry');
+    expect(boundary).toMatchObject({ attempt: 2, reason: FALSE_DISPATCH_RETRY_REASON });
+    expect((boundary as Extract<OrchestratorEvent, { type: 'turn_retry' }>).notice).toMatch(/retrying/i);
+  });
+
+  it('surfaces an error in the thread when the retry also false-dispatches, and stops at two attempts', async () => {
+    const { events, onEvent } = recorder();
+    const runAttempt = vi.fn(async (_message: string, attempt: 1 | 2): Promise<FalseDispatchAttemptResult> => {
+      onEvent({ type: 'text', text: `attempt ${attempt}: I dispatched three agents.` });
+      return { falseDispatch: true, withheldDone: done(`s${attempt}`) };
+    });
+
+    await runTurnWithFalseDispatchRetry({ message: 'fan out', onEvent, runAttempt });
+
+    // Bounded and non-recursive.
+    expect(runAttempt).toHaveBeenCalledTimes(2);
+
+    const boundary = events.findIndex((e) => e.type === 'turn_retry');
+    // Exactly one narration survives on each side of the boundary — the garbled
+    // double-narration next to the error banner is what the previous attempt
+    // shipped, and it must not reappear.
+    expect(texts(events.slice(0, boundary))).toEqual(['attempt 1: I dispatched three agents.']);
+    expect(texts(events.slice(boundary + 1))).toEqual(['attempt 2: I dispatched three agents.']);
+
+    const error = events.find((e) => e.type === 'error');
+    expect(error).toBeDefined();
+    expect((error as Extract<OrchestratorEvent, { type: 'error' }>).error).toBe(FALSE_DISPATCH_ERROR);
+
+    // `error` then the withheld `done`, mirroring the watchdog path, so the
+    // client's "Working M:SS" latch releases.
+    const order = events.filter((e) => e.type === 'error' || e.type === 'done').map((e) => e.type);
+    expect(order).toEqual(['error', 'done']);
+  });
+});

--- a/src/lib/lane/orchestrator-false-dispatch.ts
+++ b/src/lib/lane/orchestrator-false-dispatch.ts
@@ -1,0 +1,176 @@
+/**
+ * #2142 — false dispatch: the orchestrator narrates a dispatch it never made.
+ *
+ * `settleOrchestratorTurn` has always been able to SEE this: it holds both the
+ * number of `cortex_launch_agent` calls the turn made and the assistant text the
+ * turn produced. When the text claims a dispatch and the call count is zero, the
+ * turn is fiction — no lane, no worktree, no worker. Until now that produced a
+ * `console.warn` in `ws-server.log` and then a normal `done`, so every consumer
+ * (thread UI, mission surface, any automation waiting on lanes) was told the run
+ * succeeded. A false success is worse than a failure: a failure is visible and
+ * retryable in seconds, a fabrication costs however long it takes someone to
+ * notice the work does not exist.
+ *
+ * This module owns the two decisions that turn the existing telemetry into a
+ * consequence, kept pure so both can be tested without a live `claude` proc:
+ *   1. does this turn's text CLAIM a dispatch (`claimsDispatch`), and
+ *   2. what happens when it does (`runTurnWithFalseDispatchRetry`).
+ */
+import type { OrchestratorEvent } from './orchestrator-stream-events';
+
+type DoneEvent = Extract<OrchestratorEvent, { type: 'done' }>;
+
+/**
+ * Verbs that assert a dispatch actually happened (or is happening).
+ *
+ * #2142 decision — coverage vs false positives. The original list was
+ * `dispatched|launched|fired|polling|launching|kicked off`. Two members were
+ * pure false-positive surface and are dropped:
+ *   - bare `fired`: "the watchdog fired", "the hook fired" claim nothing about
+ *     agents. `fired off` (the phrasing that does claim a dispatch) is kept.
+ *   - `polling`: "I'll keep polling the mission" is a turn that explicitly did
+ *     NOT dispatch. It never asserted a dispatch on its own.
+ * `dispatching` and `spun up` are added to recover coverage of the phrasings
+ * seen in the reported traces. Net: this matches strictly fewer healthy turns
+ * and the same failing ones. A turn that says "I fired off agent X" with zero
+ * launch calls is still caught; one that says "the retry timer fired" is not.
+ */
+const DISPATCH_VERB_PATTERN = /\b(?:dispatched|dispatching|launched|launching|kicked off|fired off|spun up)\b/i;
+
+/**
+ * Negation, scoped to the sentence carrying the verb.
+ *
+ * This is the documented false positive from the issue thread: the detector
+ * flagged a turn whose text said the opposite of a dispatch —
+ *   "Nothing dispatched. The three demo-site packets from the previous turn are
+ *    still out there untouched by this turn."
+ * Under the old bare-keyword match that was only a stray `console.warn`. Under
+ * this change it would FAIL a healthy turn and feed the model a correction
+ * telling it to launch agents it deliberately did not launch — a false positive
+ * that causes an unwanted dispatch. The guard is mandatory, not cosmetic.
+ */
+const DISPATCH_NEGATION_PATTERN = /\b(?:no|not|n't|nothing|none|never|without|cannot|unable|instead of|rather than|before|would|should|could|will|can|if)\b/i;
+
+/** Split on sentence terminators AND newlines — bullet lists rarely punctuate. */
+function sentences(text: string): string[] {
+  return text.split(/(?<=[.!?])\s+|\n+/g).filter((s) => s.trim().length > 0);
+}
+
+/**
+ * True when some sentence asserts a dispatch and that same sentence is not
+ * negated or hypothetical. Sentence-scoped on purpose: a negation elsewhere in a
+ * long reply must not mask a real claim, and a real claim elsewhere must not
+ * override an explicit "nothing dispatched".
+ */
+export function claimsDispatch(text: string): boolean {
+  for (const sentence of sentences(text)) {
+    if (!DISPATCH_VERB_PATTERN.test(sentence)) continue;
+    if (DISPATCH_NEGATION_PATTERN.test(sentence)) continue;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * A turn is a false dispatch when it ran to a real stream `result` (not a
+ * timeout / abort / crash / LOCKOUT — those settle with `completedResult:false`
+ * and are excluded), produced no error, made ZERO launch calls, and still told
+ * the operator it dispatched.
+ */
+export function isFalseDispatchTurn(input: {
+  completedResult: boolean;
+  error: Error | null;
+  launchAgentCallCount: number;
+  assistantText: string;
+}): boolean {
+  if (!input.completedResult) return false;
+  if (input.error) return false;
+  if (input.launchAgentCallCount >= 1) return false;
+  return claimsDispatch(input.assistantText);
+}
+
+export const FALSE_DISPATCH_RETRY_REASON = 'false-dispatch';
+
+/** Shown in the thread at the attempt boundary so the retry is not invisible. */
+export const FALSE_DISPATCH_RETRY_NOTICE =
+  'That reply claimed a dispatch but made no launch call, so nothing was started. '
+  + 'Discarding it and retrying the turn once.';
+
+/**
+ * What the retry actually retries (#2142 design decision).
+ *
+ * NOT a bare resend of the operator's message, and NOT a fresh session:
+ *   - A resend into the same warm session leaves the model's own false claim in
+ *     its own context with no corrective signal. The most likely outcome is that
+ *     it repeats itself and the retry costs a turn for nothing.
+ *   - A fresh session throws away the repo exploration and the packet plan the
+ *     turn just built, so the retry has to redo all of it and may well produce a
+ *     different plan than the one the operator just read.
+ * The one thing with direct evidence behind it is an explicit correction: the
+ * issue thread reports that "told explicitly to call `cortex_launch_agent`, the
+ * model does call it". So the retry is a correction turn on the same warm
+ * session — it keeps the plan, names the contradiction, and asks for the call.
+ */
+export const FALSE_DISPATCH_CORRECTION = [
+  'STOP. Your previous reply reported that you dispatched agents, but you made no `cortex_launch_agent` call in that turn, so nothing was launched: no lane, no worktree, no worker.',
+  'Registering or naming a mission does not launch anything, and there is no background dispatcher that picks packets up afterwards. `cortex_launch_agent` is the only thing that launches a worker.',
+  'Redo that turn now. Call `cortex_launch_agent` once per packet you described, using the same plan, then report the lane ids the tool actually returned.',
+  'If you cannot launch — a tool error, a refused precondition, a missing repo — say exactly what blocked you. Do not report a dispatch you did not make.',
+].join('\n');
+
+/** The thread-visible failure when the retry does not fix it either. */
+export const FALSE_DISPATCH_ERROR =
+  'Dispatch failed: the orchestrator reported launching agents but made no `cortex_launch_agent` call, '
+  + 'on the original turn and again after an explicit correction. Nothing was launched — no lane, no worktree, no worker '
+  + 'was created, and any mission id named above is registered but empty. Re-send the request, or dispatch the packets '
+  + 'directly from the mission surface.';
+
+export interface FalseDispatchAttemptResult {
+  /** True when this attempt narrated a dispatch it never made. */
+  falseDispatch: boolean;
+  /**
+   * The `done` event the settle withheld because the attempt was a false
+   * dispatch. Replayed only if the LAST attempt fails, so the client latch
+   * still releases; dropped outright for a discarded attempt.
+   */
+  withheldDone: DoneEvent | null;
+}
+
+/**
+ * Run a turn with a single, non-recursive retry on a detected false dispatch.
+ *
+ * Attempt isolation (#2142, the defect that killed the previous attempt): the
+ * `text` / `thinking` / `tool_use` events of attempt 1 have ALREADY streamed
+ * live by the time the detector fires — settle only ever gated the terminal
+ * events. Without a boundary, attempt 2's narration is appended to the same chat
+ * bubble and persisted that way, so the operator reads two glued-together turns.
+ * The `turn_retry` event below is that boundary: ws-server drops everything
+ * accumulated for the discarded attempt (in memory, on disk, and on every live
+ * client) before attempt 2 emits its first token.
+ */
+export async function runTurnWithFalseDispatchRetry(options: {
+  message: string;
+  onEvent: (event: OrchestratorEvent) => void;
+  runAttempt: (message: string, attempt: 1 | 2) => Promise<FalseDispatchAttemptResult>;
+}): Promise<void> {
+  const first = await options.runAttempt(options.message, 1);
+  if (!first.falseDispatch) return;
+
+  // Boundary FIRST — attempt 2 must not be able to emit a token into attempt 1's
+  // bubble. Attempt 1's withheld `done` is dropped with the rest of its output.
+  options.onEvent({
+    type: 'turn_retry',
+    attempt: 2,
+    reason: FALSE_DISPATCH_RETRY_REASON,
+    notice: FALSE_DISPATCH_RETRY_NOTICE,
+  });
+
+  const second = await options.runAttempt(FALSE_DISPATCH_CORRECTION, 2);
+  if (!second.falseDispatch) return;
+
+  // Bounded: no third attempt, no recursion. Surface it in the thread. `error`
+  // then the withheld `done` mirrors the existing watchdog path so the client's
+  // "Working M:SS" latch releases instead of counting to the 4-hour reaper.
+  options.onEvent({ type: 'error', error: FALSE_DISPATCH_ERROR });
+  if (second.withheldDone) options.onEvent(second.withheldDone);
+}

--- a/src/lib/lane/orchestrator-session.ts
+++ b/src/lib/lane/orchestrator-session.ts
@@ -32,6 +32,11 @@ import { assertOrchestratorRepoPath } from '@/lib/lane/repo-preflight';
 import { buildOrchestratorSystemPrompt } from '@/lib/lane/orchestrator-system-prompt';
 import { fingerprintMcpConfig, firstMcpConfigDivergence } from '@/lib/lane/orchestrator-mcp-fingerprint';
 import { buildOrchestratorArgs } from '@/lib/lane/orchestrator-spawn-args';
+import {
+  isFalseDispatchTurn,
+  runTurnWithFalseDispatchRetry,
+  type FalseDispatchAttemptResult,
+} from '@/lib/lane/orchestrator-false-dispatch';
 import { pathWithNodeRuntime } from '@/lib/util/node-on-path';
 import { resolveClaudeBinary } from '@/lib/runtimes/shared/cli-locate';
 import {
@@ -555,7 +560,7 @@ interface OrchestratorProcConfig {
 interface OrchestratorActiveTurn {
   onEvent: (e: OrchestratorEvent) => void;
   captureEvent: (e: OrchestratorEvent) => void;
-  resolve: () => void;
+  resolve: (outcome: FalseDispatchAttemptResult) => void;
   reject: (err: Error) => void;
   timeout: ReturnType<typeof setTimeout>;
   abortSignal: AbortSignal | null;
@@ -684,8 +689,21 @@ export function detectPermissionRequest(raw: Record<string, unknown>): boolean {
 
 /** Settle the active turn — emit `done` (+ an error event on a bad crash), run
  *  the narrate-and-exit / false-dispatch telemetry, resolve, and (if the proc is
- *  still alive) leave it READY + schedule the idle reap. */
-function settleOrchestratorTurn(session: OrchestratorSession, w: WarmState, error: Error | null): void {
+ *  still alive) leave it READY + schedule the idle reap.
+ *
+ *  `completedResult` (#2142) means this settle came from a real stream `result`
+ *  — the model finished the turn on its own. It defaults to FALSE so every other
+ *  call site (watchdog timeout, user abort, stdin write failure, plan-mode
+ *  LOCKOUT, crash-tail end, proc close, dead rehydrated turn) is excluded from
+ *  false-dispatch handling by construction. Those turns are already abnormal;
+ *  a turn that was killed mid-narration has no business being retried as a
+ *  hallucinated dispatch. */
+function settleOrchestratorTurn(
+  session: OrchestratorSession,
+  w: WarmState,
+  error: Error | null,
+  completedResult = false,
+): void {
   const turn = w.activeTurn;
   if (!turn || turn.settled) return;
   const hadCrashRecord = !!turn.crashRecord;
@@ -703,26 +721,45 @@ function settleOrchestratorTurn(session: OrchestratorSession, w: WarmState, erro
   w.lastUsedAt = Date.now();
   if (turn.turnSessionId) session.claudeSessionId = turn.turnSessionId;
 
+  let falseDispatch = false;
   if (!error) {
     const tail = turn.lastAssistantText.trim().slice(-1200);
     const hasSummaryMarker = /VERDICT\s*[#-]|Dispatched\s+\d+\s+agent/i.test(tail);
     if (turn.sawToolUseAfterText || !hasSummaryMarker) {
+      // #2142 decision — narrate-and-exit stays a warn. Its condition
+      // (`sawToolUseAfterText || !hasSummaryMarker`) is true for most ordinary
+      // turns: any turn that ends without a VERDICT/"Dispatched N agent" marker
+      // trips it, which is nearly every healthy conversational reply. Acting on
+      // it would fail turns wholesale. False dispatch is the opposite shape — a
+      // specific contradiction between what the turn DID and what it SAID — so
+      // only that one is promoted to a failure here.
       console.warn(`[orchestrator-session] narrate-and-exit suspected for ${session.sessionName}: sawToolUseAfterText=${turn.sawToolUseAfterText} hasSummaryMarker=${hasSummaryMarker} tailLen=${tail.length}`);
     }
-    const dispatchClaimPattern = /\b(dispatched|launched|fired|launching|polling|kicked off)\b/i;
-    if (turn.launchAgentCallCount === 0 && dispatchClaimPattern.test(turn.lastAssistantText)) {
-      console.warn(`[orchestrator-session] FALSE-DISPATCH suspected for ${session.sessionName}: launchAgentCallCount=0 but text claims dispatch — text sample: ${JSON.stringify(turn.lastAssistantText.slice(-200))}`);
+    falseDispatch = isFalseDispatchTurn({
+      completedResult,
+      error,
+      launchAgentCallCount: turn.launchAgentCallCount,
+      assistantText: turn.lastAssistantText,
+    });
+    if (falseDispatch) {
+      console.warn(`[orchestrator-session] FALSE-DISPATCH for ${session.sessionName}: launchAgentCallCount=0 but text claims dispatch — text sample: ${JSON.stringify(turn.lastAssistantText.slice(-200))}`);
     }
   }
 
-  turn.onEvent({ type: 'done', sessionId: turn.turnSessionId, cost: turn.cost, ...(turn.usage ? { usage: turn.usage } : {}) });
+  // A false-dispatch turn must NOT report success. Withhold `done` and hand it
+  // to the retry driver, which replays it only if the LAST attempt also fails
+  // (so the client latch still releases) and drops it for a discarded attempt.
+  const done: Extract<OrchestratorEvent, { type: 'done' }> = {
+    type: 'done', sessionId: turn.turnSessionId, cost: turn.cost, ...(turn.usage ? { usage: turn.usage } : {}),
+  };
+  if (!falseDispatch) turn.onEvent(done);
   if (error) turn.onEvent({ type: 'error', error: error.message });
 
   if ((session.proc || hadCrashRecord) && session.status !== 'dead') {
     session.status = 'ready';
     scheduleIdleReap(session, w);
   }
-  turn.resolve();
+  turn.resolve({ falseDispatch, withheldDone: falseDispatch ? done : null });
 }
 
 function handleClaudeJsonLine(session: OrchestratorSession, w: WarmState, line: string): boolean {
@@ -743,7 +780,9 @@ function handleClaudeJsonLine(session: OrchestratorSession, w: WarmState, line: 
   processStreamEvent(raw, turn.captureEvent, (id) => { turn.turnSessionId = id; }, (c) => { turn.cost = c; }, turn.toolTracker);
   if (raw.type === 'result') {
     turn.usage = parseOrchestratorTurnUsage(raw);
-    settleOrchestratorTurn(session, w, null);
+    // The ONLY settle that passes completedResult — the model ran the turn to
+    // completion itself, so its claims are its own and the detector applies.
+    settleOrchestratorTurn(session, w, null, true);
     return false;
   }
   return true;
@@ -1006,138 +1045,148 @@ export async function sendToOrchestrator(
     }
   }
 
-  session.status = 'busy';
-  clearIdleTimer(w);
-
-  // Build the message payload (attachments → image blocks). Same CLI contract
-  // as interactive-session.ts; the message is written to the RESIDENT proc's
-  // still-open stdin (no stdin.end() — the proc lives on for the next turn).
+  // Attachments → image blocks. Same CLI contract as interactive-session.ts;
+  // the message is written to the RESIDENT proc's still-open stdin (no
+  // stdin.end() — the proc lives on for the next turn).
   const imageBlocks = (options.attachments ?? [])
     .map(attachmentToImageBlock)
     .filter((block): block is NonNullable<typeof block> => block !== null);
-  const content: string | Array<Record<string, unknown>> = imageBlocks.length > 0
-    ? [{ type: 'text', text: message }, ...imageBlocks]
-    : message;
-  const payload = `${JSON.stringify({ type: 'user', message: { role: 'user', content } })}\n`;
 
-  return new Promise<void>((resolvePromise, rejectPromise) => {
-    const proc = session.proc;
-    if (!proc || !proc.stdin || proc.stdin.destroyed) {
-      session.status = 'dead';
-      const e = new Error('Orchestrator resident proc stdin is not writable');
-      onEvent({ type: 'error', error: e.message });
-      rejectPromise(e);
-      return;
-    }
+  // #2142 — one turn, up to two attempts. The retry re-enters HERE, not through
+  // sendToOrchestrator: the carrier, MCP config and warm proc resolved above are
+  // reused as-is, and the correction rides the same warm session so the packet
+  // plan from attempt 1 is still in the model's context.
+  const runAttempt = (attemptMessage: string, attempt: 1 | 2): Promise<FalseDispatchAttemptResult> => {
+    // Attachments belong to the operator's message only — the correction turn is
+    // text, and re-sending images would double them into the session context.
+    const content: string | Array<Record<string, unknown>> = imageBlocks.length > 0 && attempt === 1
+      ? [{ type: 'text', text: attemptMessage }, ...imageBlocks]
+      : attemptMessage;
+    const payload = `${JSON.stringify({ type: 'user', message: { role: 'user', content } })}\n`;
+    session.status = 'busy';
+    clearIdleTimer(w);
 
-    const crashOffset = w.crashStdoutPath ? fileSize(w.crashStdoutPath) : 0;
-    const crashRecord = crashSurvivableOrchestratorEnabled() && w.crashStdoutPath && w.crashStderrPath && proc.pid
-      ? createOrchestratorTurnRecordForFiles({
-          backend: 'claude',
-          sessionName: session.sessionName,
-          repoPath: session.repoPath,
-          threadId: options.crashSurvival?.threadId ?? session.threadId,
-          pid: proc.pid,
-          stdoutPath: w.crashStdoutPath,
-          stderrPath: w.crashStderrPath,
-          stdoutOffset: crashOffset,
-          assistantMessageId: options.crashSurvival?.assistantMessageId ?? null,
-          assistantStartedAtMs: options.crashSurvival?.assistantStartedAtMs ?? null,
-          model,
-        })
-      : null;
-
-    // #457 — Hang watchdog. Kills the resident proc (surfacing WHY) if the turn
-    // never settles on a `result`.
-    const timeout = setTimeout(() => {
-      console.warn(`[orchestrator-session] Process timeout (${PROCESS_TIMEOUT_MS}ms) — killing ${session.sessionName}`);
-      const minutes = Math.round(PROCESS_TIMEOUT_MS / 60_000);
-      onEvent({
-        type: 'error',
-        error: `Orchestrator hit the ${minutes}-minute watchdog limit and was terminated — a turn running this long has almost certainly hung. Re-send your message to continue.`,
-      });
-      settleOrchestratorTurn(session, w, null);
-      killOrchestratorProc(session, w);
-    }, PROCESS_TIMEOUT_MS);
-
-    const turn: OrchestratorActiveTurn = {
-      onEvent,
-      captureEvent: () => {},
-      resolve: resolvePromise,
-      reject: rejectPromise,
-      timeout,
-      abortSignal: options.signal ?? null,
-      abortListener: null,
-      settled: false,
-      toolTracker: createToolCallTracker(),
-      turnSessionId: session.claudeSessionId,
-      cost: null,
-      lastAssistantText: '',
-      sawToolUseAfterText: false,
-      launchAgentCallCount: 0,
-      crashRecord,
-      stopCrashTail: null,
-    };
-    // Narrate-and-exit / false-dispatch telemetry state lives on the turn.
-    turn.captureEvent = (e: OrchestratorEvent) => {
-      if (e.type === 'text') {
-        turn.lastAssistantText += e.text;
-        turn.sawToolUseAfterText = false;
-      } else if (e.type === 'tool_use') {
-        turn.sawToolUseAfterText = true;
-        if (e.name === 'cortex_launch_agent' || e.name === 'mcp__cortex__cortex_launch_agent') {
-          turn.launchAgentCallCount += 1;
-        }
-      }
-      onEvent(e);
-    };
-    w.activeTurn = turn;
-    if (crashRecord) {
-      turn.stopCrashTail = tailJsonlFile({
-        filePath: crashRecord.stdoutPath,
-        fromOffset: crashOffset,
-        alive: () => !!session.proc && isPidAlive(crashRecord.pid) && !turn.settled,
-        onLine: (line) => handleClaudeJsonLine(session, w, line),
-        onEnd: () => {
-          if (!turn.settled) {
-            const stderr = existsSync(crashRecord.stderrPath)
-              ? (() => {
-                  try { return readFileSync(crashRecord.stderrPath, 'utf8').trim(); } catch { return ''; }
-                })()
-              : '';
-            settleOrchestratorTurn(session, w, stderr ? new Error(stderr.slice(0, 500)) : null);
-          }
-        },
-      });
-    }
-
-    // #624 — User interrupt. Kills the resident proc (sacrificed for the
-    // interrupt; the next turn spawns cold) and settles this turn.
-    if (options.signal) {
-      if (options.signal.aborted) {
-        settleOrchestratorTurn(session, w, null);
-        killOrchestratorProc(session, w);
+    return new Promise<FalseDispatchAttemptResult>((resolvePromise, rejectPromise) => {
+      const proc = session.proc;
+      if (!proc || !proc.stdin || proc.stdin.destroyed) {
+        session.status = 'dead';
+        const e = new Error('Orchestrator resident proc stdin is not writable');
+        onEvent({ type: 'error', error: e.message });
+        rejectPromise(e);
         return;
       }
-      turn.abortListener = () => {
-        console.log(`[orchestrator-session] User interrupt — killing ${session.sessionName}`);
+
+      const crashOffset = w.crashStdoutPath ? fileSize(w.crashStdoutPath) : 0;
+      const crashRecord = crashSurvivableOrchestratorEnabled() && w.crashStdoutPath && w.crashStderrPath && proc.pid
+        ? createOrchestratorTurnRecordForFiles({
+            backend: 'claude',
+            sessionName: session.sessionName,
+            repoPath: session.repoPath,
+            threadId: options.crashSurvival?.threadId ?? session.threadId,
+            pid: proc.pid,
+            stdoutPath: w.crashStdoutPath,
+            stderrPath: w.crashStderrPath,
+            stdoutOffset: crashOffset,
+            assistantMessageId: options.crashSurvival?.assistantMessageId ?? null,
+            assistantStartedAtMs: options.crashSurvival?.assistantStartedAtMs ?? null,
+            model,
+          })
+        : null;
+
+      // #457 — Hang watchdog. Kills the resident proc (surfacing WHY) if the turn
+      // never settles on a `result`.
+      const timeout = setTimeout(() => {
+        console.warn(`[orchestrator-session] Process timeout (${PROCESS_TIMEOUT_MS}ms) — killing ${session.sessionName}`);
+        const minutes = Math.round(PROCESS_TIMEOUT_MS / 60_000);
+        onEvent({
+          type: 'error',
+          error: `Orchestrator hit the ${minutes}-minute watchdog limit and was terminated — a turn running this long has almost certainly hung. Re-send your message to continue.`,
+        });
         settleOrchestratorTurn(session, w, null);
         killOrchestratorProc(session, w);
-      };
-      options.signal.addEventListener('abort', turn.abortListener, { once: true });
-    }
+      }, PROCESS_TIMEOUT_MS);
 
-    try {
-      proc.stdin.write(payload, 'utf8', (error?: Error | null) => {
-        if (error) {
-          console.warn(`[orchestrator-session] stdin write failed for ${session.sessionName}:`, error);
-          session.status = 'dead';
-          settleOrchestratorTurn(session, w, error);
+      const turn: OrchestratorActiveTurn = {
+        onEvent,
+        captureEvent: () => {},
+        resolve: resolvePromise,
+        reject: rejectPromise,
+        timeout,
+        abortSignal: options.signal ?? null,
+        abortListener: null,
+        settled: false,
+        toolTracker: createToolCallTracker(),
+        turnSessionId: session.claudeSessionId,
+        cost: null,
+        lastAssistantText: '',
+        sawToolUseAfterText: false,
+        launchAgentCallCount: 0,
+        crashRecord,
+        stopCrashTail: null,
+      };
+      // Narrate-and-exit / false-dispatch telemetry state lives on the turn.
+      turn.captureEvent = (e: OrchestratorEvent) => {
+        if (e.type === 'text') {
+          turn.lastAssistantText += e.text;
+          turn.sawToolUseAfterText = false;
+        } else if (e.type === 'tool_use') {
+          turn.sawToolUseAfterText = true;
+          if (e.name === 'cortex_launch_agent' || e.name === 'mcp__cortex__cortex_launch_agent') {
+            turn.launchAgentCallCount += 1;
+          }
         }
-      });
-    } catch (error) {
-      session.status = 'dead';
-      settleOrchestratorTurn(session, w, error instanceof Error ? error : new Error(String(error)));
-    }
-  });
+        onEvent(e);
+      };
+      w.activeTurn = turn;
+      if (crashRecord) {
+        turn.stopCrashTail = tailJsonlFile({
+          filePath: crashRecord.stdoutPath,
+          fromOffset: crashOffset,
+          alive: () => !!session.proc && isPidAlive(crashRecord.pid) && !turn.settled,
+          onLine: (line) => handleClaudeJsonLine(session, w, line),
+          onEnd: () => {
+            if (!turn.settled) {
+              const stderr = existsSync(crashRecord.stderrPath)
+                ? (() => {
+                    try { return readFileSync(crashRecord.stderrPath, 'utf8').trim(); } catch { return ''; }
+                  })()
+                : '';
+              settleOrchestratorTurn(session, w, stderr ? new Error(stderr.slice(0, 500)) : null);
+            }
+          },
+        });
+      }
+
+      // #624 — User interrupt. Kills the resident proc (sacrificed for the
+      // interrupt; the next turn spawns cold) and settles this turn.
+      if (options.signal) {
+        if (options.signal.aborted) {
+          settleOrchestratorTurn(session, w, null);
+          killOrchestratorProc(session, w);
+          return;
+        }
+        turn.abortListener = () => {
+          console.log(`[orchestrator-session] User interrupt — killing ${session.sessionName}`);
+          settleOrchestratorTurn(session, w, null);
+          killOrchestratorProc(session, w);
+        };
+        options.signal.addEventListener('abort', turn.abortListener, { once: true });
+      }
+
+      try {
+        proc.stdin.write(payload, 'utf8', (error?: Error | null) => {
+          if (error) {
+            console.warn(`[orchestrator-session] stdin write failed for ${session.sessionName}:`, error);
+            session.status = 'dead';
+            settleOrchestratorTurn(session, w, error);
+          }
+        });
+      } catch (error) {
+        session.status = 'dead';
+        settleOrchestratorTurn(session, w, error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  };
+
+  return runTurnWithFalseDispatchRetry({ message, onEvent, runAttempt });
 }

--- a/src/lib/lane/orchestrator-stream-events.ts
+++ b/src/lib/lane/orchestrator-stream-events.ts
@@ -15,6 +15,15 @@ export type OrchestratorEvent =
   //    text is buffered, not streamed, so it never pollutes the visible answer
   //    or the persisted assistant text; these two carry it to the faint pre-roll
   //    card. The aggregator's reply still flows through `text` as the sole answer.
+  // ── Attempt boundary (#2142). Emitted between the attempts of a retried turn
+  //    (today: a detected false dispatch). Everything the discarded attempt
+  //    streamed — text, thinking, tool pills — is already in the operator's
+  //    bubble and in the incrementally-persisted assistant row by the time the
+  //    detector can fire, because settle only ever gated the terminal events.
+  //    Consumers MUST drop that content on this event; otherwise the retry's
+  //    narration is appended to the discarded one and both ship as a single
+  //    glued-together reply.
+  | { type: 'turn_retry'; attempt: number; reason: string; notice: string }
   | { type: 'collide_phase'; phase: 'proposing' | 'synthesizing'; proposers?: string[] }
   | { type: 'collide_proposal'; proposer: string; text: string; breach?: boolean }
   // ── Handoff (#1730) — the responding agent changed mid-thread. Emitted at the

--- a/src/lib/ws-server/orchestrator-assistant-text.test.ts
+++ b/src/lib/ws-server/orchestrator-assistant-text.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import type { OrchestratorEvent } from '@/lib/lane/orchestrator-stream-events';
+import { createAssistantTextBuffer } from './orchestrator-assistant-text';
+
+/**
+ * ws-server's `text` case appends into this buffer and its `turn_retry` case
+ * discards it. The loop below mirrors that switch so the regression is asserted
+ * on an event stream, which is the shape the bug actually took: attempt 1's
+ * narration and attempt 2's narration concatenated into one persisted reply.
+ */
+function drain(events: OrchestratorEvent[]) {
+  const buffer = createAssistantTextBuffer();
+  for (const event of events) {
+    if (event.type === 'text') buffer.append(event.text);
+    else if (event.type === 'turn_retry') buffer.discard();
+  }
+  return buffer;
+}
+
+const retry: OrchestratorEvent = {
+  type: 'turn_retry', attempt: 2, reason: 'false-dispatch', notice: 'retrying',
+};
+
+describe('createAssistantTextBuffer', () => {
+  it('accumulates a normal turn', () => {
+    const buffer = drain([
+      { type: 'text', text: 'Launched ' },
+      { type: 'text', text: 'three agents.' },
+    ]);
+    expect(buffer.value).toBe('Launched three agents.');
+    expect(buffer.discarded).toBe(false);
+  });
+
+  it('does NOT glue a retried attempt onto the discarded one', () => {
+    const buffer = drain([
+      { type: 'text', text: 'I dispatched three agents. ' },
+      { type: 'text', text: 'Send me a message when you want me to review.' },
+      retry,
+      { type: 'text', text: 'Launched lane-a, lane-b, lane-c.' },
+    ]);
+    expect(buffer.value).toBe('Launched lane-a, lane-b, lane-c.');
+    expect(buffer.value).not.toContain('I dispatched three agents');
+    expect(buffer.discarded).toBe(true);
+  });
+
+  it('persists the retried attempt even when the discarded one was already written', () => {
+    // The 1.5s incremental persist means the discarded attempt is usually on
+    // disk by the time the detector fires. `discard()` clears the
+    // last-persisted marker too, otherwise a retry whose text happened to match
+    // would be short-circuited as "unchanged" and the stale row would stand.
+    const buffer = createAssistantTextBuffer();
+    buffer.append('I dispatched three agents.');
+    expect(buffer.shouldPersist(false)).toBe(true);
+    buffer.markPersisted();
+    expect(buffer.shouldPersist(false)).toBe(false);
+
+    buffer.discard();
+    buffer.append('I dispatched three agents.');
+    expect(buffer.shouldPersist(false)).toBe(true);
+  });
+
+  it('never persists an empty buffer, but a receipt still forces a write of real text', () => {
+    const buffer = createAssistantTextBuffer();
+    expect(buffer.shouldPersist(true)).toBe(false);
+    buffer.append('done');
+    buffer.markPersisted();
+    expect(buffer.shouldPersist(false)).toBe(false);
+    expect(buffer.shouldPersist(true)).toBe(true);
+  });
+
+  it('a discard with no retry text leaves nothing to persist', () => {
+    const buffer = drain([{ type: 'text', text: 'I dispatched three agents.' }, retry]);
+    expect(buffer.value).toBe('');
+    expect(buffer.shouldPersist(true)).toBe(false);
+  });
+});

--- a/src/lib/ws-server/orchestrator-assistant-text.ts
+++ b/src/lib/ws-server/orchestrator-assistant-text.ts
@@ -1,0 +1,53 @@
+/**
+ * #2142 — the assistant-text buffer for one orchestrator turn, with an explicit
+ * discard for a retried attempt.
+ *
+ * ws-server used to hold this as two bare `let`s declared once per WS message,
+ * outside the turn call. The `text` case appended every token to that single
+ * buffer with no attempt boundary, so when the false-dispatch retry landed, the
+ * discarded attempt's narration and the retry's narration were concatenated into
+ * one chat bubble and persisted that way — the operator read two glued-together
+ * turns with no separator. Making the buffer an object with a `discard()` gives
+ * the attempt boundary somewhere to land, and gives it a test.
+ */
+export interface AssistantTextBuffer {
+  /** Append a streamed token/segment to the CURRENT attempt. */
+  append(chunk: string): void;
+  /**
+   * Drop everything the discarded attempt streamed, including the record of
+   * what was already written to disk — the caller removes that row separately,
+   * and the next persist must not be short-circuited as "unchanged".
+   */
+  discard(): void;
+  /** Text of the current attempt only. */
+  readonly value: string;
+  /**
+   * Whether a persist would write anything new. `hasReceipt` forces the terminal
+   * write (token counts / session id land even when the text is unchanged).
+   */
+  shouldPersist(hasReceipt: boolean): boolean;
+  markPersisted(): void;
+  /** True once `discard()` has run — the turn had an attempt thrown away. */
+  readonly discarded: boolean;
+}
+
+export function createAssistantTextBuffer(): AssistantTextBuffer {
+  let text = '';
+  let persisted = '';
+  let discarded = false;
+  return {
+    append(chunk: string) { text += chunk; },
+    discard() {
+      text = '';
+      persisted = '';
+      discarded = true;
+    },
+    get value() { return text; },
+    shouldPersist(hasReceipt: boolean) {
+      if (!text) return false;
+      return text !== persisted || hasReceipt;
+    },
+    markPersisted() { persisted = text; },
+    get discarded() { return discarded; },
+  };
+}

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -135,6 +135,7 @@ import {
 } from './lib/mobile/orchestrator-thread-history';
 import { OrchestratorThreadProjectError } from './lib/mobile/orchestrator-thread-project';
 import { persistOrchestratorThreadUserMessageFromWire } from './lib/ws-server/orchestrator-thread-send';
+import { createAssistantTextBuffer } from './lib/ws-server/orchestrator-assistant-text';
 import { getLiveReviewChangeSet } from './lib/review/live-changes';
 import { mayHaveGitRepositoryContext } from './lib/git/repository-context';
 import { deriveIdempotencyKey, withIdempotency } from './lib/orchestrator/idempotency-store';
@@ -1255,6 +1256,22 @@ function handleReboundOrchestratorEvent(record: OrchestratorTurnRecord, event: O
       });
       reboundAssistantText.delete(record.id);
       reboundOrchestratorRecords.delete(record.id);
+      break;
+    // #2142 — same attempt boundary on the crash-rehydrate replay path.
+    case 'turn_retry':
+      reboundAssistantText.set(record.id, '');
+      if (threadId && assistantMessageId) {
+        try {
+          truncateMobileOrchestratorThreadFromMessage({ tabId: threadId, messageId: assistantMessageId });
+        } catch (trimErr) {
+          console.warn('[orchestrator-rehydrate] failed to drop discarded attempt text', trimErr);
+        }
+      }
+      wsMsg = JSON.stringify({
+        channel: 'orchestrator',
+        event: 'retry',
+        data: { repoPath, threadId, assistantMessageId, attempt: event.attempt, reason: event.reason, notice: event.notice, backend },
+      });
       break;
     case 'collide_phase':
     case 'collide_proposal':
@@ -5135,8 +5152,9 @@ async function handleOrchestratorSendMsgOnce(
     : `user-${turnStartedAtMs}`;
   const assistantMessageId = isThreadBacked ? `assistant-${turnStartedAtMs}` : null;
   const assistantStartedAtMs = turnStartedAtMs;
-  let assistantTextAccum = '';
-  let lastPersistedAssistantText = '';
+  // #2142 — per-ATTEMPT, not per-message. A retried turn discards everything the
+  // rejected attempt streamed so the retry's reply is not appended to it.
+  const assistantText = createAssistantTextBuffer();
   let activeAssistantModel = model ?? null;
   // Incremental persistence (2026-06-22): persist the streamed assistant text
   // every ~1.5s WHILE the turn runs, not only at terminal points. Without this,
@@ -5155,13 +5173,13 @@ async function handleOrchestratorSendMsgOnce(
   ) => {
     if (!isThreadBacked || !assistantMessageId) return;
     if (undoneOrchestratorUserMessageIds.has(userMessageId)) return;
-    if (!assistantTextAccum || (assistantTextAccum === lastPersistedAssistantText && !receipt)) return;
+    if (!assistantText.shouldPersist(!!receipt)) return;
     try {
       const updatedThread = upsertMobileOrchestratorAssistantMessage({
         tabId: threadId,
         repoPath,
         messageId: assistantMessageId,
-        content: assistantTextAccum,
+        content: assistantText.value,
         backend: backendId,
         agent: activeAgentTag,
         sessionId,
@@ -5176,7 +5194,7 @@ async function handleOrchestratorSendMsgOnce(
         } : {}),
         timestampMs: assistantStartedAtMs,
       });
-      lastPersistedAssistantText = assistantTextAccum;
+      assistantText.markPersisted();
       if (updatedThread) {
         broadcast({
           channel: 'orchestrator-threads',
@@ -5442,7 +5460,7 @@ async function handleOrchestratorSendMsgOnce(
         switch (event.type) {
           case 'text':
             if (isThreadBacked) {
-              assistantTextAccum += event.text;
+              assistantText.append(event.text);
               // Throttled mid-stream persist so a wedged turn's reply survives a
               // reload instead of dropping to user-only on disk.
               if (Date.now() - lastIncrementalPersistAt > INCREMENTAL_PERSIST_MS) {
@@ -5510,7 +5528,7 @@ async function handleOrchestratorSendMsgOnce(
             break;
 
           // ── Collide (MoA) — proposer pre-roll. Forwarded to the faint card; NEVER
-          //    accumulated into assistantTextAccum so only the aggregator's reply is
+          //    accumulated into the assistant text buffer so only the aggregator's reply is
           //    the persisted, visible answer.
           case 'collide_phase':
             wsMsg = JSON.stringify({
@@ -5580,6 +5598,42 @@ async function handleOrchestratorSendMsgOnce(
               channel: 'orchestrator',
               event: 'collide-proposal',
               data: { proposer: event.proposer, text: event.text, breach: event.breach ?? false, repoPath, threadId, backend: turnBackend.id, agent: turnAgentTag },
+            });
+            break;
+
+          // #2142 — attempt boundary. The rejected attempt already streamed its
+          //    narration into this bubble and (past the 1.5s incremental persist)
+          //    onto disk. Drop both before the retry's first token, otherwise the
+          //    two turns concatenate into one reply with no separator.
+          case 'turn_retry':
+            assistantText.discard();
+            if (isThreadBacked && assistantMessageId) {
+              try {
+                const trimmedThread = truncateMobileOrchestratorThreadFromMessage({
+                  tabId: threadId,
+                  messageId: assistantMessageId,
+                });
+                if (trimmedThread) {
+                  broadcast({ channel: 'orchestrator-threads', event: 'upsert', data: { thread: trimmedThread } });
+                }
+              } catch (trimErr) {
+                console.warn('[ws-server][orchestrator] failed to drop discarded attempt text', trimErr);
+              }
+            }
+            wsMsg = JSON.stringify({
+              channel: 'orchestrator',
+              event: 'retry',
+              data: {
+                repoPath,
+                threadId,
+                assistantMessageId,
+                attempt: event.attempt,
+                reason: event.reason,
+                notice: event.notice,
+                backend: turnBackend.id,
+                model: effectiveTurnModel,
+                agent: turnAgentTag,
+              },
             });
             break;
 


### PR DESCRIPTION
Closes #2142.

## What changed

`settleOrchestratorTurn` already held both facts it needed — the number of `cortex_launch_agent` calls in the turn, and the assistant text claiming a dispatch. It warned to `ws-server.log` and then emitted `done` anyway. A turn that launched nothing reported success, so the thread showed a confident mission plan and anything waiting on lanes waited forever.

Now:

1. **A false-dispatch turn does not emit `done`.** `settleOrchestratorTurn` takes a `completedResult` flag (default `false`) and withholds the terminal `done`, threading the outcome through the turn's `resolve`. Only the stream-`result` settle passes `true`, so timeout, user abort, stdin-write failure, plan-mode LOCKOUT, crash-tail end, proc-close and the dead-rehydrated-turn path are excluded by construction. A turn with `launchAgentCallCount >= 1` is untouched.
2. **One bounded, non-recursive retry.** `runTurnWithFalseDispatchRetry` runs at most two attempts and never calls itself.
3. **Thread-visible failure.** If the retry also false-dispatches, the turn emits an `error` naming what happened ("reported launching agents but made no `cortex_launch_agent` call… no lane, no worktree, no worker was created, and any mission id named above is registered but empty") followed by the withheld `done`, mirroring the watchdog path so the client's "Working M:SS" latch releases instead of counting to the 4-hour reaper. The retry itself is also announced in the thread via a notice, so a turn that silently succeeds on attempt 2 is not invisible.

New modules: `src/lib/lane/orchestrator-false-dispatch.ts` (detection + retry driver, pure) and `src/lib/ws-server/orchestrator-assistant-text.ts` (the per-attempt text buffer).

## How the discarded attempt is isolated

This is the defect that killed the previous attempt, so it is the part worth reading.

`settleOrchestratorTurn` gates only the terminal events. `text` / `thinking` / `tool_use` have **already streamed live** by the time the detector can fire, and `ws-server` declared `assistantMessageId` / `assistantTextAccum` once per WS message, outside the turn call, appending every token to one buffer with no attempt boundary. Buffering attempt 1 and flushing only the winner would have meant buffering every turn — the detector's verdict only exists at settle — which kills live streaming for all traffic. So this takes the other option: **reset the accumulator and emit an attempt boundary.**

A new `turn_retry` event is emitted *before* attempt 2 writes to stdin, and three consumers act on it:

- **ws-server (in memory):** `assistantTextAccum` and its last-persisted twin are replaced by `createAssistantTextBuffer()`, whose `discard()` clears both. Clearing the persisted marker matters — otherwise a retry whose text happened to match would be short-circuited as "unchanged" and the stale row would stand.
- **ws-server (on disk):** the incremental persist fires every 1.5s, so the discarded attempt is usually already written. `truncateMobileOrchestratorThreadFromMessage` removes that row; attempt 2 re-creates it at the same id. The updated thread is broadcast so any surface reading from persisted history reconciles.
- **desktop client (live bubble):** `socket.ts` handles a `retry` by emptying `currentAssistantRef`'s chunks and blanking the transcript entry's text, so the retry's tokens land in a bubble containing only the retry.

Same boundary is handled on the crash-rehydrate replay path for consistency.

## What the retry retries, and why

Not a resend of the operator's message, and not a fresh session. A resend into the same warm session leaves the model's own false claim in its own context with no corrective signal — the likely outcome is that it repeats itself and the retry costs a turn for nothing. A fresh session throws away the repo exploration and packet plan the turn just built, so it has to redo all of it and may produce a different plan than the one the operator just read.

The retry is an **explicit correction on the same warm session**: it names the contradiction, states that registering a mission launches nothing and that no background dispatcher exists, and asks for the call — with an escape hatch to report a blocker instead of inventing a dispatch. This is the option with direct evidence behind it: the issue thread reports that "told explicitly to call `cortex_launch_agent`, the model does call it." Attachments ride attempt 1 only, so images are not doubled into the session context.

## Decisions

**Dispatch-claim regex — narrowed, deliberately.** Old: `dispatched|launched|fired|launching|polling|kicked off`, matched anywhere in the turn text. Bare `fired` ("the watchdog fired") and `polling` ("I'll keep polling the mission") claim nothing about a dispatch and were pure false-positive surface; both are dropped, `fired off` is kept, and `dispatching` / `spun up` are added to recover coverage of phrasings in the reported traces. Net: strictly fewer healthy turns match, the same failing ones still do. "I fired off agent X" with zero launch calls is still caught.

**Negation guard — mandatory, not cosmetic.** The documented false positive ("Nothing dispatched. The three demo-site packets from the previous turn are still out there untouched by this turn.") was only a stray `console.warn` before. Under this change it would fail a healthy turn *and* feed the model a correction telling it to launch agents it deliberately did not launch — a false positive that causes an unwanted dispatch. The match is now sentence-scoped: a sentence must contain a dispatch verb and must not be negated or hypothetical. Scoped per sentence so a negation elsewhere in a long reply cannot mask a real claim, and vice versa.

## What I left out

**`narrate-and-exit` stays a warn.** Its condition is `sawToolUseAfterText || !hasSummaryMarker` — true for any turn that ends without a `VERDICT` / "Dispatched N agent" marker, which is nearly every healthy conversational reply. Acting on it would fail turns wholesale. False dispatch is the opposite shape: a specific contradiction between what the turn *did* and what it *said*. Only that one is promoted.

**The root cause is not addressed here.** Per #2153, Multitask mode is only a sentence prefixed to the user's message — it never names the launch tool and nothing forces the call. This is the backstop, not the cure.

**The reaper hypothesis is not addressed** — retracted in the thread, `MAX_LIVE` appears zero times in the traces.

## Verify

- `npx tsc --noEmit` — clean.
- `npx eslint` on all six changed/added source files — clean.
- `npm test` — **705 test files passed, 3 skipped; 4554 tests passed, 4 skipped.**
- The three touched/added test files were confirmed to run under `config/vitest/vitest.unit.config.ts` with `--reporter=verbose` (68 tests, all named in the output) — a file under the wrong config is silently skipped.

Tests assert on **text event count, content, and ordering relative to the boundary**, not only on `done`/`error` counts, because that is exactly how the previous attempt's suite stayed green while the double-narration bug was present:

- `orchestrator-false-dispatch.test.ts` — every `text` event before the boundary belongs to attempt 1 and every one after belongs to attempt 2; the discarded attempt's `done` is dropped rather than replayed; both-attempts-fail emits one narration per side plus `error` then `done`, with `runAttempt` called exactly twice.
- `orchestrator-assistant-text.test.ts` — drives the buffer with an event stream; a retried turn's value is the retry's text alone and does not contain the discarded attempt's.
- `socket.test.ts` — a `retry` clears the live bubble, and the next token lands in a bubble holding only the retry.
- Detector tests use the verbatim strings from the issue traces, including the false positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dVxFgHWcYwiMja5oBxySH
