### PR TITLE
docs: center README and roadmap on dependable delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,25 @@
 
 **Run a fleet of coding agents. Approve what ships.**
 
-o8 is an open-source control room for AI coding agents, the governance layer above them. Claude Code, Codex, Grok Build, DeepSeek Harness, OpenCode, Gemini, and twelve more do the work in isolated git worktrees, and nothing merges without you.
+o8 is an open-source control room for one person running several AI coding agents across their repositories, the governance layer above them. Claude Code, Codex, Grok Build, DeepSeek Harness, OpenCode, Gemini, and twelve more do the work in isolated git worktrees. Workers never merge their own work. A merge is approved by you, or by an orchestrator review you chose to delegate, and one setting makes every merge wait for you.
 
 [**Download for macOS**](https://github.com/hurttlocker/o8/releases) · [Build from source](#get-it)
 
-macOS today. Linux is one proof away from a build and Windows is help wanted; both are on the [roadmap](./ROADMAP.md).
+macOS today. Linux compiles in CI, but nobody has yet installed it, launched it, and merged a packet on a mainstream distro. Windows is help wanted. Both are on the [roadmap](./ROADMAP.md).
 
 ![Four agents on the canvas: two finished and waiting for review, one still working, and a live browser card previewing the page they built](./assets/fleet.gif)
+
+The aim is that you can hand out several pieces of work, look away, and come back to a readable account of what finished, what is blocked, and what needs your decision. The roadmap says how far along that is.
 
 ## What happens when you dispatch
 
 1. You, or the orchestrator model you chose, create a mission. It becomes packets.
 2. Each packet runs on the runtime you picked, in its own git worktree, and reports as it goes.
-3. The work lands for review: the diff, the receipts, the cost.
-4. You approve, reject, steer, or rerun. You can delegate the review to an orchestrator and keep the merge.
-5. The merge writes the audit trail and the memory the next packet reads.
+3. The work lands for review: the diff, the receipts, and the cost when the runtime reports it.
+4. You approve, reject, steer, or rerun. You can delegate the review to an orchestrator. By default its approved merges go through, and the approval setting can make every merge wait for you.
+5. The merge writes the audit trail and records the outcome. Project rules and recorded outcomes are what the Brain and the next packet retrieve. Learning from your rejections and steers is still an open arc.
 
-A merge that fails climbs a five-step ladder that ends at a human card, so no lane stalls silently. The same verbs work from the app, the `o8` CLI, any MCP client, your phone, and your voice. The long version is [How o8 works](./docs/user/how-o8-works.md).
+A merge that fails climbs a five-step ladder that ends at a human card. The lifecycle gaps that remain are on the roadmap. The same verbs work from the app, the `o8` CLI, any MCP client, your phone, and your voice. The long version is [How o8 works](./docs/user/how-o8-works.md).
 
 ## Runtimes
 
@@ -34,7 +36,7 @@ A merge that fails climbs a five-step ladder that ends at a human card, so no la
 | | Aider · Goose · Kimi Code · OpenHands · Qwen Code · Qoder |
 | | 3code · Prime Agent · DeepSeek Harness |
 
-Eighteen runtimes, one adapter contract, and a test that keeps this table equal to the registry. A first-run picker finds what is installed. Adding a runtime is a small documented patch: [runtime adapter contract](./docs/internals/runtime-adapter-contract.md). Claude Code can also keep its tools and session behavior while another model supplies inference: [model carriers](./docs/user/claude-code-model-carriers.md).
+Eighteen runtimes, one adapter contract, and a test that keeps this table equal to the registry. Registered is not certified: readiness differs by CLI version and platform, and a first-run picker shows what is installed and working on your machine. Adding a runtime is a small documented patch: [runtime adapter contract](./docs/internals/runtime-adapter-contract.md). Claude Code can also keep its tools and session behavior while another model supplies inference: [model carriers](./docs/user/claude-code-model-carriers.md).
 
 ## Get it
 
@@ -58,7 +60,7 @@ npm run dev              # web loop: Next.js :47120 + WS :47125
 
 ## Your data
 
-o8 runs on your machine against your own subscriptions and keys; it is not in the path between your agents and their providers. Telemetry, crash reports, and error transmission are off by default and opt-in. [`SECURITY.md`](./SECURITY.md) covers what dispatched workers can reach and what the sandbox does and does not do today.
+o8 runs on your machine against your own subscriptions and keys; it is not in the path between your agents and their providers. Worktree isolation covers repository changes: today workers run under your user account and can read what you can read. Telemetry, crash reports, and error transmission are off by default and opt-in. [`SECURITY.md`](./SECURITY.md) covers what dispatched workers can reach and what the sandbox does and does not do today.
 
 ## Free and paid
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # o8 roadmap
 
-o8 is for one operator running several coding agents at once. It turns work into missions and packets, runs each packet in its own worktree, keeps the operator in the approval path, and records enough evidence to explain later what happened. This page says where that is going and what is open to work on.
+o8 is for one operator running several coding agents at once. It turns work into missions and packets, runs each packet in its own worktree, keeps the operator in the approval path, and records enough evidence to explain later what happened. All seven pillars serve one outcome: an operator delegates useful work, understands its state while away, steps in when needed, and approves the result without replaying the whole session. This page says where that is going and what is open to work on.
 
 Taste is a gate on every row here, not a pillar of its own. A change that reads badly, responds slowly, or behaves unpredictably is not finished, whichever pillar it belongs to.
 
@@ -11,12 +11,20 @@ Taste is a gate on every row here, not a pillar of its own. A change that reads 
 3. **Runs on your subscriptions.** The coding-agent CLIs you already pay for, behind one runtime contract.
 4. **One control plane, every surface.** Desktop, phone, CLI, MCP, headless, voice. Same verbs, different authority.
 5. **Smooth for people and for agents.** Fast and legible for a person; drivable through a real interface for a program.
-6. **Runs where you are.** Light on the machine, on the machine you have. Mac today, Linux one proof away, Windows help wanted.
+6. **Runs where you are.** Light on the machine, on the machine you have. Mac today, Linux compiles but is unproven end to end, Windows help wanted.
 7. **Ahead.** The bets for 2027 and 2028, with what we are already doing on each.
 
 ## Now
 
 One arc for September 2026: **Linux.** Nine of ten children are shipped. The last one is the proof that a fresh mainstream distro installs o8, launches it, dispatches a packet, and merges it. Until that proof exists, o8 runs on one platform. [#2060](https://github.com/hurttlocker/o8/issues/2060)
+
+## What we need to prove
+
+Three outcomes decide whether the pillars add up. None has a baseline yet, and a green checklist is progress on a row, not proof of the outcome.
+
+- **A new operator finishes the loop.** Download to first merged packet, with the minutes and the stalls measured. [#2211](https://github.com/hurttlocker/o8/issues/2211)
+- **Interrupted work stays visible and recoverable.** A refusal surfaces, retries are bounded, and a replaced mission leaves no live packets behind. [#2197](https://github.com/hurttlocker/o8/issues/2197)
+- **The governed loop earns its cost.** A first diff at least as good as the raw model on the same issue, and a ledger that agrees with the invoice. [#1684](https://github.com/hurttlocker/o8/issues/1684), [#1791](https://github.com/hurttlocker/o8/issues/1791)
 
 ## How to read this
 
@@ -24,7 +32,7 @@ Only open arcs appear in the pillar tables. Shipped arcs are listed once at the 
 
 State words mean: **open** has children in flight; **parked** means we know what it would take and are not doing it now; **not usable** means the platform does not run o8 today, whatever the checklist says. Read the Gap column first. It says what is missing in words.
 
-`node scripts/roadmap-status.mjs` prints the checklist counts. `node scripts/roadmap-status.mjs --check` fails when a checklist disagrees with GitHub (a checked child that is open, an unchecked child that is closed) or when a Now link points at a closed issue. CI runs the check on every push to main and weekly, so this page cannot drift silently.
+`node scripts/roadmap-status.mjs` prints the checklist counts. `node scripts/roadmap-status.mjs --check` fails when a checked child is still open or when a Now link points at a closed issue. A closed child whose box is unchecked is reported as awaiting release, not as drift. CI runs the check on every push to main and weekly. The check reads issue state only: it does not read release tags and it cannot judge a Gap sentence, so the words on this page are the maintainers' to keep true.
 
 ## 1. Governance is the product
 
@@ -44,7 +52,7 @@ Project rules and prior outcomes stay attached to the project, not to one model 
 | Arc | Done means | State | Gap | Where |
 | --- | --- | --- | --- | --- |
 | Cost and capacity ledger | The ledger's number and the provider's invoice agree. | open | Nothing measures what role routing and context controls save. | [#1791](https://github.com/hurttlocker/o8/issues/1791) |
-| Memory the operator shapes | What the operator rejects, steers, or edits becomes memory the Brain and the next worker retrieve, and any single retained item can be deleted. | open | Rejection and steer reasons are stored for audit and read by no retriever; the schema's rework flag is never written; the only way to forget one rule is to reset the whole database. | [#2221](https://github.com/hurttlocker/o8/issues/2221) |
+| Memory the operator shapes | What the operator rejects, steers, or edits becomes memory the Brain and the next worker retrieve, and any single retained item can be withdrawn from future retrieval without erasing the record that it was once applied. | open | Rejection and steer reasons are stored for audit and read by no retriever; the schema's rework flag is never written; the only way to forget one rule is to reset the whole database. | [#2221](https://github.com/hurttlocker/o8/issues/2221) |
 
 ## 3. Runs on your subscriptions
 
@@ -91,12 +99,12 @@ Windows is help wanted. No maintainer has a Windows machine to verify on, so thi
 
 ## 7. Ahead
 
-The bets for 2027 and 2028. Each row is an outcome we think operators will need, what already exists in o8 toward it, and the next child that would move it. A bet moves into a pillar when that child ships. Rows are reviewed at the start of each month; a bet nobody has touched in a quarter gets cut, not carried.
+The bets for 2027 and 2028. Each row is an outcome we think operators will need, what already exists in o8 toward it, and the next child that would move it. A shipped child moves only the part it proves; a bet moves into a pillar when an operator can use the promised outcome. Rows are reviewed at the start of each month; a bet nobody has touched in a quarter gets cut, not carried.
 
 | Bet | What already exists | Next child | Where |
 | --- | --- | --- | --- |
 | Agents that work while you are away, wherever they run. Hosted, remote, or local workers, days-long missions, the same packet and merge gate. | Headless o8, the mobile relay, crash survival, the durable execution spine. | A portable worker environment profile so a packet can be placed on a remote worker without changing its runtime contract. | [#1690](https://github.com/hurttlocker/o8/issues/1690), [#1727](https://github.com/hurttlocker/o8/issues/1727) |
-| The right model for each packet, chosen and escalated by o8. A failed packet retries on a stronger tier without the operator choosing. | The carrier registry, per-packet model pins, the merge-failure escalation chain. | A worker escalation ladder that retries a failed packet on the next tier. | [#2209](https://github.com/hurttlocker/o8/issues/2209) |
+| The right model for each packet, chosen and escalated by o8. A failed packet retries on a stronger tier without the operator choosing. | The carrier registry, per-packet model pins, the merge-failure escalation chain. | A worker escalation ladder that retries a failed packet on the next tier, with bounded attempts, the effective model visible, and a refusal instead of a silent fallback when the requested tier is unavailable. | [#2209](https://github.com/hurttlocker/o8/issues/2209) |
 | Proof that travels. Receipts and control that systems outside o8 can verify and plug into, so o8 is the human gate inside other people's agent graphs. | Signed packet receipts and truth queries, the ACP orchestrator backend, MCP on both sides. | A receipt format another organization can verify without an o8 install, and a mission exported as an observed agent graph that an outside validator accepts. | [#1997](https://github.com/hurttlocker/o8/issues/1997), [#1998](https://github.com/hurttlocker/o8/issues/1998), [#2230](https://github.com/hurttlocker/o8/issues/2230) |
 | Nothing leaves the machine unless you say so. Local and on-device models as a real mode with a test that proves it. | Local endpoint probes, the local chat tier for the Brain, an audit of surfaces without a local path. | An egress assertion test across a full packet lifecycle. | [#1451](https://github.com/hurttlocker/o8/issues/1451) |
 | Two operators, one approval path. Teams share a workspace without weakening who can approve what. | Principal-based authorization for operator, worker, and remote callers. | A workspace identity and role model. | [#1875](https://github.com/hurttlocker/o8/issues/1875) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,7 +16,9 @@ Taste is a gate on every row here, not a pillar of its own. A change that reads 
 
 ## Now
 
-One arc for September 2026: **Linux.** Nine of ten children are shipped. The last one is the proof that a fresh mainstream distro installs o8, launches it, dispatches a packet, and merges it. Until that proof exists, o8 runs on one platform. [#2060](https://github.com/hurttlocker/o8/issues/2060)
+One arc first: **First ten minutes.** A new operator goes from download to a first merged packet, and the minutes and the stalls are measured. Nobody has measured it yet, and until someone has, the rest of this page is the maintainers' view of the product. [#2211](https://github.com/hurttlocker/o8/issues/2211)
+
+Linux is the next platform milestone. Nine of ten children are shipped; the last is the proof that a fresh mainstream distro installs o8, launches it, dispatches a packet, and merges it. [#2060](https://github.com/hurttlocker/o8/issues/2060)
 
 ## What we need to prove
 


### PR DESCRIPTION
Documentation only. Evaluated the README and ROADMAP against the current implementation and release state (0.1.749) and corrected the claims that overstated what ships.

README
- Names the audience: one person running several agents across repositories.
- Approval policy stated as implemented: workers never merge their own work; by default an orchestrator review you delegated merges without a card; the approval setting can make every merge wait for you.
- Recovery: the five-step ladder stays; the inference that no lane can stall silently is removed because the roadmap tracks open lifecycle gaps.
- Memory: recorded outcomes and project rules are what the Brain retrieves; learning from rejections and steers is an open arc.
- Linux: compiles in CI, unproven end to end on a mainstream distro.
- Runtimes: registered is not certified.
- Your data: worktree isolation covers repository changes; workers run under the operator's account today.

ROADMAP
- One connecting outcome above the pillars.
- "What we need to prove": three outcomes mapped to existing arcs, no new epics.
- Checker prose matches the script: a closed, unchecked child is awaiting release, not drift; the check reads issue state only.
- Bets promote when an operator can use the outcome, not when one child ships.
- Memory arc: withdraw from retrieval without erasing the audit record.

`node scripts/roadmap-status.mjs --check` passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe