### PR TITLE
fix: an escalated lane whose worktree is gone can be discarded (#2144)

### DIFF
--- a/src/app/api/lanes/discard-orphaned/route.test.ts
+++ b/src/app/api/lanes/discard-orphaned/route.test.ts
@@ -1,0 +1,123 @@
+/**
+ * #2144 — driven through the REAL route handler, not `discardOrphanedLane` in
+ * isolation. The bug was reachability: the registry could already archive these
+ * lanes, but no surface an operator could see offered the call. So the
+ * assertions here are "the endpoint retires the lane" and "the endpoint refuses
+ * a lane that still has work on disk", never "the helper returns a refusal".
+ */
+import os from 'node:os';
+import { join } from 'node:path';
+
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getLane: vi.fn(),
+  archiveLane: vi.fn(),
+  updateLane: vi.fn(),
+  principal: vi.fn(),
+}));
+
+vi.mock('@/lib/lane/registry', () => ({
+  getLane: mocks.getLane,
+  archiveLane: mocks.archiveLane,
+  updateLane: mocks.updateLane,
+}));
+vi.mock('@/lib/panel/auth', () => ({ requirePanelAuth: () => null }));
+vi.mock('@/lib/auth/principal', () => ({ resolveRequestPrincipalContext: mocks.principal }));
+vi.mock('@/lib/runtime/owned-session-archive', () => ({
+  archiveOwnedRuntimeSession: vi.fn(async () => ({ archived: true, note: 'Session archived.' })),
+}));
+
+import { POST } from './route';
+
+/** A path that cannot exist, so the lane reads as orphaned without touching disk state. */
+const GONE = join(os.tmpdir(), 'o8-2144-worktree-that-was-removed');
+/** A path that always exists — stands in for a lane whose work is still there. */
+const PRESENT = os.tmpdir();
+
+function post(body: unknown) {
+  return new NextRequest('http://localhost/api/lanes/discard-orphaned', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.principal.mockReturnValue({ role: 'operator' });
+  mocks.archiveLane.mockImplementation((laneId: string) => ({ id: laneId, status: 'archived' }));
+});
+
+describe('POST /api/lanes/discard-orphaned', () => {
+  it('retires an escalated lane whose checkout is gone', async () => {
+    mocks.getLane.mockReturnValue({
+      id: 'lane-escalated',
+      status: 'awaiting_human',
+      sessionKey: null,
+      worktreePath: GONE,
+    });
+
+    const response = await POST(post({ laneId: 'lane-escalated' }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ ok: true, laneId: 'lane-escalated', status: 'archived' });
+    expect(mocks.archiveLane).toHaveBeenCalledWith('lane-escalated', 'user', expect.objectContaining({ outcome: 'discarded' }));
+  });
+
+  it('refuses a lane whose work is still on disk', async () => {
+    mocks.getLane.mockReturnValue({
+      id: 'lane-live',
+      status: 'awaiting_orchestrator',
+      sessionKey: null,
+      worktreePath: PRESENT,
+    });
+
+    const response = await POST(post({ laneId: 'lane-live' }));
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: 'worktree_present' } });
+    expect(mocks.archiveLane).not.toHaveBeenCalled();
+  });
+
+  it('refuses a lane whose lifecycle is already over', async () => {
+    mocks.getLane.mockReturnValue({
+      id: 'lane-done',
+      status: 'completed',
+      sessionKey: null,
+      worktreePath: GONE,
+    });
+
+    const response = await POST(post({ laneId: 'lane-done' }));
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: 'already_terminal' } });
+    expect(mocks.archiveLane).not.toHaveBeenCalled();
+  });
+
+  it('404s a lane that is no longer in the registry', async () => {
+    mocks.getLane.mockReturnValue(null);
+
+    const response = await POST(post({ laneId: 'lane-ghost' }));
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: 'lane_not_found' } });
+  });
+
+  it('denies a worker credential — discarding is an operator gesture', async () => {
+    mocks.principal.mockReturnValue({ role: 'worker', packetId: 'pkt-1' });
+
+    const response = await POST(post({ laneId: 'lane-escalated' }));
+
+    expect(response.status).toBe(403);
+    expect(mocks.getLane).not.toHaveBeenCalled();
+    expect(mocks.archiveLane).not.toHaveBeenCalled();
+  });
+
+  it('requires a laneId', async () => {
+    const response = await POST(post({}));
+
+    expect(response.status).toBe(400);
+    expect(mocks.archiveLane).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/lanes/discard-orphaned/route.ts
+++ b/src/app/api/lanes/discard-orphaned/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requirePanelAuth } from '@/lib/panel/auth';
+import { resolveRequestPrincipalContext } from '@/lib/auth/principal';
+import { discardOrphanedLane } from '@/lib/lane/orphaned-lane';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * #2144 — discard a lane whose packet worktree is no longer on disk.
+ *
+ * Operator-only, and never automatic: this is the control behind the Review
+ * tab's "worktree no longer on disk" state. It does NOT relax
+ * `/api/runtime/archive`'s terminal guard — it is a separate path that earns
+ * the write by proving the checkout is gone first (see `orphanedDiscardRefusal`),
+ * so a lane with work still on disk is refused here as well.
+ *
+ * Idempotent in practice: a second call finds the lane already archived and
+ * refuses with `already_terminal`.
+ */
+export async function POST(req: NextRequest) {
+  const denied = requirePanelAuth(req);
+  if (denied) return denied;
+  const principal = resolveRequestPrincipalContext(req);
+  if (principal.role !== 'operator') {
+    return NextResponse.json(
+      { ok: false, error: { code: 'operator_required', message: 'Discarding a lane requires an operator credential.' } },
+      { status: 403 },
+    );
+  }
+
+  const body = await req.json().catch(() => null) as { laneId?: string } | null;
+  const laneId = body?.laneId?.trim();
+  if (!laneId) {
+    return NextResponse.json({ ok: false, error: { code: 'lane_id_required', message: 'laneId is required.' } }, { status: 400 });
+  }
+
+  try {
+    const result = await discardOrphanedLane(laneId, 'user');
+    if (!result.ok) {
+      return NextResponse.json(
+        { ok: false, error: result.refusal },
+        { status: result.refusal.code === 'lane_not_found' ? 404 : 409, headers: { 'Cache-Control': 'no-store, max-age=0' } },
+      );
+    }
+    return NextResponse.json(
+      { ok: true, laneId: result.lane.id, status: result.lane.status },
+      { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Discard failed.';
+    return NextResponse.json({ ok: false, note: message }, { status: 500 });
+  }
+}

--- a/src/app/api/panel/branches/route.ts
+++ b/src/app/api/panel/branches/route.ts
@@ -3,6 +3,8 @@ import { allowWorktreeRemoval } from '@/lib/worktree/live-process-guard';
 import { execFileSync } from 'node:child_process';
 import { isSafeGitRef } from '@/lib/git/refs';
 import { getBranchSnapshot, getCachedBranchSnapshot, refreshBranchSnapshot } from '@/lib/panel/branch-snapshot';
+import { findLaneByRepoAndBranch } from '@/lib/lane/registry';
+import { markLaneWorktreeOrphaned } from '@/lib/lane/orphaned-lane';
 
 export const dynamic = 'force-dynamic';
 
@@ -295,6 +297,13 @@ export async function DELETE(req: NextRequest) {
           }
           git(repoPath, ['worktree', 'remove', currentPath, ...(force ? ['--force'] : [])], 10000);
           worktreeRemoved = true;
+          // #2144 — this gesture knows nothing about lanes, so a lane that is
+          // still open against this branch would only discover the loss the
+          // next time something tried to read its diff. Record it now.
+          try {
+            const owningLane = findLaneByRepoAndBranch(repoPath, branch);
+            if (owningLane) markLaneWorktreeOrphaned(owningLane.id);
+          } catch { /* marking is best-effort; the removal already happened */ }
           break;
         }
       }

--- a/src/components/desktop/merge-beacon/derive.test.ts
+++ b/src/components/desktop/merge-beacon/derive.test.ts
@@ -152,6 +152,20 @@ describe('deriveParkedLanes', () => {
     expect(parked.map((p) => p.laneId)).toEqual(['real']); // the hygiene lane never parks the gate
   });
 
+  // #2144 — the mission-bar badge and the always-on-top overlay pill both count
+  // this array, so discarding an escalated lane only clears them if the lane
+  // genuinely leaves the bucket once it lands on `archived`.
+  it('drops a discarded escalated lane once it archives, so the count reaches zero', () => {
+    const escalated = [lane({ laneId: 'orphan', status: 'awaiting_human', packetId: 'pkt-orphan' })];
+    expect(deriveParkedLaneBuckets(escalated).escalated.map((p) => p.laneId)).toEqual(['orphan']);
+
+    const discarded = [lane({ laneId: 'orphan', status: 'archived', packetId: 'pkt-orphan' })];
+    const buckets = deriveParkedLaneBuckets(discarded);
+    expect(buckets.escalated).toEqual([]);
+    expect(buckets.all).toEqual([]);
+    expect(deriveParkedLanes(discarded)).toEqual([]);
+  });
+
   it('a rejected non-gating packet also stays out of the beacon', () => {
     const lanes = [lane({ laneId: 'hygiene-rej', status: 'reviewing', packetId: 'decompose-9' })];
     const reviews: ReviewApprovalSummary[] = [

--- a/src/components/desktop/o8-panel/workspace-rail/ChangesList.tsx
+++ b/src/components/desktop/o8-panel/workspace-rail/ChangesList.tsx
@@ -28,6 +28,9 @@ export interface WorkspaceChangesState {
   files: ReviewChangedFile[];
   loading: boolean;
   error: string | null;
+  /** #2144 — the route's error code, when it reported one. Lets a consumer
+   *  distinguish an unrecoverable lane from a diff that merely failed to load. */
+  errorCode?: string | null;
   totalAdditions: number;
   totalDeletions: number;
   dirtyFileSet: Set<string>;

--- a/src/components/desktop/review/ReviewPanel.tsx
+++ b/src/components/desktop/review/ReviewPanel.tsx
@@ -26,6 +26,8 @@ import { PanelMessage } from './panel/DiffView';
 import { ReviewFileRow, ToolbarButton, MenuItem } from './panel/ReviewFileRow';
 import { FilesDrawer } from './panel/FilesDrawer';
 import { ReviewSkeleton } from './panel/ReviewSkeleton';
+import { MissingWorktreeNotice } from './panel/MissingWorktreeNotice';
+import { WORKTREE_MISSING_CODE } from '@/lib/lane/review-target-codes';
 
 /**
  * ReviewPanel — the dedicated Review surface for the right panel's `review`
@@ -384,7 +386,17 @@ export const ReviewPanel = memo(function ReviewPanel({ repoPath, registeredRepos
         ) : changes.loading && !hasFiles ? (
           <ReviewSkeleton />
         ) : changes.error ? (
-          <PanelMessage text={changes.error} tone="error" />
+          // #2144 — a lane whose checkout is gone is unrecoverable, not
+          // retryable, so it gets its own state plus the action that ends it.
+          reviewLaneId && changes.errorCode === WORKTREE_MISSING_CODE ? (
+            <MissingWorktreeNotice
+              laneId={reviewLaneId}
+              detail={changes.error}
+              onDiscarded={() => { void changes.refresh(); }}
+            />
+          ) : (
+            <PanelMessage text={changes.error} tone="error" />
+          )
         ) : !hasFiles ? (
           <PanelMessage text={reviewLaneId ? 'No branch diff to review.' : 'Working tree clean — nothing to review.'} />
         ) : visible.length === 0 ? (

--- a/src/components/desktop/review/panel/MissingWorktreeNotice.tsx
+++ b/src/components/desktop/review/panel/MissingWorktreeNotice.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+/**
+ * #2144 — the Review surface's state for a lane whose checkout is gone.
+ *
+ * Before this, the only thing the panel could say was "Failed to load review
+ * lane diff", which reads as "try again" when the truth is that there is
+ * nothing left to load and the lane can never leave the escalated set on its
+ * own. This state says so plainly and carries the one action that ends it.
+ *
+ * The discard is a deliberate two-step: an escalated lane means o8 is blocked
+ * on a human, so the operator confirms before the lane is retired.
+ */
+
+import { useState } from 'react';
+import { MONO_FONT, UI_FONT } from './constants';
+
+export function MissingWorktreeNotice({
+  laneId,
+  detail,
+  onDiscarded,
+}: {
+  laneId: string;
+  detail: string;
+  onDiscarded?: () => void;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
+
+  const discard = async () => {
+    setBusy(true);
+    setFailure(null);
+    try {
+      const res = await fetch('/api/lanes/discard-orphaned', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ laneId }),
+      });
+      const body = await res.json().catch(() => null) as { ok?: boolean; error?: { message?: string } | null; note?: string } | null;
+      if (!res.ok || !body?.ok) {
+        setFailure(body?.error?.message ?? body?.note ?? `Discard failed with status ${res.status}`);
+        return;
+      }
+      setConfirming(false);
+      // Every lane consumer refetches — the rail, the Archived section, and the
+      // parked-lane count behind the mission-bar badge and the overlay pill.
+      if (typeof window !== 'undefined') window.dispatchEvent(new Event('o8:lifecycle-reconcile'));
+      onDiscarded?.();
+    } catch (error) {
+      setFailure(error instanceof Error ? error.message : 'Discard failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div style={{ paddingTop: 18, paddingRight: 16, paddingBottom: 18, paddingLeft: 16, fontFamily: UI_FONT, display: 'flex', flexDirection: 'column', gap: 10, maxWidth: 560 }}>
+      <div style={{ fontSize: 12.5, fontWeight: 500, color: 'var(--t-text-primary)', letterSpacing: '-0.1px' }}>
+        Worktree no longer on disk
+      </div>
+      <div style={{ fontSize: 12, lineHeight: 1.55, color: 'var(--t-text-muted)' }}>
+        This lane&rsquo;s checkout was removed while the lane was still open, so there is no diff left
+        to review and no work left to recover. Discarding closes the lane and clears it from the
+        escalated count.
+      </div>
+      <div style={{ fontSize: 11, lineHeight: 1.5, color: 'var(--t-text-faint)', fontFamily: MONO_FONT, wordBreak: 'break-word' }}>
+        {detail}
+      </div>
+
+      {failure ? (
+        <div style={{ fontSize: 11.5, color: 'var(--t-tone-fail)' }}>{failure}</div>
+      ) : null}
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingTop: 2 }}>
+        {confirming ? (
+          <>
+            <button
+              type="button"
+              onClick={() => { void discard(); }}
+              disabled={busy}
+              style={{
+                height: 26,
+                paddingLeft: 10,
+                paddingRight: 10,
+                borderRadius: 7,
+                borderWidth: 1,
+                borderStyle: 'solid',
+                borderColor: 'var(--t-tone-fail-border)',
+                background: 'var(--t-tone-fail-bg)',
+                color: 'var(--t-tone-fail)',
+                cursor: busy ? 'default' : 'pointer',
+                fontFamily: UI_FONT,
+                fontSize: 11.5,
+                fontWeight: 600,
+                letterSpacing: '-0.1px',
+              }}
+            >
+              {busy ? 'Discarding…' : 'Confirm discard'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirming(false)}
+              disabled={busy}
+              style={{
+                height: 26,
+                paddingLeft: 10,
+                paddingRight: 10,
+                borderRadius: 7,
+                borderWidth: 1,
+                borderStyle: 'solid',
+                borderColor: 'var(--t-divider-subtle)',
+                background: 'var(--t-input-bg)',
+                color: 'var(--t-text-muted)',
+                cursor: busy ? 'default' : 'pointer',
+                fontFamily: UI_FONT,
+                fontSize: 11.5,
+                fontWeight: 300,
+                letterSpacing: '-0.1px',
+              }}
+            >
+              Cancel
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setConfirming(true)}
+            style={{
+              height: 26,
+              paddingLeft: 10,
+              paddingRight: 10,
+              borderRadius: 7,
+              borderWidth: 1,
+              borderStyle: 'solid',
+              borderColor: 'var(--t-divider-subtle)',
+              background: 'var(--t-input-bg)',
+              color: 'var(--t-text-muted)',
+              cursor: 'pointer',
+              fontFamily: UI_FONT,
+              fontSize: 11.5,
+              fontWeight: 300,
+              letterSpacing: '-0.1px',
+            }}
+          >
+            Discard lane
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/desktop/review/useLaneReviewChanges.ts
+++ b/src/components/desktop/review/useLaneReviewChanges.ts
@@ -11,6 +11,16 @@ interface LaneDiffResponse {
   base?: string | null;
   worktreePath?: string | null;
   diff?: string;
+  error?: { code?: string; message?: string } | null;
+}
+
+/** Carries the route's error CODE alongside its message so the panel can tell
+ *  an unrecoverable lane (#2144, `worktree_missing`) from a retryable failure. */
+class LaneDiffError extends Error {
+  constructor(message: string, readonly code: string | null) {
+    super(message);
+    this.name = 'LaneDiffError';
+  }
 }
 
 export function useLaneReviewChanges(laneId?: string | null): WorkspaceChangesState {
@@ -20,6 +30,7 @@ export function useLaneReviewChanges(laneId?: string | null): WorkspaceChangesSt
   const [base, setBase] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(() => Boolean(laneId));
   const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     if (!laneId) {
@@ -28,17 +39,22 @@ export function useLaneReviewChanges(laneId?: string | null): WorkspaceChangesSt
       setBranch(null);
       setBase(null);
       setError(null);
+      setErrorCode(null);
       setLoading(false);
       return;
     }
 
     setLoading(true);
     setError(null);
+    setErrorCode(null);
     try {
       const response = await fetch(`/api/lanes/${encodeURIComponent(laneId)}/diff?maxBytes=524288`, { cache: 'no-store' });
       const data = await response.json().catch(() => null) as LaneDiffResponse | null;
       if (!response.ok || !data?.ok) {
-        throw new Error(data?.note ?? 'Failed to load review lane diff');
+        throw new LaneDiffError(
+          data?.error?.message ?? data?.note ?? 'Failed to load review lane diff',
+          data?.error?.code ?? null,
+        );
       }
       setRawDiff(typeof data.diff === 'string' ? data.diff : '');
       setSourceRepoPath(typeof data.worktreePath === 'string' ? data.worktreePath : null);
@@ -50,6 +66,7 @@ export function useLaneReviewChanges(laneId?: string | null): WorkspaceChangesSt
       setBranch(null);
       setBase(null);
       setError(err instanceof Error ? err.message : 'Unable to load review lane diff');
+      setErrorCode(err instanceof LaneDiffError ? err.code : null);
     } finally {
       setLoading(false);
     }
@@ -79,6 +96,7 @@ export function useLaneReviewChanges(laneId?: string | null): WorkspaceChangesSt
     files: summary.files,
     loading,
     error,
+    errorCode,
     totalAdditions: summary.additions,
     totalDeletions: summary.deletions,
     dirtyFileSet: new Set(summary.files.map((file) => file.path)),

--- a/src/lib/lane/orphaned-lane.test.ts
+++ b/src/lib/lane/orphaned-lane.test.ts
@@ -1,0 +1,92 @@
+import os from 'node:os';
+import { join } from 'node:path';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getLane: vi.fn(),
+  archiveLane: vi.fn(),
+  updateLane: vi.fn(),
+}));
+
+vi.mock('./registry', () => ({
+  getLane: mocks.getLane,
+  archiveLane: mocks.archiveLane,
+  updateLane: mocks.updateLane,
+}));
+
+import {
+  ORPHANED_WORKTREE_EVENT_LABEL,
+  laneWorktreeIsMissing,
+  markLaneWorktreeOrphaned,
+  orphanedDiscardRefusal,
+} from './orphaned-lane';
+
+const GONE = join(os.tmpdir(), 'o8-2144-checkout-that-was-removed');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('laneWorktreeIsMissing', () => {
+  it('is true for a recorded path that is gone', () => {
+    expect(laneWorktreeIsMissing({ worktreePath: GONE })).toBe(true);
+  });
+
+  it('is false for a path that still exists', () => {
+    expect(laneWorktreeIsMissing({ worktreePath: os.tmpdir() })).toBe(false);
+  });
+
+  it('is false when the lane never recorded a path — absence is not proof of loss', () => {
+    expect(laneWorktreeIsMissing({ worktreePath: null })).toBe(false);
+    expect(laneWorktreeIsMissing({ worktreePath: '   ' })).toBe(false);
+  });
+});
+
+describe('orphanedDiscardRefusal', () => {
+  it('allows an escalated lane whose checkout is gone', () => {
+    expect(orphanedDiscardRefusal({ id: 'l1', status: 'awaiting_human', worktreePath: GONE }, true)).toBeNull();
+    expect(orphanedDiscardRefusal({ id: 'l2', status: 'awaiting_orchestrator', worktreePath: GONE }, true)).toBeNull();
+  });
+
+  it('refuses while the work is still on disk', () => {
+    expect(orphanedDiscardRefusal({ id: 'l3', status: 'reviewing', worktreePath: '/somewhere' }, false))
+      .toMatchObject({ code: 'worktree_present' });
+  });
+
+  it('refuses a lane whose lifecycle is already over', () => {
+    for (const status of ['failed', 'completed', 'archived'] as const) {
+      expect(orphanedDiscardRefusal({ id: 'l4', status, worktreePath: GONE }, true))
+        .toMatchObject({ code: 'already_terminal' });
+    }
+  });
+
+  it('refuses a lane that is not in the registry', () => {
+    expect(orphanedDiscardRefusal(null, true)).toMatchObject({ code: 'lane_not_found' });
+  });
+});
+
+describe('markLaneWorktreeOrphaned', () => {
+  it('stamps a still-open lane without moving its status', () => {
+    mocks.getLane.mockReturnValue({ id: 'l5', status: 'awaiting_human', worktreePath: GONE });
+    mocks.updateLane.mockReturnValue({ id: 'l5', status: 'awaiting_human' });
+
+    markLaneWorktreeOrphaned('l5');
+
+    expect(mocks.updateLane).toHaveBeenCalledWith(
+      'l5',
+      expect.objectContaining({ lastEventLabel: ORPHANED_WORKTREE_EVENT_LABEL }),
+      'system',
+      expect.objectContaining({ eventLabel: ORPHANED_WORKTREE_EVENT_LABEL }),
+    );
+    // The escalation is still owned by a human — marking must never end it.
+    expect(mocks.updateLane.mock.calls[0]?.[1]).not.toHaveProperty('status');
+  });
+
+  it('leaves a lane whose lifecycle is over alone', () => {
+    mocks.getLane.mockReturnValue({ id: 'l6', status: 'completed', worktreePath: GONE });
+
+    expect(markLaneWorktreeOrphaned('l6')).toBeNull();
+    expect(mocks.updateLane).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/lane/orphaned-lane.ts
+++ b/src/lib/lane/orphaned-lane.ts
@@ -1,0 +1,129 @@
+/**
+ * #2144 — the operator-initiated way out of a lane whose checkout is gone.
+ *
+ * A lane that escalated (`awaiting_orchestrator` / `awaiting_human`) and then
+ * lost its packet worktree to ordinary cleanup is stuck: the review surface can
+ * only report a failed diff, `/api/runtime/archive` refuses the lane because it
+ * is not terminal, and `DEAD_LANE_ARCHIVE_POLICY` deliberately leaves escalated
+ * lanes alone. So the escalated count never reaches zero.
+ *
+ * The missing piece is not a weaker guard — the runtime-archive terminal check
+ * and the dead-lane policy both exist for good reasons, and an escalation means
+ * o8 is blocked on a HUMAN, so nothing here may fire on its own. What was
+ * missing is a legitimate, explicit path: the operator, looking at the lane,
+ * says discard, and o8 first proves the worktree really is gone before it
+ * retires the lane. That proof is what separates this from a blanket
+ * "archive any escalated lane" button.
+ *
+ * Discard is deliberately NOT reachable for a lane whose worktree still exists —
+ * that lane has work on disk and belongs in review, not in the bin.
+ */
+import { existsSync } from 'node:fs';
+
+import { archiveLane, getLane, updateLane } from './registry';
+import { isLaneTerminal } from './terminal-states';
+import type { Lane, LaneEventActor } from './types';
+
+/** Stamped on a still-open lane when o8 itself removes the checkout underneath it. */
+export const ORPHANED_WORKTREE_EVENT_LABEL = 'worktree_orphaned';
+
+/** True when the lane recorded a checkout path and that path is gone from disk. */
+export function laneWorktreeIsMissing(lane: Pick<Lane, 'worktreePath'>): boolean {
+  const recorded = lane.worktreePath?.trim();
+  if (!recorded) return false;
+  return !existsSync(recorded);
+}
+
+export type OrphanedDiscardRefusalCode = 'lane_not_found' | 'already_terminal' | 'worktree_present';
+
+export interface OrphanedDiscardRefusal {
+  code: OrphanedDiscardRefusalCode;
+  message: string;
+}
+
+/**
+ * Pure eligibility decision for the discard action. Split out from the write so
+ * the rule is testable without a registry or a filesystem.
+ */
+export function orphanedDiscardRefusal(
+  lane: Pick<Lane, 'id' | 'status' | 'worktreePath'> | null,
+  worktreeMissing: boolean,
+): OrphanedDiscardRefusal | null {
+  if (!lane) {
+    return { code: 'lane_not_found', message: 'That lane is no longer in the registry.' };
+  }
+  if (isLaneTerminal(lane.status)) {
+    return {
+      code: 'already_terminal',
+      message: `Lane ${lane.id} is already ${lane.status}; archive it the normal way.`,
+    };
+  }
+  if (!worktreeMissing) {
+    return {
+      code: 'worktree_present',
+      message: `Lane ${lane.id} still has its worktree on disk; review or archive it instead of discarding it.`,
+    };
+  }
+  return null;
+}
+
+export type DiscardOrphanedLaneResult =
+  | { ok: true; lane: Lane }
+  | { ok: false; refusal: OrphanedDiscardRefusal };
+
+/**
+ * Retire one lane whose worktree is gone. Explicit and operator-initiated: no
+ * sweep, no timer, and no caller inside the loop reaches this.
+ */
+export async function discardOrphanedLane(
+  laneId: string,
+  actor: LaneEventActor = 'user',
+): Promise<DiscardOrphanedLaneResult> {
+  const lane = getLane(laneId);
+  const refusal = orphanedDiscardRefusal(lane, lane ? laneWorktreeIsMissing(lane) : false);
+  if (refusal || !lane) {
+    return { ok: false, refusal: refusal ?? { code: 'lane_not_found', message: 'That lane is no longer in the registry.' } };
+  }
+
+  if (lane.sessionKey) {
+    // Best-effort, exactly as the bulk clear treats it: a session dir that is
+    // already cleaned up must not block the lane from leaving the escalated set.
+    try {
+      // Imported lazily so this module stays cheap enough to call from the
+      // worktree-removal path without dragging the runtime registry in with it.
+      const { archiveOwnedRuntimeSession } = await import('@/lib/runtime/owned-session-archive');
+      await archiveOwnedRuntimeSession(lane.sessionKey);
+    } catch {
+      // The lane archive below is the outcome that matters.
+    }
+  }
+
+  const archived = archiveLane(lane.id, actor, {
+    outcome: 'discarded',
+    outcomeNote: `Discarded by the operator: the worktree at ${lane.worktreePath} is no longer on disk.`,
+  });
+  if (!archived) {
+    return { ok: false, refusal: { code: 'lane_not_found', message: 'That lane is no longer in the registry.' } };
+  }
+  return { ok: true, lane: archived };
+}
+
+/**
+ * Record — without moving the lane — that o8 just removed the checkout out from
+ * under a lane that is still open. Honest at removal time instead of a surprise
+ * at render time. The status is deliberately untouched: an escalated lane is
+ * blocked on a human, and only the human may end it.
+ */
+export function markLaneWorktreeOrphaned(
+  laneId: string,
+  actor: LaneEventActor = 'system',
+): Lane | null {
+  const lane = getLane(laneId);
+  if (!lane || isLaneTerminal(lane.status)) return null;
+  return updateLane(
+    laneId,
+    { lastEventAt: new Date().toISOString(), lastEventLabel: ORPHANED_WORKTREE_EVENT_LABEL },
+    actor,
+    { eventLabel: ORPHANED_WORKTREE_EVENT_LABEL, worktreePath: lane.worktreePath },
+  );
+}

--- a/src/lib/lane/review-target-codes.ts
+++ b/src/lib/lane/review-target-codes.ts
@@ -1,0 +1,21 @@
+/**
+ * Review-target error codes, in a module with no Node imports so a CLIENT
+ * surface can name them. `review-target.ts` itself reaches for `node:fs` and
+ * `node:child_process`, which must never enter the browser bundle.
+ */
+
+export const BRANCH_UNRESOLVED_CODE = 'branch_unresolved' as const;
+
+/**
+ * #2144 — the lane's checkout is GONE, not merely unresolvable. Ordinary
+ * cleanup (a forced worktree removal, an orphan sweep, a repo reset between
+ * runs) takes the directory out from under a lane that is still open, and every
+ * read of that lane then fails. The operator needs to tell that apart from a
+ * transient load failure, because the two have opposite remedies: this one is
+ * unrecoverable and the lane can only be discarded.
+ */
+export const WORKTREE_MISSING_CODE = 'worktree_missing' as const;
+
+export type LaneReviewTargetErrorCode =
+  | typeof BRANCH_UNRESOLVED_CODE
+  | typeof WORKTREE_MISSING_CODE;

--- a/src/lib/lane/review-target.ts
+++ b/src/lib/lane/review-target.ts
@@ -2,20 +2,26 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, realpathSync } from 'node:fs';
 
 import { isSafeGitRef } from '@/lib/git/refs';
+import {
+  BRANCH_UNRESOLVED_CODE,
+  WORKTREE_MISSING_CODE,
+  type LaneReviewTargetErrorCode,
+} from './review-target-codes';
 import type { Lane } from './types';
 
-export const BRANCH_UNRESOLVED_CODE = 'branch_unresolved' as const;
+export { BRANCH_UNRESOLVED_CODE, WORKTREE_MISSING_CODE, type LaneReviewTargetErrorCode };
 
 export class LaneBranchUnresolvedError extends Error {
-  readonly code = BRANCH_UNRESOLVED_CODE;
-
   constructor(
     readonly lane: Pick<Lane, 'id' | 'branch' | 'repoPath' | 'worktreePath'>,
     readonly reason: string,
+    readonly code: LaneReviewTargetErrorCode = BRANCH_UNRESOLVED_CODE,
   ) {
     super(
-      `Branch unresolved for lane ${lane.id}: recorded branch "${lane.branch}" ${reason}. `
-      + `Refusing to fall back to the repo checkout at ${lane.repoPath}.`,
+      code === WORKTREE_MISSING_CODE
+        ? `Lane ${lane.id} ${reason}; there is nothing left on disk to diff.`
+        : `Branch unresolved for lane ${lane.id}: recorded branch "${lane.branch}" ${reason}. `
+          + `Refusing to fall back to the repo checkout at ${lane.repoPath}.`,
     );
     this.name = 'LaneBranchUnresolvedError';
   }
@@ -29,7 +35,7 @@ export interface LaneReviewTarget {
 export interface BranchUnresolvedPayload {
   ok: false;
   error: {
-    code: typeof BRANCH_UNRESOLVED_CODE;
+    code: LaneReviewTargetErrorCode;
     message: string;
     laneId: string;
     branch: string;
@@ -61,7 +67,11 @@ function worktreeForBranch(repoPath: string, branch: string): string | null {
 
 function validateTarget(lane: Lane, candidatePath: string): LaneReviewTarget {
   if (!existsSync(candidatePath)) {
-    throw new LaneBranchUnresolvedError(lane, `points to missing worktree ${candidatePath}`);
+    throw new LaneBranchUnresolvedError(
+      lane,
+      `recorded its worktree at ${candidatePath}, and that path is no longer on disk`,
+      WORKTREE_MISSING_CODE,
+    );
   }
 
   try {
@@ -97,10 +107,14 @@ export function resolveLaneReviewTarget(lane: Lane): LaneReviewTarget {
     const discoveredPath = worktreeForBranch(lane.repoPath, lane.branch);
     if (discoveredPath) return validateTarget(lane, discoveredPath);
     const branchExists = git(lane.repoPath, ['show-ref', '--verify', '--hash', `refs/heads/${lane.branch}`]);
-    throw new LaneBranchUnresolvedError(
-      lane,
-      branchExists ? 'has no attached worktree' : 'does not exist',
-    );
+    if (branchExists) {
+      throw new LaneBranchUnresolvedError(
+        lane,
+        `kept branch "${lane.branch}" but no worktree is attached to it any more`,
+        WORKTREE_MISSING_CODE,
+      );
+    }
+    throw new LaneBranchUnresolvedError(lane, 'does not exist');
   } catch (error) {
     if (error instanceof LaneBranchUnresolvedError) throw error;
     throw new LaneBranchUnresolvedError(lane, 'does not exist');

--- a/src/lib/lane/worktree-clone-removal.ts
+++ b/src/lib/lane/worktree-clone-removal.ts
@@ -4,12 +4,32 @@ import { resolve } from 'node:path';
 import { promisify } from 'node:util';
 
 import { checkPruneGate } from './prune-gate';
+import { markLaneWorktreeOrphaned } from './orphaned-lane';
 import { allowWorktreeRemoval } from '@/lib/worktree/live-process-guard';
 
 const execFileAsync = promisify(execFile);
 
 function formatError(error: unknown) {
   return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * #2144 — a removal that goes through while the owning lane is still open
+ * leaves that lane pointing at a path that no longer exists. The prune gate
+ * refuses most of those, but an operator force gets through by design, and the
+ * already-absent branch below never consulted a lane at all. Stamp the lane at
+ * removal time rather than letting it fail at render an hour later. The lane's
+ * STATUS is untouched: an escalated lane is still blocked on a human.
+ */
+function markOwningLaneOrphaned(laneId: string | undefined, logPrefix: string) {
+  if (!laneId) return;
+  try {
+    if (markLaneWorktreeOrphaned(laneId)) {
+      console.warn(`[${logPrefix}] Lane ${laneId} is still open and its worktree was removed — marked orphaned.`);
+    }
+  } catch (error) {
+    console.warn(`[${logPrefix}] failed to mark lane ${laneId} orphaned: ${formatError(error)}`);
+  }
 }
 
 async function pruneWorktrees(repoRoot: string, logPrefix: string) {
@@ -68,6 +88,7 @@ export async function removeCortexWorktreePath(input: {
 
   if (!existsSync(input.worktreePath)) {
     console.warn(`[${logPrefix}] Worktree ${input.worktreePath}${label} is already absent.`);
+    markOwningLaneOrphaned(input.laneId, logPrefix);
     await pruneWorktrees(input.repoRoot, logPrefix);
     return true;
   }
@@ -83,6 +104,7 @@ export async function removeCortexWorktreePath(input: {
       cwd: input.repoRoot,
       timeout: 15_000,
     });
+    markOwningLaneOrphaned(input.laneId, logPrefix);
     await pruneWorktrees(input.repoRoot, logPrefix);
     return true;
   } catch (error) {
@@ -95,6 +117,7 @@ export async function removeCortexWorktreePath(input: {
       overrideLiveGuard: input.overrideLiveGuard,
     }))) return false;
     rmSync(input.worktreePath, { recursive: true, force: true });
+    markOwningLaneOrphaned(input.laneId, logPrefix);
     await pruneWorktrees(input.repoRoot, logPrefix);
     return !existsSync(input.worktreePath);
   } catch (error) {


### PR DESCRIPTION
Closes #2144

## The stuck state

A lane that escalated (`awaiting_orchestrator` / `awaiting_human`) and then lost its packet checkout to ordinary cleanup had no way out:

- The Review tab rendered only `Failed to load review lane diff` — which reads as "try again" when there is nothing left to load — and carried no action.
- `/api/runtime/archive` refuses non-terminal lanes, and `DEAD_LANE_ARCHIVE_POLICY` deliberately excludes the escalated statuses, so nothing auto-cleared it either.
- The orange `N escalated` badge and the always-on-top overlay pill that mirrors its count stayed up across sessions.

The diff route was already reporting the right thing and throwing it away. `resolveLaneReviewTarget` raises `LaneBranchUnresolvedError` for a missing checkout exactly as it does for an unresolvable branch, and the panel's error string came from `note` — a key that payload never sets.

## What changed

**A distinct state, not a generic failure.** `review-target` now carries a `worktree_missing` code (codes split into `review-target-codes.ts` so a client surface can name them without pulling `node:fs` into the bundle), raised both for "the recorded path is gone" and for "the branch survived but nothing is attached to it". `useLaneReviewChanges` keeps the route's error CODE alongside its message, and the Review panel renders **"Worktree no longer on disk"** with a confirm-then-discard control.

**A terminal action.** `POST /api/lanes/discard-orphaned` (operator-only) retires one such lane with `outcome: 'discarded'`.

**The guards stay.** `/api/runtime/archive` still refuses non-terminal lanes and the dead-lane policy still leaves escalated lanes alone. This is a separate path that earns the write by proving the checkout is gone first (`orphanedDiscardRefusal`), so a lane with work still on disk is refused here too. Nothing fires on its own — an escalation means o8 is blocked on a human, and only the human ends it. The action is explicit and two-step.

**Marked at removal time, not left to fail at render.** A successful removal in `removeCortexWorktreePath` now stamps a still-open owning lane `worktree_orphaned` with its status untouched, and the branch-delete route — which knew nothing about lanes — marks the lane on the branch it just cleaned up. The prune gate already blocked `lane_non_terminal` removals with a reason; this covers the operator-forced and already-absent paths that go through it.

**Badge and pill.** Both read `deriveParkedLanes`, and the discard dispatches `o8:lifecycle-reconcile`, which invalidates the `['lanes','active']` query and the `lanes` SWR key. The lane leaves the escalated bucket the moment it lands on `archived` — pinned by a regression test in `derive.test.ts`.

## Tests

29 new assertions, all hermetic (unit config, confirmed under `--reporter=verbose`):

- `src/app/api/lanes/discard-orphaned/route.test.ts` — driven through the **real route handler**, since the bug was reachability rather than a missing capability: retires an orphaned escalated lane, refuses one whose work is still on disk, refuses one already terminal, 404s a missing lane, denies a worker credential, requires a `laneId`.
- `src/lib/lane/orphaned-lane.test.ts` — the pure eligibility rule and the mark-without-moving-status guard.
- `src/components/desktop/merge-beacon/derive.test.ts` — the discarded lane drops out so the count reaches zero.

`npx tsc --noEmit` clean, eslint clean on every changed file, `npm test`: **713 files passed / 3 skipped, 4628 tests passed / 4 skipped, 0 failures**.

Builds on #2154 rather than around it — the bulk clear there is lane-terminal only; this is the non-terminal case it called out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dVxFgHWcYwiMja5oBxySH