### PR TITLE
docs: bring remote project operation into the next milestone

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@ Taste is a gate on every row here, not a pillar of its own. A change that reads 
 4. **One control plane, every surface.** Desktop, phone, CLI, MCP, headless, voice. Same verbs, different authority.
 5. **Smooth for people and for agents.** Fast and legible for a person; drivable through a real interface for a program.
 6. **Runs where you are.** Light on the machine, on the machine you have. Mac today, Linux compiles but is unproven end to end, Windows help wanted.
-7. **Ahead.** The bets for 2027 and 2028, with what we are already doing on each.
+7. **Ahead.** Longer-term bets, advanced when their next proof warrants it.
 
 ## Now
 
@@ -21,6 +21,8 @@ One arc first: **First ten minutes.** A new operator goes from download to a fir
 Linux is the next platform milestone. Nine of ten children are shipped; the last is the proof that a fresh mainstream distro installs o8, launches it, dispatches a packet, and merges it. [#2060](https://github.com/hurttlocker/o8/issues/2060)
 
 Lane lifecycle and shared settings are gates on that path, not arcs that replace it. A refusal or a replaced mission must settle truthfully, and a changed setting must reach every surface on its next action. [#2197](https://github.com/hurttlocker/o8/issues/2197), [#2217](https://github.com/hurttlocker/o8/issues/2217)
+
+**Remote project operation is the next product milestone.** Its worker integration can proceed alongside the first-use and Linux proofs: run a project task on an external worker, close the laptop, and return to the same task, preview, diff, evidence, and approval path. A second supported agent system must then complete a later packet without rebuilding the project workflow. [#2282](https://github.com/hurttlocker/o8/issues/2282), [build order and proof](./docs/operations/remote-project-milestone.md)
 
 ## What we need to prove
 
@@ -75,6 +77,7 @@ Desktop, mobile, CLI, MCP, headless, and voice reach the same governed control p
 | --- | --- | --- | --- | --- |
 | Terminals as a workspace surface | A tmux or vim session survives an update and a pane switch byte for byte, and agent terminal actions go through a governed adapter. | open | Agent terminal actions are raw writes, and agent status inside a terminal is not inspectable. | [#1723](https://github.com/hurttlocker/o8/issues/1723) |
 | Settings take effect everywhere | An operator changes a setting once and every surface uses the new value on its next action, with no reload and no second place to set it. | open | Operator defaults are snapshotted at page load and cached per terminal server; the same bug has recurred under four names. | [#2217](https://github.com/hurttlocker/o8/issues/2217) |
+| Remote project operation | An operator reconnects to the same remote task, preview, diff, evidence, and approval path; a later packet can use another supported agent system with the same project rules. | open | The standalone worker uses the legacy protocol. Durable worker integration, remote workspace identity, and an operator-visible recovery and continuation proof remain open. | [#2282](https://github.com/hurttlocker/o8/issues/2282) |
 
 ## 5. Smooth for people and for agents
 
@@ -102,11 +105,11 @@ Windows is help wanted. No maintainer has a Windows machine to verify on, so thi
 
 ## 7. Ahead
 
-The bets for 2027 and 2028. Each row is an outcome we think operators will need, what already exists in o8 toward it, and the next child that would move it. A shipped child moves only the part it proves; a bet moves into a pillar when an operator can use the promised outcome. Rows are reviewed at the start of each month; a bet nobody has touched in a quarter gets cut, not carried.
+Longer-term bets, ordered by evidence and dependencies rather than a calendar year. Each row is an outcome we think operators will need, what already exists in o8 toward it, and the next child that would move it. A shipped child moves only the part it proves; a bounded outcome can move into an active pillar with an owner and an explicit proof. Basic remote project operation now has that scope in pillar 4. Rows are reviewed at the start of each month; a bet nobody has touched in a quarter gets cut, not carried.
 
 | Bet | What already exists | Next child | Where |
 | --- | --- | --- | --- |
-| Agents that work while you are away, wherever they run. Hosted, remote, or local workers, days-long missions, the same packet and merge gate. | Headless o8, the mobile relay, crash survival, the durable execution spine. | A portable worker environment profile so a packet can be placed on a remote worker without changing its runtime contract. | [#1690](https://github.com/hurttlocker/o8/issues/1690), [#1727](https://github.com/hurttlocker/o8/issues/1727) |
+| Portable execution across worker fleets. Placement policy, warm environments, suspension, and migration preserve the packet and merge gate. | Headless o8, the mobile relay, crash survival, the durable execution spine; a bounded remote-project milestone is active in pillar 4. | A portable worker environment profile, composed with cross-device continuity, extends the first remote proof to more environments. | [#1690](https://github.com/hurttlocker/o8/issues/1690), [#1727](https://github.com/hurttlocker/o8/issues/1727) |
 | The right model for each packet, chosen and escalated by o8. A failed packet retries on a stronger tier without the operator choosing. | The carrier registry, per-packet model pins, the merge-failure escalation chain. | A worker escalation ladder that retries a failed packet on the next tier, with bounded attempts, the effective model visible, and a refusal instead of a silent fallback when the requested tier is unavailable. | [#2209](https://github.com/hurttlocker/o8/issues/2209) |
 | Proof that travels. Receipts and control that systems outside o8 can verify and plug into, so o8 is the human gate inside other people's agent graphs. | Signed packet receipts and truth queries, the ACP orchestrator backend, MCP on both sides. | A receipt format another organization can verify without an o8 install, and a mission exported as an observed agent graph that an outside validator accepts. | [#1997](https://github.com/hurttlocker/o8/issues/1997), [#1998](https://github.com/hurttlocker/o8/issues/1998), [#2230](https://github.com/hurttlocker/o8/issues/2230) |
 | Nothing leaves the machine unless you say so. Local and on-device models as a real mode with a test that proves it. | Local endpoint probes, the local chat tier for the Brain, an audit of surfaces without a local path. | A named egress baseline across a full packet lifecycle, listing every contacted host and surface, as the first narrow proof; remediation stays with the parked all-surfaces epic. | [#2228](https://github.com/hurttlocker/o8/issues/2228), [#1451](https://github.com/hurttlocker/o8/issues/1451) |

--- a/docs/operations/remote-project-milestone.md
+++ b/docs/operations/remote-project-milestone.md
@@ -1,0 +1,51 @@
+# Remote project operation
+
+Status: planned implementation and operational proof. Tracking issue: [#2282](https://github.com/hurttlocker/o8/issues/2282).
+
+The first milestone is one persistent coordinator host, one external worker, and one project. An operator dispatches a task, disconnects the laptop, and returns to the same task, healthy preview, diff, evidence, steering controls, and approval path. A later packet uses a second supported agent system while retaining project rules and reviewed result lineage.
+
+Worker integration can proceed alongside the first-use and Linux proofs. First-use, lifecycle, and settings acceptance remain product gates. This milestone is a scoped implementation target, not a published hosted service or a promise of arbitrary runtime portability.
+
+## Current implementation boundary
+
+| Existing component | Evidence | Remaining proof |
+| --- | --- | --- |
+| Project task board | `src/lib/tasks/actions.ts` and `src/components/desktop/repo-focus/tabs/ControlRoomTab.tsx` use existing packet and lane state. | Reconnect must expose the actual remote task and workspace through that board. |
+| Headless coordinator | `cli/src/commands/serve.ts` owns the headless process lifecycle. | The operational run needs a persistent host, storage, and an authenticated worker-reachable endpoint. A process launcher does not supply those operations. |
+| Standalone worker | `scripts/worker/` clones a repository, runs a supported agent, pushes a branch, and reports legacy worker events. | Its `/api/worker/*` protocol must be integrated with the durable cloud job protocol. Its current poll loop waits during execution and does not cancel an in-flight run. |
+| Durable cloud jobs | `src/lib/runtimes/cloud-adapter.ts`, `/api/cloud/*`, and `tests/cloud-job-spine-real-path.test.ts` cover persisted jobs, leases, event replay, diffs, and controls. | A built external worker must use those paths. Queuing an abort is insufficient evidence that the process stops. |
+| Per-packet runtime selection | `src/lib/mcp/operator-handlers/mission.ts` accepts a registered runtime when dispatching work. | A later packet must demonstrate supplier continuity with project rules and reviewed result references. One successful remote runtime does not establish this. |
+| Durable schedules and event watches | `src/lib/automations/watch-store.ts`, `fire-runner.ts`, and `runner.ts` persist fires and dispatch project-associated lanes; `tests/automation-watch-real-path.test.ts` covers recovery and deduplication. | Prove one bounded event-driven follow-up while the laptop is disconnected. Dispatch creates a lane, not a task-pool card; the operator must be able to find its project association and review state. |
+
+These are source and test boundaries. The milestone stays incomplete until an operator-visible run proves the full outcome.
+
+## Build order
+
+1. **Connect the existing worker** ([#2278](https://github.com/hurttlocker/o8/issues/2278)). Resolve a cloneable repository source and pinned base revision before claim. Preserve project, task, packet, lane, job, branch, and commit associations. Use the existing scoped cloud-worker keys, leases, event stream, and control acknowledgements. Control polling and lease renewal continue while the child runs; unsupported capabilities refuse explicitly. Preserve or version legacy compatibility.
+2. **Keep the workspace attached to its task** ([#2279](https://github.com/hurttlocker/o8/issues/2279)). Compose the governed service, port, health, preview, and cleanup work in [#1725](https://github.com/hurttlocker/o8/issues/1725) with cross-device continuity in [#1727](https://github.com/hurttlocker/o8/issues/1727). Workspace links target the executing workspace or explain their limitation. Previews and evidence resolve the authorized task and execution attempt, including after reconnect.
+3. **Prove operation and supplier continuity** ([#2280](https://github.com/hurttlocker/o8/issues/2280)). Run the first remote task with one supported runtime, then use a second existing runtime for a later packet in the same project. The second runtime may run through another existing placement. This does not require a second executor in the standalone worker, live process migration, or provider-session translation.
+
+## Acceptance run
+
+Use a disposable fixture repository and an existing authorized environment. Record coordinator, worker, and client roles separately. Before an operational run, select the persistent host, private service access, runtime credentials, storage, and cleanup bounds through their existing authorization paths. Local fixtures can prepare the proof without paid provisioning; they cannot establish live remote usability.
+
+| Scenario | Required observation |
+| --- | --- |
+| Dispatch and laptop disconnect | Work continues on the external worker. Reconnect reaches the same project task, brief, state, preview, diff, logs, evidence, and controls. |
+| Coordinator restart | Persisted task, job, evidence, and pending review remain consistent after recovery. |
+| Worker disconnect and lease loss | Recovery is bounded. An old execution owner cannot publish accepted completion or merge evidence after reassignment. |
+| Steer and abort during execution | A supporting runtime receives the control, or returns an explicit limitation. Abort stops the owned process tree and settles visibly. |
+| Review and moved HEAD | Approval stays with the operator and the reviewed commit. Changed work cannot reuse stale approval. |
+| Second runtime | A later packet keeps the project rules and result references through existing per-packet runtime selection. The effective runtime and unavailable capabilities remain visible. |
+| Project event while disconnected | The persistent host's existing scheduler consumes one authorized state/check event and creates one governed follow-up lane with project rules and association. Reconnect exposes the source fingerprint, fire, lane, and review outcome. Replayed events do not duplicate the accepted action, and pause or expiry prevents further work. |
+| Service access and cleanup | Preview access is authenticated and packet-scoped. Service failure, cancel, and cleanup invalidate stale routes and leave no owned process running. |
+
+Attach commands and source/build versions, identity and commit receipts, and operator-visible evidence. Measure time to useful content after reconnect, click count, manual intervention, attempts, review and rework, elapsed time, and accepted quality. Use [#2163](https://github.com/hurttlocker/o8/issues/2163)'s interaction criteria under active output. Record attributable API spend or subscription capacity only where measured; unknown values remain unknown. A subscription allowance does not imply a per-token dollar saving.
+
+An acceptance failure remains open with a receipt and an owner. Link lifecycle failures to [#2197](https://github.com/hurttlocker/o8/issues/2197), settings propagation to [#2217](https://github.com/hurttlocker/o8/issues/2217), and cost/capacity measurement to [#1791](https://github.com/hurttlocker/o8/issues/1791). A child checkbox becomes complete only after closure and release; the tracker also requires the operational proof.
+
+## Broader direction
+
+The project workflow should survive changes of agent system and execution environment. Each runtime retains its own capabilities; the shared contract carries task identity, project rules, evidence, recovery state, and approval authority. Execution locality and inference locality must be described separately. Privacy, portability, quality, and cost claims require evidence from the actual route.
+
+[#1690](https://github.com/hurttlocker/o8/issues/1690) remains the broader portable-environment work for placement policy, caches, suspension, and migration. Fleet pools, autoscaling, managed hosting, and multi-operator workspaces remain later. The first proof reuses the project board, task pool, runner, durable queue, runtime registry, and governance system already in the repository.

--- a/scripts/worker/README.md
+++ b/scripts/worker/README.md
@@ -1,5 +1,20 @@
 # Standalone Worker CLI
 
+## Current protocol boundary
+
+This executable uses the legacy `/api/worker/*` contract described below. The
+durable cloud adapter uses `/api/cloud/*` with a separate scoped cloud-worker key
+lifecycle, job leases, persisted events, and control acknowledgements. These
+contracts and credentials are not interchangeable. The current standalone poll
+loop waits for execution to finish and does not cancel an in-flight run.
+
+[#2278](https://github.com/hurttlocker/o8/issues/2278) tracks integrating this
+existing executable with the durable protocol. The
+[remote project milestone](../../docs/operations/remote-project-milestone.md)
+defines the required dispatch, workspace, recovery, review, and operational proof.
+The instructions below describe the legacy worker; they are not a runbook for
+that planned durable integration.
+
 The standalone worker CLI runs remote o8 packets on a separate machine, pushes the finished branch back to `origin`, and reports progress back to the o8 instance so the lane merge gate can pick it up.
 
 ## Prerequisites


### PR DESCRIPTION
## Mechanic

The roadmap grouped basic remote project operation with future fleet work, even though the repository already contains a project task board, headless coordinator, legacy standalone worker, durable cloud jobs, and durable event watches. Their integration and operator-visible proof need a nearer-term owner.

## What changed

- Add the remote-project milestone under the existing control-surfaces pillar, with worker integration ready alongside the first-use and Linux proofs.
- Document the build order and acceptance for remote workspace identity, laptop disconnect, coordinator restart, worker lease loss, event-driven follow-up, and a later packet on another supported runtime.
- Name the legacy worker protocol boundary in its README. Keep broader environment, fleet, and migration work separate, and preserve the current first-use, lifecycle, settings, and export priorities.

Refs #2282. Implementation and operational proof remain open in #2278, #1725, #2279, and #2280; this documentation change does not complete that milestone.

## Verification

- `npx tsc --noEmit`: passed.
- `npm test`: 718 files passed, 3 skipped; 4,496 tests passed, 4 skipped.
- `node scripts/roadmap-status.mjs --check`: no drift; the new tracker is 0/4 complete.
- `git diff --check`, local documentation links, and added-copy public naming scan: passed.
- Independent review identified an incorrect mechanism citation; corrected the later-packet proof to use per-packet runtime selection. Final review covers that correction and the event-watch acceptance.

Documentation only. No runtime behavior changed, so no new regression test, runtime deployment, or UI capture is claimed. Full local lint was not run; no application source changed.

## Author review

- [x] Reviewed the complete diff and checked the cited implementation boundaries.
