### PR TITLE
fix: bound and surface a packet refused by dispatch preflight (#2195)

### DIFF
--- a/src/lib/orchestrator/operator-mission-service/reset.ts
+++ b/src/lib/orchestrator/operator-mission-service/reset.ts
@@ -94,6 +94,9 @@ function markPacketResetHeld(packet: OrchestratorPacket) {
   packet.zeroDiffRuntimeRetries = 0;
   advancePacketStorageAdmissionEpoch(packet);
   packet.launchAttempts = 0;
+  // #2195 — "Manual reset required" is only true if the reset actually refreshes
+  // the dispatch-preflight refusal budget.
+  packet.preflightRefusals = 0;
   packet.operatorStopped = false;
   packet.tierEscalated = undefined;
   // #2045 — reset CONSUMES a still-armed alignment (stamps `alignmentResolvedAt`)

--- a/src/lib/orchestrator/scheduling.ts
+++ b/src/lib/orchestrator/scheduling.ts
@@ -44,6 +44,26 @@ export const MAX_RECOVERY_DISPATCHES = 2;
 // resets when a fresh lane is minted on redispatch, so it never accumulated — the
 // launching<->idle thrash. This counter lives on the packet so it survives.
 export const MAX_LAUNCH_ATTEMPTS = 5;
+// Both dispatch preflights — the runtime auth gate and the execution-carrier gate,
+// thrown from the same try in dispatch-packet-launch.ts — are the refusal class
+// #2195 bounds. Matched on the error's own name rather than `instanceof` so the
+// bound cannot be switched off by a module double or a second module instance.
+const DISPATCH_PREFLIGHT_ERROR_NAMES = new Set([
+  'DispatchPreflightError',
+  'ExecutionCarrierPreflightError',
+]);
+
+function isDispatchPreflightRefusal(error: unknown): boolean {
+  return error instanceof Error && DISPATCH_PREFLIGHT_ERROR_NAMES.has(error.name);
+}
+
+// Packet-scoped dispatch-preflight refusal cap (#2195). A refusal (missing CLI
+// auth, an incompatible model pin) throws before a lane exists, so neither the
+// per-lane cap nor MAX_LAUNCH_ATTEMPTS above — which only counts launches that
+// reached a lane — bounded it, and reconcile re-derived the refused packet back
+// to 'queued' every tick. Transient refusals (a runtime still starting) still
+// get their retries; this only stops the infinite ones.
+export const MAX_PREFLIGHT_REFUSALS = 5;
 export const RUNTIME_PARALLEL_CAP: Partial<Record<OrchestratorRuntime, number>> = {
   gemini: 3,
 };
@@ -347,6 +367,12 @@ export function getDispatchBlocker(
   // lane-scoped-counter runaway); this one lives on the packet.
   if ((candidate.launchAttempts ?? 0) >= MAX_LAUNCH_ATTEMPTS) {
     return `Launch attempts exceeded (${candidate.launchAttempts}/${MAX_LAUNCH_ATTEMPTS})`;
+  }
+  // #2195 — a refused preflight never reaches a lane, so the cap above can't see
+  // it. Without this line the scheduler re-admits the packet every tick and each
+  // admission spawns another auth probe.
+  if ((candidate.preflightRefusals ?? 0) >= MAX_PREFLIGHT_REFUSALS) {
+    return `Dispatch preflight refusals exceeded (${candidate.preflightRefusals}/${MAX_PREFLIGHT_REFUSALS})`;
   }
   const dependency = packetReleaseBlockedBy(candidate, allPackets);
   if (dependency) {
@@ -701,6 +727,9 @@ export async function runDispatchTick(
               // each redispatch, unlike the per-lane cap). getDispatchBlocker
               // stops re-admitting this packet once it hits MAX_LAUNCH_ATTEMPTS.
               launchAttempts: (candidate.launchAttempts ?? 0) + 1,
+              // A dispatch that cleared preflight proves the earlier refusals
+              // were transient, so the refusal budget starts fresh (#2195).
+              preflightRefusals: 0,
               runtime: workerRouting.selectedRuntime,
               model: getLane(result.value.laneId)?.model ?? workerRouting.selectedModel,
               assignedModel: workerRouting.selectedModel,
@@ -727,14 +756,61 @@ export async function runDispatchTick(
             : candidate.storageAdmission ?? null;
           const retryableStorageHold = storageReceipt?.state === 'held';
           console.error(`[dag-scheduler] Failed to dispatch packet ${candidate.id}: ${reason}`);
+          // #2195 — a preflight refusal is an attempt and must be counted like
+          // one. It throws before a lane exists, so `launchAttempts` (bumped
+          // only on a dispatch that produced a lane) never moved and reconcile
+          // re-derived 'blocked' back to 'queued' on the next tick: an
+          // unbounded, invisible retry loop spawning an auth probe per pass.
+          // Under budget the packet still retries — a runtime that is merely
+          // still starting deserves that — and the budget resets on the
+          // dispatch that finally succeeds.
+          const preflightRefused = isDispatchPreflightRefusal(result.reason);
+          const preflightRefusals = (candidate.preflightRefusals ?? 0) + (preflightRefused ? 1 : 0);
+          const refusalBudgetSpent = preflightRefused && preflightRefusals >= MAX_PREFLIGHT_REFUSALS;
+          if (preflightRefused) {
+            // Log-only was the whole visibility defect: the app looked idle
+            // while it spun. Mirrors the dispatch mutation published above so
+            // the refusal — and its reason — reaches the operator live.
+            void publishRealtimeMutation({
+              mutation: {
+                mutationId: `packet-dispatch-refused-${candidate.id}-${Date.now()}`,
+                source: 'server',
+                action: 'packet-dispatch',
+                status: 'failed',
+                runtime: candidate.runtime,
+                laneLabel: candidate.title,
+                packetId: candidate.id,
+                packetTitle: candidate.title,
+                packetReferenceLabel: candidate.referenceLabel,
+                repoPath: candidate.workspaceTargetPath ?? undefined,
+                branch: candidate.branchTarget,
+                launchContext: packetLaunchContext(candidate),
+                note: refusalBudgetSpent
+                  ? `${candidate.referenceLabel} failed dispatch preflight ${preflightRefusals}× — no further retries. ${reason}`
+                  : `${candidate.referenceLabel} refused by dispatch preflight (${preflightRefusals}/${MAX_PREFLIGHT_REFUSALS}). ${reason}`,
+                reason,
+                createdAt: new Date().toISOString(),
+                settledAt: new Date().toISOString(),
+              },
+              refreshTargets: ['global', 'mobileInbox'],
+              fresh: true,
+            });
+          }
           return {
             ...candidate,
             ...recoveryFields,
-            status: retryableStorageHold ? 'queued' : 'blocked',
-            blockedReason: reason,
+            preflightRefusals,
+            status: retryableStorageHold
+              ? 'queued'
+              : refusalBudgetSpent ? 'failed' : 'blocked',
+            blockedReason: refusalBudgetSpent
+              ? `Dispatch preflight refused ${preflightRefusals} times. ${reason} Manual reset required.`
+              : reason,
             storageAdmission: storageReceipt,
-            lastEventAt: retryableStorageHold ? new Date().toISOString() : candidate.lastEventAt,
-            lastEventLabel: retryableStorageHold ? 'storage_admission_held' : candidate.lastEventLabel,
+            lastEventAt: retryableStorageHold || preflightRefused ? new Date().toISOString() : candidate.lastEventAt,
+            lastEventLabel: retryableStorageHold
+              ? 'storage_admission_held'
+              : preflightRefused ? 'dispatch_preflight_refused' : candidate.lastEventLabel,
           };
         } catch (foldErr) {
           const msg = foldErr instanceof Error ? foldErr.message : 'Dispatch post-processing failed.';

--- a/src/lib/orchestrator/store.ts
+++ b/src/lib/orchestrator/store.ts
@@ -73,6 +73,8 @@ function friendlyAwaitingInputReason(label: string | null | undefined): string |
 // Mirrors MAX_LAUNCH_ATTEMPTS in scheduling.ts (duplicated across files like the
 // recovery cap above) — the packet-scoped launch/attach retry ceiling.
 const MAX_LAUNCH_ATTEMPTS = 5;
+// Mirrors MAX_PREFLIGHT_REFUSALS in scheduling.ts — the dispatch-preflight ceiling.
+const MAX_PREFLIGHT_REFUSALS = 5;
 const RECOVERY_COOLDOWN_MS = 60_000;
 let orchestratorMissionCache = createEmptyOrchestratorMissionState();
 /**
@@ -362,6 +364,7 @@ function normalizePacket(raw: unknown, index: number, existing: Array<Pick<Orche
     stallRetries: normalizeAttemptCount(packet.stallRetries),
     zeroDiffRuntimeRetries: normalizeAttemptCount(packet.zeroDiffRuntimeRetries),
     launchAttempts: normalizeAttemptCount(packet.launchAttempts),
+    preflightRefusals: normalizeAttemptCount(packet.preflightRefusals),
     operatorStopped: packet.operatorStopped === true ? true : undefined,
     spendCap: normalizePacketSpendCap(packet.spendCap), spendTelemetry: normalizePacketSpendTelemetry(packet.spendTelemetry),
     contextTelemetry: normalizePacketContextTelemetry(packet.contextTelemetry),
@@ -984,6 +987,20 @@ export function reconcileOrchestratorMissionState(
     if (packet.status === 'failed' && (!domainLane || domainLane.status === 'failed')) {
       next.status = 'failed';
       next.blockedReason = packet.blockedReason ?? null;
+      return next;
+    }
+
+    // #2195 — a spent preflight budget is terminal HERE, not only where the
+    // scheduler wrote it. A refusal throws before a lane exists, so the
+    // lane-bound launch-cap branch below never sees it and the fall-through
+    // re-derives `queued` with `blockedReason` nulled: the scheduler's write was
+    // un-written every headless tick and the refusal repeated forever, spawning
+    // an auth probe each time. Keeping the reason on the packet is what puts the
+    // refusal in front of the operator — PacketCard renders `blockedReason`.
+    if ((packet.preflightRefusals ?? 0) >= MAX_PREFLIGHT_REFUSALS) {
+      next.status = 'failed';
+      next.blockedReason = packet.blockedReason
+        ?? `Dispatch preflight refused ${packet.preflightRefusals} times. Manual reset required.`;
       return next;
     }
 

--- a/src/lib/orchestrator/types.ts
+++ b/src/lib/orchestrator/types.ts
@@ -341,6 +341,17 @@ export interface OrchestratorPacket {
    */
   zeroDiffRuntimeRetries?: number;
   /**
+   * Dispatch-preflight refusal budget spent (#2195). A refusal throws before any
+   * lane exists, so every lane-bound terminal branch in reconcile is unreachable
+   * and the fall-through re-derives the packet back to `queued` — the scheduler's
+   * `blocked` write was un-written on the next tick and the refusal repeated
+   * forever, spawning an auth probe each time. The count lives ON the packet for
+   * the same reason {@link launchAttempts} does: nothing else survives the tick.
+   * Cleared on a successful dispatch (the refusal was transient) and by operator
+   * reset_packet.
+   */
+  preflightRefusals?: number;
+  /**
    * Operator hit Stop — terminal "do not re-dispatch" marker. Checked first in
    * getDispatchBlocker so NO path (headless loop, stall escalation, ralph
    * requeue) can relaunch it. Cleared by reset_packet / explicit relaunch.

--- a/src/lib/runtimes/shared/auth-detect.test.ts
+++ b/src/lib/runtimes/shared/auth-detect.test.ts
@@ -438,6 +438,54 @@ describe("OpenCode readiness preflight", () => {
     });
   });
 
+  it("re-probes a refused model at most once per refresh window (#2195)", async () => {
+    // Dispatch preflight asks the identical question on every scheduling pass.
+    // Before the cache, a packet the gate kept refusing spent a fresh pair of
+    // CLI subprocesses per retry for a condition that had not changed — the
+    // probe half of the refusal loop.
+    const probes: string[] = [];
+    setOpencodeCliProbeDependenciesForTests({
+      run: async (args: string[]) => {
+        probes.push(args[0] ?? "");
+        if (args[0] === "models") return "hosted/other\n";
+        if (args[0] === "auth") return "[]";
+        throw new Error(`unexpected opencode probe: ${args.join(" ")}`);
+      },
+    });
+    const configPath = path.join(
+      authFixture.home,
+      ".config",
+      "opencode",
+      "opencode.json",
+    );
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        provider: {
+          hosted: {
+            npm: "@ai-sdk/openai-compatible",
+            options: { baseURL: "https://api.example.com/v1" },
+            models: { coder: {} },
+          },
+        },
+      }),
+    );
+    invalidateRuntimeAuthCache();
+
+    const attempts = 12;
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      await expect(
+        assertRuntimeDispatchable("opencode", "hosted/coder"),
+      ).rejects.toMatchObject({ code: "dispatch_cli_auth_unavailable" });
+    }
+
+    // Every attempt still refuses — the cache must not turn a refusal into a
+    // pass — but the model listing is spawned once, not once per attempt.
+    expect(probes.filter((arg) => arg === "models")).toHaveLength(1);
+    expect(probes.length).toBeLessThan(attempts);
+  });
+
   it("finds credential evidence in a portable AppData location", async () => {
     vi.stubEnv("XDG_DATA_HOME", "");
     const localAppData = path.join(authFixture.home, "AppData", "Local");

--- a/src/lib/runtimes/shared/auth-detect.ts
+++ b/src/lib/runtimes/shared/auth-detect.ts
@@ -26,6 +26,7 @@ import { cliInvocation } from '@/lib/runtimes/shared/cli-spawn';
 import {
   localProviderIds,
   opencodeAuthenticatedProviders,
+  clearOpencodeCliProbeMemo,
   opencodeCliModels,
   opencodeCliResolvesModel,
   probeOpencodeServiceVersion,
@@ -615,6 +616,9 @@ export function invalidateRuntimeAuthCache(): void {
   cache = null;
   snapshotRefresh = null;
   opencodeRefresh = null;
+  // The CLI listings are memoized a level down (#2195); an operator login has to
+  // clear that with everything else, or the refusal it just fixed would persist.
+  clearOpencodeCliProbeMemo();
 }
 
 async function refreshNativeWorkerReadiness(snapshot: RuntimeAuthSnapshot): Promise<RuntimeAuthSnapshot> {

--- a/src/lib/runtimes/shared/opencode-readiness.ts
+++ b/src/lib/runtimes/shared/opencode-readiness.ts
@@ -522,6 +522,8 @@ export function setOpencodeCliProbeDependenciesForTests(
   dependencies: OpencodeCliProbeDependencies | null,
 ): void {
   cliProbeDependenciesForTests = dependencies;
+  // Swapping the probe swaps the answers — never serve one stub's reply to the next.
+  clearOpencodeCliProbeMemo();
 }
 
 async function runOpencodeCliProbe(binaryPath: string, args: string[]): Promise<string> {
@@ -540,8 +542,42 @@ function cliProbeRunner(
   dependencies?: OpencodeCliProbeDependencies,
 ): ((args: string[]) => Promise<string>) | null {
   const injected = dependencies ?? cliProbeDependenciesForTests;
-  if (injected) return injected.run;
-  return binaryPath ? (args: string[]) => runOpencodeCliProbe(binaryPath, args) : null;
+  const run = injected
+    ? injected.run
+    : binaryPath ? (args: string[]) => runOpencodeCliProbe(binaryPath, args) : null;
+  if (!run) return null;
+  return (args: string[]) => memoizedCliProbe(binaryPath, args, run);
+}
+
+// Every probe here is a subprocess, and dispatch preflight asks the same
+// question on every scheduling pass — one packet the gate kept refusing spawned
+// a pair per retry for an install state that had not changed (#2195). Keyed by
+// binary + argv because that is precisely what a listing's answer depends on:
+// nothing read from a config or credential file is memoized, so a config edit or
+// a fresh login is still seen immediately.
+const CLI_PROBE_TTL_MS = 10_000;
+const cliProbeMemo = new Map<string, { promise: Promise<string>; startedAt: number }>();
+
+export function clearOpencodeCliProbeMemo(): void {
+  cliProbeMemo.clear();
+}
+
+function memoizedCliProbe(
+  binaryPath: string | null | undefined,
+  args: string[],
+  run: (args: string[]) => Promise<string>,
+): Promise<string> {
+  const key = `${binaryPath ?? ""} ${args.join(" ")}`;
+  const now = Date.now();
+  const cached = cliProbeMemo.get(key);
+  if (cached && now - cached.startedAt < CLI_PROBE_TTL_MS) return cached.promise;
+  const promise = run(args);
+  cliProbeMemo.set(key, { promise, startedAt: now });
+  // A failed probe is not an answer — never hold one for the window.
+  promise.catch(() => {
+    if (cliProbeMemo.get(key)?.promise === promise) cliProbeMemo.delete(key);
+  });
+  return promise;
 }
 
 /**

--- a/tests/packet-control-fields-survive-normalize.test.ts
+++ b/tests/packet-control-fields-survive-normalize.test.ts
@@ -55,6 +55,7 @@ function fullPacketFixture() {
     stallRetries: 2,
     zeroDiffRuntimeRetries: 1,
     launchAttempts: 3,
+    preflightRefusals: 2,
     operatorStopped: true,
     spendCap: { carrier: 'openrouter', costUsd: 1, inputTokens: 500_000 },
     spendTelemetry: {

--- a/tests/preflight-refusal-bound-real-path.test.ts
+++ b/tests/preflight-refusal-bound-real-path.test.ts
@@ -1,0 +1,194 @@
+/**
+ * #2195 — a packet refused by dispatch preflight must stop retrying, and must
+ * say why.
+ *
+ * The loop is a two-module handshake, which is why either half alone stays
+ * green while the bug runs. `scheduling.ts` writes `status: 'blocked'` on a
+ * refusal; `reconcileOrchestratorMissionState` re-derives packet status FROM
+ * THE LANE, and a packet refused at preflight never got one — so the
+ * no-lane fall-through wrote `queued` back and nulled `blockedReason` on the
+ * very next headless tick. Measured live: ~15 refusals a minute, 1,186 log
+ * lines, an auth probe spawned per pass, and no operator-visible handle on the
+ * packet at all.
+ *
+ * So the assertions below drive the REAL pair in the REAL order the headless
+ * loop runs them — runDispatchTick -> reconcile -> repeat — and require the
+ * terminal state to SURVIVE the reconcile. Asserting only that the scheduler
+ * wrote something would pass against the original bug.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const preflight = vi.hoisted(() => ({
+  calls: 0,
+  detail: 'The selected runtime has no credential evidence.',
+}));
+
+vi.mock('@/lib/runtimes/shared/auth-detect', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/runtimes/shared/auth-detect')>();
+  return {
+    ...actual,
+    // Stands in for a preflight that refuses every time for an unchanged
+    // reason. The call counter is the probe proxy: each real invocation is what
+    // spawned the auth-probe subprocess on the demo machine.
+    assertRuntimeDispatchable: vi.fn(async (runtime: string) => {
+      preflight.calls += 1;
+      throw new actual.DispatchPreflightError({
+        house: 'opencode',
+        runtime: runtime as never,
+        installed: true,
+        ready: false,
+        authenticated: false,
+        unavailableReason: 'needs_auth',
+        detail: preflight.detail,
+        fix: 'Sign in to the runtime, then reset the packet.',
+        checkedAt: Date.now(),
+      });
+    }),
+  };
+});
+
+vi.mock('@/lib/runtime/actions', () => ({
+  launchRuntimeSurface: vi.fn(async () => {
+    throw new Error('preflight must refuse before any launch is attempted');
+  }),
+}));
+
+const { createEmptyOrchestratorMissionState, reconcileOrchestratorMissionState } =
+  await import('@/lib/orchestrator/store');
+const { runDispatchTick, getDispatchBlocker, MAX_PREFLIGHT_REFUSALS } =
+  await import('@/lib/orchestrator/scheduling');
+import type { OrchestratorMissionState, OrchestratorPacket } from '@/lib/orchestrator/types';
+
+const testRoot = mkdtempSync(join(tmpdir(), 'o8-preflight-refusal-bound-'));
+const repoPath = join(testRoot, 'repo');
+
+beforeAll(() => {
+  mkdirSync(repoPath, { recursive: true });
+  execFileSync('git', ['init', '--initial-branch=main'], { cwd: repoPath });
+  writeFileSync(join(repoPath, 'README.md'), 'preflight refusal bound\n');
+  execFileSync('git', ['add', 'README.md'], { cwd: repoPath });
+  execFileSync('git', [
+    '-c', 'user.email=test@o8.local',
+    '-c', 'user.name=o8-test',
+    'commit', '-m', 'init',
+  ], { cwd: repoPath });
+});
+
+beforeEach(() => {
+  preflight.calls = 0;
+});
+
+afterAll(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+function refusedPacket(): OrchestratorPacket {
+  return {
+    id: 'pkt-preflight-refused-2195',
+    referenceLabel: 'PKT-PREFLIGHT-2195',
+    title: 'packet the preflight always refuses',
+    summary: 'packet the preflight always refuses',
+    workspaceTargetPath: repoPath,
+    branchTarget: 'issue/2195-preflight-refusal',
+    runtime: 'opencode',
+    dependencyLabels: [],
+    dependencyPacketIds: [],
+    queueState: 'queued',
+    releaseState: 'pending',
+    status: 'queued',
+    blockedReason: null,
+    lane: null,
+  };
+}
+
+function stateWith(packet: OrchestratorPacket): OrchestratorMissionState {
+  return { ...createEmptyOrchestratorMissionState(), packets: [packet] };
+}
+
+/** One turn of the headless loop: dispatch, then re-derive from lane truth. */
+async function headlessTick(state: OrchestratorMissionState): Promise<OrchestratorMissionState> {
+  const dispatched = await runDispatchTick(state);
+  return reconcileOrchestratorMissionState(dispatched, {
+    laneSnapshots: [],
+    runtimeTruth: [],
+  });
+}
+
+function only(state: OrchestratorMissionState): OrchestratorPacket {
+  const packet = state.packets.find((candidate) => candidate.id === 'pkt-preflight-refused-2195');
+  if (!packet) throw new Error('packet vanished from mission state');
+  return packet;
+}
+
+describe('#2195 dispatch preflight refusals are bounded and visible', () => {
+  it('reaches a terminal state that survives reconcile, and stops probing', async () => {
+    let state = stateWith(refusedPacket());
+
+    // Comfortably more turns than the budget: the pre-fix loop ran until it was
+    // stopped by hand, so the bound has to hold against a scheduler that keeps
+    // being asked.
+    const turns = MAX_PREFLIGHT_REFUSALS * 4;
+    const statusPerTurn: string[] = [];
+    for (let turn = 0; turn < turns; turn += 1) {
+      state = await headlessTick(state);
+      statusPerTurn.push(only(state).status);
+    }
+
+    const packet = only(state);
+
+    // 1. Terminal, and terminal AFTER reconcile re-derived it — the exact step
+    //    that used to un-write 'blocked' back to 'queued'.
+    expect(packet.status).toBe('failed');
+    expect(packet.preflightRefusals).toBe(MAX_PREFLIGHT_REFUSALS);
+
+    // 2. Visible, with the reason. This is what PacketCard renders; before the
+    //    fix reconcile nulled it on every pass and the only evidence was a log.
+    expect(packet.blockedReason).toContain(preflight.detail);
+    expect(packet.blockedReason).toMatch(/preflight refused/i);
+
+    // 3. Bounded probes. One per refusal, and not one per turn.
+    expect(preflight.calls).toBe(MAX_PREFLIGHT_REFUSALS);
+    expect(preflight.calls).toBeLessThan(turns);
+
+    // 4. And no dispatch path will re-admit it. Checked a second time against a
+    //    packet forced back to 'queued', because that is exactly the shape the
+    //    bug produced: the count has to block on its own, without relying on a
+    //    status that something else re-derived.
+    expect(getDispatchBlocker(packet, state.packets)).not.toBeNull();
+    expect(getDispatchBlocker(
+      { ...packet, status: 'queued', blockedReason: null },
+      state.packets,
+    )).toMatch(/preflight refusals exceeded/i);
+
+    // 5. Retries were real up to the budget — a runtime that is merely still
+    //    starting must still get its attempts, so the fix must not be "refuse
+    //    once, give up".
+    expect(statusPerTurn.slice(0, MAX_PREFLIGHT_REFUSALS - 1)).toEqual(
+      Array(MAX_PREFLIGHT_REFUSALS - 1).fill('queued'),
+    );
+  });
+
+  it('keeps the terminal state and reason across further reconcile passes', async () => {
+    let state = stateWith(refusedPacket());
+    for (let turn = 0; turn < MAX_PREFLIGHT_REFUSALS; turn += 1) {
+      state = await headlessTick(state);
+    }
+    expect(only(state).status).toBe('failed');
+    const reason = only(state).blockedReason;
+
+    // Reconcile alone, with no dispatch in between — the headless loop also
+    // re-derives state on ticks that dispatch nothing.
+    for (let pass = 0; pass < 5; pass += 1) {
+      state = reconcileOrchestratorMissionState(state, { laneSnapshots: [], runtimeTruth: [] });
+    }
+
+    expect(only(state).status).toBe('failed');
+    expect(only(state).blockedReason).toBe(reason);
+    expect(preflight.calls).toBe(MAX_PREFLIGHT_REFUSALS);
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2237,6 +2237,14 @@
       ]
     },
     {
+      "path": "tests/preflight-refusal-bound-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/preship-cleanup-residuals.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
Closes #2195

## The mechanism

A dispatch preflight refusal throws before a lane exists. Every terminal branch in `reconcileOrchestratorMissionState` is reached through lane truth, so a refused packet fell all the way to the no-lane fall-through — which re-derived it to `queued` and nulled `blockedReason`.

So `scheduling.ts` wrote `status: 'blocked'` and reconcile un-wrote it on the next headless tick, forever. Measured on a live machine: ~15 refusals a minute, 1,186 log lines, an auth probe spawned per pass, and the packet absent from both `/api/lanes` and `/api/orchestrator/state`. `launchAttempts` could not bound it because it is only incremented on a dispatch that produced a lane.

The asymmetry noted in the issue holds up: `queueState: 'held'` (what stop-packet sets) survives reconcile because it is checked before the lane branches; `status: 'blocked'` does not.

## Bounded

A refusal now counts against a packet-scoped budget, the same shape as the existing launch cap. Under budget the packet still retries — a runtime that is merely still starting deserves that, and the issue asks for the count to be finite, not for retries to go away. On exhausting it:

- the packet reaches `failed`, which reconcile preserves through its existing branch, and
- `getDispatchBlocker` refuses it on the count alone, so no path re-admits it by re-deriving a status.

A dispatch that clears preflight resets the budget (the refusals were transient); operator `reset_packet` does too, which is what makes the "manual reset required" message true.

Both preflights are covered — the runtime auth gate and the execution-carrier gate, thrown from the same `try`. They are matched on the error's own name rather than `instanceof`, so a test double or a second module instance cannot quietly switch the bound off.

## Visible

The refusal reason now rides the packet through reconcile, where `PacketCard` already renders `blockedReason`, and each refusal publishes the same `packet-dispatch` realtime mutation the success path does, with `status: 'failed'` and the reason. No new surface was invented. Log-only was the whole visibility defect: the app looked idle while it spun.

## Probe cost

The CLI listings behind the gate are memoized by binary + argv for a short window, so an unchanged install state is not re-probed once per scheduling pass. Only the subprocess answers are held — config and credential files are still read fresh on every call, and an operator login clears the memo — so nothing a refusal might be waiting on goes stale. An earlier attempt cached the whole per-model verdict and broke the config-precedence test; that was the signal to narrow the cache to the subprocesses alone.

## Tests

`tests/preflight-refusal-bound-real-path.test.ts` drives the real pair in the real order the headless loop runs them — `runDispatchTick` → `reconcile` → repeat, for four times the budget — and asserts the terminal state SURVIVES the reconcile, the reason is on the packet, the probe count is bounded, and the packet still retried up to the budget. Asserting only the scheduler's write would pass against the original bug, so the test was verified against it: with the fix disabled it fails with `expected 'queued' to be 'failed'`, the exact reported signature.

`auth-detect.test.ts` gains a probe-count case: 12 consecutive refusals of the same model spawn one model listing, not twelve, and every attempt still refuses.

## Verification

- `npx tsc --noEmit` clean; eslint clean on all changed files.
- `npm test` (hermetic unit): **717 files, 4669 passed, 4 skipped, 0 failed.**
- Targeted integration subset for the touched files (16 files: scheduling, storage-admission, reset lifecycle, dispatch, preflight, opencode, reconcile): **152 passed, 0 failed.**
- Pre-existing failures confirmed identical on `origin/main` and unrelated to this change: `tests/claude-auth-preflight-real-path.test.ts`, `tests/claude-code-dispatch-spawn.test.ts`, `tests/declarative-dispatch-worktree-real-path.test.ts` — 15 failures on both, same test names. They read real identity state from the home dir.
- The full serial integration suite was not run end to end (~25+ min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dVxFgHWcYwiMja5oBxySH