### PR TITLE
chore: release 0.1.749

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "o8",
-  "version": "0.1.748",
+  "version": "0.1.749",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "o8",
-      "version": "0.1.748",
+      "version": "0.1.749",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o8",
-  "version": "0.1.748",
+  "version": "0.1.749",
   "description": "o8 — governance layer for autonomous engineering teams. Approvals, audit, organizational memory.",
   "license": "MIT",
   "productName": "o8",

--- a/release-notes/next.md
+++ b/release-notes/next.md
@@ -1,0 +1,7 @@
+- Multitask and parallel orchestration now launch workers with the correct tool instructions and resolve single-repository project context during dispatch.
+- Dispatch failures stay visible, and workers that fail before making changes receive a bounded recovery attempt.
+- The composer shows tool activity and running workers separately, using the same worker state as the crew rows.
+- Archiving a terminal clears its agent row. Orphaned review entries can be discarded safely when their worktree is already gone.
+- Session tabs expose stable handles and accessible tab semantics for reliable navigation.
+- Desktop automation supports window and app commands through the webview client.
+- Runtime readiness recognizes connected providers reported by the installed CLI.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "o8"
-version = "0.1.748"
+version = "0.1.749"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "o8"
-version = "0.1.748"
+version = "0.1.749"
 description = "o8 — governance layer for autonomous engineering teams"
 authors = ["hurttlocker"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "o8",
-  "version": "0.1.748",
+  "version": "0.1.749",
   "identifier": "ai.o8.desktop",
   "build": {
     "frontendDist": "../out/frontend",


### PR DESCRIPTION
Prepare 0.1.749 so the ten merged orchestration and desktop fixes can reach installed apps. Synchronize the package, native and lockfile versions and add release notes for dispatch, recovery, worker counts, archive behavior, session navigation and runtime readiness.

Validation: `npx tsc --noEmit` passed; `npm test` passed 717 test files and 4,460 tests, with three files and four tests skipped. Required PR checks must also pass before merge. The signed build, native boot gate, notarization and publication run from the exact merged release commit.
