### PR TITLE
fix: pin paired coding benchmark runtime settings

### DIFF
--- a/scripts/bench/coding-judge-runner.ts
+++ b/scripts/bench/coding-judge-runner.ts
@@ -29,6 +29,7 @@ export interface CodingJudgeReceipt {
   promptPath: string;
   outputPath: string;
   replyPath: string;
+  spawn: CodingJudgeCommandReceipt;
   command: CodingJudgeCommandReceipt;
   valid: boolean;
   invalidReason: string | null;
@@ -173,6 +174,7 @@ export function runCodingJudge(input: {
       promptPath,
       outputPath,
       replyPath,
+      spawn: spawn.receipt,
       command: send.receipt,
       valid: invalidReason === null,
       invalidReason,

--- a/scripts/bench/coding-judge-runner.ts
+++ b/scripts/bench/coding-judge-runner.ts
@@ -10,6 +10,7 @@ import {
   type CodingVerdict,
 } from './coding';
 import { JUDGE_PROMPT } from './coding-prompts';
+import type { CodingRequestedSettings } from './coding-runtime-config';
 
 export interface CodingJudgeCommandReceipt {
   command: string;
@@ -24,6 +25,7 @@ export interface CodingJudgeCommandReceipt {
 export interface CodingJudgeReceipt {
   task: number;
   judge: CodingJudge;
+  requestedSettings: CodingRequestedSettings;
   promptPath: string;
   outputPath: string;
   replyPath: string;
@@ -103,6 +105,7 @@ export function runCodingJudge(input: {
   repoRoot: string;
   workRoot: string;
   timeoutSeconds: number;
+  requestedSettings: CodingRequestedSettings;
   runCommand: RunCommand;
 }): { verdicts: CodingVerdict[]; receipt: CodingJudgeReceipt } {
   const artifactDir = path.join(input.workRoot, 'artifacts');
@@ -119,7 +122,11 @@ export function runCodingJudge(input: {
   if (fs.existsSync(outputPath)) fs.unlinkSync(outputPath);
 
   const worker = `bjudge${input.task.issue}${input.judge}`;
-  const spawn = input.runCommand('ginsu', ['spawn', worker, input.baseDir, '--engine', input.judge], {
+  const spawn = input.runCommand('ginsu', [
+    'spawn', worker, input.baseDir, '--engine', input.judge,
+    '--model', input.requestedSettings.model,
+    '--effort', input.requestedSettings.effort,
+  ], {
     cwd: input.repoRoot,
   });
   let send = { receipt: spawn.receipt, stdout: '', stderr: spawn.stderr };
@@ -162,6 +169,7 @@ export function runCodingJudge(input: {
     receipt: {
       task: input.task.issue,
       judge: input.judge,
+      requestedSettings: input.requestedSettings,
       promptPath,
       outputPath,
       replyPath,

--- a/scripts/bench/coding-runtime-config.ts
+++ b/scripts/bench/coding-runtime-config.ts
@@ -1,0 +1,114 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { isManualThinkingEffort, type ManualThinkingEffort } from '../../src/lib/orchestrator/thinking-effort';
+import { CODING_JUDGES, CODING_RUNTIMES, type CodingJudge, type CodingRuntime } from './coding';
+
+export const CODING_RUNTIME_CONFIG_ENV = 'O8_BENCH_RUNTIME_CONFIG';
+
+export interface CodingRequestedSettings {
+  model: string;
+  effort: ManualThinkingEffort;
+}
+
+export interface CodingRuntimeConfig {
+  schema: 'o8/coding-runtime-config/v1';
+  arms: Record<CodingRuntime, CodingRequestedSettings>;
+  judges: Record<CodingJudge, CodingRequestedSettings>;
+}
+
+function objectRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function assertExactKeys(record: Record<string, unknown>, keys: string[], label: string): void {
+  const actual = Object.keys(record).sort();
+  const expected = [...keys].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${label} must contain exactly: ${expected.join(', ')}`);
+  }
+}
+
+function requestedSettings(value: unknown, label: string): CodingRequestedSettings {
+  const record = objectRecord(value, label);
+  assertExactKeys(record, ['model', 'effort'], label);
+  const model = typeof record.model === 'string' ? record.model.trim() : '';
+  if (!/^[a-z0-9][a-z0-9._:/@+-]{0,127}$/i.test(model)) {
+    throw new Error(`${label}.model must be a non-empty launcher model id`);
+  }
+  if (!isManualThinkingEffort(record.effort)) {
+    throw new Error(`${label}.effort must be one of low, medium, high, max, xhigh, or ultra`);
+  }
+  return { model, effort: record.effort };
+}
+
+function settingsMap<T extends CodingRuntime | CodingJudge>(
+  value: unknown,
+  keys: T[],
+  label: string,
+): Record<T, CodingRequestedSettings> {
+  const record = objectRecord(value, label);
+  assertExactKeys(record, keys, label);
+  return Object.fromEntries(keys.map((key) => [
+    key,
+    requestedSettings(record[key], `${label}.${key}`),
+  ])) as Record<T, CodingRequestedSettings>;
+}
+
+export function parseCodingRuntimeConfig(value: unknown): CodingRuntimeConfig {
+  const record = objectRecord(value, 'coding runtime config');
+  assertExactKeys(record, ['schema', 'arms', 'judges'], 'coding runtime config');
+  if (record.schema !== 'o8/coding-runtime-config/v1') {
+    throw new Error('coding runtime config schema must be o8/coding-runtime-config/v1');
+  }
+  return {
+    schema: record.schema,
+    arms: settingsMap(record.arms, CODING_RUNTIMES, 'coding runtime config.arms'),
+    judges: settingsMap(record.judges, CODING_JUDGES, 'coding runtime config.judges'),
+  };
+}
+
+export function readCodingRuntimeConfig(
+  repoRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+): CodingRuntimeConfig {
+  const configuredPath = env[CODING_RUNTIME_CONFIG_ENV]?.trim();
+  if (!configuredPath) {
+    throw new Error(`${CODING_RUNTIME_CONFIG_ENV} must point to a coding runtime JSON config`);
+  }
+  const configPath = path.isAbsolute(configuredPath)
+    ? configuredPath
+    : path.resolve(repoRoot, configuredPath);
+  let raw: string;
+  try {
+    if (!fs.statSync(configPath).isFile()) throw new Error('not a regular file');
+    raw = fs.readFileSync(configPath, 'utf8');
+  } catch {
+    throw new Error(`${CODING_RUNTIME_CONFIG_ENV} could not read the configured JSON file`);
+  }
+  if (Buffer.byteLength(raw, 'utf8') > 64 * 1024) {
+    throw new Error('coding runtime config exceeds 64 KiB');
+  }
+  try {
+    return parseCodingRuntimeConfig(JSON.parse(raw));
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`invalid coding runtime config: ${detail}`);
+  }
+}
+
+export function assertMatchingCodingRuntimeConfig(
+  recorded: unknown,
+  requested: CodingRuntimeConfig,
+): void {
+  if (recorded === undefined) {
+    throw new Error('collection receipt predates requested runtime settings and cannot start new judging workers');
+  }
+  const parsed = parseCodingRuntimeConfig(recorded);
+  if (JSON.stringify(parsed) !== JSON.stringify(requested)) {
+    throw new Error('coding runtime config does not match the immutable collection receipt');
+  }
+}

--- a/scripts/bench/run-coding.ts
+++ b/scripts/bench/run-coding.ts
@@ -59,6 +59,12 @@ import {
 import { createAbortedEndToEndCollection } from './coding-end-to-end-receipt';
 import { o8CliPreflightSummary } from './coding-o8-cli';
 import { runCodingJudge, type CodingJudgeReceipt } from './coding-judge-runner';
+import {
+  assertMatchingCodingRuntimeConfig,
+  readCodingRuntimeConfig,
+  type CodingRequestedSettings,
+  type CodingRuntimeConfig,
+} from './coding-runtime-config';
 import { RAW_BRIEF } from './coding-prompts';
 import {
   abortedRunControl,
@@ -84,7 +90,7 @@ if (!/^[a-z0-9][a-z0-9._-]{0,63}$/i.test(RUN_ID)) {
   throw new Error('O8_BENCH_RUN_ID must contain only letters, numbers, dot, underscore, and hyphen');
 }
 const WORK_ROOT = path.join(os.tmpdir(), 'o8-bench-coding', RUN_ID);
-const LATEST_DIR = path.join(REPO_ROOT, 'tests/bench/latest');
+const LATEST_DIR = path.resolve(process.env.O8_BENCH_LATEST_DIR ?? path.join(REPO_ROOT, 'tests/bench/latest'));
 const COLLECTION_FILE = path.join(WORK_ROOT, 'collection.json');
 const JUDGING_FILE = path.join(WORK_ROOT, 'judging.json');
 const ARM_TIMEOUT_SECONDS = 2_400;
@@ -119,6 +125,7 @@ interface ArmReceipt extends ArmClassification {
   task: number;
   condition: CodingCondition;
   runtime: CodingRuntime;
+  requestedSettings: CodingRequestedSettings;
   treatment: 'raw' | 'contract';
   base: string;
   worktree: string;
@@ -147,6 +154,7 @@ interface CollectionReceipt {
   seed: number;
   armTimeoutSeconds: number;
   conditions: CodingCondition[];
+  requestedSettings?: CodingRuntimeConfig;
   arms: ArmReceipt[];
   outcomeTotals: ArmOutcomeTotals;
   endToEnd: EndToEndCollectionReceipt;
@@ -341,7 +349,8 @@ function emptyCommand(command: string): CommandReceipt {
   };
 }
 
-function runArm(task: CodingTask, condition: CodingCondition, issue: string): ArmReceipt {
+function runArm(task: CodingTask, condition: CodingCondition, issue: string,
+  requestedSettings: CodingRequestedSettings): ArmReceipt {
   const runtime = runtimeForCondition(condition);
   const treatment = treatmentForCondition(condition);
   const dir = prepareArmWorktree(task, condition);
@@ -354,7 +363,10 @@ function runArm(task: CodingTask, condition: CodingCondition, issue: string): Ar
   fs.writeFileSync(promptPath, prompt);
 
   const worker = `bc${task.issue}${condition.replace(/[^a-z]/g, '')}`;
-  const spawn = runCommand('ginsu', ['spawn', worker, dir, '--engine', runtime], { cwd: REPO_ROOT });
+  const spawn = runCommand('ginsu', [
+    'spawn', worker, dir, '--engine', runtime,
+    '--model', requestedSettings.model, '--effort', requestedSettings.effort,
+  ], { cwd: REPO_ROOT });
   let send = { receipt: emptyCommand('ginsu send'), stdout: '', stderr: '' };
   let stop = { receipt: emptyCommand('ginsu stop'), stdout: '', stderr: '' };
   if (spawn.receipt.status === 0) {
@@ -401,6 +413,7 @@ function runArm(task: CodingTask, condition: CodingCondition, issue: string): Ar
     task: task.issue,
     condition,
     runtime,
+    requestedSettings,
     treatment,
     base: task.base,
     worktree: dir,
@@ -433,6 +446,7 @@ function collectionSeed(): number {
 async function collectWhileApprovalHeld(
   tasks: CodingTask[],
   endToEndTasks: EndToEndTask[],
+  requestedSettings: CodingRuntimeConfig,
 ): Promise<CollectionReceipt> {
   const endToEnd = createEndToEndCollection(REPO_ROOT, RUN_ID, endToEndTasks);
   fs.mkdirSync(WORK_ROOT, { recursive: true });
@@ -445,6 +459,7 @@ async function collectWhileApprovalHeld(
     seed,
     armTimeoutSeconds: ARM_TIMEOUT_SECONDS,
     conditions: [...CODING_CONDITIONS],
+    requestedSettings,
     arms: [],
     outcomeTotals: countArmOutcomes([]),
     endToEnd,
@@ -467,7 +482,7 @@ async function collectWhileApprovalHeld(
         fs.writeFileSync(path.join(WORK_ROOT, 'artifacts', `issue-${task.issue}.md`), issue);
       }
       console.log(`[coding] collecting ${condition} on #${task.issue}`);
-      return runArm(task, condition, issue);
+      return runArm(task, condition, issue, requestedSettings.arms[runtimeForCondition(condition)]);
     },
     commitArm: (receipt) => {
       collection.arms.push(receipt);
@@ -512,11 +527,14 @@ async function collectWhileApprovalHeld(
 
 async function collect(
   tasks: CodingTask[],
+  requestedSettings: CodingRuntimeConfig,
   endToEndTasks = readEndToEndTasks(REPO_ROOT),
 ): Promise<CollectionReceipt> {
   assertUnusedCodingRunId(WORK_ROOT, RUN_ID);
   try {
-    return await withTemporaryRequireApproval(() => collectWhileApprovalHeld(tasks, endToEndTasks));
+    return await withTemporaryRequireApproval(() => (
+      collectWhileApprovalHeld(tasks, endToEndTasks, requestedSettings)
+    ));
   } catch (error) {
     if (error instanceof O8BackendAbortError && !fs.existsSync(COLLECTION_FILE)) {
       const endToEnd = createAbortedEndToEndCollection(REPO_ROOT, RUN_ID, endToEndTasks, error);
@@ -527,6 +545,7 @@ async function collect(
         seed: collectionSeed(),
         armTimeoutSeconds: ARM_TIMEOUT_SECONDS,
         conditions: [...CODING_CONDITIONS],
+        requestedSettings,
         arms: [],
         outcomeTotals: countArmOutcomes([]),
         endToEnd,
@@ -557,7 +576,9 @@ function readCollection(): CollectionReceipt {
   return parsed;
 }
 
-function judge(tasks: CodingTask[], collection: CollectionReceipt): void {
+function judge(tasks: CodingTask[], collection: CollectionReceipt,
+  requestedSettings: CodingRuntimeConfig): void {
+  assertMatchingCodingRuntimeConfig(collection.requestedSettings, requestedSettings);
   if (fs.existsSync(JUDGING_FILE)) {
     throw new Error(
       `benchmark run ${RUN_ID} already has judging receipts; use a new run ID rather than replacing verdicts`,
@@ -572,6 +593,7 @@ function judge(tasks: CodingTask[], collection: CollectionReceipt): void {
     schema: 'o8/coding-judging/v2',
     runId: RUN_ID,
     startedAt: judgingStartedAt,
+    requestedSettings: requestedSettings.judges,
     receipts: judgeReceipts,
     blindVerdicts: verdicts,
   });
@@ -615,6 +637,7 @@ function judge(tasks: CodingTask[], collection: CollectionReceipt): void {
         repoRoot: REPO_ROOT,
         workRoot: WORK_ROOT,
         timeoutSeconds: JUDGE_TIMEOUT_SECONDS,
+        requestedSettings: requestedSettings.judges[judgeRuntime],
         runCommand,
       });
       verdicts.push(...result.verdicts);
@@ -623,6 +646,7 @@ function judge(tasks: CodingTask[], collection: CollectionReceipt): void {
         schema: 'o8/coding-judging/v2',
         runId: RUN_ID,
         startedAt: judgingStartedAt,
+        requestedSettings: requestedSettings.judges,
         receipts: judgeReceipts,
         blindVerdicts: verdicts,
       });
@@ -663,6 +687,7 @@ function judge(tasks: CodingTask[], collection: CollectionReceipt): void {
     schema: 'o8/coding-judging/v2',
     runId: RUN_ID,
     startedAt: judgingStartedAt,
+    requestedSettings: requestedSettings.judges,
     completedAt: new Date().toISOString(),
     receipts: judgeReceipts,
     blindVerdicts: verdicts,
@@ -748,6 +773,7 @@ async function main(): Promise<void> {
       'use --preflight --e2e to check the standalone experiment without collecting',
     );
   }
+  const requestedSettings = readCodingRuntimeConfig(REPO_ROOT);
   const tasks = readTasks();
   const endToEndTasks = readEndToEndTasks(REPO_ROOT);
   if (args.has('--preflight')) {
@@ -755,15 +781,15 @@ async function main(): Promise<void> {
     return;
   }
   if (args.has('--collect')) {
-    await collect(tasks, endToEndTasks);
+    await collect(tasks, requestedSettings, endToEndTasks);
     return;
   }
   if (args.has('--judge')) {
-    judge(tasks, readCollection());
+    judge(tasks, readCollection(), requestedSettings);
     return;
   }
-  const collection = await collect(tasks, endToEndTasks);
-  judge(tasks, collection);
+  const collection = await collect(tasks, requestedSettings, endToEndTasks);
+  judge(tasks, collection, requestedSettings);
 }
 
 void main();

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -160,17 +160,42 @@ approves a card or invokes merge preview.
 Preflight without launching workers:
 
 ```sh
-npm run bench:coding
+O8_BENCH_RUNTIME_CONFIG=/path/to/runtime-config.json npm run bench:coding
 ```
 
 Collection and judging are separate so the paid phase is explicit and its raw
 artifacts remain inspectable between phases:
 
 ```sh
-npm run bench:coding:collect
-npm run bench:coding:judge
+O8_BENCH_RUNTIME_CONFIG=/path/to/runtime-config.json npm run bench:coding:collect
+O8_BENCH_RUNTIME_CONFIG=/path/to/runtime-config.json npm run bench:coding:judge
 npm run bench:score
 ```
+
+The operator-supplied JSON file is required for paired preflight, collection,
+judging, and `bench:coding:all`. It declares requested launcher settings without
+embedding model names in the repository:
+
+```json
+{
+  "schema": "o8/coding-runtime-config/v1",
+  "arms": {
+    "codex": { "model": "operator-selected-codex-arm", "effort": "high" },
+    "claude": { "model": "operator-selected-claude-arm", "effort": "high" }
+  },
+  "judges": {
+    "codex": { "model": "operator-selected-codex-judge", "effort": "high" },
+    "claude": { "model": "operator-selected-claude-judge", "effort": "high" }
+  }
+}
+```
+
+Each runtime can use a different model or effort, but its raw and contract arms
+always receive the same declared pair. The collection receipt snapshots all
+requested settings before an arm starts. The judging receipt snapshots judge
+settings before a judge starts and rejects a config that differs from the
+collection snapshot. These are requested-setting receipts, not proof of the
+effective backend model or usage.
 
 The default run ID is `contract-v1`. Set `O8_BENCH_RUN_ID` before both commands
 for later repetitions. Collection refuses to overwrite an existing run ID, so a
@@ -193,6 +218,7 @@ O8_BENCH_RUN_ID=<fresh-id> npm run bench:coding:e2e:judge
 Standalone judging writes `tests/bench/latest/coding-end-to-end.json`, including
 cost receipts, every invalid arm and its reasons, the three-attempt review bound,
 and all recorded review findings. Collection and judging receipts under the run
-directory remain immutable.
+directory remain immutable. The standalone shipped-output experiment retains its
+versioned v1 launcher behavior and does not read the paired runtime config.
 
 If governance is absent for a release, the scorecard records it as `automated — not run this release`. If coding is absent, the scorecard records it as `operator-triggered — not run this release`.

--- a/tests/bench/coding-runtime-config-real-path.test.ts
+++ b/tests/bench/coding-runtime-config-real-path.test.ts
@@ -1,0 +1,234 @@
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+const tsxCli = path.join(repoRoot, 'node_modules/tsx/dist/cli.mjs');
+
+const runtimeConfig = {
+  schema: 'o8/coding-runtime-config/v1',
+  arms: {
+    codex: { model: 'test/codex-arm', effort: 'high' },
+    claude: { model: 'test/claude-arm', effort: 'max' },
+  },
+  judges: {
+    codex: { model: 'test/codex-judge', effort: 'medium' },
+    claude: { model: 'test/claude-judge', effort: 'high' },
+  },
+};
+
+function writeExecutable(filePath: string, source: string): void {
+  fs.writeFileSync(filePath, source);
+  fs.chmodSync(filePath, 0o755);
+}
+
+function installFakeCommands(root: string): { binDir: string; launcherLog: string; o8Cli: string } {
+  const binDir = path.join(root, 'bin');
+  const launcherLog = path.join(root, 'launcher.jsonl');
+  fs.mkdirSync(binDir, { recursive: true });
+  writeExecutable(path.join(binDir, 'git'), `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') process.stdout.write(process.cwd() + '\\n');
+else if (args[0] === 'rev-parse') process.stdout.write('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\n');
+else if (args[0] === 'branch') process.stdout.write('main\\n');
+else if (args[0] === 'worktree' && args[1] === 'add') fs.mkdirSync(args[4], { recursive: true });
+else if (args[0] === 'worktree' && args[1] === 'remove') fs.rmSync(args[3], { recursive: true, force: true });
+else if (args[0] === 'diff' && args.includes('--name-only')) process.stdout.write('src/example.ts\\n');
+else if (args[0] === 'diff' && args.includes('--numstat')) process.stdout.write('1\\t0\\tsrc/example.ts\\n');
+else if (args[0] === 'diff' && args.includes('--binary')) process.stdout.write('diff --git a/src/example.ts b/src/example.ts\\n');
+`);
+  writeExecutable(path.join(binDir, 'gh'), `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === 'repo') process.stdout.write('example/repo\\n');
+else if (args[0] === 'api') {
+  const issue = Number(args[1].split('/').at(-1));
+  process.stdout.write(JSON.stringify({ number: issue, state: 'open', title: 'Fixture issue', body: 'Fixture body' }));
+}
+`);
+  writeExecutable(path.join(binDir, 'ginsu'), `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.FAKE_LAUNCHER_LOG, JSON.stringify(args) + '\\n');
+if (args[0] === 'send') process.stdout.write('fixture worker reply\\n');
+`);
+  writeExecutable(path.join(binDir, 'npx'), '#!/bin/sh\nexit 0\n');
+  const o8Cli = path.join(binDir, 'o8-fixture');
+  writeExecutable(o8Cli, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args.includes('--help')) process.stdout.write('--existingBranchPolicy\\n');
+else process.exit(1);
+`);
+  return { binDir, launcherLog, o8Cli };
+}
+
+async function startFakeBackend(root: string): Promise<{ port: number; stop: () => void }> {
+  const serverPath = path.join(root, 'backend.cjs');
+  fs.writeFileSync(serverPath, `
+const http = require('node:http');
+let requireApproval = 'always';
+const server = http.createServer((request, response) => {
+  response.setHeader('content-type', 'application/json');
+  if (request.url === '/api/panel/status') response.end(JSON.stringify({ product: 'o8' }));
+  else if (request.url === '/api/panel/operator-defaults' && request.method === 'GET') {
+    response.end(JSON.stringify({ values: { requireApproval } }));
+  } else if (request.url === '/api/panel/operator-defaults' && request.method === 'POST') {
+    let body = '';
+    request.on('data', (chunk) => { body += chunk; });
+    request.on('end', () => {
+      requireApproval = JSON.parse(body).requireApproval;
+      response.end(JSON.stringify({ values: { requireApproval } }));
+    });
+  } else { response.statusCode = 404; response.end('{}'); }
+});
+server.listen(0, '127.0.0.1', () => process.stdout.write(String(server.address().port) + '\\n'));
+`);
+  const child = spawn(process.execPath, [serverPath], { stdio: ['ignore', 'pipe', 'pipe'] });
+  const port = await new Promise<number>((resolve, reject) => {
+    child.once('error', reject);
+    child.stdout.once('data', (data) => resolve(Number(String(data).trim())));
+  });
+  return { port, stop: () => child.kill('SIGTERM') };
+}
+
+function runBenchmark(args: string[], env: NodeJS.ProcessEnv) {
+  return spawnSync(process.execPath, [tsxCli, 'scripts/bench/run-coding.ts', ...args], {
+    cwd: repoRoot,
+    env: {
+      ...env,
+      NODE_OPTIONS: `--import=${path.join(repoRoot, 'scripts/register-server-only-stub.mjs')}`,
+    },
+    encoding: 'utf8',
+    timeout: 120_000,
+  });
+}
+
+describe('coding benchmark runtime configuration through the process entry point', () => {
+  it('rejects missing and malformed configuration before inspecting the launcher', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'o8-coding-runtime-missing-'));
+    const { binDir, launcherLog, o8Cli } = installFakeCommands(root);
+    try {
+      const env = {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+        FAKE_LAUNCHER_LOG: launcherLog,
+        O8_BENCH_O8_CLI: o8Cli,
+        O8_BENCH_REPO: 'example/repo',
+        CORTEX_IDE_DATA_DIR: path.join(root, 'data'),
+      };
+      const missing = runBenchmark(['--preflight'], env);
+      expect(missing.status).not.toBe(0);
+      expect(missing.stderr).toContain('O8_BENCH_RUNTIME_CONFIG');
+
+      const malformedPath = path.join(root, 'malformed.json');
+      fs.writeFileSync(malformedPath, '{"schema":');
+      const malformed = runBenchmark(['--preflight'], {
+        ...env,
+        O8_BENCH_RUNTIME_CONFIG: malformedPath,
+      });
+      expect(malformed.status).not.toBe(0);
+      expect(malformed.stderr).toContain('invalid coding runtime config');
+      expect(fs.existsSync(launcherLog)).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('passes pinned arm settings through collection and persists requested-setting receipts', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'o8-coding-runtime-real-path-'));
+    const runId = `runtime-config-${process.pid}-${Date.now()}`;
+    const runRoot = path.join(os.tmpdir(), 'o8-bench-coding', runId);
+    const configPath = path.join(root, 'runtime-config.json');
+    const dataDir = path.join(root, 'data');
+    const { binDir, launcherLog, o8Cli } = installFakeCommands(root);
+    const backend = await startFakeBackend(root);
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(configPath, `${JSON.stringify(runtimeConfig)}\n`);
+    fs.writeFileSync(path.join(dataDir, 'api-port'), `${backend.port}\n`);
+    fs.writeFileSync(path.join(dataDir, 'ws-token'), 'fixture-token\n');
+    fs.writeFileSync(path.join(dataDir, 'operator-defaults.json'), '{"requireApproval":"always"}\n');
+    try {
+      const result = runBenchmark(['--collect'], {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+        FAKE_LAUNCHER_LOG: launcherLog,
+        O8_BENCH_RUNTIME_CONFIG: configPath,
+        O8_BENCH_RUN_ID: runId,
+        O8_BENCH_O8_CLI: o8Cli,
+        O8_BENCH_REPO: 'example/repo',
+        O8_BENCH_LATEST_DIR: path.join(root, 'latest'),
+        CORTEX_IDE_DATA_DIR: dataDir,
+      });
+      expect(result.status, result.stderr).toBe(0);
+
+      const collection = JSON.parse(fs.readFileSync(path.join(runRoot, 'collection.json'), 'utf8')) as {
+        requestedSettings?: typeof runtimeConfig;
+        arms: Array<{
+          runtime: 'codex' | 'claude';
+          requestedSettings?: { model: string; effort: string };
+          spawn: { command: string };
+        }>;
+      };
+      expect(collection.requestedSettings).toEqual(runtimeConfig);
+      expect(collection.arms).toHaveLength(12);
+      for (const arm of collection.arms) {
+        expect(arm.requestedSettings).toEqual(runtimeConfig.arms[arm.runtime]);
+        expect(arm.spawn.command).toContain(`--model ${runtimeConfig.arms[arm.runtime].model}`);
+        expect(arm.spawn.command).toContain(`--effort ${runtimeConfig.arms[arm.runtime].effort}`);
+      }
+      const launches = fs.readFileSync(launcherLog, 'utf8').trim().split('\n')
+        .map((line) => JSON.parse(line) as string[])
+        .filter((args) => args[0] === 'spawn' && args[1]?.startsWith('bc'));
+      expect(launches).toHaveLength(12);
+      for (const args of launches) {
+        const runtime = args[args.indexOf('--engine') + 1] as 'codex' | 'claude';
+        expect(args.slice(args.indexOf('--model'), args.indexOf('--model') + 2))
+          .toEqual(['--model', runtimeConfig.arms[runtime].model]);
+        expect(args.slice(args.indexOf('--effort'), args.indexOf('--effort') + 2))
+          .toEqual(['--effort', runtimeConfig.arms[runtime].effort]);
+      }
+
+      const judgeResult = runBenchmark(['--judge'], {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+        FAKE_LAUNCHER_LOG: launcherLog,
+        O8_BENCH_RUNTIME_CONFIG: configPath,
+        O8_BENCH_RUN_ID: runId,
+        O8_BENCH_REPO: 'example/repo',
+        O8_BENCH_LATEST_DIR: path.join(root, 'latest'),
+        CORTEX_IDE_DATA_DIR: dataDir,
+      });
+      expect(judgeResult.status, judgeResult.stderr).toBe(0);
+      const judging = JSON.parse(fs.readFileSync(path.join(runRoot, 'judging.json'), 'utf8')) as {
+        requestedSettings?: typeof runtimeConfig.judges;
+        receipts: Array<{
+          judge: 'codex' | 'claude';
+          requestedSettings?: { model: string; effort: string };
+        }>;
+      };
+      expect(judging.requestedSettings).toEqual(runtimeConfig.judges);
+      expect(judging.receipts).toHaveLength(6);
+      for (const receipt of judging.receipts) {
+        expect(receipt.requestedSettings).toEqual(runtimeConfig.judges[receipt.judge]);
+      }
+      const judgeLaunches = fs.readFileSync(launcherLog, 'utf8').trim().split('\n')
+        .map((line) => JSON.parse(line) as string[])
+        .filter((args) => args[0] === 'spawn' && args[1]?.startsWith('bjudge'));
+      expect(judgeLaunches).toHaveLength(6);
+      for (const args of judgeLaunches) {
+        const judge = args[args.indexOf('--engine') + 1] as 'codex' | 'claude';
+        expect(args.slice(args.indexOf('--model'), args.indexOf('--model') + 2))
+          .toEqual(['--model', runtimeConfig.judges[judge].model]);
+        expect(args.slice(args.indexOf('--effort'), args.indexOf('--effort') + 2))
+          .toEqual(['--effort', runtimeConfig.judges[judge].effort]);
+      }
+    } finally {
+      backend.stop();
+      fs.rmSync(runRoot, { recursive: true, force: true });
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }, 180_000);
+});

--- a/tests/bench/coding-runtime-config-real-path.test.ts
+++ b/tests/bench/coding-runtime-config-real-path.test.ts
@@ -207,12 +207,18 @@ describe('coding benchmark runtime configuration through the process entry point
         receipts: Array<{
           judge: 'codex' | 'claude';
           requestedSettings?: { model: string; effort: string };
+          spawn: { command: string };
         }>;
       };
       expect(judging.requestedSettings).toEqual(runtimeConfig.judges);
       expect(judging.receipts).toHaveLength(6);
       for (const receipt of judging.receipts) {
         expect(receipt.requestedSettings).toEqual(runtimeConfig.judges[receipt.judge]);
+        const spawnArgv = receipt.spawn.command.split(' ');
+        expect(spawnArgv.slice(spawnArgv.indexOf('--model'), spawnArgv.indexOf('--model') + 2))
+          .toEqual(['--model', receipt.requestedSettings?.model]);
+        expect(spawnArgv.slice(spawnArgv.indexOf('--effort'), spawnArgv.indexOf('--effort') + 2))
+          .toEqual(['--effort', receipt.requestedSettings?.effort]);
       }
       const judgeLaunches = fs.readFileSync(launcherLog, 'utf8').trim().split('\n')
         .map((line) => JSON.parse(line) as string[])

--- a/tests/bench/coding-runtime-config.test.ts
+++ b/tests/bench/coding-runtime-config.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertMatchingCodingRuntimeConfig,
+  parseCodingRuntimeConfig,
+} from '../../scripts/bench/coding-runtime-config';
+
+const valid = {
+  schema: 'o8/coding-runtime-config/v1',
+  arms: {
+    codex: { model: 'provider/codex-model', effort: 'high' },
+    claude: { model: 'provider/claude-model', effort: 'max' },
+  },
+  judges: {
+    codex: { model: 'provider/codex-judge', effort: 'medium' },
+    claude: { model: 'provider/claude-judge', effort: 'high' },
+  },
+} as const;
+
+describe('coding runtime config', () => {
+  it('accepts one explicit model and manual effort for every arm runtime and judge', () => {
+    expect(parseCodingRuntimeConfig(valid)).toEqual(valid);
+  });
+
+  it.each([
+    [{ ...valid, arms: { ...valid.arms, codex: { ...valid.arms.codex, effort: 'adaptive' } } }],
+    [{ ...valid, judges: { codex: valid.judges.codex } }],
+    [{ ...valid, arms: { ...valid.arms, codex: { model: '--default', effort: 'high' } } }],
+  ])('rejects incomplete or default-inheriting configuration', (input) => {
+    expect(() => parseCodingRuntimeConfig(input)).toThrow('coding runtime config');
+  });
+
+  it('refuses to judge a legacy or differently configured collection', () => {
+    const parsed = parseCodingRuntimeConfig(valid);
+    expect(() => assertMatchingCodingRuntimeConfig(undefined, parsed)).toThrow('predates requested runtime settings');
+    expect(() => assertMatchingCodingRuntimeConfig({
+      ...valid,
+      judges: { ...valid.judges, codex: { model: 'changed/judge', effort: 'medium' } },
+    }, parsed)).toThrow('does not match');
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -1140,6 +1140,17 @@
       ]
     },
     {
+      "path": "tests/bench/coding-runtime-config-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "executable-fixture",
+        "git-cli",
+        "network-listener",
+        "process-signal",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/bench/coding.test.ts",
       "reasons": [
         "worktree-api"


### PR DESCRIPTION
## Mechanic

Paired coding arms and blind judges inherited mutable launcher defaults. Two runs could request different models or reasoning settings without recording that difference, weakening the comparison.

## What changed

Require an explicit, validated configuration for each runtime and judge before a new paired collection or judging phase. Pass the same requested model and effort to each runtime's raw and treatment arms. Persist those requested settings plus arm and judge spawn receipts. Reject missing or changed configuration before launching workers; preserve read access to historical receipts.

These receipts establish the requested configuration. They do not claim to identify the provider's effective internal model or measure actual usage.

## Verification

- Red: the process-entry test demonstrated that the old collector exited successfully with no runtime configuration.
- Green: `tests/bench/coding-runtime-config-real-path.test.ts` and `tests/bench/coding-runtime-config.test.ts`, 7 tests, including all 18 pinned launches, persisted judge spawn arguments, and fail-before-launch cases.
- TypeScript, touched-file ESLint, rule-check, classification, and diff checks passed.
- Full local suite at the implementation commit: 718 files and 4,492 tests passed, 4 tests skipped. The subsequent judge-spawn receipt change passed the focused tests and TypeScript; final combined branch is subject to CI.
- No live coding benchmark was collected, and no new quality score is claimed.

Fixes #2251
