### PR TITLE
docs: clarify delegated-work vision and outcome measures

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Run a fleet of coding agents. Approve what ships.**
 
-o8 is an open-source control room for one person running several AI coding agents across their repositories. It brings the work, reviews, and decisions into one place so you can direct the agents without following every terminal.
+o8 is an open-source control room for one person running several AI coding agents across their repositories, the governance layer above them. Claude Code, Codex, Grok Build, DeepSeek Harness, OpenCode, Gemini, and twelve more do the work in isolated git worktrees; o8 brings the work, the reviews, and the decisions into one place so you can direct the agents without following every terminal.
 
 [**Download for macOS**](https://github.com/hurttlocker/o8/releases) · [Build from source](#get-it)
 
@@ -72,7 +72,7 @@ Symon is the voice layer. Ask "what needs me?" without turning around, approve t
 
 ## Where it is going
 
-o8 is building toward **an operating system for delegated work**: models and agents can change while your project's rules, decisions, and history stay with you. The goal is to let you delegate more work without supervising every step, while keeping authority over what happens and evidence of the result. Coding is where we're proving that approach first.
+o8 is building toward an operating system for delegated work: models and agents can change while your project's rules, decisions, and history stay with you. The goal is to let you delegate more work without supervising every step, while keeping authority over what happens and evidence of the result. Coding is where we're proving that approach first.
 
 [ROADMAP.md](./ROADMAP.md): seven pillars, what is open, what is missing on each, and what to claim.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Run a fleet of coding agents. Approve what ships.**
 
-o8 is an open-source control room for one person running several AI coding agents across their repositories, the governance layer above them. Claude Code, Codex, Grok Build, DeepSeek Harness, OpenCode, Gemini, and twelve more do the work in isolated git worktrees. Workers never merge their own work. A merge is approved by you, or by an orchestrator review you chose to delegate, and one setting makes every merge wait for you.
+o8 is an open-source control room for one person running several AI coding agents across their repositories. It brings the work, reviews, and decisions into one place so you can direct the agents without following every terminal.
 
 [**Download for macOS**](https://github.com/hurttlocker/o8/releases) · [Build from source](#get-it)
 
@@ -21,7 +21,7 @@ The aim is that you can hand out several pieces of work, look away, and come bac
 ## What happens when you dispatch
 
 1. You, or the orchestrator model you chose, create a mission. It becomes packets.
-2. Each packet runs on the runtime you picked, in its own git worktree, and reports as it goes.
+2. Each packet runs on the runtime you picked, in its own git worktree, and reports as it goes. Workers never merge their own work.
 3. The work lands for review: the diff, the receipts, and the cost when the runtime reports it.
 4. You approve, reject, steer, or rerun. You can delegate the review to an orchestrator. By default its approved merges go through, and the approval setting can make every merge wait for you.
 5. The merge writes the audit trail and records the outcome. Project rules and recorded outcomes are what the Brain and the next packet retrieve. Learning from your rejections and steers is still an open arc.
@@ -71,6 +71,8 @@ Everything that runs on your machine is free and open source: the app, all eight
 Symon is the voice layer. Ask "what needs me?" without turning around, approve the one thing that is blocking, and dictate anywhere on the Mac. Anything with a side effect goes through a spoken confirm card, so voice never becomes a way around governance. Controls, setup, and tiers: [Voice](./docs/user/voice.md).
 
 ## Where it is going
+
+o8 is building toward **an operating system for delegated work**: models and agents can change while your project's rules, decisions, and history stay with you. The goal is to let you delegate more work without supervising every step, while keeping authority over what happens and evidence of the result. Coding is where we're proving that approach first.
 
 [ROADMAP.md](./ROADMAP.md): seven pillars, what is open, what is missing on each, and what to claim.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ Taste is a gate on every row here, not a pillar of its own. A change that reads 
 
 ## At a glance
 
-1. **Governance is the product.** Workers cannot merge their own work; every decision and failure is recorded and visible.
+1. **Governance is the product.** Workers cannot merge their own work. The goal is to record every decision and make every failure visible and actionable.
 2. **Organizational memory.** Rules and past outcomes stay with the project, not with one model vendor.
 3. **Runs on your subscriptions.** The coding-agent CLIs you already pay for, behind one runtime contract.
 4. **One control plane, every surface.** Desktop, phone, CLI, MCP, headless, voice. Same verbs, different authority.
@@ -22,11 +22,11 @@ Linux is the next platform milestone. Nine of ten children are shipped; the last
 
 ## What we need to prove
 
-Three outcomes decide whether the pillars add up. None has a baseline yet, and a green checklist is progress on a row, not proof of the outcome.
+Three outcomes decide whether the pillars add up. The first-diff comparisons below provide evidence on code quality; operator effort and the full loop's value still need measurement. A green checklist is progress on a row, not proof of the outcome.
 
 - **A new operator finishes the loop.** Download to first merged packet, with the minutes and the stalls measured. [#2211](https://github.com/hurttlocker/o8/issues/2211)
 - **Interrupted work stays visible and recoverable.** A refusal surfaces, retries are bounded, and a replaced mission leaves no live packets behind. [#2197](https://github.com/hurttlocker/o8/issues/2197)
-- **The governed loop earns its cost.** A first diff at least as good as the raw model on the same issue, and a ledger that agrees with the invoice. [#1684](https://github.com/hurttlocker/o8/issues/1684), [#1791](https://github.com/hurttlocker/o8/issues/1791)
+- **The governed loop earns its cost.** A first diff at least as good as the raw model on the same task remains the goal. Also compare final accepted quality. Measure the operator's time spent supervising, reviewing, and repairing the result, alongside runtime costs for attempts, reviews, and rework. An accurate ledger supports that comparison; it does not establish that delegation saves time or money. [#1684](https://github.com/hurttlocker/o8/issues/1684), [#1791](https://github.com/hurttlocker/o8/issues/1791)
 
 ## How to read this
 
@@ -38,7 +38,7 @@ State words mean: **open** has children in flight; **parked** means we know what
 
 ## 1. Governance is the product
 
-Execution is separated from approval. Workers cannot merge their own packets, every decision is recorded, and every failure moves through a visible state.
+Execution is separated from approval. Workers cannot merge their own packets. This pillar requires decisions and failures to be recorded and visible, with a supported path to resolve them; the lifecycle row below tracks the remaining gaps.
 
 | Arc | Done means | State | Gap | Where |
 | --- | --- | --- | --- | --- |


### PR DESCRIPTION
## What changed

Simplifies the README introduction and adds a short vision paragraph describing an operating system for delegated work, with coding as the first proving ground. Approval-policy details remain in the mission walkthrough.

The roadmap describes complete failure visibility as a goal, preserves the first-diff quality target, and adds operator effort, final accepted quality, and rework costs to the evidence needed to judge delegation. It also acknowledges the existing first-diff comparisons instead of saying no baseline exists.

## Why

The documents explain the workflow but leave the longer-term purpose implicit. This follow-up makes that direction explicit while keeping future goals distinct from demonstrated capabilities. It builds on #2232 and changes only README.md and ROADMAP.md.

## Verification

- [x] `git diff --check`
- [x] `node scripts/roadmap-status.mjs --check` through the managed run path: exit 0, no drift; closed children awaiting release remain unchecked.
- [x] Markdown fence and relative file-link checks; issue references unchanged.
- [x] Read the complete diff for consistency with the existing approval policy, lifecycle gaps, and first-diff findings.
- TypeScript, application tests, and lint are not applicable to these Markdown-only edits.

## Author review

- [x] I reviewed and understand the complete diff.

Held open for maintainer review; no merge or release requested by this PR.
