### PR TITLE
fix(orchestrator): resolve virtual single-repo project ids (#2140)

### DIFF
--- a/src/lib/mobile/orchestrator-thread-project.test.ts
+++ b/src/lib/mobile/orchestrator-thread-project.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -6,17 +6,42 @@ import { describe, expect, it } from 'vitest';
 process.env.O8_DATA_DIR ??= mkdtempSync(path.join(os.tmpdir(), 'o8-thread-project-'));
 process.env.CORTEX_IDE_DATA_DIR ??= process.env.O8_DATA_DIR;
 
+/**
+ * A repo in the pool that belongs to no project — the state every repo is in
+ * right after it is registered, and the one the ledger projects a virtual
+ * `repo:<id>` project for. Written before the registry module loads so the
+ * first read sees it (#2140).
+ */
+const POOL_REPO_ID = 'fbf8cf7b-280e-40d6-8599-c9adb57d3172';
+writeFileSync(
+  path.join(process.env.O8_DATA_DIR, 'repos.json'),
+  JSON.stringify({
+    version: 1,
+    repos: [{
+      id: POOL_REPO_ID,
+      name: 'solo-repo',
+      localPath: path.join(process.env.O8_DATA_DIR, 'solo-repo'),
+      remoteUrl: null,
+      defaultBranch: 'main',
+      addedAt: new Date().toISOString(),
+      lastOpenedAt: null,
+    }],
+  }),
+  'utf8',
+);
+
 const {
   LEGACY_DEFAULT_PROJECT_ID,
   OrchestratorThreadProjectError,
   resolveOrchestratorThreadProjectId,
 } = await import('./orchestrator-thread-project');
 const { DEFAULT_PROJECT_ID } = await import('@/lib/repos/projects');
+const { virtualRepoProjectId } = await import('@/lib/repos/virtual-project-id');
 const { createProject } = await import('@/lib/projects/store');
 
 describe('orchestrator thread project resolution (#1752)', () => {
   it('keeps the local sentinel in step with the ledger constant', () => {
-    // Declared locally so this module does not pull the repo-pool graph.
+    // Declared locally rather than imported from the ledger module.
     expect(LEGACY_DEFAULT_PROJECT_ID).toBe(DEFAULT_PROJECT_ID);
   });
 
@@ -58,5 +83,37 @@ describe('orchestrator thread project resolution (#1752)', () => {
 
   it('leaves a no-project thread alone', () => {
     expect(resolveOrchestratorThreadProjectId(null, null)).toBeNull();
+  });
+});
+
+describe('virtual single-repo project resolution (#2140)', () => {
+  it('resolves the virtual project the ledger projects for a pool repo', () => {
+    // The composer stamps `repo:<id>` onto the thread for a repo that is in no
+    // project. SQLite has no such row, so every turn on it — parallel dispatch
+    // included — died with "Project repo:<id> does not exist".
+    const projectId = virtualRepoProjectId(POOL_REPO_ID);
+    expect(resolveOrchestratorThreadProjectId(null, projectId)).toBe(projectId);
+  });
+
+  it('resolves a thread already stamped with a virtual project id', () => {
+    const projectId = virtualRepoProjectId(POOL_REPO_ID);
+    expect(resolveOrchestratorThreadProjectId(projectId, undefined)).toBe(projectId);
+    expect(resolveOrchestratorThreadProjectId(projectId, projectId)).toBe(projectId);
+  });
+
+  it('still refuses a virtual id whose repo is not in the pool', () => {
+    expect(() => resolveOrchestratorThreadProjectId(null, virtualRepoProjectId('not-a-pool-repo')))
+      .toThrow(OrchestratorThreadProjectError);
+  });
+
+  it('names the repo rather than the internal id when a virtual id fails', () => {
+    expect(() => resolveOrchestratorThreadProjectId(null, virtualRepoProjectId('not-a-pool-repo')))
+      .toThrow('Repo not-a-pool-repo is not registered.');
+  });
+
+  it('still reports a mismatch between a virtual project and a real one', () => {
+    const real = createProject({ name: 'Mismatch Project' });
+    expect(() => resolveOrchestratorThreadProjectId(virtualRepoProjectId(POOL_REPO_ID), real.id))
+      .toThrow(OrchestratorThreadProjectError);
   });
 });

--- a/src/lib/mobile/orchestrator-thread-project.ts
+++ b/src/lib/mobile/orchestrator-thread-project.ts
@@ -1,10 +1,12 @@
 import { getProject } from '@/lib/projects/store';
+import { findRepoByIdSync } from '@/lib/repos/registry';
+import { virtualProjectRepoId } from '@/lib/repos/virtual-project-id';
 
 /**
  * The JSON-ledger's sentinel project id (`DEFAULT_PROJECT_ID` in
- * `@/lib/repos/projects`). Declared locally rather than imported so this
- * module does not pull the repo-pool graph; `orchestrator-thread-project.test.ts`
- * pins the two together so they cannot drift apart.
+ * `@/lib/repos/projects`). Declared locally rather than imported from the
+ * ledger module; `orchestrator-thread-project.test.ts` pins the two together
+ * so they cannot drift apart.
  */
 export const LEGACY_DEFAULT_PROJECT_ID = 'default';
 
@@ -22,6 +24,28 @@ export const LEGACY_DEFAULT_PROJECT_ID = 'default';
  */
 function isUnresolvedLegacyDefault(projectId: string): boolean {
   return projectId === LEGACY_DEFAULT_PROJECT_ID && !getProject(projectId);
+}
+
+/**
+ * A thread's project id is stamped from the projects ledger, and the ledger
+ * resolves ids out of TWO stores: SQLite holds the real projects, and the
+ * ledger projects a virtual `repo:<id>` row for every pool repo that belongs
+ * to no project. Only SQLite was consulted here, so a single-repo project —
+ * which is what every repo is until a second one joins it — was selectable
+ * and usable everywhere except an orchestrator turn, where it killed the turn
+ * with "Project repo:<id> does not exist" (#2140). Both families resolve on
+ * this one path so the single-repo and multi-repo cases cannot drift apart.
+ */
+function projectIdResolves(projectId: string): boolean {
+  const repoId = virtualProjectRepoId(projectId);
+  return repoId ? Boolean(findRepoByIdSync(repoId)) : Boolean(getProject(projectId));
+}
+
+function unresolvedProjectMessage(projectId: string): string {
+  // A virtual id names a pool repo, not a project — say so rather than
+  // surfacing the internal `repo:<uuid>` form the operator never typed.
+  const repoId = virtualProjectRepoId(projectId);
+  return repoId ? `Repo ${repoId} is not registered.` : `Project ${projectId} does not exist.`;
 }
 
 export type OrchestratorThreadProjectErrorCode =
@@ -68,10 +92,10 @@ function validateRequestedProjectId(value: unknown): string | null {
   }
   const projectId = value.trim();
   if (isUnresolvedLegacyDefault(projectId)) return null;
-  if (!getProject(projectId)) {
+  if (!projectIdResolves(projectId)) {
     throw new OrchestratorThreadProjectError({
       code: 'orchestrator_thread_project_not_found',
-      message: `Project ${projectId} does not exist.`,
+      message: unresolvedProjectMessage(projectId),
       projectId,
     });
   }

--- a/src/lib/repos/projects.ts
+++ b/src/lib/repos/projects.ts
@@ -19,6 +19,7 @@ import {
 import { listRepos } from './registry';
 import { removeRepoFromPool } from './remove';
 import { reconcileSqliteProjectRepos } from './project-membership';
+import { isVirtualRepoProjectId, virtualProjectRepoId, virtualRepoProjectId } from './virtual-project-id';
 
 const PROJECTS_DIR = getDataDir();
 const PROJECTS_PATH = path.join(PROJECTS_DIR, 'projects.json');
@@ -211,7 +212,7 @@ function writeSqliteProjectMeta(ledger: ProjectsLedger): void {
       'UPDATE projects SET color = ?, sort_order = ? WHERE slug = ?',
     );
     ledger.projects.forEach((project, index) => {
-      if (project.id.startsWith('repo:')) return;
+      if (isVirtualRepoProjectId(project.id)) return;
       const color = project.color ?? null;
       const sortOrder = index;
       const res = updateById.run(color, sortOrder, project.id);
@@ -268,7 +269,7 @@ async function writeLedger(ledger: ProjectsLedger) {
   // derived at read time from unassigned pool repos.
   const persistable: ProjectsLedger = {
     ...ledger,
-    projects: ledger.projects.filter((p) => !p.id.startsWith('repo:')),
+    projects: ledger.projects.filter((p) => !isVirtualRepoProjectId(p.id)),
   };
   await writeFile(PROJECTS_PATH, JSON.stringify(persistable, null, 2), 'utf8');
   // #1099 Phase 2 — mirror the migrated metadata into SQLite so the overlay
@@ -303,7 +304,7 @@ export async function getProjectsLedger(): Promise<ProjectsLedger> {
   // while a concrete project exists, prefer a concrete (non-virtual) project.
   const hasActive = enriched.projects.some((p) => p.id === enriched.activeProjectId);
   if (!hasActive || enriched.activeProjectId === DEFAULT_PROJECT_ID) {
-    const concrete = enriched.projects.find((p) => p.id !== DEFAULT_PROJECT_ID && !p.id.startsWith('repo:'))
+    const concrete = enriched.projects.find((p) => p.id !== DEFAULT_PROJECT_ID && !isVirtualRepoProjectId(p.id))
       ?? enriched.projects.find((p) => p.id !== DEFAULT_PROJECT_ID)
       ?? enriched.projects[0];
     if (concrete) return { ...enriched, activeProjectId: concrete.id };
@@ -392,7 +393,7 @@ async function enrichLedgerWithSqliteRepoPaths(ledger: ProjectsLedger): Promise<
     const repoPath = normalizeRepoPath(repo.localPath);
     if (assignedPaths.has(repoPath)) continue;
     projects.push({
-      id: `repo:${repo.id}`,
+      id: virtualRepoProjectId(repo.id),
       name: repo.name,
       repoPaths: [repoPath],
       createdAt: repo.addedAt ?? nowIso(),
@@ -583,17 +584,17 @@ export async function deleteProject(projectId: string): Promise<ProjectsLedger> 
   // the pool re-projects as a virtual single-repo row with the same name, so
   // the delete visibly "doesn't work". Repos on disk are never touched, and a
   // repo that another project still uses survives.
-  if (projectId.startsWith('repo:')) {
+  const virtualRepoId = virtualProjectRepoId(projectId);
+  if (virtualRepoId) {
     // Virtual single-repo projection — nothing is persisted for it, so the ONLY
     // real delete is removing the repo from the pool (the old filter-and-write
     // was a silent no-op: writeLedger drops repo:* ids and the projection
     // re-derived the row on every read).
     if (target) {
-      const repoId = projectId.slice('repo:'.length);
       try {
-        await removeRepoFromPool(repoId);
+        await removeRepoFromPool(virtualRepoId);
       } catch (error) {
-        console.warn(`[projects] Failed to remove repo ${repoId} for virtual project delete:`, error);
+        console.warn(`[projects] Failed to remove repo ${virtualRepoId} for virtual project delete:`, error);
       }
     }
     const remaining = ledger.projects.filter((p) => p.id !== projectId);

--- a/src/lib/repos/registry.ts
+++ b/src/lib/repos/registry.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import { execFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import { access, mkdir, realpath, stat } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -467,6 +468,32 @@ export async function listRepos() {
 export async function listReposFresh() {
   const store = await readStoreFresh();
   return store.repos;
+}
+
+/**
+ * Synchronous pool lookup by id. Orchestrator thread-project validation has to
+ * resolve virtual `repo:<id>` project ids on a synchronous path and cannot
+ * await `listRepos()` (#2140). Shares the async read's cache and normalization
+ * so both see the same pool; a missing or unreadable registry reads as an
+ * empty pool, which the caller already handles as an unresolvable id.
+ */
+export function findRepoByIdSync(id: string): RepoRegistryEntry | null {
+  if (!_cachedStore || Date.now() - _cachedStore.ts >= STORE_CACHE_TTL_MS) {
+    try {
+      const parsed = JSON.parse(readFileSync(REGISTRY_PATH, 'utf8')) as Partial<RepoRegistryStore> | null;
+      if (!parsed || !Array.isArray(parsed.repos)) return null;
+      _cachedStore = {
+        value: {
+          version: 1,
+          repos: sortRepos((parsed.repos as RepoRegistryEntry[]).map(normalizeRepoEntry)),
+        },
+        ts: Date.now(),
+      };
+    } catch {
+      return null;
+    }
+  }
+  return _cachedStore.value.repos.find((repo) => repo.id === id) ?? null;
 }
 
 export async function findRepoByLocalPath(localPath: string) {

--- a/src/lib/repos/virtual-project-id.ts
+++ b/src/lib/repos/virtual-project-id.ts
@@ -1,0 +1,29 @@
+/**
+ * The projects ledger projects a VIRTUAL single-repo project for every pool
+ * repo that belongs to no project, under the id `repo:<repoId>`. Nothing
+ * persists those rows — `writeLedger` filters them out and the projection
+ * re-derives them on every read — so they live only in the ledger's read
+ * model, which is also what the sidebar shows and what the composer stamps
+ * onto a thread.
+ *
+ * The shape lives here, clear of the repo-pool graph, so every store that has
+ * to recognize one of these ids agrees on it without importing the ledger
+ * (#2140 — the orchestrator validated thread project ids against SQLite only,
+ * where a virtual id has no row).
+ */
+export const VIRTUAL_REPO_PROJECT_PREFIX = 'repo:';
+
+/** Id of the virtual single-repo project projected for `repoId`. */
+export function virtualRepoProjectId(repoId: string): string {
+  return `${VIRTUAL_REPO_PROJECT_PREFIX}${repoId}`;
+}
+
+export function isVirtualRepoProjectId(projectId: string): boolean {
+  return projectId.startsWith(VIRTUAL_REPO_PROJECT_PREFIX);
+}
+
+/** The pool repo id behind a virtual project id; null for any other id. */
+export function virtualProjectRepoId(projectId: string): string | null {
+  if (!isVirtualRepoProjectId(projectId)) return null;
+  return projectId.slice(VIRTUAL_REPO_PROJECT_PREFIX.length) || null;
+}


### PR DESCRIPTION
Closes #2140

## The bug, confirmed

The projects ledger projects a **virtual** single-repo project for every pool repo that belongs to no project, under the id `repo:<repoId>` (`src/lib/repos/projects.ts`). Nothing persists that row — `writeLedger` filters `repo:*` out and the projection re-derives it on every read — yet it is what the sidebar shows and what the composer stamps onto a thread.

`validateRequestedProjectId` looked the thread's project id up in the SQLite `projects` table only (`getProject`), so a virtual id found no row and threw `orchestrator_thread_project_not_found`. The ws-server catch surfaces that as `Orchestrator error: Project repo:<id> does not exist.` — the exact trace in the issue.

The issue's diagnosis of the mechanic is correct. The three new tests fail on `main` with that message and pass here.

## One scope correction

The issue says solo turns work and only dispatch fails. That is not what the code does. `appendMobileOrchestratorUserMessage` resolves the project id for **every** orchestrator turn on a `thoughts-` thread, and the composer sends `projectId` on every send regardless of mode — so any turn on a thread carrying a virtual id dies the same way. Parallel dispatch is where it was noticed, not where it is special. The fix is the same either way; it just covers more than the report claimed.

## What changed

- **`validateRequestedProjectId` resolves both families the ledger can produce.** A `repo:<id>` resolves against the repo pool; anything else resolves against SQLite. One predicate (`projectIdResolves`), so the single-repo and multi-repo paths cannot drift apart. An id that matches neither still throws `orchestrator_thread_project_not_found`.
- **`findRepoByIdSync` (`src/lib/repos/registry.ts`)** gives that synchronous path a pool lookup — the resolver is sync and cannot await `listRepos()`. It reads through the same cache and the same normalization as the async path, so both see one pool.
- **`src/lib/repos/virtual-project-id.ts`** holds the `repo:` shape and replaces the five inline `'repo:'` string literals in the ledger, so the store that mints these ids and the store that has to recognize them agree on it.
- **The error names the repo** when a virtual id fails, instead of surfacing the internal `repo:<uuid>` form the operator never typed.

Not materializing the projection (the issue's second option): writing a SQLite row on first dispatch would make "virtual" a lie that every other read has to reconcile, and `deleteProject` already has a dedicated virtual branch that would then be wrong. Resolution is the smaller correct change.

## What I left

Two adjacent things this does not touch, neither of which blocks a turn:

- `getProjectsLedgerSync()` does not include the virtual projection (only the async `getProjectsLedger()` does), so `getActiveProjectScopeForRepoSync` — which stamps `projectId` onto new lanes — falls back off a virtual active id to a concrete project. Lanes cut under a single-repo project get attributed to the fallback project rather than the repo. Wrong attribution, not a failure.
- A JSON-ledger-only project (one with no SQLite match) is a third id family that `getProject` also cannot resolve. Legacy shape, not reachable from the reported path.

## Verification

- `npx tsc --noEmit` — clean.
- `npx eslint` on all five changed files — clean.
- `npm test` (unit config, the config that actually runs this file — confirmed with `--reporter=verbose`): **715 files passed, 3 skipped; 4647 tests passed, 4 skipped.** Green, including `src/lib/codex/multi-identity-sessions.test.ts`.
- Reproduction check: with `orchestrator-thread-project.ts` stashed, the three new `#2140` tests fail with `Project repo:fbf8cf7b-… does not exist.` — the issue's error, verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dVxFgHWcYwiMja5oBxySH