### PR TITLE
fix: retain merge evidence before worktree cleanup

### DIFF
--- a/src/lib/lane/lane-diff-facts.ts
+++ b/src/lib/lane/lane-diff-facts.ts
@@ -318,7 +318,17 @@ export function getLaneDiffFacts(
     throw new Error('Lane has no repository path for diff facts.');
   }
 
-  const baseRange = `${comparisonRef || lane.baseBranch}...HEAD`;
+  let baseRef = comparisonRef || lane.baseBranch;
+  if (!comparisonRef && !baseRef.startsWith('refs/')) {
+    const localRef = `refs/heads/${baseRef}`;
+    try {
+      readGitOutput(cwd, ['show-ref', '--verify', '--quiet', localRef]);
+      baseRef = localRef;
+    } catch {
+      baseRef = `refs/remotes/origin/${baseRef}`;
+    }
+  }
+  const baseRange = `${baseRef}...HEAD`;
   const stat = readGitOutputWithFallback(
     cwd,
     ['diff', '--stat', baseRange],

--- a/src/lib/lane/worktree-cleanup.ts
+++ b/src/lib/lane/worktree-cleanup.ts
@@ -4,6 +4,7 @@ import { removeCortexWorktreePath } from './worktree-clone-removal';
 import { checkPruneGate } from './prune-gate';
 import type { Lane } from './types';
 import { releaseTerminalPacketStorageReservations } from '@/lib/orchestrator/terminal-storage-release';
+import { worktreeIsConfirmedAbsent } from './lane-storage-release';
 
 type CleanupLane = Pick<Lane, 'id' | 'repoPath' | 'worktreePath'>
   & Partial<Pick<Lane, 'baseBranch' | 'packetId'>>
@@ -63,6 +64,12 @@ export async function cleanupLaneWorktree(
   if (normalizedWorktree === repoPath) {
     console.warn(`[lane-worktree] Skipping cleanup for ${lane.id}: worktree path equals repo path (no isolation).`);
     return false;
+  }
+
+  // Exact merge retirement may have removed this path before its terminal
+  // callback runs. Absence is settled cleanup, not another capture attempt.
+  if (worktreeIsConfirmedAbsent(worktreePath)) {
+    return settleRemovedWorktreeReservation(lane, true);
   }
 
   const terminal = opts.terminal === true;

--- a/src/lib/lane/worktree-side-merge.ts
+++ b/src/lib/lane/worktree-side-merge.ts
@@ -66,6 +66,7 @@ import { settleReturnedMergeState } from '@/lib/lane/merge-state-settlement';
 import { enqueueMergeDecompositions } from '@/lib/lane/merge-decomposition';
 import { fastForwardBaseBranch } from '@/lib/lane/operator-checkout-merge';
 import { canonicalRepoRoot } from '@/lib/worktree/root-layout';
+import { captureWorkspaceMaterializationSnapshot } from '@/lib/workspace/workspace-materialization-retirement';
 
 const BASE_ADVANCED_RETRY_LIMIT = 3;
 type MergeCommand = Extract<LaneCommand, { verb: 'merge' }>;
@@ -697,6 +698,11 @@ async function performWorktreeSideMergeInner(input: WorktreeSideMergeInput): Pro
         action: 'merging',
       });
       if (finalGovernanceDrift) return finalGovernanceDrift;
+
+      await captureWorkspaceMaterializationSnapshot(lane.repoPath, worktreePath, 'merge', {
+        mergeCandidateSha,
+        reviewedHeadSha: reviewedSnapshotSha,
+      });
 
       try {
         await fastForwardBaseBranch({

--- a/src/lib/workspace/workspace-materialization-retirement.ts
+++ b/src/lib/workspace/workspace-materialization-retirement.ts
@@ -13,6 +13,7 @@ import {
   type WorkspaceSnapshotRecord,
 } from '@/lib/worktree/snapshot-state';
 import type { WorkspaceSnapshotJson } from '@/lib/worktree/snapshot-state-types';
+import { canonicalRepoRoot } from '@/lib/worktree/root-layout';
 import {
   materializationAwareExecFile,
   withWorktreeMaterializationExecution,
@@ -21,6 +22,11 @@ import { ensureWorkspaceRecoveryRef } from './hibernator';
 import { readManagedWorkspaceMaterialization } from './managed-materialization-identity';
 
 export type WorkspaceRetirementAction = 'pr' | 'merge' | 'discard' | 'cleanup';
+
+interface MergeWorkspaceSnapshotEvidence {
+  mergeCandidateSha: string;
+  reviewedHeadSha: string;
+}
 
 interface WorkspaceRetirementReceipt {
   [key: string]: WorkspaceSnapshotJson;
@@ -86,17 +92,36 @@ export async function prepareWorkspaceMaterializationRetirement(
   workspacePath: string,
   action: WorkspaceRetirementAction,
 ): Promise<WorkspaceSnapshotRecord | null> {
+  const snapshot = await captureWorkspaceMaterializationSnapshot(repoPath, workspacePath, action);
+  return snapshot ? beginWorkspaceMaterializationRetirement(workspacePath, action) : null;
+}
+
+/** Capture immutable evidence while the reviewed checkout still exists. */
+export async function captureWorkspaceMaterializationSnapshot(
+  repoPath: string,
+  workspacePath: string,
+  action: WorkspaceRetirementAction,
+  mergeEvidence?: MergeWorkspaceSnapshotEvidence,
+): Promise<WorkspaceSnapshotRecord | null> {
   const existing = exactSnapshot(workspacePath);
-  if (existing) return beginWorkspaceMaterializationRetirement(workspacePath, action);
+  if (existing) {
+    if (mergeEvidence && existing.headCommit !== mergeEvidence.reviewedHeadSha) {
+      throw new Error('Workspace snapshot no longer identifies the reviewed merge HEAD.');
+    }
+    return existing;
+  }
   const repo = await findRepoByLocalPath(repoPath);
   if (!repo) return null;
   const lanes = listLanes().filter((lane) => (
     lane.packetId?.trim()
     && lane.worktreePath
-    && path.resolve(lane.repoPath) === path.resolve(repo.localPath)
+    && canonicalRepoRoot(lane.repoPath) === canonicalRepoRoot(repo.localPath)
     && path.resolve(lane.worktreePath) === path.resolve(workspacePath)
   ));
-  if (lanes.length === 0) return null;
+  if (lanes.length === 0) {
+    if (mergeEvidence) throw new Error('Merge evidence capture found no durable packet lane.');
+    return null;
+  }
   if (lanes.length !== 1) throw new Error('Workspace retirement found ambiguous managed lane truth.');
   const lane = lanes[0]!;
   const packetId = lane.packetId!;
@@ -107,14 +132,30 @@ export async function prepareWorkspaceMaterializationRetirement(
   }
   const identity = managed.identity;
   await withWorktreeMaterializationExecution(workspacePath, identity, async () => {
-    const [branch, headCommit, treeSha, baseTip] = await Promise.all([
+    const reviewedRef = mergeEvidence?.reviewedHeadSha ?? 'HEAD';
+    const [branch, headCommit, treeSha, baseTip, mergeCandidate] = await Promise.all([
       gitValue(workspacePath, ['symbolic-ref', '--quiet', '--short', 'HEAD']),
-      gitValue(workspacePath, ['rev-parse', '--verify', 'HEAD^{commit}']),
-      gitValue(workspacePath, ['rev-parse', '--verify', 'HEAD^{tree}']),
-      gitValue(workspacePath, ['rev-parse', '--verify', `${lane.baseBranch}^{commit}`]),
+      gitValue(workspacePath, ['rev-parse', '--verify', `${reviewedRef}^{commit}`]),
+      gitValue(workspacePath, ['rev-parse', '--verify', `${reviewedRef}^{tree}`]),
+      gitValue(repo.localPath, ['rev-parse', '--verify', `refs/heads/${lane.baseBranch}^{commit}`]),
+      mergeEvidence
+        ? gitValue(repo.localPath, ['rev-parse', '--verify', `${mergeEvidence.mergeCandidateSha}^{commit}`])
+        : Promise.resolve(null),
     ]);
     if (branch !== lane.branch) throw new Error('Workspace retirement branch no longer matches its lane.');
-    const baseCommit = await gitValue(workspacePath, ['merge-base', baseTip, headCommit]);
+    if (mergeEvidence && headCommit !== mergeEvidence.reviewedHeadSha) {
+      throw new Error('Workspace HEAD changed before merge evidence capture.');
+    }
+    if (mergeEvidence && mergeCandidate !== mergeEvidence.mergeCandidateSha) {
+      throw new Error('Workspace merge candidate changed before evidence capture.');
+    }
+    // A rebase can replace HEAD while the original review still identifies the
+    // evidence to retain. Bank that object before reading ancestry in the base
+    // repository; packet clones need not have a local base branch.
+    if (isolationKind === 'apfs-cow-clone') {
+      await gitValue(repo.localPath, ['fetch', '--no-tags', workspacePath, headCommit]);
+    }
+    const baseCommit = await gitValue(repo.localPath, ['merge-base', baseTip, headCommit]);
     const recoveryRef = `refs/o8/recovery/${repo.id}/${packetId}`;
     const diffFingerprint = spokenReviewSnapshotFingerprint(headCommit, baseCommit, treeSha);
     await ensureWorkspaceRecoveryRef(repo.localPath, workspacePath, {
@@ -141,10 +182,10 @@ export async function prepareWorkspaceMaterializationRetirement(
         ? [{ kind: 'owned-session', identity: lane.sessionKey }]
         : [],
       creationId: `retire:${action}:create`,
-      receipt: { terminalBootstrap: true, terminalAction: action },
+      receipt: { terminalBootstrap: true, terminalAction: action, ...mergeEvidence },
     });
   });
-  return beginWorkspaceMaterializationRetirement(workspacePath, action);
+  return exactSnapshot(workspacePath);
 }
 
 /** Persist terminal cleanup intent before any exact path removal begins. */

--- a/tests/direct-merge-canonical-repo-real-path.test.ts
+++ b/tests/direct-merge-canonical-repo-real-path.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import { join } from 'node:path';
 
@@ -28,6 +28,10 @@ const { addRepo } = await import('@/lib/repos/registry');
 const { captureWorktreeMaterializationIdentity } = await import('@/lib/worktree/materialization-identity');
 const { withWorktreeMetaTransaction } = await import('@/lib/worktree/metadata-store');
 const { worktreeRepoKey } = await import('@/lib/worktree/root-layout');
+const {
+  listWorkspaceSnapshotTransitions,
+  listWorkspaceSnapshotsByOriginalPath,
+} = await import('@/lib/worktree/snapshot-state');
 
 const roots: string[] = [];
 
@@ -127,7 +131,7 @@ async function createRelocatedCloneMission(label: string, incompleteDependencies
     chmodSync(tscPath, 0o755);
   }
 
-  await addRepo(canonicalRepo);
+  await addRepo(realpathSync.native(canonicalRepo));
   const worktreeId = `packet-${packetId}`;
   const materializationIdentity = await captureWorktreeMaterializationIdentity(packetClone);
   const materializationParentIdentity = await captureWorktreeMaterializationIdentity(relocatedBase);
@@ -206,14 +210,49 @@ afterEach(() => {
 describe('direct merge publishes through the canonical mission repository', () => {
   it('lands a relocated full-clone packet commit on canonical main', async () => {
     const fixture = await createRelocatedCloneMission('success');
+    const diagnostics: string[] = [];
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+      diagnostics.push(args.map(String).join(' '));
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      diagnostics.push(args.map(String).join(' '));
+    });
     expect(git(fixture.packetClone, ['remote', 'get-url', 'origin'])).not.toBe(fixture.canonicalRepo);
 
-    const result = await reviewAndMerge(fixture);
+    try {
+      const result = await reviewAndMerge(fixture);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const snapshots = listWorkspaceSnapshotsByOriginalPath(fixture.packetClone);
+      const creation = snapshots[0]
+        ? listWorkspaceSnapshotTransitions(snapshots[0].repositoryUuid, snapshots[0].packetId)[0]
+        : undefined;
 
-    expect(result.merged).toBe(true);
-    expect(git(fixture.canonicalRepo, ['merge-base', '--is-ancestor', fixture.packetSha, 'main'])).toBe('');
-    expect(git(fixture.canonicalRepo, ['rev-parse', 'main'])).toBe(fixture.packetSha);
-  }, 30_000);
+      expect(result.merged).toBe(true);
+      expect(git(fixture.canonicalRepo, ['merge-base', '--is-ancestor', fixture.packetSha, 'main'])).toBe('');
+      expect(git(fixture.canonicalRepo, ['rev-parse', 'main'])).toBe(fixture.packetSha);
+      expect(existsSync(fixture.packetClone)).toBe(false);
+      expect(snapshots).toHaveLength(1);
+      expect(snapshots[0]).toMatchObject({
+        state: 'retired',
+        headCommit: fixture.packetSha,
+      });
+      expect(snapshots[0]!.diffFingerprint).toBeTruthy();
+      expect(git(fixture.canonicalRepo, ['rev-parse', snapshots[0]!.recoveryRef])).toBe(fixture.packetSha);
+      expect(creation?.receipt).toMatchObject({
+        mergeCandidateSha: fixture.packetSha,
+        reviewedHeadSha: fixture.packetSha,
+      });
+      expect(diagnostics.filter((diagnostic) => (
+        diagnostic.includes('[worktree-capture]')
+        || diagnostic.includes('Failed to preserve head')
+        || diagnostic.includes('REFUSED preservation boundary')
+        || diagnostic.includes('REFUSED durable retirement begin')
+      ))).toEqual([]);
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  }, 60_000);
 
   it('blocks and escalates when canonical main loses the candidate after git merge succeeds', async () => {
     const fixture = await createRelocatedCloneMission('postcondition');


### PR DESCRIPTION
## Mechanic

Successful packet merge cleanup could remove the managed worktree before durable snapshot capture and the terminal cleanup callback then retried Git reads against the missing path, producing `spawn git ENOENT` with no retained evidence.

## What changed

- Capture the reviewed HEAD, diff fingerprint, recovery ref, and exact merge candidate before canonical publication and worktree removal.
- Match canonical repository paths across realpath aliases and qualify clone diff bases as `refs/heads/*` or `refs/remotes/origin/*`.
- Treat a confirmed-absent worktree as already settled when the asynchronous terminal cleanup callback runs.
- Assert the real merge leaves exactly one retired snapshot and emits no capture or HEAD-preservation diagnostic.

## Verification

Red tail on the test-only commit (`9984948d2`):

```text
AssertionError: expected [] to have a length of 1 but got +0
Test Files  1 failed (1)
Tests  1 failed | 2 passed (3)
```

Green tails:

```text
tests/direct-merge-canonical-repo-real-path.test.ts
Test Files  1 passed (1)
Tests  3 passed (3)

src/lib/lane/lane-diff-facts.test.ts
Test Files  1 passed (1)
Tests  7 passed (7)

npx tsc --noEmit
exit 0

npm test
Test Files  717 passed | 3 skipped (720)
Tests  4487 passed | 4 skipped (4491)

rule-check
OK — zero violations vs origin/main
```

Fixes #2241

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe