### PR TITLE
chore: bump version to 0.1.751

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "o8",
-  "version": "0.1.750",
+  "version": "0.1.751",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "o8",
-      "version": "0.1.750",
+      "version": "0.1.751",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o8",
-  "version": "0.1.750",
+  "version": "0.1.751",
   "description": "o8 — governance layer for autonomous engineering teams. Approvals, audit, organizational memory.",
   "license": "MIT",
   "productName": "o8",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "o8"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "o8"
-version = "0.1.750"
+version = "0.1.751"
 description = "o8 — governance layer for autonomous engineering teams"
 authors = ["hurttlocker"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "o8",
-  "version": "0.1.750",
+  "version": "0.1.751",
   "identifier": "ai.o8.desktop",
   "build": {
     "frontendDist": "../out/frontend",


### PR DESCRIPTION
## Mechanic

Version bump for the 0.1.751 stable release. Synced manifests only (package.json, package-lock.json, Cargo.toml, Cargo.lock, tauri.conf.json).

## What ships since 0.1.750

- #2284 (Fixes #2224): the resident OpenCode service is classified separately from a packet worker and never signaled; discard completes with the unconfirmed kill recorded instead of refusing forever.
- #2285 (Fixes #2208): the composer resolves operator defaults at turn time, so a changed orchestrator model or backend applies to the next turn without a reload and the displayed value matches the recorded one.
- #2275, #2276, #2277: roadmap documentation.

## How verified

`npm version patch --no-git-tag-version` in a clean worktree cut from origin/main at af6452612; the diff is the same five manifest files as #2273. Release proceeds after this merges: tag the merged commit, push the exact tag, `npm run ship`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4G8rVjFpi9pdGFW6mALGe
