### PR TITLE
fix: cancel queued packets when missions supersede

### DIFF
--- a/src/lib/orchestrator/operator-mission-service/mission-supersession.ts
+++ b/src/lib/orchestrator/operator-mission-service/mission-supersession.ts
@@ -1,0 +1,67 @@
+import { findLaneByPacket } from '@/lib/lane/registry';
+import {
+  listActiveMissionRegistryEntries,
+  withMissionRegistryState,
+} from '@/lib/orchestrator/mission-registry';
+import type { OrchestratorMissionState, OrchestratorPacket } from '@/lib/orchestrator/types';
+
+const SUPERSEDED_PACKET_REASON = 'superseded_by_newer_mission';
+
+function packetBelongsToThread(packet: OrchestratorPacket, threadId: string): boolean {
+  return packet.orchestratorThreadId?.trim() === threadId;
+}
+
+function packetIsInFlight(packet: OrchestratorPacket): boolean {
+  return packet.status === 'launching'
+    || packet.status === 'running'
+    || packet.status === 'awaiting_review'
+    || findLaneByPacket(packet.id) !== null;
+}
+
+export function cancelSupersededMissionPackets(
+  state: OrchestratorMissionState,
+  input: { threadId: string; successorMissionId: string; cancelledAt: string },
+): boolean {
+  const threadId = input.threadId.trim();
+  if (!threadId || state.missionId === input.successorMissionId) return false;
+
+  let changed = false;
+  for (const packet of state.packets) {
+    if (!packetBelongsToThread(packet, threadId)) continue;
+    if (packet.archivedAt || packet.releaseState === 'released' || packet.status === 'failed') continue;
+    if (packet.operatorStopped) continue;
+
+    // Supersession policy: an in-flight packet keeps running and follows the
+    // normal review path. Cancel only packets that have not launched, so the
+    // successor cannot later open a second lane for the same thread's work.
+    if (packetIsInFlight(packet)) continue;
+
+    packet.operatorStopped = true;
+    packet.queueState = 'held';
+    packet.status = 'blocked';
+    packet.blockedReason = SUPERSEDED_PACKET_REASON;
+    packet.lastEventAt = input.cancelledAt;
+    packet.lastEventLabel = SUPERSEDED_PACKET_REASON;
+    packet.releaseStatePayload = {
+      source: `mission_superseded:${input.successorMissionId}`,
+    };
+    changed = true;
+  }
+  return changed;
+}
+
+export async function cancelSupersededRegistryMissions(input: {
+  threadId: string;
+  successorMissionId: string;
+  cancelledAt: string;
+}): Promise<void> {
+  for (const entry of listActiveMissionRegistryEntries(input.successorMissionId)) {
+    if (!entry.mission.packets.some((packet) => packetBelongsToThread(packet, input.threadId))) {
+      continue;
+    }
+    await withMissionRegistryState(entry.id, (state) => {
+      cancelSupersededMissionPackets(state, input);
+      return { state, result: undefined };
+    });
+  }
+}

--- a/src/lib/orchestrator/operator-mission-service/mission.ts
+++ b/src/lib/orchestrator/operator-mission-service/mission.ts
@@ -26,6 +26,10 @@ import { releaseAbandonedMissionLifecycleHold } from '@/lib/orchestrator/mission
 import { getTopRulesForPacket, readRepoScopedRules } from '@/lib/dispatch/rules-store';
 import { prepareMissionBranches, type MissionBranchDecision } from './branch-cleanup';
 import {
+  cancelSupersededMissionPackets,
+  cancelSupersededRegistryMissions,
+} from './mission-supersession';
+import {
   activityLabel,
   latestIsoTimestamp,
   readTranscriptActivityBySession,
@@ -302,10 +306,28 @@ export async function createMission(input: CreateMissionInput) {
     branchPreparation: branchPreparation.filter((decision) => decision.action !== 'none'),
   };
   const mission = normalizeOrchestratorMissionState({ ...missionBase, creationReceipt });
+  const supersedingThreadId = input.orchestratorThreadId?.trim() ?? '';
+  const supersededAt = new Date().toISOString();
 
   const persisted = await withMissionHandoffBarrier(async () => {
     const { state, result: outgoing } = await withLockedState(
-      (current) => {
+      async (current) => {
+        if (supersedingThreadId) {
+          cancelSupersededMissionPackets(current, {
+            threadId: supersedingThreadId,
+            successorMissionId: missionId,
+            cancelledAt: supersededAt,
+          });
+          // Keep the current control-plane lock while older registry rows are
+          // cancelled. A current or non-current dispatch must finish first and
+          // count as in-flight, or observe the durable cancellation before it
+          // can create a lane. This closes the switch-then-cancel launch gap.
+          await cancelSupersededRegistryMissions({
+            threadId: supersedingThreadId,
+            successorMissionId: missionId,
+            cancelledAt: supersededAt,
+          });
+        }
         // Replace the mission under the control-plane lock so a concurrent
         // headless tick cannot restore a stale mission after createMission returns.
         if (current.missionId && current.missionId !== missionId) {

--- a/tests/mission-supersession-real-path.test.ts
+++ b/tests/mission-supersession-real-path.test.ts
@@ -1,0 +1,178 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+
+const launchMock = vi.hoisted(() => ({
+  calls: [] as Array<{ packetId?: string; repoPath: string }>,
+}));
+
+vi.mock('@/lib/worktree/storage-telemetry', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/worktree/storage-telemetry')>(),
+  measureHostVolume: vi.fn(async () => ({
+    accountingStatus: 'observed' as const,
+    probePath: '/',
+    availableBytes: 90_000_000_000,
+    freeBytes: 90_000_000_000,
+    totalBytes: 100_000_000_000,
+    error: null,
+  })),
+}));
+
+vi.mock('@/lib/runtime/actions', () => ({
+  launchRuntimeSurface: vi.fn(async (input: { packetId?: string; repoPath: string }) => {
+    launchMock.calls.push({ packetId: input.packetId, repoPath: input.repoPath });
+    return {
+      ok: true,
+      surfaceId: `codex-owned:${input.packetId ?? launchMock.calls.length}`,
+      note: 'mock runtime launched',
+      worktree: { path: input.repoPath },
+    };
+  }),
+}));
+
+vi.mock('@/lib/runtimes/shared/auth-detect', () => ({
+  assertRuntimeDispatchable: vi.fn(async () => undefined),
+}));
+
+const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-mission-supersession-'));
+const tempRepos: string[] = [];
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.O8_DATA_DIR = dataDir;
+
+function createTempRepo() {
+  const repoPath = mkdtempSync(join(os.tmpdir(), 'o8-mission-supersession-repo-'));
+  tempRepos.push(repoPath);
+  const git = (...args: string[]) => execFileSync('git', args, { cwd: repoPath, stdio: 'pipe' });
+  git('init', '--initial-branch=main');
+  writeFileSync(join(repoPath, 'README.md'), 'mission supersession test\n');
+  git('add', 'README.md');
+  git('-c', 'user.email=test@o8.test', '-c', 'user.name=o8-test', 'commit', '-m', 'init');
+  return repoPath;
+}
+
+async function createMissionThroughRoute(input: {
+  clientMutationId: string;
+  issueNumber: number;
+  repoPath: string;
+  threadId: string;
+  title: string;
+}) {
+  const { NextRequest } = await import('next/server');
+  const { POST } = await import('@/app/api/orchestrator/create-mission/route');
+  const response = await POST(new NextRequest('http://127.0.0.1:47120/api/orchestrator/create-mission', {
+    method: 'POST',
+    headers: { host: 'localhost:47120', 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      clientMutationId: input.clientMutationId,
+      repoPath: input.repoPath,
+      runtime: 'codex',
+      orchestratorThreadId: input.threadId,
+      issues: [{
+        number: input.issueNumber,
+        title: input.title,
+        body: `${input.title} body`,
+        url: '',
+      }],
+    }),
+  }));
+  const payload = await response.json() as {
+    ok: boolean;
+    result: { missionId: string; packets: Array<{ id: string }> };
+  };
+  expect(response.status).toBe(201);
+  expect(payload.ok).toBe(true);
+  return payload.result;
+}
+
+afterEach(async () => {
+  const { archiveLane, listLanes } = await import('@/lib/lane/registry');
+  for (const lane of listLanes()) {
+    if (lane.status !== 'archived') archiveLane(lane.id, 'system');
+  }
+  launchMock.calls = [];
+  for (const repoPath of tempRepos.splice(0)) {
+    rmSync(repoPath, { recursive: true, force: true });
+  }
+});
+
+afterAll(async () => {
+  const { closeDb } = await import('@/lib/db');
+  closeDb();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('mission supersession real path', () => {
+  it('cancels the predecessor before the headless dispatcher can create its lane', async () => {
+    const repoPath = createTempRepo();
+    const threadId = 'thread-supersede-2196';
+    const first = await createMissionThroughRoute({
+      clientMutationId: 'supersede-first-2196',
+      issueNumber: 219_601,
+      repoPath,
+      threadId,
+      title: 'superseded thread mission',
+    });
+    const second = await createMissionThroughRoute({
+      clientMutationId: 'supersede-second-2196',
+      issueNumber: 219_602,
+      repoPath,
+      threadId,
+      title: 'surviving thread mission',
+    });
+    const firstPacketId = first.packets[0]!.id;
+    const secondPacketId = second.packets[0]!.id;
+
+    const { readMissionRegistryEntry } = await import('@/lib/orchestrator/mission-registry');
+    expect(readMissionRegistryEntry(first.missionId, { includeArchived: true })?.mission.packets[0])
+      .toMatchObject({
+        status: 'blocked',
+        queueState: 'held',
+        operatorStopped: true,
+        blockedReason: 'superseded_by_newer_mission',
+        lastEventLabel: 'superseded_by_newer_mission',
+        releaseStatePayload: { source: `mission_superseded:${second.missionId}` },
+      });
+
+    const { runHeadlessSprintTick } = await import('@/lib/orchestrator/headless-loop');
+    const { findLaneByPacket } = await import('@/lib/lane/registry');
+    await runHeadlessSprintTick();
+
+    expect(findLaneByPacket(firstPacketId)).toBeNull();
+    expect(findLaneByPacket(secondPacketId)?.id).toMatch(/^lane-/);
+    expect(launchMock.calls.map((call) => call.packetId)).toEqual([secondPacketId]);
+  }, 20_000);
+
+  it('keeps an in-flight predecessor on its normal review path', async () => {
+    const repoPath = createTempRepo();
+    const threadId = 'thread-in-flight-supersede-2196';
+    const first = await createMissionThroughRoute({
+      clientMutationId: 'in-flight-first-2196',
+      issueNumber: 219_603,
+      repoPath,
+      threadId,
+      title: 'in-flight thread mission',
+    });
+
+    const { dispatchMission } = await import('@/lib/orchestrator/operator-mission-service/mission');
+    await expect(dispatchMission({ missionId: first.missionId })).resolves.toMatchObject({ dispatched: 1 });
+    await createMissionThroughRoute({
+      clientMutationId: 'in-flight-second-2196',
+      issueNumber: 219_604,
+      repoPath,
+      threadId,
+      title: 'newer thread mission',
+    });
+
+    const firstPacketId = first.packets[0]!.id;
+    const { readMissionRegistryEntry } = await import('@/lib/orchestrator/mission-registry');
+    const { findLaneByPacket } = await import('@/lib/lane/registry');
+    const inFlightPacket = readMissionRegistryEntry(first.missionId, { includeArchived: true })
+      ?.mission.packets.find((packet) => packet.id === firstPacketId);
+    expect(inFlightPacket).toMatchObject({ status: 'running' });
+    expect(inFlightPacket?.operatorStopped).not.toBe(true);
+    expect(inFlightPacket?.blockedReason).not.toBe('superseded_by_newer_mission');
+    expect(findLaneByPacket(firstPacketId)?.id).toMatch(/^lane-/);
+  }, 20_000);
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2030,6 +2030,14 @@
       ]
     },
     {
+      "path": "tests/mission-supersession-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/mobile-activity-route.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
## Mechanic

Creating a newer mission for an orchestrator thread replaced the current mission but left the predecessor's queued registry packets dispatchable. A later headless tick could therefore launch both missions.

## What changed

- Cancel unlaunched predecessor packets under the mission handoff lock before installing the successor.
- Persist cancellation as held, operator-stopped, and blocked with `superseded_by_newer_mission`, preventing later lane creation.
- Preserve packets that are already launching, running, awaiting review, or have a lane; the decision-point comment states that they finish and follow the normal review path.
- Add a real-path route-to-headless regression test and classify its Git fixture.

## Verification

- Red before fix: `mission-registry-headless.test.ts -t "cancels unlaunched packets when a newer mission supersedes their orchestrator thread"` — 1 failed; predecessor remained `queued`.
- `npx vitest run tests/mission-supersession-real-path.test.ts src/lib/orchestrator/mission-registry-headless.test.ts` — 2 files passed, 19 tests passed.
- `npx tsc --noEmit` — exit 0.
- `npm run rule-check -- --base=origin/main` — zero violations.
- `npm test` — 715 files passed, 3 skipped, 2 unrelated timing failures (`problem-dossiers-activity`, `stop-client-state-race`); isolated rerun of both files passed 2/2 files and 10/10 tests.

Fixes #2196

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe
