### PR TITLE
Ask the OpenCode CLI which providers are connected

### DIFF
--- a/src/app/api/setup/detect/route.ts
+++ b/src/app/api/setup/detect/route.ts
@@ -14,7 +14,7 @@ import {
   CLAUDE_PROBE_TIMEOUT_MS,
   probeClaudeLoginState,
 } from '@/lib/runtimes/shared/claude-login-probe';
-import { opencodeCredentialProviders } from '@/lib/runtimes/shared/opencode-readiness';
+import { opencodeAuthenticatedProviders } from '@/lib/runtimes/shared/opencode-readiness';
 import { hasLiveClaudeOAuth } from '@/lib/claude-code/oauth-credential';
 import { getDataDir } from '@/lib/data-dir-migration';
 
@@ -336,7 +336,7 @@ async function detectOpenCode(deadlineAt?: number): Promise<DetectedTool> {
 
   const readiness = detected ? await detectRuntimeAuthStatus('opencode') : null;
   if (detected) {
-    authedProviders = [...await opencodeCredentialProviders(homedir())].sort();
+    authedProviders = [...await opencodeAuthenticatedProviders(homedir(), path)].sort();
   }
   const authPresent = readiness?.authenticated === true;
   const ready = readiness?.ready === true;

--- a/src/lib/runtimes/shared/auth-detect.ts
+++ b/src/lib/runtimes/shared/auth-detect.ts
@@ -25,7 +25,7 @@ import {
 import { cliInvocation } from '@/lib/runtimes/shared/cli-spawn';
 import {
   localProviderIds,
-  opencodeCredentialProviders,
+  opencodeAuthenticatedProviders,
   probeOpencodeServiceVersion,
   providerHasConfiguredCredential,
   providerIdForModel,
@@ -174,7 +174,7 @@ async function opencodeModelStatus(
   }
 
   const [credentialProviders, config] = await Promise.all([
-    opencodeCredentialProviders(os.homedir()),
+    opencodeAuthenticatedProviders(os.homedir(), status.binaryPath),
     readOpencodeConfig(os.homedir(), cwd),
   ]);
   const localProviders = localProviderIds(config);
@@ -357,7 +357,7 @@ async function detectOpencode(): Promise<RuntimeAuthStatus> {
   }
 
   const [credentialProviders, config, serviceVersion] = await Promise.all([
-    opencodeCredentialProviders(os.homedir()),
+    opencodeAuthenticatedProviders(os.homedir(), binaryPath),
     readOpencodeConfig(os.homedir()),
     probeOpencodeServiceVersion(binaryPath),
   ]);

--- a/src/lib/runtimes/shared/opencode-auth-providers.test.ts
+++ b/src/lib/runtimes/shared/opencode-auth-providers.test.ts
@@ -1,0 +1,124 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const {
+  opencodeAuthenticatedProviders,
+  opencodeCliProviders,
+  setOpencodeAuthListProbeDependenciesForTests,
+} = await import('./opencode-readiness');
+
+const CLI_PATH = '/test-bin/opencode2';
+
+/** Shape of `auth list --format json`: provider ids plus how each is connected. */
+const CLI_PAYLOAD = JSON.stringify([
+  { id: 'openrouter', name: 'OpenRouter', connections: [{ type: 'credential', id: 'cred_test', label: 'default' }] },
+  { id: 'xai', name: 'xAI', connections: [{ type: 'env', name: 'XAI_API_KEY' }] },
+  { id: 'anthropic', name: 'Anthropic', connections: [] },
+]);
+
+let home: string;
+let savedDataHome: string | undefined;
+let savedAuthContent: string | undefined;
+
+function writeLegacyAuthFile(providers: Record<string, unknown>): void {
+  const directory = path.join(home, '.local', 'share', 'opencode');
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(path.join(directory, 'auth.json'), JSON.stringify(providers));
+}
+
+function stubCli(run: (args: string[]) => Promise<string>): string[][] {
+  const calls: string[][] = [];
+  setOpencodeAuthListProbeDependenciesForTests({
+    run: (args) => {
+      calls.push(args);
+      return run(args);
+    },
+  });
+  return calls;
+}
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(os.tmpdir(), 'o8-opencode-auth-'));
+  savedDataHome = process.env.XDG_DATA_HOME;
+  savedAuthContent = process.env.OPENCODE_AUTH_CONTENT;
+  delete process.env.XDG_DATA_HOME;
+  delete process.env.OPENCODE_AUTH_CONTENT;
+});
+
+afterEach(() => {
+  setOpencodeAuthListProbeDependenciesForTests(null);
+  if (savedDataHome === undefined) delete process.env.XDG_DATA_HOME;
+  else process.env.XDG_DATA_HOME = savedDataHome;
+  if (savedAuthContent === undefined) delete process.env.OPENCODE_AUTH_CONTENT;
+  else process.env.OPENCODE_AUTH_CONTENT = savedAuthContent;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe('opencodeAuthenticatedProviders', () => {
+  it('reports providers the CLI holds when no credential file exists', async () => {
+    const calls = stubCli(async () => CLI_PAYLOAD);
+
+    const providers = await opencodeAuthenticatedProviders(home, CLI_PATH);
+
+    expect([...providers].sort()).toEqual(['openrouter', 'xai']);
+    expect(calls).toEqual([['auth', 'list', '--format', 'json']]);
+  });
+
+  it('still reports providers from a credential file when the CLI is absent', async () => {
+    writeLegacyAuthFile({ openrouter: { type: 'api', key: 'legacy-key' } });
+
+    const providers = await opencodeAuthenticatedProviders(home, null);
+
+    expect([...providers]).toEqual(['openrouter']);
+  });
+
+  it('unions the credential file with what the CLI reports', async () => {
+    writeLegacyAuthFile({ anthropic: { type: 'api', key: 'legacy-key' } });
+    stubCli(async () => CLI_PAYLOAD);
+
+    const providers = await opencodeAuthenticatedProviders(home, CLI_PATH);
+
+    expect([...providers].sort()).toEqual(['anthropic', 'openrouter', 'xai']);
+  });
+
+  it('falls back to the credential file when the CLI probe fails', async () => {
+    writeLegacyAuthFile({ openrouter: { type: 'api', key: 'legacy-key' } });
+    stubCli(async () => {
+      throw new Error('probe timed out');
+    });
+
+    await expect(opencodeAuthenticatedProviders(home, CLI_PATH)).resolves.toEqual(
+      new Set(['openrouter']),
+    );
+  });
+
+  it('treats an unreadable payload as indeterminate rather than empty', async () => {
+    writeLegacyAuthFile({ openrouter: { type: 'api', key: 'legacy-key' } });
+    stubCli(async () => JSON.stringify([{ provider: 'openrouter', status: 'stored' }]));
+
+    await expect(opencodeAuthenticatedProviders(home, CLI_PATH)).resolves.toEqual(
+      new Set(['openrouter']),
+    );
+  });
+});
+
+describe('opencodeCliProviders', () => {
+  it('returns null without a CLI to ask', async () => {
+    await expect(opencodeCliProviders(null)).resolves.toBeNull();
+  });
+
+  it('returns an empty set when the CLI reports nothing connected', async () => {
+    stubCli(async () => '[]');
+
+    await expect(opencodeCliProviders(CLI_PATH)).resolves.toEqual(new Set());
+  });
+
+  it('returns null when the CLI emits output that is not JSON', async () => {
+    stubCli(async () => 'No authenticated integrations');
+
+    await expect(opencodeCliProviders(CLI_PATH)).resolves.toBeNull();
+  });
+});

--- a/src/lib/runtimes/shared/opencode-readiness.ts
+++ b/src/lib/runtimes/shared/opencode-readiness.ts
@@ -511,3 +511,81 @@ export async function probeOpencodeServiceVersion(
     serviceVersion,
   };
 }
+
+export interface OpencodeAuthListProbeDependencies {
+  run(args: string[]): Promise<string>;
+}
+
+let authListProbeDependenciesForTests: OpencodeAuthListProbeDependencies | null = null;
+
+export function setOpencodeAuthListProbeDependenciesForTests(
+  dependencies: OpencodeAuthListProbeDependencies | null,
+): void {
+  authListProbeDependenciesForTests = dependencies;
+}
+
+async function runOpencodeJsonProbe(binaryPath: string, args: string[]): Promise<string> {
+  const invocation = cliInvocation(binaryPath, args);
+  const { stdout } = await execFileAsync(invocation.command, invocation.args, {
+    windowsHide: true,
+    timeout: SERVICE_PROBE_TIMEOUT_MS,
+    env: { ...process.env, FORCE_COLOR: "0", NO_COLOR: "1" },
+    maxBuffer: 64 * 1024,
+  });
+  return stdout;
+}
+
+/**
+ * Provider ids the CLI itself reports as connected, covering credentials it
+ * keeps in its own store as well as provider environment keys. Returns null
+ * when the CLI cannot answer — an indeterminate probe must never be read as
+ * "no providers", which is the failure this exists to stop.
+ */
+export async function opencodeCliProviders(
+  binaryPath?: string | null,
+  dependencies?: OpencodeAuthListProbeDependencies,
+): Promise<Set<string> | null> {
+  const injected = dependencies ?? authListProbeDependenciesForTests;
+  const run = injected
+    ? injected.run
+    : binaryPath
+      ? (args: string[]) => runOpencodeJsonProbe(binaryPath, args)
+      : null;
+  if (!run) return null;
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(await run(["auth", "list", "--format", "json"]));
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(payload)) return null;
+
+  const providers = new Set<string>();
+  let recognized = 0;
+  for (const entry of payload) {
+    if (!isRecord(entry)) continue;
+    const id = typeof entry.id === "string" ? entry.id.trim() : "";
+    if (!id || !Array.isArray(entry.connections)) continue;
+    recognized += 1;
+    if (entry.connections.length > 0) providers.add(id);
+  }
+  // A payload we could not read at all is indeterminate, not empty.
+  return payload.length > 0 && recognized === 0 ? null : providers;
+}
+
+/**
+ * Every provider this OpenCode install can dispatch through: what the CLI
+ * reports, unioned with the credential file older installs still write.
+ */
+export async function opencodeAuthenticatedProviders(
+  home: string,
+  binaryPath?: string | null,
+): Promise<Set<string>> {
+  const [stored, reported] = await Promise.all([
+    opencodeCredentialProviders(home),
+    opencodeCliProviders(binaryPath),
+  ]);
+  if (reported) for (const provider of reported) stored.add(provider);
+  return stored;
+}


### PR DESCRIPTION
Closes #2143

## What I found on disk

The issue's mechanic is right; two of its specifics are not, and one of them matters for the fix.

- **A credential file does exist on this machine** — `~/.local/share/opencode/auth.json`, holding one `api` entry. It was written by the older CLI (v1.18.21), which is installed alongside the current one and still reads it. So `authedProviders` is not empty here; it is `["openrouter"]`. The `[]` in the issue came from a machine with no older install to leave that file behind. The bug is real either way: the current CLI never writes that file, so an install authenticated only through it reports nothing.
- **The store has no provider-id column.** Its `credential` table is keyed on `id` / `integration_id` / `label` / `value`, so the suggested "query the credential table for provider ids" would not have worked as written. It also cannot see providers supplied by environment key, which the CLI counts and dispatch honors.

That settles the open question in the issue in favor of its own preferred option: ask the CLI, do not parse the store.

## What changed

`auth list --format json` returns provider ids and how each one is connected, and nothing else — no keys, no tokens, no credential values. It is bounded by the existing probe timeout and answers in ~0.27s against the resident service.

- `opencodeCliProviders(binaryPath)` runs that probe and returns the connected provider ids, or `null` when the CLI cannot answer.
- `opencodeAuthenticatedProviders(home, binaryPath)` unions that with the existing credential-file read, so an older install keeps reporting its providers.
- The three call sites move over: the setup detect route, `detectOpencode`, and the per-model readiness check (which already counted environment-supplied keys for a single provider, and now agrees with the list feeding the model picker).

`opencodeCredentialProviders` is untouched and still the file reader.

**Indeterminate stays indeterminate.** A CLI that is missing, times out, exits non-zero, or answers in an unrecognized shape falls back to the file result instead of reporting an empty list — a wrong "not authenticated" is the bug being fixed, so the probe is never allowed to manufacture one. A payload that parses as an empty array is a real "nothing connected"; a non-empty payload with no readable entries is not.

The readiness wording needed no edit. `detectOpencode` already prefers "has provider credential evidence" whenever `authenticated` is true; the misleading keyless line only appeared because detection was wrong.

## Verification

Against this machine's real install, through the real function:

| | before | after |
|---|---|---|
| real home | `["openrouter"]` | `["google","openrouter","xai"]` |
| home with no credential file (current-CLI-only install) | `[]` | `["google","openrouter","xai"]` |

The second row is the reported failure, reproduced and fixed.

- `src/lib/runtimes/shared/opencode-auth-providers.test.ts` — 8 tests covering the acceptance list: CLI-only install, credential-file-only install, the union, a failing probe, an unrecognized payload, and nothing connected. The first case fails on `main`. Confirmed with `--reporter=verbose` that it runs under `hermetic-unit`.
- `npm test`: **716 files passed, 3 skipped; 4655 tests passed, 4 skipped; 0 failures.**
- `src/lib/runtimes/shared/opencode-service-skew.test.ts` re-run under the integration config: 5 passed.
- `npx tsc --noEmit` clean; `eslint` clean on all four changed files; `npm run test:classification:check` clean.

## What I left

Detection now tells the truth about which providers are available. Two adjacent things stayed out of scope: no credential store is read directly, and provider availability is still resolved per call rather than cached alongside the existing auth snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dVxFgHWcYwiMja5oBxySH