### PR TITLE
fix: surface exhausted dispatch preflight refusals

### DIFF
--- a/src/lib/orchestrator/dispatch-preflight-refusal.ts
+++ b/src/lib/orchestrator/dispatch-preflight-refusal.ts
@@ -1,0 +1,99 @@
+import {
+  enqueueInboxItem,
+  type EnqueueInboxItemInput,
+} from '@/lib/supervisor/inbox';
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+
+const DISPATCH_PREFLIGHT_ERROR_NAMES = new Set([
+  'DispatchPreflightError',
+  'ExecutionCarrierPreflightError',
+]);
+
+export interface DispatchPreflightRefusal {
+  count: number;
+  maxAttempts: number;
+  exhausted: boolean;
+  incidentPersisted: boolean;
+  blockedReason: string;
+}
+
+let writeIncident: (input: EnqueueInboxItemInput) => unknown = enqueueInboxItem;
+
+export function setDispatchPreflightIncidentWriterForTests(
+  writer: ((input: EnqueueInboxItemInput) => unknown) | null,
+): void {
+  writeIncident = writer ?? enqueueInboxItem;
+}
+
+export function dispatchPreflightRefusalLimit(packet: OrchestratorPacket): number {
+  return Math.max(1, packet.maxAttempts ?? 3);
+}
+
+export function dispatchPreflightRefusalBlocker(packet: OrchestratorPacket): string | null {
+  const count = packet.preflightRefusals ?? 0;
+  const maxAttempts = dispatchPreflightRefusalLimit(packet);
+  return count >= maxAttempts
+    ? `Dispatch preflight refusals exceeded (${count}/${maxAttempts})`
+    : null;
+}
+
+export function surfaceDispatchPreflightRefusalIncident(
+  packet: OrchestratorPacket,
+  reason: string,
+): boolean {
+  if (!packet.workspaceTargetPath) return false;
+  const count = packet.preflightRefusals ?? 0;
+  const maxAttempts = dispatchPreflightRefusalLimit(packet);
+  const question = `How should o8 proceed with "${packet.title}" after dispatch preflight refused ${count}/${maxAttempts} attempts: ${reason}?`;
+  try {
+    writeIncident({
+      repoPath: packet.workspaceTargetPath,
+      packetId: packet.id,
+      kind: 'bounded_retry_exhausted',
+      status: 'human_required',
+      payload: {
+        packetTitle: packet.title,
+        packetReferenceLabel: packet.referenceLabel,
+        runtime: packet.runtime,
+        stage: 'dispatch_preflight',
+        attempts: `${count}/${maxAttempts}`,
+        errorMessage: reason,
+        blockedReason: packet.blockedReason ?? reason,
+        question,
+        note: question,
+      },
+    });
+    return true;
+  } catch (incidentError) {
+    console.error(
+      `[dag-scheduler] Failed to surface exhausted preflight for ${packet.id}:`,
+      incidentError,
+    );
+    return false;
+  }
+}
+
+export function recordDispatchPreflightRefusal(
+  packet: OrchestratorPacket,
+  error: unknown,
+): DispatchPreflightRefusal | null {
+  if (!(error instanceof Error) || !DISPATCH_PREFLIGHT_ERROR_NAMES.has(error.name)) {
+    return null;
+  }
+
+  const count = (packet.preflightRefusals ?? 0) + 1;
+  const maxAttempts = dispatchPreflightRefusalLimit(packet);
+  const exhausted = count >= maxAttempts;
+  const blockedReason = exhausted
+    ? `Dispatch preflight refused ${count}/${maxAttempts} attempts. ${error.message} Manual reset required.`
+    : error.message;
+
+  const incidentPersisted = exhausted
+    ? surfaceDispatchPreflightRefusalIncident(
+        { ...packet, preflightRefusals: count, blockedReason },
+        blockedReason,
+      )
+    : false;
+
+  return { count, maxAttempts, exhausted, incidentPersisted, blockedReason };
+}

--- a/src/lib/orchestrator/scheduling.ts
+++ b/src/lib/orchestrator/scheduling.ts
@@ -31,6 +31,11 @@ import {
 } from '@/lib/orchestrator/storage-admission';
 import { getStoragePressureAdmissionCoordinator } from '@/lib/orchestrator/storage-pressure-policy';
 import { isDispatchHalted } from './dispatch-halt';
+import {
+  dispatchPreflightRefusalBlocker,
+  recordDispatchPreflightRefusal,
+  surfaceDispatchPreflightRefusalIncident,
+} from './dispatch-preflight-refusal';
 import { forgetRecoverySkip, pruneRecoverySkipMemo, shouldLogRecoverySkip } from './recovery-skip-log';
 
 import { computePredictedFiles, filterOverlappingPackets } from './preservation-envelope';
@@ -44,26 +49,6 @@ export const MAX_RECOVERY_DISPATCHES = 2;
 // resets when a fresh lane is minted on redispatch, so it never accumulated — the
 // launching<->idle thrash. This counter lives on the packet so it survives.
 export const MAX_LAUNCH_ATTEMPTS = 5;
-// Both dispatch preflights — the runtime auth gate and the execution-carrier gate,
-// thrown from the same try in dispatch-packet-launch.ts — are the refusal class
-// #2195 bounds. Matched on the error's own name rather than `instanceof` so the
-// bound cannot be switched off by a module double or a second module instance.
-const DISPATCH_PREFLIGHT_ERROR_NAMES = new Set([
-  'DispatchPreflightError',
-  'ExecutionCarrierPreflightError',
-]);
-
-function isDispatchPreflightRefusal(error: unknown): boolean {
-  return error instanceof Error && DISPATCH_PREFLIGHT_ERROR_NAMES.has(error.name);
-}
-
-// Packet-scoped dispatch-preflight refusal cap (#2195). A refusal (missing CLI
-// auth, an incompatible model pin) throws before a lane exists, so neither the
-// per-lane cap nor MAX_LAUNCH_ATTEMPTS above — which only counts launches that
-// reached a lane — bounded it, and reconcile re-derived the refused packet back
-// to 'queued' every tick. Transient refusals (a runtime still starting) still
-// get their retries; this only stops the infinite ones.
-export const MAX_PREFLIGHT_REFUSALS = 5;
 export const RUNTIME_PARALLEL_CAP: Partial<Record<OrchestratorRuntime, number>> = {
   gemini: 3,
 };
@@ -368,12 +353,8 @@ export function getDispatchBlocker(
   if ((candidate.launchAttempts ?? 0) >= MAX_LAUNCH_ATTEMPTS) {
     return `Launch attempts exceeded (${candidate.launchAttempts}/${MAX_LAUNCH_ATTEMPTS})`;
   }
-  // #2195 — a refused preflight never reaches a lane, so the cap above can't see
-  // it. Without this line the scheduler re-admits the packet every tick and each
-  // admission spawns another auth probe.
-  if ((candidate.preflightRefusals ?? 0) >= MAX_PREFLIGHT_REFUSALS) {
-    return `Dispatch preflight refusals exceeded (${candidate.preflightRefusals}/${MAX_PREFLIGHT_REFUSALS})`;
-  }
+  const preflightBlocker = dispatchPreflightRefusalBlocker(candidate);
+  if (preflightBlocker) return preflightBlocker;
   const dependency = packetReleaseBlockedBy(candidate, allPackets);
   if (dependency) {
     return `Blocked by ${dependency.id}`;
@@ -442,6 +423,16 @@ export async function runDispatchTick(
 ): Promise<OrchestratorMissionState> {
   let nextState = releaseAbandonedMissionLifecycleHold(normalizeOrchestratorMissionState(state));
   if (nextState.lifecycleHold) return nextState;
+  nextState = {
+    ...nextState,
+    packets: nextState.packets.map((packet) => {
+      const blocker = dispatchPreflightRefusalBlocker(packet);
+      if (!blocker || packet.queueState !== 'queued') return packet;
+      return surfaceDispatchPreflightRefusalIncident(packet, packet.blockedReason ?? blocker)
+        ? { ...packet, status: 'blocked', queueState: 'held' }
+        : packet;
+    }),
+  };
   if (isDispatchHalted()) {
     return nextState;
   }
@@ -764,10 +755,8 @@ export async function runDispatchTick(
           // Under budget the packet still retries — a runtime that is merely
           // still starting deserves that — and the budget resets on the
           // dispatch that finally succeeds.
-          const preflightRefused = isDispatchPreflightRefusal(result.reason);
-          const preflightRefusals = (candidate.preflightRefusals ?? 0) + (preflightRefused ? 1 : 0);
-          const refusalBudgetSpent = preflightRefused && preflightRefusals >= MAX_PREFLIGHT_REFUSALS;
-          if (preflightRefused) {
+          const preflightRefusal = recordDispatchPreflightRefusal(candidate, result.reason);
+          if (preflightRefusal) {
             // Log-only was the whole visibility defect: the app looked idle
             // while it spun. Mirrors the dispatch mutation published above so
             // the refusal — and its reason — reaches the operator live.
@@ -785,9 +774,9 @@ export async function runDispatchTick(
                 repoPath: candidate.workspaceTargetPath ?? undefined,
                 branch: candidate.branchTarget,
                 launchContext: packetLaunchContext(candidate),
-                note: refusalBudgetSpent
-                  ? `${candidate.referenceLabel} failed dispatch preflight ${preflightRefusals}× — no further retries. ${reason}`
-                  : `${candidate.referenceLabel} refused by dispatch preflight (${preflightRefusals}/${MAX_PREFLIGHT_REFUSALS}). ${reason}`,
+                note: preflightRefusal.exhausted
+                  ? `${candidate.referenceLabel} failed dispatch preflight ${preflightRefusal.count}× — no further retries. ${reason}`
+                  : `${candidate.referenceLabel} refused by dispatch preflight (${preflightRefusal.count}/${preflightRefusal.maxAttempts}). ${reason}`,
                 reason,
                 createdAt: new Date().toISOString(),
                 settledAt: new Date().toISOString(),
@@ -799,18 +788,15 @@ export async function runDispatchTick(
           return {
             ...candidate,
             ...recoveryFields,
-            preflightRefusals,
-            status: retryableStorageHold
-              ? 'queued'
-              : refusalBudgetSpent ? 'failed' : 'blocked',
-            blockedReason: refusalBudgetSpent
-              ? `Dispatch preflight refused ${preflightRefusals} times. ${reason} Manual reset required.`
-              : reason,
+            preflightRefusals: preflightRefusal?.count ?? candidate.preflightRefusals ?? 0,
+            status: retryableStorageHold ? 'queued' : 'blocked',
+            queueState: preflightRefusal?.incidentPersisted ? 'held' : candidate.queueState,
+            blockedReason: preflightRefusal?.blockedReason ?? reason,
             storageAdmission: storageReceipt,
-            lastEventAt: retryableStorageHold || preflightRefused ? new Date().toISOString() : candidate.lastEventAt,
+            lastEventAt: retryableStorageHold || preflightRefusal ? new Date().toISOString() : candidate.lastEventAt,
             lastEventLabel: retryableStorageHold
               ? 'storage_admission_held'
-              : preflightRefused ? 'dispatch_preflight_refused' : candidate.lastEventLabel,
+              : preflightRefusal ? 'dispatch_preflight_refused' : candidate.lastEventLabel,
           };
         } catch (foldErr) {
           const msg = foldErr instanceof Error ? foldErr.message : 'Dispatch post-processing failed.';

--- a/src/lib/orchestrator/store.ts
+++ b/src/lib/orchestrator/store.ts
@@ -73,8 +73,6 @@ function friendlyAwaitingInputReason(label: string | null | undefined): string |
 // Mirrors MAX_LAUNCH_ATTEMPTS in scheduling.ts (duplicated across files like the
 // recovery cap above) — the packet-scoped launch/attach retry ceiling.
 const MAX_LAUNCH_ATTEMPTS = 5;
-// Mirrors MAX_PREFLIGHT_REFUSALS in scheduling.ts — the dispatch-preflight ceiling.
-const MAX_PREFLIGHT_REFUSALS = 5;
 const RECOVERY_COOLDOWN_MS = 60_000;
 let orchestratorMissionCache = createEmptyOrchestratorMissionState();
 /**
@@ -984,23 +982,19 @@ export function reconcileOrchestratorMissionState(
     }
     clearUnprovenReleaseClaim(next);
 
-    if (packet.status === 'failed' && (!domainLane || domainLane.status === 'failed')) {
-      next.status = 'failed';
-      next.blockedReason = packet.blockedReason ?? null;
+    // A preflight refusal has no lane to carry awaiting_human. Hold the packet
+    // blocked while the durable supervisor incident carries the human question.
+    if ((packet.preflightRefusals ?? 0) >= Math.max(1, packet.maxAttempts ?? 3)) {
+      next.status = 'blocked';
+      next.queueState = packet.queueState;
+      next.blockedReason = packet.blockedReason
+        ?? `Dispatch preflight refused ${packet.preflightRefusals}/${packet.maxAttempts ?? 3} attempts. Manual reset required.`;
       return next;
     }
 
-    // #2195 — a spent preflight budget is terminal HERE, not only where the
-    // scheduler wrote it. A refusal throws before a lane exists, so the
-    // lane-bound launch-cap branch below never sees it and the fall-through
-    // re-derives `queued` with `blockedReason` nulled: the scheduler's write was
-    // un-written every headless tick and the refusal repeated forever, spawning
-    // an auth probe each time. Keeping the reason on the packet is what puts the
-    // refusal in front of the operator — PacketCard renders `blockedReason`.
-    if ((packet.preflightRefusals ?? 0) >= MAX_PREFLIGHT_REFUSALS) {
+    if (packet.status === 'failed' && (!domainLane || domainLane.status === 'failed')) {
       next.status = 'failed';
-      next.blockedReason = packet.blockedReason
-        ?? `Dispatch preflight refused ${packet.preflightRefusals} times. Manual reset required.`;
+      next.blockedReason = packet.blockedReason ?? null;
       return next;
     }
 

--- a/tests/preflight-refusal-bound-real-path.test.ts
+++ b/tests/preflight-refusal-bound-real-path.test.ts
@@ -1,42 +1,32 @@
 /**
- * #2195 — a packet refused by dispatch preflight must stop retrying, and must
- * say why.
- *
- * The loop is a two-module handshake, which is why either half alone stays
- * green while the bug runs. `scheduling.ts` writes `status: 'blocked'` on a
- * refusal; `reconcileOrchestratorMissionState` re-derives packet status FROM
- * THE LANE, and a packet refused at preflight never got one — so the
- * no-lane fall-through wrote `queued` back and nulled `blockedReason` on the
- * very next headless tick. Measured live: ~15 refusals a minute, 1,186 log
- * lines, an auth probe spawned per pass, and no operator-visible handle on the
- * packet at all.
- *
- * So the assertions below drive the REAL pair in the REAL order the headless
- * loop runs them — runDispatchTick -> reconcile -> repeat — and require the
- * terminal state to SURVIVE the reconcile. Asserting only that the scheduler
- * wrote something would pass against the original bug.
+ * #2195 — drive the persisted headless scheduler, not the refusal guard alone.
  */
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const preflight = vi.hoisted(() => ({
-  calls: 0,
   detail: 'The selected runtime has no credential evidence.',
+  probeLogPath: '',
 }));
 
 vi.mock('@/lib/runtimes/shared/auth-detect', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/runtimes/shared/auth-detect')>();
+  const { execFileSync: spawnProbe } = await import('node:child_process');
   return {
     ...actual,
-    // Stands in for a preflight that refuses every time for an unchanged
-    // reason. The call counter is the probe proxy: each real invocation is what
-    // spawned the auth-probe subprocess on the demo machine.
     assertRuntimeDispatchable: vi.fn(async (runtime: string) => {
-      preflight.calls += 1;
+      // Each call launches a real child process, standing in for the auth CLI
+      // probe that the production preflight spawned on every scheduler pass.
+      spawnProbe(process.execPath, [
+        '-e',
+        'require("node:fs").appendFileSync(process.env.O8_PROBE_LOG, "probe\\n")',
+      ], {
+        env: { ...process.env, O8_PROBE_LOG: preflight.probeLogPath },
+      });
       throw new actual.DispatchPreflightError({
         house: 'opencode',
         runtime: runtime as never,
@@ -52,20 +42,34 @@ vi.mock('@/lib/runtimes/shared/auth-detect', async (importOriginal) => {
   };
 });
 
-vi.mock('@/lib/runtime/actions', () => ({
-  launchRuntimeSurface: vi.fn(async () => {
-    throw new Error('preflight must refuse before any launch is attempted');
-  }),
+const runtimeLaunch = vi.hoisted(() => vi.fn(async () => {
+  throw new Error('preflight must refuse before any launch is attempted');
 }));
 
-const { createEmptyOrchestratorMissionState, reconcileOrchestratorMissionState } =
-  await import('@/lib/orchestrator/store');
-const { runDispatchTick, getDispatchBlocker, MAX_PREFLIGHT_REFUSALS } =
-  await import('@/lib/orchestrator/scheduling');
-import type { OrchestratorMissionState, OrchestratorPacket } from '@/lib/orchestrator/types';
+vi.mock('@/lib/runtime/actions', () => ({
+  launchRuntimeSurface: runtimeLaunch,
+}));
+
+vi.mock('@/lib/realtime/publisher', () => ({
+  publishRealtimeMutation: vi.fn(async () => {}),
+}));
+
+const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+const {
+  readOrchestratorControlPlaneState,
+  writeOrchestratorControlPlaneState,
+} = await import('@/lib/orchestrator/control-plane');
+const { runHeadlessSprintTick } = await import('@/lib/orchestrator/headless-loop');
+const { getDispatchBlocker } = await import('@/lib/orchestrator/scheduling');
+const { setDispatchPreflightIncidentWriterForTests } =
+  await import('@/lib/orchestrator/dispatch-preflight-refusal');
+const { findLaneByPacket } = await import('@/lib/lane/registry');
+const { enqueueInboxItem, listInboxItems } = await import('@/lib/supervisor/inbox');
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
 
 const testRoot = mkdtempSync(join(tmpdir(), 'o8-preflight-refusal-bound-'));
 const repoPath = join(testRoot, 'repo');
+const probeLogPath = join(testRoot, 'auth-probes.log');
 
 beforeAll(() => {
   mkdirSync(repoPath, { recursive: true });
@@ -80,10 +84,19 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  preflight.calls = 0;
+  preflight.probeLogPath = probeLogPath;
+  rmSync(probeLogPath, { force: true });
+  runtimeLaunch.mockClear();
+  let writes = 0;
+  setDispatchPreflightIncidentWriterForTests((input) => {
+    writes += 1;
+    if (writes === 1) throw new Error('injected first incident write failure');
+    return enqueueInboxItem(input);
+  });
 });
 
 afterAll(() => {
+  setDispatchPreflightIncidentWriterForTests(null);
   rmSync(testRoot, { recursive: true, force: true });
 });
 
@@ -96,99 +109,73 @@ function refusedPacket(): OrchestratorPacket {
     workspaceTargetPath: repoPath,
     branchTarget: 'issue/2195-preflight-refusal',
     runtime: 'opencode',
+    dispatchRuntimePin: 'opencode',
     dependencyLabels: [],
     dependencyPacketIds: [],
     queueState: 'queued',
     releaseState: 'pending',
     status: 'queued',
+    attemptCount: 0,
+    maxAttempts: 2,
     blockedReason: null,
     lane: null,
   };
 }
 
-function stateWith(packet: OrchestratorPacket): OrchestratorMissionState {
-  return { ...createEmptyOrchestratorMissionState(), packets: [packet] };
-}
-
-/** One turn of the headless loop: dispatch, then re-derive from lane truth. */
-async function headlessTick(state: OrchestratorMissionState): Promise<OrchestratorMissionState> {
-  const dispatched = await runDispatchTick(state);
-  return reconcileOrchestratorMissionState(dispatched, {
-    laneSnapshots: [],
-    runtimeTruth: [],
-  });
-}
-
-function only(state: OrchestratorMissionState): OrchestratorPacket {
-  const packet = state.packets.find((candidate) => candidate.id === 'pkt-preflight-refused-2195');
-  if (!packet) throw new Error('packet vanished from mission state');
+function onlyPersisted(): OrchestratorPacket {
+  const packet = readOrchestratorControlPlaneState().packets
+    .find((candidate) => candidate.id === 'pkt-preflight-refused-2195');
+  if (!packet) throw new Error('persisted packet vanished');
   return packet;
 }
 
 describe('#2195 dispatch preflight refusals are bounded and visible', () => {
-  it('reaches a terminal state that survives reconcile, and stops probing', async () => {
-    let state = stateWith(refusedPacket());
+  it('persists a blocked packet and human-required incident after bounded probes', async () => {
+    writeOrchestratorControlPlaneState({
+      ...createEmptyOrchestratorMissionState(),
+      missionId: 'mission-preflight-refused-2195',
+      repoPath,
+      packets: [refusedPacket()],
+    });
 
-    // Comfortably more turns than the budget: the pre-fix loop ran until it was
-    // stopped by hand, so the bound has to hold against a scheduler that keeps
-    // being asked.
-    const turns = MAX_PREFLIGHT_REFUSALS * 4;
-    const statusPerTurn: string[] = [];
+    const turns = 12;
     for (let turn = 0; turn < turns; turn += 1) {
-      state = await headlessTick(state);
-      statusPerTurn.push(only(state).status);
+      await runHeadlessSprintTick();
     }
 
-    const packet = only(state);
-
-    // 1. Terminal, and terminal AFTER reconcile re-derived it — the exact step
-    //    that used to un-write 'blocked' back to 'queued'.
-    expect(packet.status).toBe('failed');
-    expect(packet.preflightRefusals).toBe(MAX_PREFLIGHT_REFUSALS);
-
-    // 2. Visible, with the reason. This is what PacketCard renders; before the
-    //    fix reconcile nulled it on every pass and the only evidence was a log.
+    const packet = onlyPersisted();
+    expect(packet).toMatchObject({
+      status: 'blocked',
+      queueState: 'held',
+      attemptCount: 0,
+      maxAttempts: 2,
+      preflightRefusals: 2,
+      lastEventLabel: 'dispatch_preflight_refused',
+    });
     expect(packet.blockedReason).toContain(preflight.detail);
-    expect(packet.blockedReason).toMatch(/preflight refused/i);
+    expect(packet.blockedReason).toMatch(/preflight refused 2\/2 attempts/i);
+    expect(findLaneByPacket(packet.id)).toBeNull();
+    expect(runtimeLaunch).not.toHaveBeenCalled();
 
-    // 3. Bounded probes. One per refusal, and not one per turn.
-    expect(preflight.calls).toBe(MAX_PREFLIGHT_REFUSALS);
-    expect(preflight.calls).toBeLessThan(turns);
-
-    // 4. And no dispatch path will re-admit it. Checked a second time against a
-    //    packet forced back to 'queued', because that is exactly the shape the
-    //    bug produced: the count has to block on its own, without relying on a
-    //    status that something else re-derived.
-    expect(getDispatchBlocker(packet, state.packets)).not.toBeNull();
+    const probes = readFileSync(probeLogPath, 'utf8').trim().split('\n');
+    expect(probes).toHaveLength(2);
+    expect(probes.length).toBeLessThan(turns);
     expect(getDispatchBlocker(
-      { ...packet, status: 'queued', blockedReason: null },
-      state.packets,
-    )).toMatch(/preflight refusals exceeded/i);
+      { ...packet, status: 'queued', queueState: 'queued', blockedReason: null },
+      [packet],
+    )).toMatch(/preflight refusals exceeded \(2\/2\)/i);
 
-    // 5. Retries were real up to the budget — a runtime that is merely still
-    //    starting must still get its attempts, so the fix must not be "refuse
-    //    once, give up".
-    expect(statusPerTurn.slice(0, MAX_PREFLIGHT_REFUSALS - 1)).toEqual(
-      Array(MAX_PREFLIGHT_REFUSALS - 1).fill('queued'),
-    );
-  });
-
-  it('keeps the terminal state and reason across further reconcile passes', async () => {
-    let state = stateWith(refusedPacket());
-    for (let turn = 0; turn < MAX_PREFLIGHT_REFUSALS; turn += 1) {
-      state = await headlessTick(state);
-    }
-    expect(only(state).status).toBe('failed');
-    const reason = only(state).blockedReason;
-
-    // Reconcile alone, with no dispatch in between — the headless loop also
-    // re-derives state on ticks that dispatch nothing.
-    for (let pass = 0; pass < 5; pass += 1) {
-      state = reconcileOrchestratorMissionState(state, { laneSnapshots: [], runtimeTruth: [] });
-    }
-
-    expect(only(state).status).toBe('failed');
-    expect(only(state).blockedReason).toBe(reason);
-    expect(preflight.calls).toBe(MAX_PREFLIGHT_REFUSALS);
+    const incidents = listInboxItems({ includeAllProjects: true })
+      .filter((item) => item.packetId === packet.id && item.kind === 'bounded_retry_exhausted');
+    expect(incidents).toHaveLength(1);
+    expect(incidents[0]).toMatchObject({
+      status: 'human_required',
+      payload: {
+        stage: 'dispatch_preflight',
+        attempts: '2/2',
+        errorMessage: expect.stringContaining(preflight.detail),
+        question: expect.stringContaining(preflight.detail),
+      },
+    });
   });
 });


### PR DESCRIPTION
## Mechanic

Dispatch preflight refusals happened before lane creation, so scheduler reconciliation could re-admit the packet and repeat the same authentication probe indefinitely.

## What changed

- Count preflight refusals against the packet configured attempt budget.
- Persist a blocked, held packet with the refusal reason once the budget is exhausted.
- Surface exhaustion through the existing human-required supervisor incident path, retrying incident persistence without re-running preflight.
- Keep runtime launch retry accounting unchanged.

## Verification

- `tests/preflight-refusal-bound-real-path.test.ts`
- `src/lib/runtimes/shared/auth-detect.test.ts`
- `tests/retry-budget.test.ts`
- `src/lib/orchestrator/scheduling.test.ts`
- `tests/real-path-seams.test.ts`
- `npx tsc --noEmit`
- `npm test` — 720 files passed; 4,474 tests passed

Fixes #2195

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe