### PR TITLE
fix: distinguish resident services from packet workers

### DIFF
--- a/src/lib/orchestrator/close-unmerged.ts
+++ b/src/lib/orchestrator/close-unmerged.ts
@@ -25,6 +25,7 @@ import { collectPacketLifecycleLanes } from '@/lib/orchestrator/packet-lifecycle
 import { markOutcomeClosedUnmerged } from '@/lib/orchestrator/context-relay';
 import { removeMergedWorktree } from '@/lib/orchestrator/worktree-cleanup';
 import { runRuntimeAwareWorktreeCleanup } from '@/lib/orchestrator/runtime-worktree-cleanup';
+import { getOwnedSessionLifecycle } from '@/lib/runtimes/shared/owned-session-lifecycle';
 import { formatWorktreeHolderPids } from '@/lib/worktree/holder-diagnostics';
 import { requestRealtimeRefresh } from '@/lib/realtime/publisher';
 import { unregisterWatchedAgent } from '@/lib/supervisor/agent-supervisor';
@@ -203,6 +204,11 @@ async function closePacketUnmergedUnlocked(input: {
       ? [`${target.id}\0${worktreePath}`]
       : [];
   }));
+  const detachedSessionRollbacks: Array<() => Promise<unknown>> = [];
+  const restoreDetachedSessions = async () => {
+    await Promise.allSettled(detachedSessionRollbacks.map((rollback) => rollback()));
+    detachedSessionRollbacks.length = 0;
+  };
   try {
     const stoppedReviewTurns = [];
     const reviewedLaneIds = new Set<string>();
@@ -216,15 +222,7 @@ async function closePacketUnmergedUnlocked(input: {
 
     const kills = await killLaneSessionsConfirmed(liveWorkerSessionLanes(lanesToClose));
     const survivors = kills.filter((outcome) => !outcome.confirmed && !outcome.alreadyDead);
-    if (survivors.length > 0) {
-      await markPacketLifecycleFailure(guard, 'kill_unconfirmed');
-      return {
-        ok: false,
-        code: 'kill_unconfirmed',
-        message: `Close refused because ${survivors.length} worker session class process${survivors.length === 1 ? '' : 'es'} could not be confirmed stopped. The lane and worktree remain intact.`,
-        status: 409,
-      };
-    }
+    const survivorLaneIds = new Set(survivors.map((outcome) => outcome.laneId));
     const unverifiedMissing = lanesToClose.find((target) => {
       const worktreePath = target.worktreePath?.trim();
       if (!worktreePath || !missingWorktreeBindings.has(`${target.id}\0${worktreePath}`)) return false;
@@ -280,18 +278,53 @@ async function closePacketUnmergedUnlocked(input: {
     }
     const preservedBranch = preservedBranches.length === 1 ? preservedBranches[0] ?? null : null;
 
-    const outcomeNote = closeUnmergedOutcomeNote({
+    const killUnconfirmedNote = survivors.length > 0
+      ? ` Kill unconfirmed for ${survivors.length} worker session class process${survivors.length === 1 ? '' : 'es'}. The packet was closed; any existing worktree and owned-session recovery metadata were preserved.`
+      : '';
+    const outcomeNote = `${closeUnmergedOutcomeNote({
       disposition: rawDisposition,
       note,
       preservedBranch,
       preservedBranches,
       preservationReceipts,
       preservationFailure,
-    });
+    })}${killUnconfirmedNote}`;
+    for (const survivor of survivors) {
+      const lifecycle = getOwnedSessionLifecycle(survivor.sessionKey);
+      if (!lifecycle?.setDetachedSession) {
+        if (!survivor.sessionKey.includes('-owned:')) continue;
+        await restoreDetachedSessions();
+        await markPacketLifecycleFailure(guard, 'session_archive_unconfirmed');
+        return {
+          ok: false,
+          code: 'session_archive_unconfirmed',
+          message: `Close could not detach owned-session recovery metadata for ${survivor.sessionKey}; the packet remains held.`,
+          status: 409,
+        };
+      }
+      const detached = await lifecycle.setDetachedSession(
+        survivor.sessionKey,
+        `Packet ${input.packetId} closed while worker exit remained unconfirmed.`,
+      );
+      if (!detached.updated) {
+        await restoreDetachedSessions();
+        await markPacketLifecycleFailure(guard, 'session_archive_unconfirmed');
+        return {
+          ok: false,
+          code: 'session_archive_unconfirmed',
+          message: `Close could not preserve detached owned-session recovery metadata for ${survivor.sessionKey}; the packet remains held.`,
+          status: 409,
+        };
+      }
+      if (!detached.previouslyDetached) {
+        detachedSessionRollbacks.push(() => lifecycle.setDetachedSession!(survivor.sessionKey, null));
+      }
+    }
     try {
-      await archiveLaneSessionsConfirmed(lanesToClose);
+      await archiveLaneSessionsConfirmed(lanesToClose.filter((candidate) => !survivorLaneIds.has(candidate.id)));
     } catch (error) {
       if (!(error instanceof LaneSessionArchiveUnconfirmedError)) throw error;
+      await restoreDetachedSessions();
       await markPacketLifecycleFailure(guard, 'session_archive_unconfirmed');
       return {
         ok: false,
@@ -300,11 +333,11 @@ async function closePacketUnmergedUnlocked(input: {
         status: 409,
       };
     }
-    for (const candidate of lanesToClose) {
+    for (const candidate of lanesToClose.filter((target) => !survivorLaneIds.has(target.id))) {
       if (candidate.sessionKey?.trim()) unregisterWatchedAgent(candidate.sessionKey.trim());
     }
     let worktreeRemoved = false;
-    for (const candidate of lanesToClose) {
+    for (const candidate of survivors.length === 0 ? lanesToClose : []) {
       const worktreePath = candidate.worktreePath?.trim();
       if (worktreePath && missingWorktreeBindings.has(`${candidate.id}\0${worktreePath}`)) {
         continue;
@@ -355,6 +388,7 @@ async function closePacketUnmergedUnlocked(input: {
         actor: 'user',
       });
       if (!archived.ok) {
+        await restoreDetachedSessions();
         await markPacketLifecycleFailure(guard, 'lane_archive_failed');
         return {
           ok: false,
@@ -388,17 +422,29 @@ async function closePacketUnmergedUnlocked(input: {
         reason: candidateCleanup === 'missing' ? 'worktree_missing' : 'close_unmerged',
         acknowledgedMissingWorktree: input.acknowledgeMissingWorktree,
         stoppedReviewTurns: stoppedReviewTurns.length,
+        killUnconfirmed: survivors.length,
       });
     }
 
     const closedAt = new Date().toISOString();
     if (!await markPacketClosed(guard, closedAt, worktreeCleanup)) {
+      await restoreDetachedSessions();
       return {
         ok: false,
         code: 'close_failed',
         message: `Packet ${input.packetId} disappeared before its closed state could be persisted.`,
         status: 409,
       };
+    }
+    detachedSessionRollbacks.length = 0;
+    for (const survivor of survivors) {
+      recordLaneEvent(survivor.laneId, 'update', 'system', {
+        code: 'kill_unconfirmed',
+        packetId: input.packetId,
+        sessionKey: survivor.sessionKey,
+        resolution: 'closed_unmerged_worker_ownership_preserved',
+        note: survivor.note,
+      });
     }
     await markOutcomeClosedUnmerged({
       laneId: lane.id,
@@ -460,6 +506,7 @@ async function closePacketUnmergedUnlocked(input: {
       },
     };
   } catch (error) {
+    await restoreDetachedSessions();
     await markPacketLifecycleFailure(guard, 'close_failed');
     return {
       ok: false,

--- a/src/lib/runtime/interrupt-escalation.ts
+++ b/src/lib/runtime/interrupt-escalation.ts
@@ -3,7 +3,11 @@ import { promisify } from 'node:util';
 
 import { isBridgeSessionAlive, signalBridgeTerminalSession } from '@/lib/runtime/pty-bridge';
 import { lookupOwnedActiveRunFresh } from '@/lib/runtimes/shared/owned-session-index';
-import { commandLineMatchesOwnedRun, isPidAlive, pidCommandLine } from '@/lib/runtimes/shared/owned-session/helpers';
+import {
+  classifyOwnedRunCommandLine,
+  isPidAlive,
+  pidCommandLine,
+} from '@/lib/runtimes/shared/owned-session/helpers';
 import { getOwnedSessionLifecycle } from '@/lib/runtimes/shared/owned-session-lifecycle';
 import { withOwnedStopOutcome } from '@/lib/runtimes/shared/owned-session/stop-outcome';
 import {
@@ -571,8 +575,19 @@ export async function escalateInterruptOwnedSurface(surfaceId: string): Promise<
     : false;
   if (activeRun.pid && !bridgeAlive) {
     const expectedCommand = activeRun.commandIdentity ?? commandLabel;
+    const pidAlive = isPidAlive(activeRun.pid);
+    const commandLine = surfaceId.startsWith('opencode-owned:')
+      || process.platform === 'win32'
+      || !pidAlive
+      ? await pidCommandLine(activeRun.pid)
+      : null;
+    const commandClassification = classifyOwnedRunCommandLine(
+      commandLine,
+      activeRun.commandIdentity,
+      commandLabel,
+    );
     let identityMatches: boolean;
-    if (process.platform !== 'win32' && isPidAlive(activeRun.pid)) {
+    if (process.platform !== 'win32' && pidAlive) {
       // A launcher can exec the runtime without changing PID. The persisted
       // run marker survives that transition; a binary name does not. Require
       // both the exact PID's marker and its recorded group before signaling.
@@ -583,14 +598,14 @@ export async function escalateInterruptOwnedSurface(surfaceId: string): Promise<
       const group = claim?.state === 'match'
         ? await resolveSpawnedProcessGroupId(activeRun.pid)
         : undefined;
-      identityMatches = claim?.state === 'match'
+      identityMatches = commandClassification !== 'resident-service'
+        && claim?.state === 'match'
         && group !== undefined
         && group === (activeRun.processGroupId ?? activeRun.pid);
     } else {
-      const commandLine = await pidCommandLine(activeRun.pid);
       identityMatches = commandLine
-        ? commandLineMatchesOwnedRun(commandLine, activeRun.commandIdentity, commandLabel)
-        : !isPidAlive(activeRun.pid);
+        ? commandClassification === 'owned-run'
+        : !pidAlive;
     }
     if (!identityMatches) {
       return {
@@ -600,7 +615,9 @@ export async function escalateInterruptOwnedSurface(surfaceId: string): Promise<
         steps: [],
         pid: activeRun.pid,
         tmuxSession: activeRun.tmuxSession,
-        note: `Stored pid ${activeRun.pid} could not be verified as the owned ${expectedCommand} run, so its process tree was not signaled or confirmed stopped. Legacy runs require an owner-verified stop before retry.`,
+        note: commandClassification === 'resident-service'
+          ? 'The stored pid belongs to the resident service, not the packet worker. The service was not signaled, and worker exit remains unconfirmed.'
+          : `Stored pid ${activeRun.pid} could not be verified as the owned ${expectedCommand} run, so its process tree was not signaled or confirmed stopped. Legacy runs require an owner-verified stop before retry.`,
       };
     }
   }

--- a/src/lib/runtimes/shared/owned-acp/store.ts
+++ b/src/lib/runtimes/shared/owned-acp/store.ts
@@ -138,7 +138,7 @@ export function createOwnedAcpSessionStore(adapter: OwnedAcpRuntimeAdapter): Own
 
   async function listSessions(): Promise<OwnedAcpSessionRecord[]> {
     const sessions = (await Promise.all((await listDirs()).map(loadSession)))
-      .filter((session): session is OwnedAcpSessionRecord => Boolean(session));
+      .filter((session): session is OwnedAcpSessionRecord => Boolean(session && !session.detachedAt));
     await Promise.all(sessions.map(refreshSession));
     return sessions;
   }
@@ -331,6 +331,9 @@ export function createOwnedAcpSessionStore(adapter: OwnedAcpRuntimeAdapter): Own
     return withSession(surfaceId, async () => {
       const session = await findSession(surfaceId, false);
       if (!session) throw new Error(`${adapter.humanLabel} session was not found.`);
+      if (session.detachedAt) {
+        throw new Error(`${adapter.humanLabel} session was detached from its closed packet and cannot be resumed.`);
+      }
       if (session.activeRun?.outcome === 'running') {
         throw new Error(`${adapter.humanLabel} session still has an active turn.`);
       }
@@ -515,6 +518,35 @@ export function createOwnedAcpSessionStore(adapter: OwnedAcpRuntimeAdapter): Own
     return archived;
   }
 
+  function setDetachedSession(surfaceId: string, reason: string | null) {
+    return withSession(surfaceId, async () => {
+      const session = await findSession(surfaceId, false);
+      if (!session) {
+        return {
+          updated: false,
+          previouslyDetached: false,
+          note: `${adapter.humanLabel} session was not found.`,
+        };
+      }
+      const previouslyDetached = Boolean(session.detachedAt);
+      if (reason === null) {
+        delete session.detachedAt;
+        delete session.detachedReason;
+      } else {
+        session.detachedAt = session.detachedAt ?? nowIso();
+        session.detachedReason = reason;
+      }
+      await saveSession(session);
+      return {
+        updated: true,
+        previouslyDetached,
+        note: reason === null
+          ? `${adapter.humanLabel} session was restored to active discovery.`
+          : `${adapter.humanLabel} recovery metadata was preserved outside active fleet discovery.`,
+      };
+    });
+  }
+
   const presentation = createOwnedAcpPresentation({
     adapter,
     findSession,
@@ -532,6 +564,7 @@ export function createOwnedAcpSessionStore(adapter: OwnedAcpRuntimeAdapter): Own
     ...presentation,
     sessionState: (surfaceId) => readOwnedSessionState(root(), surfaceId, adapter.surfaceIdPrefix),
     archiveSession,
+    setDetachedSession,
     sweepOrphanedSessions,
     getSessionIdentityId: async () => null,
     invalidateFleetCache: () => {},
@@ -544,6 +577,7 @@ export function createOwnedAcpSessionStore(adapter: OwnedAcpRuntimeAdapter): Own
     resolveRoot: root,
     sessionState: store.sessionState,
     archiveSession: store.archiveSession,
+    setDetachedSession: store.setDetachedSession,
   });
 
   return store;

--- a/src/lib/runtimes/shared/owned-acp/types.ts
+++ b/src/lib/runtimes/shared/owned-acp/types.ts
@@ -50,6 +50,9 @@ export interface OwnedAcpSessionRecord {
   commandIdentity?: string;
   serverVersion?: string;
   supportsResume?: boolean;
+  /** Packet ownership ended without process-exit proof; keep recovery data but hide active discovery. */
+  detachedAt?: string;
+  detachedReason?: string;
 }
 
 export interface OwnedAcpLaunchResolution {

--- a/src/lib/runtimes/shared/owned-session-lifecycle.ts
+++ b/src/lib/runtimes/shared/owned-session-lifecycle.ts
@@ -14,6 +14,11 @@ export interface OwnedSessionLifecycleRegistration {
   resolveRoot(): string;
   sessionState(surfaceId: string): Promise<OwnedSessionState>;
   archiveSession(surfaceId: string): Promise<OwnedArchiveResponse>;
+  setDetachedSession?(surfaceId: string, reason: string | null): Promise<{
+    updated: boolean;
+    previouslyDetached: boolean;
+    note: string;
+  }>;
   getWorkspaceBinding?(surfaceId: string): Promise<OwnedWorkspaceBindingReceipt | null>;
   rebindWorkspace?(surfaceId: string, input: RebindOwnedWorkspaceInput): Promise<RebindOwnedWorkspaceResult>;
 }
@@ -42,6 +47,11 @@ export function registerOwnedSessionLifecycle(options: {
     resolveRoot: () => process.env[options.rootEnvVar] || options.rootDefault,
     sessionState: (surfaceId) => options.store.sessionState(surfaceId),
     archiveSession: (surfaceId) => options.store.archiveSession(surfaceId),
+    ...(options.store.setDetachedSession ? {
+      setDetachedSession: (surfaceId: string, reason: string | null) => (
+        options.store.setDetachedSession!(surfaceId, reason)
+      ),
+    } : {}),
     ...(options.store.getWorkspaceBinding && options.store.rebindWorkspace ? {
       getWorkspaceBinding: (surfaceId: string) => options.store.getWorkspaceBinding!(surfaceId),
       rebindWorkspace: (surfaceId: string, input: RebindOwnedWorkspaceInput) => (

--- a/src/lib/runtimes/shared/owned-session/fleet.ts
+++ b/src/lib/runtimes/shared/owned-session/fleet.ts
@@ -81,10 +81,12 @@ export function createFleetComputer({
           const filePath = metadataPath(sessionDir);
           if (!(await pathExists(filePath))) return null;
           const session = await io.loadSession(sessionDir);
+          if (session.detachedAt) return null;
           return withSurfaceLock(session.surfaceId, async () => {
             // Stop, resume or exit recording may have changed the run while
             // this inventory read waited. Never write that stale snapshot back.
             const current = await io.loadSession(sessionDir);
+            if (current.detachedAt) return null;
             await runController.refreshSession(current);
             return current;
           });
@@ -311,11 +313,13 @@ export function createFleetComputer({
       try {
         if (!(await pathExists(metadataPath(sessionDir)))) continue;
         const session = await io.loadSession(sessionDir);
+        if (session.detachedAt) continue;
         if (activeSurfaceIds.has(session.surfaceId)) continue;
         if (Date.now() - sessionLastActivityMs(session) < maxAgeMs) continue;
         const didArchive = await withSurfaceLock(session.surfaceId, async () => {
           if (!(await pathExists(metadataPath(sessionDir)))) return false;
           const current = await io.loadSession(sessionDir);
+          if (current.detachedAt) return false;
           if (activeSurfaceIds.has(current.surfaceId)) return false;
           if (Date.now() - sessionLastActivityMs(current) < maxAgeMs) return false;
           if (current.activeRun) {

--- a/src/lib/runtimes/shared/owned-session/helpers.test.ts
+++ b/src/lib/runtimes/shared/owned-session/helpers.test.ts
@@ -66,6 +66,14 @@ describe('commandLineMatchesOwnedRun', () => {
     expect(commandLineMatchesOwnedRun('git fetch origin', 'ori', 'codex')).toBe(false);
     expect(commandLineMatchesOwnedRun('/Users/victoria/bin/node task.js', 'ori', 'codex')).toBe(false);
   });
+
+  it.each([
+    ['/opt/runtime/opencode2 serve --service', 'darwin'],
+    ['C:\\Tools\\runtime\\opencode2.exe serve --service', 'win32'],
+    ['cmd.exe /d /c "C:\\Tools\\runtime\\opencode2.exe" serve --service', 'win32'],
+  ] as const)('does not classify a resident service as an owned worker: %s', (commandLine, platform) => {
+    expect(commandLineMatchesOwnedRun(commandLine, undefined, 'opencode2', platform)).toBe(false);
+  });
 });
 
 describe('isOwnedRunAlive — finished runs are terminal (#1293)', () => {

--- a/src/lib/runtimes/shared/owned-session/helpers.ts
+++ b/src/lib/runtimes/shared/owned-session/helpers.ts
@@ -286,14 +286,16 @@ export function isPidAlive(pid?: number) {
   }
 }
 
-export function commandLineMatchesOwnedRun(
+export type OwnedRunCommandLineClassification = 'owned-run' | 'resident-service' | 'mismatch';
+
+export function classifyOwnedRunCommandLine(
   commandLine: string | null,
   commandIdentity: string | undefined,
   fallbackBinaryName: string,
   platform: NodeJS.Platform = process.platform,
-): boolean {
+): OwnedRunCommandLineClassification {
   const identity = commandIdentity?.trim() || fallbackBinaryName;
-  if (!commandLine) return false;
+  if (!commandLine) return 'mismatch';
   const normalize = (value: string) => platform === 'win32' ? value.toLowerCase() : value;
   const normalizedIdentity = normalize(identity);
   const tokens = commandLine.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
@@ -302,20 +304,56 @@ export function commandLineMatchesOwnedRun(
   // Only that executable position is authority, never a later argv mention.
   if (platform === 'win32' && path.win32.basename(unquote(tokens[0] ?? '')).toLowerCase() === 'cmd.exe'
     && tokens[1]?.toLowerCase() === '/d' && tokens[2]?.toLowerCase() === '/c') {
-    return commandLineMatchesOwnedRun(tokens.slice(3).join(' '), commandIdentity, fallbackBinaryName, platform);
+    return classifyOwnedRunCommandLine(tokens.slice(3).join(' '), commandIdentity, fallbackBinaryName, platform);
   }
   const identityIsPath = identity.includes('/') || identity.includes('\\');
+  let matches = false;
+  let args: string[] = [];
   if (identityIsPath) {
     const normalizedCommandLine = normalize(commandLine.trimStart());
-    return [normalizedIdentity, `"${normalizedIdentity}"`, `'${normalizedIdentity}'`].some((prefix) => (
-      normalizedCommandLine.startsWith(prefix)
-      && (!normalizedCommandLine[prefix.length] || /\s/.test(normalizedCommandLine[prefix.length]!))
+    const prefix = [normalizedIdentity, `"${normalizedIdentity}"`, `'${normalizedIdentity}'`].find((candidate) => (
+      normalizedCommandLine.startsWith(candidate)
+      && (!normalizedCommandLine[candidate.length] || /\s/.test(normalizedCommandLine[candidate.length]!))
     ));
+    matches = Boolean(prefix);
+    args = prefix
+      ? normalizedCommandLine.slice(prefix.length).trim().match(/"[^"]*"|'[^']*'|\S+/g) ?? []
+      : [];
+  } else {
+    const token = normalize(unquote(tokens[0] ?? ''));
+    const basename = platform === 'win32' ? path.win32.basename(token) : path.basename(token);
+    matches = basename === normalizedIdentity || (platform === 'win32' && !path.win32.extname(identity)
+      && ['.cmd', '.exe', '.com'].some((extension) => basename === `${normalizedIdentity}${extension}`));
+    args = tokens.slice(1);
   }
-  const token = normalize(unquote(tokens[0] ?? ''));
-  const basename = platform === 'win32' ? path.win32.basename(token) : path.basename(token);
-  return basename === normalizedIdentity || (platform === 'win32' && !path.win32.extname(identity)
-    && ['.cmd', '.exe', '.com'].some((extension) => basename === `${normalizedIdentity}${extension}`));
+  if (!matches) return 'mismatch';
+  const normalizedArgs = args.map((token) => normalize(unquote(token)));
+  const identityBasename = platform === 'win32'
+    ? path.win32.basename(normalizedIdentity)
+    : path.basename(normalizedIdentity);
+  const residentServiceIdentity = platform === 'win32'
+    ? identityBasename.replace(/\.(?:cmd|exe|com)$/i, '')
+    : identityBasename;
+  if (residentServiceIdentity === 'opencode2'
+    && normalizedArgs[0] === 'serve'
+    && normalizedArgs.includes('--service')) {
+    return 'resident-service';
+  }
+  return 'owned-run';
+}
+
+export function commandLineMatchesOwnedRun(
+  commandLine: string | null,
+  commandIdentity: string | undefined,
+  fallbackBinaryName: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return classifyOwnedRunCommandLine(
+    commandLine,
+    commandIdentity,
+    fallbackBinaryName,
+    platform,
+  ) === 'owned-run';
 }
 
 /** POSIX run ownership survives wrapper exec; an argv mention does not prove ownership. */

--- a/src/lib/runtimes/shared/owned-session/store.ts
+++ b/src/lib/runtimes/shared/owned-session/store.ts
@@ -275,6 +275,9 @@ export function createOwnedSessionStore(
     if (!session) {
       throw new Error(`Owned ${adapter.squadShortName} session was not found.`);
     }
+    if (session.detachedAt) {
+      throw new Error(`This owned ${adapter.squadShortName} session was detached from its closed packet and cannot be resumed.`);
+    }
 
     const rollbackColdRestore = async () => {
       if (!coldRestored || !session) return;
@@ -412,6 +415,36 @@ export function createOwnedSessionStore(
         ? 'Marked this owned result resolved. It stays visible, but no longer needs active attention unless new evidence appears.'
         : 'Switched this owned result back to keep-watching mode.',
     };
+  }
+
+  function setDetachedSession(surfaceId: string, reason: string | null) {
+    return withSurfaceLock(surfaceId, async () => {
+      const session = await io.findSession(surfaceId);
+      if (!session) {
+        return {
+          updated: false,
+          previouslyDetached: false,
+          note: 'Owned session was not found.',
+        };
+      }
+      const previouslyDetached = Boolean(session.detachedAt);
+      if (reason === null) {
+        delete session.detachedAt;
+        delete session.detachedReason;
+      } else {
+        session.detachedAt = session.detachedAt ?? nowIso();
+        session.detachedReason = reason;
+      }
+      await io.saveSession(session);
+      invalidateFleetCache();
+      return {
+        updated: true,
+        previouslyDetached,
+        note: reason === null
+          ? 'Owned session was restored to active discovery.'
+          : 'Owned session recovery metadata was preserved outside active fleet discovery.',
+      };
+    });
   }
 
   async function getFleetAdditions(options: { fresh?: boolean } = {}): Promise<OwnedFleetAdditions> {
@@ -633,6 +666,7 @@ export function createOwnedSessionStore(
     getFleetAdditions,
     sessionState: (surfaceId) => readOwnedSessionState(root, surfaceId, surfacePrefix),
     archiveSession: io.archiveSession,
+    setDetachedSession,
     sweepOrphanedSessions: fleetComputer.sweepOrphanedSessions,
     getTelemetrySources: reviewTailController.getTelemetrySources,
     getSessionIdentityId,

--- a/src/lib/runtimes/shared/owned-session/types.ts
+++ b/src/lib/runtimes/shared/owned-session/types.ts
@@ -126,6 +126,9 @@ export interface OwnedSessionRecord {
   orphanedAt?: string;
   orphanedReason?: string;
   orphanedCostLine?: string;
+  /** Packet ownership ended without process-exit proof; keep recovery data but hide active discovery. */
+  detachedAt?: string;
+  detachedReason?: string;
 }
 
 export interface OwnedWorkspaceBinding {
@@ -428,6 +431,11 @@ export interface OwnedSessionStore {
   getFleetAdditions(options?: { fresh?: boolean }): Promise<OwnedFleetAdditions>;
   sessionState(surfaceId: string): Promise<OwnedSessionState>;
   archiveSession(surfaceId: string): Promise<OwnedArchiveResponse>;
+  setDetachedSession?(surfaceId: string, reason: string | null): Promise<{
+    updated: boolean;
+    previouslyDetached: boolean;
+    note: string;
+  }>;
   /** #1292 — archive owned-session dirs not bound to an active lane (orphans) so
    *  discovery can't re-spawn phantom lanes. Skips active/in-flight sessions. */
   sweepOrphanedSessions(activeSurfaceIds: Set<string>, maxAgeMs: number): Promise<number>;

--- a/tests/close-packet-unmerged.test.ts
+++ b/tests/close-packet-unmerged.test.ts
@@ -309,7 +309,7 @@ describe('close_packet_unmerged real path (#1570)', () => {
     expect(readOrchestratorControlPlaneState().missionId).toBe('different-current-close-mission');
   });
 
-  it('keeps the lane and packet live when process death cannot be confirmed', async () => {
+  it('closes with a durable warning when process death cannot be confirmed', async () => {
     const packetId = 'pkt-close-unmerged-live-worker';
     const repoPath = join(dataDir, 'repo-live-worker');
     const lane = createLane({
@@ -325,8 +325,8 @@ describe('close_packet_unmerged real path (#1570)', () => {
     const packet = {
       id: packetId,
       referenceLabel: '#live-worker',
-      title: 'Keep unconfirmed worker visible',
-      summary: 'Close must fail closed.',
+      title: 'Record unconfirmed worker closure',
+      summary: 'Close must preserve the uncertainty.',
       workspaceTargetPath: repoPath,
       branchTarget: lane.branch,
       runtime: 'codex',
@@ -360,26 +360,36 @@ describe('close_packet_unmerged real path (#1570)', () => {
       disposition: 'wontfix',
     }));
 
-    expect(response.status).toBe(409);
+    expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
-      ok: false,
-      error: {
-        code: 'kill_unconfirmed',
-        message: expect.stringContaining('worker session class'),
+      ok: true,
+      result: {
+        closed: true,
+        worktreeRemoved: false,
+        worktreeCleanup: 'preserved',
+        note: expect.stringContaining('Kill unconfirmed'),
       },
     });
     expect(getLane(lane.id)).toMatchObject({
-      status: 'paused',
+      status: 'archived',
       sessionKey: 'codex:unverified-live-worker',
+      outcomeNote: expect.stringContaining('Kill unconfirmed'),
     });
     expect(readOrchestratorControlPlaneState().packets[0]).toMatchObject({
       id: packetId,
-      status: 'blocked',
-      archivedAt: null,
+      status: 'archived',
+      archivedAt: expect.any(String),
+    });
+    expect(getLaneEvents(lane.id).find((event) => (
+      event.verb === 'update' && event.payload.code === 'kill_unconfirmed'
+    ))).toMatchObject({
+      payload: {
+        resolution: 'closed_unmerged_worker_ownership_preserved',
+      },
     });
   });
 
-  it('refuses to hide a second packet lane whose worker remains live', async () => {
+  it('records every unconfirmed worker when duplicate packet lanes close', async () => {
     const packetId = 'pkt-close-unmerged-duplicate-live-worker';
     const repoPath = join(dataDir, 'repo-duplicate-live-worker');
     const first = createLane({
@@ -427,10 +437,17 @@ describe('close_packet_unmerged real path (#1570)', () => {
 
     const response = await closeRoute.POST(operatorRequest({ packetId, disposition: 'wontfix' }));
 
-    expect(response.status).toBe(409);
-    expect(getLane(first.id)?.status).toBe('paused');
-    expect(getLane(second.id)?.status).toBe('paused');
-    expect(readOrchestratorControlPlaneState().packets[0]?.archivedAt).toBeNull();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      result: { note: expect.stringContaining('Kill unconfirmed for 2 worker session class processes') },
+    });
+    expect(getLane(first.id)).toMatchObject({
+      status: 'archived',
+      outcomeNote: expect.stringContaining('Kill unconfirmed for 2 worker session class processes'),
+    });
+    expect(getLane(second.id)?.status).toBe('archived');
+    expect(readOrchestratorControlPlaneState().packets[0]?.archivedAt).toEqual(expect.any(String));
   });
 
   it('never reports a preserved branch when the production ref postcondition fails (#1631)', async () => {

--- a/tests/grok-acp-real-path.test.ts
+++ b/tests/grok-acp-real-path.test.ts
@@ -83,7 +83,16 @@ describe('Grok official ACP production runtime seam', () => {
         ownership: 'owned',
       }),
     ]);
-    const { archiveOwnedGrokSession, ownedGrokSessionState } = await import('@/lib/grok/owned');
+    const { getOwnedSessionLifecycle } = await import('@/lib/runtimes/shared/owned-session-lifecycle');
+    const lifecycle = getOwnedSessionLifecycle(sessionKey);
+    await expect(lifecycle?.setDetachedSession?.(sessionKey, 'fixture detached close')).resolves.toMatchObject({
+      updated: true,
+    });
+    await expect(grokRuntime.discoverSessions()).resolves.toEqual([]);
+    const { archiveOwnedGrokSession, ownedGrokSessionState, sweepOrphanedGrokSessions } = await import('@/lib/grok/owned');
+    await expect(sweepOrphanedGrokSessions(new Set(), 0)).resolves.toBe(0);
+    await expect(grokRuntime.resume(sessionKey, 'detached turn')).rejects.toThrow('detached from its closed packet');
+    await expect(lifecycle?.setDetachedSession?.(sessionKey, null)).resolves.toMatchObject({ updated: true });
     await expect(archiveOwnedGrokSession(sessionKey)).resolves.toMatchObject({ archived: true });
     await expect(ownedGrokSessionState(sessionKey)).resolves.toBe('archived');
   }, 30_000);

--- a/tests/reset-stop-registry-truth.test.ts
+++ b/tests/reset-stop-registry-truth.test.ts
@@ -523,6 +523,7 @@ describe('reset and stop preserve runtime truth', () => {
     const closePromise = closeRoute.POST(post('/api/orchestrator/discard-packet', {
       packetId: current.packetId,
       disposition: 'wontfix',
+      acknowledgeMissingWorktree: true,
       clientMutationId: 'close-outgoing-handoff',
     }));
     await new Promise((resolve) => setTimeout(resolve, 25));
@@ -531,14 +532,14 @@ describe('reset and stop preserve runtime truth', () => {
     releaseHandoff();
     const next = await switchPromise;
     const response = await closePromise;
-    expect(response.status).toBe(409);
+    expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
-      ok: false,
-      error: { code: 'kill_unconfirmed' },
+      ok: true,
+      result: { closed: true, note: expect.stringContaining('Kill unconfirmed') },
     });
     expect(readOrchestratorControlPlaneState().missionId).toBe(next.missionId);
     expect(readMissionRegistryEntry(current.missionId, { includeArchived: true })?.mission.packets[0])
-      .toMatchObject({ status: 'blocked', queueState: 'held', blockedReason: 'kill_unconfirmed' });
+      .toMatchObject({ status: 'archived', queueState: 'held', blockedReason: null });
   });
 
   it('serializes distinct retry and reset requests and rejects the queued destructive intent', async () => {
@@ -1486,6 +1487,7 @@ describe('reset and stop preserve runtime truth', () => {
     const closePromise = closeRoute.POST(post('/api/orchestrator/discard-packet', {
       packetId,
       disposition: 'wontfix',
+      acknowledgeMissingWorktree: true,
       clientMutationId: 'close-kill-window',
     }));
     await vi.waitFor(() => expect(readOrchestratorControlPlaneState().packets[0]).toMatchObject({
@@ -1503,15 +1505,15 @@ describe('reset and stop preserve runtime truth', () => {
     });
     releaseKill();
     const response = await closePromise;
-    expect(response.status).toBe(409);
+    expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
-      ok: false,
-      error: { code: 'kill_unconfirmed' },
+      ok: true,
+      result: { closed: true, note: expect.stringContaining('Kill unconfirmed') },
     });
     expect(readOrchestratorControlPlaneState().packets[0]).toMatchObject({
-      status: 'blocked',
-      blockedReason: 'kill_unconfirmed',
-      lane: { sessionKey: packet.lane.sessionKey, worktreePath: packet.lane.worktreePath },
+      status: 'archived',
+      blockedReason: null,
+      lane: null,
     });
   });
 

--- a/tests/resident-service-close-real-path.test.ts
+++ b/tests/resident-service-close-real-path.test.ts
@@ -1,0 +1,318 @@
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import type { OrchestratorPacket } from '@/lib/orchestrator/types';
+import { createOpenCodeServiceFixture } from './helpers/opencode-service-fixture';
+
+vi.mock('@/lib/receipts/packet-receipt', () => ({
+  createPacketReceiptForClosedPacket: async () => {},
+}));
+
+const dataDir = mkdtempSync(join(os.tmpdir(), 'o8-resident-service-close-'));
+const ownedRoot = join(dataDir, 'owned-runtime');
+const wsToken = 'operator-resident-service-close-0123456789';
+const originalEnv = {
+  dataDir: process.env.CORTEX_IDE_DATA_DIR,
+  o8DataDir: process.env.O8_DATA_DIR,
+  ownedRoot: process.env.O8_OWNED_OPENCODE_ROOT,
+};
+process.env.CORTEX_IDE_DATA_DIR = dataDir;
+process.env.O8_DATA_DIR = dataDir;
+process.env.O8_OWNED_OPENCODE_ROOT = ownedRoot;
+writeFileSync(join(dataDir, 'ws-token'), `${wsToken}\n`, 'utf8');
+
+const closeRoute = await import('@/app/api/orchestrator/discard-packet/route');
+const { closeDb } = await import('@/lib/db');
+const { createLane, getLane, getLaneEvents, setLaneStatus } = await import('@/lib/lane/registry');
+const { getOwnedOpencodeFleetAdditions, sweepOrphanedOpencodeSessions } = await import('@/lib/opencode/owned');
+const { readOrchestratorControlPlaneState, writeOrchestratorControlPlaneState } = await import('@/lib/orchestrator/control-plane');
+const { createEmptyOrchestratorMissionState } = await import('@/lib/orchestrator/store');
+
+const roots: string[] = [];
+const children: ChildProcess[] = [];
+
+function restoreEnv(key: keyof typeof originalEnv, envName: string) {
+  const value = originalEnv[key];
+  if (value === undefined) delete process.env[envName];
+  else process.env[envName] = value;
+}
+
+function operatorRequest(packetId: string) {
+  return new NextRequest('http://localhost:3001/api/orchestrator/discard-packet', {
+    method: 'POST',
+    headers: {
+      host: 'localhost:3001',
+      authorization: `Bearer ${wsToken}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      packetId,
+      disposition: 'wontfix',
+      clientMutationId: `resident-service-close-${randomUUID()}`,
+    }),
+  });
+}
+
+function createFixture(label: string, commandLine: string, options: { liveMarker?: string } = {}) {
+  const root = mkdtempSync(join(dataDir, `${label}-`));
+  const repoPath = join(root, 'repo');
+  const worktreePath = join(root, 'worktree');
+  const branch = `issue/${label}`;
+  const packetId = `pkt-${label}`;
+  const surfaceId = `opencode-owned:${label}`;
+  roots.push(root);
+
+  const run = (cwd: string, command: string, args: string[]) => {
+    execFileSync(command, args, { cwd, stdio: 'pipe' });
+  };
+  run(root, 'git', ['init', '--initial-branch=main', repoPath]);
+  run(repoPath, 'git', ['-c', 'user.email=test@o8.test', '-c', 'user.name=o8-test',
+    'commit', '--allow-empty', '-m', 'init']);
+  run(repoPath, 'git', ['worktree', 'add', '-b', branch, worktreePath]);
+
+  const service = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+    stdio: 'ignore',
+  });
+  if (!service.pid) throw new Error('Fixture service did not start.');
+  children.push(service);
+
+  const runtimeFixture = createOpenCodeServiceFixture(root, worktreePath);
+  const psBin = join(runtimeFixture.binDir, 'ps');
+  writeFileSync(psBin, `#!${process.execPath}
+const args = process.argv.slice(2);
+if (args.includes('-p') && args.includes(${JSON.stringify(String(service.pid))})) {
+  process.stdout.write(${JSON.stringify(`${commandLine}\n`)});
+  process.exit(0);
+}
+if (args.includes('-axo')) {
+  process.stdout.write(${JSON.stringify(options.liveMarker
+    ? `999 /opt/runtime/opencode2 run O8_OWNED_RUN_MARKER=${options.liveMarker}\n`
+    : '')});
+  process.exit(0);
+}
+process.exit(1);
+`, 'utf8');
+  chmodSync(psBin, 0o755);
+
+  const sessionDir = join(ownedRoot, label);
+  mkdirSync(join(sessionDir, 'runs'), { recursive: true });
+  const timestamp = new Date().toISOString();
+  writeFileSync(join(sessionDir, 'session.json'), JSON.stringify({
+    surfaceId,
+    sessionDir,
+    cwd: worktreePath,
+    repoPath,
+    branch,
+    title: label,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    latestPrompt: 'fixture',
+    latestSummary: 'fixture',
+    recentRuns: [],
+    activeRun: {
+      id: `run-${label}`,
+      mode: 'launch',
+      prompt: 'fixture',
+      startedAt: timestamp,
+      pid: service.pid,
+      processMarker: options.liveMarker,
+      stdoutPath: join(sessionDir, 'runs', 'stdout.log'),
+      stderrPath: join(sessionDir, 'runs', 'stderr.log'),
+      outcome: 'running',
+    },
+  }), 'utf8');
+
+  const lane = createLane({
+    repoPath,
+    worktreePath,
+    branch,
+    baseBranch: 'main',
+    runtime: 'opencode',
+    label,
+    packetId,
+    sessionKey: surfaceId,
+  });
+  setLaneStatus(lane.id, 'reviewing', 'system', 'review_requested');
+  writeOrchestratorControlPlaneState({
+    ...createEmptyOrchestratorMissionState(),
+    missionId: `mission-${label}`,
+    repoPath,
+    runtime: 'opencode',
+    packets: [{
+      id: packetId,
+      referenceLabel: '#2224',
+      title: label,
+      summary: label,
+      workspaceTargetPath: repoPath,
+      branchTarget: branch,
+      runtime: 'opencode',
+      dependencyLabels: [],
+      dependencyPacketIds: [],
+      queueState: 'held',
+      releaseState: 'pending',
+      status: 'awaiting_review',
+      blockedReason: null,
+      lane: {
+        tileId: lane.id,
+        tabId: lane.id,
+        repoPath,
+        worktreePath,
+        runtime: 'opencode',
+        laneId: lane.id,
+        sessionKey: surfaceId,
+      },
+      review: null,
+    } as OrchestratorPacket],
+    updatedAt: timestamp,
+  });
+  return { lane, packetId, repoPath, runtimeFixture, service, sessionDir, worktreePath };
+}
+
+async function closeWithFixture(fixture: ReturnType<typeof createFixture>) {
+  const originalPath = process.env.PATH;
+  const originalBinary = process.env.O8_OPENCODE_BIN;
+  try {
+    process.env.PATH = `${fixture.runtimeFixture.binDir}:${originalPath ?? ''}`;
+    process.env.O8_OPENCODE_BIN = fixture.runtimeFixture.opencodeBin;
+    return await closeRoute.POST(operatorRequest(fixture.packetId));
+  } finally {
+    process.env.PATH = originalPath;
+    if (originalBinary === undefined) delete process.env.O8_OPENCODE_BIN;
+    else process.env.O8_OPENCODE_BIN = originalBinary;
+  }
+}
+
+afterEach(() => {
+  for (const child of children.splice(0)) {
+    if (child.pid) {
+      try {
+        process.kill(child.pid, 'SIGKILL');
+      } catch {
+        // The production path must not stop this fixture, but cleanup tolerates
+        // an already-exited child so a failed assertion does not mask the test.
+      }
+    }
+  }
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+afterAll(() => {
+  closeDb();
+  rmSync(dataDir, { recursive: true, force: true });
+  rmSync(`${ownedRoot}-archive`, { recursive: true, force: true });
+  restoreEnv('dataDir', 'CORTEX_IDE_DATA_DIR');
+  restoreEnv('o8DataDir', 'O8_DATA_DIR');
+  restoreEnv('ownedRoot', 'O8_OWNED_OPENCODE_ROOT');
+});
+
+describe('discard packet through the resident-service process boundary', () => {
+  it('closes a reviewing packet without signaling the resident service', async () => {
+    const fixture = createFixture('resident-service', '/opt/runtime/opencode2 serve --service');
+
+    const response = await closeWithFixture(fixture);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      result: {
+        closed: true,
+        worktreeRemoved: false,
+        worktreeCleanup: 'preserved',
+        note: expect.stringContaining('Kill unconfirmed'),
+      },
+    });
+    expect(() => process.kill(fixture.service.pid!, 0)).not.toThrow();
+    expect(existsSync(fixture.worktreePath)).toBe(true);
+    expect(existsSync(fixture.sessionDir)).toBe(true);
+    expect(getLane(fixture.lane.id)?.status).toBe('archived');
+    expect(getLaneEvents(fixture.lane.id).find((event) => (
+      event.verb === 'update' && event.payload.code === 'kill_unconfirmed'
+    ))).toMatchObject({ payload: { note: expect.stringContaining('resident service') } });
+    expect((await getOwnedOpencodeFleetAdditions({ fresh: true })).agents).toEqual([]);
+    expect(await sweepOrphanedOpencodeSessions(new Set(), 0)).toBe(0);
+    expect(JSON.parse(readFileSync(join(fixture.sessionDir, 'session.json'), 'utf8'))).toMatchObject({
+      detachedAt: expect.any(String),
+      detachedReason: expect.stringContaining('worker exit remained unconfirmed'),
+    });
+  });
+
+  it('closes with kill_unconfirmed recorded and preserves the checkout', async () => {
+    const fixture = createFixture('unconfirmed-worker', '/opt/runtime/opencode2 run --standalone');
+
+    const response = await closeWithFixture(fixture);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      result: {
+        closed: true,
+        worktreeRemoved: false,
+        worktreeCleanup: 'preserved',
+        note: expect.stringContaining('Kill unconfirmed'),
+      },
+    });
+    expect(existsSync(fixture.worktreePath)).toBe(true);
+    expect(getLane(fixture.lane.id)).toMatchObject({
+      status: 'archived',
+      outcomeNote: expect.stringContaining('Kill unconfirmed'),
+    });
+    expect(readOrchestratorControlPlaneState().packets[0]?.status).toBe('archived');
+    expect(existsSync(fixture.sessionDir)).toBe(true);
+    expect(getLaneEvents(fixture.lane.id).find((event) => (
+      event.verb === 'update' && event.payload.code === 'kill_unconfirmed'
+    ))).toMatchObject({ payload: { resolution: 'closed_unmerged_worker_ownership_preserved' } });
+  });
+
+  it('preserves a marker-bearing worker when its recorded pid was reused by the service', async () => {
+    const fixture = createFixture(
+      'resident-service-reused-pid',
+      '/opt/runtime/opencode2 serve --service',
+      { liveMarker: 'worker-marker-reused-pid' },
+    );
+
+    const response = await closeWithFixture(fixture);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      result: {
+        closed: true,
+        worktreeCleanup: 'preserved',
+        note: expect.stringContaining('Kill unconfirmed'),
+      },
+    });
+    expect(existsSync(fixture.worktreePath)).toBe(true);
+    expect(existsSync(fixture.sessionDir)).toBe(true);
+    expect(() => process.kill(fixture.service.pid!, 0)).not.toThrow();
+  });
+
+  it('does not record closure when an unconfirmed worker still fails the missing-worktree gate', async () => {
+    const fixture = createFixture('unconfirmed-missing', '/opt/runtime/opencode2 run --standalone');
+    rmSync(fixture.worktreePath, { recursive: true, force: true });
+
+    const response = await closeWithFixture(fixture);
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'worktree_missing_unverified' },
+    });
+    expect(getLaneEvents(fixture.lane.id).some((event) => (
+      event.verb === 'update' && event.payload.code === 'kill_unconfirmed'
+    ))).toBe(false);
+  });
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2509,6 +2509,16 @@
       ]
     },
     {
+      "path": "tests/resident-service-close-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "executable-fixture",
+        "git-cli",
+        "process-signal",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/resource-lease-cli-real-path.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
## Mechanic

The close path fresh-read the packet-owned session's stored PID, but the Windows and legacy command-line fallback verified only the runtime executable position. When that PID resolved to the long-lived `serve --service` process, the service could be accepted as the packet worker and could never satisfy worker-exit confirmation. The issue's process-table theory was broader than the implementation: the false match came through stored-PID identity verification, not an unrestricted machine-wide scan.

## What changed

- Classify resident-service arguments separately from packet-worker arguments on POSIX and Windows, and never signal the service.
- Allow discard/close to resolve an unconfirmed kill with a durable operator-visible warning while preserving the checkout and owned-session recovery metadata.
- Mark preserved unconfirmed owned sessions detached so they cannot reappear in fleet discovery, be swept, or resume; cover both owned-session implementations.
- Keep stop and reset fail-closed when worker exit is genuinely unconfirmed.

## How verified

Regression coverage:

- `discard packet through the resident-service process boundary`
- `commandLineMatchesOwnedRun`
- `close_packet_unmerged real path`
- owned ACP production seam

Red on `origin/main`:

```text
Test Files  4 failed (4)
Tests  10 failed | 19 passed (29)
Duration  15.78s
```

Green on this branch:

```text
Test Files  4 passed (4)
Tests  29 passed (29)
Duration  17.64s
```

Additional gates passed: `npx tsc --noEmit`, test classification (721 hermetic / 418 resource-owning), changed-line rule check, touched-file ESLint, and diff hygiene. The reset/stop registry suite retains five existing dispatch-fixture failures (expected 200, received 400); the same five failures were reproduced on `origin/main`.

Fixes #2224

🤖 Generated with [Claude Code](https://claude.com/claude-code)
