### PR TITLE
Composer counts dispatched workers, not the orchestrator's tool calls (#2148)

### DIFF
--- a/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
+++ b/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
@@ -2158,6 +2158,11 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
   // active assistant turn's Task tool calls. Status is tied to the turn
   // (busy → running) rather than per-tool completion: parallel scouts fire
   // together and the serial tool-done heuristic can't track them individually.
+  // Worker packets this thread dispatched. One list, two consumers: the crew
+  // card's rows and the composer status bar's worker count — so the number
+  // under the composer is the number of rows on screen (#2148).
+  const threadWorkerPackets = packetsForOrchestratorThread(missionState?.packets ?? [], threadId);
+
   const orchestratorScouts: SwarmScoutView[] = (() => {
     if (!isOrchestratorMode) return [];
     const assistants = displayMessages.filter((message) => message.role === 'assistant');
@@ -2240,7 +2245,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
             topContent={transcriptTopContent}
             bottomContent={isOrchestratorMode && displayMessages.length > 0 ? (
               <SwarmStatusCard
-                packets={packetsForOrchestratorThread(missionState?.packets ?? [], threadId)}
+                packets={threadWorkerPackets}
                 scouts={orchestratorScouts}
                 onFocusPacket={onLaunchPacket ? (packet) => { void onLaunchPacket(packet); } : undefined}
               />
@@ -2320,6 +2325,7 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
         isSingleMode={isSingleMode}
         displayWaiting={displayWaiting}
         chatMessages={displayMessages}
+        workerPackets={threadWorkerPackets}
         activeTargetLabel={activeTargetLabel}
         targetAgentExists={Boolean(targetAgent)}
         // Feed the EFFECTIVE transcript (orchestrator streams live into

--- a/src/components/desktop/thoughts/chat-panel/ComposerArea.tsx
+++ b/src/components/desktop/thoughts/chat-panel/ComposerArea.tsx
@@ -6,6 +6,7 @@ import { composerModeSpec, type ComposerMode } from '../composer-mode';
 import type { OrchestratorBackendSetting } from '../operator-defaults';
 import { SlashCommandPicker } from './SlashCommandPicker';
 import { ComposerStatusBar } from './ComposerStatusBar';
+import type { ComposerActivityPacket } from '@/lib/orchestrator/composer-activity';
 import type { MobileTranscriptEntry, MobileTranscriptToolCall } from '@/lib/mobile/types';
 import type { OrchestratorWorkspaceTarget } from '@/lib/orchestrator/types';
 import { getOrchestratorSlashCommandSuggestions, type OrchestratorSlashCommandDefinition } from '@/lib/slash-commands';
@@ -25,6 +26,8 @@ interface ComposerAreaProps {
   isSingleMode?: boolean;
   displayWaiting: boolean;
   chatMessages: MobileTranscriptEntry[];
+  /** Packets this thread dispatched — the status bar counts the live ones. */
+  workerPackets?: readonly ComposerActivityPacket[];
   activeTargetLabel: string;
   targetAgentExists: boolean;
   thoughtsBodyBackground: string;
@@ -90,6 +93,7 @@ export const ComposerArea = forwardRef<HTMLTextAreaElement, ComposerAreaProps>(f
   isSingleMode = false,
   displayWaiting,
   chatMessages,
+  workerPackets,
   activeTargetLabel,
   targetAgentExists,
   enhancing,
@@ -329,6 +333,7 @@ export const ComposerArea = forwardRef<HTMLTextAreaElement, ComposerAreaProps>(f
         <ComposerStatusBar
           displayWaiting={displayWaiting}
           runningTools={runningTools}
+          workerPackets={workerPackets}
           activeTargetLabel={activeTargetLabel}
           latestUserMessageId={latestUserMessageId}
           latestUserMessageAt={latestUserEntry?.timestamp ?? null}

--- a/src/components/desktop/thoughts/chat-panel/ComposerStatusBar.test.ts
+++ b/src/components/desktop/thoughts/chat-panel/ComposerStatusBar.test.ts
@@ -1,0 +1,143 @@
+/** @vitest-environment jsdom */
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { summarizeComposerActivity, type ComposerActivityPacket } from '@/lib/orchestrator/composer-activity';
+import type { OrchestratorPacketStatus } from '@/lib/orchestrator/types';
+import type { MobileTranscriptToolCall } from '@/lib/mobile/types';
+import { ComposerStatusBar } from './ComposerStatusBar';
+
+vi.mock('@/components/desktop/AgentStatusDot', () => ({
+  AgentStatusDot: () => null,
+}));
+
+function packet(status: OrchestratorPacketStatus, overrides: Partial<ComposerActivityPacket> = {}): ComposerActivityPacket {
+  return { status, releaseState: 'pending', archivedAt: null, ...overrides };
+}
+
+function toolCall(id: string): MobileTranscriptToolCall {
+  return { id, name: 'cortex_launch_agent', status: 'running' } as MobileTranscriptToolCall;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(props: Partial<Parameters<typeof ComposerStatusBar>[0]> = {}) {
+  act(() => {
+    root.render(createElement(ComposerStatusBar, {
+      displayWaiting: false,
+      runningTools: [],
+      workerPackets: [],
+      activeTargetLabel: 'Orchestrator',
+      latestUserMessageId: null,
+      latestUserMessageAt: null,
+      awaitingReply: false,
+      ...props,
+    }));
+  });
+  return container.querySelector<HTMLElement>('[data-composer-activity]');
+}
+
+beforeEach(() => {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe('ComposerStatusBar worker counter (#2148)', () => {
+  it('stays on screen and counts the workers after a Multitask dispatch settles the turn', () => {
+    // The exact shape of the failure: `cortex_launch_agent` has returned, so
+    // the orchestrator's turn is over and it has no running tool calls — while
+    // three workers it just launched are running. The bar used to unmount here.
+    const bar = render({
+      displayWaiting: false,
+      runningTools: [],
+      awaitingReply: false,
+      workerPackets: [packet('running'), packet('running'), packet('launching')],
+    });
+
+    expect(bar).not.toBeNull();
+    expect(bar?.dataset.workerCount).toBe('3');
+    expect(bar?.dataset.orchestratorTools).toBe('0');
+    expect(bar?.dataset.orchestratorBusy).toBe('false');
+    expect(bar?.textContent).toContain('3 workers');
+    expect(bar?.getAttribute('aria-label')).toContain('3 workers running');
+  });
+
+  it('names the orchestrator’s own tool calls as tools, not workers', () => {
+    const bar = render({
+      displayWaiting: true,
+      runningTools: [toolCall('t1'), toolCall('t2')],
+      workerPackets: [],
+    });
+
+    expect(bar?.dataset.workerCount).toBe('0');
+    expect(bar?.dataset.orchestratorTools).toBe('2');
+    expect(bar?.dataset.orchestratorBusy).toBe('true');
+    expect(bar?.textContent).toContain('2 tools');
+    expect(bar?.textContent).not.toContain('worker');
+  });
+
+  it('keeps the two sides distinguishable while both are in flight', () => {
+    const bar = render({
+      displayWaiting: true,
+      runningTools: [toolCall('t1')],
+      workerPackets: [packet('running'), packet('running')],
+    });
+
+    expect(bar?.textContent).toContain('1 tool');
+    expect(bar?.textContent).toContain('2 workers');
+    expect(bar?.dataset.orchestratorTools).toBe('1');
+    expect(bar?.dataset.workerCount).toBe('2');
+  });
+
+  it('stays hidden when the thread only holds packets that are not running', () => {
+    const bar = render({
+      workerPackets: [packet('draft'), packet('idle'), packet('awaiting_review'), packet('failed')],
+    });
+
+    expect(bar).toBeNull();
+  });
+});
+
+describe('summarizeComposerActivity', () => {
+  it('counts only packets whose dispatch is still in flight', () => {
+    const activity = summarizeComposerActivity({
+      runningToolCount: 0,
+      packets: [
+        packet('queued'),
+        packet('launching'),
+        packet('running'),
+        packet('recovering'),
+        packet('awaiting_review'),
+        packet('blocked'),
+        packet('draft'),
+        packet('idle'),
+        packet('failed'),
+        packet('archived'),
+      ],
+    });
+
+    expect(activity).toEqual({ orchestratorToolCount: 0, workerCount: 4, hasActivity: true });
+  });
+
+  it('does not count a released or archived packet that still reads as running', () => {
+    const activity = summarizeComposerActivity({
+      runningToolCount: 0,
+      packets: [
+        packet('running', { releaseState: 'released' }),
+        packet('running', { archivedAt: '2026-09-11T00:00:00.000Z' }),
+      ],
+    });
+
+    expect(activity.workerCount).toBe(0);
+    expect(activity.hasActivity).toBe(false);
+  });
+});

--- a/src/components/desktop/thoughts/chat-panel/ComposerStatusBar.tsx
+++ b/src/components/desktop/thoughts/chat-panel/ComposerStatusBar.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { AgentStatusDot } from '@/components/desktop/AgentStatusDot';
 import type { MobileTranscriptToolCall } from '@/lib/mobile/types';
+import { pluralizeActivity, summarizeComposerActivity, type ComposerActivityPacket } from '@/lib/orchestrator/composer-activity';
 
 function formatElapsed(ms: number): string {
   const total = Math.max(0, Math.floor(ms / 1000));
@@ -14,6 +15,7 @@ function formatElapsed(ms: number): string {
 export function ComposerStatusBar({
   displayWaiting,
   runningTools,
+  workerPackets = [],
   activeTargetLabel,
   latestUserMessageId,
   latestUserMessageAt,
@@ -21,6 +23,12 @@ export function ComposerStatusBar({
 }: {
   displayWaiting: boolean;
   runningTools: MobileTranscriptToolCall[];
+  /**
+   * Packets this thread dispatched — the same list the crew card renders. The
+   * bar counts the live ones as WORKERS, separately from the orchestrator's own
+   * turn, and stays on screen while they run (#2148).
+   */
+  workerPackets?: readonly ComposerActivityPacket[];
   activeTargetLabel: string;
   latestUserMessageId: string | null;
   /** Timestamp (ms) of that message — gates the latch to FRESH sends. */
@@ -36,7 +44,16 @@ export function ComposerStatusBar({
   const prevLatestUserMessageIdRef = useRef<string | null>(latestUserMessageId);
   const hasRunningTools = runningTools.length > 0;
   const [turnLatched, setTurnLatched] = useState(false);
-  const active = displayWaiting || hasRunningTools || turnLatched;
+  const activity = summarizeComposerActivity({
+    runningToolCount: runningTools.length,
+    packets: workerPackets,
+  });
+  // A Multitask turn ends the moment the launch calls return, so the
+  // orchestrator goes idle while its workers are just starting. Dispatched
+  // workers keep the bar alive on their own (#2148); the latch effects below
+  // still release on the orchestrator's own terms.
+  const orchestratorBusy = displayWaiting || hasRunningTools || turnLatched;
+  const active = orchestratorBusy || activity.workerCount > 0;
 
   useEffect(() => {
     const risingEdge = displayWaiting && !prevDisplayWaitingRef.current;
@@ -108,11 +125,27 @@ export function ComposerStatusBar({
     ? runningTools.slice(0, 2).map((t) => t.name).join(', ') + (runningTools.length > 2 ? ` +${runningTools.length - 2}` : '')
     : null;
 
+  // `N running` read as a worker count while it only ever counted the
+  // orchestrator's tool calls. Each side now names itself (#2148).
+  const activityParts: string[] = [];
+  if (activity.orchestratorToolCount > 0) activityParts.push(pluralizeActivity(activity.orchestratorToolCount, 'tool'));
+  if (activity.workerCount > 0) activityParts.push(pluralizeActivity(activity.workerCount, 'worker'));
+  const workersRunning = activity.workerCount > 0 ? `${pluralizeActivity(activity.workerCount, 'worker')} running` : null;
+  const ariaLabel = orchestratorBusy
+    ? `${activeTargetLabel} working for ${formatElapsed(elapsed)}${workersRunning ? `, ${workersRunning}` : ''}`
+    : `${workersRunning} for ${formatElapsed(elapsed)}`;
+
   return (
     <div
       role="status"
       aria-live="polite"
-      aria-label={`${activeTargetLabel} working for ${formatElapsed(elapsed)}`}
+      aria-label={ariaLabel}
+      // Discrete counts for callers that need the split without parsing the
+      // rendered text (#2148 acceptance).
+      data-composer-activity=""
+      data-orchestrator-busy={orchestratorBusy ? 'true' : 'false'}
+      data-orchestrator-tools={activity.orchestratorToolCount}
+      data-worker-count={activity.workerCount}
       title={runningSummary ? `Running ${runningSummary}` : undefined}
       style={{
         display: 'inline-flex',
@@ -141,14 +174,14 @@ export function ComposerStatusBar({
       }}>
         {formatElapsed(elapsed)}
       </span>
-      {hasRunningTools ? (
+      {activityParts.length > 0 ? (
         <span style={{
           fontSize: 11.5,
           fontWeight: 400,
           letterSpacing: '0',
           color: 'var(--t-text-faint)',
         }}>
-          {`· ${runningTools.length} running`}
+          {activityParts.map((part) => `· ${part}`).join(' ')}
         </span>
       ) : null}
     </div>

--- a/src/lib/orchestrator/composer-activity.ts
+++ b/src/lib/orchestrator/composer-activity.ts
@@ -1,0 +1,57 @@
+import { packetTerminalState } from './packet-state';
+import type { OrchestratorPacket, OrchestratorPacketStatus } from './types';
+
+/**
+ * Packet states a worker occupies while its dispatch is still in flight. The
+ * composer counter reads off this set so the number under the composer is the
+ * number of live workers the operator can count on screen — `awaiting_review`
+ * and the terminal states are dispatched work that has stopped running, and the
+ * crew card already carries those with their own vocabulary (#2148).
+ */
+const ACTIVE_WORKER_STATUSES: ReadonlySet<OrchestratorPacketStatus> = new Set([
+  'queued',
+  'launching',
+  'running',
+  'recovering',
+]);
+
+export type ComposerActivityPacket = Pick<OrchestratorPacket, 'status' | 'releaseState' | 'archivedAt'>;
+
+export interface ComposerActivity {
+  /** Tool calls the orchestrator's OWN turn currently has in flight. */
+  orchestratorToolCount: number;
+  /** Worker packets this thread dispatched that are still running. */
+  workerCount: number;
+  /** True when either side has work in flight — what keeps the bar on screen. */
+  hasActivity: boolean;
+}
+
+export function isActiveWorkerPacket(packet: ComposerActivityPacket): boolean {
+  return packetTerminalState(packet) === null && ACTIVE_WORKER_STATUSES.has(packet.status);
+}
+
+/**
+ * Split what the composer status bar is measuring into two discrete counts.
+ *
+ * The bar used to render a single `N running` off the orchestrator's running
+ * tool calls. `cortex_launch_agent` returns as soon as the lane is launched, so
+ * a Multitask dispatch drove that count to zero at the exact moment the workers
+ * started — the surface went idle while three workers were on screen (#2148).
+ */
+export function summarizeComposerActivity(input: {
+  runningToolCount: number;
+  packets: readonly ComposerActivityPacket[];
+}): ComposerActivity {
+  const orchestratorToolCount = Math.max(0, input.runningToolCount);
+  const workerCount = input.packets.filter(isActiveWorkerPacket).length;
+  return {
+    orchestratorToolCount,
+    workerCount,
+    hasActivity: orchestratorToolCount > 0 || workerCount > 0,
+  };
+}
+
+/** Plain-language count, e.g. `3 workers` / `1 tool`. */
+export function pluralizeActivity(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}


### PR DESCRIPTION
Closes #2148

## What the counter actually read

The issue's headline symptom ("shows 0 running") was observed while dispatch was still broken, so it needed re-tracing on current main. The counter never literally printed `0 running` — it hides below one. The real mechanic, confirmed on main:

`ComposerStatusBar` rendered `m:ss · N running` off `runningTools.length`, which `ComposerArea` computes by scanning the latest assistant message for tool calls still marked `running`/`calling`. That is the orchestrator's own turn, not its workers. `cortex_launch_agent` POSTs `/api/orchestrator/delegate` and returns as soon as the lane is launched — it does not stay open for the worker's lifetime. So the count went to zero at the exact moment the workers started, and once the turn settled (`displayWaiting` false, no running tools, latch released) the bar unmounted completely while three workers were live on screen.

So the defect is real but narrower than the title: not a wrong number, an **absent** one, from a surface that was never wired to lane state at all.

## What changed

- **`src/lib/orchestrator/composer-activity.ts`** (new) — `summarizeComposerActivity` splits the bar's subject into two discrete counts: the orchestrator's in-flight tool calls, and the packets whose dispatch is still live. A worker counts while `queued` / `launching` / `running` / `recovering` and `packetTerminalState` says it has not finished, so released/archived/failed rows never inflate it.
- **`ThoughtsChatPanel`** — hoists the existing `packetsForOrchestratorThread(missionState?.packets ?? [], threadId)` call into `threadWorkerPackets` and feeds it to both consumers. This is the same list `SwarmStatusCard` already renders, so the number under the composer is the number of rows above it — real lane state, not a derived guess.
- **`ComposerArea` / `ComposerStatusBar`** — pass-through, and the bar now stays mounted while dispatched workers are live (`active = orchestratorBusy || workerCount > 0`). The latch and stall-ceiling effects are untouched; they still release on the orchestrator's own terms.
- **Label** — each side names itself: `· 2 tools`, `· 3 workers`, or `· 1 tool · 3 workers`. The `aria-label` reads `3 workers running` when the orchestrator has gone idle.
- **Discrete values for callers** — `data-orchestrator-tools`, `data-worker-count`, `data-orchestrator-busy` on the status element, so the split is readable without parsing text.

`isWorkingLocked` is deliberately unchanged — running workers must not lock the composer.

## Tests

`src/components/desktop/thoughts/chat-panel/ComposerStatusBar.test.ts` (jsdom, unit config). The first case is the original failure: turn settled, zero running tools, three live packets.

Verified it catches the regression — run against the pre-fix component, 3 of the 6 fail (the bar is absent / still says `running`); all 6 pass on this branch.

```
npx vitest run --config config/vitest/vitest.unit.config.ts \
  src/components/desktop/thoughts/chat-panel/ComposerStatusBar.test.ts --reporter=verbose
Test Files  1 passed (1)
     Tests  6 passed (6)
```

## Verification

- `npx tsc --noEmit` — clean.
- `npx eslint` on the five changed files — 0 errors. Two pre-existing warnings in `ComposerArea.tsx` (the `Date.now()` stale-turn gate at :171 and an `<img>` at :387), both in untouched code, both present on main.
- `npm test` — **717 files passed, 3 skipped; 4661 tests passed, 4 skipped. Zero failures** (`multi-identity-sessions.test.ts` passed on this run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dVxFgHWcYwiMja5oBxySH
