### PR TITLE
fix: align repository dispatch readiness

### DIFF
--- a/cli/src/commands/resources.ts
+++ b/cli/src/commands/resources.ts
@@ -18,7 +18,14 @@ interface RepoEntry {
   remoteUrl?: string | null;
   defaultBranch?: string;
   exists?: boolean;
-  readiness?: { state?: string; label?: string };
+  readiness?: {
+    state?: string;
+    label?: string;
+    dispatchable?: boolean;
+    nextAction?: string;
+    failedCheck?: string;
+    correctiveAction?: string;
+  };
 }
 
 interface RepoListResponse {
@@ -239,6 +246,10 @@ function repoPayload(repo: RepoEntry) {
     defaultBranch: repo.defaultBranch ?? null,
     exists: repo.exists ?? null,
     readiness: repo.readiness?.state ?? null,
+    dispatchable: repo.readiness?.dispatchable ?? null,
+    failedCheck: repo.readiness?.failedCheck ?? null,
+    correctiveAction: repo.readiness?.correctiveAction ?? repo.readiness?.nextAction ?? null,
+    nextAction: repo.readiness?.nextAction ?? repo.readiness?.correctiveAction ?? null,
   };
 }
 

--- a/src/app/api/orchestrator/dispatch/route.ts
+++ b/src/app/api/orchestrator/dispatch/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { requirePanelAuth } from '@/lib/panel/auth';
+import { RepoDispatchAdmissionError } from '@/lib/lane/repo-preflight';
 import {
   dispatchMission,
   MissionNotFoundError,
@@ -18,6 +19,23 @@ import { asRecord, operatorError, operatorSuccess, parseJsonBody, replayShape, u
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+
+function repoAdmissionErrorResponse(error: RepoDispatchAdmissionError) {
+  const { admission } = error;
+  return NextResponse.json({
+    ok: false,
+    error: {
+      code: 'repo_dispatch_blocked',
+      message: admission.message,
+      failedCheck: admission.failedCheck,
+      correctiveAction: admission.correctiveAction,
+      nextAction: admission.correctiveAction,
+    },
+  }, {
+    status: 400,
+    headers: { 'Cache-Control': 'no-store, max-age=0' },
+  });
+}
 
 export async function POST(request: NextRequest) {
   const denied = requirePanelAuth(request);
@@ -92,35 +110,41 @@ export async function POST(request: NextRequest) {
     // Runtime launch remains asynchronous, but an API-process exit can no
     // longer lose the explicit held -> queued transition; the headless loop
     // resumes it from durable mission state after restart.
-    if (idemKey) {
-      const outcome = await withIdempotency(
-        { key: idemKey, verb: 'dispatch_mission', scopeId: targetMissionId },
-        async () => {
-          const admitted = await prepareMissionDispatch({ missionId: targetMissionId, runtime: requestedRuntime });
-          if (admitted.blocked) {
-            return { initiated: false, async: true, missionId: targetMissionId, blocked: true };
-          }
-          void dispatchMission({ missionId: targetMissionId, runtime: requestedRuntime }).catch((error) => {
-            console.error('[orchestrator] async dispatch failed:', error instanceof Error ? error.message : error);
-          });
-          return { initiated: true, async: true, missionId: targetMissionId };
-        },
-      );
-      if (outcome.inProgress) return unresolvedIdempotencyResponse(outcome, 'mission dispatch') ?? operatorSuccess(replayShape(outcome), 202);
-      return operatorSuccess(replayShape(outcome));
+    try {
+      if (idemKey) {
+        const outcome = await withIdempotency(
+          { key: idemKey, verb: 'dispatch_mission', scopeId: targetMissionId },
+          async () => {
+            const admitted = await prepareMissionDispatch({ missionId: targetMissionId, runtime: requestedRuntime });
+            if (admitted.blocked) {
+              return { initiated: false, async: true, missionId: targetMissionId, blocked: true };
+            }
+            void dispatchMission({ missionId: targetMissionId, runtime: requestedRuntime }).catch((error) => {
+              console.error('[orchestrator] async dispatch failed:', error instanceof Error ? error.message : error);
+            });
+            return { initiated: true, async: true, missionId: targetMissionId };
+          },
+        );
+        if (outcome.inProgress) return unresolvedIdempotencyResponse(outcome, 'mission dispatch') ?? operatorSuccess(replayShape(outcome), 202);
+        return operatorSuccess(replayShape(outcome));
+      }
+      const admitted = await prepareMissionDispatch({ missionId: targetMissionId, runtime: requestedRuntime });
+      if (admitted.blocked) {
+        return operatorError(
+          'dispatch_blocked',
+          'The mission has an active lifecycle hold and was not dispatched.',
+          409,
+        );
+      }
+      void dispatchMission({ missionId: targetMissionId, runtime: requestedRuntime }).catch((error) => {
+        console.error('[orchestrator] async dispatch failed:', error instanceof Error ? error.message : error);
+      });
+      return operatorSuccess({ initiated: true, async: true, missionId: targetMissionId });
+    } catch (error) {
+      if (error instanceof RepoDispatchAdmissionError) return repoAdmissionErrorResponse(error);
+      const message = error instanceof Error ? error.message : 'Unable to dispatch mission.';
+      return operatorError('dispatch_failed', message, 500, error);
     }
-    const admitted = await prepareMissionDispatch({ missionId: targetMissionId, runtime: requestedRuntime });
-    if (admitted.blocked) {
-      return operatorError(
-        'dispatch_blocked',
-        'The mission has an active lifecycle hold and was not dispatched.',
-        409,
-      );
-    }
-    void dispatchMission({ missionId: targetMissionId, runtime: requestedRuntime }).catch((error) => {
-      console.error('[orchestrator] async dispatch failed:', error instanceof Error ? error.message : error);
-    });
-    return operatorSuccess({ initiated: true, async: true, missionId: targetMissionId });
   }
 
   try {
@@ -140,6 +164,7 @@ export async function POST(request: NextRequest) {
     const result = await dispatchMission({ missionId: targetMissionId, runtime: requestedRuntime });
     return operatorSuccess(result);
   } catch (error) {
+    if (error instanceof RepoDispatchAdmissionError) return repoAdmissionErrorResponse(error);
     if (error instanceof DispatchPreflightError) {
       return operatorError(error.code, `${error.status.detail} ${error.status.fix}`, 400, {
         runtime: error.status.runtime,

--- a/src/app/api/panel/repos/route.ts
+++ b/src/app/api/panel/repos/route.ts
@@ -277,7 +277,7 @@ export async function POST(request: Request) {
         if (isOrchestratorHomePath(body.localPath)) {
           return NextResponse.json({ error: 'Home mode is not a registered repository.' }, { status: 400 });
         }
-        const repo = await enrichRepoReadiness(await addRepo(body.localPath));
+        const repo = await appendExistence(await enrichRepoReadiness(await addRepo(body.localPath)));
         // Auto-scan skeleton for newly added repo + start change polling
         triggerScan(repo.localPath);
         startChangePolling(repo.localPath);

--- a/src/lib/lane/repo-preflight.test.ts
+++ b/src/lib/lane/repo-preflight.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { assertOrchestratorRepoPath } from './repo-preflight';
+import { assertOrchestratorRepoPath, getRepoDispatchAdmission } from './repo-preflight';
 
 const tempDirs: string[] = [];
 
@@ -13,8 +13,14 @@ afterEach(() => {
 });
 
 describe('assertOrchestratorRepoPath', () => {
+  it('allows an unbound mission without a repository path', () => {
+    expect(() => assertOrchestratorRepoPath(null)).not.toThrow();
+    expect(() => assertOrchestratorRepoPath('')).not.toThrow();
+  });
+
   it('allows the resolved home anchor without requiring a Git work tree', () => {
     expect(() => assertOrchestratorRepoPath(homedir())).not.toThrow();
+    expect(getRepoDispatchAdmission(homedir())).toEqual({ ok: true, repoPath: homedir() });
   });
 
   it('still rejects an arbitrary existing non-Git directory', () => {

--- a/src/lib/lane/repo-preflight.ts
+++ b/src/lib/lane/repo-preflight.ts
@@ -20,6 +20,29 @@ function couldContainGitWorkTree(repoPath: string): boolean {
   }
 }
 
+export type RepoDispatchFailedCheck = 'repository_folder_exists' | 'git_work_tree';
+
+export type RepoDispatchAdmission = {
+  ok: true;
+  repoPath: string;
+} | {
+  ok: false;
+  repoPath: string;
+  failedCheck: RepoDispatchFailedCheck;
+  correctiveAction: string;
+  message: string;
+};
+
+export class RepoDispatchAdmissionError extends Error {
+  readonly admission: Extract<RepoDispatchAdmission, { ok: false }>;
+
+  constructor(admission: Extract<RepoDispatchAdmission, { ok: false }>) {
+    super(admission.message);
+    this.name = 'RepoDispatchAdmissionError';
+    this.admission = admission;
+  }
+}
+
 /**
  * #1551 — repo-path preflight shared by BOTH orchestrator spawn paths.
  *
@@ -55,20 +78,43 @@ export function isGitWorkTreeSync(repoPath: string): boolean {
   }
 }
 
+export function getRepoDispatchAdmission(repoPath: string): RepoDispatchAdmission {
+  const normalized = repoPath.trim();
+  if (!normalized || !existsSync(normalized)) {
+    const correctiveAction = 'Re-add the repo at its current location, or remove the stale registry entry.';
+    return {
+      ok: false,
+      repoPath: normalized,
+      failedCheck: 'repository_folder_exists',
+      correctiveAction,
+      message: normalized
+        ? `Repository folder not found at ${normalized}. ${correctiveAction}`
+        : `Repository path is missing. ${correctiveAction}`,
+    };
+  }
+  if (isOrchestratorHomePath(normalized)) return { ok: true, repoPath: normalized };
+  if (!isGitWorkTreeSync(normalized)) {
+    const correctiveAction = `Run "git init" in ${normalized}, create an initial commit, or select an existing Git repository.`;
+    return {
+      ok: false,
+      repoPath: normalized,
+      failedCheck: 'git_work_tree',
+      correctiveAction,
+      message: `${normalized} isn't a Git repository. ${correctiveAction}`,
+    };
+  }
+  return { ok: true, repoPath: normalized };
+}
+
+export function assertRepoDispatchAdmission(repoPath: string): void {
+  const admission = getRepoDispatchAdmission(repoPath);
+  if (!admission.ok) throw new RepoDispatchAdmissionError(admission);
+}
+
 /** Throws a human-actionable error when `repoPath` is missing or not a Git
  *  work tree. A null/empty repoPath passes — some sessions run unbound. */
 export function assertOrchestratorRepoPath(repoPath: string | null | undefined): void {
   if (!repoPath) return;
-  if (!existsSync(repoPath)) {
-    throw new Error(
-      `This chat's repo folder no longer exists at ${repoPath} — it may have been moved or deleted. `
-      + 'Re-add the repo (or point its project at the new location in Settings → Projects), then start a new session.',
-    );
-  }
   if (isOrchestratorHomePath(repoPath)) return;
-  if (!isGitWorkTreeSync(repoPath)) {
-    throw new Error(
-      `${repoPath} isn't a Git repository — run "git init" there (or point this chat at a Git repo), then try again.`,
-    );
-  }
+  assertRepoDispatchAdmission(repoPath);
 }

--- a/src/lib/orchestrator/operator-mission-service/dispatch-admission.ts
+++ b/src/lib/orchestrator/operator-mission-service/dispatch-admission.ts
@@ -1,4 +1,5 @@
 import { reconcileOrchestratorControlPlaneState, withLockedState } from '@/lib/orchestrator/control-plane';
+import { assertOrchestratorRepoPath } from '@/lib/lane/repo-preflight';
 import { withMissionHandoffBarrier } from '@/lib/orchestrator/lifecycle-mutation-lock';
 import { releaseAbandonedMissionLifecycleHold } from '@/lib/orchestrator/mission-lifecycle-hold';
 import { withMissionRegistryState } from '@/lib/orchestrator/mission-registry';
@@ -18,6 +19,7 @@ export async function prepareMissionDispatch(input: DispatchMissionInput) {
     const current = currentMissionState();
     if (requestedMissionId !== current.missionId?.trim()) {
       const { state } = await withMissionRegistryState(requestedMissionId, async (stored) => {
+        assertOrchestratorRepoPath(stored.repoPath);
         const prepared = releaseAbandonedMissionLifecycleHold(
           reconcileOrchestratorControlPlaneState(stored),
           { allowOwnerTakeover: true },
@@ -29,6 +31,7 @@ export async function prepareMissionDispatch(input: DispatchMissionInput) {
     }
 
     const { state } = await withLockedState(async (stored) => {
+      assertOrchestratorRepoPath(stored.repoPath);
       const prepared = releaseAbandonedMissionLifecycleHold(stored, { allowOwnerTakeover: true });
       if (!prepared.lifecycleHold) preparePacketsForExplicitDispatch(prepared, input.runtime);
       Object.assign(stored, prepared);

--- a/src/lib/orchestrator/operator-mission-service/mission.ts
+++ b/src/lib/orchestrator/operator-mission-service/mission.ts
@@ -5,6 +5,7 @@ import { reconcileOrchestratorControlPlaneState, withLockedState, writeOrchestra
 import { buildDagMetadata, buildDependencyGraph } from '@/lib/orchestrator/dag';
 import { applyPacketScopePolicy, buildRemainingLaunchBudget, computePredictedFiles, runDispatchTick } from '@/lib/orchestrator/dispatch';
 import { findLaneByPacket, getLaneEvents, listLanes } from '@/lib/lane/registry';
+import { assertOrchestratorRepoPath } from '@/lib/lane/repo-preflight';
 import { recoveryInfoFromLaneEvents } from '@/lib/lane/recovery-info';
 import { getOperatorDefaultsSync, resolveBranchPrefixSync } from '@/lib/operator/defaults';
 import { currentLaneMergePolicy } from '@/lib/lane/dogfood-guard';
@@ -428,6 +429,7 @@ export async function dispatchMission(input: DispatchMissionInput) {
 
   if (requestedMissionId && requestedMissionId !== currentMissionId) {
     const { result, state: finalState } = await withMissionRegistryState(requestedMissionId, async (stored) => {
+      assertOrchestratorRepoPath(stored.repoPath);
       const registryBefore = releaseAbandonedMissionLifecycleHold(
         reconcileOrchestratorControlPlaneState(stored),
         { allowOwnerTakeover: true },
@@ -450,6 +452,7 @@ export async function dispatchMission(input: DispatchMissionInput) {
 
   // Use locked state to prevent race with headless loop tick
   const { result, state: finalState } = await withLockedState(async (current) => {
+    assertOrchestratorRepoPath(current.repoPath);
     // #23 — an EXPLICIT dispatch re-arms any packet a prior reset_packet left in
     // 'held'. Held packets are skipped by the supervisor's automatic dispatch tick
     // (so reset doesn't boomerang); an explicit dispatch_mission is the operator

--- a/src/lib/repos/readiness.ts
+++ b/src/lib/repos/readiness.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 import type { RepoReadiness, RepoSetupConfig } from './types';
 import { checkRepoOriginConfigured, getRepoOriginConfiguredOverride } from './origin-readiness';
+import { getRepoDispatchAdmission } from '@/lib/lane/repo-preflight';
 
 interface RepoReadinessInput {
   localPath: string;
@@ -146,12 +147,17 @@ async function refreshRepoReadinessUncached(repo: RepoReadinessInput): Promise<R
   // fallbacks), so a deleted/moved checkout used to read as 'unknown' (or
   // even 'ready' via the saved contract) and the operator only learned the
   // truth from a failed spawn.
-  if (!(await pathExists(repo.localPath))) {
+  const dispatchAdmission = getRepoDispatchAdmission(repo.localPath);
+  if (!dispatchAdmission.ok) {
+    const state = dispatchAdmission.failedCheck === 'repository_folder_exists' ? 'missing' : 'blocked';
     const value: RepoReadiness = {
-      state: 'missing',
-      label: readinessLabel('missing'),
-      summary: `Repo folder not found at ${repo.localPath} — it may have been moved or deleted.`,
-      nextAction: 'Re-add the repo at its new location, or remove it from the registry.',
+      state,
+      label: readinessLabel(state),
+      summary: dispatchAdmission.message,
+      dispatchable: false,
+      nextAction: dispatchAdmission.correctiveAction,
+      failedCheck: dispatchAdmission.failedCheck,
+      correctiveAction: dispatchAdmission.correctiveAction,
       currentBranch: null,
       onDefaultBranch: null,
       originConfigured: false,
@@ -189,6 +195,8 @@ async function refreshRepoReadinessUncached(repo: RepoReadinessInput): Promise<R
   let state: RepoReadiness['state'] = 'unknown';
   let summary = 'No saved repo setup contract yet.';
   let nextAction: string | undefined;
+  let failedCheck: string | undefined;
+  let correctiveAction: string | undefined;
 
   const envFallbacks = new Map<string, string>();
   await Promise.all(
@@ -199,7 +207,8 @@ async function refreshRepoReadinessUncached(repo: RepoReadinessInput): Promise<R
   );
 
   if (missingEnvFiles.length > 0) {
-    state = 'blocked';
+    state = 'needs_setup';
+    failedCheck = 'environment_files';
     const missingWithFallback = missingEnvFiles.filter((file) => envFallbacks.has(file));
     if (missingWithFallback.length > 0) {
       const file = missingWithFallback[0];
@@ -210,6 +219,7 @@ async function refreshRepoReadinessUncached(repo: RepoReadinessInput): Promise<R
       summary = `Missing env files: ${missingEnvFiles.join(', ')}.`;
       nextAction = 'Restore the missing env files or change the repo env mode before trusting runtime validation.';
     }
+    correctiveAction = nextAction;
   } else if (installLooksNeeded) {
     state = 'needs_setup';
     summary = `Dependencies still need setup with ${repo.setup.installCommand}.`;
@@ -224,13 +234,19 @@ async function refreshRepoReadinessUncached(repo: RepoReadinessInput): Promise<R
     state = 'needs_setup';
     summary = 'Install metadata is saved, but no dev/build command is configured yet.';
     nextAction = 'Save a dev or build command so the IDE can verify this repo end to end.';
+  } else {
+    state = 'ready';
+    summary = `Repository is ready for mission work on ${currentBranch}.${dirty ? ' Working tree has local changes.' : ''}`;
   }
 
   const value: RepoReadiness = {
     state,
     label: readinessLabel(state),
     summary,
+    dispatchable: true,
     nextAction,
+    failedCheck,
+    correctiveAction,
     currentBranch,
     onDefaultBranch,
     originConfigured,

--- a/src/lib/repos/registry.ts
+++ b/src/lib/repos/registry.ts
@@ -20,6 +20,7 @@ import type {
 import { isRepoWorkspaceIsolationPreference } from './types';
 import { emitProductEvent } from '@/lib/analytics/server';
 import { withStoragePressurePolicyLock } from '@/lib/orchestrator/storage-pressure-policy-lock';
+import { getRepoDispatchAdmission } from '@/lib/lane/repo-preflight';
 import { dependencyInstallCommandForManager } from '@/lib/workspace/dependency-manager-contract';
 import { loadWorkspaceManifest, workspaceManifestPath } from '@/lib/workspace/manifest';
 
@@ -279,9 +280,13 @@ async function detectSetupConfig(repoRoot: string): Promise<RepoSetupConfig> {
     devCommand = 'go run .';
   }
 
+  const envFiles = (await Promise.all(['.env', '.env.local'].map(async (file) => (
+    await pathExists(path.join(repoRoot, file)) ? file : null
+  )))).filter((file): file is string => Boolean(file));
+
   return {
-    envMode: 'copy',
-    envFiles: ['.env', '.env.local'],
+    envMode: envFiles.length > 0 ? 'copy' : 'skip',
+    envFiles,
     installCommand,
     installOnCreateWorkspace: Boolean(installCommand),
     buildCommand,
@@ -331,7 +336,8 @@ async function inspectLocalRepo(localPath: string): Promise<ValidatedRepoCandida
   if (isOrchestratorHomePath(localPath)) {
     throw new Error('Home mode is not a registered repository.');
   }
-  const { localPath: repoRoot, isGitRepo } = await resolveRepoRoot(localPath);
+  const { localPath: repoRoot } = await resolveRepoRoot(localPath);
+  const isGitRepo = getRepoDispatchAdmission(repoRoot).ok;
   const [remoteUrl, defaultBranch, setup] = await Promise.all([
     isGitRepo ? gitValue(repoRoot, ['remote', 'get-url', 'origin']) : null,
     resolveDefaultBranch(repoRoot, isGitRepo),

--- a/src/lib/repos/types.ts
+++ b/src/lib/repos/types.ts
@@ -22,7 +22,10 @@ export interface RepoReadiness {
   state: RepoReadinessState;
   label: string;
   summary: string;
+  dispatchable?: boolean;
   nextAction?: string;
+  failedCheck?: string;
+  correctiveAction?: string;
   currentBranch: string | null;
   onDefaultBranch: boolean | null;
   originConfigured: boolean;

--- a/tests/cli-resource-management-real-path.test.ts
+++ b/tests/cli-resource-management-real-path.test.ts
@@ -73,9 +73,26 @@ function runCli(args: string[]): Promise<CliResult> {
   });
 }
 
+function initializeRepo(repoPath: string): void {
+  execFileSync('git', ['init', '-q', '-b', 'main', repoPath]);
+  writeFileSync(path.join(repoPath, 'README.md'), 'local-only repository\n', 'utf8');
+  execFileSync('git', ['-C', repoPath, 'add', 'README.md']);
+  execFileSync('git', [
+    '-C',
+    repoPath,
+    '-c',
+    'user.name=o8 test',
+    '-c',
+    'user.email=test@o8.local',
+    'commit',
+    '-qm',
+    'test: seed local repository',
+  ]);
+}
+
 beforeAll(async () => {
-  execFileSync('git', ['init', '-q', repoA]);
-  execFileSync('git', ['init', '-q', repoB]);
+  initializeRepo(repoA);
+  initializeRepo(repoB);
   execFileSync(process.execPath, [path.join(process.cwd(), 'cli/esbuild.config.mjs')], {
     cwd: process.cwd(),
     stdio: 'ignore',
@@ -182,7 +199,15 @@ describe('o8 repo and project CLI real path', () => {
     expect(repoAResult).toMatchObject({
       schema: 'o8/cli/repo.add/v1',
       registered: true,
-      repo: { path: realpathSync.native(repoA) },
+      repo: {
+        path: realpathSync.native(repoA),
+        remoteUrl: null,
+        exists: true,
+        readiness: 'ready',
+        dispatchable: true,
+        failedCheck: null,
+        correctiveAction: null,
+      },
     });
 
     const addB = await runCli(['repo', 'add', repoB]);

--- a/tests/real-path-seams.test.ts
+++ b/tests/real-path-seams.test.ts
@@ -33,7 +33,7 @@
  *      operator-defaults resolution, not resolveBrainEnabledWith in isolation.
  */
 import { execFileSync } from 'node:child_process';
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import { basename, join } from 'node:path';
 import { createElement } from 'react';
@@ -142,6 +142,8 @@ const { addSessionRule } = await import('@/lib/db/session-rules-store');
 const mergeRoute = await import('@/app/api/orchestrator/merge/route');
 const mergePreviewRoute = await import('@/app/api/orchestrator/merge-preview/route');
 const stateRoute = await import('@/app/api/orchestrator/state/route');
+const dispatchRoute = await import('@/app/api/orchestrator/dispatch/route');
+const reposRoute = await import('@/app/api/panel/repos/route');
 const operatorStatusRoute = await import('@/app/api/operator/status/route');
 const createMissionRoute = await import('@/app/api/orchestrator/create-mission/route');
 const chatHistoryRoute = await import('@/app/api/v2/chat-history/route');
@@ -343,6 +345,72 @@ describe('seam C — typecheckAutoRetries survives the orchestrator-state persis
     // type-broken packet loops full workers forever — this asserts it persists.
     expect(packet).toBeTruthy();
     expect(packet.typecheckAutoRetries).toBe(2);
+  });
+});
+
+describe('repository dispatch admission stays consistent across registration and launch', () => {
+  it('returns the same structured Git failure before an async mission can launch', async () => {
+    const repoPath = mkdtempSync(join(os.tmpdir(), 'o8-non-git-dispatch-seam-'));
+    tempDirs.push(repoPath);
+    let addedRepoId: string | null = null;
+    try {
+      const addResponse = await reposRoute.POST(new Request('http://localhost/api/panel/repos', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'add', localPath: repoPath }),
+      }));
+      expect(addResponse.status).toBe(201);
+      const added = await addResponse.json();
+      addedRepoId = added.repo.id;
+      const canonicalRepoPath = realpathSync(repoPath);
+      expect(added.repo).toMatchObject({
+        localPath: canonicalRepoPath,
+        exists: true,
+        isGitRepo: false,
+        readiness: {
+          state: 'blocked',
+          dispatchable: false,
+          failedCheck: 'git_work_tree',
+          correctiveAction: expect.any(String),
+        },
+      });
+
+      const missionId = `mission-non-git-${Date.now()}`;
+      writeOrchestratorControlPlaneState({
+        ...createEmptyOrchestratorMissionState(),
+        missionId,
+        prompt: 'non-Git admission seam',
+        summary: 'non-Git admission seam',
+        repoPath: canonicalRepoPath,
+        runtime: 'codex',
+        packets: [packetFixture({ id: `pkt-non-git-${Date.now()}`, queueState: 'held' })],
+      });
+
+      const dispatchResponse = await dispatchRoute.POST(operatorReq(
+        'http://localhost/api/orchestrator/dispatch',
+        { missionId, wait: false },
+      ));
+      expect(dispatchResponse.status).toBe(400);
+      const dispatched = await dispatchResponse.json();
+      expect(dispatched).toMatchObject({
+        ok: false,
+        error: {
+          code: 'repo_dispatch_blocked',
+          failedCheck: added.repo.readiness.failedCheck,
+          correctiveAction: added.repo.readiness.correctiveAction,
+          nextAction: added.repo.readiness.correctiveAction,
+        },
+      });
+    } finally {
+      writeOrchestratorControlPlaneState(createEmptyOrchestratorMissionState());
+      if (addedRepoId) {
+        await reposRoute.DELETE(new Request('http://localhost/api/panel/repos', {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id: addedRepoId }),
+        }));
+      }
+    }
   });
 });
 

--- a/tests/repo-readiness-missing.test.ts
+++ b/tests/repo-readiness-missing.test.ts
@@ -56,4 +56,22 @@ describe('#1565 — missing repo folder is a first-class readiness state', () =>
 
     expect(readiness.state).not.toBe('missing');
   });
+
+  it('treats missing configured env as setup work without blocking dispatch', async () => {
+    const repoPath = mkdtempSync(join(os.tmpdir(), 'o8-readiness-env-'));
+    execFileSync('git', ['init', '-q', repoPath]);
+
+    const readiness = await getRepoReadiness({
+      localPath: repoPath,
+      defaultBranch: 'main',
+      setup: { ...setup, envMode: 'copy', envFiles: ['.env'] },
+    });
+
+    expect(readiness).toMatchObject({
+      state: 'needs_setup',
+      dispatchable: true,
+      failedCheck: 'environment_files',
+      correctiveAction: expect.any(String),
+    });
+  });
 });

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2836,6 +2836,13 @@
       ]
     },
     {
+      "path": "tests/ui-edit-runtime-preset-route.test.ts",
+      "reasons": [
+        "child-process",
+        "git-cli"
+      ]
+    },
+    {
       "path": "tests/ui-loop-budgets-real-path.test.ts",
       "reasons": [
         "child-process",

--- a/tests/ui-edit-runtime-preset-route.test.ts
+++ b/tests/ui-edit-runtime-preset-route.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -126,6 +127,7 @@ const dataDir = path.join(testRoot, 'data');
 const repoPath = path.join(testRoot, 'repo');
 mkdirSync(dataDir, { recursive: true });
 mkdirSync(repoPath, { recursive: true });
+execFileSync('git', ['init', '-q', '-b', 'main', repoPath]);
 process.env.CORTEX_IDE_DATA_DIR = dataDir;
 process.env.O8_DATA_DIR = dataDir;
 delete process.env.CORTEX_IDE_DB_PATH;


### PR DESCRIPTION
## Mechanic

Repository registration and mission dispatch now consume the same structured Git admission contract. A local-only committed repository is ready; denied repositories expose the failed check and corrective action before any worker launch.

## What changed

- Return existence and structured readiness fields from repository registration and the CLI.
- Auto-detect only present environment files, so absent optional files do not block a usable repository.
- Apply the shared admission contract to persisted mission preparation and synchronous/asynchronous dispatch while preserving home and unbound missions.
- Update the dispatch-routing fixture to use a real Git repository and record its resource classification.

## Verification

- src/lib/lane/repo-preflight.test.ts
- tests/repo-readiness-missing.test.ts
- tests/cli-resource-management-real-path.test.ts
- tests/real-path-seams.test.ts
- tests/ui-edit-runtime-preset-route.test.ts
- npx tsc --noEmit
- npm run test:classify
- npm test: 716 files passed, 3 skipped; 4,487 tests passed, 4 skipped

Fixes #2237

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe