### PR TITLE
Treat an empty OpenCode auth listing as unknown, not as no providers (#2194)

### DIFF
--- a/src/lib/runtimes/shared/auth-detect.test.ts
+++ b/src/lib/runtimes/shared/auth-detect.test.ts
@@ -59,6 +59,23 @@ const {
   getRuntimeAuthSnapshot,
   invalidateRuntimeAuthCache,
 } = await import("./auth-detect");
+const { setOpencodeCliProbeDependenciesForTests } =
+  await import("./opencode-readiness");
+
+/**
+ * Stands in for the OpenCode 2 CLI. `auth list` answers the way an install that
+ * keeps its credentials server-side answers: exit 0, empty array. `models` names
+ * only what such an install can actually resolve.
+ */
+function stubOpencodeCli(models: string[], authList = "[]"): void {
+  setOpencodeCliProbeDependenciesForTests({
+    run: async (args: string[]) => {
+      if (args[0] === "models") return `${models.join("\n")}\n`;
+      if (args[0] === "auth") return authList;
+      throw new Error(`unexpected opencode probe: ${args.join(" ")}`);
+    },
+  });
+}
 const createMissionRoute =
   await import("@/app/api/orchestrator/create-mission/route");
 const operatorDefaultsRoute =
@@ -114,6 +131,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllEnvs();
+  setOpencodeCliProbeDependenciesForTests(null);
   authFixture.installed = new Set(["opencode2"]);
   invalidateRuntimeAuthCache();
   rmSync(path.join(authFixture.home, ".config"), {
@@ -180,7 +198,8 @@ describe("OpenCode readiness preflight", () => {
     ).toHaveLength(1);
   });
 
-  it("reports the trusted keyless default as ready without claiming authentication", async () => {
+  it("reports a CLI that lists resolvable models as ready without claiming authentication", async () => {
+    stubOpencodeCli(["opencode/nemotron-3.5-lightning-free"]);
     invalidateRuntimeAuthCache();
     const snapshot = await getRuntimeAuthSnapshot();
     const status = snapshot.statuses.opencode;
@@ -192,8 +211,7 @@ describe("OpenCode readiness preflight", () => {
       runtime: "opencode",
       unavailableReason: null,
     });
-    expect(status.detail).toContain("default model");
-    expect(status.detail).toContain("keyless dispatch");
+    expect(status.detail).toContain("lists models it can resolve");
     expect(status.fix).toBe("No action needed.");
 
     const response = await operatorDefaultsRoute.GET(new Request(
@@ -209,6 +227,79 @@ describe("OpenCode readiness preflight", () => {
         }),
       ]),
     });
+  });
+
+  it("dispatches a model the CLI resolves when `auth list` answers with an empty payload", async () => {
+    // OpenCode 2 keeps credentials server-side, so `auth list --format json`
+    // exits 0 with [] on a fully connected machine. The model listing is the
+    // evidence that survives that: this install resolves both of these.
+    stubOpencodeCli([
+      "opencode/nemotron-3.5-lightning-free",
+      "openrouter/deepseek/deepseek-v4.1-flash",
+    ]);
+    invalidateRuntimeAuthCache();
+
+    await expect(
+      assertRuntimeDispatchable(
+        "opencode",
+        "openrouter/deepseek/deepseek-v4.1-flash",
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      assertRuntimeDispatchable("opencode", "opencode/nemotron-3.5-lightning-free"),
+    ).resolves.toBeUndefined();
+    // An effort pin resolves through the base model the listing names.
+    await expect(
+      assertRuntimeDispatchable(
+        "opencode",
+        "opencode/nemotron-3.5-lightning-free/high",
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("still refuses a provider the CLI cannot resolve when the payload is empty", async () => {
+    stubOpencodeCli(["opencode/nemotron-3.5-lightning-free"]);
+    invalidateRuntimeAuthCache();
+
+    await expect(
+      assertRuntimeDispatchable(
+        "opencode",
+        "openrouter/deepseek/deepseek-v4.1-flash",
+      ),
+    ).rejects.toMatchObject({
+      code: "dispatch_cli_auth_unavailable",
+      status: {
+        ready: false,
+        unavailableReason: "needs_auth",
+        detail: expect.stringContaining(
+          'provider "openrouter" has no credential evidence',
+        ),
+      },
+    });
+  });
+
+  it("keeps the credential-file answer when the CLI cannot be asked at all", async () => {
+    // No stub: the probes fail the way a missing or hanging CLI fails them.
+    const authPath = path.join(
+      authFixture.home,
+      ".local",
+      "share",
+      "opencode",
+      "auth.json",
+    );
+    mkdirSync(path.dirname(authPath), { recursive: true });
+    writeFileSync(
+      authPath,
+      JSON.stringify({ openrouter: { type: "api", key: "test-key" } }),
+    );
+    invalidateRuntimeAuthCache();
+
+    await expect(
+      assertRuntimeDispatchable(
+        "opencode",
+        "openrouter/deepseek/deepseek-v4.1-flash",
+      ),
+    ).resolves.toBeUndefined();
   });
 
   it.each([
@@ -577,14 +668,31 @@ describe("OpenCode readiness preflight", () => {
     expect(await response.json()).toMatchObject({ ok: true });
   });
 
-  it("accepts the known zero-setup OpenCode model through the real create-mission route", async () => {
+  it("accepts a zero-setup OpenCode model the CLI lists, through the real create-mission route", async () => {
+    // Zero-setup models are whichever free-tier ids this install resolves, not a
+    // list baked in here that goes stale the day the free tier changes.
+    stubOpencodeCli(["opencode/nemotron-3.5-lightning-free"]);
     invalidateRuntimeAuthCache();
 
     const response = await createMissionRoute.POST(
-      createMissionRequest("opencode/deepseek-v4-flash-free", 91_761_004),
+      createMissionRequest("opencode/nemotron-3.5-lightning-free", 91_761_004),
     );
     expect(response.status).toBe(201);
     expect(await response.json()).toMatchObject({ ok: true });
+  });
+
+  it("refuses a free-tier model this install does not list, through the real create-mission route", async () => {
+    stubOpencodeCli(["opencode/nemotron-3.5-lightning-free"]);
+    invalidateRuntimeAuthCache();
+
+    const response = await createMissionRoute.POST(
+      createMissionRequest("opencode/retired-flash-free", 91_761_010),
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      ok: false,
+      error: { code: "dispatch_cli_auth_unavailable" },
+    });
   });
 
   it("uses inherited and configured provider env credentials without exposing their values", async () => {

--- a/src/lib/runtimes/shared/auth-detect.ts
+++ b/src/lib/runtimes/shared/auth-detect.ts
@@ -26,6 +26,8 @@ import { cliInvocation } from '@/lib/runtimes/shared/cli-spawn';
 import {
   localProviderIds,
   opencodeAuthenticatedProviders,
+  opencodeCliModels,
+  opencodeCliResolvesModel,
   probeOpencodeServiceVersion,
   providerHasConfiguredCredential,
   providerIdForModel,
@@ -42,9 +44,6 @@ const execFileAsync = promisify(execFile);
 const CACHE_TTL_MS = 60_000;
 const UNKNOWN_CLAUDE_CACHE_TTL_MS = 5_000;
 const PROBE_TIMEOUT_MS = 1_500;
-const TRUSTED_KEYLESS_OPENCODE_MODELS = new Set([
-  'opencode/deepseek-v4-flash-free',
-]);
 
 export type RuntimeHouse = RuntimeAuthHouse;
 export type RuntimeUnavailableReason = 'not_installed' | 'needs_auth' | 'needs_restart' | 'adapter_unavailable' | 'incompatible_model';
@@ -181,19 +180,26 @@ async function opencodeModelStatus(
   const authenticated = credentialProviders.has(providerId)
     || providerHasConfiguredCredential(config, providerId);
   const local = localProviders.has(providerId);
-  const keyless = TRUSTED_KEYLESS_OPENCODE_MODELS.has(model.trim());
-  const ready = authenticated || local || keyless;
+  // Absent credential evidence is unknown, not "no": OpenCode 2 keeps credentials
+  // server-side, where neither the auth listing nor the credential file can see
+  // them. Ask the CLI what it resolves — a model it lists is a model it will
+  // dispatch, and an install with nothing connected lists nothing — but only once
+  // the cheaper local evidence has come up empty.
+  const cliResolves = !authenticated
+    && !local
+    && await opencodeCliResolvesModel(status.binaryPath, model);
+  const ready = authenticated || local || cliResolves;
   return {
     ...status,
     authenticated,
     ready,
     unavailableReason: ready ? null : 'needs_auth',
-    detail: keyless
-      ? `OpenCode 2 model "${model.trim()}" supports keyless dispatch.`
+    detail: authenticated
+      ? `OpenCode 2 provider "${providerId}" has credential evidence.`
       : local
-      ? `OpenCode 2 provider "${providerId}" is configured for local dispatch.`
-      : authenticated
-        ? `OpenCode 2 provider "${providerId}" has credential evidence.`
+        ? `OpenCode 2 provider "${providerId}" is configured for local dispatch.`
+      : cliResolves
+        ? `OpenCode 2 lists model "${model.trim()}" as one it can resolve.`
         : `OpenCode 2 provider "${providerId}" has no credential evidence and is not configured for local dispatch.`,
     fix: ready
       ? 'No action needed.'
@@ -356,10 +362,11 @@ async function detectOpencode(): Promise<RuntimeAuthStatus> {
     });
   }
 
-  const [credentialProviders, config, serviceVersion] = await Promise.all([
+  const [credentialProviders, config, serviceVersion, cliModels] = await Promise.all([
     opencodeAuthenticatedProviders(os.homedir(), binaryPath),
     readOpencodeConfig(os.homedir()),
     probeOpencodeServiceVersion(binaryPath),
+    opencodeCliModels(binaryPath),
   ]);
   const authenticated = credentialProviders.size > 0;
   const localProviderConfigured = localProviderIds(config).size > 0;
@@ -385,26 +392,25 @@ async function detectOpencode(): Promise<RuntimeAuthStatus> {
       binaryPath,
     });
   }
-  const defaultModel = getRuntimeCapability('opencode').defaultModel;
-  const defaultModelReady = Boolean(
-    defaultModel && TRUSTED_KEYLESS_OPENCODE_MODELS.has(defaultModel),
-  );
+  // A listing that names anything is dispatch evidence for the same reason the
+  // per-model gate trusts it, and it replaces a hardcoded keyless-model list that
+  // went stale the moment the free tier changed.
+  const cliDispatchable = Boolean(cliModels?.size);
+  const ready = authenticated || cliDispatchable || localProviderConfigured;
   return nowStatus('opencode', 'opencode', {
     installed: true,
     authenticated,
-    ready: authenticated || defaultModelReady,
+    ready,
     detail: authenticated
       ? 'OpenCode 2 CLI is installed and has provider credential evidence.'
-      : defaultModelReady
-        ? `OpenCode 2 CLI is installed and its default model "${defaultModel}" supports keyless dispatch.`
+      : cliDispatchable
+        ? 'OpenCode 2 CLI is installed and lists models it can resolve.'
       : localProviderConfigured
         ? 'OpenCode 2 CLI is installed and has a configured local provider; select one of that provider\'s models to dispatch.'
         : 'OpenCode 2 CLI is installed but has no credential evidence or configured local provider.',
-    fix: authenticated || defaultModelReady
+    fix: ready
       ? 'No action needed.'
-      : localProviderConfigured
-        ? 'Select a model from the configured local provider, or run `opencode2 auth login`.'
-        : 'Run `opencode2 auth login` or configure a provider with a local baseURL.',
+      : 'Run `opencode2 auth login` or configure a provider with a local baseURL.',
     binaryPath,
   });
 }

--- a/src/lib/runtimes/shared/opencode-auth-providers.test.ts
+++ b/src/lib/runtimes/shared/opencode-auth-providers.test.ts
@@ -6,9 +6,18 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const {
   opencodeAuthenticatedProviders,
+  opencodeCliModels,
   opencodeCliProviders,
-  setOpencodeAuthListProbeDependenciesForTests,
+  opencodeCliResolvesModel,
+  setOpencodeCliProbeDependenciesForTests,
 } = await import('./opencode-readiness');
+
+/** Shape of `models`: one `provider/model` id per line. */
+const MODELS_PAYLOAD = [
+  'opencode/nemotron-3.5-lightning-free',
+  'openrouter/deepseek/deepseek-v4.1-flash',
+  'xai/grok-4',
+].join('\n') + '\n';
 
 const CLI_PATH = '/test-bin/opencode2';
 
@@ -31,7 +40,7 @@ function writeLegacyAuthFile(providers: Record<string, unknown>): void {
 
 function stubCli(run: (args: string[]) => Promise<string>): string[][] {
   const calls: string[][] = [];
-  setOpencodeAuthListProbeDependenciesForTests({
+  setOpencodeCliProbeDependenciesForTests({
     run: (args) => {
       calls.push(args);
       return run(args);
@@ -49,7 +58,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  setOpencodeAuthListProbeDependenciesForTests(null);
+  setOpencodeCliProbeDependenciesForTests(null);
   if (savedDataHome === undefined) delete process.env.XDG_DATA_HOME;
   else process.env.XDG_DATA_HOME = savedDataHome;
   if (savedAuthContent === undefined) delete process.env.OPENCODE_AUTH_CONTENT;
@@ -110,15 +119,82 @@ describe('opencodeCliProviders', () => {
     await expect(opencodeCliProviders(null)).resolves.toBeNull();
   });
 
-  it('returns an empty set when the CLI reports nothing connected', async () => {
+  it('treats an empty payload as indeterminate, since credentials can live server-side', async () => {
     stubCli(async () => '[]');
 
-    await expect(opencodeCliProviders(CLI_PATH)).resolves.toEqual(new Set());
+    await expect(opencodeCliProviders(CLI_PATH)).resolves.toBeNull();
   });
 
   it('returns null when the CLI emits output that is not JSON', async () => {
     stubCli(async () => 'No authenticated integrations');
 
     await expect(opencodeCliProviders(CLI_PATH)).resolves.toBeNull();
+  });
+});
+
+describe('opencodeCliModels', () => {
+  it('reads the ids the CLI says it can resolve', async () => {
+    const calls = stubCli(async () => MODELS_PAYLOAD);
+
+    await expect(opencodeCliModels(CLI_PATH)).resolves.toEqual(
+      new Set([
+        'opencode/nemotron-3.5-lightning-free',
+        'openrouter/deepseek/deepseek-v4.1-flash',
+        'xai/grok-4',
+      ]),
+    );
+    expect(calls).toEqual([['models']]);
+  });
+
+  it('returns null without a CLI to ask', async () => {
+    await expect(opencodeCliModels(null)).resolves.toBeNull();
+  });
+
+  it('returns null when the CLI names nothing', async () => {
+    stubCli(async () => '\n');
+
+    await expect(opencodeCliModels(CLI_PATH)).resolves.toBeNull();
+  });
+
+  it('drops output that is not a provider-qualified id', async () => {
+    stubCli(async () => 'No models available\nopencode/mimo-v2.5-free\n');
+
+    await expect(opencodeCliModels(CLI_PATH)).resolves.toEqual(
+      new Set(['opencode/mimo-v2.5-free']),
+    );
+  });
+});
+
+describe('opencodeCliResolvesModel', () => {
+  it('matches an id the listing names', async () => {
+    stubCli(async () => MODELS_PAYLOAD);
+
+    await expect(
+      opencodeCliResolvesModel(CLI_PATH, 'openrouter/deepseek/deepseek-v4.1-flash'),
+    ).resolves.toBe(true);
+  });
+
+  it('matches an effort pin through its base model', async () => {
+    stubCli(async () => MODELS_PAYLOAD);
+
+    await expect(
+      opencodeCliResolvesModel(CLI_PATH, 'opencode/nemotron-3.5-lightning-free/high'),
+    ).resolves.toBe(true);
+  });
+
+  it('does not match a model the listing leaves out', async () => {
+    stubCli(async () => MODELS_PAYLOAD);
+
+    await expect(
+      opencodeCliResolvesModel(CLI_PATH, 'anthropic/claude-opus-4-8'),
+    ).resolves.toBe(false);
+  });
+
+  it('does not promote a provider id into a model match', async () => {
+    stubCli(async () => 'opencode\nopencode/mimo-v2.5-free\n');
+
+    await expect(
+      opencodeCliResolvesModel(CLI_PATH, 'opencode/big-pickle'),
+    ).resolves.toBe(false);
   });
 });

--- a/src/lib/runtimes/shared/opencode-readiness.ts
+++ b/src/lib/runtimes/shared/opencode-readiness.ts
@@ -512,27 +512,36 @@ export async function probeOpencodeServiceVersion(
   };
 }
 
-export interface OpencodeAuthListProbeDependencies {
+export interface OpencodeCliProbeDependencies {
   run(args: string[]): Promise<string>;
 }
 
-let authListProbeDependenciesForTests: OpencodeAuthListProbeDependencies | null = null;
+let cliProbeDependenciesForTests: OpencodeCliProbeDependencies | null = null;
 
-export function setOpencodeAuthListProbeDependenciesForTests(
-  dependencies: OpencodeAuthListProbeDependencies | null,
+export function setOpencodeCliProbeDependenciesForTests(
+  dependencies: OpencodeCliProbeDependencies | null,
 ): void {
-  authListProbeDependenciesForTests = dependencies;
+  cliProbeDependenciesForTests = dependencies;
 }
 
-async function runOpencodeJsonProbe(binaryPath: string, args: string[]): Promise<string> {
+async function runOpencodeCliProbe(binaryPath: string, args: string[]): Promise<string> {
   const invocation = cliInvocation(binaryPath, args);
   const { stdout } = await execFileAsync(invocation.command, invocation.args, {
     windowsHide: true,
     timeout: SERVICE_PROBE_TIMEOUT_MS,
     env: { ...process.env, FORCE_COLOR: "0", NO_COLOR: "1" },
-    maxBuffer: 64 * 1024,
+    maxBuffer: 256 * 1024,
   });
   return stdout;
+}
+
+function cliProbeRunner(
+  binaryPath?: string | null,
+  dependencies?: OpencodeCliProbeDependencies,
+): ((args: string[]) => Promise<string>) | null {
+  const injected = dependencies ?? cliProbeDependenciesForTests;
+  if (injected) return injected.run;
+  return binaryPath ? (args: string[]) => runOpencodeCliProbe(binaryPath, args) : null;
 }
 
 /**
@@ -540,17 +549,17 @@ async function runOpencodeJsonProbe(binaryPath: string, args: string[]): Promise
  * keeps in its own store as well as provider environment keys. Returns null
  * when the CLI cannot answer — an indeterminate probe must never be read as
  * "no providers", which is the failure this exists to stop.
+ *
+ * An answer that names nothing is indeterminate for the same reason: OpenCode 2
+ * keeps credentials server-side, out of this listing's reach, so a successful
+ * empty payload reports the absence of local records rather than the absence of
+ * credentials.
  */
 export async function opencodeCliProviders(
   binaryPath?: string | null,
-  dependencies?: OpencodeAuthListProbeDependencies,
+  dependencies?: OpencodeCliProbeDependencies,
 ): Promise<Set<string> | null> {
-  const injected = dependencies ?? authListProbeDependenciesForTests;
-  const run = injected
-    ? injected.run
-    : binaryPath
-      ? (args: string[]) => runOpencodeJsonProbe(binaryPath, args)
-      : null;
+  const run = cliProbeRunner(binaryPath, dependencies);
   if (!run) return null;
 
   let payload: unknown;
@@ -570,8 +579,58 @@ export async function opencodeCliProviders(
     recognized += 1;
     if (entry.connections.length > 0) providers.add(id);
   }
-  // A payload we could not read at all is indeterminate, not empty.
-  return payload.length > 0 && recognized === 0 ? null : providers;
+  // A payload that named nothing we could read is indeterminate, not empty.
+  return recognized === 0 ? null : providers;
+}
+
+/**
+ * Model ids this install can actually resolve, as the CLI reports them. The
+ * listing is scoped to what the install can reach — an install with nothing
+ * connected lists nothing at all — so a model it names is evidence the CLI will
+ * dispatch that model, including through credentials it holds server-side where
+ * neither the auth listing nor the credential file can see them.
+ *
+ * Returns null when the CLI cannot answer or names nothing.
+ */
+export async function opencodeCliModels(
+  binaryPath?: string | null,
+  dependencies?: OpencodeCliProbeDependencies,
+): Promise<Set<string> | null> {
+  const run = cliProbeRunner(binaryPath, dependencies);
+  if (!run) return null;
+
+  let output: string;
+  try {
+    output = await run(["models"]);
+  } catch {
+    return null;
+  }
+
+  const models = new Set<string>();
+  for (const line of output.split("\n")) {
+    const id = line.trim();
+    // Every id the listing emits is `provider/model`; anything else is chrome.
+    if (id && providerIdForModel(id)) models.add(id);
+  }
+  return models.size > 0 ? models : null;
+}
+
+/**
+ * Whether the CLI will resolve this model id. An effort-suffixed pin
+ * (`provider/model/high`) resolves through the base model the listing names.
+ */
+export async function opencodeCliResolvesModel(
+  binaryPath: string | null | undefined,
+  model: string,
+  dependencies?: OpencodeCliProbeDependencies,
+): Promise<boolean> {
+  const id = model.trim();
+  if (!id) return false;
+  const models = await opencodeCliModels(binaryPath, dependencies);
+  if (!models) return false;
+  if (models.has(id)) return true;
+  const base = id.slice(0, id.lastIndexOf("/"));
+  return Boolean(providerIdForModel(base)) && models.has(base);
 }
 
 /**

--- a/src/lib/runtimes/shared/opencode-service-skew.test.ts
+++ b/src/lib/runtimes/shared/opencode-service-skew.test.ts
@@ -36,6 +36,7 @@ process.env.CORTEX_IDE_DATA_DIR = dataDir;
 
 const {
   probeOpencodeServiceVersion,
+  setOpencodeCliProbeDependenciesForTests,
   setOpencodeServiceProbeDependenciesForTests,
 } = await import('./opencode-readiness');
 const {
@@ -68,6 +69,21 @@ function createMissionRequest(): NextRequest {
   });
 }
 
+/**
+ * An install whose credentials live server-side: `auth list` answers with an
+ * empty array, and the model listing names what it can actually resolve. Keeps
+ * this file's subject the resident service version rather than readiness.
+ */
+function stubOpencodeCli(): void {
+  setOpencodeCliProbeDependenciesForTests({
+    run: async (args: string[]) => {
+      if (args[0] === 'models') return 'opencode/deepseek-v4-flash-free\n';
+      if (args[0] === 'auth') return '[]';
+      throw new Error(`Unexpected OpenCode probe: ${args.join(' ')}`);
+    },
+  });
+}
+
 function serviceRun(serviceVersion: () => string) {
   return vi.fn(async (args: string[]) => {
     if (args[0] === '--version') return 'opencode2 v0.0.0-beta-17794\n';
@@ -93,10 +109,12 @@ beforeEach(() => {
   vi.stubEnv('OPENCODE_CONFIG_CONTENT', '');
   vi.stubEnv('OPENCODE_AUTH_CONTENT', '');
   setOpencodeServiceProbeDependenciesForTests(null);
+  stubOpencodeCli();
   invalidateRuntimeAuthCache();
 });
 
 afterEach(() => {
+  setOpencodeCliProbeDependenciesForTests(null);
   setOpencodeServiceProbeDependenciesForTests(null);
   invalidateRuntimeAuthCache();
   vi.unstubAllEnvs();


### PR DESCRIPTION
Closes #2194

## The hole

`opencode2 auth list --format json` exits 0 and returns `[]` on a machine whose credentials live server-side, which is the OpenCode 2 default. #2190 taught the reader that a CLI which *could not answer* is indeterminate; it still read *an empty answer* as an empty provider set. Unioned with an empty credential file that resolved to "no providers", and dispatch was refused for a provider the CLI was actively using — 74,203 times in one demo machine's server log, while the model it named ran worker packets to `exitCode: 0`.

## The fix

**An answer that names nothing is indeterminate.** `opencodeCliProviders` returns `null` for an empty payload, exactly as it already did for a CLI that timed out or replied in an unreadable shape.

**Indeterminate alone cannot clear the gate, so ask the CLI what it resolves.** `opencode2 models` lists only models the install can actually reach. Verified on an isolated unauthenticated install: it exits 0 and lists **zero** models. So a listed model is positive evidence that dispatch works, and a genuinely unauthenticated provider is still refused — this is not "always allow".

The model probe runs only after the cheaper credential-file and local-provider evidence comes up empty. An effort pin (`provider/model/high`) resolves through the base model the listing names.

**The hardcoded keyless allowlist is deleted, not refreshed.** `TRUSTED_KEYLESS_OPENCODE_MODELS` held a single id the CLI no longer resolves at all, so every `opencode/*` pin failed the gate — including the free orchestrator model the product ships with — and nothing failed loudly when the upstream catalog moved. A list of model ids rots silently; the CLI's own listing cannot rot the same way. The runtime-level gate now reads the same evidence, and picks up local-provider configuration explicitly rather than by accident of the stale default.

## Verification

- Regression driven through the dispatch preflight (`assertRuntimeDispatchable`) and through the real `create-mission` route, not the detector alone.
- **Confirmed failing on `origin/main`**: with the production files reverted to `origin/main`, the empty-array test fails with the exact refusal from the issue — `OpenCode 2 provider "openrouter" has no credential evidence and is not configured for local dispatch.`
- The empty-array case is driven synthetically through the probe seam, so it does not depend on any machine's live auth state.
- Kept covered: a CLI that is absent or times out still falls back to the credential file (#2190), and a provider the CLI cannot resolve is still refused.
- `npx tsc --noEmit` clean; eslint clean on changed files.
- `npm test` (hermetic-unit): **717 files passed, 4669 tests passed**, 3 files / 4 tests skipped.
- `auth-detect.test.ts` under the integration config: **35 passed**, confirmed with `--reporter=verbose` that each new test actually ran.

Both CLI probes stay bounded by the existing probe timeout. No credential value is printed, logged or embedded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dVxFgHWcYwiMja5oBxySH