### PR TITLE
fix: authenticate broadcast speaker polling

### DIFF
--- a/src/lib/broadcast/speaker.ts
+++ b/src/lib/broadcast/speaker.ts
@@ -3,8 +3,8 @@ import 'server-only';
 import type Database from 'better-sqlite3';
 
 import { getSqlite } from '@/lib/db';
-import { apiFetch } from '@/lib/mcp/operator-handlers/shared';
 import { getOperatorDefaultsSync } from '@/lib/operator/defaults';
+import { fetchNextJson } from '@/lib/ws-server/next-fetch';
 import {
   attentionEventIsCurrent,
   attentionSubscriptionEnabled,
@@ -100,8 +100,9 @@ function voiceSettings(): BroadcastVoiceSettings {
 }
 
 async function loadCommentary(cursor: string | null): Promise<CommentaryPage> {
-  const suffix = cursor ? `?since=${encodeURIComponent(cursor)}&limit=${COMMENTARY_PAGE_LIMIT}` : `?limit=${COMMENTARY_PAGE_LIMIT}`;
-  const response = await apiFetch(`/api/broadcast/commentary${suffix}`) as Partial<CommentaryPage>;
+  const searchParams = new URLSearchParams({ limit: String(COMMENTARY_PAGE_LIMIT) });
+  if (cursor) searchParams.set('since', cursor);
+  const response = await fetchNextJson<Partial<CommentaryPage>>('/api/broadcast/commentary', { searchParams });
   if (!Array.isArray(response.commentary) || typeof response.hasMore !== 'boolean') {
     throw new Error('Broadcast commentary endpoint returned an invalid page.');
   }
@@ -691,14 +692,22 @@ export class BroadcastSpeaker {
 
 let speakerTimer: NodeJS.Timeout | null = null;
 let loopSpeaker: BroadcastSpeaker | null = null;
+let speakerUnavailableWarningActive = false;
 
 export function startBroadcastSpeakerLoop(): () => void {
   if (speakerTimer) return () => undefined;
   loopSpeaker = new BroadcastSpeaker();
   const tick = () => {
-    void loopSpeaker?.tick().catch((error) => {
-      console.warn(`[broadcast-speaker] ${error instanceof Error ? error.message : String(error)}`);
-    });
+    void loopSpeaker?.tick()
+      .then((result) => {
+        if (result?.status === 'processed') speakerUnavailableWarningActive = false;
+      })
+      .catch((error) => {
+        if (!speakerUnavailableWarningActive) {
+          console.warn(`[broadcast-speaker] ${error instanceof Error ? error.message : String(error)}`);
+        }
+        speakerUnavailableWarningActive = true;
+      });
   };
   tick();
   speakerTimer = setInterval(tick, SPEAKER_TICK_MS);
@@ -707,5 +716,6 @@ export function startBroadcastSpeakerLoop(): () => void {
     if (speakerTimer) clearInterval(speakerTimer);
     speakerTimer = null;
     loopSpeaker = null;
+    speakerUnavailableWarningActive = false;
   };
 }

--- a/tests/broadcast-speaker-real-path.test.ts
+++ b/tests/broadcast-speaker-real-path.test.ts
@@ -19,7 +19,7 @@ const { getSqlite } = await import('@/lib/db');
 const { appendBroadcastEvent } = await import('@/lib/broadcast/post');
 const { recordCalendarAttention } = await import('@/lib/broadcast/calendar-attention');
 const { recordAutomationAttention } = await import('@/lib/broadcast/automation-attention');
-const { BroadcastSpeaker } = await import('@/lib/broadcast/speaker');
+const { BroadcastSpeaker, startBroadcastSpeakerLoop } = await import('@/lib/broadcast/speaker');
 const { appendEvent, createLane, setLaneStatus } = await import('@/lib/lane/registry');
 const { createApproval, recordOrchestratorReview } = await import('@/lib/approvals/store');
 const commentaryRoute = await import('@/app/api/broadcast/commentary/route');
@@ -69,6 +69,31 @@ async function emptyCommentary() {
 }
 
 describe('Broadcast speaker real path', () => {
+  it('logs one warning for a continuous commentary outage', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      error: { message: 'Commentary unavailable.' },
+    }), {
+      status: 503,
+      headers: { 'content-type': 'application/json' },
+    }));
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const stop = startBroadcastSpeakerLoop();
+    try {
+      await vi.advanceTimersByTimeAsync(3_500);
+      const speakerWarnings = warning.mock.calls.filter(([message]) => (
+        String(message).startsWith('[broadcast-speaker]')
+      ));
+      expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+      expect(speakerWarnings).toHaveLength(1);
+    } finally {
+      stop();
+      warning.mockRestore();
+      fetchMock.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it('advances the route cursor, prevents overlap, summarizes overflow, and lets say preempt pending lines', async () => {
     const base = Date.now();
     for (let index = 1; index <= 5; index += 1) {

--- a/tests/review-idle-real-path.test.ts
+++ b/tests/review-idle-real-path.test.ts
@@ -15,11 +15,15 @@ const token = `review-idle-${process.pid}`;
 const requests: { path: string; fresh: boolean }[] = [];
 const frames: Frame[] = [];
 let apiServer: Server;
+let decoyServer: Server;
 let wsProcess: ChildProcess | null = null;
 let socket: WebSocket | null = null;
 let apiPort = 0;
+let decoyPort = 0;
 let wsPort = 0;
 let output = '';
+const decoyRequests: string[] = [];
+const commentaryAuthorizations: string[] = [];
 let holdSnapshot = false;
 let releaseSnapshot: (() => void) | null = null;
 
@@ -71,9 +75,19 @@ beforeAll(async () => {
   mkdirSync(reviewRoot);
   writeFileSync(join(dataDir, 'ws-token'), token, { mode: 0o600 });
   apiPort = await freePort();
+  decoyPort = await freePort();
   wsPort = await freePort();
-  writeFileSync(join(dataDir, 'api-port'), String(apiPort));
+  // A stale disk port must never override the source stack's explicit
+  // O8_API_PORT. The decoy catches regressions without touching another app.
+  writeFileSync(join(dataDir, 'api-port'), String(decoyPort));
   writeFileSync(join(dataDir, 'ws-port'), String(wsPort));
+  decoyServer = createServer((request, response) => {
+    decoyRequests.push(request.url ?? '');
+    response.writeHead(401, { 'Content-Type': 'application/json' });
+    response.end(JSON.stringify({ error: 'wrong source API port' }));
+  });
+  decoyServer.listen(decoyPort, '127.0.0.1');
+  await once(decoyServer, 'listening');
   apiServer = createServer(async (request, response) => {
     const url = new URL(request.url ?? '/', `http://127.0.0.1:${apiPort}`);
     requests.push({ path: url.pathname, fresh: url.searchParams.get('fresh') === '1' });
@@ -102,7 +116,13 @@ beforeAll(async () => {
     } else if (url.pathname === '/api/setup/identity') {
       response.end(JSON.stringify({ configured: false }));
     } else if (url.pathname === '/api/broadcast/commentary') {
-      response.end(JSON.stringify({ commentary: [], cursor: null, hasMore: false }));
+      commentaryAuthorizations.push(request.headers.authorization ?? '');
+      if (request.headers.authorization !== `Bearer ${token}`) {
+        response.statusCode = 401;
+        response.end(JSON.stringify({ error: 'missing operator bearer' }));
+      } else {
+        response.end(JSON.stringify({ commentary: [], cursor: null, hasMore: false }));
+      }
     } else if (url.pathname === '/api/orchestrator/headless-tick') {
       response.end(JSON.stringify({ ok: true }));
     } else {
@@ -112,16 +132,18 @@ beforeAll(async () => {
   });
   apiServer.listen(apiPort, '127.0.0.1');
   await once(apiServer, 'listening');
+  const childEnv: NodeJS.ProcessEnv = {
+    ...process.env, O8_DATA_DIR: dataDir, CORTEX_IDE_DATA_DIR: dataDir,
+    O8_REVIEW_TEST_DIR: root, CORTEX_IDE_REVIEW_REPO_ROOT: reviewRoot,
+    O8_API_PORT: String(apiPort), O8_WS_PORT: String(wsPort),
+  };
+  delete childEnv.NEXT_ORIGIN;
   wsProcess = execFile(process.execPath, [
     '--require=./tests/helpers/review-idle-preload.cjs',
     '--import=./scripts/register-server-only-stub.mjs', '--import=tsx', 'src/ws-server.ts',
   ], {
     cwd: process.cwd(),
-    env: {
-      ...process.env, O8_DATA_DIR: dataDir, CORTEX_IDE_DATA_DIR: dataDir,
-      O8_REVIEW_TEST_DIR: root, CORTEX_IDE_REVIEW_REPO_ROOT: reviewRoot,
-      O8_API_PORT: String(apiPort), O8_WS_PORT: String(wsPort), NEXT_ORIGIN: `http://127.0.0.1:${apiPort}`,
-    },
+    env: childEnv,
   });
   wsProcess.stdout?.on('data', (chunk) => { output = `${output}${chunk}`.slice(-16_000); });
   wsProcess.stderr?.on('data', (chunk) => { output = `${output}${chunk}`.slice(-16_000); });
@@ -150,10 +172,21 @@ afterAll(async () => {
     apiServer.closeAllConnections();
     await new Promise<void>((resolve) => apiServer.close(() => resolve()));
   }
+  if (decoyServer?.listening) {
+    decoyServer.closeAllConnections();
+    await new Promise<void>((resolve) => decoyServer.close(() => resolve()));
+  }
   rmSync(root, { recursive: true, force: true });
 });
 
 describe('review refresh through the real WebSocket server', () => {
+  it('authenticates speaker polling against the explicit source API port', async () => {
+    await waitFor(() => commentaryAuthorizations.length > 0, 'authenticated commentary poll');
+    expect(commentaryAuthorizations.every((authorization) => authorization === `Bearer ${token}`)).toBe(true);
+    expect(decoyRequests.some((path) => path.startsWith('/api/broadcast/commentary'))).toBe(false);
+    expect(output).not.toContain('[broadcast-speaker]');
+  });
+
   it('keeps ordinary-folder timer scans free of diff shells and runtime rediscovery', async () => {
     // The review root has no Git watcher. Its periodic safety scan still runs.
     const before = freshReads();


### PR DESCRIPTION
## Mechanic

- Route broadcast commentary polling through the source server's authenticated Next transport, honoring the explicit `O8_API_PORT`.
- Collapse a continuous polling outage to one warning until a successful speaker tick.
- Exercise the spawned WebSocket server with a stale-port decoy and capture the bearer received by the real commentary endpoint.

## Verification

- Red: `authenticates speaker polling against the explicit source API port` timed out while the pre-fix process emitted 11 repeated 401 warnings.
- Green: `npx vitest run tests/broadcast-speaker-real-path.test.ts tests/review-idle-real-path.test.ts` — 2 files, 15 tests passed.
- `npx tsc --noEmit`, touched ESLint, changed-line rule check, and `npm run test:classify` passed.
- `npm test` — 715 files passed, 3 skipped, 2 unrelated failures; 4,478 tests passed, 4 skipped, 2 unrelated failures. The untouched CLI-policy timeout passed in isolation; the untouched stop-state race passed on current `origin/main` after reproducing intermittently.

Fixes #2240

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe