### PR TITLE
docs: point the community links at the Discord invite

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders through the
-[o8 Discord](https://o8.run/discord). Ask a moderator for a private
+[o8 Discord](https://discord.gg/TFK2x9A5WS). Ask a moderator for a private
 conversation rather than posting sensitive details in a public channel. All
 complaints will be reviewed and investigated promptly and fairly.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ o8 is building toward an operating system for delegated work: models and agents 
 
 Start with [CONTRIBUTING.md](./CONTRIBUTING.md) and the issues labeled [`claimable`](https://github.com/hurttlocker/o8/issues?q=is%3Aissue+is%3Aopen+label%3Aclaimable) or [`help wanted`](https://github.com/hurttlocker/o8/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22). UI changes read [`docs/design`](./docs/design/DESIGN.md) first. The full documentation index is [`docs/README.md`](./docs/README.md); the `o8` CLI reference is [`AGENTS.md`](./AGENTS.md).
 
-Community: [Discord](https://o8.run/discord) · Built in public by [@marquisehurtt](https://x.com/marquisehurtt)
+Community: [Discord](https://discord.gg/TFK2x9A5WS) · Built in public by [@marquisehurtt](https://x.com/marquisehurtt)
 
 ## License
 


### PR DESCRIPTION
README and CODE_OF_CONDUCT linked o8.run/discord; the community server is the Discord invite. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe