### PR TITLE
fix(supervisor): retry a worker that errored before writing anything (#2141)

### DIFF
--- a/src/components/desktop/repo-focus/tabs/control-room/constants.ts
+++ b/src/components/desktop/repo-focus/tabs/control-room/constants.ts
@@ -53,5 +53,7 @@ export const STALE_CLEANUP_SIGNALS = new Set([
   'relaunch_error',
   'session_lost',
   'zero_diff_failed',
+  'zero_diff_runtime_error',
+  'zero_diff_unclassified',
   'silent_exit_work_present',
 ]);

--- a/src/components/desktop/repo-focus/tabs/control-room/helpers.ts
+++ b/src/components/desktop/repo-focus/tabs/control-room/helpers.ts
@@ -125,6 +125,13 @@ export function taskSignal(task: TaskPoolTask): string | null {
   switch (value) {
     case 'zero_diff_failed':
       return 'No changes produced';
+    // #2141 — a dead runtime and a deliberate no-op are different outcomes.
+    case 'zero_diff_runtime_error':
+      return 'Runtime errored before writing';
+    case 'zero_diff_runtime_error_requeued':
+      return 'Runtime errored — retrying';
+    case 'zero_diff_unclassified':
+      return 'No changes, cause unknown';
     case 'silent_exit_work_present':
       return 'Work present';
     case 'review_ready':

--- a/src/lib/orchestrator/operator-mission-service/reset.ts
+++ b/src/lib/orchestrator/operator-mission-service/reset.ts
@@ -90,6 +90,8 @@ function markPacketResetHeld(packet: OrchestratorPacket) {
   // Same for the self-review stall budget + the operator-Stop flag (2026-06-22):
   // a reset gives a fresh stall budget and re-enables dispatch.
   packet.stallRetries = 0;
+  // #2141 — and the zero-diff runtime-fault budget.
+  packet.zeroDiffRuntimeRetries = 0;
   advancePacketStorageAdmissionEpoch(packet);
   packet.launchAttempts = 0;
   packet.operatorStopped = false;

--- a/src/lib/orchestrator/store.ts
+++ b/src/lib/orchestrator/store.ts
@@ -360,6 +360,7 @@ function normalizePacket(raw: unknown, index: number, existing: Array<Pick<Orche
     typecheckAutoRetries: normalizeAttemptCount(packet.typecheckAutoRetries),
     leaseWaitAutoRetries: normalizeAttemptCount(packet.leaseWaitAutoRetries), uiLoopIterations: normalizeAttemptCount(packet.uiLoopIterations), uiLoopStartedAt: typeof packet.uiLoopStartedAt === 'string' && Number.isFinite(Date.parse(packet.uiLoopStartedAt)) ? packet.uiLoopStartedAt : undefined,
     stallRetries: normalizeAttemptCount(packet.stallRetries),
+    zeroDiffRuntimeRetries: normalizeAttemptCount(packet.zeroDiffRuntimeRetries),
     launchAttempts: normalizeAttemptCount(packet.launchAttempts),
     operatorStopped: packet.operatorStopped === true ? true : undefined,
     spendCap: normalizePacketSpendCap(packet.spendCap), spendTelemetry: normalizePacketSpendTelemetry(packet.spendTelemetry),

--- a/src/lib/orchestrator/types.ts
+++ b/src/lib/orchestrator/types.ts
@@ -333,6 +333,14 @@ export interface OrchestratorPacket {
    */
   launchAttempts?: number;
   /**
+   * Zero-diff runtime-fault retry budget spent (#2141). Same lifecycle as
+   * {@link stallRetries}: a worker that errors before writing anything gets one
+   * fresh dispatch, and the count lives ON the packet because the retry mints a
+   * new lane, so any per-lane counter would reset and bound nothing. Reset only
+   * by operator reset_packet.
+   */
+  zeroDiffRuntimeRetries?: number;
+  /**
    * Operator hit Stop — terminal "do not re-dispatch" marker. Checked first in
    * getDispatchBlocker so NO path (headless loop, stall escalation, ralph
    * requeue) can relaunch it. Cleared by reset_packet / explicit relaunch.

--- a/src/lib/supervisor/agent-completion.ts
+++ b/src/lib/supervisor/agent-completion.ts
@@ -94,7 +94,6 @@ export async function handleAgentCompletion(
         }
         if (probe.noChangesProduced) {
           const packetId = lane.packetId?.trim();
-          const now = new Date().toISOString();
           const { captureSettledReadOnlyCompletionContext, completeReadOnlyZeroDiffLane, isReadOnlyPacketLane, } = await guard.wait(() => import('@/lib/orchestrator/read-only-completion'));
           let readOnlyContext = null;
           if (isReadOnlyPacketLane(lane) && packetId && lane.sessionKey) {
@@ -145,36 +144,63 @@ export async function handleAgentCompletion(
               detail,
             };
           }
-          const failedLane = setLaneStatus(lane.id, 'failed', 'system', 'zero_diff_failed');
-          if (packetId) {
+          // #2141 — an empty worktree has two causes and only one is worth
+          // retrying. A runtime that ERRORED before writing anything is the
+          // most transient failure we own and has no partial work to lose; a
+          // run that finished cleanly and legitimately changed nothing must
+          // never be retried or a no-op packet loops forever. The normalized
+          // transcript is the signal that separates them.
+          const label = packetId ? `Packet ${packetId}` : `Lane ${lane.id}`;
+          const {
+            markZeroDiffTerminal,
+            readZeroDiffClassification,
+            requeueZeroDiffRuntimeFault,
+          } = await guard.wait(() => import('@/lib/supervisor/zero-diff-runtime-fault'));
+          const zeroDiff = await guard.wait(() => readZeroDiffClassification(lane.sessionKey ?? surfaceId));
+          if (zeroDiff.cause === 'runtime_error') {
             try {
-              const { withLockedState } = await guard.wait(() => import('@/lib/orchestrator/control-plane'));
-              await guard.wait(() => withLockedState((state) => {
-                guard.check();
-                const packet = state.packets.find((candidate) => candidate.id === packetId);
-                if (!packet)
-                  return;
-                packet.status = 'failed';
-                packet.blockedReason = 'no_changes_produced';
-                packet.lastEventAt = now;
-                packet.lastEventLabel = 'zero_diff_failed';
-                if (packet.lane) {
-                  packet.lane = {
-                    ...packet.lane,
-                    laneId: failedLane?.id ?? lane.id,
-                    sessionKey: failedLane?.sessionKey ?? lane.sessionKey ?? surfaceId,
-                    lastEventAt: now,
-                    lastEventLabel: 'zero_diff_failed',
-                  };
-                }
+              const requeue = await guard.wait(() => requeueZeroDiffRuntimeFault({
+                lane,
+                packetId,
+                worktreePath: completionCwd,
+                detail: zeroDiff.detail,
               }));
+              if (requeue.requeued) {
+                // This RUN failed — the lane is terminal and the retry mints a
+                // fresh one. `block: true` is what records it as failed instead
+                // of leaving the operator waiting on a finished agent.
+                setLaneStatus(lane.id, 'failed', 'system', 'zero_diff_runtime_error_requeued');
+                const requeuedDetail = `${label} errored before writing anything (${zeroDiff.detail}). Re-queued - retry ${requeue.retryNumber}/${requeue.cap}.`;
+                console.warn(`[supervisor] ${requeuedDetail}`);
+                void triggerHeadlessSprintTick().catch((error) => {
+                  console.error(`[supervisor] Failed to trigger the zero-diff retry dispatch for ${label}:`, error);
+                });
+                return {
+                  block: true,
+                  detail: requeuedDetail,
+                };
+              }
             } catch (error) {
               guard.check();
-              console.error(`[supervisor] Failed to persist no_changes_produced for packet ${packetId}:`, error);
+              console.error(`[supervisor] Zero-diff runtime retry failed for ${label}:`, error);
             }
           }
-          const label = packetId ? `Packet ${packetId}` : `Lane ${lane.id}`;
-          const detail = `${label} completed with no changes - needs redispatch with clearer guidance.`;
+          try {
+            await guard.wait(() => markZeroDiffTerminal({
+              lane,
+              packetId,
+              sessionKey: surfaceId,
+              cause: zeroDiff.cause,
+            }));
+          } catch (error) {
+            guard.check();
+            console.error(`[supervisor] Failed to persist the zero-diff outcome for ${label}:`, error);
+          }
+          const detail = zeroDiff.cause === 'runtime_error'
+            ? `${label} errored before writing anything (${zeroDiff.detail}) and its retry budget is spent - operator input is required.`
+            : zeroDiff.cause === 'clean_no_op'
+              ? `${label} completed with no changes - needs redispatch with clearer guidance.`
+              : `${label} completed with no changes, and the runtime gave no evidence either way (${zeroDiff.detail}) - operator input is required.`;
           console.warn(`[supervisor] ${detail}`);
           return {
             block: true,

--- a/src/lib/supervisor/agent-supervisor.ts
+++ b/src/lib/supervisor/agent-supervisor.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { getSqlite } from '@/lib/db';
 import type { WorkerLaunchContext } from '@/lib/orchestrator/types';
+import { settledCompletionStatus, watchedAgentOutcome } from './fleet-outcome';
 import { retryWatchedAgent } from './retry-watched-agent';
 import type {
   AgentStatusEntry,
@@ -620,6 +621,10 @@ async function handleStatusChange(
       return;
     }
     if (completionDecision?.block) {
+      // #2141 — the runtime said `finished`, the completion callback said the
+      // lane failed. Settle on the callback's verdict BEFORE persisting, or
+      // the fleet summary counts a failed lane among the completed ones.
+      watched.lastStatus = settledCompletionStatus(true);
       recordWatchedAgentEvent(watched, now);
       persistWatchedAgent(watched);
       callbacks.broadcastAgentUpdate({
@@ -898,14 +903,10 @@ function buildFleetStatusSummaries(repoPath?: string): SupervisorFleetStatusSumm
       || agent.lastStatus === 'launching'
     )).length;
     const idleAgents = agents.filter((agent) => isIdleAgent(agent)).length;
-    const completedAgents = agents.filter((agent) => (
-      agent.completionReported && agent.lastStatus === 'finished'
-    )).length;
-    const failedAgents = agents.filter((agent) => (
-      agent.completionReported
-      && (agent.lastStatus === 'failed' || agent.lastStatus === 'interrupted')
-    )).length;
-    const pendingAgents = Math.max(0, agents.length - completedAgents - failedAgents);
+    const outcomes = agents.map(watchedAgentOutcome);
+    const completedAgents = outcomes.filter((outcome) => outcome === 'completed').length;
+    const failedAgents = outcomes.filter((outcome) => outcome === 'failed').length;
+    const pendingAgents = outcomes.filter((outcome) => outcome === 'pending').length;
     const nextPollAt = agents.reduce<number | null>((next, agent) => {
       if (next === null) return agent.nextPollAt;
       return Math.min(next, agent.nextPollAt);

--- a/src/lib/supervisor/fleet-outcome.test.ts
+++ b/src/lib/supervisor/fleet-outcome.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { settledCompletionStatus, watchedAgentOutcome } from './fleet-outcome';
+
+describe('settledCompletionStatus', () => {
+  it('settles a blocked completion on failed, not on the runtime status', () => {
+    expect(settledCompletionStatus(true)).toBe('failed');
+    expect(settledCompletionStatus(false)).toBe('finished');
+  });
+});
+
+describe('watchedAgentOutcome', () => {
+  it('counts a blocked-completion agent as failed and never as pending', () => {
+    const agent = { completionReported: true, lastStatus: settledCompletionStatus(true) };
+
+    expect(watchedAgentOutcome(agent)).toBe('failed');
+  });
+
+  it('counts a clean completion as completed', () => {
+    expect(watchedAgentOutcome({ completionReported: true, lastStatus: 'finished' })).toBe('completed');
+  });
+
+  it('counts an interrupted agent as failed', () => {
+    expect(watchedAgentOutcome({ completionReported: true, lastStatus: 'interrupted' })).toBe('failed');
+  });
+
+  it('only counts an agent as pending while its completion is unreported', () => {
+    expect(watchedAgentOutcome({ completionReported: false, lastStatus: 'running' })).toBe('pending');
+    expect(watchedAgentOutcome({ completionReported: false, lastStatus: 'finished' })).toBe('pending');
+  });
+});

--- a/src/lib/supervisor/fleet-outcome.ts
+++ b/src/lib/supervisor/fleet-outcome.ts
@@ -1,0 +1,37 @@
+/**
+ * #2141 — what the fleet summary says a watched agent DID.
+ *
+ * The summary used to derive this from `lastStatus` alone, which the poller
+ * sets from the runtime's inventory. A worker that ran to `finished` and then
+ * had its completion BLOCKED (zero diff, failed verification, exhausted retry
+ * budget — the lane is terminal-failed) kept `lastStatus: 'finished'`, so the
+ * escalation reported it as one of the completed agents and closed with "All
+ * agents completed successfully." The operator was told to go read results
+ * that do not exist.
+ *
+ * Two halves of one rule live here so they cannot drift: the status a settled
+ * completion lands on, and how the summary counts each agent.
+ */
+import type { WatchedAgent } from './agent-supervisor-types';
+
+export type WatchedAgentOutcome = 'completed' | 'failed' | 'pending';
+
+/**
+ * The runtime status a finished agent settles on once its completion callback
+ * has ruled. A blocked completion is a failure of THIS run, whatever the
+ * runtime's own inventory said.
+ */
+export function settledCompletionStatus(blocked: boolean): 'finished' | 'failed' {
+  return blocked ? 'failed' : 'finished';
+}
+
+/**
+ * An agent is only `pending` while its completion has not been reported. Once
+ * it has, it is `completed` or `failed` — never pending, and never unclassified.
+ */
+export function watchedAgentOutcome(
+  agent: Pick<WatchedAgent, 'completionReported' | 'lastStatus'>,
+): WatchedAgentOutcome {
+  if (!agent.completionReported) return 'pending';
+  return agent.lastStatus === 'finished' ? 'completed' : 'failed';
+}

--- a/src/lib/supervisor/zero-diff-runtime-fault.test.ts
+++ b/src/lib/supervisor/zero-diff-runtime-fault.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TranscriptEvent } from '@/lib/orchestrator/transcript-normalizer';
+import {
+  classifyZeroDiffTranscript,
+  planZeroDiffRuntimeRetry,
+  ZERO_DIFF_RUNTIME_RETRY_CAP,
+} from './zero-diff-runtime-fault';
+
+function assistant(text: string): TranscriptEvent {
+  return { seq: 1, ts: '2026-09-11T00:00:00.000Z', type: 'assistant', text };
+}
+
+describe('classifyZeroDiffTranscript', () => {
+  it('reads an error event as a runtime failure and keeps its message', () => {
+    const classification = classifyZeroDiffTranscript({
+      events: [
+        assistant('Planning the change.'),
+        { seq: 2, ts: '2026-09-11T00:00:01.000Z', type: 'error', message: 'opencode run error' },
+      ],
+    });
+
+    expect(classification.cause).toBe('runtime_error');
+    expect(classification.detail).toBe('opencode run error');
+  });
+
+  it('reads a non-zero terminal exit as a runtime failure', () => {
+    const classification = classifyZeroDiffTranscript({
+      events: [
+        assistant('Working.'),
+        { seq: 2, ts: '2026-09-11T00:00:01.000Z', type: 'done', exitCode: 1 },
+      ],
+    });
+
+    expect(classification.cause).toBe('runtime_error');
+    expect(classification.detail).toContain('code 1');
+  });
+
+  it('reads a clean terminal exit as a deliberate no-op, never a fault', () => {
+    const classification = classifyZeroDiffTranscript({
+      events: [
+        assistant('Everything already satisfies the request; nothing to change.'),
+        { seq: 2, ts: '2026-09-11T00:00:01.000Z', type: 'done', exitCode: 0 },
+      ],
+    });
+
+    expect(classification.cause).toBe('clean_no_op');
+  });
+
+  it('will not call a run clean when the runtime has no transcript support', () => {
+    const classification = classifyZeroDiffTranscript({
+      events: [],
+      unsupportedReason: 'gemini-transcript-not-supported-yet',
+    });
+
+    expect(classification.cause).toBe('indeterminate');
+    expect(classification.detail).toContain('gemini-transcript-not-supported-yet');
+  });
+
+  it('will not call a run clean when the transcript is empty', () => {
+    expect(classifyZeroDiffTranscript({ events: [] }).cause).toBe('indeterminate');
+  });
+
+  it('will not call a run clean when it stopped without a terminal event', () => {
+    const classification = classifyZeroDiffTranscript({ events: [assistant('Thinking...')] });
+
+    expect(classification.cause).toBe('indeterminate');
+  });
+});
+
+describe('planZeroDiffRuntimeRetry', () => {
+  it('authorizes the first retry on a fresh packet', () => {
+    expect(planZeroDiffRuntimeRetry(undefined)).toMatchObject({
+      retry: true,
+      retriesSpent: 0,
+      retryNumber: 1,
+      cap: ZERO_DIFF_RUNTIME_RETRY_CAP,
+    });
+  });
+
+  it('refuses once the budget is spent, so the loop is bounded', () => {
+    expect(planZeroDiffRuntimeRetry(ZERO_DIFF_RUNTIME_RETRY_CAP).retry).toBe(false);
+    expect(planZeroDiffRuntimeRetry(ZERO_DIFF_RUNTIME_RETRY_CAP + 5).retry).toBe(false);
+  });
+
+  it('treats a corrupt counter as unspent rather than as infinite budget', () => {
+    expect(planZeroDiffRuntimeRetry(Number.NaN).retriesSpent).toBe(0);
+    expect(planZeroDiffRuntimeRetry(-3).retriesSpent).toBe(0);
+  });
+});

--- a/src/lib/supervisor/zero-diff-runtime-fault.ts
+++ b/src/lib/supervisor/zero-diff-runtime-fault.ts
@@ -1,0 +1,257 @@
+/**
+ * #2141 — telling a dead worker apart from a worker that had nothing to do.
+ *
+ * A completion with an empty worktree has two causes that are indistinguishable
+ * from git alone:
+ *   1. the runtime ERRORED before writing anything (the free-model rails that
+ *      plan, narrate, then die on `opencode run error`), and
+ *   2. the worker ran to a clean finish and legitimately changed nothing.
+ *
+ * The first is the most transient failure we have and the cheapest to retry —
+ * there is no partial work to preserve. The second must NEVER be retried: a
+ * packet whose correct answer is "nothing to change" would loop forever.
+ * `agent-completion` used to collapse both into `zero_diff_failed` and retry
+ * neither, which is why a flaky rail silently cost a third of a parallel
+ * dispatch.
+ *
+ * The signal that separates them already exists: the normalized transcript
+ * carries `error` events (`Codex run error` / `opencode run error`) and a
+ * terminal `done` with an exit code. This module reads it, and owns the
+ * bounded retry the `runtime_error` case earns.
+ */
+import { setLaneStatus } from '@/lib/lane/registry';
+import type { Lane } from '@/lib/lane/types';
+import { persistAttemptLearnings } from '@/lib/orchestrator/attempt-log';
+import { withLockedState } from '@/lib/orchestrator/control-plane';
+import { readSessionTranscriptEvents } from '@/lib/orchestrator/packet-transcript';
+import type { TranscriptEvent } from '@/lib/orchestrator/transcript-normalizer';
+import { markRalphRetryRequeued } from './post-completion-packet';
+
+/**
+ * Retries this fault class is allowed, per packet, across redispatches.
+ *
+ * One. A runtime that dies before its first write is failing for a transient
+ * reason (endpoint blip, rate limit, killed process) that a single fresh
+ * dispatch clears, or for a structural one (unreachable model, bad binding, a
+ * prompt the rail cannot execute) that no number of dispatches clears. The
+ * second identical failure is the evidence that it is structural, so the
+ * budget stops there instead of burning a worktree and a full worker run per
+ * cycle. The counter lives ON THE PACKET for the same reason as
+ * {@link OrchestratorPacket.stallRetries}: a per-lane count resets every
+ * redispatch and would never bound anything.
+ */
+export const ZERO_DIFF_RUNTIME_RETRY_CAP = 1;
+
+export type ZeroDiffCause =
+  /** The transcript shows the run errored — the empty worktree is the fallout. */
+  | 'runtime_error'
+  /** The run reached a clean terminal `done` and changed nothing on purpose. */
+  | 'clean_no_op'
+  /** No readable transcript, so the two cannot be told apart. */
+  | 'indeterminate';
+
+export interface ZeroDiffClassification {
+  cause: ZeroDiffCause;
+  detail: string;
+}
+
+export interface ZeroDiffTranscriptReadback {
+  events: TranscriptEvent[];
+  unsupportedReason?: string;
+}
+
+/**
+ * Pure classifier over a normalized transcript.
+ *
+ * `indeterminate` is a real answer, not a fallback for `clean_no_op`: a runtime
+ * with no normalized transcript (Gemini today) or an unreadable one gives us no
+ * evidence either way, and guessing `clean_no_op` hides a dead worker while
+ * guessing `runtime_error` retries a legitimate no-op. Both indeterminate and
+ * clean completions stay terminal; only their labels differ, so the operator
+ * can see which one they are looking at.
+ */
+export function classifyZeroDiffTranscript(
+  readback: ZeroDiffTranscriptReadback,
+): ZeroDiffClassification {
+  if (readback.unsupportedReason) {
+    return {
+      cause: 'indeterminate',
+      detail: `runtime transcript unavailable (${readback.unsupportedReason})`,
+    };
+  }
+
+  const events = readback.events;
+  if (events.length === 0) {
+    return { cause: 'indeterminate', detail: 'runtime transcript is empty' };
+  }
+
+  let lastError: string | null = null;
+  let lastDoneExitCode: number | null = null;
+  for (const event of events) {
+    if (event.type === 'error') lastError = event.message;
+    else if (event.type === 'done') lastDoneExitCode = event.exitCode;
+  }
+
+  if (lastError) {
+    return { cause: 'runtime_error', detail: lastError };
+  }
+  if (lastDoneExitCode !== null && lastDoneExitCode !== 0) {
+    return { cause: 'runtime_error', detail: `runtime exited with code ${lastDoneExitCode}` };
+  }
+  if (lastDoneExitCode === 0) {
+    return { cause: 'clean_no_op', detail: 'runtime finished cleanly without changing anything' };
+  }
+  // Events but no terminal marker: the run stopped without saying how.
+  return { cause: 'indeterminate', detail: 'runtime transcript has no terminal event' };
+}
+
+/** Read + classify. Any read failure is `indeterminate`, never a guess. */
+export async function readZeroDiffClassification(
+  sessionKey: string | null | undefined,
+): Promise<ZeroDiffClassification> {
+  const normalized = sessionKey?.trim();
+  if (!normalized) {
+    return { cause: 'indeterminate', detail: 'lane has no session binding' };
+  }
+  try {
+    return classifyZeroDiffTranscript(await readSessionTranscriptEvents(normalized));
+  } catch (error) {
+    return {
+      cause: 'indeterminate',
+      detail: `runtime transcript could not be read (${error instanceof Error ? error.message : String(error)})`,
+    };
+  }
+}
+
+export interface ZeroDiffRetryPlan {
+  retry: boolean;
+  /** Budget already spent before this decision. */
+  retriesSpent: number;
+  /** 1-based ordinal of the retry this plan authorizes, when it authorizes one. */
+  retryNumber: number;
+  cap: number;
+}
+
+/** Pure bound check — kept separate so the budget is testable without a packet. */
+export function planZeroDiffRuntimeRetry(retriesSpent: number | undefined): ZeroDiffRetryPlan {
+  const spent = Number.isFinite(retriesSpent) && (retriesSpent ?? 0) > 0
+    ? Math.floor(retriesSpent as number)
+    : 0;
+  return {
+    retry: spent < ZERO_DIFF_RUNTIME_RETRY_CAP,
+    retriesSpent: spent,
+    retryNumber: spent + 1,
+    cap: ZERO_DIFF_RUNTIME_RETRY_CAP,
+  };
+}
+
+export interface ZeroDiffRequeueResult {
+  requeued: boolean;
+  retryNumber: number;
+  cap: number;
+  /** Why the requeue did not happen, when it did not. */
+  reason: 'requeued' | 'budget_spent' | 'packet_not_found' | 'requeue_failed';
+}
+
+/**
+ * Spend one unit of the zero-diff runtime budget and put the packet back on the
+ * queue, mirroring the verification-failure requeue (`markRalphRetryRequeued` +
+ * `queueState: 'queued'` + `lane: null`) so the headless dispatcher picks it up
+ * on its next tick. `attemptCount` is deliberately NOT advanced: this fault
+ * produced no work to learn from, and spending the packet's shared attempt
+ * budget on a dead rail would starve the verification retries that do.
+ */
+export async function requeueZeroDiffRuntimeFault(input: {
+  lane: Lane;
+  packetId: string | null | undefined;
+  worktreePath: string;
+  detail: string;
+}): Promise<ZeroDiffRequeueResult> {
+  const packetId = input.packetId?.trim();
+  if (!packetId) {
+    return { requeued: false, retryNumber: 0, cap: ZERO_DIFF_RUNTIME_RETRY_CAP, reason: 'packet_not_found' };
+  }
+
+  const { result: plan } = await withLockedState((state) => {
+    const packet = state.packets.find((candidate) => candidate.id === packetId);
+    if (!packet) return null;
+    // An operator Stop is terminal for every relaunch path, this one included.
+    if (packet.operatorStopped) return { ...planZeroDiffRuntimeRetry(packet.zeroDiffRuntimeRetries), retry: false };
+    const decision = planZeroDiffRuntimeRetry(packet.zeroDiffRuntimeRetries);
+    if (!decision.retry) return decision;
+    const now = new Date().toISOString();
+    packet.zeroDiffRuntimeRetries = decision.retryNumber;
+    packet.queueState = 'queued';
+    packet.status = 'queued';
+    packet.blockedReason = null;
+    packet.lastEventAt = now;
+    packet.lastEventLabel = 'zero_diff_runtime_error_requeued';
+    packet.lane = null;
+    return decision;
+  });
+
+  if (!plan) {
+    return { requeued: false, retryNumber: 0, cap: ZERO_DIFF_RUNTIME_RETRY_CAP, reason: 'packet_not_found' };
+  }
+  if (!plan.retry) {
+    return { requeued: false, retryNumber: plan.retryNumber, cap: plan.cap, reason: 'budget_spent' };
+  }
+
+  try {
+    markRalphRetryRequeued(input.lane.id, packetId);
+  } catch (error) {
+    console.error(`[supervisor] Zero-diff runtime retry requeue failed for packet ${packetId}:`, error);
+    return { requeued: false, retryNumber: plan.retryNumber, cap: plan.cap, reason: 'requeue_failed' };
+  }
+
+  try {
+    await persistAttemptLearnings(input.worktreePath, packetId, plan.retryNumber, {
+      filesChanged: [],
+      summary: `Worker runtime errored before writing any files: ${input.detail}. Retry ${plan.retryNumber}/${plan.cap}.`,
+    });
+  } catch (error) {
+    // Non-fatal — the requeue already landed; the retry just loses its note.
+    console.warn(`[supervisor] Failed to record zero-diff runtime learning for packet ${packetId}:`, error);
+  }
+
+  return { requeued: true, retryNumber: plan.retryNumber, cap: plan.cap, reason: 'requeued' };
+}
+
+/** Lane label + packet `blockedReason` per cause — the states must not collapse. */
+const TERMINAL_MARKERS: Record<ZeroDiffCause, { laneLabel: string; blockedReason: string }> = {
+  runtime_error: { laneLabel: 'zero_diff_runtime_error', blockedReason: 'worker_runtime_error' },
+  clean_no_op: { laneLabel: 'zero_diff_failed', blockedReason: 'no_changes_produced' },
+  indeterminate: { laneLabel: 'zero_diff_unclassified', blockedReason: 'no_changes_produced' },
+};
+
+/** Land a zero-diff completion in its terminal state, labelled by cause. */
+export async function markZeroDiffTerminal(input: {
+  lane: Lane;
+  packetId: string | null | undefined;
+  sessionKey: string;
+  cause: ZeroDiffCause;
+}): Promise<void> {
+  const marker = TERMINAL_MARKERS[input.cause];
+  const failedLane = setLaneStatus(input.lane.id, 'failed', 'system', marker.laneLabel);
+  const packetId = input.packetId?.trim();
+  if (!packetId) return;
+
+  const now = new Date().toISOString();
+  await withLockedState((state) => {
+    const packet = state.packets.find((candidate) => candidate.id === packetId);
+    if (!packet) return;
+    packet.status = 'failed';
+    packet.blockedReason = marker.blockedReason;
+    packet.lastEventAt = now;
+    packet.lastEventLabel = marker.laneLabel;
+    if (packet.lane) {
+      packet.lane = {
+        ...packet.lane,
+        laneId: failedLane?.id ?? input.lane.id,
+        sessionKey: failedLane?.sessionKey ?? input.lane.sessionKey ?? input.sessionKey,
+        lastEventAt: now,
+        lastEventLabel: marker.laneLabel,
+      };
+    }
+  });
+}

--- a/tests/packet-control-fields-survive-normalize.test.ts
+++ b/tests/packet-control-fields-survive-normalize.test.ts
@@ -53,6 +53,7 @@ function fullPacketFixture() {
     uiLoopIterations: 3,
     uiLoopStartedAt: '2026-01-01T00:00:00.000Z',
     stallRetries: 2,
+    zeroDiffRuntimeRetries: 1,
     launchAttempts: 3,
     operatorStopped: true,
     spendCap: { carrier: 'openrouter', costUsd: 1, inputTokens: 500_000 },


### PR DESCRIPTION
Closes #2141

## What was actually wrong

A zero-diff completion was a single state — `zero_diff_failed`, terminal, never retried. That collapsed two outcomes that are not the same thing:

- a runtime that **errored before writing anything** (the free-model rails that plan, narrate, then die on `opencode run error`), and
- a run that **finished cleanly and legitimately changed nothing**.

The first is the most transient failure the supervisor owns and has no partial work to lose. The second must never be retried or a no-op packet loops forever. Both dead-ended, so one flaky rail silently cost a third of a parallel dispatch.

The signal that separates them already existed and was unread: the normalized transcript carries `error` events (`transcript-normalizer.ts` → `Codex run error`, `transcript-normalizer-multi.ts` → `opencode run error`) and a terminal `done` with an exit code.

## What changed

**`src/lib/supervisor/zero-diff-runtime-fault.ts` (new)** — classifies a zero-diff completion and owns the retry:

| cause | evidence | outcome |
|---|---|---|
| `runtime_error` | an `error` event, or `done` with a non-zero exit | bounded retry, then terminal |
| `clean_no_op` | `done` with exit 0 and no error | terminal, never retried |
| `indeterminate` | no readable transcript | terminal, never retried |

**`indeterminate` is a real third answer, not a fallback.** A runtime with no normalized transcript (Gemini today), an empty one, or one that stops with no terminal event gives no evidence either way. Guessing `clean_no_op` hides a dead worker; guessing `runtime_error` retries a legitimate no-op. It stays terminal under its own label so the operator can see which one they are looking at.

**The bound: one retry per packet**, held in a new `zeroDiffRuntimeRetries` counter **on the packet**. A runtime that dies before its first write is failing either for a transient reason one fresh dispatch clears (endpoint blip, rate limit, killed process) or for a structural one no number of dispatches clears (unreachable model, bad binding). The second identical failure is the evidence that it is structural, so the budget stops there rather than burning a worktree and a full worker run per cycle. The counter lives on the packet for the same reason as `stallRetries`: the retry mints a **new lane**, so any per-lane counter would reset and bound nothing. Reset only by `reset_packet`, and an operator Stop refuses the requeue outright.

It does **not** spend the packet's shared `attemptCount` budget — this fault produced no work to learn from, and draining that budget on a dead rail would starve the verification retries that do.

**Each outcome gets its own lane label** so the states cannot collapse: `zero_diff_runtime_error` / `zero_diff_runtime_error_requeued` / `zero_diff_failed` (unchanged, clean no-op) / `zero_diff_unclassified`. Surfaced in the control-room task signal and the stale-cleanup set.

**Recorded as failed, not pending.** The requeued run returns `block: true` — this run failed, the lane goes terminal, and the retry mints a fresh lane on the next headless tick. The operator is never left waiting on a finished agent.

## Where the issue was wrong

The issue reports defect 2 as "the fleet summary miscounts a failed lane as **pending**". Reading the code, it miscounts in the opposite and worse direction. `handleStatusChange`'s `block` branch set `completionReported = true` but left `lastStatus: 'finished'`, so `buildFleetStatusSummaries` counted a just-failed lane among `completedAgents`, and the escalation's suffix (`agents.every(lastStatus === 'finished')`) closed with **"All agents completed successfully."** An agent with `completionReported` can never be pending under that arithmetic.

Fixed at the source in `fleet-outcome.ts`: a blocked completion settles on `failed` **before** it persists, and completed/failed/pending now derive from one rule (`watchedAgentOutcome`) so the assignment and the count cannot drift. The "All agents completed successfully" suffix and `allSucceeded` correct themselves as a consequence.

## Scope boundary

`src/lib/lane/commands.ts` has a sibling zero-diff guard on the `request_review` verb that also marks `zero_diff_failed` without a retry. It is operator/orchestrator-initiated review rather than the headless completion path the issue describes, and it is only reachable from `scheduling.ts` when the worktree already has reviewable work. Left alone deliberately.

## Verification

- `npx tsc --noEmit` — clean.
- `npx eslint` on all changed files — clean.
- `npm test` — **715 files passed, 3 skipped; 4642 tests passed, 4 skipped, 0 failed.** (`multi-identity-sessions.test.ts` passed on this run.)
- New tests confirmed to actually execute under the unit config with `--reporter=verbose` (19 tests across the two new files plus the packet-normalize guard).
- `npm run test:classification:check` — manifest matches.
- `tests/packet-control-fields-survive-normalize.test.ts` forced the new packet field to pin its normalize behavior; the fixture was updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dVxFgHWcYwiMja5oBxySH
