### PR TITLE
fix: fail source folder selection promptly

### DIFF
--- a/src/components/desktop/onboarding/OnboardingReposStep.test.ts
+++ b/src/components/desktop/onboarding/OnboardingReposStep.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OnboardingReposStep } from './OnboardingReposStep';
+import type { OnboardingRequest } from './request';
+
+const ACT_ENV = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+ACT_ENV.IS_REACT_ACT_ENVIRONMENT = true;
+
+function findButton(container: HTMLElement, label: string): HTMLButtonElement | null {
+  return Array.from(container.querySelectorAll('button'))
+    .find((candidate) => candidate.textContent === label) ?? null;
+}
+
+describe('OnboardingReposStep source folder picker', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Reflect.deleteProperty(window, '__TAURI_INTERNALS__');
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('fails promptly without browsing when source web cannot open a native picker', async () => {
+    const request = vi.fn<OnboardingRequest>(async (input) => {
+      if (String(input) === '/api/panel/github-status') {
+        return Response.json({ authenticated: false });
+      }
+      return new Promise<Response>(() => undefined);
+    });
+
+    await act(async () => {
+      root.render(createElement(OnboardingReposStep, {
+        request,
+        deviceFlowEnabled: false,
+        githubFlow: { stage: 'idle' },
+        onConnectGithub: vi.fn(),
+        onSkip: vi.fn(),
+        onContinue: vi.fn(),
+        renderContinueButton: ({ label, onClick, disabled }) => createElement('button', {
+          type: 'button',
+          onClick,
+          disabled,
+        }, label),
+      }));
+      await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
+    });
+
+    const chooseButton = findButton(container, 'Choose a folder on this Mac');
+    expect(chooseButton).not.toBeNull();
+    const startedAt = performance.now();
+    act(() => chooseButton!.click());
+
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
+    expect(container.textContent).toContain('The native o8 shell is required');
+    expect(container.textContent).toContain('npm run build:cli');
+    expect(container.textContent).toContain('node cli/dist/o8.mjs repo add /absolute/path');
+    expect(chooseButton?.disabled).toBe(false);
+    expect(request.mock.calls.some(([input]) => String(input) === '/api/panel/browse-folder')).toBe(false);
+  });
+});

--- a/src/components/desktop/onboarding/OnboardingReposStep.tsx
+++ b/src/components/desktop/onboarding/OnboardingReposStep.tsx
@@ -20,9 +20,11 @@
 
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { requestPrompt } from '@/components/shared/ConfirmToastHost';
+import { isTauri } from '@/lib/tauri/bridge';
 import type { OnboardingRequest } from './request';
 
 const FONT = 'var(--font-sans-system)';
+const SOURCE_WEB_FOLDER_ERROR = 'The native o8 shell is required to choose a folder. From this source checkout, run `npm run build:cli` then `node cli/dist/o8.mjs repo add /absolute/path`.';
 
 // ── GitHub device flow state (owned by the parent, passed down read-only) ──
 export interface DeviceFlowState {
@@ -192,6 +194,11 @@ export function OnboardingReposStep({
 
   const handleAddFolder = useCallback(async () => {
     if (addingFolder) return;
+    if (!pickFolder && !isTauri()) {
+      setErrorKind('action');
+      setReposError(SOURCE_WEB_FOLDER_ERROR);
+      return;
+    }
     setAddingFolder(true);
     try {
       const folderPath = await (pickFolder ? pickFolder() : pickFolderPath(request));


### PR DESCRIPTION
## Mechanic
The onboarding folder action now identifies source-web mode before entering the native picker chain. It reports the supported source workflow immediately instead of waiting on the server-side folder route.

## What changed
- Guarded the folder action when the Tauri shell is absent and no picker is injected.
- Displayed the native-shell requirement with the exact npm run build:cli and node cli/dist/o8.mjs repo add /absolute/path sequence.
- Kept the folder button enabled and prevented POST /api/panel/browse-folder in source-web mode.
- Preserved the existing Tauri and injected-picker flows.

## Verification
- src/components/desktop/onboarding/OnboardingReposStep.test.ts: the real button reports the source command promptly, stays enabled, and never calls the hanging browse route.
- npx tsc --noEmit: passed.
- Focused Vitest: 1 file, 1 test passed.
- npm test: 718 files passed, 3 skipped; 4,488 tests passed, 4 skipped.

Fixes #2235

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe