### PR TITLE
fix: require exact repository paths for coverage evidence

### DIFF
--- a/src/lib/orchestrator/task-contract-coverage.ts
+++ b/src/lib/orchestrator/task-contract-coverage.ts
@@ -74,19 +74,14 @@ export interface ContractCoverageInput {
 }
 
 function normalizePath(value: string): string {
-  return value.trim().replace(/^\.\//, '').replace(/^\/+/, '');
+  return value.trim().replace(/^\.\//, '');
 }
 
 /** A cited path counts only if the change actually touched that file. */
 function pathWasChanged(citedPath: string, changedPaths: readonly string[]): boolean {
   const cited = normalizePath(citedPath);
   if (cited.length === 0) return false;
-  return changedPaths.some((changed) => {
-    const normalized = normalizePath(changed);
-    return normalized === cited
-      || normalized.endsWith(`/${cited}`)
-      || cited.endsWith(`/${normalized}`);
-  });
+  return changedPaths.some((changed) => normalizePath(changed) === cited);
 }
 
 function failAll(

--- a/tests/contract-coverage-real-path.test.ts
+++ b/tests/contract-coverage-real-path.test.ts
@@ -83,6 +83,8 @@ beforeAll(() => {
   git(['config', 'user.email', 'review@example.invalid'], reviewRepo);
   git(['config', 'user.name', 'review'], reviewRepo);
   fs.writeFileSync(path.join(reviewRepo, 'file.txt'), 'base\n');
+  fs.mkdirSync(path.join(reviewRepo, 'other'));
+  fs.writeFileSync(path.join(reviewRepo, 'other/file.txt'), 'unchanged\n');
   git(['add', '-A'], reviewRepo);
   git(['commit', '-q', '-m', 'base'], reviewRepo);
   git(['checkout', '-q', '-b', 'inline/contract-review'], reviewRepo);
@@ -118,6 +120,7 @@ const capturedContract: PacketTaskContract = {
 async function assessPersistedContractPacket(input: {
   source: PacketTaskContractSource;
   taskContract?: PacketTaskContract;
+  coveragePath?: string;
 }) {
   const packetId = `pkt-contract-review-${input.source}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
   const lane = createLane({
@@ -171,6 +174,13 @@ async function assessPersistedContractPacket(input: {
     reviewer: 'codex',
     reviewedHeadSha: reviewHeadSha,
     requiresSecondPass: false,
+    ...(input.coveragePath ? {
+      contractCoverageEvidence: {
+        contractVersion: 1,
+        headSha: reviewHeadSha,
+        entries: [{ requirementId: 'R1', productionPath: input.coveragePath }],
+      },
+    } : {}),
   });
 
   return {
@@ -180,6 +190,42 @@ async function assessPersistedContractPacket(input: {
 }
 
 describe('durable approval enforces contract coverage on the real path', () => {
+  it.each(['other/file.txt', '/file.txt', path.join(reviewRepo, 'file.txt')])(
+    'rejects a persisted review citing %s instead of the changed repository path',
+    async (coveragePath) => {
+      expect(git(['diff', '--name-only', 'main..HEAD'], reviewRepo)).toBe('file.txt');
+      expect(git(['show', 'HEAD:other/file.txt'], reviewRepo)).toBe('unchanged');
+
+      const { assessment } = await assessPersistedContractPacket({
+        source: 'explicit',
+        taskContract: capturedContract,
+        coveragePath,
+      });
+
+      expect(assessment).toMatchObject({
+        approved: false,
+        contractCoverage: {
+          status: 'failed',
+          missingRequirementIds: ['R1'],
+          checks: [{ requirementId: 'R1', failureReason: 'cited-path-not-in-change' }],
+        },
+      });
+    },
+  );
+
+  it.each(['file.txt', './file.txt'])('accepts a persisted review citing %s', async (coveragePath) => {
+    const { assessment } = await assessPersistedContractPacket({
+      source: 'explicit',
+      taskContract: capturedContract,
+      coveragePath,
+    });
+
+    expect(assessment).toMatchObject({
+      approved: true,
+      contractCoverage: { status: 'passed', missingRequirementIds: [] },
+    });
+  });
+
   it('rejects an approved review that carries no coverage evidence', async () => {
     const { evaluateContractCoverage, readCoverageEvidence } =
       await import('@/lib/orchestrator/task-contract-coverage');

--- a/tests/task-contract-coverage-gate.test.ts
+++ b/tests/task-contract-coverage-gate.test.ts
@@ -101,6 +101,49 @@ describe('task-contract coverage gate', () => {
       .toBe('cited-path-not-in-change');
   });
 
+  it.each([
+    ['ledger.ts', 'src/lib/ledger.ts'],
+    ['lib/ledger.ts', 'src/lib/ledger.ts'],
+    ['other/src/lib/ledger.ts', 'src/lib/ledger.ts'],
+    ['src/lib/ledger.ts', 'other/src/lib/ledger.ts'],
+    ['/src/lib/ledger.ts', 'src/lib/ledger.ts'],
+    ['../src/lib/ledger.ts', 'src/lib/ledger.ts'],
+  ])('rejects citation %s when the changed path is %s', (productionPath, changedPath) => {
+    const result = evaluateContractCoverage({
+      contract,
+      contractRequired: true,
+      evidence: evidence({
+        entries: [
+          { requirementId: 'R1', productionPath: 'src/lib/publish.ts' },
+          { requirementId: 'R2', productionPath },
+        ],
+      }),
+      reviewedHeadSha: HEAD,
+      changedPaths: ['src/lib/publish.ts', changedPath],
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.missingRequirementIds).toEqual(['R2']);
+    expect(result.checks[1]?.failureReason).toBe('cited-path-not-in-change');
+  });
+
+  it('accepts an exact repository path with a leading dot segment', () => {
+    const result = evaluateContractCoverage({
+      contract,
+      contractRequired: true,
+      evidence: evidence({
+        entries: [
+          { requirementId: 'R1', productionPath: './src/lib/publish.ts' },
+          { requirementId: 'R2', productionPath: 'src/lib/ledger.ts' },
+        ],
+      }),
+      reviewedHeadSha: HEAD,
+      changedPaths: CHANGED,
+    });
+
+    expect(result.status).toBe('passed');
+  });
+
   it('rejects evidence gathered at a different commit than the review authorizes', () => {
     const result = evaluateContractCoverage({
       contract,


### PR DESCRIPTION
An approved review could count an unchanged file as requirement evidence when its path shared a suffix with a changed file. For example, changing `file.txt` allowed a persisted review citing unchanged `other/file.txt` to authorize the packet. Absolute and parent-qualified citations could also pass through the same matching logic.

Require the complete repository-relative path to match the packet's changed paths. Keep support for a leading `./`. Regression tests drive persisted review records through `assessDurableApprovedReview` against a real Git fixture, with both rejected citations and valid controls.

Related to #1684. This repairs evidence matching in the existing coverage gate; it does not establish semantic requirement coverage, improve first-diff benchmark scores, or close the parent issue. Contract arming, the existing missing-default-contract behavior, and operator approval policy are unchanged.

Validation:

- Before the fix: nine new negative cases failed, including three persisted approval cases that incorrectly returned approved; 22 controls passed.
- After the fix: all 31 focused tests pass, including a repeat after incorporating main's dispatch-preflight change.
- Full hermetic suite: 4,484 passed, four skipped on the initial base. The full suite has not been repeated locally after that main integration; PR CI covers the combined head.
- TypeScript, touched-file lint, changed-line rules, test classification, and whitespace checks passed. TypeScript passed again after main integration.

No visual proof applies to this approval-logic change.
