### PR TITLE
fix: preserve merged packet release truth

### DIFF
--- a/src/lib/lane/worktree-side-merge.ts
+++ b/src/lib/lane/worktree-side-merge.ts
@@ -747,7 +747,9 @@ async function performWorktreeSideMergeInner(input: WorktreeSideMergeInput): Pro
       pushedToOrigin,
       mergedEquivalentHeadSha,
     });
-    setLaneStatus(command.laneId, 'completed', actor, pushedToOrigin ? 'merged_pushed' : 'merged');
+    if (getLane(command.laneId)?.status !== 'archived') {
+      setLaneStatus(command.laneId, 'completed', actor, pushedToOrigin ? 'merged_pushed' : 'merged');
+    }
 
     // Coarse product signal: the governance loop closed. Fire-and-forget.
     void emitProductEvent('merge.approved', { runtime: lane.runtime, pushed: pushedToOrigin });

--- a/src/lib/orchestrator/operator-mission-service/merge.ts
+++ b/src/lib/orchestrator/operator-mission-service/merge.ts
@@ -428,17 +428,30 @@ async function dispatchPacketMerge(
     }
   }
 
-  // Sync first so reconciliation runs, then apply the release on top.
-  // This prevents reconciliation from resetting the packet status after we set it.
-  // Pass undefined so sync re-reads inside the mutex — otherwise we race the
-  // /api/orchestrator/state GET poll and other concurrent writers.
+  // Persist canonical release evidence before lane reconciliation projects the
+  // retired workspace as archived. Evidence-backed release then survives sync.
   const [
-    { syncOrchestratorControlPlaneState },
+    { readOrchestratorControlPlaneState, syncOrchestratorControlPlaneState, withLockedState },
     { runDispatchTick },
   ] = await Promise.all([
     loadControlPlane(),
     loadDispatch(),
   ]);
+  if (result.ok) {
+    await withLockedState((fresh) => {
+      const packetState = fresh.packets.find((candidate) => candidate.id === input.packetId);
+      if (!packetState || !packetReleaseIdentityIsCurrent(packetState, lane.id, releaseGeneration)) return;
+      markPacketReleased(packetState, {
+        source: 'approve_and_merge',
+        mergeCommit: result.mergeSha ?? null,
+        headSha: result.reviewedHeadSha ?? result.mergeSha ?? null,
+        evidenceKind: 'merge_command',
+      });
+      if (packetState.lane) {
+        packetState.lane.lastEventLabel = 'merged';
+      }
+    });
+  }
   const synced = await syncOrchestratorControlPlaneState();
 
   const releasedAfterDispatch = await alreadyReleasedResultForPacketId(input.packetId, synced.packets);
@@ -452,27 +465,6 @@ async function dispatchPacketMerge(
   if (!result.ok && (failedLane?.status === 'reviewing' || failedLane?.status === 'awaiting_orchestrator')) {
     log(`Merge command held for packet ${packet.id}.`, { note: result.note, actor });
     return withGateVerdict(packet.id, mergePacketResultFromLaneCommand(result), packet.review?.approved === true);
-  }
-
-  // Adversarial F3 — the release mutation lands under the lock against a
-  // FRESH read; the old code mutated the pre-release snapshot and whole-state
-  // wrote it after the (async) dispatch tick, clobbering every concurrent
-  // locked write on the highest-traffic path in the app.
-  const { withLockedState, readOrchestratorControlPlaneState } = await loadControlPlane();
-  if (result.ok) {
-    await withLockedState((fresh) => {
-      const packetState = fresh.packets.find((candidate) => candidate.id === input.packetId);
-      if (!packetState || !packetReleaseIdentityIsCurrent(packetState, lane.id, releaseGeneration)) return;
-      markPacketReleased(packetState, {
-        source: 'approve_and_merge',
-        mergeCommit: result.mergeSha ?? null,
-        headSha: result.reviewedHeadSha ?? null,
-        evidenceKind: 'merge_command',
-      });
-      if (packetState.lane) {
-        packetState.lane.lastEventLabel = 'merged';
-      }
-    });
   }
 
   // The receipt signer re-reads the persisted release payload. Launch it only

--- a/tests/direct-merge-canonical-repo-real-path.test.ts
+++ b/tests/direct-merge-canonical-repo-real-path.test.ts
@@ -17,6 +17,7 @@ const { recordMission } = await import('@/lib/db/missions-store');
 const { createLane, getLane, getLaneEvents, setLaneStatus } = await import('@/lib/lane/registry');
 const {
   approveAndMergePacket,
+  getMissionStatus,
   submitPacketReview,
 } = await import('@/lib/orchestrator/operator-mission-service');
 const {
@@ -72,7 +73,7 @@ function packetFixture(packetId: string, canonicalRepo: string, branch: string):
 }
 
 async function createRelocatedCloneMission(label: string, incompleteDependencies = false) {
-  const root = mkdtempSync(join(os.tmpdir(), `o8-direct-merge-${label}-`));
+  const root = realpathSync(mkdtempSync(join(os.tmpdir(), `o8-direct-merge-${label}-`)));
   const origin = join(root, 'github-like.git');
   const canonicalRepo = join(root, 'canonical');
   const packetId = `pkt-canonical-${label}-${Date.now()}`;
@@ -185,7 +186,7 @@ async function createRelocatedCloneMission(label: string, incompleteDependencies
   });
   writeOrchestratorControlPlaneState(mission);
 
-  return { baseSha, branch, canonicalRepo, lane, packetClone, packetId, packetSha, typecheckMarker };
+  return { baseSha, branch, canonicalRepo, lane, missionId, packetClone, packetId, packetSha, typecheckMarker };
 }
 
 async function reviewAndMerge(fixture: Awaited<ReturnType<typeof createRelocatedCloneMission>>) {
@@ -203,6 +204,7 @@ async function reviewAndMerge(fixture: Awaited<ReturnType<typeof createRelocated
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   writeOrchestratorControlPlaneState(createEmptyOrchestratorMissionState());
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
@@ -222,6 +224,12 @@ describe('direct merge publishes through the canonical mission repository', () =
     try {
       const result = await reviewAndMerge(fixture);
       await new Promise((resolve) => setTimeout(resolve, 50));
+      const lane = getLane(fixture.lane.id);
+      const terminalEvents = getLaneEvents(fixture.lane.id)
+        .filter((event) => event.verb === 'status_change')
+        .map((event) => event.payload.status)
+        .filter((status) => status === 'completed' || status === 'archived');
+      const mission = await getMissionStatus({ missionId: fixture.missionId, includeCost: false });
       const snapshots = listWorkspaceSnapshotsByOriginalPath(fixture.packetClone);
       const creation = snapshots[0]
         ? listWorkspaceSnapshotTransitions(snapshots[0].repositoryUuid, snapshots[0].packetId)[0]
@@ -242,11 +250,18 @@ describe('direct merge publishes through the canonical mission repository', () =
         mergeCandidateSha: fixture.packetSha,
         reviewedHeadSha: fixture.packetSha,
       });
+      expect(lane).toMatchObject({ status: 'archived', outcome: 'merged' });
+      expect(terminalEvents).toEqual(['archived']);
+      expect(mission.packets.find((packet) => packet.id === fixture.packetId)).toMatchObject({
+        status: 'released',
+        releaseState: 'released',
+      });
       expect(diagnostics.filter((diagnostic) => (
         diagnostic.includes('[worktree-capture]')
         || diagnostic.includes('Failed to preserve head')
         || diagnostic.includes('REFUSED preservation boundary')
         || diagnostic.includes('REFUSED durable retirement begin')
+        || diagnostic.includes('Refusing to transition lane')
       ))).toEqual([]);
     } finally {
       warnSpy.mockRestore();


### PR DESCRIPTION
## Mechanic

A successful direct merge retired its workspace and archived the lane before the merge path attempted to record completion. That follow-up write was rejected, and control-plane reconciliation projected the packet as archived before canonical release evidence was persisted.

## What changed

- Treat the post-cleanup completion write as idempotent when retirement already archived the lane.
- Persist the evidence-backed packet release before reconciliation can project the retired lane as archived.
- Pin release verification to the successful merge SHA when the reviewed HEAD is no longer separately returned.
- Extend the real-path merge harness to assert one archived terminal event, a released packet state, retained workspace evidence, and no refusal or preservation diagnostics.

## Verification

Red tail:

    AssertionError: expected releaseState released, status released
    Received: releaseState pending, status blocked
    Test Files  1 failed (1)
    Tests  1 failed | 2 skipped (3)

Green tails:

    tests/direct-merge-canonical-repo-real-path.test.ts
    Test Files  1 passed (1)
    Tests  3 passed (3)

    bounded merge/release set
    Test Files  6 passed (6)
    Tests  65 passed (65)

    npm test
    Test Files  719 passed | 3 skipped (722)
    Tests  4493 passed | 4 skipped (4497)

    npx tsc --noEmit
    exit 0

    npm run rule-check -- --base=origin/main
    OK - zero violations

Fixes #2242

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe
