### PR TITLE
docs: write down the GitHub operating standard for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ o8 is maintained by one person, and review capacity is limited. Small, focused c
 
 Open an issue before starting any non-trivial change. An issue is not a promise that a pull request will be accepted, but it can prevent both sides from spending time on work that does not fit the project.
 
+The way we run issues, pull requests, and merges is written down in [docs/operations/github-operating-standard.md](./docs/operations/github-operating-standard.md).
+
 ## Claiming work
 
 Find work through [`ROADMAP.md`](./ROADMAP.md). Each open arc there links to one tracking issue, and that issue's checklist lists its children. Pick an unchecked child labeled `claimable`: those have a brief that is complete enough to start from.

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,6 +67,7 @@ For maintainers who build, verify, release, recover, or harden o8.
 
 | Document | What you will learn |
 |---|---|
+| [GitHub operating standard](operations/github-operating-standard.md) | How issues, tracking checklists, pull requests, and merges run here, and what a contributor can expect from us. |
 | [Pre-ship gate](operations/PRE-SHIP-GATE-CHECKLIST.md) | The clean-profile checks required before a public build is considered releasable. |
 | [Desktop build and deployment](operations/deployment.md) | How the native shell, sidecars, packaging, signing, and runtime prerequisites fit together. |
 | [Smoke-test prompt](operations/smoke-test-prompt.md) | The repeatable end-to-end product checks for a candidate build. |

--- a/docs/operations/github-operating-standard.md
+++ b/docs/operations/github-operating-standard.md
@@ -1,0 +1,33 @@
+# GitHub operating standard
+
+How work moves through this repository. It applies to maintainers and to the agents they run, and it is what a contributor can expect from us.
+
+## Findings become issues
+
+Anything that fails, surprises, or stalls becomes an issue when it is found, not at the end of the session. The title names the mechanic in one line. The body has three sections in order: **Mechanic** (what happens, and where in the code if known), **Expected**, and **Acceptance** (a checkbox list a reviewer can verify). Each issue carries one `pillar/*` label. `claimable` means anyone may take it; `claimed` means someone has, and it expires after seven days with no linked pull request.
+
+Issue text describes mechanics, never sources. No names of people or other products, no logs pasted without a scan for paths, tokens, or machine names. Issue bodies are never edited to remove something after the fact, because the edit history is public.
+
+## Tracking issues own progress
+
+Each open arc on [ROADMAP.md](../../ROADMAP.md) links one tracking issue. A tracking issue has a "Done means" line, a `## Checklist` of child issues, and a "How to help" line. A box is checked only when the child is closed and its fix is in a shipped release. `node scripts/roadmap-status.mjs --check` fails when a checked child is still open, and CI runs it on every push to main. When reality changes, a measurement or a state, the roadmap row changes the same day.
+
+## One pull request per issue
+
+A pull request fixes one issue, from a branch cut from `main`. Its body has the mechanic, what changed, how it was verified with test file names, and `Fixes #n`.
+
+Verification means a test that drives the real entry point: the route handler, the CLI command, the merge path, or persisted state, not the helper in isolation. The test is written first and fails, then the fix makes it pass, and both tails appear in the pull request. `npx tsc --noEmit` and `npm test` run before push. See CLAUDE.md, "Real-path tests", for why.
+
+Documentation uses plain punctuation and states what ships. A claim the roadmap contradicts does not go in.
+
+## Merge discipline
+
+Someone who did not write the change reads the whole diff before it merges. Workers never merge their own work. Merges happen on green checks, squashed, with the branch deleted. Shipping a release is a separate, human decision.
+
+## Other people's repositories
+
+When we contribute elsewhere, we follow that project's contributing guide, pull request template, and proof rules as written, say plainly what we could not do, and never merge on their side.
+
+## Closing the loop
+
+Every session that touches issues or pull requests ends with the roadmap and tracking issues matching reality. Every session starts by answering any issue or pull request whose last comment came from outside the maintainers.


### PR DESCRIPTION
Adds docs/operations/github-operating-standard.md: how findings become issues, how tracking issues own progress, one PR per issue with real-path tests and fail-then-pass evidence, merge discipline, how we behave in other people's repositories, and closing the loop. Linked from CONTRIBUTING.md and the docs index. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe