### PR TITLE
docs(roadmap): open arcs only, one Now, state words, drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,3 +256,25 @@ jobs:
       - run: mkdir -p out/frontend out/server
       - run: cargo check --locked
         working-directory: src-tauri
+
+  roadmap-check:
+    name: Roadmap Drift Check
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      # Fails when a tracking-issue checklist claims a child shipped that is
+      # still open, or when ROADMAP.md's Now section links a closed issue.
+      # Closed-but-unreleased children are listed as awaiting release, not
+      # failed. Read-only; touches no files.
+      - name: Check ROADMAP.md against the tracking issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/roadmap-status.mjs --check

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,6 +44,7 @@ Project rules and prior outcomes stay attached to the project, not to one model 
 | Arc | Done means | State | Gap | Where |
 | --- | --- | --- | --- | --- |
 | Cost and capacity ledger | The ledger's number and the provider's invoice agree. | open | Nothing measures what role routing and context controls save. | [#1791](https://github.com/hurttlocker/o8/issues/1791) |
+| Memory the operator shapes | What the operator rejects, steers, or edits becomes memory the Brain and the next worker retrieve, and any single retained item can be deleted. | open | Rejection and steer reasons are stored for audit and read by no retriever; the schema's rework flag is never written; the only way to forget one rule is to reset the whole database. | [#2221](https://github.com/hurttlocker/o8/issues/2221) |
 
 ## 3. Runs on your subscriptions
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,8 +6,6 @@ Taste is a gate on every row here, not a pillar of its own. A change that reads 
 
 ## At a glance
 
-Seven pillars. One line each.
-
 1. **Governance is the product.** Workers cannot merge their own work; every decision and failure is recorded and visible.
 2. **Organizational memory.** Rules and past outcomes stay with the project, not with one model vendor.
 3. **Runs on your subscriptions.** The coding-agent CLIs you already pay for, behind one runtime contract.
@@ -18,107 +16,75 @@ Seven pillars. One line each.
 
 ## Now
 
-The maintainer's focus for September 2026. Three arcs, each one gap from its next milestone.
-
-| Arc | The gap | Where |
-| --- | --- | --- |
-| Linux | Prove that a fresh mainstream distro installs o8, launches it, dispatches a packet, and merges it. Nine of ten children are shipped; this is the one that makes Linux usable. | [#2060](https://github.com/hurttlocker/o8/issues/2060) |
-| Lane lifecycle and recovery honesty | Two failure modes still hide: a packet refused at dispatch preflight retries forever without surfacing, and superseding a mission leaves its packets live. | [#2195](https://github.com/hurttlocker/o8/issues/2195), [#2196](https://github.com/hurttlocker/o8/issues/2196) |
-| Runtime readiness | An authenticated OpenCode 2 install can still be refused dispatch because the CLI reports an empty provider list. Readiness checks are written per CLI; a shared conformance check would have caught this before a user did. | [#2194](https://github.com/hurttlocker/o8/issues/2194), [#2200](https://github.com/hurttlocker/o8/issues/2200) |
-| First ten minutes | Nobody has measured how long a stranger takes from download to a first merged packet, or where they stall. The number goes here once it exists. | [#2211](https://github.com/hurttlocker/o8/issues/2211) |
+One arc for September 2026: **Linux.** Nine of ten children are shipped. The last one is the proof that a fresh mainstream distro installs o8, launches it, dispatches a packet, and merges it. Until that proof exists, o8 runs on one platform. [#2060](https://github.com/hurttlocker/o8/issues/2060)
 
 ## How to read this
 
-Each open arc has one tracking issue. Its checklist is the real progress; the percent here only summarizes that checklist. A box is checked when the child issue is closed and its fix is in a shipped release.
+Only open arcs appear in the pillar tables. Shipped arcs are listed once at the bottom with the release they landed in. Each open arc links to one tracking issue whose checklist is the real progress; a box is checked when the child issue is closed and its fix is in a shipped release, and GitHub shows the count on the issue itself.
 
-Read the Gap column before the percent. Most open arcs are one child from done. That says the maintainer files small issues; it does not say the work is nearly finished.
+State words mean: **open** has children in flight; **parked** means we know what it would take and are not doing it now; **not usable** means the platform does not run o8 today, whatever the checklist says. Read the Gap column first. It says what is missing in words.
 
-Ahead rows are bets, not committed arcs. Each names the outcome we are betting on, what already exists toward it, and the next child. A bet moves into a pillar when that child ships.
-
-`node scripts/roadmap-status.mjs` recomputes the percents from the tracking issues. It prints a table and does not rewrite this file.
+`node scripts/roadmap-status.mjs` prints the checklist counts. `node scripts/roadmap-status.mjs --check` fails when a checklist disagrees with GitHub (a checked child that is open, an unchecked child that is closed) or when a Now link points at a closed issue. CI runs the check on every push to main and weekly, so this page cannot drift silently.
 
 ## 1. Governance is the product
 
 Execution is separated from approval. Workers cannot merge their own packets, every decision is recorded, and every failure moves through a visible state.
 
-| Arc | Done means | Status | Gap | Where |
+| Arc | Done means | State | Gap | Where |
 | --- | --- | --- | --- | --- |
-| Merge-gate truth | A recorded verdict never disagrees with what lands on main. | 100% | none | shipped in 0.1.738 |
-| Lane lifecycle and recovery honesty | No lane stalls silently. Every terminal state is reachable from the UI and the CLI. | 75% | A preflight-refused packet retries forever without surfacing. A superseded mission leaves its packets live. | [#2197](https://github.com/hurttlocker/o8/issues/2197) |
-| Dispatch honesty | A mission plan in the thread implies a launched worker, or an error. | 100% | none | shipped in 0.1.749 |
-| Signed receipts and truth queries | Someone who does not trust the operator can still verify a packet's claims. | 100% | none | shipped in 0.1.722 |
-| Worker capability boundaries | A worker cannot read or reach anything its packet does not grant. | 75% | Native workers run under the operator's user account and can read the operator's environment. | [#2198](https://github.com/hurttlocker/o8/issues/2198) |
-| Broadcast: the audit trail as a live feed | The operator watches the audit trail instead of only querying it. | 100% | none | shipped in 0.1.717 |
-| Contributor-ready public repo | An outside pull request gets green checks and a human reply without maintainer plumbing. | 85% | This roadmap and the claiming protocol are new. No outside claim has gone through them yet. | [#2199](https://github.com/hurttlocker/o8/issues/2199) |
-| First-diff quality | A governed packet's first diff scores at least as well as the raw model coding alone on the same issue. | 0% | Two blind benchmarks, two months and two model generations apart, both lost three of three to the raw model, and both lost the same two ways: over-engineering and missed sub-requirements. The maintainer owns this one directly. | [#1684](https://github.com/hurttlocker/o8/issues/1684) |
+| Lane lifecycle and recovery honesty | No lane stalls silently. Every terminal state is reachable from the UI and the CLI. | open | A preflight-refused packet retries forever without surfacing. A superseded mission leaves its packets live. | [#2197](https://github.com/hurttlocker/o8/issues/2197) |
+| Worker capability boundaries | A worker cannot read or reach anything its packet does not grant. | open | Native workers run under the operator's user account and can read the operator's environment. | [#2198](https://github.com/hurttlocker/o8/issues/2198) |
+| Contributor-ready public repo | An outside pull request gets green checks and a human reply without maintainer plumbing. | open | This roadmap and the claiming protocol are new. No outside claim has gone through them yet. | [#2199](https://github.com/hurttlocker/o8/issues/2199) |
+| First-diff quality | A governed packet's first diff scores at least as well as the raw model coding alone on the same issue. | open | Two blind benchmarks, two months and two model generations apart, both lost three of three to the raw model, and both lost the same two ways: over-engineering and missed sub-requirements. The maintainer owns this one directly. | [#1684](https://github.com/hurttlocker/o8/issues/1684) |
 
 ## 2. Organizational memory
 
 Project rules and prior outcomes stay attached to the project, not to one model vendor. An orchestrator and its workers share the same operating context across runtimes.
 
-| Arc | Done means | Status | Gap | Where |
+| Arc | Done means | State | Gap | Where |
 | --- | --- | --- | --- | --- |
-| Engineering Brain question and answer | Any consumer, on any surface, gets a cited answer from the same retrieval path. | 100% | none | shipped, [#915](https://github.com/hurttlocker/o8/issues/915) |
-| Workers write back to memory | A packet's lesson survives the packet. | 100% | none | shipped in 0.1.716 |
-| Cost and capacity ledger | The ledger's number and the provider's invoice agree. | 75% | Nothing measures what role routing and context controls save. | [#1791](https://github.com/hurttlocker/o8/issues/1791) |
-| Spec review inversion | The operator owns the project rules. Agents annotate them and never rewrite them. | 100% | none | shipped |
+| Cost and capacity ledger | The ledger's number and the provider's invoice agree. | open | Nothing measures what role routing and context controls save. | [#1791](https://github.com/hurttlocker/o8/issues/1791) |
 
 ## 3. Runs on your subscriptions
 
 Local worker adapters launch the coding-agent CLIs you already pay for and reuse the authentication those tools already hold. The runtime contract keeps callers independent of any one provider's protocol.
 
-| Arc | Done means | Status | Gap | Where |
+| Arc | Done means | State | Gap | Where |
 | --- | --- | --- | --- | --- |
-| Execution carriers | A model wrapper is a carrier choice, not a new entry in the runtime registry. | 100% | none | shipped in 0.1.748 |
-| Declarative runtimes | A CLI-shaped runtime is a config row, not a six-file patch. | 100% | none | shipped in 0.1.725 |
-| Carrier coverage and auth probes | A new carrier lands as a registry entry plus a readiness and auth probe, with no fork in the dispatch path. | 50% | Readiness and auth checks are written per CLI, and the operator cannot see what evidence o8 used to call a runtime connected. The one adapter waiting is blocked on an upstream build for Intel Macs. | [#2200](https://github.com/hurttlocker/o8/issues/2200) |
-| OpenCode 2 and ACP | A CLI that is not tied to a subscription works as a worker and as an orchestrator backend. | 80% | An authenticated install can be refused dispatch when the CLI reports an empty provider list. | [#2201](https://github.com/hurttlocker/o8/issues/2201) |
+| Carrier coverage and auth probes | A new carrier lands as a registry entry plus a readiness and auth probe, with no fork in the dispatch path. | open | Readiness and auth checks are written per CLI, and the operator cannot see what evidence o8 used to call a runtime connected. The one adapter waiting is blocked on an upstream build for Intel Macs. | [#2200](https://github.com/hurttlocker/o8/issues/2200) |
+| OpenCode 2 and ACP | A CLI that is not tied to a subscription works as a worker and as an orchestrator backend. | open | The empty-provider-list refusal is fixed on main and waits for the next release; after that the arc is shipped. | [#2201](https://github.com/hurttlocker/o8/issues/2201) |
 | Local models first-class | Every surface names its local provider, and a test proves no egress for a full packet lifecycle. | parked | No surface-by-surface local path exists, and nothing proves that a packet leaves nothing behind on the network. | [#1451](https://github.com/hurttlocker/o8/issues/1451) |
 
 ## 4. One control plane, every surface
 
 Desktop, mobile, CLI, MCP, headless, and voice reach the same governed control plane. Each caller gets its own authority; none of them gets the operator's by default.
 
-| Arc | Done means | Status | Gap | Where |
+| Arc | Done means | State | Gap | Where |
 | --- | --- | --- | --- | --- |
-| Headless o8 | The control plane runs on a machine with no screen. | 100% | none | shipped in 0.1.727 |
-| Mobile as an operator surface | Approve, reject, steer, and read evidence from the phone. | 100% | none | shipped, [#1074](https://github.com/hurttlocker/o8/issues/1074) |
-| Voice as an operator surface | The voice agent's planning seat is a registry choice, not a vendor branch. | 100% | none | shipped in 0.1.748 |
-| Terminals as a workspace surface | A tmux or vim session survives an update and a pane switch byte for byte, and agent terminal actions go through a governed adapter. | 90% | Agent terminal actions are raw writes, and agent status inside a terminal is not inspectable. | [#1723](https://github.com/hurttlocker/o8/issues/1723) |
+| Terminals as a workspace surface | A tmux or vim session survives an update and a pane switch byte for byte, and agent terminal actions go through a governed adapter. | open | Agent terminal actions are raw writes, and agent status inside a terminal is not inspectable. | [#1723](https://github.com/hurttlocker/o8/issues/1723) |
+| Settings take effect everywhere | An operator changes a setting once and every surface uses the new value on its next action, with no reload and no second place to set it. | open | Operator defaults are snapshotted at page load and cached per terminal server; the same bug has recurred under four names. | [#2217](https://github.com/hurttlocker/o8/issues/2217) |
 
 ## 5. Smooth for people and for agents
 
 Two lanes, one pillar. The people lane covers the surfaces a person works in. The agents lane covers whether another program can drive o8 through a real interface instead of imitating a mouse.
 
-### People
-
-| Arc | Done means | Status | Gap | Where |
-| --- | --- | --- | --- | --- |
-| Canvas IDE parity | A full editing session happens on the canvas: open a file by name, search the repo, edit, diff, commit. | 100% of carved scope | The seven carved children are shipped and the epic is closed. Further canvas work will be filed as new children here. | shipped in 0.1.722, [#1664](https://github.com/hurttlocker/o8/issues/1664) |
-| Rich Markdown editor | Editing a document in o8 never corrupts it. | 100% | none | shipped in 0.1.722 |
-| Design Mode loop | "Change this button" is one bounded loop with a before-and-after proof card. | 85% | Screenshot crop timing is not measured through the supported capture path. | [#1695](https://github.com/hurttlocker/o8/issues/1695) |
-| Interaction budgets | Boot, typing, navigation, and scale each have a measured budget that a regression can fail. | 100% | none | shipped in 0.1.748 |
-
-### Agents
-
-| Arc | Done means | Status | Gap | Where |
-| --- | --- | --- | --- | --- |
-| Control surfaces, not scraping | Every operator action is reachable from the CLI, MCP, and the webview socket. | 100% | none | shipped in 0.1.749 |
-| CLI and MCP symmetry | The same control verb reaches the same governed route from an operator surface and from a worker context. | 100% | none | shipped in 0.1.738 |
-| Agent-facing API manifest | One manifest lists every operator verb and its surfaces, and CI fails when a verb exists on one surface and not another. | 0% | No manifest exists; parity between the CLI, MCP, and the webview socket is checked by hand. | [#2212](https://github.com/hurttlocker/o8/issues/2212) |
+| Arc | Lane | Done means | State | Gap | Where |
+| --- | --- | --- | --- | --- | --- |
+| First ten minutes | people | A stranger goes from download to a first merged packet, and the minutes and the stalls are measured. | open | Nobody has measured it. | [#2211](https://github.com/hurttlocker/o8/issues/2211) |
+| Design Mode loop | people | "Change this button" is one bounded loop with a before-and-after proof card. | open | Screenshot crop timing is not measured through the supported capture path. | [#1695](https://github.com/hurttlocker/o8/issues/1695) |
+| Agent-facing API manifest | agents | One manifest lists every operator verb and its surfaces, and CI fails when a verb exists on one surface and not another. | open | No manifest exists; parity between the CLI, MCP, and the webview socket is checked by hand. | [#2212](https://github.com/hurttlocker/o8/issues/2212) |
 
 ## 6. Runs where you are
 
 o8 should be light on the machine it runs on, and it should run on the machine you have.
 
-| Arc | Done means | Status | Gap | Where |
+| Arc | Done means | State | Gap | Where |
 | --- | --- | --- | --- | --- |
-| Mac hardening | A populated daily profile passes an unchanged native idle gate, with receipts. | 100% | none | shipped in 0.1.748 |
-| Speed and idle-work pass | Interaction budgets hold under real load, not only at idle. | 85% | Conversation switching and long histories slow down under streaming load. | [#2202](https://github.com/hurttlocker/o8/issues/2202) |
-| Storage admission and reclaim | o8 never blocks a dispatch it could have serviced, and never fills the disk. | 90% | Admission uses one flat free-space reserve instead of the job's size. | [#2203](https://github.com/hurttlocker/o8/issues/2203) |
-| Linux | A fresh Ubuntu machine installs o8, launches it, dispatches a packet, and merges it through the governed path. | 90%, not usable yet | Nobody has proven the install on a mainstream distro. | [#1672](https://github.com/hurttlocker/o8/issues/1672) |
-| Windows | The same as Linux, on Windows. | 50%, not usable | Code signing is pending validation, and every child after the audit is unbuilt. | [#2204](https://github.com/hurttlocker/o8/issues/2204) |
-| Release channels and build integrity | Preview and stable are separable, and a build is reproducible from a tag. | 90% | Preview enrollment with an isolated app identity and data does not exist. | [#2205](https://github.com/hurttlocker/o8/issues/2205) |
+| Linux | A fresh Ubuntu machine installs o8, launches it, dispatches a packet, and merges it through the governed path. | not usable yet | Nobody has proven the install on a mainstream distro. | [#1672](https://github.com/hurttlocker/o8/issues/1672) |
+| Windows | The same as Linux, on Windows. | not usable | Code signing is pending validation, and every child after the audit is unbuilt. | [#2204](https://github.com/hurttlocker/o8/issues/2204) |
+| Speed and idle-work pass | Interaction budgets hold under real load, not only at idle. | open | Conversation switching and long histories slow down under streaming load. | [#2202](https://github.com/hurttlocker/o8/issues/2202) |
+| Storage admission and reclaim | o8 never blocks a dispatch it could have serviced, and never fills the disk. | open | Admission uses one flat free-space reserve instead of the job's size. | [#2203](https://github.com/hurttlocker/o8/issues/2203) |
+| Release channels and build integrity | Preview and stable are separable, and a build is reproducible from a tag. | open | Preview enrollment with an isolated app identity and data does not exist. | [#2205](https://github.com/hurttlocker/o8/issues/2205) |
 
 Windows is help wanted. No maintainer has a Windows machine to verify on, so this arc needs a contributor who does. The port audit is written, with file-and-line evidence, in `docs/internals/port-audit-windows.md`.
 
@@ -134,6 +100,17 @@ The bets for 2027 and 2028. Each row is an outcome we think operators will need,
 | Nothing leaves the machine unless you say so. Local and on-device models as a real mode with a test that proves it. | Local endpoint probes, the local chat tier for the Brain, an audit of surfaces without a local path. | An egress assertion test across a full packet lifecycle. | [#1451](https://github.com/hurttlocker/o8/issues/1451) |
 | Two operators, one approval path. Teams share a workspace without weakening who can approve what. | Principal-based authorization for operator, worker, and remote callers. | A workspace identity and role model. | [#1875](https://github.com/hurttlocker/o8/issues/1875) |
 | Agents that use the screen, not only the repo. A packet can drive a browser or a GUI with the same isolation, review, and receipt. | The embedded browser agent and its governed verbs. | Computer-use as a worker capability behind the packet contract. | not yet filed |
+
+## Shipped
+
+Arcs whose every child is closed and released. They stay here so the pillars read as a whole, and they get no tracking issue.
+
+- **Governance:** merge-gate truth (0.1.738); dispatch honesty (0.1.749); signed receipts and truth queries (0.1.722); Broadcast, the audit trail as a live feed (0.1.717).
+- **Organizational memory:** Engineering Brain question and answer ([#915](https://github.com/hurttlocker/o8/issues/915)); workers write back to memory (0.1.716); spec review inversion, where the operator owns the rules and agents only annotate.
+- **Runs on your subscriptions:** execution carriers (0.1.748); declarative runtimes (0.1.725).
+- **One control plane, every surface:** headless o8 (0.1.727); mobile as an operator surface ([#1074](https://github.com/hurttlocker/o8/issues/1074)); voice as an operator surface, with the planning seat as a registry choice (0.1.748).
+- **Smooth for people and for agents:** canvas IDE parity, carved scope ([#1664](https://github.com/hurttlocker/o8/issues/1664), 0.1.722); rich Markdown editor (0.1.722); interaction budgets (0.1.748); control surfaces instead of scraping (0.1.749); CLI and MCP symmetry (0.1.738).
+- **Runs where you are:** Mac hardening, a populated daily profile through an unchanged native idle gate (0.1.748).
 
 ## Claiming work
 

--- a/scripts/roadmap-status.mjs
+++ b/scripts/roadmap-status.mjs
@@ -5,6 +5,8 @@
 import { execFileSync } from 'node:child_process';
 
 const REPO = process.env.ROADMAP_REPO || 'hurttlocker/o8';
+const CHECK = process.argv.includes('--check');
+import { readFileSync } from 'node:fs';
 
 function gh(path) {
   const out = execFileSync('gh', ['api', '--paginate', '-H', 'Accept: application/vnd.github+json', path], {
@@ -38,6 +40,33 @@ function countChecklist(texts) {
   return { checked, total };
 }
 
+// --check: a checked child must be closed, and every issue linked from the Now
+// section of ROADMAP.md must be open. An unchecked child that is already closed
+// is reported as awaiting release, not as drift: the box is checked only once
+// the fix is in a shipped release.
+function issueState(num) {
+  const out = execFileSync('gh', ['api', `repos/${REPO}/issues/${num}`], { encoding: 'utf8' });
+  return JSON.parse(out).state;
+}
+function checklistItems(texts) {
+  const items = [];
+  for (const text of texts) {
+    if (!text || !/^##\s+Checklist\s*$/m.test(text)) continue;
+    const section = text.split(/^##\s+Checklist\s*$/m).pop().split(/^##\s+/m)[0];
+    for (const line of section.split('\n')) {
+      const m = /^\s*-\s*\[([ xX])\]\s*#(\d+)/.exec(line);
+      if (m) items.push({ checked: m[1] !== ' ', num: Number(m[2]) });
+    }
+  }
+  return items;
+}
+function nowLinks() {
+  let md = '';
+  try { md = readFileSync(new URL('../ROADMAP.md', import.meta.url), 'utf8'); } catch { return []; }
+  const now = md.split(/^## Now\s*$/m)[1]?.split(/^## /m)[0] || '';
+  return [...now.matchAll(/issues\/(\d+)/g)].map((m) => Number(m[1]));
+}
+
 function pad(s, n) {
   s = String(s);
   return s.length >= n ? s.slice(0, n - 1) + ' ' : s + ' '.repeat(n - s.length);
@@ -50,12 +79,21 @@ if (issues.length === 0) {
 }
 
 const rows = [];
+const problems = [];
+const awaiting = [];
 for (const issue of issues) {
   const texts = [issue.body || ''];
   if (issue.comments > 0) {
     for (const c of gh(`repos/${REPO}/issues/${issue.number}/comments?per_page=100`)) texts.push(c.body || '');
   }
   const { checked, total } = countChecklist(texts);
+  if (CHECK) {
+    for (const item of checklistItems(texts)) {
+      const state = issueState(item.num);
+      if (item.checked && state !== 'closed') problems.push(`#${issue.number}: checked #${item.num} is ${state}`);
+      if (!item.checked && state !== 'open') awaiting.push(`#${issue.number}: #${item.num} is closed, box stays open until it ships`);
+    }
+  }
   const pct = total > 0 ? Math.round((checked / total) * 20) * 5 : null;
   rows.push({ number: issue.number, title: issue.title, checked, total, pct });
 }
@@ -72,3 +110,20 @@ const done = rows.reduce((a, r) => a + r.checked, 0);
 const all = rows.reduce((a, r) => a + r.total, 0);
 console.log('-'.repeat(76));
 console.log(`${rows.length} tracking issues, ${done} of ${all} children shipped.`);
+
+if (CHECK) {
+  if (awaiting.length) {
+    console.log('\nawaiting release:');
+    for (const a of awaiting) console.log(`  ${a}`);
+  }
+  for (const num of nowLinks()) {
+    const state = issueState(num);
+    if (state !== 'open') problems.push(`ROADMAP.md Now links #${num}, which is ${state}`);
+  }
+  if (problems.length) {
+    console.error('\nroadmap drift:');
+    for (const p of problems) console.error(`  ${p}`);
+    process.exit(1);
+  }
+  console.log('roadmap check: no drift.');
+}


### PR DESCRIPTION
Fourth pass on ROADMAP.md, from the maintainer's read.

- Pillar tables list only open arcs (15 rows). Shipped arcs move to one list at the bottom with their release.
- Now is one arc: Linux, for September.
- Percent column becomes a state word (open, parked, not usable). GitHub renders the count on each tracking issue.
- New arcs: settings take effect everywhere (#2217) under the control plane; first ten minutes (#2211) and the API manifest (#2212) placed in pillar 5.
- `scripts/roadmap-status.mjs --check` fails on a checked child that is still open or a Now link that is closed, and lists closed-but-unreleased children as awaiting release. A CI job for it follows once the push-to-main trigger (#2216) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe