### PR TITLE
fix: record CLI review coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,7 @@ o8 packet retry [--packet <id>] [--reason "..."]         # reset while keeping t
 o8 packet rerun --feedback "..." [--packet <id>]         # fresh worker, immediate relaunch
 o8 packet steer --message "..." [--packet <id>]          # nudge the warm session
 o8 packet merge-preview [--packet <id>]                  # read-only five-layer merge preview
-o8 packet review --approve [--packet <id>] [--expected-sha <sha>] [--commit-message "..."]   # records review, then uses the gated merge path
+o8 packet review --approve [--packet <id>] --expected-sha <full-sha> [--coverage <requirement-id>=<repo-relative-path> ...] [--contract-version <n>] [--commit-message "..."]   # records per-requirement coverage, shows the gate verdict, then merges
 o8 packet approve-merge [--packet <id>] [--commit-message "..."]   # worker context raises an operator card; it does not self-merge
 
 # Task artifacts — hand the operator a sandboxed form; its exact payload returns to you with a receipt

--- a/cli/src/commands/packet/help.ts
+++ b/cli/src/commands/packet/help.ts
@@ -36,7 +36,7 @@ export const PACKET_COMMAND_LINES = `  packet info [id]     packet metadata; exp
   packet diff [id]     the packet's code diff vs base (committed + uncommitted)
   packet commit -m ".." stage + commit the current worktree with an explicit pathspec
   packet heartbeat [id] update a packet lane heartbeat
-  packet review [id]   approve + merge a reviewed packet
+  packet review [id]   approve + merge; repeat --coverage <requirement-id>=<repo-relative-path>
   packet park [id]     remove a verified review-ready workspace while preserving immutable review
   packet restore [id]  restore a parked workspace to its exact reviewed state
   packet close [id]    close without merging (--reason adopted_elsewhere|superseded|spec_changed|wontfix)

--- a/cli/src/commands/packet/review.ts
+++ b/cli/src/commands/packet/review.ts
@@ -20,6 +20,11 @@ interface ReviewArgs {
   expectedHeadSha: string | null;
   commitMessage: string | null;
   idempotencyKey: string | null;
+  contractVersion: number | null;
+  coverageEntries: Array<{
+    requirementId: string;
+    productionPath: string;
+  }>;
 }
 
 interface OperatorResponse<T> {
@@ -31,9 +36,50 @@ interface OperatorResponse<T> {
 function parseReviewArgs(rest: string[]): ReviewArgs {
   const args = parsePacketArguments(rest, {
     command: 'review',
-    valueFlags: ['expected-sha', 'commit-message', 'idempotency-key'],
+    valueFlags: ['expected-sha', 'commit-message', 'idempotency-key', 'contract-version'],
+    repeatableValueFlags: ['coverage'],
     booleanFlags: ['approve'],
   });
+
+  const rawContractVersion = args.values['contract-version']?.trim();
+  if (rawContractVersion && !/^\d+$/.test(rawContractVersion)) {
+    throw new CliError('invalid_args', '--contract-version must be a positive integer.', EXIT.INVALID_ARGS);
+  }
+  const contractVersion = rawContractVersion ? Number.parseInt(rawContractVersion, 10) : null;
+  if (contractVersion !== null && contractVersion < 1) {
+    throw new CliError('invalid_args', '--contract-version must be a positive integer.', EXIT.INVALID_ARGS);
+  }
+
+  const seenRequirementIds = new Set<string>();
+  const coverageEntries = (args.multiValues.coverage ?? []).map((entry) => {
+    const separator = entry.indexOf('=');
+    const requirementId = separator >= 0 ? entry.slice(0, separator).trim() : '';
+    const productionPath = separator >= 0 ? entry.slice(separator + 1).trim() : '';
+    if (!requirementId || !productionPath) {
+      throw new CliError(
+        'invalid_args',
+        '--coverage must use <requirement-id>=<repo-relative-production-path>.',
+        EXIT.INVALID_ARGS,
+      );
+    }
+    if (seenRequirementIds.has(requirementId)) {
+      throw new CliError(
+        'invalid_args',
+        `--coverage repeats requirement ${requirementId}.`,
+        EXIT.INVALID_ARGS,
+      );
+    }
+    seenRequirementIds.add(requirementId);
+    return { requirementId, productionPath };
+  });
+
+  if (contractVersion !== null && coverageEntries.length === 0) {
+    throw new CliError(
+      'invalid_args',
+      '--contract-version requires at least one --coverage entry.',
+      EXIT.INVALID_ARGS,
+    );
+  }
 
   return {
     packetId: args.target,
@@ -41,6 +87,8 @@ function parseReviewArgs(rest: string[]): ReviewArgs {
     expectedHeadSha: args.values['expected-sha']?.trim() || null,
     commitMessage: args.values['commit-message']?.trim() || null,
     idempotencyKey: args.values['idempotency-key']?.trim() || null,
+    contractVersion,
+    coverageEntries,
   };
 }
 
@@ -65,6 +113,22 @@ export async function runPacketReview(mode: OutputMode, rest: string[]): Promise
   }
 
   const packetId = requirePacketId(await resolvePacketTarget(args.packetId), 'review');
+  if (args.coverageEntries.length > 0 && !args.expectedHeadSha) {
+    throw new CliError(
+      'invalid_args',
+      '--coverage requires --expected-sha so the evidence is bound to the reviewed commit.',
+      EXIT.INVALID_ARGS,
+      'Pass the full output of `git rev-parse HEAD` with --expected-sha.',
+    );
+  }
+  if (args.coverageEntries.length > 0 && !/^[0-9a-f]{40}$/i.test(args.expectedHeadSha ?? '')) {
+    throw new CliError(
+      'invalid_args',
+      '--coverage requires a full 40-character commit SHA in --expected-sha.',
+      EXIT.INVALID_ARGS,
+      'Pass the full output of `git rev-parse HEAD` with --expected-sha.',
+    );
+  }
   const cfg = resolveConfig();
   const receiptKey = args.idempotencyKey ?? randomUUID();
   const reviewRes = await fetchCorrelatedPacketMutation<OperatorResponse<{
@@ -73,11 +137,26 @@ export async function runPacketReview(mode: OutputMode, rest: string[]): Promise
     inProgress?: boolean;
     status?: string;
     note?: string;
+    contractCoverage?: {
+      status: 'passed' | 'failed' | 'not-applicable';
+      reason: string;
+      checks: Array<{
+        requirementId: string;
+        covered: boolean;
+        citedPath: string | null;
+      }>;
+      missingRequirementIds: string[];
+    } | null;
   }>>(cfg, '/api/orchestrator/review', {
     packetId,
     approved: true,
     findings: [],
     reviewedHeadSha: args.expectedHeadSha ?? undefined,
+    contractCoverageEvidence: args.coverageEntries.length > 0 ? {
+      contractVersion: args.contractVersion ?? 1,
+      headSha: args.expectedHeadSha!,
+      entries: args.coverageEntries,
+    } : undefined,
     clientMutationId: receiptKey,
   });
   if (!reviewRes.data?.ok) {
@@ -86,6 +165,14 @@ export async function runPacketReview(mode: OutputMode, rest: string[]): Promise
   const reviewResult = reviewRes.data.result;
   if (!reviewResult) {
     throw new CliError('review_failed', 'Packet review returned no result.', EXIT.CONFLICT);
+  }
+  if (reviewResult.contractCoverage?.status === 'failed') {
+    throw new CliError(
+      'contract_coverage_failed',
+      reviewResult.contractCoverage.reason,
+      EXIT.CONFLICT,
+      'Repeat --coverage <requirement-id>=<repo-relative-production-path> for every sealed requirement.',
+    );
   }
 
   const mergeBody = {
@@ -115,6 +202,7 @@ export async function runPacketReview(mode: OutputMode, rest: string[]): Promise
       id: packetId,
       approved: true,
       reviewedHeadSha: reviewResult.reviewedHeadSha ?? args.expectedHeadSha,
+      contractCoverage: reviewResult.contractCoverage ?? null,
       mergeInProgress,
       merge: mergeRes.data.result,
     },
@@ -126,6 +214,12 @@ export async function runPacketReview(mode: OutputMode, rest: string[]): Promise
       ['packet', packetId],
       ['approved', 'yes'],
       ['reviewed HEAD', payload.packet.reviewedHeadSha ?? '(captured by server)'],
+      ['contract coverage', payload.packet.contractCoverage
+        ? `${payload.packet.contractCoverage.status}: ${payload.packet.contractCoverage.reason}`
+        : 'not required'],
+      ['coverage checks', payload.packet.contractCoverage?.checks
+        .map((check) => `${check.requirementId}=${check.covered ? 'covered' : 'missing'}${check.citedPath ? ` (${check.citedPath})` : ''}`)
+        .join(', ') ?? ''],
       ['merged', mergeInProgress ? 'already in progress (not merged twice)' : mergeRes.data.result.merged ? 'yes' : 'no'],
       ['note', mergeRes.data.result.note ?? ''],
     ]);

--- a/cli/src/commands/packet/target.ts
+++ b/cli/src/commands/packet/target.ts
@@ -5,6 +5,7 @@ import { detectWorktree, type WorktreeMatch } from './worktree-resolve.js';
 export interface PacketArgumentSpec {
   command: string;
   valueFlags?: readonly string[];
+  repeatableValueFlags?: readonly string[];
   booleanFlags?: readonly string[];
   aliases?: Readonly<Record<string, string>>;
   allowTarget?: boolean;
@@ -19,6 +20,7 @@ export interface ParsedPacketArguments {
   target: string | null;
   targetWasExplicit: boolean;
   values: Record<string, string>;
+  multiValues: Record<string, string[]>;
   booleans: Set<string>;
 }
 
@@ -79,6 +81,7 @@ export function parsePacketArguments(
   spec: PacketArgumentSpec,
 ): ParsedPacketArguments {
   const valueFlags = new Set(spec.valueFlags ?? []);
+  const repeatableValueFlags = new Set(spec.repeatableValueFlags ?? []);
   const booleanFlags = new Set(spec.booleanFlags ?? []);
   const aliases = spec.aliases ?? {};
   const allowTarget = spec.allowTarget !== false;
@@ -86,6 +89,7 @@ export function parsePacketArguments(
   const positionalValues = spec.positionalValues ?? [];
   const knownFlags = new Set([
     ...valueFlags,
+    ...repeatableValueFlags,
     ...booleanFlags,
     ...targetFlags,
   ]);
@@ -97,6 +101,7 @@ export function parsePacketArguments(
     return knownFlags.has(name);
   };
   const values: Record<string, string> = {};
+  const multiValues: Record<string, string[]> = {};
   const booleans = new Set<string>();
   let flagTarget: string | null = null;
   let positionalTarget: string | null = null;
@@ -134,6 +139,18 @@ export function parsePacketArguments(
         : requireFlagValue(rest, index, `--${flagName}`, isKnownFlag);
       if (!canonicalToken.includes('=')) index += 1;
       values[flagName] = value;
+      continue;
+    }
+
+    if (flagName && repeatableValueFlags.has(flagName)) {
+      const value = canonicalToken.includes('=')
+        ? canonicalToken.slice(canonicalToken.indexOf('=') + 1)
+        : requireFlagValue(rest, index, `--${flagName}`, isKnownFlag);
+      if (!canonicalToken.includes('=')) index += 1;
+      if (!value.trim()) {
+        throw new CliError('invalid_args', `--${flagName} requires a value.`, EXIT.INVALID_ARGS);
+      }
+      multiValues[flagName] = [...(multiValues[flagName] ?? []), value];
       continue;
     }
 
@@ -185,6 +202,7 @@ export function parsePacketArguments(
     target: target || null,
     targetWasExplicit: Boolean(target),
     values,
+    multiValues,
     booleans,
   };
 }

--- a/src/lib/orchestrator/operator-mission-service/review.ts
+++ b/src/lib/orchestrator/operator-mission-service/review.ts
@@ -437,6 +437,12 @@ export async function submitPacketReview(input: SubmitReviewInput) {
     secondPassSchedulingWarning = rearmed.reason;
   }
 
+  let contractCoverage = null;
+  if (input.approved && verdictLane) {
+    const { assessDurableApprovedReview } = await import('@/lib/lane/durable-review-approval');
+    contractCoverage = (await assessDurableApprovedReview(verdictLane)).contractCoverage ?? null;
+  }
+
   log(`Recorded review for packet ${packet.id}${orphanLane ? ` (orphan via lane ${orphanLane.id})` : ''}.`, {
     approved: input.approved,
     findings: input.findings.length,
@@ -458,5 +464,6 @@ export async function submitPacketReview(input: SubmitReviewInput) {
     }),
     auditEventType: 'orchestrator_review',
     auditApprovalId: resolvedAuditApprovalId,
+    contractCoverage,
   };
 }

--- a/tests/cli-packet-target-parsing.test.ts
+++ b/tests/cli-packet-target-parsing.test.ts
@@ -12,6 +12,7 @@ import {
 import { parsePacketRecoveryArgs } from '../cli/src/commands/packet/recover';
 import { parseMirrorArgs, runPacketMirrorProof } from '../cli/src/commands/packet/mirror-proof';
 import {
+  parsePacketArguments,
   resolvePacketTargetFromLanes,
   type PacketTargetLane,
 } from '../cli/src/commands/packet/target';
@@ -74,6 +75,21 @@ describe('packet CLI target parsing', () => {
       .toBe('-v flag is broken');
     expect(() => parsePacketRecoveryArgs('steer', ['--message', '--packet', 'pkt-target']))
       .toThrow('--message requires a value.');
+  });
+
+  it('preserves every repeatable value in command order', () => {
+    const parsed = parsePacketArguments([
+      'pkt-target',
+      '--coverage',
+      'R1=src/one.ts',
+      '--coverage=R2=src/two.ts',
+    ], {
+      command: 'review',
+      repeatableValueFlags: ['coverage'],
+    });
+
+    expect(parsed.target).toBe('pkt-target');
+    expect(parsed.multiValues.coverage).toEqual(['R1=src/one.ts', 'R2=src/two.ts']);
   });
 
   it('routes capture and mirror-proof positional targets through the shared parser', () => {

--- a/tests/require-approval-merge-real-path.test.ts
+++ b/tests/require-approval-merge-real-path.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import { runPacketReview } from '../cli/src/commands/packet/review';
 
 const { publishRealtimeMutation } = vi.hoisted(() => ({
   publishRealtimeMutation: vi.fn(async () => {}),
@@ -322,6 +323,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
   rmSync(defaultsPath, { force: true });
   rmSync(settingsTomlPath, { force: true });
   for (const dir of tempDirs.splice(0)) {
@@ -429,6 +432,9 @@ describe('requireApproval merge governance through the real command path', () =>
     ));
 
     expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      result: { contractCoverage: { status: 'passed', missingRequirementIds: [] } },
+    });
     const approval = listApprovalsForContext({ laneId: fixture.lane.id })
       .find((candidate) => candidate.toolName === 'orchestrator_review');
     expect(approval?.args?.contractCoverageEvidence).toMatchObject({
@@ -441,6 +447,76 @@ describe('requireApproval merge governance through the real command path', () =>
       contractCoverage: { status: 'passed', missingRequirementIds: [] },
     });
   }, 30_000);
+
+  it('records one-requirement coverage and merges through the documented CLI review flow', async () => {
+    const fixture = await createStandardLane('cli-contract-review', false);
+    const taskContract = {
+      version: 1 as const,
+      requirements: [{
+        id: 'R1',
+        source: 'Complete one governed operator review.',
+        expectedBehavior: 'The CLI review records coverage before entering the merge gate.',
+        productionPath: 'file.txt',
+        verification: 'Inspect the committed file.',
+      }],
+      smallestRoute: [{
+        path: 'file.txt',
+        requirements: ['R1'],
+        reason: 'The packet changes one file.',
+      }],
+      exclusions: [],
+    };
+    persistDispatcherMission(
+      fixture.lane.packetId!,
+      fixture.repo,
+      `thoughts-cli-contract-${Date.now()}`,
+      { taskContract, taskContractRequired: true },
+    );
+
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/api/lanes') {
+        return new Response(JSON.stringify({ lanes: [fixture.lane] }), {
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      const request = new NextRequest(url, {
+        method: init?.method,
+        headers: init?.headers,
+        body: typeof init?.body === 'string' ? init.body : undefined,
+      });
+      if (url.pathname === '/api/orchestrator/review') return reviewRoute.POST(request);
+      if (url.pathname === '/api/orchestrator/merge') return mergeRoute.POST(request);
+      throw new Error(`Unexpected CLI request: ${url.pathname}`);
+    }));
+
+    await expect(runPacketReview(
+      { human: false, verbose: false },
+      [
+        fixture.lane.packetId!,
+        '--approve',
+        '--expected-sha',
+        fixture.reviewedHeadSha,
+        '--coverage',
+        'R1=file.txt',
+      ],
+    )).resolves.toBe(0);
+
+    const output = JSON.parse(stdout.mock.calls.map(([chunk]) => String(chunk)).join(''));
+    expect(output).toMatchObject({
+      packet: {
+        id: fixture.lane.packetId,
+        contractCoverage: {
+          status: 'passed',
+          checks: [{ requirementId: 'R1', covered: true, citedPath: 'file.txt' }],
+          missingRequirementIds: [],
+        },
+        merge: { merged: true },
+      },
+    });
+    expect(git(fixture.repo, ['rev-parse', 'HEAD'])).toBe(fixture.reviewedHeadSha);
+  }, 60_000);
 
   it('does not let a pending review waive spoken merge-gate blockers', async () => {
     const fixture = await createBudgetBlockedLane('pending-spoken-review');


### PR DESCRIPTION
## Mechanic

`o8 packet review --approve` now accepts repeatable `--coverage <requirement-id>=<repo-relative-path>` evidence bound to a full `--expected-sha`. The review route returns the deterministic persisted coverage verdict, the CLI prints the exact per-requirement checks used by the merge gate, and failed coverage stops before creating a second merge approval path. Worker-context `approve-merge` behavior is unchanged.

## What changed

- Added repeatable value support to the shared packet argument parser.
- Added structured task-contract coverage flags and output to packet review.
- Returned the durable coverage assessment from the review service.
- Documented the one-command operator review flow in CLI help and `AGENTS.md`.

## Verification

- `records one-requirement coverage and merges through the documented CLI review flow` — passed through CLI, route handler, persisted approval, gate, and real Git merge.
- `preserves every repeatable value in command order` — passed.
- `npx vitest run tests/cli-packet-target-parsing.test.ts tests/require-approval-merge-real-path.test.ts` — 39 passed.
- `npx tsc --noEmit` — passed.
- `npm test` — 717 files passed, 3 skipped; 4,477 tests passed, 4 skipped.
- `npm run rule-check -- --base=origin/main` and touched-file ESLint — passed.

Fixes #2238

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe