### PR TITLE
docs(roadmap): Now section, Gap column, usable-or-not for platforms

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,109 +1,131 @@
 # o8 roadmap
 
-o8 is the governance layer for autonomous engineering teams: approvals, audit, organizational memory, and operator control across AI providers. It sits above the coding agents, turns work into missions and packets, isolates execution in worktrees, keeps the operator in the approval path, and records enough evidence to explain what happened later. This page is the map of where that is going and what is open to work on. Taste is not a pillar on this map; it is a gate on all seven, because a change that does not read well, respond quickly, or behave predictably is not finished no matter which pillar it belongs to.
+o8 is for one operator running several coding agents at once. It turns work into missions and packets, runs each packet in its own worktree, keeps the operator in the approval path, and records enough evidence to explain later what happened. This page says where that is going and what is open to work on.
+
+Taste is a gate on every row here, not a pillar of its own. A change that reads badly, responds slowly, or behaves unpredictably is not finished, whichever pillar it belongs to.
+
+## Now
+
+The maintainer's focus for September 2026. Three arcs, each one gap from its next milestone.
+
+| Arc | The gap | Where |
+| --- | --- | --- |
+| Linux | Prove that a fresh mainstream distro installs o8, launches it, dispatches a packet, and merges it. Nine of ten children are shipped; this is the one that makes Linux usable. | [#2060](https://github.com/hurttlocker/o8/issues/2060) |
+| Lane lifecycle and recovery honesty | Two failure modes still hide: a packet refused at dispatch preflight retries forever without surfacing, and superseding a mission leaves its packets live. | [#2195](https://github.com/hurttlocker/o8/issues/2195), [#2196](https://github.com/hurttlocker/o8/issues/2196) |
+| Runtime readiness | An authenticated OpenCode 2 install can still be refused dispatch because the CLI reports an empty provider list. Readiness checks are written per CLI; a shared conformance check would have caught this before a user did. | [#2194](https://github.com/hurttlocker/o8/issues/2194), [#2200](https://github.com/hurttlocker/o8/issues/2200) |
 
 ## How to read this
 
-A checkbox is checked only when the child issue is closed and its fix is on `main` at or before the latest release tag (`v0.1.749` when this page was written), and a status percent is checked divided by total, rounded to the nearest 5. Each open arc has one tracking issue whose checklist is the real progress; the percent here only summarizes it. Frontier arcs carry a verdict and a date instead of a percent, because they are not committed work yet, and a Frontier arc graduates into a pillar when it ships its first child. Run `node scripts/roadmap-status.mjs` to recompute the numbers from the tracking issues; it prints a table and does not rewrite this file.
+Each open arc has one tracking issue. Its checklist is the real progress; the percent here only summarizes that checklist. A box is checked when the child issue is closed and its fix is in a shipped release.
+
+Read the Gap column before the percent. Most open arcs are one child from done. That says the maintainer files small issues; it does not say the work is nearly finished.
+
+Frontier arcs carry a question and a verdict instead of a percent. They are not committed work. A Frontier arc moves into a pillar when it ships its first child.
+
+`node scripts/roadmap-status.mjs` recomputes the percents from the tracking issues. It prints a table and does not rewrite this file.
 
 ## 1. Governance is the product
 
 Execution is separated from approval. Workers cannot merge their own packets, every decision is recorded, and every failure moves through a visible state.
 
-| Arc | Done means | Status | Where |
-| --- | --- | --- | --- |
-| Merge-gate truth | A recorded verdict can never disagree with what actually lands on main. | 100% | shipped in 0.1.738 |
-| Lane lifecycle and recovery honesty | No lane stalls silently, and every terminal state is reachable from the UI and the CLI. | 75% | [#2197](https://github.com/hurttlocker/o8/issues/2197) |
-| Dispatch honesty | A confident mission plan in the thread implies a launched worker, or an error. | 100% | shipped in 0.1.749 |
-| Signed receipts and truth queries | Someone who does not trust the operator can still verify a packet's claims. | 100% | shipped in 0.1.722 |
-| Worker capability boundaries | A worker cannot read or reach anything its packet does not grant. | 75% | [#2198](https://github.com/hurttlocker/o8/issues/2198) |
-| Broadcast: the audit trail as a live feed | The audit trail is something an operator watches, not only something they query. | 100% | shipped in 0.1.717 |
-| Contributor-ready public repo | An outside pull request gets green checks and a human reply without maintainer plumbing. | 85% | [#2199](https://github.com/hurttlocker/o8/issues/2199) |
+| Arc | Done means | Status | Gap | Where |
+| --- | --- | --- | --- | --- |
+| Merge-gate truth | A recorded verdict never disagrees with what lands on main. | 100% | none | shipped in 0.1.738 |
+| Lane lifecycle and recovery honesty | No lane stalls silently. Every terminal state is reachable from the UI and the CLI. | 75% | A preflight-refused packet retries forever without surfacing. A superseded mission leaves its packets live. | [#2197](https://github.com/hurttlocker/o8/issues/2197) |
+| Dispatch honesty | A mission plan in the thread implies a launched worker, or an error. | 100% | none | shipped in 0.1.749 |
+| Signed receipts and truth queries | Someone who does not trust the operator can still verify a packet's claims. | 100% | none | shipped in 0.1.722 |
+| Worker capability boundaries | A worker cannot read or reach anything its packet does not grant. | 75% | Native workers run under the operator's user account and can read the operator's environment. | [#2198](https://github.com/hurttlocker/o8/issues/2198) |
+| Broadcast: the audit trail as a live feed | The operator watches the audit trail instead of only querying it. | 100% | none | shipped in 0.1.717 |
+| Contributor-ready public repo | An outside pull request gets green checks and a human reply without maintainer plumbing. | 85% | This roadmap and the claiming protocol are new. No outside claim has gone through them yet. | [#2199](https://github.com/hurttlocker/o8/issues/2199) |
 
 ## 2. Organizational memory
 
-Project rules and prior outcomes stay attached to the project rather than to one model vendor, so an orchestrator and its workers share the same operating context across runtimes.
+Project rules and prior outcomes stay attached to the project, not to one model vendor. An orchestrator and its workers share the same operating context across runtimes.
 
-| Arc | Done means | Status | Where |
-| --- | --- | --- | --- |
-| Engineering Brain question and answer | Any consumer, on any surface, gets a cited answer from the same retrieval path. | 100% | shipped, [#915](https://github.com/hurttlocker/o8/issues/915) |
-| Workers write back to memory | A packet's lesson survives the packet. | 100% | shipped in 0.1.716 |
-| Cost and capacity ledger | The ledger's number and the provider's invoice agree. | 75% | [#1791](https://github.com/hurttlocker/o8/issues/1791) |
-| Spec review inversion | Project rules are operator-owned and agent-annotated, never agent-rewritten. | 100% | shipped |
+| Arc | Done means | Status | Gap | Where |
+| --- | --- | --- | --- | --- |
+| Engineering Brain question and answer | Any consumer, on any surface, gets a cited answer from the same retrieval path. | 100% | none | shipped, [#915](https://github.com/hurttlocker/o8/issues/915) |
+| Workers write back to memory | A packet's lesson survives the packet. | 100% | none | shipped in 0.1.716 |
+| Cost and capacity ledger | The ledger's number and the provider's invoice agree. | 75% | Nothing measures what role routing and context controls save. | [#1791](https://github.com/hurttlocker/o8/issues/1791) |
+| Spec review inversion | The operator owns the project rules. Agents annotate them and never rewrite them. | 100% | none | shipped |
 
 ## 3. Runs on your subscriptions
 
-Local worker adapters launch the coding-agent CLIs you already pay for and reuse the authentication those tools already have. The runtime contract keeps callers independent of any one provider's protocol.
+Local worker adapters launch the coding-agent CLIs you already pay for and reuse the authentication those tools already hold. The runtime contract keeps callers independent of any one provider's protocol.
 
-| Arc | Done means | Status | Where |
-| --- | --- | --- | --- |
-| Execution carriers | A model wrapper is a carrier choice, not a new entry in the runtime registry. | 100% | shipped in 0.1.748 |
-| Declarative runtimes | A CLI-shaped runtime is a config row, not a six-file patch. | 100% | shipped in 0.1.725 |
-| Carrier coverage and auth probes | A new carrier lands as a registry entry plus a readiness and auth probe, with no fork in the dispatch path. | 65% | [#2200](https://github.com/hurttlocker/o8/issues/2200) |
-| OpenCode 2 and ACP | A non-subscription CLI is a first-class worker and a first-class orchestrator backend. | 80% | [#2201](https://github.com/hurttlocker/o8/issues/2201) |
-| Local models first-class | Every surface names its local provider, and a test proves no egress for a full packet lifecycle. | parked, 3 of 3 carved children shipped | [#1451](https://github.com/hurttlocker/o8/issues/1451) |
+| Arc | Done means | Status | Gap | Where |
+| --- | --- | --- | --- | --- |
+| Execution carriers | A model wrapper is a carrier choice, not a new entry in the runtime registry. | 100% | none | shipped in 0.1.748 |
+| Declarative runtimes | A CLI-shaped runtime is a config row, not a six-file patch. | 100% | none | shipped in 0.1.725 |
+| Carrier coverage and auth probes | A new carrier lands as a registry entry plus a readiness and auth probe, with no fork in the dispatch path. | 65% | Readiness and auth checks are written per CLI. The one adapter waiting is blocked on an upstream build for Intel Macs. | [#2200](https://github.com/hurttlocker/o8/issues/2200) |
+| OpenCode 2 and ACP | A CLI that is not tied to a subscription works as a worker and as an orchestrator backend. | 80% | An authenticated install can be refused dispatch when the CLI reports an empty provider list. | [#2201](https://github.com/hurttlocker/o8/issues/2201) |
+| Local models first-class | Every surface names its local provider, and a test proves no egress for a full packet lifecycle. | parked | No surface-by-surface local path exists, and nothing proves that a packet leaves nothing behind on the network. | [#1451](https://github.com/hurttlocker/o8/issues/1451) |
 
 ## 4. One control plane, every surface
 
-Desktop, mobile, CLI, MCP, headless, and voice all reach the same governed control plane, without giving every caller the same authority.
+Desktop, mobile, CLI, MCP, headless, and voice reach the same governed control plane. Each caller gets its own authority; none of them gets the operator's by default.
 
-| Arc | Done means | Status | Where |
-| --- | --- | --- | --- |
-| Headless o8 | The control plane runs on a box with no screen. | 100% | shipped in 0.1.727 |
-| Mobile as an operator surface | Approve, reject, steer, and read evidence from the phone. | 100% | shipped, [#1074](https://github.com/hurttlocker/o8/issues/1074) |
-| Voice as an operator surface | The voice agent's brain seat is a registry choice, not a vendor branch. | 100% | shipped in 0.1.748 |
-| Terminals as a workspace surface | A tmux or vim session survives a ship and a pane switch byte-faithfully, and terminal actions go through a governed adapter. | 90% | [#1723](https://github.com/hurttlocker/o8/issues/1723) |
+| Arc | Done means | Status | Gap | Where |
+| --- | --- | --- | --- | --- |
+| Headless o8 | The control plane runs on a machine with no screen. | 100% | none | shipped in 0.1.727 |
+| Mobile as an operator surface | Approve, reject, steer, and read evidence from the phone. | 100% | none | shipped, [#1074](https://github.com/hurttlocker/o8/issues/1074) |
+| Voice as an operator surface | The voice agent's planning seat is a registry choice, not a vendor branch. | 100% | none | shipped in 0.1.748 |
+| Terminals as a workspace surface | A tmux or vim session survives an update and a pane switch byte for byte, and agent terminal actions go through a governed adapter. | 90% | Agent terminal actions are raw writes, and agent status inside a terminal is not inspectable. | [#1723](https://github.com/hurttlocker/o8/issues/1723) |
 
 ## 5. Smooth for people and for agents
 
-Two lanes, one pillar. The people lane is about the surfaces a human works in. The agents lane is about whether another program can drive o8 without pretending to be a mouse.
+Two lanes, one pillar. The people lane covers the surfaces a person works in. The agents lane covers whether another program can drive o8 through a real interface instead of imitating a mouse.
 
 ### People
 
-| Arc | Done means | Status | Where |
-| --- | --- | --- | --- |
-| Canvas IDE parity | The canvas is a place you can actually work, not a demo surface. | 7 of 7 carved children shipped, epic open | [#1664](https://github.com/hurttlocker/o8/issues/1664) |
-| Rich Markdown editor | Editing a document in o8 never corrupts it. | 100% | shipped in 0.1.722 |
-| Design Mode loop | "Change this button" is one bounded loop with a proof card, not a packet. | 85% | [#1695](https://github.com/hurttlocker/o8/issues/1695) |
-| Interaction budgets | Boot, typing, navigation, and scale each have a measured budget that a regression can fail. | 100% | shipped in 0.1.748 |
+| Arc | Done means | Status | Gap | Where |
+| --- | --- | --- | --- | --- |
+| Canvas IDE parity | A full editing session happens on the canvas: open a file by name, search the repo, edit, diff, commit. | open | The seven carved children are shipped. The rest of the scope is not yet carved into issues. | [#1664](https://github.com/hurttlocker/o8/issues/1664) |
+| Rich Markdown editor | Editing a document in o8 never corrupts it. | 100% | none | shipped in 0.1.722 |
+| Design Mode loop | "Change this button" is one bounded loop with a before-and-after proof card. | 85% | Screenshot crop timing is not measured through the supported capture path. | [#1695](https://github.com/hurttlocker/o8/issues/1695) |
+| Interaction budgets | Boot, typing, navigation, and scale each have a measured budget that a regression can fail. | 100% | none | shipped in 0.1.748 |
 
 ### Agents
 
-| Arc | Done means | Status | Where |
-| --- | --- | --- | --- |
-| Control surfaces, not scraping | Every operator action is reachable from the CLI, MCP, and the socket, not only from a mouse. | 100% | shipped in 0.1.749 |
-| CLI and MCP symmetry | The same control verb reaches the same governed route from an operator surface and from a worker context. | 100% | shipped in 0.1.738 |
+| Arc | Done means | Status | Gap | Where |
+| --- | --- | --- | --- | --- |
+| Control surfaces, not scraping | Every operator action is reachable from the CLI, MCP, and the webview socket. | 100% | none | shipped in 0.1.749 |
+| CLI and MCP symmetry | The same control verb reaches the same governed route from an operator surface and from a worker context. | 100% | none | shipped in 0.1.738 |
+
+Both rows in this lane are shipped. The lane has no open arc, which means the next agent-facing gap has not been named yet.
 
 ## 6. Runs where you are
 
 o8 should be light on the machine it runs on, and it should run on the machine you have.
 
-| Arc | Done means | Status | Where |
-| --- | --- | --- | --- |
-| Mac hardening | A populated daily profile passes an unchanged native idle gate, with receipts. | 100% | shipped in 0.1.748 |
-| Speed and idle-work pass | Interaction budgets hold under real load, not only at idle. | 85% | [#2202](https://github.com/hurttlocker/o8/issues/2202) |
-| Storage admission and reclaim | o8 never blocks a dispatch it could have serviced, and never fills the disk. | 90% | [#2203](https://github.com/hurttlocker/o8/issues/2203) |
-| Linux | A fresh Ubuntu box installs o8, launches it, dispatches a packet, and merges it through the governed path. | 90% | [#1672](https://github.com/hurttlocker/o8/issues/1672) |
-| Windows | The same as Linux, on Windows. Help wanted: this needs a contributor with Windows hardware, because no maintainer has a Windows machine to verify on. The audit is already written, with file-and-line evidence, in `docs/internals/port-audit-windows.md`. | 50% | [#2204](https://github.com/hurttlocker/o8/issues/2204) |
-| Release channels and build integrity | Preview and stable are separable, and a build is reproducible from a tag. | 90% | [#2205](https://github.com/hurttlocker/o8/issues/2205) |
+| Arc | Done means | Status | Gap | Where |
+| --- | --- | --- | --- | --- |
+| Mac hardening | A populated daily profile passes an unchanged native idle gate, with receipts. | 100% | none | shipped in 0.1.748 |
+| Speed and idle-work pass | Interaction budgets hold under real load, not only at idle. | 85% | Conversation switching and long histories slow down under streaming load. | [#2202](https://github.com/hurttlocker/o8/issues/2202) |
+| Storage admission and reclaim | o8 never blocks a dispatch it could have serviced, and never fills the disk. | 90% | Admission uses one flat free-space reserve instead of the job's size. | [#2203](https://github.com/hurttlocker/o8/issues/2203) |
+| Linux | A fresh Ubuntu machine installs o8, launches it, dispatches a packet, and merges it through the governed path. | 90%, not usable yet | Nobody has proven the install on a mainstream distro. | [#1672](https://github.com/hurttlocker/o8/issues/1672) |
+| Windows | The same as Linux, on Windows. | 50%, not usable | Code signing is pending validation, and every child after the audit is unbuilt. | [#2204](https://github.com/hurttlocker/o8/issues/2204) |
+| Release channels and build integrity | Preview and stable are separable, and a build is reproducible from a tag. | 90% | Preview enrollment with an isolated app identity and data does not exist. | [#2205](https://github.com/hurttlocker/o8/issues/2205) |
+
+Windows is help wanted. No maintainer has a Windows machine to verify on, so this arc needs a contributor who does. The port audit is written, with file-and-line evidence, in `docs/internals/port-audit-windows.md`.
 
 ## 7. Frontier
 
-Directions we are looking at rather than committed to. These carry a verdict and a date instead of a percent. Exploring means the question is open and worth answering. Parked means we know what it would take and are not doing it now. An arc here graduates into a pillar when it ships its first child.
+Directions we are looking at, not committed work. Each row names the question it has to answer. "Exploring" means the question is open and worth answering. "Parked" means we know what it would take and are not doing it now. Verdicts are reviewed at the start of each month, and a row that ships its first child moves into a pillar.
 
-| Arc | Verdict | Since | Where |
-| --- | --- | --- | --- |
-| Connector layer for external tools | exploring | 2026-08-01 | [#1665](https://github.com/hurttlocker/o8/issues/1665) |
-| Portable worker environments | exploring | 2026-08-03 | [#1690](https://github.com/hurttlocker/o8/issues/1690) |
-| Cross-device execution continuity | exploring | 2026-08-04 | [#1727](https://github.com/hurttlocker/o8/issues/1727) |
-| Worker OS sandbox as the default | parked | 2026-08-01 | [#1657](https://github.com/hurttlocker/o8/issues/1657) |
-| Multiplayer workspace identity | parked | 2026-08-26 | [#1875](https://github.com/hurttlocker/o8/issues/1875) |
-| Client-delegation transport for the voice brain seat | parked | 2026-09-11 | [#2166](https://github.com/hurttlocker/o8/issues/2166) |
+| Arc | Question it must answer | Verdict | Since | Where |
+| --- | --- | --- | --- | --- |
+| Connector layer for external tools | Does a connector catalog belong in o8, or in the runtimes that already have one? | exploring | 2026-08-01 | [#1665](https://github.com/hurttlocker/o8/issues/1665) |
+| Portable worker environments | Can a packet's environment move to another machine without a rebuild? | exploring | 2026-08-03 | [#1690](https://github.com/hurttlocker/o8/issues/1690) |
+| Cross-device execution continuity | Can a session started on the desktop continue from the phone under the same authority rules? | exploring | 2026-08-04 | [#1727](https://github.com/hurttlocker/o8/issues/1727) |
+| Worker OS sandbox as the default | Can the opt-in sandbox run the daily profile with no regressions? | parked | 2026-08-01 | [#1657](https://github.com/hurttlocker/o8/issues/1657) |
+| Multiplayer workspace identity | Can two operators share a workspace without weakening the approval path? | parked | 2026-08-26 | [#1875](https://github.com/hurttlocker/o8/issues/1875) |
+| Client-delegation transport for the voice planning seat | Can the voice transport run on a subscription instead of an API key? | parked | 2026-09-11 | [#2166](https://github.com/hurttlocker/o8/issues/2166) |
 
 ## Claiming work
 
-Start from a tracking issue above, open its checklist, and pick an unchecked child labeled `claimable`. Comment "claiming" on that child; a maintainer flips it to `claimed`, which expires after seven days with no linked pull request. The full protocol, including what a pull request needs before review, is in [CONTRIBUTING.md](./CONTRIBUTING.md#claiming-work).
+Start from a tracking issue above, open its checklist, and pick an unchecked child labeled `claimable`. Comment "claiming" on that child. A maintainer flips it to `claimed`, which expires after seven days with no linked pull request. The full protocol, including what a pull request needs before review, is in [CONTRIBUTING.md](./CONTRIBUTING.md#claiming-work).
 
 ## Not on this map
 
-Bug fixes, chores, security advisories, and dependency work are tracked as plain issues rather than roadmap arcs.
+Bug fixes, chores, security advisories, and dependency work are tracked as plain issues, not as roadmap arcs.


### PR DESCRIPTION
Editorial pass on ROADMAP.md, one day after it landed.

- Adds a Now section: the three arcs in focus this month and the single gap on each.
- Adds a Gap column to every pillar table. The percent alone read as nearly done everywhere because nine of the thirteen open arcs are one child from their checklist end; the gap says what is missing in words.
- Platform rows state usable or not usable next to the percent.
- Frontier rows name the question each direction has to answer; verdicts get reviewed at the start of each month.
- The Windows help-wanted note moves out of the table cell into a line under it.
- Plain wording throughout; no change to any issue number, status, or link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe