### PR TITLE
fix: treat absent push remote as local merge

### DIFF
--- a/src/lib/lane/worktree-merge-git.ts
+++ b/src/lib/lane/worktree-merge-git.ts
@@ -363,6 +363,18 @@ export async function pushExactBase(
   ], { timeout: 60_000 });
 }
 
+export async function hasPushRemote(repoPath: string, remote = 'origin'): Promise<boolean> {
+  const { stdout: remotesOutput } = await git(repoPath, ['remote'], { timeout: 5000 });
+  const remotes = remotesOutput.split('\n').map((value) => value.trim()).filter(Boolean);
+  if (!remotes.includes(remote)) return false;
+  const { stdout } = await git(
+    repoPath,
+    ['remote', 'get-url', '--push', remote],
+    { timeout: 5000 },
+  );
+  return stdout.trim().length > 0;
+}
+
 export async function exactPushLeaseForCandidate(
   repoPath: string,
   originBaseRef: string | null,

--- a/src/lib/lane/worktree-side-merge.ts
+++ b/src/lib/lane/worktree-side-merge.ts
@@ -46,6 +46,7 @@ import {
   fetchWorkerHeadIntoMainRepo,
   git,
   gitErrorMessage,
+  hasPushRemote,
   isAncestor,
   mergeRefForLane,
   pushExactBase, pushWorkerBranchBestEffort,
@@ -627,10 +628,15 @@ async function performWorktreeSideMergeInner(input: WorktreeSideMergeInput): Pro
     let mergeCandidateSha = rebasedSha;
     let mergedEquivalentHeadSha = spokenEvidence.present ? reviewedSnapshotSha : rebasedSha;
     let expectedRemoteBaseSha: string | undefined;
+    const originPushAvailable = await hasPushRemote(lane.repoPath);
     try {
       await fetchWorkerHeadIntoMainRepo(lane.repoPath, mergeWorktreePath, rebasedSha, integrationRef);
-      await pushWorkerBranchBestEffort(worktreePath, actualBranch, rebasedSha);
-      const originBaseRef = await refreshOriginBaseBestEffort(lane.repoPath, lane.baseBranch);
+      if (originPushAvailable) {
+        await pushWorkerBranchBestEffort(worktreePath, actualBranch, rebasedSha);
+      }
+      const originBaseRef = originPushAvailable
+        ? await refreshOriginBaseBestEffort(lane.repoPath, lane.baseBranch)
+        : null;
       if (originBaseRef && !(await isAncestor(lane.repoPath, originBaseRef, integrationRef))) {
         const retryResult = await retryBaseAdvancedAfterRebase(input, {
           mgr,
@@ -646,7 +652,7 @@ async function performWorktreeSideMergeInner(input: WorktreeSideMergeInput): Pro
       const integrationSha = (await git(lane.repoPath, ['rev-parse', integrationRef], { timeout: 5000 })).stdout.trim();
       mergeCandidateSha = integrationSha;
       if (!spokenEvidence.present) mergedEquivalentHeadSha = integrationSha;
-      if (integrationSha !== rebasedSha) {
+      if (originPushAvailable && integrationSha !== rebasedSha) {
         await pushWorkerBranchLeaseBestEffort(worktreePath, actualBranch, integrationSha, rebasedSha);
       }
       let pushLease = await exactPushLeaseForCandidate(lane.repoPath, originBaseRef, integrationRef);
@@ -670,7 +676,7 @@ async function performWorktreeSideMergeInner(input: WorktreeSideMergeInput): Pro
         return { ok: false, laneId: command.laneId, note: governedCandidate.note };
       }
       mergeCandidateSha = governedCandidate.candidateSha;
-      if (governedCandidate.squashed) {
+      if (originPushAvailable && governedCandidate.squashed) {
         await pushWorkerBranchLeaseBestEffort(
           lane.repoPath,
           actualBranch,
@@ -718,13 +724,15 @@ async function performWorktreeSideMergeInner(input: WorktreeSideMergeInput): Pro
     const mergeSha = mergeCandidateSha;
     appendEvent(command.laneId, 'merge', actor, { laneHeadSha: mergeSha, baseBranch: lane.baseBranch });
     let pushedToOrigin = false, pushError: string | undefined;
-    try {
-      await pushExactBase(lane.repoPath, lane.baseBranch, mergeSha, expectedRemoteBaseSha);
-      pushedToOrigin = true;
-      console.log(`[lane-merge] Pushed ${lane.baseBranch} to origin after fast-forwarding ${actualBranch}`);
-    } catch (error) {
-      pushError = gitErrorMessage(error);
-      console.warn(`[lane-merge] Push to origin failed for ${lane.baseBranch} after fast-forwarding ${actualBranch}: ${pushError}`);
+    if (originPushAvailable) {
+      try {
+        await pushExactBase(lane.repoPath, lane.baseBranch, mergeSha, expectedRemoteBaseSha);
+        pushedToOrigin = true;
+        console.log(`[lane-merge] Pushed ${lane.baseBranch} to origin after fast-forwarding ${actualBranch}`);
+      } catch (error) {
+        pushError = gitErrorMessage(error);
+        console.warn(`[lane-merge] Push to origin failed for ${lane.baseBranch} after fast-forwarding ${actualBranch}: ${pushError}`);
+      }
     }
     const worktreeRemoved = await settleSuccessfulMergeWorktreeCleanup({
       manager: mgr,
@@ -743,7 +751,9 @@ async function performWorktreeSideMergeInner(input: WorktreeSideMergeInput): Pro
     const cleanupNote = worktreeRemoved ? '' : ' Worktree cleanup is pending and remains addressable for retry.';
     const mergeNote = pushedToOrigin
       ? `Rebased ${lane.branch} onto ${lane.baseBranch}, fast-forwarded ${lane.baseBranch}, and pushed to origin.${cleanupNote}${decompositionNote}`
-      : `Rebased ${lane.branch} onto ${lane.baseBranch} and fast-forwarded ${lane.baseBranch} LOCALLY - push to origin failed: ${pushError ?? 'unknown error'}. Run \`git push origin ${lane.baseBranch}\` to ship the commit.${cleanupNote}${decompositionNote}`;
+      : originPushAvailable
+        ? `Rebased ${lane.branch} onto ${lane.baseBranch} and fast-forwarded ${lane.baseBranch} LOCALLY - push to origin failed: ${pushError ?? 'unknown error'}. Run \`git push origin ${lane.baseBranch}\` to ship the commit.${cleanupNote}${decompositionNote}`
+        : `Rebased ${lane.branch} onto ${lane.baseBranch} and fast-forwarded ${lane.baseBranch} locally. No push remote is configured; the local merge commit is ${mergeSha}.${cleanupNote}${decompositionNote}`;
     return {
       ok: true,
       laneId: command.laneId,

--- a/tests/approve-and-merge-squash-real-path.test.ts
+++ b/tests/approve-and-merge-squash-real-path.test.ts
@@ -47,6 +47,7 @@ const mergeRoute = await import('@/app/api/orchestrator/merge/route');
 const { recordOrchestratorReview } = await import('@/lib/approvals/store');
 const { AGENT_COMMIT_TRAILER } = await import('@/lib/lane/commit-attribution');
 const { createLane } = await import('@/lib/lane/registry');
+const { getMissionStatus } = await import('@/lib/orchestrator/operator-mission-service');
 const { recordMission } = await import('@/lib/db/missions-store');
 const { readOrchestratorControlPlaneState, writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
 const {
@@ -234,6 +235,24 @@ afterAll(() => {
 });
 
 describe('approve_and_merge governed squash through the route handler', () => {
+  it('reports a successful local merge when the canonical repository has no push remote', async () => {
+    const fixture = await createFixture('local-only');
+    git(fixture.repo, ['remote', 'remove', 'origin']);
+    expect(git(fixture.repo, ['remote'])).toBe('');
+
+    const response = await mergeRoute.POST(mergeRequest(fixture.packetId));
+    const payload = await response.json();
+    const status = await getMissionStatus({ includeCost: false });
+    const packet = status.packets.find((candidate) => candidate.id === fixture.packetId);
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({ ok: true, result: { merged: true } });
+    expect(payload.result.note).toContain('No push remote is configured');
+    expect(payload.result.note).not.toMatch(/push(?: to origin)? failed|fatal:/i);
+    expect(git(fixture.repo, ['rev-parse', 'refs/heads/main'])).toBe(payload.result.mergeSha);
+    expect(packet).toMatchObject({ status: 'released', releaseState: 'released' });
+  }, 60_000);
+
   it('does not attach a landed merge to a successor attempt that arrived before release persistence', async () => {
     const fixture = await createFixture('successor-attempt');
     lifecycle.afterMerge = () => {


### PR DESCRIPTION
## Mechanic

The governed merge path treated a missing origin remote as a failed push after the canonical local branch had already advanced.

## What changed

- Detect an origin push target before worker-branch, refresh, lease, and base-push operations.
- Preserve real push failures when origin exists, while returning a successful local-only receipt merge receipt with the exact merge commit when it does not.
- Prove the route receipt and persisted mission status agree that the packet released.

## Verification

- RED — `reports a successful local merge when the canonical repository has no push remote`: `1 failed | 4 skipped`; expected `No push remote is configured`, received fatal origin/push-failed wording.
- GREEN — `tests/approve-and-merge-squash-real-path.test.ts`: `5 passed (5)`.
- `npx tsc --noEmit`: pass.
- `npm run test:classify`: `720 hermetic, 411 resource-owning`; manifest unchanged.
- `npm test`: `717 passed | 3 skipped` files; `4477 passed | 4 skipped` tests.

Fixes #2239

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe