### PR TITLE
docs: public roadmap, tracking issues, and claiming protocol

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ o8 is maintained by one person, and review capacity is limited. Small, focused c
 - Reliability and performance improvements with evidence.
 - New runtime adapters that follow the six-file recipe in [`docs/internals/runtime-adapter-contract.md`](./docs/internals/runtime-adapter-contract.md).
 
+[`ROADMAP.md`](./ROADMAP.md) is the map of what is open and what each arc has to satisfy to be finished. Work that appears there has already been scoped and accepted.
+
 ## What we do not accept
 
 - Large refactors without prior agreement.
@@ -15,6 +17,14 @@ o8 is maintained by one person, and review capacity is limited. Small, focused c
 - Style-only churn, dependency reshuffling, or rewrites that do not change behavior.
 
 Open an issue before starting any non-trivial change. An issue is not a promise that a pull request will be accepted, but it can prevent both sides from spending time on work that does not fit the project.
+
+## Claiming work
+
+Find work through [`ROADMAP.md`](./ROADMAP.md). Each open arc there links to one tracking issue, and that issue's checklist lists its children. Pick an unchecked child labeled `claimable`: those have a brief that is complete enough to start from.
+
+Comment "claiming" on the child issue. A maintainer flips the label to `claimed`, which expires seven days after the claim comment if no pull request links to the issue. That keeps an issue from sitting reserved by someone who moved on, and reclaiming it later is fine.
+
+Branch from `main` in your fork, one branch per issue. Your pull request body needs an "Evidence" section that names the commit you tested and the exact commands you ran, with their results. A reviewer other than the author verifies the change, and a maintainer merges it. Pull requests carrying the `needs-review` label are the ones waiting on that independent review.
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ o8 is an open-source desktop control room for AI coding agents.
 
 [Download the latest signed macOS build](https://github.com/hurttlocker/o8/releases) · [Build from source](#quickstart)
 
+Where o8 is going, and what is open: [ROADMAP.md](./ROADMAP.md)
+
 ![o8 running a fleet of coding agents: three agents at work in isolated worktrees on the left, the governance queue holding incidents that need an operator decision on the right](./assets/hero.jpg)
 
 **Run a fleet of coding agents. Approve what ships.**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,109 @@
+# o8 roadmap
+
+o8 is the governance layer for autonomous engineering teams: approvals, audit, organizational memory, and operator control across AI providers. It sits above the coding agents, turns work into missions and packets, isolates execution in worktrees, keeps the operator in the approval path, and records enough evidence to explain what happened later. This page is the map of where that is going and what is open to work on. Taste is not a pillar on this map; it is a gate on all seven, because a change that does not read well, respond quickly, or behave predictably is not finished no matter which pillar it belongs to.
+
+## How to read this
+
+A checkbox is checked only when the child issue is closed and its fix is on `main` at or before tag `v0.1.749`, and a status percent is checked divided by total, rounded to the nearest 5. Each open arc has one tracking issue whose checklist is the real progress; the percent here only summarizes it. Frontier arcs carry a verdict and a date instead of a percent, because they are not committed work yet, and a Frontier arc graduates into a pillar when it ships its first child. Run `node scripts/roadmap-status.mjs` to recompute the numbers from the tracking issues; it prints a table and does not rewrite this file.
+
+## 1. Governance is the product
+
+Execution is separated from approval. Workers cannot merge their own packets, every decision is recorded, and every failure moves through a visible state.
+
+| Arc | Done means | Status | Where |
+| --- | --- | --- | --- |
+| Merge-gate truth | A recorded verdict can never disagree with what actually lands on main. | 100% | shipped in 0.1.738 |
+| Lane lifecycle and recovery honesty | No lane stalls silently, and every terminal state is reachable from the UI and the CLI. | 75% | [#2197](https://github.com/hurttlocker/o8/issues/2197) |
+| Dispatch honesty | A confident mission plan in the thread implies a launched worker, or an error. | 100% | shipped in 0.1.749 |
+| Signed receipts and truth queries | Someone who does not trust the operator can still verify a packet's claims. | 100% | shipped in 0.1.722 |
+| Worker capability boundaries | A worker cannot read or reach anything its packet does not grant. | 75% | [#2198](https://github.com/hurttlocker/o8/issues/2198) |
+| Broadcast: the audit trail as a live feed | The audit trail is something an operator watches, not only something they query. | 100% | shipped in 0.1.717 |
+| Contributor-ready public repo | An outside pull request gets green checks and a human reply without maintainer plumbing. | 85% | [#2199](https://github.com/hurttlocker/o8/issues/2199) |
+
+## 2. Organizational memory
+
+Project rules and prior outcomes stay attached to the project rather than to one model vendor, so an orchestrator and its workers share the same operating context across runtimes.
+
+| Arc | Done means | Status | Where |
+| --- | --- | --- | --- |
+| Engineering Brain question and answer | Any consumer, on any surface, gets a cited answer from the same retrieval path. | 100% | shipped, [#915](https://github.com/hurttlocker/o8/issues/915) |
+| Workers write back to memory | A packet's lesson survives the packet. | 100% | shipped in 0.1.716 |
+| Cost and capacity ledger | The ledger's number and the provider's invoice agree. | 75% | [#1791](https://github.com/hurttlocker/o8/issues/1791) |
+| Spec review inversion | Project rules are operator-owned and agent-annotated, never agent-rewritten. | 100% | shipped |
+
+## 3. Runs on your subscriptions
+
+Local worker adapters launch the coding-agent CLIs you already pay for and reuse the authentication those tools already have. The runtime contract keeps callers independent of any one provider's protocol.
+
+| Arc | Done means | Status | Where |
+| --- | --- | --- | --- |
+| Execution carriers | A model wrapper is a carrier choice, not a new entry in the runtime registry. | 100% | shipped in 0.1.748 |
+| Declarative runtimes | A CLI-shaped runtime is a config row, not a six-file patch. | 100% | shipped in 0.1.725 |
+| Carrier coverage and auth probes | A new carrier lands as a registry entry plus a readiness and auth probe, with no fork in the dispatch path. | 65% | [#2200](https://github.com/hurttlocker/o8/issues/2200) |
+| OpenCode 2 and ACP | A non-subscription CLI is a first-class worker and a first-class orchestrator backend. | 80% | [#2201](https://github.com/hurttlocker/o8/issues/2201) |
+| Local models first-class | Every surface names its local provider, and a test proves no egress for a full packet lifecycle. | parked, 3 of 3 carved children shipped | [#1451](https://github.com/hurttlocker/o8/issues/1451) |
+
+## 4. One control plane, every surface
+
+Desktop, mobile, CLI, MCP, headless, and voice all reach the same governed control plane, without giving every caller the same authority.
+
+| Arc | Done means | Status | Where |
+| --- | --- | --- | --- |
+| Headless o8 | The control plane runs on a box with no screen. | 100% | shipped in 0.1.727 |
+| Mobile as an operator surface | Approve, reject, steer, and read evidence from the phone. | 100% | shipped, [#1074](https://github.com/hurttlocker/o8/issues/1074) |
+| Voice as an operator surface | The voice agent's brain seat is a registry choice, not a vendor branch. | 100% | shipped in 0.1.748 |
+| Terminals as a workspace surface | A tmux or vim session survives a ship and a pane switch byte-faithfully, and terminal actions go through a governed adapter. | 90% | [#1723](https://github.com/hurttlocker/o8/issues/1723) |
+
+## 5. Smooth for people and for agents
+
+Two lanes, one pillar. The people lane is about the surfaces a human works in. The agents lane is about whether another program can drive o8 without pretending to be a mouse.
+
+### People
+
+| Arc | Done means | Status | Where |
+| --- | --- | --- | --- |
+| Canvas IDE parity | The canvas is a place you can actually work, not a demo surface. | 7 of 7 carved children shipped, epic open | [#1664](https://github.com/hurttlocker/o8/issues/1664) |
+| Rich Markdown editor | Editing a document in o8 never corrupts it. | 100% | shipped in 0.1.722 |
+| Design Mode loop | "Change this button" is one bounded loop with a proof card, not a packet. | 85% | [#1695](https://github.com/hurttlocker/o8/issues/1695) |
+| Interaction budgets | Boot, typing, navigation, and scale each have a measured budget that a regression can fail. | 100% | shipped in 0.1.748 |
+
+### Agents
+
+| Arc | Done means | Status | Where |
+| --- | --- | --- | --- |
+| Control surfaces, not scraping | Every operator action is reachable from the CLI, MCP, and the socket, not only from a mouse. | 100% | shipped in 0.1.749 |
+| CLI and MCP symmetry | The same control verb reaches the same governed route from an operator surface and from a worker context. | 100% | shipped in 0.1.738 |
+
+## 6. Runs where you are
+
+o8 should be light on the machine it runs on, and it should run on the machine you have.
+
+| Arc | Done means | Status | Where |
+| --- | --- | --- | --- |
+| Mac hardening | A populated daily profile passes an unchanged native idle gate, with receipts. | 100% | shipped in 0.1.748 |
+| Speed and idle-work pass | Interaction budgets hold under real load, not only at idle. | 85% | [#2202](https://github.com/hurttlocker/o8/issues/2202) |
+| Storage admission and reclaim | o8 never blocks a dispatch it could have serviced, and never fills the disk. | 90% | [#2203](https://github.com/hurttlocker/o8/issues/2203) |
+| Linux | A fresh Ubuntu box installs o8, launches it, dispatches a packet, and merges it through the governed path. | 90% | [#1672](https://github.com/hurttlocker/o8/issues/1672) |
+| Windows | The same as Linux, on Windows. Help wanted: this needs a contributor with Windows hardware, because no maintainer has a Windows machine to verify on. The audit is already written, with file-and-line evidence, in `docs/internals/port-audit-windows.md`. | 50% | [#2204](https://github.com/hurttlocker/o8/issues/2204) |
+| Release channels and build integrity | Preview and stable are separable, and a build is reproducible from a tag. | 90% | [#2205](https://github.com/hurttlocker/o8/issues/2205) |
+
+## 7. Frontier
+
+Directions we are looking at rather than committed to. These carry a verdict and a date instead of a percent. Exploring means the question is open and worth answering. Parked means we know what it would take and are not doing it now. An arc here graduates into a pillar when it ships its first child.
+
+| Arc | Verdict | Since | Where |
+| --- | --- | --- | --- |
+| Connector layer for external tools | exploring | 2026-08-01 | [#1665](https://github.com/hurttlocker/o8/issues/1665) |
+| Portable worker environments | exploring | 2026-08-03 | [#1690](https://github.com/hurttlocker/o8/issues/1690) |
+| Cross-device execution continuity | exploring | 2026-08-04 | [#1727](https://github.com/hurttlocker/o8/issues/1727) |
+| Worker OS sandbox as the default | parked | 2026-08-01 | [#1657](https://github.com/hurttlocker/o8/issues/1657) |
+| Multiplayer workspace identity | parked | 2026-08-26 | [#1875](https://github.com/hurttlocker/o8/issues/1875) |
+| Client-delegation transport for the voice brain seat | parked | 2026-09-11 | [#2166](https://github.com/hurttlocker/o8/issues/2166) |
+
+## Claiming work
+
+Start from a tracking issue above, open its checklist, and pick an unchecked child labeled `claimable`. Comment "claiming" on that child; a maintainer flips it to `claimed`, which expires after seven days with no linked pull request. The full protocol, including what a pull request needs before review, is in [CONTRIBUTING.md](./CONTRIBUTING.md#claiming-work).
+
+## Not on this map
+
+Bug fixes, chores, security advisories, and dependency work are tracked as plain issues rather than roadmap arcs.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ o8 is the governance layer for autonomous engineering teams: approvals, audit, o
 
 ## How to read this
 
-A checkbox is checked only when the child issue is closed and its fix is on `main` at or before tag `v0.1.749`, and a status percent is checked divided by total, rounded to the nearest 5. Each open arc has one tracking issue whose checklist is the real progress; the percent here only summarizes it. Frontier arcs carry a verdict and a date instead of a percent, because they are not committed work yet, and a Frontier arc graduates into a pillar when it ships its first child. Run `node scripts/roadmap-status.mjs` to recompute the numbers from the tracking issues; it prints a table and does not rewrite this file.
+A checkbox is checked only when the child issue is closed and its fix is on `main` at or before the latest release tag (`v0.1.749` when this page was written), and a status percent is checked divided by total, rounded to the nearest 5. Each open arc has one tracking issue whose checklist is the real progress; the percent here only summarizes it. Frontier arcs carry a verdict and a date instead of a percent, because they are not committed work yet, and a Frontier arc graduates into a pillar when it ships its first child. Run `node scripts/roadmap-status.mjs` to recompute the numbers from the tracking issues; it prints a table and does not rewrite this file.
 
 ## 1. Governance is the product
 

--- a/scripts/roadmap-status.mjs
+++ b/scripts/roadmap-status.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Read-only roadmap status. Reads every open issue labeled `tracking`, counts the
+// checkboxes in its `## Checklist` section, and prints a table. Never writes ROADMAP.md.
+// Requires the GitHub CLI (`gh`) to be installed and authenticated.
+import { execFileSync } from 'node:child_process';
+
+const REPO = process.env.ROADMAP_REPO || 'hurttlocker/o8';
+
+function gh(path) {
+  const out = execFileSync('gh', ['api', '--paginate', '-H', 'Accept: application/vnd.github+json', path], {
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  // --paginate concatenates JSON arrays; splice them back into one array.
+  return JSON.parse(`[${out.trim().replace(/^\[/, '').replace(/\]$/, '').replace(/\]\s*\[/g, ',')}]`);
+}
+
+// The last `## Checklist` section wins, so a converted epic's comment beats its body.
+function countChecklist(texts) {
+  let checked = 0;
+  let total = 0;
+  for (const text of texts) {
+    if (!text || !/^##\s+Checklist\s*$/m.test(text)) continue;
+    const section = text.split(/^##\s+Checklist\s*$/m).pop().split(/^##\s+/m)[0];
+    let c = 0;
+    let t = 0;
+    for (const line of section.split('\n')) {
+      const m = /^\s*-\s*\[([ xX])\]/.exec(line);
+      if (!m) continue;
+      t += 1;
+      if (m[1] !== ' ') c += 1;
+    }
+    if (t > 0) {
+      checked = c;
+      total = t;
+    }
+  }
+  return { checked, total };
+}
+
+function pad(s, n) {
+  s = String(s);
+  return s.length >= n ? s.slice(0, n - 1) + ' ' : s + ' '.repeat(n - s.length);
+}
+
+const issues = gh(`repos/${REPO}/issues?state=open&labels=tracking&per_page=100`).filter((i) => !i.pull_request);
+if (issues.length === 0) {
+  console.log('No open issues labeled `tracking`.');
+  process.exit(0);
+}
+
+const rows = [];
+for (const issue of issues) {
+  const texts = [issue.body || ''];
+  if (issue.comments > 0) {
+    for (const c of gh(`repos/${REPO}/issues/${issue.number}/comments?per_page=100`)) texts.push(c.body || '');
+  }
+  const { checked, total } = countChecklist(texts);
+  const pct = total > 0 ? Math.round((checked / total) * 20) * 5 : null;
+  rows.push({ number: issue.number, title: issue.title, checked, total, pct });
+}
+rows.sort((a, b) => (b.pct ?? -1) - (a.pct ?? -1) || a.number - b.number);
+
+console.log(`${pad('ISSUE', 7)}${pad('TITLE', 52)}${pad('SHIPPED', 10)}PERCENT`);
+console.log('-'.repeat(76));
+for (const r of rows) {
+  const shipped = r.total > 0 ? `${r.checked}/${r.total}` : 'none';
+  const pct = r.pct === null ? 'no checklist' : `${r.pct}%`;
+  console.log(`${pad('#' + r.number, 7)}${pad(r.title, 52)}${pad(shipped, 10)}${pct}`);
+}
+const done = rows.reduce((a, r) => a + r.checked, 0);
+const all = rows.reduce((a, r) => a + r.total, 0);
+console.log('-'.repeat(76));
+console.log(`${rows.length} tracking issues, ${done} of ${all} children shipped.`);


### PR DESCRIPTION
Adds a public contributor map: `ROADMAP.md`, a status script, and a claiming protocol in `CONTRIBUTING.md`.

Seven pillars, one table row per arc. Every arc carries a "done means" sentence and a status computed from checkboxes rather than asserted. A box counts only when the child issue is closed and its fix is on `main` at or before `v0.1.749`. Taste is a gate on all seven pillars, stated once at the top, not a pillar of its own. Frontier arcs carry a verdict and a date instead of a percent, and graduate into a pillar when they ship their first child.

## Tracking issues created

| Issue | Arc | Status |
| --- | --- | --- |
| #2197 | Lane lifecycle and recovery honesty | 75% |
| #2198 | Worker capability boundaries | 75% |
| #2199 | Contributor-ready public repo | 85% |
| #2200 | Carrier coverage and auth probes | 65% |
| #2201 | OpenCode 2 and ACP | 80% |
| #2202 | Speed and idle-work pass | 85% |
| #2203 | Storage admission and reclaim | 90% |
| #2204 | Windows port | 50% |
| #2205 | Release channels and build integrity | 90% |

## Epics converted

Labels added and a checklist appended as a comment, with no existing body text changed: #1451 local models, #1664 canvas, #1672 Linux, #1695 Design Mode, #1723 terminals.

## Labels added

`tracking`, `claimable`, `claimed`, `needs-review`, and seven `pillar/*` labels. Nothing was renamed or deleted.

## Evidence

Tested at `df1e39879`. Every issue and pull request number on the map was verified with `gh issue view` or `gh pr view` before it was written, and every same-day fix was checked against the tag with `git merge-base --is-ancestor <merge-commit> v0.1.749`.

```
node scripts/roadmap-status.mjs
```

prints 14 tracking issues, 74 of 86 children shipped, and its percentages match the Status column in `ROADMAP.md`.

Markdown-only change plus one script, so no type or test gate applies to the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe
