### PR TITLE
fix: resolve composer defaults at each turn

### DIFF
--- a/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
+++ b/src/components/desktop/thoughts/ThoughtsChatPanel.tsx
@@ -42,8 +42,10 @@ import {
   generateSuggestions,
   isRenderableThoughtEntry,
   isRunnableCliSession,
+  isRuntimeSessionKey,
   mergeSameThreadHistoryLoad,
   mergeTranscriptEntries,
+  repoPathLabel,
   resolveThreadLoadPlan,
 } from './utils';
 import { useOrchestratorStream } from './useOrchestratorStream';
@@ -116,26 +118,13 @@ import {
 } from './history-transcript';
 import {
   composerBackendTurnOverride,
+  resolveFreshComposerTurnOptions,
   formatComposerBackendLabel,
   resolveActiveComposerBackend,
   useBackendSwitchChoice,
 } from './useBackendSwitchChoice';
 
 export type { ThoughtsChatPanelHandle, ThoughtsChatPanelChromeState, ThoughtsChatPermissionMode };
-function isRuntimeSessionKey(sessionKey: string): boolean {
-  return sessionKey.startsWith('claude-code:')
-    || sessionKey.startsWith('codex:')
-    || sessionKey.startsWith('codex-owned:')
-    || sessionKey.startsWith('codex-discovered:')
-    || sessionKey.startsWith('codex-live:')
-    || sessionKey.startsWith('gemini-owned:')
-    || sessionKey.startsWith('opencode-owned:');
-}
-
-function repoPathLabel(path: string | null | undefined): string | null {
-  if (!path?.trim()) return null;
-  return path.split('/').filter(Boolean).pop() ?? path;
-}
 
 export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
   open: boolean;
@@ -1591,8 +1580,17 @@ export const ThoughtsChatPanel = forwardRef<ThoughtsChatPanelHandle, {
 
   const sendOrchestrator = useCallback((message: string, options: OrchestratorSendOptions) => {
     const handoffMode = backendSwitch.currentHandoffMode();
-    return orchStream.send(message, handoffMode ? { ...options, handoffMode } : options);
-  }, [backendSwitch, orchStream]);
+    return orchStream.send(message, {
+      ...options,
+      ...(handoffMode ? { handoffMode } : {}),
+      resolveTurnOptions: (signal) => resolveFreshComposerTurnOptions({
+        repoPath: resolvedRepoPath,
+        backend: orchestratorBackend,
+        backendSourceRef, setBackend: setOrchestratorBackend,
+        setModel: setOrchestratorModel, setOperatorDefaults,
+      }, signal),
+    });
+  }, [backendSwitch, orchStream, orchestratorBackend, resolvedRepoPath]);
 
   const startSlashOrchestration = useCallback(async (request: SlashOrchestrationRequest) => {
     const localEntriesAfterUser = request.commandEntry ? [request.commandEntry] : [];

--- a/src/components/desktop/thoughts/operator-defaults.test.ts
+++ b/src/components/desktop/thoughts/operator-defaults.test.ts
@@ -2,11 +2,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   fetchThoughtsOperatorDefaults,
+  fetchFreshThoughtsOperatorDefaults,
   normalizeThoughtsOperatorDefaults,
   scheduleThoughtsRuntimeReadiness,
   THOUGHTS_OPERATOR_DEFAULTS_FALLBACK,
   THOUGHTS_RUNTIME_READINESS_DELAY_MS,
 } from './operator-defaults';
+import { invalidateOperatorDefaultsValuesSnapshot } from '@/lib/operator/operator-defaults-values-client';
 
 afterEach(() => {
   vi.useRealTimers();
@@ -44,6 +46,14 @@ describe('thoughts operator defaults', () => {
       '/api/panel/operator-defaults?include=values',
       expect.objectContaining({ cache: 'no-store' }),
     );
+  });
+
+  it('keeps initial-load fallback but rejects a failed fresh turn refresh', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('unavailable', { status: 503 })));
+    invalidateOperatorDefaultsValuesSnapshot();
+
+    await expect(fetchFreshThoughtsOperatorDefaults()).rejects.toThrow('Failed to load operator defaults.');
+    await expect(fetchThoughtsOperatorDefaults()).resolves.toEqual(THOUGHTS_OPERATOR_DEFAULTS_FALLBACK);
   });
 
   it('defers the full readiness probe until after first paint', async () => {

--- a/src/components/desktop/thoughts/operator-defaults.ts
+++ b/src/components/desktop/thoughts/operator-defaults.ts
@@ -55,16 +55,31 @@ export const THOUGHTS_OPERATOR_DEFAULTS_FALLBACK: ThoughtsOperatorDefaults = {
 
 export async function fetchThoughtsOperatorDefaults(signal?: AbortSignal): Promise<ThoughtsOperatorDefaults> {
   try {
-    const response = await fetchOperatorDefaultsValues();
-    if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
-    const payload = await response.json().catch(() => null) as OperatorDefaultsPayload | null;
-    if (!response.ok) {
-      throw new Error('Failed to load operator defaults.');
-    }
-    return normalizeThoughtsOperatorDefaults(payload);
+    return await parseThoughtsOperatorDefaults(fetchOperatorDefaultsValues(), signal);
   } catch {
     return THOUGHTS_OPERATOR_DEFAULTS_FALLBACK;
   }
+}
+
+/** Bypass the short UI snapshot when a turn needs persisted truth at send time. */
+export async function fetchFreshThoughtsOperatorDefaults(signal?: AbortSignal): Promise<ThoughtsOperatorDefaults> {
+  return await parseThoughtsOperatorDefaults(
+    fetch('/api/panel/operator-defaults?include=values', { cache: 'no-store', signal }),
+    signal,
+  );
+}
+
+async function parseThoughtsOperatorDefaults(
+  responsePromise: Promise<Response>,
+  signal?: AbortSignal,
+): Promise<ThoughtsOperatorDefaults> {
+  const response = await responsePromise;
+  if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+  const payload = await response.json().catch(() => null) as OperatorDefaultsPayload | null;
+  if (!response.ok || !payload || typeof payload !== 'object' || !payload.values || typeof payload.values !== 'object') {
+    throw new Error('Failed to load operator defaults.');
+  }
+  return normalizeThoughtsOperatorDefaults(payload);
 }
 
 export async function fetchThoughtsRuntimeReadiness(): Promise<number | null> {

--- a/src/components/desktop/thoughts/use-orchestrator-stream/fresh-turn-options.test.ts
+++ b/src/components/desktop/thoughts/use-orchestrator-stream/fresh-turn-options.test.ts
@@ -1,0 +1,265 @@
+// @vitest-environment jsdom
+
+import { act, createElement, createRef, useEffect, useRef, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET, POST } from '@/app/api/panel/operator-defaults/route';
+import type { OrchestratorMissionState } from '@/lib/orchestrator/types';
+import { writeStoredOrchestratorModel } from '@/lib/orchestrator/store';
+import { ThoughtsChatPanel, type ThoughtsChatPanelHandle } from '../ThoughtsChatPanel';
+import { THOUGHTS_OPERATOR_DEFAULTS_FALLBACK, type OrchestratorBackendSetting } from '../operator-defaults';
+import { resolveFreshComposerTurnOptions } from '../useBackendSwitchChoice';
+import { useOrchestratorStream } from '../useOrchestratorStream';
+import { invalidateOperatorDefaultsValuesSnapshot } from '@/lib/operator/operator-defaults-values-client';
+
+const transport = vi.hoisted(() => ({ socket: null as WebSocket | null }));
+vi.mock('./shared', async (importOriginal) => ({
+  ...await importOriginal<typeof import('./shared')>(),
+  openOrchestratorWebSocket: () => transport.socket,
+}));
+vi.mock('../chat-panel/ProfiledChatMessageList', async () => {
+  const { createElement: element, forwardRef: withRef } = await import('react');
+  return { ProfiledChatMessageList: withRef<HTMLDivElement>(() => element('div')) };
+});
+
+const repoPath = '/repo/live-defaults';
+let root: Root;
+let host: HTMLDivElement;
+let freshFetchFails = false;
+let freshFetchGate: Promise<void> | null = null;
+let releaseFreshFetch: (() => void) | null = null;
+
+interface ComposerTestWindow extends Window {
+  interruptComposerTurn?: () => void;
+  setComposerBackendOwnership?: (source: 'thread' | 'user') => void;
+  submitComposerTurn?: () => void;
+  switchComposerRepo?: () => void;
+}
+
+function composerWindow(): ComposerTestWindow {
+  return window as unknown as ComposerTestWindow;
+}
+
+function invokeComposerAction(action: keyof ComposerTestWindow, ...args: unknown[]) {
+  const callback = composerWindow()[action];
+  if (typeof callback !== 'function') throw new Error(`Missing composer test action: ${action}`);
+  Reflect.apply(callback, composerWindow(), args);
+}
+
+function blockFreshFetch() {
+  freshFetchGate = new Promise<void>((resolve) => { releaseFreshFetch = resolve; });
+}
+
+async function persistDefaults(orchestratorModel: string, orchestratorBackend: 'claude' | 'codex') {
+  const response = await POST(new Request('http://127.0.0.1/api/panel/operator-defaults', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ orchestratorModel, orchestratorBackend }),
+  }));
+  expect(response.ok).toBe(true);
+}
+
+function ComposerSubmissionHarness() {
+  const [activeRepoPath, setActiveRepoPath] = useState(repoPath);
+  const [displayedModel, setDisplayedModel] = useState('gpt-5.6-sol');
+  const [displayedBackend, setDisplayedBackend] = useState<OrchestratorBackendSetting>('codex');
+  const backendSourceRef = useRef<'default' | 'thread' | 'user'>('default');
+  const [, setOperatorDefaults] = useState(THOUGHTS_OPERATOR_DEFAULTS_FALLBACK);
+  const result = useOrchestratorStream(activeRepoPath, { threadId: 'fresh-turn-options' });
+
+  useEffect(() => {
+    composerWindow().submitComposerTurn = () => {
+      result.send('operator message', {
+        model: displayedModel,
+        backend: displayedBackend === 'auto' ? undefined : displayedBackend,
+        resolveTurnOptions: (signal) => resolveFreshComposerTurnOptions({
+          repoPath: activeRepoPath,
+          backend: displayedBackend,
+          backendSourceRef,
+          setBackend: setDisplayedBackend,
+          setModel: setDisplayedModel,
+          setOperatorDefaults,
+        }, signal),
+      });
+    };
+    composerWindow().interruptComposerTurn = result.interrupt;
+    composerWindow().switchComposerRepo = () => setActiveRepoPath('/repo/switched');
+    composerWindow().setComposerBackendOwnership = (source) => {
+      backendSourceRef.current = source;
+      setDisplayedBackend('codex');
+    };
+  }, [activeRepoPath, displayedBackend, displayedModel, result]);
+
+  return createElement('output', { 'data-testid': 'displayed-model' }, displayedModel);
+}
+
+async function waitForPayload(count: number) {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    const payloads = sentTurnPayloads();
+    if (payloads.length >= count) return payloads[count - 1]!;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(`Timed out waiting for outbound payload ${count}`);
+}
+
+function sentTurnPayloads() {
+  const sent = transport.socket!.send as ReturnType<typeof vi.fn>;
+  return sent.mock.calls
+    .map(([payload]) => JSON.parse(payload as string) as Record<string, unknown>)
+    .filter((payload) => payload.type === 'orchestrator-send');
+}
+
+beforeEach(async () => {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  Object.defineProperty(HTMLElement.prototype, 'scrollTo', { configurable: true, value: vi.fn() });
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.startsWith('/api/panel/operator-defaults')) {
+      if (freshFetchFails) return new Response('unavailable', { status: 503 });
+      if (freshFetchGate) await freshFetchGate;
+      return GET(new Request(`http://127.0.0.1${url}`));
+    }
+    return new Response('{}', { headers: { 'Content-Type': 'application/json' } });
+  }));
+  transport.socket = { readyState: WebSocket.OPEN, send: vi.fn(), close: vi.fn() } as unknown as WebSocket;
+  freshFetchFails = false;
+  freshFetchGate = null;
+  releaseFreshFetch = null;
+  host = document.createElement('div');
+  document.body.append(host);
+  root = createRoot(host);
+  await act(async () => root.render(createElement(ComposerSubmissionHarness)));
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  delete (HTMLElement.prototype as { scrollTo?: unknown }).scrollTo;
+  host.remove();
+  localStorage.clear();
+  transport.socket = null;
+  vi.unstubAllGlobals();
+});
+
+describe('composer fresh operator defaults at the send seam', () => {
+  it('reaches the live resolver through the real ThoughtsChatPanel send callback', async () => {
+    await act(async () => root.unmount());
+    root = createRoot(host);
+    invalidateOperatorDefaultsValuesSnapshot();
+    await persistDefaults('gpt-5.6-sol', 'codex');
+    const panelRef = createRef<ThoughtsChatPanelHandle>();
+    const missionState: OrchestratorMissionState = {
+      version: 2,
+      prompt: '',
+      summary: '',
+      packets: [],
+      updatedAt: new Date(0).toISOString(),
+    };
+    await act(async () => {
+      root.render(createElement(ThoughtsChatPanel, {
+        ref: panelRef,
+        open: false,
+        agents: [],
+        missionState,
+        preferredRuntime: 'codex',
+        sessionTargets: [],
+        workspaceTargets: [],
+        repoPath,
+        initialMode: 'fleet',
+        onModePersist: () => {},
+        suppressAutoRestore: true,
+        suppressRuntimePrewarm: true,
+        thoughtsBodyBackground: 'var(--t-bg)',
+        thoughtsElevatedSurface: 'var(--t-panel)',
+        thoughtsElevatedBorder: 'var(--t-border)',
+        thoughtsElevatedShadow: 'var(--t-panel-shadow)',
+        thoughtsMutedGlass: 'var(--t-muted)',
+        onMissionStateChange: () => {},
+        onChromeChange: () => {},
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+    await persistDefaults('gpt-5.6-terra', 'codex');
+    let payload: Record<string, unknown> = {};
+    await act(async () => {
+      expect(panelRef.current?.sendNow('operator message')).toBe(true);
+      payload = await waitForPayload(1);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+    const modelButton = [...host.querySelectorAll('button')]
+      .find((button) => button.title.startsWith('Terra'));
+    expect(modelButton).toBeTruthy();
+    expect(payload).toMatchObject({ model: 'gpt-5.6-terra', backend: 'codex' });
+  });
+
+  it('carries and displays each persisted default without remounting, while retaining a repo model pin', async () => {
+    await persistDefaults('gpt-5.6-sol', 'codex');
+    let first: Record<string, unknown> = {};
+    await act(async () => {
+      invokeComposerAction('submitComposerTurn');
+      first = await waitForPayload(1);
+    });
+    expect(first).toMatchObject({ model: 'gpt-5.6-sol', backend: 'codex' });
+    expect(host.querySelector('[data-testid="displayed-model"]')?.textContent).toBe('gpt-5.6-sol');
+
+    await persistDefaults('claude-sonnet-5', 'claude');
+    let second: Record<string, unknown> = {};
+    await act(async () => {
+      invokeComposerAction('submitComposerTurn');
+      second = await waitForPayload(2);
+    });
+    expect(second).toMatchObject({ model: 'claude-sonnet-5', backend: 'claude' });
+    expect(host.querySelector('[data-testid="displayed-model"]')?.textContent).toBe('claude-sonnet-5');
+
+    writeStoredOrchestratorModel(repoPath, 'gpt-5.6-sol');
+    await persistDefaults('claude-sonnet-5', 'claude');
+    await act(async () => {
+      invokeComposerAction('setComposerBackendOwnership', 'thread');
+    });
+    let pinned: Record<string, unknown> = {};
+    await act(async () => {
+      invokeComposerAction('submitComposerTurn');
+      pinned = await waitForPayload(3);
+    });
+    expect(pinned).toMatchObject({ model: 'gpt-5.6-sol', backend: 'codex' });
+    expect(host.querySelector('[data-testid="displayed-model"]')?.textContent).toBe('gpt-5.6-sol');
+
+    await act(async () => {
+      invokeComposerAction('setComposerBackendOwnership', 'user');
+    });
+    let userOwned: Record<string, unknown> = {};
+    await act(async () => {
+      invokeComposerAction('submitComposerTurn');
+      userOwned = await waitForPayload(4);
+    });
+    expect(userOwned).toMatchObject({ model: 'gpt-5.6-sol', backend: 'codex' });
+
+    freshFetchFails = true;
+    let fallback: Record<string, unknown> = {};
+    await act(async () => {
+      invokeComposerAction('submitComposerTurn');
+      fallback = await waitForPayload(5);
+    });
+    expect(fallback).toMatchObject({ model: 'gpt-5.6-sol', backend: 'codex' });
+  });
+
+  it('cancels a pending default refresh when the operator stops or changes repo context', async () => {
+    await persistDefaults('claude-sonnet-5', 'claude');
+    blockFreshFetch();
+    await act(async () => {
+      invokeComposerAction('submitComposerTurn');
+      invokeComposerAction('interruptComposerTurn');
+      releaseFreshFetch?.();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(sentTurnPayloads()).toHaveLength(0);
+
+    blockFreshFetch();
+    await act(async () => {
+      invokeComposerAction('submitComposerTurn');
+      invokeComposerAction('switchComposerRepo');
+      releaseFreshFetch?.();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(sentTurnPayloads()).toHaveLength(0);
+  });
+});

--- a/src/components/desktop/thoughts/use-orchestrator-stream/resolve-turn-options.ts
+++ b/src/components/desktop/thoughts/use-orchestrator-stream/resolve-turn-options.ts
@@ -1,0 +1,18 @@
+import type { OrchestratorSendOptions } from './types';
+
+export const TURN_OPTIONS_REFRESH_TIMEOUT = Symbol('turn-options-refresh-timeout');
+
+export async function resolveOrchestratorTurnOptions(
+  options: OrchestratorSendOptions | undefined,
+  signal: AbortSignal,
+): Promise<OrchestratorSendOptions | null | undefined> {
+  try {
+    const liveOptions = await options?.resolveTurnOptions?.(signal);
+    return liveOptions ? { ...options, ...liveOptions } : options;
+  } catch {
+    if (signal.aborted && signal.reason !== TURN_OPTIONS_REFRESH_TIMEOUT) return null;
+    // A failed refresh must not discard an operator-authored turn. The
+    // captured values are the bounded fallback for this one send.
+    return options;
+  }
+}

--- a/src/components/desktop/thoughts/use-orchestrator-stream/turn-option-resolution.ts
+++ b/src/components/desktop/thoughts/use-orchestrator-stream/turn-option-resolution.ts
@@ -1,0 +1,62 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import type { OrchestratorExecutionMode } from '@/lib/orchestrator/types';
+import type { OrchestratorBackendId } from '@/lib/lane/orchestrator-backends/types';
+import {
+  DEFAULT_ORCHESTRATOR_MODEL,
+  type OrchestratorPermissionMode,
+} from './shared';
+import {
+  resolveOrchestratorTurnOptions,
+  TURN_OPTIONS_REFRESH_TIMEOUT,
+} from './resolve-turn-options';
+import type { OrchestratorSendOptions } from './types';
+
+const TURN_OPTIONS_REFRESH_TIMEOUT_MS = 5_000;
+
+export function prepareOrchestratorTurn(message: string, options?: OrchestratorSendOptions) {
+  const permissionMode: OrchestratorPermissionMode = options?.permissionMode ?? 'full';
+  const requestedOrchestrationMode = options?.orchestrationMode ?? 'fleet';
+  const collide = options?.collide === true && requestedOrchestrationMode !== 'single';
+  const backend: OrchestratorBackendId | undefined = collide ? 'collide' : options?.backend;
+  const orchestrationMode: OrchestratorExecutionMode = collide ? 'fleet' : requestedOrchestrationMode;
+  return {
+    permissionMode,
+    thinkingEffort: options?.thinkingEffort,
+    model: options?.model?.trim() || DEFAULT_ORCHESTRATOR_MODEL,
+    displayMessage: options?.displayMessage?.trim() || message,
+    wireMessage: options?.wireMessage?.trim() || message,
+    localEntriesAfterUser: options?.localEntriesAfterUser ?? [],
+    collideBaseBackend: collide ? options?.backend : undefined,
+    backend,
+    orchestrationMode,
+  };
+}
+
+export function useTurnOptionResolution(repoPath: string | null) {
+  const controllersRef = useRef(new Map<string, AbortController>());
+  const abort = useCallback((clientMessageId?: string) => {
+    for (const [pendingId, controller] of controllersRef.current) {
+      if (clientMessageId && pendingId !== clientMessageId) continue;
+      controller.abort();
+      controllersRef.current.delete(pendingId);
+    }
+  }, []);
+  useEffect(() => {
+    abort();
+    return () => abort();
+  }, [abort, repoPath]);
+  const resolve = useCallback(async (clientMessageId: string, options?: OrchestratorSendOptions) => {
+    const controller = new AbortController();
+    controllersRef.current.set(clientMessageId, controller);
+    const timeout = window.setTimeout(() => controller.abort(TURN_OPTIONS_REFRESH_TIMEOUT), TURN_OPTIONS_REFRESH_TIMEOUT_MS);
+    try {
+      return await resolveOrchestratorTurnOptions(options, controller.signal);
+    } finally {
+      window.clearTimeout(timeout);
+      controllersRef.current.delete(clientMessageId);
+    }
+  }, []);
+  return useMemo(() => ({ abort, resolve }), [abort, resolve]);
+}

--- a/src/components/desktop/thoughts/use-orchestrator-stream/types.ts
+++ b/src/components/desktop/thoughts/use-orchestrator-stream/types.ts
@@ -30,6 +30,12 @@ export interface OrchestratorSendOptions {
   /** Explicit consent to seed a cold cross-backend continuation. */
   handoffMode?: 'handoff';
   attachments?: Array<{ dataUri: string; name?: string }>;
+  /**
+   * Resolves settings which must be current when this turn is constructed.
+   * The composer uses this for persisted operator defaults, which can change
+   * while a tab remains mounted.
+   */
+  resolveTurnOptions?: (signal: AbortSignal) => Promise<Pick<OrchestratorSendOptions, 'backend' | 'model'>>;
 }
 
 export interface OrchestratorStreamOptions {

--- a/src/components/desktop/thoughts/useBackendSwitchChoice.ts
+++ b/src/components/desktop/thoughts/useBackendSwitchChoice.ts
@@ -1,9 +1,9 @@
 import { useCallback, useMemo, useRef, useState, type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
 import { formatModelLabel } from '@/lib/format';
 import type { OrchestratorBackendId } from '@/lib/lane/orchestrator-backends/types';
-import { writeStoredOrchestratorModel } from '@/lib/orchestrator/store';
+import { readStoredOrchestratorModel, writeStoredOrchestratorModel } from '@/lib/orchestrator/store';
 import type { PendingBackendSwitch } from './chat-panel/BackendSwitchChoice';
-import type { OrchestratorBackendSetting, ThoughtsOperatorDefaults } from './operator-defaults';
+import { fetchFreshThoughtsOperatorDefaults, type OrchestratorBackendSetting, type ThoughtsOperatorDefaults } from './operator-defaults';
 
 export function resolveActiveComposerBackend(defaults: Pick<ThoughtsOperatorDefaults, 'orchestratorBackend' | 'inAppOrchestratorEnabled'>): OrchestratorBackendSetting {
   if (defaults.orchestratorBackend !== 'auto') return defaults.orchestratorBackend;
@@ -20,6 +20,26 @@ export function formatComposerBackendLabel(backend: OrchestratorBackendSetting, 
 
 export function composerBackendTurnOverride(backend: OrchestratorBackendSetting): OrchestratorBackendId | undefined {
   return backend === 'auto' ? undefined : backend;
+}
+
+export async function resolveFreshComposerTurnOptions(input: {
+  repoPath: string | null;
+  backend: OrchestratorBackendSetting;
+  backendSourceRef: MutableRefObject<'default' | 'thread' | 'user'>;
+  setBackend: Dispatch<SetStateAction<OrchestratorBackendSetting>>;
+  setModel: Dispatch<SetStateAction<string>>;
+  setOperatorDefaults: Dispatch<SetStateAction<ThoughtsOperatorDefaults>>;
+}, signal?: AbortSignal) {
+  const defaults = await fetchFreshThoughtsOperatorDefaults(signal);
+  if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+  const model = readStoredOrchestratorModel(input.repoPath) ?? defaults.orchestratorModel;
+  const backend = input.backendSourceRef.current === 'default'
+    ? resolveActiveComposerBackend(defaults)
+    : input.backend;
+  input.setOperatorDefaults(defaults);
+  input.setModel(model);
+  if (input.backendSourceRef.current === 'default') input.setBackend(backend);
+  return { model, backend: composerBackendTurnOverride(backend) };
 }
 
 export function useBackendSwitchChoice(input: {

--- a/src/components/desktop/thoughts/useOrchestratorStream.ts
+++ b/src/components/desktop/thoughts/useOrchestratorStream.ts
@@ -16,7 +16,6 @@ import {
   subscribeOrchestratorMissionCompleted,
   type OrchestratorMissionCompletedDetail,
 } from '@/lib/orchestrator/store';
-import type { OrchestratorExecutionMode } from '@/lib/orchestrator/types';
 import {
   buildOrchestratorSendPayload,
   createOrchestratorClientMessageId,
@@ -35,7 +34,6 @@ import {
   useNoSnapshotBusyFallback,
 } from './use-orchestrator-stream/snapshot-reconcile';
 import {
-  DEFAULT_ORCHESTRATOR_MODEL,
   ORCHESTRATOR_AUTO_COMPACT_RESET_FLOOR,
   ORCHESTRATOR_AUTO_COMPACT_THRESHOLD,
   ORCHESTRATOR_COMPACTION_STATUS_MIN_MS,
@@ -52,7 +50,6 @@ import {
   openOrchestratorWebSocket,
   refreshWsCredentials,
   sortTranscriptEntries,
-  type OrchestratorPermissionMode,
   type OrchestratorStreamStatus,
 } from './use-orchestrator-stream/shared';
 import {
@@ -60,15 +57,14 @@ import {
   type CurrentAssistantStreamState,
   type OrchestratorSnapshotTurn,
 } from './use-orchestrator-stream/socket';
+import { prepareOrchestratorTurn, useTurnOptionResolution } from './use-orchestrator-stream/turn-option-resolution';
 import type {
   OrchestratorSendHandle,
   OrchestratorSendOptions,
   OrchestratorStreamOptions,
   OrchestratorStreamResult,
 } from './use-orchestrator-stream/types';
-
 export type { OrchestratorSendHandle } from './use-orchestrator-stream/types';
-
 export {
   DEFAULT_ORCHESTRATOR_MODEL,
   ORCHESTRATOR_TOKEN_EVENT,
@@ -161,6 +157,7 @@ export function useOrchestratorStream(
   // It must be set before the send ACK because the operator can press Stop
   // while the selected backend is still resolving its CLI (#1557).
   const activeTurnBackendRef = useRef<OrchestratorBackendId | null>(null);
+  const turnOptionResolution = useTurnOptionResolution(repoPath);
   const missionRotationInFlightRef = useRef(false);
   const pendingMissionCompletionRef = useRef<OrchestratorMissionCompletedDetail | null>(null);
   const transitionStripTimerRef = useRef<number | null>(null);
@@ -311,6 +308,7 @@ export function useOrchestratorStream(
   }, []);
 
   const reset = useCallback(() => {
+    turnOptionResolution.abort();
     const nextStatus = connected ? 'ready' : 'connecting';
     resetEpochRef.current += 1;
     lastSeqRef.current = 0;
@@ -343,7 +341,7 @@ export function useOrchestratorStream(
     }
     clearQueuedOrchestratorSessionPrelude(repoPathRef.current, threadIdRef.current);
     emitTokenUsage({ repoPath: repoPathRef.current, tokenCount: 0, runningTotal: 0 });
-  }, [connected, resetFirstTurnPlanCapture, syncMessages, updateRunningTotal]);
+  }, [connected, resetFirstTurnPlanCapture, syncMessages, turnOptionResolution, updateRunningTotal]);
 
   const archiveMissionThread = useCallback(async (detail: OrchestratorMissionCompletedDetail) => {
     const activeRepoPath = repoPathRef.current;
@@ -843,6 +841,7 @@ export function useOrchestratorStream(
   // 'done' event within 1-2s which reinforces the idle state. Partial events
   // already accumulated in the transcript stay intact.
   const interrupt = useCallback(() => {
+    turnOptionResolution.abort();
     const activeRepoPath = repoPathRef.current;
     if (!activeRepoPath) return;
     const ws = wsRef.current;
@@ -862,31 +861,13 @@ export function useOrchestratorStream(
       activeTurnRef.current = null;
       currentAssistantRef.current = null;
     }
-  }, [connected]);
-
+  }, [connected, turnOptionResolution]);
   const send = useCallback((message: string, options?: OrchestratorSendOptions) => {
-    const permissionMode: OrchestratorPermissionMode = options?.permissionMode ?? 'full';
-    const thinkingEffort = options?.thinkingEffort;
-    const model = options?.model?.trim() || DEFAULT_ORCHESTRATOR_MODEL;
-    const displayMessage = options?.displayMessage?.trim() || message;
-    const wireMessage = options?.wireMessage?.trim() || message;
-    const localEntriesAfterUser = options?.localEntriesAfterUser ?? [];
-    const requestedOrchestrationMode = options?.orchestrationMode ?? 'fleet';
-    // Single is the hard boundary: even a stale UI state that still has MoA
-    // armed must not route into Collide's proposer fan-out.
-    const collide = options?.collide === true && requestedOrchestrationMode !== 'single';
-    const collideBaseBackend = collide ? options?.backend : undefined;
-    const backend = collide ? 'collide' : options?.backend;
-    activeTurnBackendRef.current = backend ?? null;
-    // Collide owns its proposal/aggregation pass; the separate Fusion directive
-    // would nest a second fan-out inside it.
-    const orchestrationMode: OrchestratorExecutionMode = collide
-      ? 'fleet'
-      : requestedOrchestrationMode;
     suppressTurnEventsRef.current = false;
     const clientMessageId = createOrchestratorClientMessageId();
     const sentAtMs = Date.now();
     const transcriptBeforeSend = messagesRef.current;
+    const repoPathAtSend = repoPathRef.current;
 
     // Mint before returning the handle so undo always targets the exact durable
     // thread even when this is the first message on a fresh tab.
@@ -899,7 +880,7 @@ export function useOrchestratorStream(
       clientMessageId,
       userMessageId: `orch-user-${clientMessageId}`,
       threadId: threadIdRef.current,
-      backend: backend ?? null,
+      backend: options?.backend ?? null,
       transcriptBeforeSend,
     };
     lastSendAtRef.current = sentAtMs;
@@ -907,6 +888,23 @@ export function useOrchestratorStream(
     setPendingStatusBusy();
 
     void (async () => {
+      const turnOptions = await turnOptionResolution.resolve(clientMessageId, options);
+      if (turnOptions === null || repoPathRef.current !== repoPathAtSend || threadIdRef.current !== sendHandle.threadId) {
+        activeTurnBackendRef.current = null;
+        if (statusRef.current === 'busy') {
+          const nextStatus = connected ? 'ready' : 'connecting';
+          statusRef.current = nextStatus;
+          setStatus(nextStatus);
+          setBusyState(createIdleBusyState());
+        }
+        return;
+      }
+      const {
+        permissionMode, thinkingEffort, model, displayMessage, wireMessage,
+        localEntriesAfterUser, collideBaseBackend, backend, orchestrationMode,
+      } = prepareOrchestratorTurn(message, turnOptions);
+      activeTurnBackendRef.current = backend ?? null;
+      sendHandle.backend = backend ?? null;
       const activeRepoPath = repoPathRef.current;
       if (!activeRepoPath) {
         activeTurnBackendRef.current = null;
@@ -1004,9 +1002,9 @@ export function useOrchestratorStream(
         // Per-turn override stays truthful while the global default write settles.
         backend,
         collideBaseBackend,
-        handoffMode: options?.handoffMode,
-        attachments: options?.attachments,
-        taskArtifactAction: options?.taskArtifactAction,
+        handoffMode: turnOptions?.handoffMode,
+        attachments: turnOptions?.attachments,
+        taskArtifactAction: turnOptions?.taskArtifactAction,
       });
       const pendingRecord = {
         text: outboundMessage,
@@ -1036,9 +1034,10 @@ export function useOrchestratorStream(
       setPendingStatusBusy();
     })();
     return sendHandle;
-  }, [connect, connected, durablePendingSend, estimateNextTurnTokens, primeCompactedSession, requestCompaction, setPendingStatusBusy]);
+  }, [connect, connected, durablePendingSend, estimateNextTurnTokens, primeCompactedSession, requestCompaction, setPendingStatusBusy, turnOptionResolution]);
 
   const undoSend = useCallback((handle: OrchestratorSendHandle) => {
+    turnOptionResolution.abort(handle.clientMessageId);
     const activeRepoPath = repoPathRef.current;
     durablePendingSend.cancelPending(handle.clientMessageId);
     syncMessages(handle.transcriptBeforeSend);
@@ -1067,7 +1066,7 @@ export function useOrchestratorStream(
       getWebSocket: () => wsRef.current,
       connect: () => { console.warn('[orchestrator-stream] WS not open, reconnecting to undo send...'); connect(); },
     });
-  }, [connect, connected, durablePendingSend, resetFirstTurnPlanCapture, syncMessages]);
+  }, [connect, connected, durablePendingSend, resetFirstTurnPlanCapture, syncMessages, turnOptionResolution]);
 
   return {
     messages,

--- a/src/components/desktop/thoughts/utils.ts
+++ b/src/components/desktop/thoughts/utils.ts
@@ -135,6 +135,21 @@ export function isRunnableCliSession(agent: FleetAgent) {
   return true;
 }
 
+export function isRuntimeSessionKey(sessionKey: string): boolean {
+  return sessionKey.startsWith('claude-code:')
+    || sessionKey.startsWith('codex:')
+    || sessionKey.startsWith('codex-owned:')
+    || sessionKey.startsWith('codex-discovered:')
+    || sessionKey.startsWith('codex-live:')
+    || sessionKey.startsWith('gemini-owned:')
+    || sessionKey.startsWith('opencode-owned:');
+}
+
+export function repoPathLabel(path: string | null | undefined): string | null {
+  if (!path?.trim()) return null;
+  return path.split('/').filter(Boolean).pop() ?? path;
+}
+
 export function buildAgentTargets(
   agents: FleetAgent[],
   preferredRuntime: OrchestratorRuntime,

--- a/tests/orchestrator-model-attribution-real-path.test.ts
+++ b/tests/orchestrator-model-attribution-real-path.test.ts
@@ -1,0 +1,188 @@
+import { execFile, execFileSync, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { WebSocket } from 'ws';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { GET, POST } from '@/app/api/panel/operator-defaults/route';
+import { buildOrchestratorSendPayload } from '@/components/desktop/thoughts/use-orchestrator-stream/send-payload';
+import { resolveOrchestratorTurnOptions } from '@/components/desktop/thoughts/use-orchestrator-stream/resolve-turn-options';
+import { prepareOrchestratorTurn } from '@/components/desktop/thoughts/use-orchestrator-stream/turn-option-resolution';
+import {
+  THOUGHTS_OPERATOR_DEFAULTS_FALLBACK,
+  type OrchestratorBackendSetting,
+  type ThoughtsOperatorDefaults,
+} from '@/components/desktop/thoughts/operator-defaults';
+import {
+  composerBackendTurnOverride,
+  resolveFreshComposerTurnOptions,
+} from '@/components/desktop/thoughts/useBackendSwitchChoice';
+
+const dataDir = mkdtempSync(join(tmpdir(), 'o8-orchestrator-model-attribution-'));
+const repoPath = join(dataDir, 'repo');
+const token = 'orchestrator-model-attribution-token';
+const sockets = new Set<WebSocket>();
+let apiServer: Server;
+let wsProcess: ChildProcess;
+let apiPort = 0;
+let wsPort = 0;
+let serverOutput = '';
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') return reject(new Error('missing test port'));
+      server.close((error) => error ? reject(error) : resolve(address.port));
+    });
+  });
+}
+
+async function waitFor(predicate: () => boolean, description: string, timeoutMs = 20_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out waiting for ${description}: ${serverOutput.slice(-2_000)}`);
+}
+
+async function persistDefaults(orchestratorModel: string, orchestratorBackend: 'claude' | 'codex') {
+  const response = await POST(new Request('http://127.0.0.1/api/panel/operator-defaults', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ orchestratorModel, orchestratorBackend }),
+  }));
+  expect(response.ok).toBe(true);
+}
+
+async function submitComposerTurn(
+  socket: WebSocket,
+  threadId: string,
+  capturedModel: string,
+  capturedBackend: OrchestratorBackendSetting,
+) {
+  let displayedModel = capturedModel;
+  let displayedBackend = capturedBackend;
+  let displayedDefaults: ThoughtsOperatorDefaults = THOUGHTS_OPERATOR_DEFAULTS_FALLBACK;
+  const backendSourceRef = { current: 'default' as const };
+  const controller = new AbortController();
+  const turnOptions = await resolveOrchestratorTurnOptions({
+    model: capturedModel,
+    backend: composerBackendTurnOverride(capturedBackend),
+    resolveTurnOptions: (signal) => resolveFreshComposerTurnOptions({
+      repoPath,
+      backend: capturedBackend,
+      backendSourceRef,
+      setBackend: (value) => { displayedBackend = typeof value === 'function' ? value(displayedBackend) : value; },
+      setModel: (value) => { displayedModel = typeof value === 'function' ? value(displayedModel) : value; },
+      setOperatorDefaults: (value) => { displayedDefaults = typeof value === 'function' ? value(displayedDefaults) : value; },
+    }, signal),
+  }, controller.signal);
+  if (!turnOptions) throw new Error('Composer turn option resolution was cancelled.');
+  const turn = prepareOrchestratorTurn('reply deterministically', turnOptions);
+  socket.send(buildOrchestratorSendPayload({
+    repoPath,
+    threadId,
+    clientMessageId: `${threadId}-client-message`,
+    wireMessage: turn.wireMessage,
+    displayMessage: turn.displayMessage,
+    permissionMode: turn.permissionMode,
+    orchestrationMode: turn.orchestrationMode,
+    model: turn.model,
+    backend: turn.backend,
+  }));
+  const historyPath = join(dataDir, 'chat-history', `${threadId}.json`);
+  await waitFor(() => {
+    try {
+      const history = JSON.parse(readFileSync(historyPath, 'utf8')) as { messages?: Array<{ role?: string; model?: string; content?: string }> };
+      return history.messages?.some((entry) => entry.role === 'assistant' && entry.content === 'deterministic assistant reply') ?? false;
+    } catch {
+      return false;
+    }
+  }, 'persisted assistant attribution');
+  const history = JSON.parse(readFileSync(historyPath, 'utf8')) as { messages: Array<{ role: string; model?: string }> };
+  return {
+    displayedModel,
+    displayedBackend,
+    recordedModel: history.messages.find((entry) => entry.role === 'assistant')?.model,
+  };
+}
+
+beforeAll(async () => {
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.startsWith('/api/panel/operator-defaults')) {
+      return GET(new Request(`http://127.0.0.1${url}`));
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  }));
+  mkdirSync(repoPath, { recursive: true });
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repoPath });
+  writeFileSync(join(dataDir, 'ws-token'), `${token}\n`, { mode: 0o600 });
+  const fakeCodex = join(dataDir, 'fake-codex.mjs');
+  writeFileSync(fakeCodex, `#!/usr/bin/env node
+if (process.argv.includes('--version')) { console.log('codex-cli 0.130.0'); process.exit(0); }
+console.log(JSON.stringify({ type: 'thread.started', thread_id: 'fake-codex-thread' }));
+console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'deterministic assistant reply' } }));
+`);
+  chmodSync(fakeCodex, 0o755);
+  apiPort = await freePort();
+  wsPort = await freePort();
+  apiServer = createServer((request, response) => {
+    if (request.url === '/api/setup/identity') {
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify({ configured: false }));
+      return;
+    }
+    response.writeHead(404);
+    response.end();
+  });
+  apiServer.listen(apiPort, '127.0.0.1');
+  await once(apiServer, 'listening');
+  wsProcess = execFile(process.execPath, ['--import=./scripts/register-server-only-stub.mjs', '--import=tsx', 'src/ws-server.ts'], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      CORTEX_IDE_DATA_DIR: dataDir,
+      O8_API_PORT: String(apiPort),
+      O8_WS_PORT: String(wsPort),
+      O8_CODEX_BIN: fakeCodex,
+      NEXT_ORIGIN: `http://127.0.0.1:${apiPort}`,
+    },
+  });
+  wsProcess.stdout?.on('data', (chunk) => { serverOutput += String(chunk); });
+  wsProcess.stderr?.on('data', (chunk) => { serverOutput += String(chunk); });
+  await waitFor(() => serverOutput.includes('WebSocket server listening'), 'ws-server startup');
+}, 30_000);
+
+afterAll(async () => {
+  for (const socket of sockets) socket.close();
+  if (wsProcess?.exitCode === null) {
+    wsProcess.kill('SIGTERM');
+    await Promise.race([once(wsProcess, 'exit'), new Promise((resolve) => setTimeout(resolve, 5_000))]);
+  }
+  if (apiServer?.listening) await new Promise<void>((resolve) => apiServer.close(() => resolve()));
+  rmSync(dataDir, { recursive: true, force: true });
+  vi.unstubAllGlobals();
+});
+
+describe('orchestrator model attribution through the real WebSocket turn handler', () => {
+  it('records the freshly resolved default on the next real WebSocket turn', async () => {
+    const socket = new WebSocket(`ws://127.0.0.1:${wsPort}/ws?token=${encodeURIComponent(token)}`);
+    sockets.add(socket);
+    await once(socket, 'open');
+
+    await persistDefaults('gpt-5.6-sol', 'codex');
+    const first = await submitComposerTurn(socket, `thoughts-model-attribution-a-${Date.now()}`, 'gpt-5.6-sol', 'codex');
+    expect(first).toMatchObject({ displayedModel: 'gpt-5.6-sol', displayedBackend: 'codex', recordedModel: 'gpt-5.6-sol' });
+
+    await persistDefaults('gpt-5.6-terra', 'codex');
+    const second = await submitComposerTurn(socket, `thoughts-model-attribution-b-${Date.now()}`, 'gpt-5.6-sol', 'codex');
+    expect(second).toMatchObject({ displayedModel: 'gpt-5.6-terra', displayedBackend: 'codex', recordedModel: 'gpt-5.6-terra' });
+  }, 30_000);
+});

--- a/tests/test-classification.json
+++ b/tests/test-classification.json
@@ -2141,6 +2141,17 @@
       ]
     },
     {
+      "path": "tests/orchestrator-model-attribution-real-path.test.ts",
+      "reasons": [
+        "child-process",
+        "executable-fixture",
+        "git-cli",
+        "network-listener",
+        "process-signal",
+        "real-path"
+      ]
+    },
+    {
       "path": "tests/orchestrator-spawn-preflight.test.ts",
       "reasons": [
         "child-process",


### PR DESCRIPTION
## Mechanic

The composer captured the operator-default model and backend from its mount-time snapshot. The real turn path enters through the WebSocket server, which trusted those stale per-turn values even though server-side settings reads were already live.

## What changed

- Refresh persisted operator defaults immediately before each composer turn, bypassing the short-lived UI snapshot.
- Apply the same turn-time refresh to the default backend while preserving thread/user backend ownership and per-repository model pins.
- Update the rendered model surface from the same resolved value sent on the turn.
- Bound refreshes to five seconds, fall back to the displayed choice on lookup failure, and cancel unresolved sends on Stop, Undo, repository changes, or thread changes.
- Cover the real panel callback, stream send seam, operator-defaults route, authenticated WebSocket handler, and persisted assistant attribution.

## How verified

Red, with the old send seam restored:

```diff
- Expected: { model: "claude-sonnet-5", backend: "claude" }
+ Received: { model: "gpt-5.6-sol", backend: "codex" }
Test Files  1 failed (1)
Tests       1 failed | 1 skipped (2)
```

Green:

```text
Client:      Test Files 2 passed (2), Tests 8 passed (8)
Real path:   Test Files 1 passed (1), Tests 1 passed (1)
Full unit:   Test Files 719 passed | 3 skipped (722)
             Tests 4497 passed | 4 skipped (4501)
```

Also passed `npx tsc --noEmit`, touched-file ESLint, changed-line rule check, fixture classification, and diff check. Independent review reported no findings.

Fixes #2208

🤖 Generated with [Claude Code](https://claude.com/claude-code)