### PR TITLE
Expose the webview socket's window and app commands to the TypeScript client

### DIFF
--- a/src/lib/mcp/o8-webview-client.test.ts
+++ b/src/lib/mcp/o8-webview-client.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import {
+  afterAll, beforeAll, beforeEach, describe, expect, it, vi, type MockInstance,
+} from 'vitest';
 
+import { O8WebviewClient } from './o8-webview-client';
 import { resolveO8WebviewSocketPath } from './o8-webview-socket';
 
 describe('resolveO8WebviewSocketPath', () => {
@@ -19,5 +22,168 @@ describe('resolveO8WebviewSocketPath', () => {
   it('retains the installed-app default without a data-dir override', () => {
     expect(resolveO8WebviewSocketPath({}, 'operator'))
       .toBe('/tmp/tauri-mcp-o8-operator.sock');
+  });
+});
+
+/**
+ * The window/app commands the client gained for #2151. These exercise the real
+ * sendCommand path (so the retry classification is under test too) and stub
+ * only the single-shot socket write.
+ */
+describe('O8WebviewClient window and app commands', () => {
+  type ClientInternals = {
+    sendCommandOnce(command: string, payload: Record<string, unknown>): Promise<unknown>;
+  };
+
+  let client: O8WebviewClient;
+  let sendOnce: MockInstance<ClientInternals['sendCommandOnce']>;
+  let previousSocketEnv: string | undefined;
+
+  beforeAll(() => {
+    previousSocketEnv = process.env.O8_TAURI_MCP_SOCKET;
+    process.env.O8_TAURI_MCP_SOCKET = '/tmp/o8-webview-client-test.sock';
+    client = new O8WebviewClient();
+    sendOnce = vi.spyOn(client as unknown as ClientInternals, 'sendCommandOnce');
+  });
+
+  afterAll(() => {
+    sendOnce.mockRestore();
+    if (previousSocketEnv === undefined) delete process.env.O8_TAURI_MCP_SOCKET;
+    else process.env.O8_TAURI_MCP_SOCKET = previousSocketEnv;
+  });
+
+  beforeEach(() => {
+    sendOnce.mockReset();
+  });
+
+  function epipe(): Error {
+    const error = new Error('write EPIPE') as Error & { code?: string };
+    error.code = 'EPIPE';
+    return error;
+  }
+
+  it('lists windows with their visible/focused state', async () => {
+    sendOnce.mockResolvedValue({
+      windows: [
+        { label: 'main', visible: true, focused: false },
+        { label: 'agent-partials', visible: true, focused: true },
+      ],
+    });
+
+    const result = await client.listWindows();
+
+    expect(sendOnce).toHaveBeenCalledWith('list_windows', {});
+    // The observed failure this exists for: an overlay holds focus, main does not.
+    expect(result.windows.find((window) => window.focused)?.label).toBe('agent-partials');
+  });
+
+  it('returns an empty window list rather than throwing on a malformed response', async () => {
+    sendOnce.mockResolvedValue(null);
+    await expect(client.listWindows()).resolves.toEqual({ windows: [] });
+  });
+
+  it('unwraps a doubly-nested data envelope', async () => {
+    sendOnce.mockResolvedValue({ data: { windows: [{ label: 'dock' }] } });
+    const result = await client.listWindows();
+    expect(result.windows).toEqual([{ label: 'dock' }]);
+  });
+
+  it('reads app info including monitors', async () => {
+    sendOnce.mockResolvedValue({
+      app: { name: 'o8', version: '0.1.0' },
+      monitors: [{ name: 'Built-in', scaleFactor: 2 }],
+    });
+
+    const info = await client.getAppInfo();
+
+    expect(sendOnce).toHaveBeenCalledWith('get_app_info', {});
+    expect(info.monitors?.[0]?.scaleFactor).toBe(2);
+  });
+
+  it('sends manage_window with `operation`, not `action`', async () => {
+    sendOnce.mockResolvedValue({ success: true });
+
+    await client.manageWindow({ operation: 'focus', windowLabel: 'main' });
+
+    const [command, payload] = sendOnce.mock.calls[0];
+    expect(command).toBe('manage_window');
+    expect(payload).toEqual({ window_label: 'main', operation: 'focus' });
+    expect(payload).not.toHaveProperty('action');
+  });
+
+  it('defaults manage_window to the main window and omits unset geometry', async () => {
+    sendOnce.mockResolvedValue({ success: true });
+    await client.manageWindow({ operation: 'center' });
+    expect(sendOnce).toHaveBeenCalledWith('manage_window', { window_label: 'main', operation: 'center' });
+  });
+
+  it('passes geometry through for setPosition', async () => {
+    sendOnce.mockResolvedValue({ success: true });
+    await client.manageWindow({ operation: 'setPosition', windowLabel: 'dock', x: 10, y: 20 });
+    expect(sendOnce).toHaveBeenCalledWith('manage_window', {
+      window_label: 'dock', operation: 'setPosition', x: 10, y: 20,
+    });
+  });
+
+  it('sends navigate_webview with `action`, not `operation`', async () => {
+    sendOnce.mockResolvedValue({ action: 'reload' });
+
+    await client.navigateWebview({ action: 'reload' });
+
+    const [command, payload] = sendOnce.mock.calls[0];
+    expect(command).toBe('navigate_webview');
+    expect(payload).toEqual({ window_label: 'main', action: 'reload' });
+    expect(payload).not.toHaveProperty('operation');
+  });
+
+  it('keeps navigate() on the SPA bridge rather than a real navigation', async () => {
+    // Regression guard for issue #863: routing o8's own page moves through
+    // navigate_webview triggers a full document load and freezes the route.
+    sendOnce.mockResolvedValue({ result: '/dashboard' });
+
+    await client.navigate('/dashboard');
+
+    const [command, payload] = sendOnce.mock.calls[0];
+    expect(command).toBe('execute_js');
+    expect(String(payload.code)).toContain('__o8Navigate__');
+  });
+
+  it('sends restart_app with the camelCase delay the plugin expects', async () => {
+    sendOnce.mockResolvedValue({ message: 'Restarting application in 250ms' });
+    await client.restartApp({ delayMs: 250 });
+    expect(sendOnce).toHaveBeenCalledWith('restart_app', { delayMs: 250 });
+  });
+
+  it('maps manageEvents options onto the snake_case payload', async () => {
+    sendOnce.mockResolvedValue({ emitted: 'o8:test' });
+    await client.manageEvents({ action: 'emit', event: 'o8:test', payload: { a: 1 }, durationMs: 500 });
+    expect(sendOnce).toHaveBeenCalledWith('manage_events', {
+      action: 'emit', event: 'o8:test', payload: { a: 1 }, duration_ms: 500,
+    });
+  });
+
+  it('retries list_windows after a dropped socket', async () => {
+    sendOnce.mockRejectedValueOnce(epipe()).mockResolvedValueOnce({ windows: [{ label: 'main' }] });
+
+    await expect(client.listWindows()).resolves.toEqual({ windows: [{ label: 'main' }] });
+    expect(sendOnce).toHaveBeenCalledTimes(2);
+  });
+
+  it('refuses to retry manage_window after a dropped socket', async () => {
+    // Retrying would run the window operation a second time.
+    sendOnce.mockRejectedValue(epipe());
+
+    await expect(client.manageWindow({ operation: 'hide', windowLabel: 'dock' }))
+      .rejects.toThrow(/may have already executed/);
+    expect(sendOnce).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses to retry navigate_webview or restart_app after a dropped socket', async () => {
+    sendOnce.mockRejectedValue(epipe());
+
+    await expect(client.navigateWebview({ action: 'navigate', url: 'https://example.test' }))
+      .rejects.toThrow(/may have already executed/);
+    await expect(client.restartApp()).rejects.toThrow(/may have already executed/);
+    expect(sendOnce).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/mcp/o8-webview-client.ts
+++ b/src/lib/mcp/o8-webview-client.ts
@@ -7,22 +7,13 @@ import {
   createCodedError, getErrorCode, isMutationAckTimeout, queueCommandWrite,
   type PendingRequest,
 } from '@/lib/mcp/o8-webview-command-transport';
+// Retry-safety is classified once, next to the command's documentation, in the
+// socket command catalog. See o8-webview-commands.ts for the full surface.
+import { RECONNECT_RETRY_SAFE_COMMANDS } from '@/lib/mcp/o8-webview-commands';
 
 const DEFAULT_WINDOW_LABEL = 'main';
 const REQUEST_TIMEOUT_MS = 30_000;
 
-/**
- * Commands safe to re-fire after a reconnect: pure reads with no side
- * effects. Mutating commands (type_into_focused, execute_js — which carries
- * clicks — scroll_page) must NOT auto-retry: when the socket drops after the
- * write, the action usually already fired on the Rust side, so re-running
- * types text twice or double-fires a click.
- */
-const RECONNECT_RETRY_SAFE_COMMANDS = new Set([
-  'get_page_map',
-  'get_element_position',
-  'take_screenshot',
-]);
 const UNAVAILABLE_MESSAGE = 'o8 webview tools unavailable — launch o8 with --features dev-mcp-plugin or use the signed build';
 const JPEG_MIME_TYPE = 'image/jpeg';
 
@@ -62,6 +53,56 @@ interface PageMapResult {
   elements?: PageMapElement[];
   content?: string;
 }
+
+export interface O8WindowInfo {
+  label: string;
+  title?: string;
+  url?: string;
+  visible?: boolean;
+  focused?: boolean;
+  maximized?: boolean;
+  fullscreen?: boolean;
+  scaleFactor?: number;
+  outerSize?: { width: number; height: number };
+  innerSize?: { width: number; height: number };
+  position?: { x: number; y: number };
+  monitor?: { name?: string | null } | null;
+}
+
+export interface O8MonitorInfo {
+  name?: string | null;
+  size?: { width: number; height: number };
+  position?: { x: number; y: number };
+  scaleFactor?: number;
+}
+
+export interface O8AppInfo {
+  app?: { name?: string; version?: string };
+  os?: { os?: string; arch?: string; family?: string };
+  windows?: O8WindowInfo[];
+  monitors?: O8MonitorInfo[];
+  primaryMonitor?: O8MonitorInfo | null;
+}
+
+/** Values accepted by `manage_window`'s `operation` field. */
+export type O8WindowOperation =
+  | 'show'
+  | 'hide'
+  | 'focus'
+  | 'center'
+  | 'minimize'
+  | 'maximize'
+  | 'unmaximize'
+  | 'close'
+  | 'setPosition'
+  | 'setSize'
+  | 'toggleFullscreen';
+
+/** Values accepted by `navigate_webview`'s `action` field. */
+export type O8NavigateWebviewAction = 'navigate' | 'reload' | 'back' | 'forward' | 'get_url';
+
+/** Values accepted by `manage_events`' `action` field. */
+export type O8EventsAction = 'emit' | 'emit_to' | 'listen' | 'sniff';
 
 function extractDataUrlPayload(value: unknown): { base64: string; mimeType: string } {
   const candidate = resolveImageDataCandidate(value);
@@ -193,6 +234,23 @@ function getJpegDimensions(bytes: Buffer): { width: number; height: number } {
   }
 
   throw new Error('Failed to parse screenshot dimensions from JPEG response');
+}
+
+/**
+ * The plugin sometimes wraps a command result in a second `data` envelope.
+ * Peel one level so callers see the handler's own JSON either way.
+ */
+function unwrapCommandData(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+
+  const record = value as Record<string, unknown>;
+  if (record.data && typeof record.data === 'object' && !Array.isArray(record.data)) {
+    return record.data as Record<string, unknown>;
+  }
+
+  return record;
 }
 
 function coercePageMap(value: unknown): PageMapResult {
@@ -632,6 +690,11 @@ export class O8WebviewClient {
     //
     // The pushState + popstate path is kept as a fallback for the few
     // moments before NavigationBridge mounts after a cold launch.
+    //
+    // `navigateWebview()` exposes the real `navigate_webview` command for the
+    // cases this cannot serve — hard reload, a URL outside the app's routes,
+    // an overlay window. Routing o8's own page-to-page moves through it is
+    // the regression this method exists to avoid.
     await this.evalJs(`(() => {
       const next = new URL(${JSON.stringify(path)}, window.location.origin);
       const route = \`\${next.pathname}\${next.search}\${next.hash}\`;
@@ -648,6 +711,106 @@ export class O8WebviewClient {
       return route;
     })()`);
     return { ok: true };
+  }
+
+  /**
+   * Every window the app owns, with `visible` / `focused` / position / size.
+   *
+   * This is the only way to see o8's overlay windows (`dock`, `spatial-ink`,
+   * `agent-partials`). They are separate always-on-top, transparent,
+   * click-through windows, so nothing in the main window's document reports
+   * whether they are on screen. It is also how you catch an overlay holding
+   * focus while `main` does not: keystrokes disappear into a click-through
+   * window and the DOM shows nothing that explains it. `manageWindow({
+   * operation: 'focus' })` is the fix once you can see it.
+   */
+  async listWindows(): Promise<{ windows: O8WindowInfo[] }> {
+    const data = unwrapCommandData(await this.sendCommand('list_windows', {}));
+    return { windows: Array.isArray(data.windows) ? data.windows as O8WindowInfo[] : [] };
+  }
+
+  /** Package name/version, OS, every window, and monitors with scale factors. */
+  async getAppInfo(): Promise<O8AppInfo> {
+    return unwrapCommandData(await this.sendCommand('get_app_info', {})) as O8AppInfo;
+  }
+
+  /**
+   * Show / hide / focus / center / minimize a window by label.
+   *
+   * The wire field is `operation`, not `action` — `navigate_webview` and the
+   * `manage_*` commands take `action`, this one does not. Encoded here so
+   * callers never have to discover it through `missing field 'operation'`.
+   */
+  async manageWindow(opts: {
+    operation: O8WindowOperation;
+    windowLabel?: string;
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+  }): Promise<{ ok: boolean }> {
+    await this.sendCommand('manage_window', {
+      window_label: opts.windowLabel ?? DEFAULT_WINDOW_LABEL,
+      operation: opts.operation,
+      ...(typeof opts.x === 'number' ? { x: opts.x } : {}),
+      ...(typeof opts.y === 'number' ? { y: opts.y } : {}),
+      ...(typeof opts.width === 'number' ? { width: opts.width } : {}),
+      ...(typeof opts.height === 'number' ? { height: opts.height } : {}),
+    });
+    return { ok: true };
+  }
+
+  /**
+   * Real webview navigation through the Rust `navigate_webview` command.
+   *
+   * Deliberately separate from `navigate(path)`, which stays the in-app SPA
+   * route transition (see the comment there and issue #863). `navigate`
+   * here performs a genuine document load, so use it for a hard reload, a URL
+   * outside the app's own routes, or an overlay window — not for moving
+   * between o8's own pages, which this would freeze mid-route.
+   */
+  async navigateWebview(opts: {
+    action: O8NavigateWebviewAction;
+    url?: string;
+    windowLabel?: string;
+  }): Promise<{ action?: string; url?: string }> {
+    const data = unwrapCommandData(await this.sendCommand('navigate_webview', {
+      window_label: opts.windowLabel ?? DEFAULT_WINDOW_LABEL,
+      action: opts.action,
+      ...(typeof opts.url === 'string' ? { url: opts.url } : {}),
+    }));
+    return data as { action?: string; url?: string };
+  }
+
+  /** Emit, target, listen on or sniff the internal Tauri event bus. */
+  async manageEvents(opts: {
+    action: O8EventsAction;
+    event?: string;
+    target?: string;
+    payload?: unknown;
+    durationMs?: number;
+  }): Promise<Record<string, unknown>> {
+    return unwrapCommandData(await this.sendCommand('manage_events', {
+      action: opts.action,
+      ...(typeof opts.event === 'string' ? { event: opts.event } : {}),
+      ...(typeof opts.target === 'string' ? { target: opts.target } : {}),
+      ...(opts.payload !== undefined ? { payload: opts.payload } : {}),
+      ...(typeof opts.durationMs === 'number' ? { duration_ms: opts.durationMs } : {}),
+    }));
+  }
+
+  /**
+   * Restart the app. The Rust side clamps the delay to 100–5000ms.
+   *
+   * `restart_app` is the one command whose payload is camelCase (`delayMs`);
+   * every other command takes snake_case fields. Sending `delay_ms` here is
+   * silently ignored and you get the 500ms default.
+   */
+  async restartApp(opts: { delayMs?: number } = {}): Promise<{ ok: boolean; message?: string }> {
+    const data = unwrapCommandData(await this.sendCommand('restart_app', {
+      ...(typeof opts.delayMs === 'number' ? { delayMs: opts.delayMs } : {}),
+    }));
+    return { ok: true, message: typeof data.message === 'string' ? data.message : undefined };
   }
 
   dispose(): void {

--- a/src/lib/mcp/o8-webview-commands.test.ts
+++ b/src/lib/mcp/o8-webview-commands.test.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  O8_WEBVIEW_SOCKET_COMMANDS,
+  RECONNECT_RETRY_SAFE_COMMANDS,
+} from './o8-webview-commands';
+
+// Resolved from this file, not the working directory, so the drift guard holds
+// wherever the runner is launched from.
+const PLUGIN_SHARED_MOD = fileURLToPath(new URL('../../../tauri-plugin-mcp/src/shared/mod.rs', import.meta.url));
+const PLUGIN_DISPATCHER = fileURLToPath(new URL('../../../tauri-plugin-mcp/src/tools/mod.rs', import.meta.url));
+
+/** Every `pub const NAME: &str = "value";` inside the plugin's `commands` module. */
+function readPluginCommandConstants(): string[] {
+  const source = readFileSync(PLUGIN_SHARED_MOD, 'utf8');
+  const moduleStart = source.indexOf('pub mod commands {');
+  expect(moduleStart, 'plugin no longer declares a `commands` module').toBeGreaterThan(-1);
+
+  const body = source.slice(moduleStart);
+  return [...body.matchAll(/pub const [A-Z_]+: &str = "([a-z_]+)";/g)].map((match) => match[1]);
+}
+
+describe('o8 webview socket command catalog', () => {
+  it('lists exactly the commands the plugin declares', () => {
+    const declared = readPluginCommandConstants();
+    expect(declared.length).toBeGreaterThan(0);
+    expect([...O8_WEBVIEW_SOCKET_COMMANDS].map((entry) => entry.command).sort())
+      .toEqual([...declared].sort());
+  });
+
+  it('lists exactly the commands the dispatcher routes', () => {
+    // handle_command matches on `commands::NAME`; a constant that exists but is
+    // never routed would be documented here as reachable when it is not.
+    const dispatcher = readFileSync(PLUGIN_DISPATCHER, 'utf8');
+    const routed = new Set(
+      [...dispatcher.matchAll(/commands::([A-Z_]+) =>/g)].map((match) => match[1]),
+    );
+    const shared = readFileSync(PLUGIN_SHARED_MOD, 'utf8');
+    const constantNames = new Map(
+      [...shared.matchAll(/pub const ([A-Z_]+): &str = "([a-z_]+)";/g)]
+        .map((match) => [match[1], match[2]] as const),
+    );
+
+    const routedWireNames = [...routed].map((name) => constantNames.get(name)).sort();
+    expect([...O8_WEBVIEW_SOCKET_COMMANDS].map((entry) => entry.command).sort())
+      .toEqual(routedWireNames);
+  });
+
+  it('has no duplicate entries', () => {
+    const names = O8_WEBVIEW_SOCKET_COMMANDS.map((entry) => entry.command);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('gives every command a summary', () => {
+    for (const entry of O8_WEBVIEW_SOCKET_COMMANDS) {
+      expect(entry.summary.length, `${entry.command} has no summary`).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('reconnect retry safety', () => {
+  it('keeps the commands that were already retry-safe', () => {
+    // Behavioral lock: these three were the hand-maintained set before the
+    // catalog derived it. Reclassifying one is a real change, not a refactor.
+    for (const command of ['get_page_map', 'get_element_position', 'take_screenshot']) {
+      expect(RECONNECT_RETRY_SAFE_COMMANDS.has(command), command).toBe(true);
+    }
+  });
+
+  it('treats the new read-only commands as retry-safe', () => {
+    expect(RECONNECT_RETRY_SAFE_COMMANDS.has('list_windows')).toBe(true);
+    expect(RECONNECT_RETRY_SAFE_COMMANDS.has('get_app_info')).toBe(true);
+  });
+
+  it('never retries a command that mutates app or window state', () => {
+    // A retried window operation runs twice. Name the mutators explicitly so a
+    // future `mutating: false` typo on one of them fails here.
+    const mustNotRetry = [
+      'manage_window',
+      'navigate_webview',
+      'manage_events',
+      'restart_app',
+      'execute_js',
+      'type_into_focused',
+      'scroll_page',
+      'simulate_text_input',
+      'simulate_mouse_movement',
+      'send_text_to_element',
+      'fill_form',
+      'navigate_back',
+      'manage_local_storage',
+      'manage_cookies',
+      'manage_devtools',
+      'manage_zoom',
+      'manage_webview_state',
+    ];
+    for (const command of mustNotRetry) {
+      expect(RECONNECT_RETRY_SAFE_COMMANDS.has(command), `${command} must not auto-retry`).toBe(false);
+    }
+  });
+
+  it('derives the set from the catalog rather than a second list', () => {
+    const expected = O8_WEBVIEW_SOCKET_COMMANDS
+      .filter((entry) => !entry.mutating)
+      .map((entry) => entry.command)
+      .sort();
+    expect([...RECONNECT_RETRY_SAFE_COMMANDS].sort()).toEqual(expected);
+  });
+});

--- a/src/lib/mcp/o8-webview-commands.ts
+++ b/src/lib/mcp/o8-webview-commands.ts
@@ -1,0 +1,77 @@
+/**
+ * The o8 webview socket command surface — one list, matching what the Rust
+ * plugin actually dispatches.
+ *
+ * Rust source of truth: the `commands` module in
+ * `tauri-plugin-mcp/src/shared/mod.rs` (constants), routed by `handle_command`
+ * in `tauri-plugin-mcp/src/tools/mod.rs`. `o8-webview-commands.test.ts` parses
+ * those constants and fails when this catalog drifts from them, so the list
+ * cannot quietly go stale.
+ *
+ * Protocol notes that are easy to get wrong when driving the socket by hand:
+ *
+ * - `id` must be a STRING. An integer is rejected by the request deserializer
+ *   with `Invalid request format: invalid type: integer 1, expected a string`,
+ *   which reads like a protocol fault rather than a type error.
+ *   `O8WebviewClient` always sends a string id.
+ * - The verb field is NOT uniform. `manage_window` takes `operation`, while
+ *   `navigate_webview`, `manage_events`, `manage_cookies`, `manage_zoom`,
+ *   `manage_local_storage` and `manage_webview_state` take `action`. The typed
+ *   client methods encode the right one per command so callers never guess.
+ * - `window_label` defaults to `main` on the Rust side. o8 also runs the
+ *   `dock`, `spatial-ink` and `agent-partials` overlay windows, which are only
+ *   addressable by passing their label explicitly.
+ * - Payload fields are snake_case for every command except `restart_app`,
+ *   whose struct is `#[serde(rename_all = "camelCase")]` — it wants `delayMs`.
+ *   `delay_ms` is silently ignored there and you get the 500ms default.
+ */
+
+export interface O8WebviewSocketCommand {
+  /** Wire name, exactly as `handle_command` matches it. */
+  readonly command: string;
+  /**
+   * True when the command changes app state. Mutating commands are NEVER
+   * auto-retried after a dropped socket: the Rust side has usually already run
+   * the action by the time the write fails, so a retry fires it twice.
+   */
+  readonly mutating: boolean;
+  readonly summary: string;
+}
+
+export const O8_WEBVIEW_SOCKET_COMMANDS: readonly O8WebviewSocketCommand[] = [
+  { command: 'ping', mutating: false, summary: 'Liveness probe.' },
+  { command: 'take_screenshot', mutating: false, summary: 'Capture a window as base64 PNG/JPEG; works while the JS thread is busy.' },
+  { command: 'get_dom', mutating: false, summary: 'Serialized DOM of a window.' },
+  { command: 'manage_local_storage', mutating: true, summary: 'action: get / set / remove / clear on localStorage.' },
+  { command: 'execute_js', mutating: true, summary: 'Evaluate code in a webview. Reads are common but the code can click and type, so it is never retry-safe.' },
+  { command: 'manage_window', mutating: true, summary: 'operation: show / hide / focus / center / minimize / maximize / unmaximize / close / setPosition / setSize / toggleFullscreen.' },
+  { command: 'simulate_text_input', mutating: true, summary: 'Native keystroke injection into a window.' },
+  { command: 'simulate_mouse_movement', mutating: true, summary: 'Native pointer move / click / drag.' },
+  { command: 'get_element_position', mutating: false, summary: 'Locate an element and return its viewport coordinates. Retry-safe only while `should_click` stays false, which is all this client ever sends.' },
+  { command: 'send_text_to_element', mutating: true, summary: 'Focus an element and type into it.' },
+  { command: 'get_page_map', mutating: false, summary: 'Numbered accessibility tree of a window.' },
+  { command: 'get_page_state', mutating: false, summary: 'URL, title, readyState and viewport of a window.' },
+  { command: 'navigate_back', mutating: true, summary: 'History back in a webview.' },
+  { command: 'scroll_page', mutating: true, summary: 'Scroll by direction/amount or to a ref, top or bottom.' },
+  { command: 'fill_form', mutating: true, summary: 'Set several form fields in one call.' },
+  { command: 'wait_for', mutating: false, summary: 'Block until a selector resolves in a webview.' },
+  { command: 'get_app_info', mutating: false, summary: 'Package name/version, OS, every window, and monitors with scale factors.' },
+  { command: 'list_windows', mutating: false, summary: 'Every window with visible / focused / position / size — the app’s own truth about what is on screen.' },
+  { command: 'navigate_webview', mutating: true, summary: 'action: navigate / reload / back / forward / get_url. A real webview navigation, not a history push.' },
+  { command: 'manage_events', mutating: true, summary: 'action: emit / emit_to / listen on the internal Tauri event bus.' },
+  { command: 'manage_cookies', mutating: true, summary: 'action: list / get / set / delete cookies.' },
+  { command: 'manage_devtools', mutating: true, summary: 'Open or close devtools. Requires the plugin’s `devtools` feature.' },
+  { command: 'manage_zoom', mutating: true, summary: 'Get or set a webview’s zoom factor.' },
+  { command: 'manage_webview_state', mutating: true, summary: 'Read or restore webview state (scroll, focus, storage).' },
+  { command: 'type_into_focused', mutating: true, summary: 'Type into whatever element currently holds focus.' },
+  { command: 'restart_app', mutating: true, summary: 'Restart the whole app after a clamped 100–5000ms delay.' },
+];
+
+/**
+ * Commands safe to re-fire after a reconnect: pure reads with no side effects.
+ * Derived from the catalog so a new command is classified once, where it is
+ * documented, instead of in a second hand-maintained list that can disagree.
+ */
+export const RECONNECT_RETRY_SAFE_COMMANDS: ReadonlySet<string> = new Set(
+  O8_WEBVIEW_SOCKET_COMMANDS.filter((entry) => !entry.mutating).map((entry) => entry.command),
+);

--- a/src/lib/mcp/o8-webview-tools.test.ts
+++ b/src/lib/mcp/o8-webview-tools.test.ts
@@ -125,3 +125,60 @@ describe('o8 active composer typing', () => {
     expect(result.content[0]).toMatchObject({ type: 'text', text: expect.stringContaining('No visible active composer.') });
   });
 });
+
+describe('o8 window tools', () => {
+  it('registers both window tools with handlers', () => {
+    for (const name of ['o8_view_windows', 'o8_view_manage_window']) {
+      expect(O8_WEBVIEW_TOOLS.some((tool) => tool.name === name), name).toBe(true);
+      expect(createO8WebviewToolHandlers(() => {
+        throw new Error('not used');
+      })[name], name).toBeTypeOf('function');
+    }
+  });
+
+  it('reports which window holds focus', async () => {
+    const client = {
+      listWindows: async () => ({
+        windows: [
+          { label: 'main', visible: true, focused: false },
+          { label: 'agent-partials', visible: true, focused: true },
+        ],
+      }),
+    } as unknown as O8WebviewClient;
+
+    const result = await createO8WebviewToolHandlers(() => client).o8_view_windows({});
+
+    expect(result.isError).not.toBe(true);
+    expect(result.content[0]).toMatchObject({ text: expect.stringContaining('agent-partials') });
+  });
+
+  it('focuses a window by label', async () => {
+    const calls: Array<{ operation: string; windowLabel?: string }> = [];
+    const client = {
+      manageWindow: async (opts: { operation: string; windowLabel?: string }) => {
+        calls.push(opts);
+        return { ok: true };
+      },
+    } as unknown as O8WebviewClient;
+
+    const result = await createO8WebviewToolHandlers(() => client)
+      .o8_view_manage_window({ operation: 'focus', windowLabel: 'main' });
+
+    expect(result.isError).not.toBe(true);
+    expect(calls).toEqual([{ operation: 'focus', windowLabel: 'main' }]);
+  });
+
+  it('refuses operations the agent surface does not offer', async () => {
+    const client = {
+      manageWindow: async () => {
+        throw new Error('must not reach the client');
+      },
+    } as unknown as O8WebviewClient;
+
+    const result = await createO8WebviewToolHandlers(() => client)
+      .o8_view_manage_window({ operation: 'close' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]).toMatchObject({ text: expect.stringContaining('Unsupported window operation') });
+  });
+});

--- a/src/lib/mcp/o8-webview-tools.ts
+++ b/src/lib/mcp/o8-webview-tools.ts
@@ -9,7 +9,7 @@ import {
   createO8WebviewCompositeHandlers,
   O8_WEBVIEW_COMPOSITE_TOOLS,
 } from '@/lib/mcp/o8-webview-composites';
-import { O8WebviewClient } from '@/lib/mcp/o8-webview-client';
+import { O8WebviewClient, type O8WindowOperation } from '@/lib/mcp/o8-webview-client';
 import { buildPrepareComposerTargetScript } from '@/lib/mcp/o8-webview-composer-target';
 import { O8_WEBVIEW_ASYNC_EVAL_GUARD } from '@/lib/mcp/o8-webview-async-eval-guard';
 
@@ -315,6 +315,15 @@ function imageResult(base64: string, mimeType: string, meta: Record<string, unkn
  *  the base64 (the canvas, whose orchestrator stream truncates tool output) can
  *  still SHOW it via /api/panel/serve-image. Returns the path, or null if the
  *  write fails — the base64 in the result is always the source of truth. */
+/**
+ * Window operations an agent may drive. The client supports more (`close`,
+ * `setPosition`, `setSize`); those stay out of the tool surface on purpose.
+ * Keep in sync with the `operation` enum on `o8_view_manage_window`.
+ */
+const AGENT_WINDOW_OPERATIONS: readonly O8WindowOperation[] = [
+  'show', 'hide', 'focus', 'center', 'minimize', 'maximize', 'unmaximize', 'toggleFullscreen',
+];
+
 const SCREENSHOT_DIR = '/tmp/o8-screenshots';
 function persistScreenshot(base64: string, mimeType: string): string | null {
   try {
@@ -540,6 +549,33 @@ export const O8_WEBVIEW_TOOLS: McpTool[] = [
         },
       },
       required: ['selector'],
+    },
+  },
+  {
+    name: 'o8_view_windows',
+    description: 'USE THIS WHEN typing or clicking lands nowhere, or you need to know what is actually on screen. Lists every o8 window with visible / focused / position / size. o8 runs transparent click-through overlays (`dock`, `spatial-ink`, `agent-partials`) alongside `main`; when one of them holds focus, keystrokes vanish into it and nothing in the DOM explains why. Fix it with o8_view_manage_window {operation: "focus", windowLabel: "main"}.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'o8_view_manage_window',
+    description: 'Show / hide / focus / center / minimize an o8 window by label. Most common use: return focus to `main` after o8_view_windows shows an overlay holding it. Labels come from o8_view_windows.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        operation: {
+          type: 'string',
+          enum: ['show', 'hide', 'focus', 'center', 'minimize', 'maximize', 'unmaximize', 'toggleFullscreen'],
+          description: 'What to do to the window.',
+        },
+        windowLabel: {
+          type: 'string',
+          description: 'Window label from o8_view_windows (e.g. "main", "dock", "spatial-ink", "agent-partials"). Defaults to "main".',
+        },
+      },
+      required: ['operation'],
     },
   },
 ];
@@ -770,6 +806,29 @@ export function createO8WebviewToolHandlers(getClient: () => O8WebviewClient): R
       const timeoutMs = parseOptionalNumber(args.timeoutMs);
       const result = await getClient().waitFor({ selector, text, timeoutMs });
       return jsonResult(result);
+    }),
+
+    o8_view_windows: async () => withStructuredErrors(async () => {
+      const result = await getClient().listWindows();
+      return jsonResult(result);
+    }),
+
+    o8_view_manage_window: async (args) => withStructuredErrors(async () => {
+      const operation = requiredString(args, 'operation');
+      // `close`, `setPosition` and `setSize` are reachable on the client but
+      // deliberately not offered here: `close` on `main` quits the app, and
+      // geometry belongs to the user, not to an agent poking at focus.
+      if (!AGENT_WINDOW_OPERATIONS.includes(operation as O8WindowOperation)) {
+        throw new Error(`Unsupported window operation "${operation}". Use one of: ${AGENT_WINDOW_OPERATIONS.join(', ')}.`);
+      }
+      const windowLabel = typeof args.windowLabel === 'string' && args.windowLabel.trim()
+        ? args.windowLabel.trim()
+        : undefined;
+      const result = await getClient().manageWindow({
+        operation: operation as O8WindowOperation,
+        windowLabel,
+      });
+      return jsonResult({ ...result, operation, windowLabel: windowLabel ?? 'main' });
     }),
 
   };


### PR DESCRIPTION
Closes #2151.

## What was wrong

The Rust plugin dispatches 26 commands (constants in `tauri-plugin-mcp/src/shared/mod.rs`, routed by `handle_command` in `tauri-plugin-mcp/src/tools/mod.rs`). The TypeScript client sent six: `get_page_map`, `get_element_position`, `type_into_focused`, `scroll_page`, `execute_js`, `take_screenshot`. Everything else was implemented, working, and unreachable through the supported client.

## Why it matters

o8 runs four windows: `main` plus the always-on-top, transparent, click-through overlays `dock`, `spatial-ink` and `agent-partials`. None is reachable from the main window's document, so a caller with only `execute_js` cannot tell whether an overlay is on screen or which window holds focus.

That is not hypothetical: **`agent-partials` was observed holding focus while `main` did not.** Keystrokes go into a transparent click-through window and the composer never receives them, with nothing in the DOM to explain it. `list_windows` answers the first question and `manage_window` fixes it.

## What changed

**`src/lib/mcp/o8-webview-commands.ts` (new)** — the socket's supported command list in one place, matching what Rust dispatches. Each entry carries a summary and a `mutating` flag. `o8-webview-commands.test.ts` parses the plugin's own constants *and* its dispatcher match arms and fails if the catalog drifts from either, so the documentation cannot quietly go stale.

**Retry classification** — `RECONNECT_RETRY_SAFE_COMMANDS` is now derived from that catalog instead of a second hand-maintained list, so a command is classified once, where it is documented. The three previously-safe commands stay safe (locked by a test). Every mutating command — `manage_window`, `navigate_webview`, `manage_events`, `restart_app` included — throws the existing "the action may have already executed" error instead of auto-retrying. Tests assert both directions: `list_windows` retries after `EPIPE`, `manage_window` does not.

**Client methods** — `listWindows`, `getAppInfo`, `manageWindow`, `navigateWebview`, plus `manageEvents` and `restartApp`, which were straightforward once the first four landed.

**Tool surface** — `o8_view_windows` and `o8_view_manage_window`. Without these the client methods exist but the agent that actually hits the focus bug still cannot reach them. `close`, `setPosition` and `setSize` are reachable on the client but deliberately kept off the tool surface: `close` on `main` quits the app, and geometry belongs to the user.

## navigate: kept, with the real command alongside

The existing behavior is load-bearing, so it stays. `navigate(path)` drives the renderer's App Router through `NavigationBridge`. A real `navigate_webview` call performs a full document load, and `pushState + popstate` does not always cross page-route segments — either one leaves Next.js mid-route and freezes the JS thread for 10-30s (#863).

The real command lands alongside it as `navigateWebview({ action, url, windowLabel })` for what the SPA path cannot serve: hard reload, a URL outside the app's own routes, an overlay window. A regression test locks `navigate()` to the bridge so a future edit cannot quietly reroute o8's page-to-page moves through a full navigation.

## Rough edges: fixed or documented

- **String request `id`** — the client already generated one; an integer returns `Invalid request format: invalid type: integer 1, expected a string`, which reads like a protocol fault rather than a type error. Documented in the catalog's protocol notes.
- **`operation` vs `action`** — `manage_window` takes `operation`; `navigate_webview` and the `manage_*` commands take `action`. Both are now encoded in typed method signatures, so callers cannot guess wrong, and the asymmetry is documented. Tests assert each payload carries the right field and not the other.
- **A third one found while implementing:** `restart_app` is the only command whose payload struct is `#[serde(rename_all = "camelCase")]` — it wants `delayMs`. Sending `delay_ms` is silently ignored and you get the 500ms default. Fixed in the client, documented, and covered by a test.

The issue says 27 commands; the real count is 26, which the plugin's own `test_command_constants_are_unique` already asserts.

## Verification

- `npx tsc --noEmit` clean.
- `npx eslint` clean on all six changed files.
- `npm run test:classification:check` — manifest unchanged; all three test files run under `hermetic-unit`, confirmed with `--reporter=verbose` (17 in the client file, 8 in the catalog file, 15 in the tools file).
- `npm test`: **704 files passed | 3 skipped, 4551 tests passed | 4 skipped.**

## Overlap

None. PRs #2182, #2183, #2184 and #2185 touch the orchestrator session/ws-server and the agent rail; this branch touches only `src/lib/mcp/o8-webview-*`. Verified file-by-file against all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dVxFgHWcYwiMja5oBxySH