### PR TITLE
ci: run CI on every push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,14 @@
 name: CI
 
-# PR-triggered since 2026-07-08 (Actions-billing discipline, Q ruling). The push
-# trigger re-verified work the LOCAL gate already ran (npx tsc --noEmit + npm
-# test before every commit per CLAUDE.md, real build at ship time) — at ~20
-# direct pushes/day × ~17 job-minutes that was the entire Actions bill for
-# zero new signal. PRs are the un-gated lanes (PR agents), so event-driven CI
-# stays there.
+# Runs on every pull request and on every push to main. The repo is public,
+# so Linux and Windows runners are free; the main-branch run keeps the README
+# badge and the default-branch status honest after each merge (Q ruling
+# 2026-09-11, reversing the PR-only rule from the private-repo days).
 # A weekly run keeps integration coverage and dependency audits current;
-# workflow_dispatch remains the on-demand path for a full remote check against
-# main.
+# workflow_dispatch remains the on-demand path for a full remote check.
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
   schedule:
@@ -216,7 +215,7 @@ jobs:
   # the rest of event CI.
   rust-check-windows:
     name: Rust Compile Gate (Windows)
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: windows-latest
     timeout-minutes: 30
     steps:

--- a/tests/workflow-policy.test.ts
+++ b/tests/workflow-policy.test.ts
@@ -161,11 +161,23 @@ describe('workflow policy — every workflow is classified from the filesystem',
     ).toEqual([]);
   });
 
-  it('forbids push triggers, including tag pushes', () => {
-    const violations = workflowFiles
-      .filter((file) => triggerNames(file.workflow).has('push'))
-      .map((file) => file.name);
-    expect(violations, 'push-triggered Actions spend money rechecking direct pushes without review signal').toEqual([]);
+  it('allows push triggers only for pushes to main, never tags or other branches', () => {
+    // The repo is public, so runners are free; a push-to-main run keeps the
+    // default-branch status honest after every merge (ruling 2026-09-11,
+    // reversing the PR-only rule from the private-repo days). Tag pushes and
+    // unscoped pushes stay forbidden: tags would re-run CI on every release,
+    // and an unscoped push would run it on every branch push.
+    const violations: string[] = [];
+    for (const file of workflowFiles) {
+      if (!triggerNames(file.workflow).has('push')) continue;
+      const trigger = file.workflow.on;
+      const push = isRecord(trigger) ? trigger.push : undefined;
+      const branches = isRecord(push) && Array.isArray(push.branches) ? push.branches : null;
+      const tags = isRecord(push) ? push.tags : undefined;
+      const onlyMain = branches !== null && branches.length === 1 && branches[0] === 'main';
+      if (!onlyMain || tags !== undefined) violations.push(file.name);
+    }
+    expect(violations, 'push triggers are permitted only as push.branches: [main] with no tag filter').toEqual([]);
   });
 
   it('allows macOS runners only in workflow_dispatch-only workflows', () => {


### PR DESCRIPTION
Adds `push: branches: [main]` to the CI workflow and lets the Windows compile gate run on push too.

Why: the README badge reports the last CI run on main, and CI had not run on main since August 24, so the badge showed a stale failure while every PR since passed. The PR-only rule was an Actions-billing decision from when the repo was private; the repo is public now and these runners are free. `concurrency: cancel-in-progress` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe