### PR TITLE
chore: bump version to 0.1.750

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "o8",
-  "version": "0.1.749",
+  "version": "0.1.750",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "o8",
-      "version": "0.1.749",
+      "version": "0.1.750",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o8",
-  "version": "0.1.749",
+  "version": "0.1.750",
   "description": "o8 — governance layer for autonomous engineering teams. Approvals, audit, organizational memory.",
   "license": "MIT",
   "productName": "o8",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "o8"
-version = "0.1.749"
+version = "0.1.750"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "o8"
-version = "0.1.749"
+version = "0.1.750"
 description = "o8 — governance layer for autonomous engineering teams"
 authors = ["hurttlocker"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "o8",
-  "version": "0.1.749",
+  "version": "0.1.750",
   "identifier": "ai.o8.desktop",
   "build": {
     "frontendDist": "../out/frontend",


### PR DESCRIPTION
Synchronize the five desktop and native version manifests for the approved 0.1.750 release. The diff changes version numbers only; neither lockfile changes dependencies.

This release includes the merged dispatch, repository-readiness, review-coverage and merge-recovery fixes, plus the bounded coding-comparison tooling. #1684 remains open until its separate measurement meets the registered decision rule.

Validation: TypeScript passed (managed run cortex-run-1ccbcde6); the full hermetic suite passed 4,493 tests with four skipped (cortex-run-58ac4969); diff review confirmed exactly five synchronized manifests; the roadmap status check reports no drift.

Signing, notarization, publication and installed-app verification follow this PR and remain separate receipts.
